### PR TITLE
apply 8e5bc0f to IceRuby

### DIFF
--- a/ruby/src/IceRuby/Makefile.mk
+++ b/ruby/src/IceRuby/Makefile.mk
@@ -30,6 +30,7 @@ IceRuby_extra_sources   := $(filter-out %Util.cpp %Python.cpp,\
 #
 $(foreach p,$(supported-platforms),$(eval $$p_targetdir[IceRuby] := /$$p))
 $(firstword $(supported-platforms))_targetdir[IceRuby] :=
+$(firstword $(supported-platforms))_installdir[IceRuby] :=
 
 projects += $(project)
 srcs:: $(project)


### PR DESCRIPTION
so we don't end up with a fun "ruby64" directory on x64