### PR TITLE
Fix marshalling values with no own fields

### DIFF
--- a/js/src/Ice/Exception.js
+++ b/js/src/Ice/Exception.js
@@ -226,7 +226,7 @@ const writeImpl = function(obj, os, type)
     }
 
     os.startSlice(type._id, -1, type._parent === UserException);
-    if(type.prototype._writeMemberImpl)
+    if(type.prototype.hasOwnProperty('_writeMemberImpl'))
     {
         type.prototype._writeMemberImpl.call(obj, os);
     }
@@ -248,7 +248,7 @@ const readImpl = function(obj, is, type)
     }
 
     is.startSlice();
-    if(type.prototype._readMemberImpl)
+    if(type.prototype.hasOwnProperty('_readMemberImpl'))
     {
         type.prototype._readMemberImpl.call(obj, is);
     }

--- a/js/src/Ice/Value.js
+++ b/js/src/Ice/Value.js
@@ -127,7 +127,7 @@ const writeImpl = function(obj, os, type)
     os.startSlice(type.ice_staticId(),
                   Object.prototype.hasOwnProperty.call(type, '_iceCompactId') ? type._iceCompactId : -1 ,
                   Object.getPrototypeOf(type) === Ice.Value);
-    if(type.prototype._iceWriteMemberImpl)
+    if(type.prototype.hasOwnProperty('_iceWriteMemberImpl'))
     {
         type.prototype._iceWriteMemberImpl.call(obj, os);
     }
@@ -149,7 +149,7 @@ const readImpl = function(obj, is, type)
     }
 
     is.startSlice();
-    if(type.prototype._iceReadMemberImpl)
+    if(type.prototype.hasOwnProperty('_iceReadMemberImpl'))
     {
         type.prototype._iceReadMemberImpl.call(obj, is);
     }


### PR DESCRIPTION
Consider the following slice definition:

```
class A {
  string someField;
}

class B extends A {}
```

In this case, `slice2js` only generates `_iceWriteMemberImpl` method for `A` and not for `B`. But `B.prototype._iceWriteMemberImpl` would still be defined as it exists on the prototype of the prototype. Which leads to `_iceWriteMemberImpl` of `A` being called twice.