### PR TITLE
Force correct overload selection to fix compatibility with Intel C++

### DIFF
--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1669,7 +1669,7 @@ IceInternal::RoutableReference::getConnectionNoRouterInfo(const GetConnectionCal
     if(_locatorInfo)
     {
         RoutableReference* self = const_cast<RoutableReference*>(this);
-        _locatorInfo->getEndpoints(self, _locatorCacheTimeout, new Callback(self, callback));
+        _locatorInfo->getEndpoints(self, _locatorCacheTimeout, LocatorInfo::GetEndpointsCallbackPtr(new Callback(self, callback)));
     }
     else
     {


### PR DESCRIPTION
Hi. We've managed to build a working version of Ice with intel compiler (Composer XE 2015, Win x64). It works with our (quite complex) app, so hopefully build is correct.

However, it required patch to Ice code which took a while to figure out. Everything just froze on connection establishment. Patch seems to be correct and harmless, so we suggest it to developers to apply in some later version to save trouble to other desperate Intel C++ users.

The problem is in subtle difference in overload selection. In a code:

```C++
#include <iostream>

struct T {}; 
struct PtrT { PtrT(T*) {} };

void f(bool&) { std::cout << "FAIL - bool" << std::endl; }
void f(PtrT) { std::cout << "OK - PtrT" << std::endl; }

int main() {
  f(new T);
}
```

Intel selects "bool&" overload without a warning. Ice source contains few overloads of this type (e.g. IceInternal::OutgoingConnectionFactory::create, Ice::Handle is similar to PtrT in example). The result is awful - pointer to callback gets casted to bool, callback is lost, application freezes.

Hopefully, we got all such places.