### PR TITLE
Add "error" in static text when handling IceUtilInternal::BadOptException

### DIFF
--- a/cpp/test/Ice/invoke/Server.cpp
+++ b/cpp/test/Ice/invoke/Server.cpp
@@ -99,7 +99,7 @@ Server::run(int argc, char** argv)
     }
     catch(const IceUtilInternal::BadOptException& e)
     {
-        cout << argv[0] << ": " << e.reason << endl;
+        cout << argv[0] << ": error: " << e.reason << endl;
         throw;
     }
     bool array = opts.isSet("array");

--- a/cpp/test/IceStorm/rep1/Sub.cpp
+++ b/cpp/test/IceStorm/rep1/Sub.cpp
@@ -49,7 +49,7 @@ Sub::run(int argc, char** argv)
     catch(const IceUtilInternal::BadOptException& e)
     {
         ostringstream os;
-        os << argv[0] << ": " << e.reason;
+        os << argv[0] << ": error: " << e.reason;
         throw invalid_argument(os.str());
     }
 

--- a/cpp/test/IceStorm/rep1/Subscriber.cpp
+++ b/cpp/test/IceStorm/rep1/Subscriber.cpp
@@ -95,7 +95,7 @@ Subscriber::run(int argc, char** argv)
     catch(const IceUtilInternal::BadOptException& e)
     {
         ostringstream os;
-        os << argv[0] << ": " << e.reason;
+        os << argv[0] << ": error: " << e.reason;
         throw invalid_argument(os.str());
     }
 

--- a/cpp/test/IceStorm/stress/Publisher.cpp
+++ b/cpp/test/IceStorm/stress/Publisher.cpp
@@ -41,7 +41,7 @@ Publisher::run(int argc, char** argv)
     catch(const IceUtilInternal::BadOptException& e)
     {
         ostringstream os;
-        os << argv[0] << ": " << e.reason;
+        os << argv[0] << ": error: " << e.reason;
         throw invalid_argument(os.str());
     }
 

--- a/cpp/test/IceStorm/stress/Subscriber.cpp
+++ b/cpp/test/IceStorm/stress/Subscriber.cpp
@@ -330,7 +330,7 @@ Subscriber::run(int argc, char** argv)
     catch(const IceUtilInternal::BadOptException& e)
     {
         ostringstream os;
-        os << argv[0] << ": " << e.reason;
+        os << argv[0] << ": error: " << e.reason;
         throw invalid_argument(os.str());
     }
 


### PR DESCRIPTION
We have found eight log revisions that all add _error_ in static text when handling _IceUtilInternal::BadOptException_.

With this knowledge, we have found five missed spot in the latest version and we suggest to add the "error".

These eight log revisions taken place between Ice-3.3.0  and Ice-3.3.1 in cpp/src/slice2cs/Main.cpp, cpp/src/slice2docbook/Main.cpp, cpp/src/slice2freeze/Main.cpp, cpp/src/slice2freezej/Main.cpp, cpp/src/slice2html/Main.cpp, cpp/src/slice2java/Main.cpp, and cpp/src/slice2py/Main.cpp, cpp/src/slice2rb/Main.cpp. 

One of them is as follows:
```
  catch(const IceUtilInternal::BadOptException& e)
  {
-    cerr << argv[0] << ": " << e.reason << endl;
+   cerr << argv[0] << ": error: " << e.reason << endl;
      usage(argv[0]);
      return EXIT_FAILURE;
  }
```

More information about the nine log revisions or others, please leave a comment ^^