### PR TITLE
Simplify InputStream in C#

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -93,7 +93,7 @@ namespace IceInternal
                 // Adopt the OutputStream's buffer.
                 Ice.InputStream iss = new Ice.InputStream(os.communicator(), os.GetEncoding(), os.GetBuffer(), true);
 
-                iss.pos(Protocol.replyHdr.Length + 4);
+                iss.Pos = Protocol.replyHdr.Length + 4;
 
                 if (_traceLevels.protocol >= 1)
                 {
@@ -254,7 +254,7 @@ namespace IceInternal
 
             Ice.InputStream iss = new Ice.InputStream(os.communicator(), os.GetEncoding(), os.GetBuffer(), false);
 
-            iss.pos(Protocol.requestHdr.Length);
+            iss.Pos = Protocol.requestHdr.Length;
 
             int invokeNum = 1;
             ServantManager servantManager = _adapter.getServantManager();

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -2506,7 +2506,7 @@ namespace Ice
 
             ProtocolVersion protocol;
             EncodingVersion encoding;
-            if (!s.GetEncoding().Equals(Ice.Util.Encoding_1_0))
+            if (!s.Encoding.Equals(Ice.Util.Encoding_1_0))
             {
                 byte major = s.ReadByte();
                 byte minor = s.ReadByte();

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -2596,7 +2596,7 @@ namespace Ice
                     {
                         IceInternal.Buffer ubuf = BZip2.uncompress(info.stream.GetBuffer(), Protocol.headerSize,
                                                                    _messageSizeMax);
-                        info.stream = new InputStream(info.stream.Communicator(), info.stream.GetEncoding(), ubuf, true);
+                        info.stream = new InputStream(info.stream.Communicator, info.stream.Encoding, ubuf, true);
                     }
                     else
                     {

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -389,7 +389,7 @@ namespace Ice
                     }
                 }
 
-                if (_readStream.size() > Protocol.headerSize || !_writeStream.isEmpty())
+                if (_readStream.Size > Protocol.headerSize || !_writeStream.isEmpty())
                 {
                     //
                     // If writing or reading, nothing to do, the connection
@@ -1181,7 +1181,7 @@ namespace Ice
                                 //
                                 _validated = true;
 
-                                int pos = _readStream.pos();
+                                int pos = _readStream.Pos;
                                 if (pos < Protocol.headerSize)
                                 {
                                     //
@@ -1190,7 +1190,7 @@ namespace Ice
                                     throw new IllegalMessageSizeException();
                                 }
 
-                                _readStream.pos(0);
+                                _readStream.Pos = 0;
                                 byte[] m = new byte[4];
                                 m[0] = _readStream.ReadByte();
                                 m[1] = _readStream.ReadByte();
@@ -1226,11 +1226,11 @@ namespace Ice
                                 {
                                     Ex.throwMemoryLimitException(size, _messageSizeMax);
                                 }
-                                if (size > _readStream.size())
+                                if (size > _readStream.Size)
                                 {
                                     _readStream.Resize(size);
                                 }
-                                _readStream.pos(pos);
+                                _readStream.Pos = pos;
                             }
 
                             if (buf.b.hasRemaining())
@@ -1335,10 +1335,10 @@ namespace Ice
                     {
                         if (_warnUdp)
                         {
-                            _logger.warning(string.Format("maximum datagram size of {0} exceeded", _readStream.pos()));
+                            _logger.warning(string.Format("maximum datagram size of {0} exceeded", _readStream.Pos));
                         }
                         _readStream.Resize(Protocol.headerSize);
-                        _readStream.pos(0);
+                        _readStream.Pos = 0;
                         _readHeader = true;
                         return;
                     }
@@ -1356,7 +1356,7 @@ namespace Ice
                                 _logger.warning(string.Format("datagram connection exception:\n{0}\n{1}", ex, _desc));
                             }
                             _readStream.Resize(Protocol.headerSize);
-                            _readStream.pos(0);
+                            _readStream.Pos = 0;
                             _readHeader = true;
                         }
                         else
@@ -2229,10 +2229,10 @@ namespace Ice
                 }
                 else // The client side has the passive role for connection validation.
                 {
-                    if (_readStream.size() == 0)
+                    if (_readStream.Size == 0)
                     {
                         _readStream.Resize(Protocol.headerSize);
-                        _readStream.pos(0);
+                        _readStream.Pos = 0;
                     }
 
                     if (_observer != null)
@@ -2240,7 +2240,7 @@ namespace Ice
                         ObserverStartRead(_readStream.GetBuffer());
                     }
 
-                    if (_readStream.pos() != _readStream.size())
+                    if (_readStream.Pos != _readStream.Size)
                     {
                         int op = Read(_readStream.GetBuffer());
                         if (op != 0)
@@ -2258,8 +2258,8 @@ namespace Ice
 
                     _validated = true;
 
-                    Debug.Assert(_readStream.pos() == Protocol.headerSize);
-                    _readStream.pos(0);
+                    Debug.Assert(_readStream.Pos == Protocol.headerSize);
+                    _readStream.Pos = 0;
                     byte[] m = _readStream.ReadBlob(4);
                     if (m[0] != Protocol.magic[0] || m[1] != Protocol.magic[1] ||
                         m[2] != Protocol.magic[2] || m[3] != Protocol.magic[3])
@@ -2298,7 +2298,7 @@ namespace Ice
             _writeStream.pos(0);
 
             _readStream.Resize(Protocol.headerSize);
-            _readStream.pos(0);
+            _readStream.Pos = 0;
             _readHeader = true;
 
             if (_communicator.traceLevels().network >= 1)
@@ -2577,17 +2577,17 @@ namespace Ice
             info.stream = new InputStream(_communicator, Util.currentProtocolEncoding);
             _readStream.Swap(info.stream);
             _readStream.Resize(Protocol.headerSize);
-            _readStream.pos(0);
+            _readStream.Pos = 0;
             _readHeader = true;
 
-            Debug.Assert(info.stream.pos() == info.stream.size());
+            Debug.Assert(info.stream.Pos == info.stream.Size);
 
             try
             {
                 //
                 // The magic and version fields have already been checked.
                 //
-                info.stream.pos(8);
+                info.stream.Pos = 8;
                 byte messageType = info.stream.ReadByte();
                 info.compress = info.stream.ReadByte();
                 if (info.compress == 2)
@@ -2604,7 +2604,7 @@ namespace Ice
                         throw new FeatureNotSupportedException($"Cannot uncompress compressed message: {lib} not found");
                     }
                 }
-                info.stream.pos(Protocol.headerSize);
+                info.stream.Pos = Protocol.headerSize;
 
                 switch (messageType)
                 {

--- a/csharp/src/Ice/EndpointFactoryManager.cs
+++ b/csharp/src/Ice/EndpointFactoryManager.cs
@@ -138,7 +138,7 @@ namespace IceInternal
                     ue.streamWrite(os);
                     Ice.InputStream iss =
                         new Ice.InputStream(_communicator, Ice.Util.currentProtocolEncoding, os.GetBuffer(), true);
-                    iss.pos(0);
+                    iss.Pos = 0;
                     iss.ReadShort(); // type
                     iss.StartEndpointEncapsulation();
                     Endpoint e = factory.read(iss);

--- a/csharp/src/Ice/EndpointFactoryManager.cs
+++ b/csharp/src/Ice/EndpointFactoryManager.cs
@@ -140,9 +140,9 @@ namespace IceInternal
                         new Ice.InputStream(_communicator, Ice.Util.currentProtocolEncoding, os.GetBuffer(), true);
                     iss.pos(0);
                     iss.ReadShort(); // type
-                    iss.StartEncapsulation();
+                    iss.StartEndpointEncapsulation();
                     Endpoint e = factory.read(iss);
-                    iss.EndEncapsulation();
+                    iss.EndEndpointEncapsulation();
                     return e;
                 }
                 return ue; // Endpoint is opaque, but we don't have a factory for its type.
@@ -160,7 +160,7 @@ namespace IceInternal
                 IEndpointFactory factory = get(type);
                 Endpoint e = null;
 
-                s.StartEncapsulation();
+                s.StartEndpointEncapsulation();
 
                 if (factory != null)
                 {
@@ -177,7 +177,7 @@ namespace IceInternal
                     e = new OpaqueEndpointI(type, s);
                 }
 
-                s.EndEncapsulation();
+                s.EndEndpointEncapsulation();
 
                 return e;
             }

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -100,7 +100,7 @@ namespace IceInternal
         {
             _is = stream;
 
-            int start = _is.pos();
+            int start = _is.Pos;
             //
             // Read the current.
             //
@@ -141,9 +141,9 @@ namespace IceInternal
             {
                 // Read the encapsulation size.
                 int size = _is.ReadInt();
-                _is.pos(_is.pos() - 4);
+                _is.Pos = _is.Pos - 4;
 
-                _observer = obsv.getDispatchObserver(_current, _is.pos() - start + size);
+                _observer = obsv.getDispatchObserver(_current, _is.Pos - start + size);
                 if (_observer != null)
                 {
                     _observer.attach();
@@ -407,14 +407,14 @@ namespace IceInternal
                 //
                 // That's the first startOver, so almost nothing to do
                 //
-                _inParamPos = _is.pos();
+                _inParamPos = _is.Pos;
             }
             else
             {
                 //
                 // Let's rewind _is, reset _os
                 //
-                _is.pos(_inParamPos);
+                _is.Pos = _inParamPos;
                 if (_response && _os != null)
                 {
                     _os.Reset();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -86,7 +86,7 @@ namespace Ice
 
         // TODO: should we cache those per InputStream?
         //       should we clear the caches in ResetEncapsulation?
-        private Dictionary<string, Type>? _typeIdCache;
+        private Dictionary<string, Type?>? _typeIdCache;
         private Dictionary<int, Type>? _compactIdCache;
 
         // Map of type-id index to type-id string.
@@ -233,7 +233,7 @@ namespace Ice
         /// </summary>
         /// <param name="preserve">True if unknown slices should be preserved, false otherwise.</param>
         /// <returns>A SlicedData object containing the preserved slices for unknown types.</returns>
-        public SlicedData EndClass(bool preserve)
+        public SlicedData? EndClass(bool preserve)
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
             return EndInstance(preserve);
@@ -253,7 +253,7 @@ namespace Ice
         /// </summary>
         /// <param name="preserve">True if unknown slices should be preserved, false otherwise.</param>
         /// <returns>A SlicedData object containing the preserved slices for unknown types.</returns>
-        public SlicedData EndException(bool preserve)
+        public SlicedData? EndException(bool preserve)
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
             return EndInstance(preserve);
@@ -419,7 +419,7 @@ namespace Ice
         /// <summary>
         /// Reads the start of a class instance or exception slice.
         /// </summary>
-        /// <returns>The Slice type ID for this slice.</returns>
+        /// <returns>The Slice type ID for this slice.</returns>x
         public string StartSlice() // Returns type ID of next slice
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
@@ -2071,9 +2071,9 @@ namespace Ice
             {
                 string typeId = ReadString();
 
-                // We only want to insert this typeId in the map and increment the index
+                // We only want to add this typeId in the map list increment the Count
                 // when it's the first time we read it, so we save the largest pos we
-                // read to figure when to insert.
+                // read to figure when to add.
                 if (Pos > _posAfterLatestInsertedTypeId)
                 {
                     _posAfterLatestInsertedTypeId = Pos;
@@ -2087,21 +2087,14 @@ namespace Ice
         private Type? ResolveClass(string typeId)
         {
             Type? cls = null;
-            if (_typeIdCache?.TryGetValue(typeId, out cls) == true)
+            if (_typeIdCache?.TryGetValue(typeId, out cls) != true)
             {
-                // UnknowSlicedClass is our marker for class previously not found.
-                if (cls == typeof(UnknownSlicedClass))
-                {
-                    cls = null;
-                }
-            }
-            else
-            {
+                // Not found in typeIdCache
                 try
                 {
                     cls = _classResolver?.Invoke(typeId);
-                    _typeIdCache ??= new Dictionary<string, Type>(); // Lazy initialization
-                    _typeIdCache.Add(typeId, cls ?? typeof(UnknownSlicedClass));
+                    _typeIdCache ??= new Dictionary<string, Type?>(); // Lazy initialization
+                    _typeIdCache.Add(typeId, cls);
                 }
                 catch (Exception ex)
                 {
@@ -2632,7 +2625,7 @@ namespace Ice
             // Instance attributes
             internal SliceType sliceType;
             internal bool skipFirstSlice;
-            internal List<SliceInfo> slices;     // Preserved slices.
+            internal List<SliceInfo>? slices;     // Preserved slices.
             internal List<AnyClass[]?>? IndirectionTableList;
 
             // Position of indirection tables that we skipped for now and that will
@@ -2642,7 +2635,7 @@ namespace Ice
             // Slice attributes
             internal byte sliceFlags;
             internal int sliceSize;
-            internal string typeId;
+            internal string? typeId;
             internal int compactId;
 
             // Indirection table of the current slice

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2,15 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Protocol = IceInternal.Protocol;
+
 namespace Ice
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Runtime.Serialization;
-    using System.Runtime.Serialization.Formatters.Binary;
-    using Protocol = IceInternal.Protocol;
-
     /// <summary>
     /// Throws a UserException corresponding to the given Slice type Id, such as "::Module::MyException".
     /// If the implementation does not throw an exception, the Ice run time will fall back
@@ -164,80 +164,6 @@ namespace Ice
         {
             ResetEncapsulation();
         }
-
-        /*
-        /// <summary>
-        /// Sets the logger to use when logging trace messages. If the stream
-        /// was initialized with a communicator, the communicator's logger will
-        /// be used by default.
-        /// </summary>
-        /// <param name="logger">The logger to use for logging trace messages.</param>
-        public void SetLogger(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        /// <summary>
-        /// Sets the compact ID resolver to use when unmarshaling value and exception
-        /// instances. If the stream was initialized with a communicator, the communicator's
-        /// resolver will be used by default.
-        /// </summary>
-        /// <param name="r">The compact ID resolver.</param>
-        public void SetCompactIdResolver(Func<int, string> r)
-        {
-            _compactIdResolver = r;
-        }
-
-        /// <summary>
-        /// Sets the class resolver, which the stream will use when attempting to unmarshal
-        /// a value or exception. If the stream was initialized with a communicator, the communicator's
-        /// resolver will be used by default.
-        /// </summary>
-        /// <param name="r">The class resolver.</param>
-        public void SetClassResolver(Func<string, Type> r)
-        {
-            _classResolver = r;
-        }
-
-        /// <summary>
-        /// Determines the behavior of the stream when extracting instances of Slice classes.
-        /// An instance is "sliced" when a factory cannot be found for a Slice type ID.
-        /// The stream's default behavior is to slice instances.
-        /// </summary>
-        /// <param name="b">If true (the default), slicing is enabled; if false,
-        /// slicing is disabled. If slicing is disabled and the stream encounters a Slice type ID
-        /// during decoding for which no class factory is installed, it raises NoClassFactoryException.
-        /// </param>
-        public void SetSliceClasses(bool b)
-        {
-            _sliceClasses = b;
-        }
-
-        /// <summary>
-        /// Determines whether the stream logs messages about slicing instances of Slice values.
-        /// </summary>
-        /// <param name="b">True to enable logging, false to disable logging.</param>
-        public void SetTraceSlicing(bool b)
-        {
-            _traceSlicing = b;
-        }
-
-        /// <summary>
-        /// Set the maximum depth allowed for graph of Slice class instances.
-        /// </summary>
-        /// <param name="classGraphDepthMax">The maximum depth.</param>
-        public void SetClassGraphDepthMax(int classGraphDepthMax)
-        {
-            if (classGraphDepthMax < 1)
-            {
-                _classGraphDepthMax = 0x7fffffff;
-            }
-            else
-            {
-                _classGraphDepthMax = classGraphDepthMax;
-            }
-        }
-        */
 
         /// <summary>
         /// Swaps the contents of one stream with another.

--- a/csharp/src/Ice/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/OpaqueEndpointI.cs
@@ -34,7 +34,7 @@ namespace IceInternal
         public OpaqueEndpointI(short type, Ice.InputStream s)
         {
             _type = type;
-            _rawEncoding = s.GetEncoding();
+            _rawEncoding = s.Encoding;
             int sz = s.GetEncapsulationSize();
             _rawBytes = new byte[sz];
             s.ReadBlob(_rawBytes);

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -755,7 +755,7 @@ namespace IceInternal
 
             if (childObserver_ != null)
             {
-                childObserver_.reply(is_.size() - Protocol.headerSize - 4);
+                childObserver_.reply(is_.Size - Protocol.headerSize - 4);
                 childObserver_.detach();
                 childObserver_ = null;
             }
@@ -1046,7 +1046,7 @@ namespace IceInternal
                 {
                     if (read_ == null)
                     {
-                        if (is_ == null || is_.isEmpty())
+                        if (is_ == null || is_.IsEmpty)
                         {
                             //
                             // If there's no response (oneway), we just set the result

--- a/csharp/src/Ice/StreamWrapper.cs
+++ b/csharp/src/Ice/StreamWrapper.cs
@@ -347,7 +347,7 @@ namespace IceInternal
                         break;
                     }
             }
-            _s.pos(_pos);
+            _s.Pos = _pos;
             return _pos;
         }
 

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -16,7 +16,7 @@ namespace IceInternal
             {
                 int p = str.pos();
                 Ice.InputStream iss = new Ice.InputStream(str.communicator(), str.GetEncoding(), str.GetBuffer(), false);
-                iss.pos(0);
+                iss.Pos = 0;
 
                 using (System.IO.StringWriter s = new System.IO.StringWriter(CultureInfo.CurrentCulture))
                 {
@@ -32,8 +32,8 @@ namespace IceInternal
         {
             if (tl.protocol >= 1)
             {
-                int p = str.pos();
-                str.pos(0);
+                int p = str.Pos;
+                str.Pos = 0;
 
                 using (System.IO.StringWriter s = new System.IO.StringWriter(CultureInfo.CurrentCulture))
                 {
@@ -41,7 +41,7 @@ namespace IceInternal
 
                     logger.trace(tl.protocolCat, "received " + getMessageTypeAsString(type) + " " + s.ToString());
                 }
-                str.pos(p);
+                str.Pos = p;
             }
         }
 
@@ -51,7 +51,7 @@ namespace IceInternal
             {
                 int p = str.pos();
                 Ice.InputStream iss = new Ice.InputStream(str.communicator(), str.GetEncoding(), str.GetBuffer(), false);
-                iss.pos(0);
+                iss.Pos = 0;
 
                 using (System.IO.StringWriter s = new System.IO.StringWriter(CultureInfo.CurrentCulture))
                 {
@@ -68,8 +68,8 @@ namespace IceInternal
         {
             if (tl.protocol >= 1)
             {
-                int p = str.pos();
-                str.pos(0);
+                int p = str.Pos;
+                str.Pos = 0;
 
                 using (System.IO.StringWriter s = new System.IO.StringWriter(CultureInfo.CurrentCulture))
                 {
@@ -78,7 +78,7 @@ namespace IceInternal
 
                     logger.trace(tl.protocolCat, s.ToString());
                 }
-                str.pos(p);
+                str.Pos = p;
             }
         }
 
@@ -101,14 +101,14 @@ namespace IceInternal
 
         public static void dumpStream(Ice.InputStream stream)
         {
-            int pos = stream.pos();
-            stream.pos(0);
+            int pos = stream.Pos;
+            stream.Pos = 0;
 
-            byte[] data = new byte[stream.size()];
+            byte[] data = new byte[stream.Size];
             stream.ReadBlob(data);
             dumpOctets(data);
 
-            stream.pos(pos);
+            stream.Pos = pos;
         }
 
         public static void dumpOctets(byte[] data)
@@ -497,8 +497,8 @@ namespace IceInternal
         {
             if (tl.protocol >= 1)
             {
-                int p = str.pos();
-                str.pos(0);
+                int p = str.Pos;
+                str.Pos = 0;
 
                 using (System.IO.StringWriter s = new System.IO.StringWriter(CultureInfo.CurrentCulture))
                 {
@@ -507,7 +507,7 @@ namespace IceInternal
 
                     logger.trace(tl.protocolCat, s.ToString());
                 }
-                str.pos(p);
+                str.Pos = p;
             }
         }
 

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -170,7 +170,7 @@ namespace IceInternal
         {
             try
             {
-                Ice.ToStringMode toStringMode = str.Communicator()?.ToStringMode ?? Ice.ToStringMode.Unicode;
+                Ice.ToStringMode toStringMode = str.Communicator.ToStringMode;
 
                 Ice.Identity identity = new Ice.Identity();
                 identity.ice_readMembers(str);

--- a/csharp/src/Ice/UdpEndpointI.cs
+++ b/csharp/src/Ice/UdpEndpointI.cs
@@ -31,7 +31,7 @@ namespace IceInternal
         public UdpEndpointI(ProtocolInstance instance, Ice.InputStream s) :
             base(instance, s)
         {
-            if (s.GetEncoding().Equals(Ice.Util.Encoding_1_0))
+            if (s.Encoding.Equals(Ice.Util.Encoding_1_0))
             {
                 s.ReadByte();
                 s.ReadByte();

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -223,22 +223,19 @@ namespace Ice.stream
                 o.by = 5;
                 o.sh = 4;
                 o.i = 3;
+                // Can only read/write classes within encaps
+                outS.StartEncapsulation();
                 outS.WriteClass(o);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var o2 = inS.ReadClass<Test.OptionalClass>();
+                inS.EndEncapsulation();
                 test(o2.bo == o.bo);
                 test(o2.by == o.by);
-                if (communicator.GetProperty("Ice.Default.EncodingVersion") == "1.0")
-                {
-                    test(!o2.sh.HasValue);
-                    test(!o2.i.HasValue);
-                }
-                else
-                {
-                    test(o2.sh == o.sh);
-                    test(o2.i == o.i);
-                }
+                test(o2.sh == o.sh);
+                test(o2.i == o.i);
             }
 
             {
@@ -465,10 +462,14 @@ namespace Ice.stream
 
             {
                 outS = new OutputStream(communicator);
+                outS.StartEncapsulation();
                 Test.MyClassSHelper.Write(outS, myClassArray);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var arr2 = Test.MyClassSHelper.Read(inS);
+                inS.EndEncapsulation();
                 test(arr2.Length == myClassArray.Length);
                 for (int i = 0; i < arr2.Length; ++i)
                 {
@@ -490,10 +491,14 @@ namespace Ice.stream
 
                 Test.MyClass[][] arrS = { myClassArray, new Test.MyClass[0], myClassArray };
                 outS = new OutputStream(communicator);
+                outS.StartEncapsulation();
                 Test.MyClassSSHelper.Write(outS, arrS);
+                outS.EndEncapsulation();
                 data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var arr2S = Test.MyClassSSHelper.Read(inS);
+                inS.EndEncapsulation();
                 test(arr2S.Length == arrS.Length);
                 test(arr2S[0].Length == arrS[0].Length);
                 test(arr2S[1].Length == arrS[1].Length);
@@ -526,17 +531,22 @@ namespace Ice.stream
                 obj.s = new Test.SmallStruct();
                 obj.s.e = Test.MyEnum.enum2;
                 var writer = new TestClassWriter(obj);
+                outS.StartEncapsulation();
                 outS.WriteClass(writer);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 test(writer.called);
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var robj = inS.ReadClass<Test.MyClass>();
+                inS.EndEncapsulation();
                 test(robj != null);
                 test(robj.s.e == Test.MyEnum.enum2);
             }
 
             {
                 outS = new OutputStream(communicator);
+                outS.StartEncapsulation();
                 var ex = new Test.MyException();
 
                 var c = new Test.MyClass();
@@ -560,9 +570,11 @@ namespace Ice.stream
                 ex.c = c;
 
                 outS.WriteException(ex);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
 
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 try
                 {
                     inS.ThrowException();
@@ -585,6 +597,7 @@ namespace Ice.stream
                 {
                     test(false);
                 }
+                inS.EndEncapsulation();
             }
 
             {
@@ -646,10 +659,14 @@ namespace Ice.stream
                 c.s.e = Test.MyEnum.enum3;
                 dict.Add("key2", c);
                 outS = new OutputStream(communicator);
+                outS.StartEncapsulation();
                 Test.StringMyClassDHelper.Write(outS, dict);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var dict2 = Test.StringMyClassDHelper.Read(inS);
+                inS.EndEncapsulation();
                 test(dict2.Count == dict.Count);
                 test(dict2["key1"].s.e == Test.MyEnum.enum2);
                 test(dict2["key2"].s.e == Test.MyEnum.enum3);
@@ -659,10 +676,14 @@ namespace Ice.stream
                 bool[] arr = { true, false, true, false };
                 outS = new OutputStream(communicator);
                 var l = new List<bool>(arr);
+                outS.StartEncapsulation();
                 Test.BoolListHelper.Write(outS, l);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var l2 = Test.BoolListHelper.Read(inS);
+                inS.EndEncapsulation();
                 test(Compare(l, l2));
             }
 
@@ -704,11 +725,15 @@ namespace Ice.stream
 
             {
                 outS = new OutputStream(communicator);
+                outS.StartEncapsulation();
                 var l = new List<Test.MyClass>(myClassArray);
                 Test.MyClassListHelper.Write(outS, l);
+                outS.EndEncapsulation();
                 var data = outS.Finished();
                 inS = new InputStream(communicator, data);
+                inS.StartEncapsulation();
                 var l2 = Test.MyClassListHelper.Read(inS);
+                inS.EndEncapsulation();
                 test(l2.Count == l.Count);
                 for (int i = 0; i < l2.Count; ++i)
                 {


### PR DESCRIPTION
This is a further step in the simplification of InputStream in C#, but not the last one. This step:
- replaces the Encaps stack/nesting by just two simple encaps (_mainEncaps and _endpointEncaps)
- requires class/exception reading to occur only within a top-level encaps (_mainEncaps)
- removes constructors that were not used, and various SetXxx methods that were not tested (and not particularly useful).

This is a partial fix for #280.