### PR TITLE
Use existing service definition instead of loading one when operating on replica in ServerI.

### DIFF
--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1232,7 +1232,7 @@ ServerI::load(const AMD_Node_loadServerPtr& amdCB, const InternalServerDescripto
             updateRevision(desc->uuid, desc->revision);
         }
 
-        if(!_desc)
+        if(!_desc || (_load && descriptorUpdated(_load->getInternalServerDescriptor(), _desc)))
         {
             _load->addCallback(amdCB);
             return 0;


### PR DESCRIPTION
Short problem description:
When changing adapters in an icebox server (e.g. adding an adapter),
a replicated registry still uses the previous list of
adapter ids - which means, an icegridnode starting a service fails
to do so in case it's using a replicated registry. As it's common
to have one master registry and many replicated ones, this gets
worse the more replicated registries exist. This basically means, that after
adding a service to an icebox, the service might not come up any more.

A full description of the problem and code to easily reproduce it
can be found here (you basically git pull it, change paths to ice in
the Makefile and do "make run"):

https://github.com/grembo/gridfail

Note that this is a workaround, it seems to make sense, but it might
have unwanted side effects (I figured it's better someone with a
good understanding of the code looks at it) and the problem might be
more complicated to fix/happen somewhere else.