### PR TITLE
update consoleOut to consoleErr when handling return value of isSet("version")

### DIFF
--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -275,7 +275,7 @@ run(const Ice::StringSeq& args)
     }
     if(opts.isSet("version"))
     {
-        consoleOut << ICE_STRING_VERSION << endl;
+        consoleErr << ICE_STRING_VERSION << endl;
         return 0;
     }
 

--- a/cpp/src/IcePatch2/Client.cpp
+++ b/cpp/src/IcePatch2/Client.cpp
@@ -332,7 +332,7 @@ run(const Ice::StringSeq& args)
     }
     if(opts.isSet("version"))
     {
-        consoleOut << ICE_STRING_VERSION << endl;
+        consoleErr << ICE_STRING_VERSION << endl;
         return 0;
     }
     if(opts.isSet("thorough"))

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -117,7 +117,7 @@ run(const Ice::StringSeq& args)
     }
     if(opts.isSet("version"))
     {
-        consoleOut << ICE_STRING_VERSION << endl;
+        consoleErr << ICE_STRING_VERSION << endl;
         return 0;
     }
     if(opts.isSet("e"))

--- a/cpp/src/iceserviceinstall/Install.cpp
+++ b/cpp/src/iceserviceinstall/Install.cpp
@@ -148,7 +148,7 @@ run(const Ice::StringSeq& args)
     }
     if(opts.isSet("version"))
     {
-        consoleOut << ICE_STRING_VERSION << endl;
+        consoleErr << ICE_STRING_VERSION << endl;
         pause = true;
         return 0;
     }


### PR DESCRIPTION
We have found nine log revisions that all update _cout_ to _cerr_ when handling return value of _isSet("version")_. 

With this knowledge, we have found four missed spot in the latest version and we suggest to update _consoleOut_ to _consoleErr_.

These nice log revisions taken place between Ice-3.3.0  and Ice-3.3.1 in cpp/src/slice2cpp/Main.cpp, cpp/src/slice2cs/Main.cpp, cpp/src/slice2docbook/Main.cpp, cpp/src/slice2freeze/Main.cpp, cpp/src/slice2freezej/Main.cpp, cpp/src/slice2html/Main.cpp, cpp/src/slice2java/Main.cpp, and cpp/src/slice2py/Main.cpp, cpp/src/slice2rb/Main.cpp. 

One of them is as follows:
```
   if(opts.isSet("version"))
   {
-     cout << ICE_STRING_VERSION << endl;
+    cerr << ICE_STRING_VERSION << endl;
       return EXIT_SUCCESS;
    }
```

More information about the nine log revisions or others, please leave a comment ^^