### PR TITLE
Correct warnings emitted by doxygen

### DIFF
--- a/doxygen/config
+++ b/doxygen/config
@@ -770,7 +770,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/slice/Ice/Instrumentation.ice
+++ b/slice/Ice/Instrumentation.ice
@@ -330,14 +330,14 @@ local interface InvocationObserver extends Observer
  *
  * The observer updater interface. This interface is implemented by
  * the Ice run-time and an instance of this interface is provided by
- * the Ice communicator on initialization to the {@link
- * CommunicatorObserver} object set with the communicator
- * initialization data. The Ice communicator calls {@link
- * CommunicatorObserver#setObserverUpdater} to provide the observer
+ * the Ice communicator on initialization to the
+ * {@link CommunicatorObserver} object set with the communicator
+ * initialization data. The Ice communicator calls
+ * {@link CommunicatorObserver#setObserverUpdater} to provide the observer
  * updater.
  *
- * This interface can be used by add-ins implementing the {@link
- * CommunicatorObserver} interface to update the observers of
+ * This interface can be used by add-ins implementing the
+ * {@link CommunicatorObserver} interface to update the observers of
  * connections and threads.
  *
  **/

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -21,9 +21,9 @@
 
 /**
  *
- * The Ice Management eXtension facility. It provides the {@link
- * IceMX#MetricsAdmin} interface for management clients to retrieve
- * metrics from Ice applications.
+ * The Ice Management eXtension facility. It provides the
+ * {@link IceMX#MetricsAdmin} interface for management clients to
+ * retrieve metrics from Ice applications.
  *
  **/
 #ifndef __SLICE2JAVA_COMPAT__
@@ -325,8 +325,8 @@ class DispatchMetrics extends Metrics
  * Provides information on child invocations. A child invocation is
  * either remote (sent over an Ice connection) or collocated. An
  * invocation can have multiple child invocation if it is
- * retried. Child invocation metrics are embedded within {@link
- * InvocationMetrics}.
+ * retried. Child invocation metrics are embedded within
+ * {@link InvocationMetrics}.
  *
  **/
 class ChildInvocationMetrics extends Metrics


### PR DESCRIPTION
Doxygen doesn't like it when the `{@link...}` is split over multiple lines.