### PR TITLE
Fix compiling classes with fields of type Value to JS

### DIFF
--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -103,7 +103,7 @@ bool
 Slice::JsGenerator::isClassType(const TypePtr& type)
 {
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
-    return (builtin && builtin->kind() == Builtin::KindObject) || ClassDeclPtr::dynamicCast(type);
+    return (builtin && (builtin->kind() == Builtin::KindObject || builtin->kind() == Builtin::KindValue)) || ClassDeclPtr::dynamicCast(type);
 }
 
 //


### PR DESCRIPTION
When I try to compile this class with `slice2js`, I get an error in output:
```
class SomeClass {
  Value field;
}
```
```
Assertion failed: (false), function writeMarshalUnmarshalCode, file ../ice/cpp/src/slice2js/JsUtil.cpp, line 466.
```