### PR TITLE
Add non-const overload to Ice::Request::getCurrent

### DIFF
--- a/cpp/include/Ice/Incoming.h
+++ b/cpp/include/Ice/Incoming.h
@@ -152,7 +152,12 @@ public:
 
     Incoming(Instance*, ResponseHandler*, Ice::Connection*, const Ice::ObjectAdapterPtr&, bool, Ice::Byte, Ice::Int);
 
-    const Ice::Current& getCurrent()
+    Ice::Current& getCurrent()
+    {
+        return _current;
+    }
+
+    const Ice::Current& getCurrent() const
     {
         return _current;
     }

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -79,7 +79,8 @@ public:
      * Obtains the Current object associated with the request.
      * @return The Current object.
      */
-    virtual const Current& getCurrent() = 0;
+    virtual const Current& getCurrent() const = 0;
+    virtual Current& getCurrent() = 0;
 };
 
 #ifdef ICE_CPP11_MAPPING

--- a/cpp/src/Ice/Incoming.cpp
+++ b/cpp/src/Ice/Incoming.cpp
@@ -789,6 +789,12 @@ IceInternal::Incoming::invoke(const ServantManagerPtr& servantManager, InputStre
 }
 
 const Current&
+IceInternal::IncomingRequest::getCurrent() const
+{
+    return _in.getCurrent();
+}
+
+Current&
 IceInternal::IncomingRequest::getCurrent()
 {
     return _in.getCurrent();

--- a/cpp/src/Ice/IncomingRequest.h
+++ b/cpp/src/Ice/IncomingRequest.h
@@ -23,7 +23,8 @@ public:
     {
     }
 
-    virtual const Ice::Current& getCurrent();
+    virtual const Ice::Current& getCurrent() const;
+    virtual Ice::Current& getCurrent();
 
     Incoming& _in;
 };

--- a/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
+++ b/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
@@ -55,7 +55,7 @@ AMDInterceptorI::dispatch(Ice::Request& request)
     };
 #endif
 
-    Ice::Current& current = const_cast<Ice::Current&>(request.getCurrent());
+    Ice::Current& current = request.getCurrent();
 
     Ice::Context::const_iterator p = current.ctx.find("raiseBeforeDispatch");
     if(p != current.ctx.end())

--- a/cpp/test/Ice/interceptor/InterceptorI.cpp
+++ b/cpp/test/Ice/interceptor/InterceptorI.cpp
@@ -17,7 +17,7 @@ InterceptorI::InterceptorI(const Ice::ObjectPtr& servant) :
 bool
 InterceptorI::dispatch(Ice::Request& request)
 {
-    Ice::Current& current = const_cast<Ice::Current&>(request.getCurrent());
+    Ice::Current& current = request.getCurrent();
 
     Ice::Context::const_iterator p = current.ctx.find("raiseBeforeDispatch");
     if(p != current.ctx.end())


### PR DESCRIPTION
This enables C++ implementations of `Ice::DispatchInterceptor` to modify the incoming request before passing it to the servant. Due to the constness of `Ice::Request::getCurrent`, this was impossible before.

This brings C++ in line with other language implementations, where such a limitation does not exist, as far as I can tell.

Please let me know if this is something you guys are interested in merging, then I'll send the signed contributor agreement.