### PR TITLE
Always enable error checks for mutexes

### DIFF
--- a/cpp/include/IceUtil/Mutex.h
+++ b/cpp/include/IceUtil/Mutex.h
@@ -235,9 +235,8 @@ Mutex::init(MutexProtocol
     }
 
     //
-    // Enable mutex error checking in debug builds
+    // Enable mutex error checking
     //
-#ifndef NDEBUG
     rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
     assert(rc == 0);
     if(rc != 0)
@@ -245,7 +244,6 @@ Mutex::init(MutexProtocol
         pthread_mutexattr_destroy(&attr);
         throw ThreadSyscallException(__FILE__, __LINE__, rc);
     }
-#endif
 
     //
     // If system has support for priority inheritance we set the protocol


### PR DESCRIPTION
We discovered that mutexes on FreeBSD and MacOS behave different than on Linux: if a thread holds the lock and then locks the mutex again, Linux mutexes will just deadlock while the implementation on other operating systems return an error (EDEADLK). On Linux, the behaviour was even inconsistent between Debug and Release builds: Debug builds return an error, Release builds deadlock.

By unconditionally enabling PTHREAD_MUTEX_ERRORCHECK there will be consistent behaviour between all systems and between Debug/Release builds on Linux. And the code will be more resilient against deadlocks and other runtime errors.

(Enabling error checks is anyway considered good practice - see https://wiki.sei.cmu.edu/confluence/display/c/POS04-C.+Avoid+using+PTHREAD_MUTEX_NORMAL+type+mutex+locks)