### PR TITLE
fix disabling namespaces for php in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - DOCKER_BASE_IMAGE=zerocci/ice-base:${DOCKER_BASE_TAG}
   - DOCKER_BUILD_IMAGE=zerocci/ice-travis-build:${TRAVIS_BUILD_NUMBER}
   - DOCKER_BUILD_CPP11_IMAGE=zerocci/ice-travis-build:${TRAVIS_BUILD_NUMBER}-cpp11
-  - MAKEFLAGS="-j3 V=1 OPTIMIZE=no USER_NAMESPACES=no CONFIGS=shared"
+  - MAKEFLAGS="-j3 V=1 OPTIMIZE=no USE_NAMESPACES=no CONFIGS=shared"
   - DOCKER_RUN="docker run -it --rm ${DOCKER_BUILD_IMAGE} /bin/bash -c"
   - DOCKER_RUN_CPP11="docker run -it --rm ${DOCKER_BUILD_IMAGE}-cpp11 /bin/bash -c"
   - ALLTESTS="python allTests.py --protocol=ssl --workers=4"


### PR DESCRIPTION
even though travis never failed with these enabled (its the default iirc?) that's probably what was desired.