### PR TITLE
IcePy: allow float NaN and Inf values

### DIFF
--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -724,9 +724,10 @@ IcePy::PrimitiveInfo::validate(PyObject* p)
         }
         else
         {
-            // Ensure double does not exceed maximum float value before casting
+            // Ensure double does not exceed maximum float value
+            // before casting.  NaN and Inf are OK too.
             double val = PyFloat_AsDouble(p);
-            return val <= numeric_limits<float>::max() && val >= -numeric_limits<float>::max();
+            return (val <= numeric_limits<float>::max() && val >= -numeric_limits<float>::max()) || !isfinite (val);
         }
 
         break;

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -141,6 +141,10 @@ def twoways(communicator, p):
     r, f, d = p.opFloatDouble(3.402823466E38, 0.0)
     r, f, d = p.opFloatDouble(-3.402823466E38, 0.0)
 
+    # NaN and Infinity are OK for float or double
+    for val in ('inf', '-inf', 'nan', '-nan'):
+        r, f, d = p.opFloatDouble (float (val), float (val))
+
     try:
         r, f, d = p.opFloatDouble(3.402823466E38*2, 0.0)
         test(False)


### PR DESCRIPTION
NaN and Inf are valid floats but fail the new range check in Types.cpp.  Fixed, with test-case.