### PR TITLE
Fix incorrect uses of empty().

### DIFF
--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -2798,7 +2798,7 @@ Parser::parse(FILE* file, bool debug)
     parser = this;
 
     _errors = 0;
-    _commands.empty();
+    _commands.clear();
     yyin = file;
     assert(yyin);
 

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -582,7 +582,7 @@ Parser::parse(FILE* file, bool debug)
     parser = this;
 
     _errors = 0;
-    _commands.empty();
+    _commands.clear();
     yyin = file;
     assert(yyin);
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3780,7 +3780,7 @@ void
 Slice::ClassDef::destroy()
 {
     _declaration = 0;
-    _bases.empty();
+    _bases.clear();
     Container::destroy();
 }
 


### PR DESCRIPTION
This fixes places where clear() should have been used instead of empty(). Fixes gcc-9 warnings about unused result of empty().