### PR TITLE
Fix timed conditon on FreeBSD

### DIFF
--- a/cpp/src/IceUtil/Cond.cpp
+++ b/cpp/src/IceUtil/Cond.cpp
@@ -332,7 +332,7 @@ IceUtil::Cond::Cond()
         throw ThreadSyscallException(__FILE__, __LINE__, rc);
     }
 
-#if !defined(__hppa) && !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__hppa) && !defined(__APPLE__)
     rc = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC); 
     if(rc != 0)
     {


### PR DESCRIPTION
As part of 8e5becc229ed4da6164977567671791d378d1cbd this condition sneaked into the code. Since the other part of the change in Time.cpp wasn't merged into 3.6.3 (doesn't build), this was probably forgotten, effectively breaking timed conditions on FreeBSD (caught by unit test IceUtil/timer).