### PR TITLE
Fixed non-thread safe AMD dispatch, fixes #448

### DIFF
--- a/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
+++ b/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
@@ -103,6 +103,15 @@ AMDInterceptorI::dispatch(Ice::Request& request)
 
         current.ctx["retry"] = "no";
     }
+    else if(current.ctx.find("retry") != current.ctx.end() && current.ctx["retry"] == "yes")
+    {
+        //
+        // Retry the dispatch to ensure that abandoning the result of the dispatch
+        // works fine and is thread-safe
+        //
+        _servant->ice_dispatch(request);
+        _servant->ice_dispatch(request);
+    }
 
 #ifdef ICE_CPP11_MAPPING
     _lastStatus = _servant->ice_dispatch(request, []() { return true; }, [this](exception_ptr ex) {

--- a/cpp/test/Ice/interceptor/Client.cpp
+++ b/cpp/test/Ice/interceptor/Client.cpp
@@ -189,6 +189,16 @@ Client::runAmdTest(const Test::MyObjectPrxPtr& prx, const AMDInterceptorIPtr& in
     test(prx->amdAddWithRetry(33, 12) == 45);
     test(interceptor->getLastOperation() == "amdAddWithRetry");
     test(!interceptor->getLastStatus());
+    {
+        Ice::Context ctx;
+        ctx["retry"] = "yes";
+        for(int i = 0; i < 10; ++i)
+        {
+            test(prx->amdAdd(33, 12, ctx) == 45);
+            test(interceptor->getLastOperation() == "amdAdd");
+            test(!interceptor->getLastStatus());
+        }
+    }
     cout << "ok" << endl;
     cout << "testing user exception... " << flush;
     try

--- a/csharp/Makefile
+++ b/csharp/Makefile
@@ -2,14 +2,16 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+DOTNETARGS = $(if $(filter $(OPTIMIZE),no),/p:Configuration=Debug)
+
 all:
-	dotnet msbuild msbuild/ice.proj /m
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /m
 
 tests:
-	dotnet msbuild msbuild/ice.proj /m
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /m
 
 srcs:
-	dotnet msbuild msbuild/ice.proj /t:BuildDist /m
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /t:BuildDist /m
 
 distclean clean:
 	dotnet msbuild msbuild/ice.proj /t:Clean /m

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -114,6 +114,18 @@ namespace Ice
                 test(prx.amdAddWithRetry(33, 12) == 45);
                 test(interceptor.getLastOperation().Equals("amdAddWithRetry"));
                 test(interceptor.getLastStatus());
+
+                {
+                    var ctx = new Dictionary<string, string>();
+                    ctx.Add("retry", "yes");
+                    for(int i = 0; i < 10; ++i)
+                    {
+                        test(prx.amdAdd(33, 12, ctx) == 45);
+                        test(interceptor.getLastOperation().Equals("amdAdd"));
+                        test(interceptor.getLastStatus());
+                    }
+                }
+
                 output.WriteLine("ok");
 
                 output.Write("testing user exception... ");

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -75,6 +75,15 @@ namespace Ice
 
                     current.ctx["retry"] = "no";
                 }
+                else if(current.ctx.TryGetValue("retry", out context) && context.Equals("yes"))
+                {
+                    //
+                    // Retry the dispatch to ensure that abandoning the result of the dispatch
+                    // works fine and is thread-safe
+                    //
+                    servant_.ice_dispatch(request);
+                    servant_.ice_dispatch(request);
+                }
 
                 var task = servant_.ice_dispatch(request);
                 lastStatus_ = task != null;

--- a/java-compat/test/src/main/java/test/Ice/interceptor/AMDInterceptorI.java
+++ b/java-compat/test/src/main/java/test/Ice/interceptor/AMDInterceptorI.java
@@ -70,6 +70,15 @@ class AMDInterceptorI extends InterceptorI implements Ice.DispatchInterceptorAsy
 
             request.getCurrent().ctx.put("retry", "no");
         }
+        else if(current.ctx.get("retry") != null && current.ctx.get("retry").equals("yes"))
+        {
+            //
+            // Retry the dispatch to ensure that abandoning the result of the dispatch
+            // works fine and is thread-safe
+            //
+            _servant.ice_dispatch(request);
+            _servant.ice_dispatch(request);
+        }
 
         _lastStatus = _servant.ice_dispatch(request, this);
 

--- a/java-compat/test/src/main/java/test/Ice/interceptor/Client.java
+++ b/java-compat/test/src/main/java/test/Ice/interceptor/Client.java
@@ -119,6 +119,16 @@ public class Client extends test.TestHelper
         test(prx.amdAddWithRetry(33, 12) == 45);
         test(interceptor.getLastOperation().equals("amdAddWithRetry"));
         test(!interceptor.getLastStatus());
+        {
+            java.util.Map<String, String> ctx = new java.util.HashMap<>();
+            ctx.put("retry", "yes");
+            for(int i = 0; i < 10; ++i)
+            {
+                test(prx.amdAdd(33, 12, ctx) == 45);
+                test(interceptor.getLastOperation().equals("amdAdd"));
+                test(!interceptor.getLastStatus());
+            }
+        }
         out.println("ok");
         out.print("testing user exception... ");
         out.flush();

--- a/java-compat/test/src/main/java/test/Ice/interceptor/MyObjectI.java
+++ b/java-compat/test/src/main/java/test/Ice/interceptor/MyObjectI.java
@@ -65,6 +65,7 @@ class MyObjectI extends _MyObjectDisp
     public void
     amdAdd_async(final AMD_MyObject_amdAdd cb, final int x, final int y, Ice.Current current)
     {
+        final boolean retry = current.ctx.get("retry") != null && current.ctx.get("retry").equals("yes");
         Thread thread = new Thread()
             {
                 @Override
@@ -78,7 +79,17 @@ class MyObjectI extends _MyObjectDisp
                     catch(InterruptedException e)
                     {
                     }
-                    cb.ice_response(x + y);
+                    try
+                    {
+                        cb.ice_response(x + y);
+                    }
+                    catch(Ice.ResponseSentException ex)
+                    {
+                        if(!retry)
+                        {
+                            throw ex;
+                        }
+                    }
                 }
             };
 

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Blobject.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Blobject.java
@@ -39,6 +39,6 @@ public interface Blobject extends com.zeroc.Ice.Object
     {
         byte[] inEncaps = in.readParamEncaps();
         com.zeroc.Ice.Object.Ice_invokeResult r = ice_invoke(inEncaps, current);
-        return in.setResult(in.writeParamEncaps(r.outParams, r.returnValue));
+        return in.setResult(in.writeParamEncaps(in.getAndClearCachedOutputStream(), r.outParams, r.returnValue));
     }
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/BlobjectAsync.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/BlobjectAsync.java
@@ -45,7 +45,9 @@ public interface BlobjectAsync extends com.zeroc.Ice.Object
     {
         byte[] inEncaps = in.readParamEncaps();
         CompletableFuture<OutputStream> f = new CompletableFuture<>();
-        ice_invokeAsync(inEncaps, current).whenComplete((result, ex) ->
+        CompletionStage<Object.Ice_invokeResult> s = ice_invokeAsync(inEncaps, current);
+        final OutputStream cached = in.getAndClearCachedOutputStream(); // If an output stream is cached, re-use it
+        s.whenComplete((result, ex) ->
             {
                 if(ex != null)
                 {
@@ -53,7 +55,7 @@ public interface BlobjectAsync extends com.zeroc.Ice.Object
                 }
                 else
                 {
-                    f.complete(in.writeParamEncaps(result.outParams, result.returnValue));
+                    f.complete(in.writeParamEncaps(cached, result.outParams, result.returnValue));
                 }
             });
         return f;

--- a/java/test/src/main/java/test/Ice/interceptor/Client.java
+++ b/java/test/src/main/java/test/Ice/interceptor/Client.java
@@ -111,6 +111,16 @@ public class Client extends test.TestHelper
         test(prx.amdAddWithRetry(33, 12) == 45);
         test(interceptor.getLastOperation().equals("amdAddWithRetry"));
         test(interceptor.getLastStatus());
+        {
+            java.util.Map<String, String> ctx = new java.util.HashMap<>();
+            ctx.put("retry", "yes");
+            for(int i = 0; i < 10; ++i)
+            {
+                test(prx.amdAdd(33, 12, ctx) == 45);
+                test(interceptor.getLastOperation().equals("amdAdd"));
+                test(interceptor.getLastStatus());
+            }
+        }
         out.println("ok");
         out.print("testing user exception... ");
         out.flush();

--- a/java/test/src/main/java/test/Ice/interceptor/InterceptorI.java
+++ b/java/test/src/main/java/test/Ice/interceptor/InterceptorI.java
@@ -70,6 +70,15 @@ class InterceptorI extends com.zeroc.Ice.DispatchInterceptor
 
             current.ctx.put("retry", "no");
         }
+        else if(current.ctx.get("retry") != null && current.ctx.get("retry").equals("yes"))
+        {
+            //
+            // Retry the dispatch to ensure that abandoning the result of the dispatch
+            // works fine and is thread-safe
+            //
+            _servant.ice_dispatch(request);
+            _servant.ice_dispatch(request);
+        }
 
         CompletionStage<OutputStream> f = _servant.ice_dispatch(request);
         _lastStatus = f != null;


### PR DESCRIPTION
The caching of the output stream which was added back to solve #414 made the
dispatch of AMD requests non thread-safe if a dispatch interceptor was installed
and if the interceptor retried the dispatch. Multiple continuation could run
concurrently and eventually re-use the cached output stream to marshal multiple
responses.