### PR TITLE
gcc 9 complains that it is creating an implicit copy constructor.

### DIFF
--- a/cpp/include/IceUtil/Optional.h
+++ b/cpp/include/IceUtil/Optional.h
@@ -45,6 +45,10 @@ public:
     Optional(IceUtilInternal::NoneType) : _isSet(false)
     {
     }
+    
+    Optional(const Optional<T>& r) : _value(r._value), _isSet(r._isSet)
+    {
+    }
 
     /**
      * Constructs an optional with the given value.

--- a/cpp/include/IceUtil/Optional.h
+++ b/cpp/include/IceUtil/Optional.h
@@ -46,7 +46,11 @@ public:
     {
     }
     
-    Optional(const Optional<T>& r) : _value(r._value), _isSet(r._isSet)
+    /**
+     * Constructs an optional as a copy of the given optional.
+     * @param r The source optional.
+     */
+    Optional(const Optional& r) : _value(r._value), _isSet(r._isSet)
     {
     }
 


### PR DESCRIPTION
This is deprecated behavior since C++11 and gcc 9 treats it as a warning now that breaks the build.
Adding a copy constructor to silences this.