### PR TITLE
Fix compilation in C++17 mode

### DIFF
--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -132,6 +132,47 @@ protected:
                                                                                                 memberFn)));
         }
 
+#if __cplusplus >= 201703L
+        // C++17 overloads with noexcept being part of the type
+        template<typename Y> void
+        add(const std::string& name, Y (Helper::*memberFn)() const noexcept)
+        {
+            typedef Y (Helper::*memberFn_t)() const;
+            add(name, (memberFn_t)memberFn);
+        }
+
+        template<typename I, typename O, typename Y> void
+        add(const std::string& name, O (Helper::*getFn)() const noexcept, Y I::*member)
+        {
+            typedef O (Helper::*getFn_t)() const;
+            add(name, (getFn_t)getFn, member);
+        }
+
+        template<typename I, typename O, typename Y> void
+        add(const std::string& name, O (Helper::*getFn)() const noexcept, Y (I::*memberFn)() const)
+        {
+            typedef O (Helper::*getFn_t)() const;
+            typedef Y (Helper::*memberFn_t)() const;
+            add(name, (getFn_t)getFn, (memberFn_t)memberFn);
+        }
+
+        template<typename I, typename O, typename Y> void
+        add(const std::string& name, O (Helper::*getFn)() const, Y (I::*memberFn)() const noexcept)
+        {
+            typedef O (Helper::*getFn_t)() const;
+            typedef Y (Helper::*memberFn_t)() const;
+            add(name, (getFn_t)getFn, (memberFn_t)memberFn);
+        }
+
+        template<typename I, typename O, typename Y> void
+        add(const std::string& name, O (Helper::*getFn)() const noexcept, Y (I::*memberFn)() const noexcept)
+        {
+            typedef O (Helper::*getFn_t)() const;
+            typedef Y (Helper::*memberFn_t)() const;
+            add(name, (getFn_t)getFn, (memberFn_t)memberFn);
+        }
+#endif
+
     private:
 
         template<typename Y> class HelperMemberResolver : public Resolver


### PR DESCRIPTION
C++17 introduced `noexcept` specifiers into function signature types. Because of this, `AttributeResolverT::add` function templates fail to deduce their template arguments when called with `noexcept`-qualified functions. This results in compilation errors.

This commit adds more `AttributeResolverT::add` overloads with `noexcept`-qualified function pointers which help template argument deduction.