### PR TITLE
Fix updating runtime properties for services using shared communicator

### DIFF
--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -328,7 +328,22 @@ private:
         {
             assert(_p->first.find("config_") == 0);
             const string service = _p->first.substr(7);
-            facet = "IceBox.Service." + service + ".Properties";
+            bool useSharedCommunicator = false;
+            for (PropertyDescriptorSeq::const_iterator d = _properties.at("config").begin(); d != _properties.at("config").end(); ++d)
+            {
+                if (d->name == "IceBox.UseSharedCommunicator." + service)
+                {
+                   useSharedCommunicator = (atoi(d->value.c_str()) > 0);
+                }
+            }
+            if (useSharedCommunicator)
+            {
+                facet = "IceBox.SharedCommunicator.Properties";
+            }
+            else
+            {
+                facet = "IceBox.Service." + service + ".Properties";
+            }
             if(_traceLevels->server > 1)
             {
                 const string id = _server->getId();

--- a/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
+++ b/cpp/test/IceGrid/noRestartUpdate/AllTests.cpp
@@ -558,6 +558,9 @@ allTests(const Ice::CommunicatorPtr& communicator)
         service->name = "Service2";
         icebox->services[1].descriptor = ServiceDescriptorPtr::dynamicCast(service->ice_clone());
         service->name = "Service3";
+        // Test also with shared communicator because it uses different proxy name
+        // and thus different branches in code.
+        addProperty(icebox, "IceBox.UseSharedCommunicator.Service3", "1");
         icebox->services[2].descriptor = ServiceDescriptorPtr::dynamicCast(service->ice_clone());
 
         try


### PR DESCRIPTION
As reported [here](https://forums.zeroc.com/discussion/46487/icegridnode-fails-to-apply-configuration-changes-to-services-using-a-shared-communicator/p1).

We tested that this change is working by using the `application update --no-restart <XMLFILENAME>` command, which correctly propagated the change into the IceBox service. 

If desired, I can also provide a unit test later on. Right now, there seems to be no existing unit test with a service using shared communicator.