### PR TITLE
Port to AIX with g++, xlC_r and xlclang++

### DIFF
--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -43,11 +43,11 @@ component-configs       = $(call unique,$(foreach c,$(configs),\
 #
 # Some variables for utilities
 #
-INSTALL                 = install -p
-MV                      = mv -f
-RM                      = rm -f
-MKDIR                   = mkdir
-CHMOD                   = chmod
+INSTALL                 ?= install -p
+MV                      ?= mv -f
+RM                      ?= rm -f
+MKDIR                   ?= mkdir
+CHMOD                   ?= chmod
 
 Q                       := $(if $(V),,@)
 E                       := $(if $(V),@:,@echo)
@@ -1087,7 +1087,7 @@ platform-and-config-var = $(strip $(platform-var) $(config-var))
 
 #
 # Functions to transform a list of source filenames to generated source/header, object or dependency filenames.
-# 
+#
 generated-extensions := ice
 source-extensions    := ice y l cpp m mm
 

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -936,6 +936,7 @@ currentdir      = $(call dirname,$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIS
 unique          = $(strip $(if $1,$(firstword $1) $(call unique,$(filter-out $(firstword $1),$1))))
 runique         = $(strip $(if $1,$(lastword $1) $(call runique,$(filter-out $(lastword $1),$1))))
 files-to-dirs   = $(call unique,$(call dirname,$(filter $(if $2,$(addprefix %.,$2),%),$1)))
+join-with       = $(subst $(space),$1,$(strip $2))
 
 empty           :=
 space           := $(empty) $(empty)

--- a/config/Make.rules
+++ b/config/Make.rules
@@ -26,7 +26,7 @@ embedded_runpath       ?= yes
 #
 # Define new_dtags as yes if you want the linker to enable the new style
 # dtags, this will cause the linker to add a runpath entry instead of
-# a rpath entry. This only aplly to gcc builds on Linux
+# a rpath entry. This only apply to gcc builds on Linux
 #
 new_dtags              ?= no
 

--- a/config/Make.rules.AIX
+++ b/config/Make.rules.AIX
@@ -2,27 +2,30 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-supported-platforms = ppc ppc64
+# The default platform (ppc64) is listed first
+supported-platforms = ppc64 ppc
 
-ppc_cppflags        = -q32 -D_LARGE_FILES
-ppc_ldflags         = $(ppc_cppflags)
-ppc_targetdir       = $(if $(filter %/build,$5),/ppc)
+supported-compilers = xlC_r xlclang++ g++
+COMPILER            ?= $(firstword $(supported-compilers))
 
-ppc64_cppflags      = -q64
-ppc64_ldflags       = $(ppc64_cppflags)
-ppc64_targetdir     = $(if $(filter %/build,$5),/ppc64,$(if $(filter-out $($1_target),program),64))
-ppc64_targetname    = $(if $(and $(filter $(bindir)%,$($4_targetdir)),$(filter $($1_target),program)),_64)
+ifneq ($(filter $(COMPILER),$(supported-compilers)),$(COMPILER))
+    $(error invalid compiler $(COMPILER); the supported compilers are: $(supported-compilers))
+endif
 
-shared_cppflags     = -brtl
-static_targetdir        = $(if $(and $(filter-out %/build,$5),$(filter $($1_target),program)),,static)
-
-platform_cxx        = xlC_r
-platform_ld         = xlC_r
 platform_ar         = $(AR)
+INSTALL             = installbsd -c
 
-xlc_compiler        = yes
+ppc_targetdir       = $(if $(filter %/build,$5),/ppc,$(if $(filter-out $($1_target),program),32))
+ppc_installdir      = $(if $(and $(filter-out $($1_target),program),$(if $5,$(filter-out %32,$5),true)),32)
+# All 32-bit programs in "bin" get the _32 suffix
+ppc_targetname      = $(if $(and $(filter $(bindir)%,$($4_targetdir)),$(filter $($1_target),program)),_32)
 
-cppflags            = -qrtti=all -qstaticinline -qhalt=i $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g)
+ppc64_targetdir     = $(if $(filter %/build,$5),/ppc64)
+
+static_targetdir    = $(if $(and $(filter-out %/build,$5),$(filter $($1_target),program)),,static)
+
+platform_cxx        = $(COMPILER)
+platform_ld         = $(COMPILER)
 
 ifeq ($(embedded_runpath),yes)
     #
@@ -33,25 +36,103 @@ ifeq ($(embedded_runpath),yes)
     endif
 endif
 
-depend-cppflags = -qmakedep=gcc -MF $1
-rpath-ldflag    = -Wl,-blibpath:$1:/usr/lib
-
-# $(call mklib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
-mklib           = $(or $($7_ar),$(AR)) -X32_64 cr $1 $2
-
-# $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
-tmpsofile       = $(dir $1)lib$2.so$(if $3,.$3)
-mkshlib         ?= $(platform_cxx) -qmkshrobj -o $(call tmpsofile,$1,$3,$5) $2 $6 && \
-                  $(platform_ar) -X32_64 cr $1 $(call tmpsofile,$1,$3,$5) && \
-                  rm $(call tmpsofile,$1,$3,$5)
-
 #
 # $(call mkxxx,$1=libname,$2=version,$3=soversion)
 #
 mkshlibfilename = lib$(1).a
-
 mkpymodulename  = $(1).so
+
+# $(call mklib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
+mklib           = $(or $($7_ar),$(AR)) -X32_64 crs $1 $2
 
 Ice_system_libs         = -lcrypto
 IceSSL_system_libs      = -lssl -lcrypto
 Glacier2CryptPermissionsVerifier_system_libs = -lcrypt
+
+#
+# Compiler-specific section
+#
+ifeq ($(COMPILER),g++)
+
+# It's critical to list /opt/freeware/lib/pthread first to get the thread-safe version
+# of the C++ library runtime.
+# Note that rpath-ldflag is not usable on AIX as unlike the Linux version, -blibpath is not cumulative
+# and the last option wins.
+#
+ifeq ($(embedded_runpath),yes)
+    libpath         = /opt/freeware/lib/pthread:$(embedded_runpath_prefix)/lib:/opt/freeware/lib:/usr/lib
+else
+    libpath         = /opt/freeware/lib/pthread:/opt/freeware/lib:/usr/lib
+endif
+
+ppc_cppflags        = -maix32 -D_LARGE_FILES -pthread
+ppc_ldflags         = $(ppc_cppflags) -Wl,-blibpath:$(libpath)
+ppc64_cppflags      = -maix64 -pthread
+ppc64_ldflags       = $(ppc64_cppflags) -Wl,-blibpath:$(libpath)
+
+shared_cppflags     = $(if $(filter-out program,$($1_target)),-fPIC,-fPIE) -fvisibility=hidden
+
+cppflags            = $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g)
+nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations
+
+# disabled
+rpath-ldflag        :=
+
+# $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
+tmpsofile       = $(dir $1)lib$2.so$(if $3,.$3)
+mkshlib         ?= $(platform_cxx) -shared -o $(call tmpsofile,$1,$3,$5) $2 $6 && \
+                   $(platform_ar) -X32_64 crs $1 $(call tmpsofile,$1,$3,$5) && \
+                   rm $(call tmpsofile,$1,$3,$5)
+
+else
+
+ifeq ($(embedded_runpath),yes)
+    libpath         = $(embedded_runpath_prefix)/lib:/usr/lib
+else
+    libpath         = /usr/lib
+endif
+
+ppc_cppflags        = -q32 -D_LARGE_FILES
+ppc_ldflags         = $(ppc_cppflags) -Wl,-blibpath:$(libpath)
+ppc64_cppflags      = -q64
+ppc64_ldflags       = $(ppc64_cppflags) -Wl,-blibpath:$(libpath)
+
+shared_cppflags     = $(if $(filter-out program,$($1_target)),-qpic,)
+
+ifeq ($(COMPILER),xlC_r)
+    # Used to suppress warnings in generated code
+    xlc_compiler        = yes
+endif
+
+cppflags            = $(if $(filter yes,$(OPTIMIZE)),-O2 -qmaxmem=-1 -DNDEBUG,-g)
+
+ifeq ($(COMPILER),xlC_r)
+     cppflags        += -qrtti -qstaticinline -qhalt=i
+else ifeq ($(COMPILER),xlclang++)
+     cppflags        += -mcpu=pwr8 -Werror
+     nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations
+endif
+
+depend-cppflags = -qmakedep=gcc -MF $1
+
+rpath-ldflag    :=
+
+# $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
+tmpsofile       = $(dir $1)lib$2.so$(if $3,.$3)
+mkshlib         ?= $(platform_cxx) -qmkshrobj -o $(call tmpsofile,$1,$3,$5) $2 $6 && \
+                   $(platform_ar) -X32_64 crs $1 $(call tmpsofile,$1,$3,$5) && \
+                   rm $(call tmpsofile,$1,$3,$5)
+
+ifeq ($(ICONV_HOME),)
+# Make sure we load /usr/lib/libiconv
+iconv_program_system_libs = -Wl,-blibpath:/usr/lib:$(libpath)
+endif
+
+ifeq ($(EXPAT_HOME),)
+# Add /opt/lib/freeware to libpath for libgcc_s
+ifneq ($(embedded_runpath_prefix),/opt/freeware)
+expat_program_system_libs = -Wl,-blibpath:/opt/freeware/lib:$(libpath)
+endif
+endif
+
+endif

--- a/config/Make.rules.AIX
+++ b/config/Make.rules.AIX
@@ -129,9 +129,9 @@ iconv_program_system_libs = -Wl,-blibpath:/usr/lib:$(libpath)
 endif
 
 ifeq ($(EXPAT_HOME),)
-# Add /opt/lib/freeware to libpath for libgcc_s
+# Add /opt/freeware/lib/pthread to libpath for libgcc_s
 ifneq ($(embedded_runpath_prefix),/opt/freeware)
-expat_program_system_libs = -Wl,-blibpath:/opt/freeware/lib:$(libpath)
+expat_program_system_libs = -Wl,-blibpath:/opt/freeware/lib/pthread:$(libpath)
 endif
 endif
 

--- a/config/Make.rules.AIX
+++ b/config/Make.rules.AIX
@@ -49,6 +49,18 @@ Ice_system_libs         = -lcrypto
 IceSSL_system_libs      = -lssl -lcrypto
 Glacier2CryptPermissionsVerifier_system_libs = -lcrypt
 
+# Disabled, AIX doesn't support rpath
+rpath-ldflag        :=
+
+#
+# Compute the libpath ldflag to add when when linking an executable/library. We
+# go through the dependencies and add the libpath directories for 3rd party
+# libraries. When then append the global libpath variable.
+#
+make-lib-libpath = $(call unique,$(foreach d,$1 $(call get-all-deps,$1),$(foreach l,$($d_libs),$($l_libpath))) $2)
+shared_ldflags  = -Wl,-blibpath:$$(call join-with,:,$$(call make-lib-libpath,$4,$(subst :,$(space),$(libpath))))
+static_ldflags  = -Wl,-blibpath:$$(call join-with,:,$$(call make-lib-libpath,$4,$(subst :,$(space),$(libpath))))
+
 #
 # Compiler-specific section
 #
@@ -66,17 +78,14 @@ else
 endif
 
 ppc_cppflags        = -maix32 -D_LARGE_FILES -pthread
-ppc_ldflags         = $(ppc_cppflags) -Wl,-blibpath:$(libpath)
+ppc_ldflags         = $(ppc_cppflags)
 ppc64_cppflags      = -maix64 -pthread
-ppc64_ldflags       = $(ppc64_cppflags) -Wl,-blibpath:$(libpath)
+ppc64_ldflags       = $(ppc64_cppflags)
 
 shared_cppflags     = $(if $(filter-out program,$($1_target)),-fPIC,-fPIE) -fvisibility=hidden
 
 cppflags            = $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g)
 nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations
-
-# disabled
-rpath-ldflag        :=
 
 # $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
 tmpsofile       = $(dir $1)lib$2.so$(if $3,.$3)
@@ -93,9 +102,9 @@ else
 endif
 
 ppc_cppflags        = -q32 -D_LARGE_FILES
-ppc_ldflags         = $(ppc_cppflags) -Wl,-blibpath:$(libpath)
+ppc_ldflags         = $(ppc_cppflags)
 ppc64_cppflags      = -q64
-ppc64_ldflags       = $(ppc64_cppflags) -Wl,-blibpath:$(libpath)
+ppc64_ldflags       = $(ppc64_cppflags)
 
 shared_cppflags     = $(if $(filter-out program,$($1_target)),-qpic,)
 
@@ -115,24 +124,20 @@ endif
 
 depend-cppflags = -qmakedep=gcc -MF $1
 
-rpath-ldflag    :=
-
 # $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
 tmpsofile       = $(dir $1)lib$2.so$(if $3,.$3)
 mkshlib         ?= $(platform_cxx) -qmkshrobj -o $(call tmpsofile,$1,$3,$5) $2 $6 && \
                    $(platform_ar) -X32_64 crs $1 $(call tmpsofile,$1,$3,$5) && \
                    rm $(call tmpsofile,$1,$3,$5)
 
-ifeq ($(ICONV_HOME),)
+ifeq ($(iconv_home),)
 # Make sure we load /usr/lib/libiconv
-iconv_program_system_libs = -Wl,-blibpath:/usr/lib:$(libpath)
+iconv_libpath = /usr/lib
 endif
 
-ifeq ($(EXPAT_HOME),)
+ifeq ($(expat_home),)
 # Add /opt/freeware/lib/pthread to libpath for libgcc_s
-ifneq ($(embedded_runpath_prefix),/opt/freeware)
-expat_program_system_libs = -Wl,-blibpath:/opt/freeware/lib/pthread:$(libpath)
-endif
+expat_libpath = /opt/freeware/lib/pthread
 endif
 
 endif

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -98,6 +98,7 @@ endif
 # directory.
 #
 cpp11_cppflags          = -DICE_CPP11_MAPPING -std=c++11
+cpp11_ldflags           = $(cpp11_cppflags)
 cpp11_targetname        = $(if $(or $(filter-out $($1_target),program),$(filter $(bindir)%,$($4_targetdir))),++11)
 cpp11_targetdir         = $(if $(filter %/build,$5),cpp11)
 

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -21,12 +21,14 @@
 #endif
 
 #if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && (__BYTE_ORDER == __LITTLE_ENDIAN)) || \
-    (defined(_BYTE_ORDER) && defined(_LITTLE_ENDIAN) && (_BYTE_ORDER == _LITTLE_ENDIAN))
+    (defined(_BYTE_ORDER) && defined(_LITTLE_ENDIAN) && (_BYTE_ORDER == _LITTLE_ENDIAN)) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 
 #   define ICE_LITTLE_ENDIAN
 
 #elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && (__BYTE_ORDER == __BIG_ENDIAN)) || \
-      (defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && (_BYTE_ORDER == _BIG_ENDIAN))
+      (defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && (_BYTE_ORDER == _BIG_ENDIAN)) || \
+      (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
 
 #   define ICE_BIG_ENDIAN
 
@@ -171,9 +173,9 @@
 //  With Visual Studio, we can import/export member functions without importing/
 //  exporting the whole class
 #   define ICE_MEMBER_IMPORT_EXPORT
-#elif defined(__GNUC__) || defined(__clang__)
-#   define ICE_DECLSPEC_EXPORT __attribute__((visibility ("default")))
-#   define ICE_DECLSPEC_IMPORT __attribute__((visibility ("default")))
+#elif (defined(__GNUC__) || defined(__clang__)) && !defined(__ibmxl__)
+#   define ICE_DECLSPEC_EXPORT __attribute__((visibility("default")))
+#   define ICE_DECLSPEC_IMPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_CC)
 #   define ICE_DECLSPEC_EXPORT __global
 #   define ICE_DECLSPEC_IMPORT /**/

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -641,20 +641,50 @@ Activator::activate(const string& name,
     }
 
     vector<gid_t> groups;
+#ifdef _AIX
+    char* grouplist = getgrset(pw->pw_name);
+    if(grouplist == 0)
+    {
+        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+    }
+    vector<string> grps;
+    if(IceUtilInternal::splitString(grouplist, ",", grps))
+    {
+        for(vector<string>::const_iterator p = grps.begin(); p != grps.end(); ++p)
+        {
+            gid_t group;
+            istringstream is(*p);
+            if(is >> group)
+            {
+                groups.push_back(group);
+            }
+        }
+    }
+#else
     groups.resize(20);
     int ngroups = static_cast<int>(groups.size());
-#if defined(__APPLE__)
+    #if defined(__APPLE__)
     if(getgrouplist(pw->pw_name, static_cast<int>(gid), reinterpret_cast<int*>(&groups[0]), &ngroups) < 0)
-#else
+    #else
     if(getgrouplist(pw->pw_name, gid, &groups[0], &ngroups) < 0)
-#endif
+    #endif
     {
         groups.resize(static_cast<size_t>(ngroups));
-#if defined(__APPLE__)
+        #if defined(__APPLE__)
         getgrouplist(pw->pw_name, static_cast<int>(gid), reinterpret_cast<int*>(&groups[0]), &ngroups);
-#else
+        #else
         getgrouplist(pw->pw_name, gid, &groups[0], &ngroups);
+        #endif
+    }
+    else
+    {
+       groups.resize(static_cast<size_t>(ngroups));
+    }
 #endif
+
+    if(groups.size() > NGROUPS_MAX)
+    {
+        groups.resize(NGROUPS_MAX);
     }
     else
     {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -664,18 +664,18 @@ Activator::activate(const string& name,
 #else
     groups.resize(20);
     int ngroups = static_cast<int>(groups.size());
-    #if defined(__APPLE__)
+#   if defined(__APPLE__)
     if(getgrouplist(pw->pw_name, static_cast<int>(gid), reinterpret_cast<int*>(&groups[0]), &ngroups) < 0)
-    #else
+#   else
     if(getgrouplist(pw->pw_name, gid, &groups[0], &ngroups) < 0)
-    #endif
+#   endif
     {
         groups.resize(static_cast<size_t>(ngroups));
-        #if defined(__APPLE__)
+#   if defined(__APPLE__)
         getgrouplist(pw->pw_name, static_cast<int>(gid), reinterpret_cast<int*>(&groups[0]), &ngroups);
-        #else
+#   else
         getgrouplist(pw->pw_name, gid, &groups[0], &ngroups);
-        #endif
+#   endif
     }
     else
     {

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -660,6 +660,7 @@ Activator::activate(const string& name,
             }
         }
     }
+    free(grouplist);
 #else
     groups.resize(20);
     int ngroups = static_cast<int>(groups.size());

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -686,15 +686,6 @@ Activator::activate(const string& name,
     {
         groups.resize(NGROUPS_MAX);
     }
-    else
-    {
-       groups.resize(static_cast<size_t>(ngroups));
-    }
-
-    if(groups.size() > NGROUPS_MAX)
-    {
-        groups.resize(NGROUPS_MAX);
-    }
 
     int fds[2];
     if(pipe(fds) != 0)

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -32,7 +32,12 @@ using namespace Ice;
 using namespace IceInternal;
 using namespace IceGrid;
 
+// Work-around for anonymous namspace bug in xlclang++
+#ifdef __ibmxl__
+namespace IceGridNodeNamespace
+#else
 namespace
+#endif
 {
 
 class ProcessI : public Process
@@ -109,6 +114,10 @@ setNoIndexingAttribute(const string& path)
 #endif
 
 }
+
+#ifdef __ibmxl__
+using namespace IceGridNodeNamespace;
+#endif
 
 CollocatedRegistry::CollocatedRegistry(const CommunicatorPtr& com,
                                        const ActivatorPtr& activator,

--- a/cpp/src/IceGrid/Makefile.mk
+++ b/cpp/src/IceGrid/Makefile.mk
@@ -68,13 +68,16 @@ icegridnode_sources             := $(addprefix $(currentdir)/,$(local_node_srcs)
                                    $(slicedir)/IceLocatorDiscovery/IceLocatorDiscovery.ice
 icegridnode_dependencies        := IceBox IceStormService IceStorm IceXML IceSSL IcePatch2 IceDB
 icegridnode_cppflags            := $(if $(lmdb_includedir),-I$(lmdb_includedir))
+icegridnode_system_libs         := $(expat_program_system_libs)
 
 icegridregistry_sources         := $(addprefix $(currentdir)/,$(local_registry_srcs) IceGridRegistry.cpp) \
                                    $(slicedir)/IceLocatorDiscovery/IceLocatorDiscovery.ice
 icegridregistry_dependencies    := IceBox IceStormService IceStorm IceXML IceSSL IcePatch2 IceDB $(local_dependencies)
 icegridregistry_cppflags        := $(if $(lmdb_includedir),-I$(lmdb_includedir))
+icegridregistry_system_libs     := $(expat_program_system_libs)
 
 icegridadmin_dependencies       := IcePatch2 IceBox IceXML IceLocatorDiscovery
 icegridadmin_sources            := $(addprefix $(currentdir)/,$(local_admin_srcs))
+icegridadmin_system_libs        := $(expat_program_system_libs)
 
 projects += $(project)

--- a/cpp/src/IceGrid/Makefile.mk
+++ b/cpp/src/IceGrid/Makefile.mk
@@ -68,16 +68,13 @@ icegridnode_sources             := $(addprefix $(currentdir)/,$(local_node_srcs)
                                    $(slicedir)/IceLocatorDiscovery/IceLocatorDiscovery.ice
 icegridnode_dependencies        := IceBox IceStormService IceStorm IceXML IceSSL IcePatch2 IceDB
 icegridnode_cppflags            := $(if $(lmdb_includedir),-I$(lmdb_includedir))
-icegridnode_system_libs         := $(expat_program_system_libs)
 
 icegridregistry_sources         := $(addprefix $(currentdir)/,$(local_registry_srcs) IceGridRegistry.cpp) \
                                    $(slicedir)/IceLocatorDiscovery/IceLocatorDiscovery.ice
 icegridregistry_dependencies    := IceBox IceStormService IceStorm IceXML IceSSL IcePatch2 IceDB $(local_dependencies)
 icegridregistry_cppflags        := $(if $(lmdb_includedir),-I$(lmdb_includedir))
-icegridregistry_system_libs     := $(expat_program_system_libs)
 
 icegridadmin_dependencies       := IcePatch2 IceBox IceXML IceLocatorDiscovery
 icegridadmin_sources            := $(addprefix $(currentdir)/,$(local_admin_srcs))
-icegridadmin_system_libs        := $(expat_program_system_libs)
 
 projects += $(project)

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -192,7 +192,7 @@ PlatformInfo::PlatformInfo(const string& prefix,
     _last15Total = 0;
 #elif defined(_AIX)
     struct nlist nl;
-    nl.n_name = "avenrun";
+    nl.n_name = const_cast<char*>("avenrun");
     nl.n_value = 0;
     if(knlist(&nl, 1, sizeof(nl)) == 0)
     {
@@ -510,7 +510,7 @@ PlatformInfo::getLoadInfo()
     {
         long long avenrun[3];
         struct nlist nl;
-        nl.n_name = "avenrun";
+        nl.n_name = const_cast<char*>("avenrun");
         nl.n_value = 0;
         if(knlist(&nl, 1, sizeof(nl)) == 0)
         {

--- a/cpp/src/IceUtil/UtilException.cpp
+++ b/cpp/src/IceUtil/UtilException.cpp
@@ -43,7 +43,7 @@
 #       endif
 #   endif
 
-#   if !defined(__sun) && !defined(__FreeBSD__) && !defined(__MINGW32__) && !defined(ICE_STATIC_LIBS)
+#   if !defined(_AIX) && !defined(__sun) && !defined(__FreeBSD__) && !defined(__MINGW32__) && !defined(ICE_STATIC_LIBS)
 #       include <execinfo.h>
 #       include <cxxabi.h>
 #       include <stdint.h>

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -166,7 +166,7 @@ public:
     }
 
 #ifdef ICE_CPP11_MAPPING
-    void join(thread& t)
+    void join(std::thread& t)
 #else
     void join()
 #endif
@@ -735,11 +735,11 @@ allTests(Test::TestHelper* helper)
     }
 
 #ifdef ICE_CPP11_MAPPING
-    vector<pair<thread, TestCasePtr>> threads;
+    vector<pair<std::thread, TestCasePtr>> threads;
     for(auto p = tests.begin(); p != tests.end(); ++p)
     {
         TestCasePtr testCase = *p;
-        thread t([testCase]()
+        std::thread t([testCase]()
             {
                 testCase->run();
             });

--- a/cpp/test/Ice/impl/Makefile.mk
+++ b/cpp/test/Ice/impl/Makefile.mk
@@ -36,4 +36,8 @@ endef
 
 $(test)_component_with_config_extensions = make-impl-with-config
 
+ifeq ($(xlc_compiler),yes)
+    $(test)_cppflags += -qsuppress="1540-0895"
+endif
+
 tests += $(test)

--- a/cpp/test/Ice/interceptor/MyObjectI.cpp
+++ b/cpp/test/Ice/interceptor/MyObjectI.cpp
@@ -85,7 +85,7 @@ MyObjectI::amdAddAsync(int x,
                        function<void(exception_ptr)>,
                        const Ice::Current&)
 {
-    thread t(
+    std::thread t(
         [x, y, response]()
         {
             this_thread::sleep_for(chrono::milliseconds(10));
@@ -101,7 +101,7 @@ MyObjectI::amdAddWithRetryAsync(int x,
                                 function<void(exception_ptr)> error,
                                 const Ice::Current& current)
 {
-    thread t(
+    std::thread t(
         [x, y, response]()
         {
             try
@@ -137,7 +137,7 @@ MyObjectI::amdBadAddAsync(int,
                           function<void(exception_ptr)> error,
                           const Ice::Current&)
 {
-    thread t(
+    std::thread t(
         [error]()
         {
             this_thread::sleep_for(chrono::milliseconds(10));
@@ -160,7 +160,7 @@ MyObjectI::amdNotExistAddAsync(int,
                                function<void(exception_ptr)> error,
                                const Ice::Current&)
 {
-    thread t(
+    std::thread t(
         [error]()
         {
             this_thread::sleep_for(chrono::milliseconds(10));
@@ -183,7 +183,7 @@ MyObjectI::amdBadSystemAddAsync(int,
                                 function<void(exception_ptr)> error,
                                 const Ice::Current&)
 {
-    thread t(
+    std::thread t(
         [error]()
         {
             this_thread::sleep_for(chrono::milliseconds(10));

--- a/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
@@ -8,7 +8,12 @@
 
 using namespace std;
 
+// Work-around for anonymous namspace bug in xlclang++
+#ifdef __ibmxl__
+namespace BatchOnewaysAMINamespace
+#else
 namespace
+#endif
 {
 
 class Callback : public IceUtil::Monitor<IceUtil::Mutex>, public IceUtil::Shared
@@ -84,6 +89,10 @@ public:
     }
 };
 }
+
+#ifdef __ibmxl__
+using namespace BatchOnewaysAMINamespace;
+#endif
 
 void
 batchOnewaysAMI(const Test::MyClassPrxPtr& p)

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -8,7 +8,12 @@
 
 using namespace std;
 
+// Work-around for anonymous namspace bug in xlclang++
+#ifdef __ibmxl__
+namespace OnewaysAMINamespace
+#else
 namespace
+#endif
 {
 
 class CallbackBase
@@ -74,6 +79,10 @@ public:
 ICE_DEFINE_PTR(CallbackPtr, Callback);
 
 }
+
+#ifdef __ibmxl__
+using namespace OnewaysAMINamespace;
+#endif
 
 void
 onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -22,7 +22,7 @@
 #endif
 
 using namespace std;
-using namespace Test;
+
 namespace
 {
 
@@ -157,8 +157,8 @@ public:
 
     void opMyEnum(Test::MyEnum r, Test::MyEnum e)
     {
-        test(e == ICE_ENUM(Test::MyEnum, enum2));
-        test(r == ICE_ENUM(Test::MyEnum, enum3));
+        test(e == Test::ICE_ENUM(MyEnum, enum2));
+        test(r == Test::ICE_ENUM(MyEnum, enum3));
         called();
     }
 
@@ -190,9 +190,9 @@ public:
     void opStruct(const Test::Structure& rso, const Test::Structure& so)
     {
         test(rso.p == 0);
-        test(rso.e == ICE_ENUM(Test::MyEnum, enum2));
+        test(rso.e == Test::ICE_ENUM(MyEnum, enum2));
         test(rso.s.s == "def");
-        test(so.e == ICE_ENUM(Test::MyEnum, enum3));
+        test(so.e == Test::ICE_ENUM(MyEnum, enum3));
         test(so.s.s == "a new string");
 
         //
@@ -497,18 +497,18 @@ public:
     void opStringMyEnumD(const Test::StringMyEnumD& ro, const Test::StringMyEnumD& _do)
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[""] = ICE_ENUM(Test::MyEnum, enum2);
+        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
         test(_do == di1);
         test(ro.size() == 4);
         test(ro.find("abc") != ro.end());
-        test(ro.find("abc")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro.find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro.find("qwerty") != ro.end());
-        test(ro.find("qwerty")->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(ro.find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
         test(ro.find("") != ro.end());
-        test(ro.find("")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro.find("")->second == Test::ICE_ENUM(MyEnum, enum2));
         test(ro.find("Hello!!") != ro.end());
-        test(ro.find("Hello!!")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro.find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
         called();
     }
 
@@ -517,20 +517,20 @@ public:
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(Test::MyEnum, enum2);
+        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
         test(_do == di1);
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         test(ro.size() == 4);
         test(ro.find(ms11) != ro.end());
-        test(ro.find(ms11)->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro.find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro.find(ms12) != ro.end());
-        test(ro.find(ms12)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro.find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
         test(ro.find(ms22) != ro.end());
-        test(ro.find(ms22)->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(ro.find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
         test(ro.find(ms23) != ro.end());
-        test(ro.find(ms23)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro.find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
         called();
     }
 
@@ -675,32 +675,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find("abc") != ro[0].end());
-        test(ro[0].find("abc")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro[0].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro[0].find("qwerty") != ro[0].end());
-        test(ro[0].find("qwerty")->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(ro[0].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
         test(ro[0].find("Hello!!") != ro[0].end());
-        test(ro[0].find("Hello!!")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro[0].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
         test(ro[1].size() == 2);
         test(ro[1].find("abc") != ro[1].end());
-        test(ro[1].find("abc")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro[1].find("") != ro[1].end());
-        test(ro[1].find("")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find("Goodbye") != _do[0].end());
-        test(_do[0].find("Goodbye")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(_do[0].find("Goodbye")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(_do[1].size() == 2);
         test(_do[1].find("abc") != _do[1].end());
-        test(_do[1].find("abc")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(_do[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(_do[1].find("") != _do[1].end());
-        test(_do[1].find("")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(_do[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
         test(_do[2].size() == 3);
         test(_do[2].find("abc") != _do[2].end());
-        test(_do[2].find("abc")->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(_do[2].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
         test(_do[2].find("qwerty") != _do[2].end());
-        test(_do[2].find("qwerty")->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(_do[2].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
         test(_do[2].find("Hello!!") != _do[2].end());
-        test(_do[2].find("Hello!!")->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(_do[2].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
         called();
     }
 
@@ -708,25 +708,25 @@ public:
     {
         test(ro.size() == 2);
         test(ro[0].size() == 2);
-        test(ro[0].find(ICE_ENUM(Test::MyEnum, enum2)) != ro[0].end());
-        test(ro[0].find(ICE_ENUM(Test::MyEnum, enum2))->second == "Hello!!");
-        test(ro[0].find(ICE_ENUM(Test::MyEnum, enum3)) != ro[0].end());
-        test(ro[0].find(ICE_ENUM(Test::MyEnum, enum3))->second == "qwerty");
+        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2)) != ro[0].end());
+        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
+        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3)) != ro[0].end());
+        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
         test(ro[1].size() == 1);
-        test(ro[1].find(ICE_ENUM(Test::MyEnum, enum1)) != ro[1].end());
-        test(ro[1].find(ICE_ENUM(Test::MyEnum, enum1))->second == "abc");
+        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1)) != ro[1].end());
+        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
         test(_do.size() == 3);
         test(_do[0].size() == 1);
-        test(_do[0].find(ICE_ENUM(Test::MyEnum, enum1)) != _do[0].end());
-        test(_do[0].find(ICE_ENUM(Test::MyEnum, enum1))->second == "Goodbye");
+        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[0].end());
+        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1))->second == "Goodbye");
         test(_do[1].size() == 1);
-        test(_do[1].find(ICE_ENUM(Test::MyEnum, enum1)) != _do[1].end());
-        test(_do[1].find(ICE_ENUM(Test::MyEnum, enum1))->second == "abc");
+        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[1].end());
+        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
         test(_do[2].size() == 2);
-        test(_do[2].find(ICE_ENUM(Test::MyEnum, enum2)) != _do[2].end());
-        test(_do[2].find(ICE_ENUM(Test::MyEnum, enum2))->second == "Hello!!");
-        test(_do[2].find(ICE_ENUM(Test::MyEnum, enum3)) != _do[2].end());
-        test(_do[2].find(ICE_ENUM(Test::MyEnum, enum3))->second == "qwerty");
+        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2)) != _do[2].end());
+        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
+        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3)) != _do[2].end());
+        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
         called();
     }
 
@@ -740,32 +740,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find(ms11) != ro[0].end());
-        test(ro[0].find(ms11)->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro[0].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro[0].find(ms22) != ro[0].end());
-        test(ro[0].find(ms22)->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(ro[0].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
         test(ro[0].find(ms23) != ro[0].end());
-        test(ro[0].find(ms23)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
         test(ro[1].size() == 2);
         test(ro[1].find(ms11) != ro[1].end());
-        test(ro[1].find(ms11)->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(ro[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
         test(ro[1].find(ms12) != ro[1].end());
-        test(ro[1].find(ms12)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(ro[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find(ms23) != _do[0].end());
-        test(_do[0].find(ms23)->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(_do[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum3));
         test(_do[1].size() == 2);
         test(_do[1].find(ms11) != _do[1].end());
-        test(_do[1].find(ms11)->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(_do[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
         test(_do[1].find(ms12) != _do[1].end());
-        test(_do[1].find(ms12)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(_do[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
         test(_do[2].size() == 3);
         test(_do[2].find(ms11) != _do[2].end());
-        test(_do[2].find(ms11)->second == ICE_ENUM(Test::MyEnum, enum1));
+        test(_do[2].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
         test(_do[2].find(ms22) != _do[2].end());
-        test(_do[2].find(ms22)->second == ICE_ENUM(Test::MyEnum, enum3));
+        test(_do[2].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
         test(_do[2].find(ms23) != _do[2].end());
-        test(_do[2].find(ms23)->second == ICE_ENUM(Test::MyEnum, enum2));
+        test(_do[2].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
         called();
     }
 
@@ -958,24 +958,24 @@ public:
     void opMyEnumMyEnumSD(const Test::MyEnumMyEnumSD& ro, const Test::MyEnumMyEnumSD& _do)
     {
         test(_do.size() == 1);
-        test(_do.find(ICE_ENUM(Test::MyEnum, enum1)) != _do.end());
-        test(_do.find(ICE_ENUM(Test::MyEnum, enum1))->second.size() == 2);
-        test(_do.find(ICE_ENUM(Test::MyEnum, enum1))->second[0] == ICE_ENUM(Test::MyEnum, enum3));
-        test(_do.find(ICE_ENUM(Test::MyEnum, enum1))->second[1] == ICE_ENUM(Test::MyEnum, enum3));
+        test(_do.find(Test::ICE_ENUM(MyEnum, enum1)) != _do.end());
+        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
+        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
         test(ro.size() == 3);
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum3)) != ro.end());
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum3))->second.size() == 3);
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum3))->second[0] == ICE_ENUM(Test::MyEnum, enum1));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum3))->second[1] == ICE_ENUM(Test::MyEnum, enum1));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum3))->second[2] == ICE_ENUM(Test::MyEnum, enum2));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum2)) != ro.end());
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum2))->second.size() == 2);
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum2))->second[0] == ICE_ENUM(Test::MyEnum, enum1));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum2))->second[1] == ICE_ENUM(Test::MyEnum, enum2));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum1)) != ro.end());
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum1))->second.size() == 2);
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum1))->second[0] == ICE_ENUM(Test::MyEnum, enum3));
-        test(ro.find(ICE_ENUM(Test::MyEnum, enum1))->second[1] == ICE_ENUM(Test::MyEnum, enum3));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum3)) != ro.end());
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second.size() == 3);
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[1] == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[2] == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum2)) != ro.end());
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second.size() == 2);
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[1] == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum1)) != ro.end());
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
         called();
     }
 
@@ -1237,8 +1237,8 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
 #ifdef ICE_CPP11_MAPPING
-        p->opMyEnumAsync(MyEnum::enum2,
-            [&](MyEnum e1, MyEnum e2)
+        p->opMyEnumAsync(Test::MyEnum::enum2,
+                         [&](Test::MyEnum e1, Test::MyEnum e2)
             {
                 cb->opMyEnum(e1, e2);
             },
@@ -1256,7 +1256,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
 #ifdef ICE_CPP11_MAPPING
         p->opMyClassAsync(p,
-            [&](shared_ptr<MyClassPrx> c1, shared_ptr<MyClassPrx> c2, shared_ptr<MyClassPrx> c3)
+                          [&](shared_ptr<Test::MyClassPrx> c1, shared_ptr<Test::MyClassPrx> c2, shared_ptr<Test::MyClassPrx> c3)
             {
                 cb->opMyClass(move(c1), move(c2), move(c3));
             },
@@ -1273,11 +1273,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = ICE_ENUM(Test::MyEnum, enum3);
+        si1.e = Test::ICE_ENUM(MyEnum, enum3);
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = ICE_ENUM(Test::MyEnum, enum2);
+        si2.e = Test::ICE_ENUM(MyEnum, enum2);
         si2.s.s = "def";
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
@@ -1700,12 +1700,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[""] = ICE_ENUM(Test::MyEnum, enum2);
+        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(Test::MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(Test::MyEnum, enum2);
+        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
+        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
 #ifdef ICE_CPP11_MAPPING
@@ -1727,15 +1727,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(Test::MyEnum, enum2);
+        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(Test::MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(Test::MyEnum, enum2);
+        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
+        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
 #ifdef ICE_CPP11_MAPPING
@@ -1906,14 +1906,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[""] = ICE_ENUM(Test::MyEnum, enum2);
+        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(Test::MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(Test::MyEnum, enum2);
+        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
+        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = ICE_ENUM(Test::MyEnum, enum1);
+        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1942,12 +1942,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(Test::MyEnum, enum1)] = "abc";
+        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(Test::MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(Test::MyEnum, enum3)] = "qwerty";
+        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
+        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[ICE_ENUM(Test::MyEnum, enum1)] = "Goodbye";
+        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1978,18 +1978,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(Test::MyEnum, enum2);
+        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(Test::MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(Test::MyEnum, enum2);
+        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
+        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = ICE_ENUM(Test::MyEnum, enum3);
+        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1998,7 +1998,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
 #ifdef ICE_CPP11_MAPPING
         p->opMyStructMyEnumDSAsync(dsi1, dsi2,
-            [&](Test::MyStructMyEnumDS dsi3, MyStructMyEnumDS dsi4)
+                                   [&](Test::MyStructMyEnumDS dsi3, Test::MyStructMyEnumDS dsi4)
             {
                 cb->opMyStructMyEnumDS(move(dsi3), move(dsi4));
             },
@@ -2304,17 +2304,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum2));
-        si2.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si2.push_back(ICE_ENUM(Test::MyEnum, enum2));
-        si3.push_back(ICE_ENUM(Test::MyEnum, enum3));
-        si3.push_back(ICE_ENUM(Test::MyEnum, enum3));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
+        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
+        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
 
-        sdi1[ICE_ENUM(Test::MyEnum, enum3)] = si1;
-        sdi1[ICE_ENUM(Test::MyEnum, enum2)] = si2;
-        sdi2[ICE_ENUM(Test::MyEnum, enum1)] = si3;
+        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
+        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
+        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
 #ifdef ICE_CPP11_MAPPING
@@ -2475,7 +2475,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
                 Ice::PropertiesPtr properties = ic->getProperties();
                 Test::MyClassPrxPtr q =
                     ICE_UNCHECKED_CAST(Test::MyClassPrx,
-                                       ic->stringToProxy("test:" + TestHelper::getTestEndpoint(properties)));
+                                       ic->stringToProxy("test:" + Test::TestHelper::getTestEndpoint(properties)));
                 ic->getImplicitContext()->setContext(ctx);
                 test(ic->getImplicitContext()->getContext() == ctx);
                 {
@@ -2894,11 +2894,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = ICE_ENUM(Test::MyEnum, enum3);
+        si1.e = Test::ICE_ENUM(MyEnum, enum3);
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = ICE_ENUM(Test::MyEnum, enum2);
+        si2.e = Test::ICE_ENUM(MyEnum, enum2);
         si2.s.s = "def";
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
@@ -3276,12 +3276,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[""] = ICE_ENUM(Test::MyEnum, enum2);
+        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(Test::MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(Test::MyEnum, enum2);
+        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
+        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opStringMyEnumDAsync(di1, di2);
@@ -3305,15 +3305,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(Test::MyEnum, enum2);
+        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(Test::MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(Test::MyEnum, enum2);
+        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
+        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opMyStructMyEnumDAsync(di1, di2);
@@ -3493,14 +3493,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[""] = ICE_ENUM(Test::MyEnum, enum2);
+        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(Test::MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(Test::MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(Test::MyEnum, enum2);
+        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
+        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
+        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = ICE_ENUM(Test::MyEnum, enum1);
+        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3531,12 +3531,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(Test::MyEnum, enum1)] = "abc";
+        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(Test::MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(Test::MyEnum, enum3)] = "qwerty";
+        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
+        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[ICE_ENUM(Test::MyEnum, enum1)] = "Goodbye";
+        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3569,18 +3569,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(Test::MyEnum, enum2);
+        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(Test::MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(Test::MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(Test::MyEnum, enum2);
+        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
+        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
+        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = ICE_ENUM(Test::MyEnum, enum3);
+        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3914,17 +3914,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si1.push_back(ICE_ENUM(Test::MyEnum, enum2));
-        si2.push_back(ICE_ENUM(Test::MyEnum, enum1));
-        si2.push_back(ICE_ENUM(Test::MyEnum, enum2));
-        si3.push_back(ICE_ENUM(Test::MyEnum, enum3));
-        si3.push_back(ICE_ENUM(Test::MyEnum, enum3));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
+        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
+        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
+        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
 
-        sdi1[ICE_ENUM(Test::MyEnum, enum3)] = si1;
-        sdi1[ICE_ENUM(Test::MyEnum, enum2)] = si2;
-        sdi2[ICE_ENUM(Test::MyEnum, enum1)] = si3;
+        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
+        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
+        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opMyEnumMyEnumSDAsync(sdi1, sdi2);

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -55,7 +55,7 @@ Client::run(int argc, char** argv)
         narrowEncoding = "iso815";
         wideEncoding = "ucs4";
 
-#elif defined(_AIX)
+#elif defined(_AIX) && !defined(_LIBICONV_VERSION)
 
         // Always big-endian
         narrowEncoding = "ISO8859-15";

--- a/cpp/test/Ice/stringConverter/Makefile.mk
+++ b/cpp/test/Ice/stringConverter/Makefile.mk
@@ -2,8 +2,6 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-$(test)_ldflags      = $(iconv_ldflags)
-
-$(test)_system_libs  = $(iconv_program_system_libs)
+$(test)_libs      = iconv
 
 tests += $(test)

--- a/cpp/test/Ice/stringConverter/Makefile.mk
+++ b/cpp/test/Ice/stringConverter/Makefile.mk
@@ -4,4 +4,6 @@
 
 $(test)_ldflags      = $(iconv_ldflags)
 
+$(test)_system_libs  = $(iconv_program_system_libs)
+
 tests += $(test)

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -154,7 +154,22 @@ allTests(Test::TestHelper* helper)
     while(nRetry-- > 0)
     {
         replyI->reset();
-        objMcast->ping(reply);
+        try
+        {
+            objMcast->ping(reply);
+        }
+        catch(const Ice::SocketException&)
+        {
+            // Multicast IPv6 not supported on the platform. This occurs for example
+            // on AIX PVP clould VMs.
+            if(communicator->getProperties()->getProperty("Ice.IPv6") == "1")
+            {
+                cout << "(not supported) ";
+                ret = 5;
+                break;
+            }
+            throw;
+        }
         ret = replyI->waitReply(5, IceUtil::Time::seconds(2));
         if(ret)
         {
@@ -175,7 +190,6 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing udp bi-dir connection... " << flush;
     obj->ice_getConnection()->setAdapter(adapter);
-    objMcast->ice_getConnection()->setAdapter(adapter);
     nRetry = 5;
     while(nRetry-- > 0)
     {
@@ -205,6 +219,7 @@ allTests(Test::TestHelper* helper)
     //
 //     cout << "testing udp bi-dir connection... " << flush;
 //     nRetry = 5;
+//     objMcast->ice_getConnection()->setAdapter(adapter);
 //     while(nRetry-- > 0)
 //     {
 //         replyI->reset();

--- a/cpp/test/Ice/udp/Server.cpp
+++ b/cpp/test/Ice/udp/Server.cpp
@@ -56,10 +56,26 @@ Server::run(int argc, char** argv)
 #endif
     }
     communicator->getProperties()->setProperty("McastTestAdapter.Endpoints", endpoint.str());
-    Ice::ObjectAdapterPtr mcastAdapter = communicator->createObjectAdapter("McastTestAdapter");
-    mcastAdapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    mcastAdapter->activate();
 
+    try
+    {
+        Ice::ObjectAdapterPtr mcastAdapter = communicator->createObjectAdapter("McastTestAdapter");
+        mcastAdapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        mcastAdapter->activate();
+    }
+    catch(const Ice::SocketException&)
+    {
+        // Multicast IPv6 not supported on the platform. This occurs for example
+        // on AIX PVP clould VMs.
+        if(communicator->getProperties()->getProperty("Ice.IPv6") == "1")
+        {
+            cout << "McastTestAdapter ready" << endl;
+        }
+        else
+        {
+            throw;
+        }
+    }
     serverReady();
 
     communicator->waitForShutdown();

--- a/cpp/test/IceGrid/fileLock/test.py
+++ b/cpp/test/IceGrid/fileLock/test.py
@@ -8,7 +8,7 @@ class IceGridAdminTestCase(IceGridTestCase):
     def runClientSide(self, current):
 
         sys.stdout.write("testing IceGrid file lock... ")
-        registry = IceGridRegistryMaster(portnum=25, readyCount=0, quiet=True);
+        registry = IceGridRegistryMaster(portnum=25, ready="", quiet=True);
         registry.start(current)
         registry.expect(current, ".*IceUtil::FileLockException.*")
         registry.stop(current, False)

--- a/cpp/test/IceGrid/session/AllTests.cpp
+++ b/cpp/test/IceGrid/session/AllTests.cpp
@@ -480,6 +480,10 @@ testFailedAndPrintObservers(const char* expr, const char* file, unsigned int lin
 #undef test
 #define test(ex) ((ex) ? ((void)0) : testFailedAndPrintObservers(#ex, __FILE__, __LINE__))
 
+#if defined(_AIX) && defined(__GNUC__) && !defined(__ibmxl__)
+// Strange optimization bug with catching ExtendedPermissionDeniedException with GCC 8.1 on AIX
+__attribute__((optimize("O0")))
+#endif
 void
 allTests(Test::TestHelper* helper)
 {

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -6,16 +6,16 @@
 #
 # Make sure the subscriber uses a larger size receive buffer size then
 # the IceStorm send buffer size. This ensures the test works with bogus
-# OS configurations where the reicever buffer size is smaller than the
+# OS configurations where the receiver buffer size is smaller than the
 # send buffer size (causing the received messages to be truncated). See
 # bug #6070 and #7558.
 #
-props = { "Ice.UDP.SndSize" : 2048 * 1024, "Ice.Warn.Dispatch" : 0 }
+props = { "Ice.UDP.SndSize" : 512 * 1024, "Ice.Warn.Dispatch" : 0 }
 persistent = IceStorm(props = props)
 transient = IceStorm(props = props, transient=True)
 replicated = [ IceStorm(replica=i, nreplicas=3, props = props) for i in range(0,3) ]
 
-sub = Subscriber(args=["{testcase.parent.name}"], props = { "Ice.UDP.RcvSize" : 4096 * 1024 }, readyCount=3)
+sub = Subscriber(args=["{testcase.parent.name}"], props = { "Ice.UDP.RcvSize" : 1024 * 1024 }, readyCount=3)
 pub = Publisher(args=["{testcase.parent.name}"])
 
 class IceStormSingleTestCase(IceStormTestCase):

--- a/cpp/test/IceUtil/unicode/Client.cpp
+++ b/cpp/test/IceUtil/unicode/Client.cpp
@@ -187,8 +187,12 @@ main(int argc, char* argv[])
         //
         // Euro sign (U+20AC) is encoded with 1 UTF-16 code unit, and 3 UTF-8 code units
         // U+10437 is a Deseret character, encoded with 2 UTF-16 code units, and 4 UTF-8 code units
-        //
+        // xlC in 32-bit mode truncates U+10437 into a single UTF-16 character
+#if defined(__IBMCPP__) && !defined(__64BIT__)
+        wstring ws = L"\u20ac\u20ac\ud801\udc37";
+#else
         wstring ws = L"\u20ac\u20ac\U00010437";
+#endif
 
         if(sizeof(wchar_t) == 2)
         {

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -93,7 +93,7 @@ class SliceHeadersTestCase(ClientTestCase):
         os.system("mkdir -p tmp/Ice-x.y.z/slice/Ice")
         os.system("cd tmp && ln -s Ice-x.y.z Ice-x.y")
         f = open("tmp/Ice-x.y.z/slice/Ice/Identity.ice", "w")
-        f.write("// dumy file")
+        f.write("// dummy file")
 
         os.system("mkdir -p project1")
         f = open("project1/A.ice", "w")
@@ -108,23 +108,24 @@ class SliceHeadersTestCase(ClientTestCase):
 
         #
         # symlink directory with extra / at end
+        # (the symlink with / at the end fails on AIX)
         #
-        #
-        os.system("mkdir -p tmp/Ice-x.y.z/slice/Ice")
-        os.system("mkdir -p tmp/Ice")
-        os.system("cd tmp/Ice && ln -s ../Ice-x.y.z/slice/ .")
-        f = open("tmp/Ice-x.y.z/slice/Ice/Identity.ice", "w")
-        f.write("// dumy file")
-        f.close()
-        os.system("mkdir -p project1")
-        f = open("project1/A.ice", "w")
-        f.write("#include <Ice/Identity.ice>")
-        f.close()
-        os.system("cd project1 && %s -I%s/tmp/Ice/slice A.ice" % (slice2cpp, basedir))
-        f = open("project1/A.h")
-        if not re.search(re.escape('#include <Ice/Identity.h>'), f.read()):
-            raise RuntimeError("failed!")
-        self.clean()
+        if not sys.platform.startswith("aix"):
+            os.system("mkdir -p tmp/Ice-x.y.z/slice/Ice")
+            os.system("mkdir -p tmp/Ice")
+            os.system("cd tmp/Ice && ln -s ../Ice-x.y.z/slice/ .")
+            f = open("tmp/Ice-x.y.z/slice/Ice/Identity.ice", "w")
+            f.write("// dummy file")
+            f.close()
+            os.system("mkdir -p project1")
+            f = open("project1/A.ice", "w")
+            f.write("#include <Ice/Identity.ice>")
+            f.close()
+            os.system("cd project1 && %s -I%s/tmp/Ice/slice A.ice" % (slice2cpp, basedir))
+            f = open("project1/A.h")
+            if not re.search(re.escape('#include <Ice/Identity.h>'), f.read()):
+                raise RuntimeError("failed!")
+            self.clean()
 
         current.writeln("ok")
 

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -110,7 +110,7 @@ class SliceHeadersTestCase(ClientTestCase):
         # symlink directory with extra / at end
         # (the symlink with / at the end fails on AIX)
         #
-        if not sys.platform.startswith("aix"):
+        if not isinstance(platform, AIX):
             os.system("mkdir -p tmp/Ice-x.y.z/slice/Ice")
             os.system("mkdir -p tmp/Ice")
             os.system("cd tmp/Ice && ln -s ../Ice-x.y.z/slice/ .")

--- a/cpp/test/Slice/parser/Makefile.mk
+++ b/cpp/test/Slice/parser/Makefile.mk
@@ -3,7 +3,6 @@
 #
 
 $(test)_libraries    := SliceParser
-
-$(test)_sliceflags	:= -I$(test)
+$(test)_sliceflags   := -I$(test)
 
 tests += $(test)

--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -33,6 +33,12 @@ allow-undefined-symbols := yes
 python_ldflags          := $(filter-out -lpython% -ldl -lutil,$(python_ldflags))
 endif
 
+ifeq ($(os),AIX)
+# We use an attribute (not an export file) to export the entry point
+link-with-python-exp   := -Wl,-bE:Modules/python.exp
+python_ldflags         := $(filter-out $(link-with-python-exp),$(python_ldflags))
+endif
+
 ifneq ($(OPTIMIZE),yes)
 # Remove optimization options if building debug build
 python_cppflags         := $(filter-out -O% -DNDEBUG -Wp$(comma)-D_FORTIFY_SOURCE=%,$(python_cppflags))

--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -37,6 +37,9 @@ ifeq ($(os),AIX)
 # We use an attribute (not an export file) to export the entry point
 link-with-python-exp   := -Wl,-bE:Modules/python.exp
 python_ldflags         := $(filter-out $(link-with-python-exp),$(python_ldflags))
+
+# $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
+mkshlib                = $(or $($7_cxx),$(CXX)) -shared -o $1 $2 $6
 endif
 
 ifneq ($(OPTIMIZE),yes)

--- a/python/config/Make.rules.AIX
+++ b/python/config/Make.rules.AIX
@@ -1,6 +1,0 @@
-#
-# Copyright (c) ZeroC, Inc. All rights reserved.
-#
-
-# $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
-mkshlib        = $(or $($7_cxx),$(CXX)) -shared -o $1 $2 $6

--- a/python/config/Make.rules.AIX
+++ b/python/config/Make.rules.AIX
@@ -3,4 +3,4 @@
 #
 
 # $(call mkshlib,$1=target,$2=objects,$3=libname,$4=version,$5=soversion,$6=ldflags,$7=platform)
-mkshlib        = $(or $($7_cxx),$(CXX)) -qmkshrobj -o $1 $2 $6
+mkshlib        = $(or $($7_cxx),$(CXX)) -shared -o $1 $2 $6

--- a/scripts/Controller.py
+++ b/scripts/Controller.py
@@ -139,7 +139,8 @@ class ControllerDriver(Driver):
                     self.testcase = None
 
                 current = self.driver.getCurrent(mapping, testsuite, testcase, cross)
-                self.testcase = Test.Common.TestCasePrx.uncheckedCast(c.adapter.addWithUUID(TestCaseI(self.driver, current)))
+                prx = c.adapter.addWithUUID(TestCaseI(self.driver, current))
+                self.testcase = Test.Common.TestCasePrx.uncheckedCast(c.adapter.createDirectProxy(prx.ice_getIdentity()))
                 return self.testcase
 
             def getTestSuites(self, mapping, c):

--- a/scripts/IceBoxUtil.py
+++ b/scripts/IceBoxUtil.py
@@ -45,6 +45,9 @@ class IceBox(ProcessFromBinDir, Server):
                platform.getLinuxId() in ["centos", "rhel", "fedora"] and \
                current.config.buildPlatform == "x86":
                 name += "32" # Multilib platform
+            if isinstance(platform, AIX) and \
+               current.config.buildPlatform == "ppc":
+                name += "_32"
             if current.config.cpp11:
                 name += "++11"
             return name
@@ -75,5 +78,8 @@ class IceBoxAdmin(ProcessFromBinDir, ProcessIsReleaseOnly, Client):
             return "IceBox.Admin"
         elif isinstance(mapping, JavaMapping):
             return "com.zeroc.IceBox.Admin"
+        elif isinstance(platform, AIX) and \
+             current.config.buildPlatform == "ppc":
+            return "iceboxadmin_32"
         else:
             return "iceboxadmin"

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -114,10 +114,11 @@ class IceGridNode(ProcessFromBinDir, Server):
 
 class IceGridRegistry(ProcessFromBinDir, Server):
 
-    def __init__(self, name, portnum=20, readyCount=5, *args, **kargs):
+    def __init__(self, name, portnum=20, ready="AdminSessionManager", *args, **kargs):
         Server.__init__(self, "icegridregistry", mapping=Mapping.getByName("cpp"), desc="IceGrid registry " + name,
-                        readyCount=readyCount, *args, **kargs)
+                        ready=ready, *args, **kargs)
         self.portnum = portnum
+        self.readyCount = -1
         self.name = name
 
     def setup(self, current):

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -309,7 +309,7 @@ class AIX(Platform):
 
     def _getLibDir(self, component, process, mapping, current):
         installDir = component.getInstallDir(mapping, current)
-        return os.path.join(installDir, "lib32") if current.config.buildPlatform == "ppc" else os.path.join(installDir, "lib")
+        return os.path.join(installDir, "lib32" if current.config.buildPlatform == "ppc" else "lib")
 
     def getDefaultBuildPlatform(self):
         return "ppc64"

--- a/scripts/tests/Ice/objects.py
+++ b/scripts/tests/Ice/objects.py
@@ -20,6 +20,13 @@ class ObjectClientServerTestCase(ClientServerTestCase):
             # test on arm64 devices with a debug Ice libraries which require lots of stack space.
             #
             props["Ice.ThreadPool.Server.StackSize"] = 768 * 1024
+        elif current.config.buildPlatform == "ppc":
+            #
+            # The AIX ppc default stack size is too small
+            #
+            props["Ice.ThreadPool.Server.StackSize"] = 256 * 1024
+        elif current.config.buildPlatform == "ppc64":
+            props["Ice.ThreadPool.Server.StackSize"] = 768 * 1024
         return props
 
 testcases = [

--- a/scripts/tests/IceDiscovery/simple.py
+++ b/scripts/tests/IceDiscovery/simple.py
@@ -34,7 +34,13 @@ def suppressWarning(x):
 # Filter-out the warning about invalid lookup proxy
 outfilters = [ lambda x: suppressWarning(x) ]
 
+options = None
+if isinstance(platform,AIX):
+    # AIX test VMs only have IPv6 enabled on the loopback interface
+    # where multicast doesn't work
+    options = { "ipv6" : [False] }
+
 TestSuite(__name__, [
    ClientServerTestCase(client=Client(args=[3], props=props, outfilters=outfilters),
                         servers=[Server(args=[i], readyCount=4, props=props) for i in range(0, 3)])
-], multihost=False)
+], multihost=False, options=options)


### PR DESCRIPTION
This is a port of Ice 3.7 (C++ and Python) to AIX 7.2.

C++98 works with all 3 C++ compilers. C++11 works only with g++.

Python was tested with python3 64-bit (and g++), and requires setting LIBPATH to `/opt/freeware/lib/pthread` to pick up the thread-safe C++ standard library.