### PR TITLE
Support bzip2 compression on all Apple targets

### DIFF
--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -44,7 +44,7 @@
 
 #include <deque>
 
-#if TARGET_OS_IPHONE == 0 && !defined(ICE_OS_WINRT)
+#if !defined(ICE_OS_WINRT)
 #    ifndef ICE_HAS_BZIP2
 #        define ICE_HAS_BZIP2
 #    endif


### PR DESCRIPTION
Since currently all Apple devices seem to support bzip2 compression I don't see a point in disabling it for iOS on iPhone.