### PR TITLE
Optimize proxy object creation

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -107,9 +107,15 @@ namespace IceInternal
 {
 
 template<typename P>
-::std::shared_ptr<P> createProxy()
+inline ::std::shared_ptr<P> createProxy()
 {
-    return ::std::shared_ptr<P>(new P());
+    // Proxy default constructor is protected, we can't use make_shared to create it directly
+    struct ProxyHolder
+    {
+        P proxy;
+    };
+    ::std::shared_ptr<ProxyHolder> p(::std::make_shared<ProxyHolder>());
+    return ::std::shared_ptr<P>(p, &p->proxy);
 }
 
 inline ::std::pair<const Ice::Byte*, const Ice::Byte*>


### PR DESCRIPTION
Use make_shared to allocate proxy objects, which reduces memory allocations by one. Use ProxyHolder wrapper class and shared_ptr aliasing to work around protected default constructor of proxies.