### PR TITLE
C# communicator refactoring

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -108,18 +108,11 @@ namespace Ice
         private readonly Func<int, string>? _compactIdResolver;
         private ILocatorPrx? _defaultLocator;
         private IRouterPrx? _defaultRouter;
-        private EndpointFactoryManager _endpointFactoryManager;
-        private EndpointHostResolver _endpointHostResolver;
         private readonly ImplicitContext? _implicitContext; // Immutable
-        private LocatorManager _locatorManager;
-        private ObjectAdapterFactory _objectAdapterFactory;
         private static bool _oneOffDone = false;
         private OutgoingConnectionFactory _outgoingConnectionFactory;
         private static bool _printProcessIdDone = false;
-        private RequestHandlerFactory? _requestHandlerFactory;
         private readonly int[] _retryIntervals;
-        private RetryQueue _retryQueue;
-        private RouterManager _routerManager;
         private IceInternal.ThreadPool? _serverThreadPool;
         private readonly Dictionary<short, BufSizeWarnInfo> _setBufSizeWarn = new Dictionary<short, BufSizeWarnInfo>();
         private int _state;
@@ -363,9 +356,8 @@ namespace Ice
                 CacheMessageBuffers = GetPropertyAsInt("Ice.CacheMessageBuffers") ?? 2;
 
                 _implicitContext = ImplicitContext.Create(GetProperty("Ice.ImplicitContext"));
-                _routerManager = new RouterManager();
 
-                _locatorManager = new LocatorManager(this);
+                _backgroundLocatorCacheUpdates = GetPropertyAsInt("Ice.BackgroundLocatorCacheUpdates") > 0;
 
                 string[]? arr = GetPropertyAsList("Ice.RetryIntervals");
 
@@ -392,8 +384,6 @@ namespace Ice
                     }
                 }
 
-                _requestHandlerFactory = new RequestHandlerFactory(this);
-
                 bool isIPv6Supported = Network.isIPv6Supported();
                 bool ipv4 = (GetPropertyAsInt("Ice.IPv4") ?? 1) > 0;
                 bool ipv6 = (GetPropertyAsInt("Ice.IPv6") ?? (isIPv6Supported ? 1 : 0)) > 0;
@@ -417,25 +407,13 @@ namespace Ice
 
                 NetworkProxy = CreateNetworkProxy(ProtocolSupport);
 
-                _endpointFactoryManager = new EndpointFactoryManager(this);
-
-                ProtocolInstance tcpInstance = new ProtocolInstance(this, TCPEndpointType.value, "tcp", false);
-                _endpointFactoryManager.add(new TcpEndpointFactory(tcpInstance));
-
-                ProtocolInstance udpInstance = new ProtocolInstance(this, UDPEndpointType.value, "udp", false);
-                _endpointFactoryManager.add(new UdpEndpointFactory(udpInstance));
-
-                ProtocolInstance wsInstance = new ProtocolInstance(this, WSEndpointType.value, "ws", false);
-                _endpointFactoryManager.add(new WSEndpointFactory(wsInstance, TCPEndpointType.value));
-
-                ProtocolInstance wssInstance = new ProtocolInstance(this, WSSEndpointType.value, "wss", true);
-                _endpointFactoryManager.add(new WSEndpointFactory(wssInstance, SSLEndpointType.value));
+                _endpointFactories = new List<IEndpointFactory>();
+                AddEndpointFactory(new TcpEndpointFactory(new ProtocolInstance(this, TCPEndpointType.value, "tcp", false)));
+                AddEndpointFactory(new UdpEndpointFactory(new ProtocolInstance(this, UDPEndpointType.value, "udp", false)));
+                AddEndpointFactory(new WSEndpointFactory(new ProtocolInstance(this, WSEndpointType.value, "ws", false), TCPEndpointType.value));
+                AddEndpointFactory(new WSEndpointFactory(new ProtocolInstance(this, WSSEndpointType.value, "wss", true), SSLEndpointType.value));
 
                 _outgoingConnectionFactory = new OutgoingConnectionFactory(this);
-
-                _objectAdapterFactory = new ObjectAdapterFactory(this);
-
-                _retryQueue = new RetryQueue(this);
 
                 if (GetPropertyAsInt("Ice.PreloadAssemblies") > 0)
                 {
@@ -452,7 +430,10 @@ namespace Ice
                 // Initialize the endpoint factories once all the plugins are loaded. This gives
                 // the opportunity for the endpoint factories to find underyling factories.
                 //
-                _endpointFactoryManager.initialize();
+                foreach (IEndpointFactory f in _endpointFactories)
+                {
+                    f.initialize();
+                }
 
                 //
                 // Create Admin facets, if enabled.
@@ -564,7 +545,9 @@ namespace Ice
 
                 try
                 {
-                    _endpointHostResolver = new EndpointHostResolver(this);
+                    _endpointHostResolverThread = new HelperThread(this);
+                    UpdateEndpointHostResolverObserver();
+                    _endpointHostResolverThread.Start(IceInternal.Util.stringToThreadPriority(GetProperty("Ice.ThreadPriority")));
                 }
                 catch (System.Exception ex)
                 {
@@ -632,8 +615,9 @@ namespace Ice
                     GetAdmin();
                 }
             }
-            catch (System.Exception)
+            catch (System.Exception ex)
             {
+                Console.WriteLine(ex);
                 Destroy();
                 throw;
             }
@@ -724,7 +708,7 @@ namespace Ice
                 {
                     if (GetProperty("Ice.Admin.Endpoints") != null)
                     {
-                        adminAdapter = _objectAdapterFactory.createObjectAdapter("Ice.Admin", null);
+                        adminAdapter = CreateObjectAdapter("Ice.Admin", null);
                     }
                     else
                     {
@@ -784,10 +768,7 @@ namespace Ice
         /// <returns>The new object adapter.
         ///
         /// </returns>
-        public ObjectAdapter CreateObjectAdapter(string name)
-        {
-            return ObjectAdapterFactory().createObjectAdapter(name, null);
-        }
+        public ObjectAdapter CreateObjectAdapter(string name) => CreateObjectAdapter(name, null);
 
         /// <summary>
         /// Create a new object adapter with endpoints.
@@ -817,7 +798,7 @@ namespace Ice
             }
 
             SetProperty($"{name}.Endpoints", endpoints);
-            return ObjectAdapterFactory().createObjectAdapter(name, null);
+            return CreateObjectAdapter(name, null);
         }
 
         /// <summary>
@@ -854,7 +835,7 @@ namespace Ice
                 SetProperty(entry.Key, entry.Value);
             }
 
-            return ObjectAdapterFactory().createObjectAdapter(name, router);
+            return CreateObjectAdapter(name, router);
         }
 
         public Reference CreateReference(string s, string? propertyPrefix = null)
@@ -1152,7 +1133,7 @@ namespace Ice
                     }
 
                     string es = s.Substring(beg, end - beg);
-                    Endpoint? endp = EndpointFactoryManager().create(es, false);
+                    Endpoint? endp = CreateEndpoint(es, false);
                     if (endp != null)
                     {
                         endpoints.Add(endp);
@@ -1162,6 +1143,7 @@ namespace Ice
                         unknownEndpoints.Add(es);
                     }
                 }
+
                 if (endpoints.Count == 0)
                 {
                     Debug.Assert(unknownEndpoints.Count > 0);
@@ -1292,7 +1274,7 @@ namespace Ice
                 endpoints = new Endpoint[sz];
                 for (int i = 0; i < sz; i++)
                 {
-                    endpoints[i] = EndpointFactoryManager().read(s);
+                    endpoints[i] = ReadEndpoint(s);
                 }
             }
             else
@@ -1337,13 +1319,33 @@ namespace Ice
             // Shutdown and destroy all the incoming and outgoing Ice
             // connections and wait for the connections to be finished.
             //
-            _objectAdapterFactory.shutdown();
+            Shutdown();
             _outgoingConnectionFactory.destroy();
 
-            _objectAdapterFactory.destroy();
+            //
+            // First wait for shutdown to finish.
+            //
+            WaitForShutdown();
+
+            List<ObjectAdapter> adapters;
+            lock (this)
+            {
+                adapters = new List<ObjectAdapter>(_adapters);
+            }
+
+            foreach (ObjectAdapter adapter in adapters)
+            {
+                adapter.Destroy();
+            }
+
+            lock (this)
+            {
+                _adapters.Clear();
+            }
+
             _outgoingConnectionFactory.waitUntilFinished();
 
-            _retryQueue.destroy(); // Must be called before destroying thread pools.
+            DestroyRetryTask(); // Must be called before destroying thread pools.
 
             if (Observer != null)
             {
@@ -1370,7 +1372,13 @@ namespace Ice
             {
                 _asyncIOThread.destroy();
             }
-            _endpointHostResolver.destroy();
+
+            lock (_endpointHostResolverThread)
+            {
+                Debug.Assert(!_endpointHostResolverDestroyed);
+                _endpointHostResolverDestroyed = true;
+                Monitor.Pulse(_endpointHostResolverThread);
+            }
 
             //
             // Wait for all the threads to be finished.
@@ -1385,10 +1393,33 @@ namespace Ice
             {
                 _asyncIOThread.joinWithThread();
             }
-            _endpointHostResolver.joinWithThread();
-            _routerManager.destroy();
-            _locatorManager.destroy();
-            _endpointFactoryManager.destroy();
+
+            _endpointHostResolverThread.Join();
+
+            lock (_routerInfoTable)
+            {
+                foreach (RouterInfo i in _routerInfoTable.Values)
+                {
+                    i.Destroy();
+                }
+                _routerInfoTable.Clear();
+            }
+
+            lock (_locatorInfoMap)
+            {
+                foreach (LocatorInfo info in _locatorInfoMap.Values)
+                {
+                    info.Destroy();
+                }
+                _locatorInfoMap.Clear();
+                _locatorTableMap.Clear();
+            }
+
+            foreach (IEndpointFactory f in _endpointFactories)
+            {
+                f.destroy();
+            }
+            _endpointFactories.Clear();
 
             if (GetPropertyAsInt("Ice.Warn.UnusedProperties") > 0)
             {
@@ -1431,8 +1462,6 @@ namespace Ice
             {
                 _serverThreadPool = null;
                 _asyncIOThread = null;
-
-                _requestHandlerFactory = null;
 
                 _adminAdapter = null;
                 _adminFacets.Clear();
@@ -1529,7 +1558,7 @@ namespace Ice
                 {
                     if (GetProperty("Ice.Admin.Endpoints") != null)
                     {
-                        adminAdapter = _objectAdapterFactory.createObjectAdapter("Ice.Admin", null);
+                        adminAdapter = CreateObjectAdapter("Ice.Admin", null);
                     }
                     else
                     {
@@ -1620,37 +1649,9 @@ namespace Ice
         /// <returns>True if the communicator has been shut down; false otherwise.</returns>
         public bool IsShutdown()
         {
-            try
-            {
-                return ObjectAdapterFactory().isShutdown();
-            }
-            catch (CommunicatorDestroyedException)
-            {
-                return true;
-            }
-        }
-
-        public LocatorManager LocatorManager()
-        {
             lock (this)
             {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _locatorManager;
-            }
-        }
-
-        public ObjectAdapterFactory ObjectAdapterFactory()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _objectAdapterFactory;
+                return _isShutdown;
             }
         }
 
@@ -1684,18 +1685,6 @@ namespace Ice
                     _adminAdapter.Remove(_adminIdentity.Value, facet);
                 }
                 return result;
-            }
-        }
-
-        public RouterManager RouterManager()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _routerManager;
             }
         }
 
@@ -1766,13 +1755,30 @@ namespace Ice
         /// </summary>
         public void Shutdown()
         {
-            try
+            List<ObjectAdapter> adapters;
+            lock (this)
             {
-                ObjectAdapterFactory().shutdown();
+                //
+                // Ignore shutdown requests if the object adapter factory has
+                // already been shut down.
+                //
+                if (_isShutdown)
+                {
+                    return;
+                }
+
+                adapters = new List<ObjectAdapter>(_adapters);
+                _isShutdown = true;
+                Monitor.PulseAll(this);
             }
-            catch (CommunicatorDestroyedException)
+
+            //
+            // Deactivate outside the thread synchronization, to avoid
+            // deadlocks.
+            //
+            foreach (ObjectAdapter adapter in adapters)
             {
-                // Ignore
+                adapter.Deactivate();
             }
         }
 
@@ -1804,13 +1810,26 @@ namespace Ice
         /// </summary>
         public void WaitForShutdown()
         {
-            try
+            List<ObjectAdapter> adapters;
+            lock (this)
             {
-                ObjectAdapterFactory().waitForShutdown();
+                //
+                // First we wait for the shutdown of the factory itself.
+                //
+                while (!_isShutdown)
+                {
+                    Monitor.Wait(this);
+                }
+
+                adapters = new List<ObjectAdapter>(_adapters);
             }
-            catch (CommunicatorDestroyedException)
+
+            //
+            // Now we wait for deactivation of each object adapter.
+            //
+            foreach (ObjectAdapter adapter in adapters)
             {
-                // Ignore
+                adapter.WaitForDeactivate();
             }
         }
 
@@ -1857,7 +1876,7 @@ namespace Ice
                     // to the router.
                     //
 
-                    ri.clearCache(@ref);
+                    ri.ClearCache(@ref);
 
                     if (TraceLevels.retry >= 1)
                     {
@@ -1875,7 +1894,7 @@ namespace Ice
 
                     if (@ref.isWellKnown())
                     {
-                        @ref.getLocatorInfo()?.clearCache(@ref);
+                        @ref.getLocatorInfo()?.ClearCache(@ref);
                     }
                 }
                 else
@@ -2008,30 +2027,6 @@ namespace Ice
                 null);
         }
 
-        internal EndpointFactoryManager EndpointFactoryManager()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _endpointFactoryManager;
-            }
-        }
-
-        internal EndpointHostResolver EndpointHostResolver()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _endpointHostResolver;
-            }
-        }
-
         internal BufSizeWarnInfo GetBufSizeWarn(short type)
         {
             lock (_setBufSizeWarn)
@@ -2063,20 +2058,6 @@ namespace Ice
                     throw new CommunicatorDestroyedException();
                 }
                 return _outgoingConnectionFactory;
-            }
-        }
-
-        internal RequestHandlerFactory RequestHandlerFactory()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-
-                Debug.Assert(_requestHandlerFactory != null);
-                return _requestHandlerFactory;
             }
         }
 
@@ -2153,18 +2134,6 @@ namespace Ice
                 }
             }
             return result;
-        }
-
-        internal RetryQueue RetryQueue()
-        {
-            lock (this)
-            {
-                if (_state == StateDestroyed)
-                {
-                    throw new CommunicatorDestroyedException();
-                }
-                return _retryQueue;
-            }
         }
 
         internal IceInternal.ThreadPool ServerThreadPool()
@@ -2275,7 +2244,17 @@ namespace Ice
             try
             {
                 _outgoingConnectionFactory.updateConnectionObservers();
-                _objectAdapterFactory.updateConnectionObservers();
+
+                List<ObjectAdapter> adapters;
+                lock (this)
+                {
+                    adapters = new List<ObjectAdapter>(_adapters);
+                }
+
+                foreach (ObjectAdapter adapter in adapters)
+                {
+                    adapter.updateConnectionObservers();
+                }
             }
             catch (CommunicatorDestroyedException)
             {
@@ -2291,8 +2270,19 @@ namespace Ice
                 {
                     _serverThreadPool.updateObservers();
                 }
-                _objectAdapterFactory.updateThreadObservers();
-                _endpointHostResolver.updateObserver();
+
+                List<ObjectAdapter> adapters;
+                lock (this)
+                {
+                    adapters = new List<ObjectAdapter>(_adapters);
+                }
+
+                foreach (ObjectAdapter adapter in adapters)
+                {
+                    adapter.updateThreadObservers();
+                }
+
+                UpdateEndpointHostResolverObserver();
 
                 if (_asyncIOThread != null)
                 {
@@ -2410,6 +2400,14 @@ namespace Ice
             string? adapterId,
             string? propertyPrefix)
         {
+            lock (this)
+            {
+                if (_state == StateDestroyed)
+                {
+                    throw new CommunicatorDestroyedException();
+                }
+            }
+
             //
             // Default local proxy options.
             //
@@ -2418,17 +2416,17 @@ namespace Ice
             {
                 if (!_defaultLocator.IceReference.getEncoding().Equals(encoding))
                 {
-                    locatorInfo = LocatorManager().get(_defaultLocator.Clone(encodingVersion: encoding));
+                    locatorInfo = GetLocatorInfo(_defaultLocator.Clone(encodingVersion: encoding));
                 }
                 else
                 {
-                    locatorInfo = LocatorManager().get(_defaultLocator);
+                    locatorInfo = GetLocatorInfo(_defaultLocator);
                 }
             }
             RouterInfo? routerInfo = null;
             if (_defaultRouter != null)
             {
-                routerInfo = RouterManager().get(_defaultRouter);
+                routerInfo = GetRouterInfo(_defaultRouter);
             }
             bool collocOptimized = DefaultsAndOverrides.defaultCollocationOptimization;
             bool cacheConnection = true;
@@ -2457,11 +2455,11 @@ namespace Ice
                 {
                     if (!locator.IceReference.getEncoding().Equals(encoding))
                     {
-                        locatorInfo = LocatorManager().get(locator.Clone(encodingVersion: encoding));
+                        locatorInfo = GetLocatorInfo(locator.Clone(encodingVersion: encoding));
                     }
                     else
                     {
-                        locatorInfo = LocatorManager().get(locator);
+                        locatorInfo = GetLocatorInfo(locator);
                     }
                 }
 
@@ -2475,7 +2473,7 @@ namespace Ice
                     }
                     else
                     {
-                        routerInfo = RouterManager().get(router);
+                        routerInfo = GetRouterInfo(router);
                     }
                 }
 

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using Ice;
 
 namespace IceInternal
 {
@@ -118,7 +119,7 @@ namespace IceInternal
             //
             Debug.Assert(_proxy != null);
             RouterInfo? ri = _reference.getRouterInfo();
-            if (ri != null && !ri.addProxy(_proxy, this))
+            if (ri != null && !ri.AddProxy(_proxy, this))
             {
                 return; // The request handler will be initialized once addProxy returns.
             }
@@ -145,7 +146,7 @@ namespace IceInternal
             //
             try
             {
-                _reference.getCommunicator().RequestHandlerFactory().removeRequestHandler(_reference, this);
+                _reference.getCommunicator().RemoveRequestHandler(_reference, this);
             }
             catch (Ice.CommunicatorDestroyedException)
             {
@@ -252,7 +253,7 @@ namespace IceInternal
                     exception = ex.get();
 
                     // Remove the request handler before retrying.
-                    _reference.getCommunicator().RequestHandlerFactory().removeRequestHandler(_reference, this);
+                    _reference.getCommunicator().RemoveRequestHandler(_reference, this);
 
                     outAsync.RetryException();
                 }
@@ -293,7 +294,7 @@ namespace IceInternal
                 // Only remove once all the requests are flushed to
                 // guarantee serialization.
                 //
-                _reference.getCommunicator().RequestHandlerFactory().removeRequestHandler(_reference, this);
+                _reference.getCommunicator().RemoveRequestHandler(_reference, this);
 
                 _proxies.Clear();
                 _proxy = null; // Break cyclic reference count.

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -2,13 +2,13 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Ice;
+
 namespace IceInternal
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Text;
-
     public class MultiDictionary<K, V> : Dictionary<K, ICollection<V>>
     {
         public void
@@ -39,8 +39,8 @@ namespace IceInternal
     {
         public interface CreateConnectionCallback
         {
-            void setConnection(Ice.Connection connection, bool compress);
-            void setException(Ice.LocalException ex);
+            void setConnection(Connection connection, bool compress);
+            void setException(LocalException ex);
         }
 
         public void destroy()
@@ -177,8 +177,8 @@ namespace IceInternal
         public void setRouterInfo(RouterInfo routerInfo)
         {
             Debug.Assert(routerInfo != null);
-            Ice.ObjectAdapter adapter = routerInfo.getAdapter();
-            Endpoint[] endpoints = routerInfo.getClientEndpoints(); // Must be called outside the synchronization
+            Ice.ObjectAdapter? adapter = routerInfo.Adapter;
+            Endpoint[] endpoints = routerInfo.GetClientEndpoints(); // Must be called outside the synchronization
 
             lock (this)
             {
@@ -1099,7 +1099,7 @@ namespace IceInternal
                 {
                     createAcceptor();
                 }
-                catch (Exception ex)
+                catch (System.Exception ex)
                 {
                     Debug.Assert(_acceptor != null);
                     _communicator.Logger.error($"acceptor creation failed:\n{ex}\n{_acceptor}");
@@ -1558,7 +1558,7 @@ namespace IceInternal
                     createAcceptor();
                 }
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 //
                 // Clean up.
@@ -1569,7 +1569,7 @@ namespace IceInternal
                     {
                         _transceiver.close();
                     }
-                    catch (Ice.LocalException)
+                    catch (LocalException)
                     {
                         // Ignore
                     }
@@ -1714,7 +1714,7 @@ namespace IceInternal
 
                 _acceptorStarted = true;
             }
-            catch (SystemException)
+            catch (System.Exception)
             {
                 if (_acceptor != null)
                 {

--- a/csharp/src/Ice/IProtocolPluginFacade.cs
+++ b/csharp/src/Ice/IProtocolPluginFacade.cs
@@ -10,49 +10,47 @@ namespace IceInternal
         // Get the Communicator instance with which this facade is
         // associated.
         //
-        Ice.Communicator getCommunicator();
+        Ice.Communicator Communicator { get; }
 
         //
         // Register an EndpointFactory.
         //
-        void addEndpointFactory(IEndpointFactory factory);
+        void AddEndpointFactory(IEndpointFactory factory);
 
         //
         // Get an EndpointFactory.
         //
-        IEndpointFactory getEndpointFactory(short type);
+        IEndpointFactory? GetEndpointFactory(short type);
 
         //
         // Obtain the type for a name.
         //
-        System.Type? findType(string name);
+        System.Type? FindType(string name);
     }
 
     public sealed class ProtocolPluginFacade : IProtocolPluginFacade
     {
-        public ProtocolPluginFacade(Ice.Communicator communicator) => _communicator = communicator;
+        public ProtocolPluginFacade(Ice.Communicator communicator) => Communicator = communicator;
 
         //
         // Get the Communicator instance with which this facade is
         // associated.
         //
-        public Ice.Communicator getCommunicator() => _communicator;
+        public Ice.Communicator Communicator { get; private set; }
 
         //
         // Register an EndpointFactory.
         //
-        public void addEndpointFactory(IEndpointFactory factory) => _communicator.EndpointFactoryManager().add(factory);
+        public void AddEndpointFactory(IEndpointFactory factory) => Communicator.AddEndpointFactory(factory);
 
         //
         // Get an EndpointFactory.
         //
-        public IEndpointFactory getEndpointFactory(short type) => _communicator.EndpointFactoryManager().get(type);
+        public IEndpointFactory? GetEndpointFactory(short type) => Communicator.GetEndpointFactory(type);
 
         //
         // Obtain the type for a name.
         //
-        public System.Type? findType(string name) => AssemblyUtil.findType(name);
-
-        private Ice.Communicator _communicator;
+        public System.Type? FindType(string name) => AssemblyUtil.findType(name);
     }
 }

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -2,28 +2,39 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Ice;
+using IceInternal;
 
-namespace IceInternal
+namespace Ice
 {
     public sealed class LocatorInfo
     {
         public interface IGetEndpointsCallback
         {
-            void setEndpoints(Endpoint[] endpoints, bool cached);
-            void setException(LocalException ex);
+            void SetEndpoints(Endpoint[] endpoints, bool cached);
+            void SetException(LocalException ex);
         }
 
         private class RequestCallback
         {
-            public void
-            response(LocatorInfo locatorInfo, IObjectPrx proxy)
+            private readonly Reference _ref;
+            private readonly int _ttl;
+            private readonly IGetEndpointsCallback? _callback;
+
+            public RequestCallback(Reference reference, int ttl, IGetEndpointsCallback? cb)
             {
-                Endpoint[] endpoints = null;
+                _ref = reference;
+                _ttl = ttl;
+                _callback = cb;
+            }
+
+            public void Response(LocatorInfo locatorInfo, IObjectPrx? proxy)
+            {
+                Endpoint[]? endpoints = null;
                 if (proxy != null)
                 {
                     Reference r = proxy.IceReference;
@@ -48,57 +59,61 @@ namespace IceInternal
                         //
                         if (_ref.getCommunicator().TraceLevels.location >= 1)
                         {
-                            locatorInfo.trace("retrieved adapter for well-known object from locator, " +
+                            locatorInfo.Trace("retrieved adapter for well-known object from locator, " +
                                               "adding to locator cache", _ref, r);
                         }
-                        locatorInfo.getEndpoints(r, _ref, _ttl, _callback);
+                        locatorInfo.GetEndpoints(r, _ref, _ttl, _callback);
                         return;
                     }
                 }
 
                 if (_ref.getCommunicator().TraceLevels.location >= 1)
                 {
-                    locatorInfo.getEndpointsTrace(_ref, endpoints, false);
+                    locatorInfo.GetEndpointsTrace(_ref, endpoints, false);
                 }
                 if (_callback != null)
                 {
-                    _callback.setEndpoints(endpoints == null ? System.Array.Empty<Endpoint>() : endpoints, false);
+                    _callback.SetEndpoints(endpoints ?? Array.Empty<Endpoint>(), false);
                 }
             }
 
-            public void
-            exception(LocatorInfo locatorInfo, Exception exc)
+            public void Exception(LocatorInfo locatorInfo, Exception exc)
             {
                 try
                 {
-                    locatorInfo.getEndpointsException(_ref, exc); // This throws.
+                    locatorInfo.GetEndpointsException(_ref, exc); // This throws.
                 }
                 catch (LocalException ex)
                 {
                     if (_callback != null)
                     {
-                        _callback.setException(ex);
+                        _callback.SetException(ex);
                     }
                 }
             }
-
-            public
-            RequestCallback(Reference reference, int ttl, IGetEndpointsCallback cb)
-            {
-                _ref = reference;
-                _ttl = ttl;
-                _callback = cb;
-            }
-
-            private readonly Reference _ref;
-            private readonly int _ttl;
-            private readonly IGetEndpointsCallback _callback;
         }
 
         private abstract class Request
         {
-            public void
-            addCallback(Reference reference, Reference wellKnownRef, int ttl, IGetEndpointsCallback cb)
+            protected readonly LocatorInfo _locatorInfo;
+            protected readonly Reference _ref;
+
+            private readonly List<RequestCallback> _callbacks = new List<RequestCallback>();
+            private Exception? _exception;
+            private IObjectPrx? _proxy;
+            private bool _response;
+            private bool _sent;
+            private readonly List<Reference> _wellKnownRefs = new List<Reference>();
+
+            internal Request(LocatorInfo locatorInfo, Reference reference)
+            {
+                _locatorInfo = locatorInfo;
+                _ref = reference;
+                _sent = false;
+                _response = false;
+            }
+
+            internal void AddCallback(Reference reference, Reference? wellKnownRef, int ttl, IGetEndpointsCallback? cb)
             {
                 RequestCallback callback = new RequestCallback(reference, ttl, cb);
                 lock (this)
@@ -114,7 +129,7 @@ namespace IceInternal
                         if (!_sent)
                         {
                             _sent = true;
-                            send();
+                            Send();
                         }
                         return;
                     }
@@ -122,142 +137,124 @@ namespace IceInternal
 
                 if (_response)
                 {
-                    callback.response(_locatorInfo, _proxy);
+                    callback.Response(_locatorInfo, _proxy);
                 }
                 else
                 {
                     Debug.Assert(_exception != null);
-                    callback.exception(_locatorInfo, _exception);
+                    callback.Exception(_locatorInfo, _exception);
                 }
             }
 
-            public Request(LocatorInfo locatorInfo, Reference reference)
-            {
-                _locatorInfo = locatorInfo;
-                _ref = reference;
-                _sent = false;
-                _response = false;
-            }
-
-            public void
-            response(IObjectPrx proxy)
+            internal void Response(IObjectPrx proxy)
             {
                 lock (this)
                 {
-                    _locatorInfo.finishRequest(_ref, _wellKnownRefs, proxy, false);
+                    _locatorInfo.FinishRequest(_ref, _wellKnownRefs, proxy, false);
                     _response = true;
                     _proxy = proxy;
                     Monitor.PulseAll(this);
                 }
                 foreach (RequestCallback callback in _callbacks)
                 {
-                    callback.response(_locatorInfo, proxy);
+                    callback.Response(_locatorInfo, proxy);
                 }
             }
 
-            public void
-            exception(Exception ex)
+            internal void Exception(Exception ex)
             {
                 lock (this)
                 {
-                    _locatorInfo.finishRequest(_ref, _wellKnownRefs, null, ex is UserException);
+                    _locatorInfo.FinishRequest(_ref, _wellKnownRefs, null, ex is UserException);
                     _exception = ex;
                     Monitor.PulseAll(this);
                 }
                 foreach (RequestCallback callback in _callbacks)
                 {
-                    callback.exception(_locatorInfo, ex);
+                    callback.Exception(_locatorInfo, ex);
                 }
             }
 
-            protected abstract void send();
-
-            protected readonly LocatorInfo _locatorInfo;
-            protected readonly Reference _ref;
-
-            private List<RequestCallback> _callbacks = new List<RequestCallback>();
-            private List<Reference> _wellKnownRefs = new List<Reference>();
-            private bool _sent;
-            private bool _response;
-            private IObjectPrx _proxy;
-            private Exception _exception;
+            protected internal abstract void Send();
         }
 
         private class ObjectRequest : Request
         {
-            public ObjectRequest(LocatorInfo locatorInfo, Reference reference) : base(locatorInfo, reference)
+            internal ObjectRequest(LocatorInfo locatorInfo, Reference reference) : base(locatorInfo, reference)
             {
             }
 
-            protected override void
-            send()
+            protected internal override void
+            Send()
             {
                 try
                 {
-                    _locatorInfo.getLocator().FindObjectByIdAsync(_ref.getIdentity()).ContinueWith(
+                    _locatorInfo.Locator.FindObjectByIdAsync(_ref.getIdentity()).ContinueWith(
                         (Task<IObjectPrx> p) =>
                         {
                             try
                             {
-                                response(p.Result);
+                                Response(p.Result);
                             }
-                            catch (System.AggregateException ex)
+                            catch (AggregateException ex)
                             {
-                                exception(ex.InnerException as Exception);
+                                Debug.Assert(ex.InnerException is Ice.Exception);
+                                Exception((Ice.Exception)ex.InnerException);
                             }
                         });
                 }
-                catch (Exception ex)
+                catch (Ice.Exception ex)
                 {
-                    exception(ex);
+                    Exception(ex);
                 }
             }
         }
 
         private class AdapterRequest : Request
         {
-            public AdapterRequest(LocatorInfo locatorInfo, Reference reference) : base(locatorInfo, reference)
+            internal AdapterRequest(LocatorInfo locatorInfo, Reference reference) : base(locatorInfo, reference)
             {
             }
 
-            protected override void
-            send()
+            protected internal override void
+            Send()
             {
                 try
                 {
-                    _locatorInfo.getLocator().FindAdapterByIdAsync(_ref.getAdapterId()).ContinueWith(
+                    _locatorInfo.Locator.FindAdapterByIdAsync(_ref.getAdapterId()).ContinueWith(
                         (Task<IObjectPrx> p) =>
                         {
                             try
                             {
-                                response(p.Result);
+                                Response(p.Result);
                             }
-                            catch (System.AggregateException ex)
+                            catch (AggregateException ex)
                             {
-                                exception(ex.InnerException as Exception);
+                                Debug.Assert(ex.InnerException is Ice.Exception);
+                                Exception((Ice.Exception)ex.InnerException);
                             }
                         });
                 }
-                catch (Exception ex)
+                catch (Ice.Exception ex)
                 {
-                    exception(ex);
+                    Exception(ex);
                 }
             }
         }
 
         internal LocatorInfo(ILocatorPrx locator, LocatorTable table, bool background)
         {
-            _locator = locator;
+            Locator = locator;
             _table = table;
             _background = background;
         }
 
-        public void destroy()
+        public void Destroy()
         {
             lock (this)
             {
                 _locatorRegistry = null;
-                _table.clear();
+                _table.Clear();
             }
         }
 
@@ -268,24 +265,15 @@ namespace IceInternal
                 return true;
             }
 
-            LocatorInfo? rhs = obj as LocatorInfo;
-            return rhs == null ? false : _locator.Equals(rhs._locator);
+            return !(obj is LocatorInfo rhs) ? false : Locator.Equals(rhs.Locator);
         }
 
-        public override int GetHashCode()
-        {
-            return _locator.GetHashCode();
-        }
+        public override int GetHashCode() => Locator.GetHashCode();
 
-        public ILocatorPrx getLocator()
-        {
-            //
-            // No synchronization necessary, _locator is immutable.
-            //
-            return _locator;
-        }
+        // No synchronization necessary, _locator is immutable.
+        public ILocatorPrx Locator { get; set; }
 
-        public ILocatorRegistryPrx getLocatorRegistry()
+        public ILocatorRegistryPrx? GetLocatorRegistry()
         {
             lock (this)
             {
@@ -298,7 +286,7 @@ namespace IceInternal
             //
             // Do not make locator calls from within sync.
             //
-            ILocatorRegistryPrx locatorRegistry = _locator.GetRegistry();
+            ILocatorRegistryPrx locatorRegistry = Locator.GetRegistry();
             if (locatorRegistry == null)
             {
                 return null;
@@ -316,50 +304,48 @@ namespace IceInternal
             }
         }
 
-        public void
-        getEndpoints(Reference reference, int ttl, IGetEndpointsCallback callback)
-        {
-            getEndpoints(reference, null, ttl, callback);
-        }
+        public void GetEndpoints(Reference reference, int ttl, IGetEndpointsCallback callback) =>
+            GetEndpoints(reference, null, ttl, callback);
 
         public void
-        getEndpoints(Reference reference, Reference wellKnownRef, int ttl, IGetEndpointsCallback callback)
+        GetEndpoints(Reference reference, Reference? wellKnownRef, int ttl, IGetEndpointsCallback? callback)
         {
             Debug.Assert(reference.isIndirect());
-            Endpoint[] endpoints = null;
+            Endpoint[]? endpoints = null;
             bool cached;
             if (!reference.isWellKnown())
             {
-                endpoints = _table.getAdapterEndpoints(reference.getAdapterId(), ttl, out cached);
+                endpoints = _table.GetAdapterEndpoints(reference.getAdapterId(), ttl, out cached);
                 if (!cached)
                 {
                     if (_background && endpoints != null)
                     {
-                        getAdapterRequest(reference).addCallback(reference, wellKnownRef, ttl, null);
+                        GetAdapterRequest(reference).AddCallback(reference, wellKnownRef, ttl, null);
                     }
                     else
                     {
-                        getAdapterRequest(reference).addCallback(reference, wellKnownRef, ttl, callback);
+                        GetAdapterRequest(reference).AddCallback(reference, wellKnownRef, ttl, callback);
                         return;
                     }
                 }
             }
             else
             {
-                Reference r = _table.getObjectReference(reference.getIdentity(), ttl, out cached);
+                Reference? r = _table.GetObjectReference(reference.getIdentity(), ttl, out cached);
                 if (!cached)
                 {
                     if (_background && r != null)
                     {
-                        getObjectRequest(reference).addCallback(reference, null, ttl, null);
+                        GetObjectRequest(reference).AddCallback(reference, null, ttl, null);
                     }
                     else
                     {
-                        getObjectRequest(reference).addCallback(reference, null, ttl, callback);
+                        GetObjectRequest(reference).AddCallback(reference, null, ttl, callback);
                         return;
                     }
                 }
 
+                Debug.Assert(r != null);
                 if (!r.isIndirect())
                 {
                     endpoints = r.getEndpoints();
@@ -368,9 +354,9 @@ namespace IceInternal
                 {
                     if (reference.getCommunicator().TraceLevels.location >= 1)
                     {
-                        trace("found adapter for well-known object in locator cache", reference, r);
+                        Trace("found adapter for well-known object in locator cache", reference, r);
                     }
-                    getEndpoints(r, reference, ttl, callback);
+                    GetEndpoints(r, reference, ttl, callback);
                     return;
                 }
             }
@@ -378,51 +364,51 @@ namespace IceInternal
             Debug.Assert(endpoints != null);
             if (reference.getCommunicator().TraceLevels.location >= 1)
             {
-                getEndpointsTrace(reference, endpoints, true);
+                GetEndpointsTrace(reference, endpoints, true);
             }
             if (callback != null)
             {
-                callback.setEndpoints(endpoints, true);
+                callback.SetEndpoints(endpoints, true);
             }
         }
 
-        public void clearCache(Reference rf)
+        public void ClearCache(Reference rf)
         {
             Debug.Assert(rf.isIndirect());
             if (!rf.isWellKnown())
             {
-                Endpoint[] endpoints = _table.removeAdapterEndpoints(rf.getAdapterId());
+                Endpoint[]? endpoints = _table.RemoveAdapterEndpoints(rf.getAdapterId());
 
                 if (endpoints != null && rf.getCommunicator().TraceLevels.location >= 2)
                 {
-                    trace("removed endpoints for adapter from locator cache", rf, endpoints);
+                    Trace("removed endpoints for adapter from locator cache", rf, endpoints);
                 }
             }
             else
             {
-                Reference r = _table.removeObjectReference(rf.getIdentity());
+                Reference? r = _table.RemoveObjectReference(rf.getIdentity());
                 if (r != null)
                 {
                     if (!r.isIndirect())
                     {
                         if (rf.getCommunicator().TraceLevels.location >= 2)
                         {
-                            trace("removed endpoints for well-known object from locator cache", rf, r.getEndpoints());
+                            Trace("removed endpoints for well-known object from locator cache", rf, r.getEndpoints());
                         }
                     }
                     else if (!r.isWellKnown())
                     {
                         if (rf.getCommunicator().TraceLevels.location >= 2)
                         {
-                            trace("removed adapter for well-known object from locator cache", rf, r);
+                            Trace("removed adapter for well-known object from locator cache", rf, r);
                         }
-                        clearCache(r);
+                        ClearCache(r);
                     }
                 }
             }
         }
 
-        private void trace(string msg, Reference r, Endpoint[] endpoints)
+        private void Trace(string msg, Reference r, Endpoint[] endpoints)
         {
             System.Text.StringBuilder s = new System.Text.StringBuilder();
             s.Append(msg + "\n");
@@ -449,7 +435,7 @@ namespace IceInternal
             r.getCommunicator().Logger.trace(r.getCommunicator().TraceLevels.locationCat, s.ToString());
         }
 
-        private void trace(string msg, Reference r, Reference resolved)
+        private void Trace(string msg, Reference r, Reference resolved)
         {
             Debug.Assert(r.isWellKnown());
 
@@ -465,7 +451,7 @@ namespace IceInternal
             r.getCommunicator().Logger.trace(r.getCommunicator().TraceLevels.locationCat, s.ToString());
         }
 
-        private void getEndpointsException(Reference reference, System.Exception exc)
+        private void GetEndpointsException(Reference reference, System.Exception exc)
         {
             try
             {
@@ -473,7 +459,7 @@ namespace IceInternal
             }
             catch (AdapterNotFoundException ex)
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 if (communicator.TraceLevels.location >= 1)
                 {
                     System.Text.StringBuilder s = new System.Text.StringBuilder();
@@ -482,14 +468,15 @@ namespace IceInternal
                     communicator.Logger.trace(communicator.TraceLevels.locationCat, s.ToString());
                 }
 
-                NotRegisteredException e = new NotRegisteredException(ex);
-                e.kindOfObject = "object adapter";
-                e.id = reference.getAdapterId();
-                throw e;
+                throw new NotRegisteredException(ex)
+                {
+                    kindOfObject = "object adapter",
+                    id = reference.getAdapterId()
+                };
             }
             catch (ObjectNotFoundException ex)
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 if (communicator.TraceLevels.location >= 1)
                 {
                     System.Text.StringBuilder s = new System.Text.StringBuilder();
@@ -498,10 +485,11 @@ namespace IceInternal
                     communicator.Logger.trace(communicator.TraceLevels.locationCat, s.ToString());
                 }
 
-                NotRegisteredException e = new NotRegisteredException(ex);
-                e.kindOfObject = "object";
-                e.id = reference.getIdentity().ToString(communicator.ToStringMode);
-                throw e;
+                throw new NotRegisteredException(ex)
+                {
+                    kindOfObject = "object",
+                    id = reference.getIdentity().ToString(communicator.ToStringMode)
+                };
             }
             catch (NotRegisteredException)
             {
@@ -509,7 +497,7 @@ namespace IceInternal
             }
             catch (LocalException ex)
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 if (communicator.TraceLevels.location >= 1)
                 {
                     System.Text.StringBuilder s = new System.Text.StringBuilder();
@@ -533,7 +521,7 @@ namespace IceInternal
             }
         }
 
-        private void getEndpointsTrace(Reference reference, Endpoint[]? endpoints, bool cached)
+        private void GetEndpointsTrace(Reference reference, Endpoint[]? endpoints, bool cached)
         {
             if (endpoints != null && endpoints.Length > 0)
             {
@@ -541,30 +529,30 @@ namespace IceInternal
                 {
                     if (reference.isWellKnown())
                     {
-                        trace("found endpoints for well-known proxy in locator cache", reference, endpoints);
+                        Trace("found endpoints for well-known proxy in locator cache", reference, endpoints);
                     }
                     else
                     {
-                        trace("found endpoints for adapter in locator cache", reference, endpoints);
+                        Trace("found endpoints for adapter in locator cache", reference, endpoints);
                     }
                 }
                 else
                 {
                     if (reference.isWellKnown())
                     {
-                        trace("retrieved endpoints for well-known proxy from locator, adding to locator cache",
+                        Trace("retrieved endpoints for well-known proxy from locator, adding to locator cache",
                               reference, endpoints);
                     }
                     else
                     {
-                        trace("retrieved endpoints for adapter from locator, adding to locator cache",
+                        Trace("retrieved endpoints for adapter from locator, adding to locator cache",
                               reference, endpoints);
                     }
                 }
             }
             else
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 System.Text.StringBuilder s = new System.Text.StringBuilder();
                 s.Append("no endpoints configured for ");
                 if (reference.getAdapterId().Length > 0)
@@ -581,12 +569,11 @@ namespace IceInternal
             }
         }
 
-        private Request
-        getAdapterRequest(Reference reference)
+        private Request GetAdapterRequest(Reference reference)
         {
             if (reference.getCommunicator().TraceLevels.location >= 1)
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 System.Text.StringBuilder s = new System.Text.StringBuilder();
                 s.Append("searching for adapter by id\nadapter = ");
                 s.Append(reference.getAdapterId());
@@ -595,8 +582,7 @@ namespace IceInternal
 
             lock (this)
             {
-                Request request;
-                if (_adapterRequests.TryGetValue(reference.getAdapterId(), out request))
+                if (_adapterRequests.TryGetValue(reference.getAdapterId(), out Request request))
                 {
                     return request;
                 }
@@ -607,12 +593,11 @@ namespace IceInternal
             }
         }
 
-        private Request
-        getObjectRequest(Reference reference)
+        private Request GetObjectRequest(Reference reference)
         {
             if (reference.getCommunicator().TraceLevels.location >= 1)
             {
-                var communicator = reference.getCommunicator();
+                Communicator communicator = reference.getCommunicator();
                 System.Text.StringBuilder s = new System.Text.StringBuilder();
                 s.Append("searching for well-known object\nwell-known proxy = ");
                 s.Append(reference.ToString());
@@ -621,8 +606,7 @@ namespace IceInternal
 
             lock (this)
             {
-                Request request;
-                if (_objectRequests.TryGetValue(reference.getIdentity(), out request))
+                if (_objectRequests.TryGetValue(reference.getIdentity(), out Request request))
                 {
                     return request;
                 }
@@ -634,7 +618,7 @@ namespace IceInternal
         }
 
         private void
-        finishRequest(Reference reference, List<Reference> wellKnownRefs, IObjectPrx proxy, bool notRegistered)
+        FinishRequest(Reference reference, List<Reference> wellKnownRefs, IObjectPrx? proxy, bool notRegistered)
         {
             if (proxy == null || proxy.IceReference.isIndirect())
             {
@@ -644,7 +628,7 @@ namespace IceInternal
                 //
                 foreach (Reference r in wellKnownRefs)
                 {
-                    _table.removeObjectReference(r.getIdentity());
+                    _table.RemoveObjectReference(r.getIdentity());
                 }
             }
 
@@ -653,11 +637,11 @@ namespace IceInternal
                 if (proxy != null && !proxy.IceReference.isIndirect())
                 {
                     // Cache the adapter endpoints.
-                    _table.addAdapterEndpoints(reference.getAdapterId(), proxy.IceReference.getEndpoints());
+                    _table.AddAdapterEndpoints(reference.getAdapterId(), proxy.IceReference.getEndpoints());
                 }
                 else if (notRegistered) // If the adapter isn't registered anymore, remove it from the cache.
                 {
-                    _table.removeAdapterEndpoints(reference.getAdapterId());
+                    _table.RemoveAdapterEndpoints(reference.getAdapterId());
                 }
 
                 lock (this)
@@ -671,11 +655,11 @@ namespace IceInternal
                 if (proxy != null && !proxy.IceReference.isWellKnown())
                 {
                     // Cache the well-known object reference.
-                    _table.addObjectReference(reference.getIdentity(), proxy.IceReference);
+                    _table.AddObjectReference(reference.getIdentity(), proxy.IceReference);
                 }
                 else if (notRegistered) // If the well-known object isn't registered anymore, remove it from the cache.
                 {
-                    _table.removeObjectReference(reference.getIdentity());
+                    _table.RemoveObjectReference(reference.getIdentity());
                 }
 
                 lock (this)
@@ -686,39 +670,27 @@ namespace IceInternal
             }
         }
 
-        private readonly ILocatorPrx _locator;
         private ILocatorRegistryPrx? _locatorRegistry;
         private readonly LocatorTable _table;
         private readonly bool _background;
 
-        private Dictionary<string, Request> _adapterRequests = new Dictionary<string, Request>();
-        private Dictionary<Identity, Request> _objectRequests = new Dictionary<Identity, Request>();
+        private readonly Dictionary<string, Request> _adapterRequests = new Dictionary<string, Request>();
+        private readonly Dictionary<Identity, Request> _objectRequests = new Dictionary<Identity, Request>();
     }
 
-    public sealed class LocatorManager
+    public sealed partial class Communicator
     {
-        private struct LocatorKey
+        private readonly struct LocatorKey : IEquatable<LocatorKey>
         {
             public LocatorKey(ILocatorPrx prx)
             {
-                Reference r = prx.IceReference;
-                _id = r.getIdentity();
-                _encoding = r.getEncoding();
+                _id = prx.Identity;
+                _encoding = prx.EncodingVersion;
             }
 
-            public override bool Equals(object o)
-            {
-                LocatorKey k = (LocatorKey)o;
-                if (!k._id.Equals(_id))
-                {
-                    return false;
-                }
-                if (!k._encoding.Equals(_encoding))
-                {
-                    return false;
-                }
-                return true;
-            }
+            public bool Equals(LocatorKey other) => _id.Equals(other._id) && _encoding.Equals(other._encoding);
+
+            public override bool Equals(object obj) => (obj is LocatorKey other) && Equals(other);
 
             public override int GetHashCode()
             {
@@ -728,39 +700,18 @@ namespace IceInternal
                 return h;
             }
 
-            private Identity _id;
-            private EncodingVersion _encoding;
+            private readonly Identity _id;
+            private readonly EncodingVersion _encoding;
         }
-
-        internal LocatorManager(Communicator communicator)
-        {
-            _table = new Dictionary<ILocatorPrx, LocatorInfo>();
-            _locatorTables = new Dictionary<LocatorKey, LocatorTable>();
-            _background = communicator.GetPropertyAsInt("Ice.BackgroundLocatorCacheUpdates") > 0;
-        }
-
-        internal void destroy()
-        {
-            lock (this)
-            {
-                foreach (LocatorInfo info in _table.Values)
-                {
-                    info.destroy();
-                }
-                _table.Clear();
-                _locatorTables.Clear();
-            }
-        }
-
         //
         // Returns locator info for a given locator. Automatically creates
         // the locator info if it doesn't exist yet.
         //
-        public LocatorInfo get(ILocatorPrx loc)
+        internal LocatorInfo GetLocatorInfo(ILocatorPrx loc)
         {
             if (loc == null)
             {
-                throw new System.ArgumentNullException(nameof(loc));
+                throw new ArgumentNullException(nameof(loc));
             }
 
             //
@@ -771,46 +722,38 @@ namespace IceInternal
             //
             // TODO: reap unused locator info objects?
             //
-            lock (this)
+            lock (_locatorInfoMap)
             {
-                LocatorInfo info;
-                if (!_table.TryGetValue(locator, out info))
+                if (!_locatorInfoMap.TryGetValue(locator, out LocatorInfo info))
                 {
                     //
                     // Rely on locator identity for the adapter table. We want to
                     // have only one table per locator (not one per locator
                     // proxy).
                     //
-                    LocatorTable? table = null;
-                    LocatorKey key = new LocatorKey(locator);
-                    if (!_locatorTables.TryGetValue(key, out table))
+                    var key = new LocatorKey(locator);
+                    if (!_locatorTableMap.TryGetValue(key, out LocatorTable table))
                     {
                         table = new LocatorTable();
-                        _locatorTables[key] = table;
+                        _locatorTableMap[key] = table;
                     }
 
-                    info = new LocatorInfo(locator, table, _background);
-                    _table[locator] = info;
+                    info = new LocatorInfo(locator, table, _backgroundLocatorCacheUpdates);
+                    _locatorInfoMap[locator] = info;
                 }
 
                 return info;
             }
         }
 
-        private Dictionary<ILocatorPrx, LocatorInfo> _table;
-        private Dictionary<LocatorKey, LocatorTable> _locatorTables;
-        private readonly bool _background;
+        private readonly Dictionary<ILocatorPrx, LocatorInfo> _locatorInfoMap = new Dictionary<ILocatorPrx, LocatorInfo>();
+        private readonly Dictionary<LocatorKey, LocatorTable> _locatorTableMap = new Dictionary<LocatorKey, LocatorTable>();
+        private readonly bool _backgroundLocatorCacheUpdates;
     }
 
     internal sealed class LocatorTable
     {
-        internal LocatorTable()
-        {
-            _adapterEndpointsTable = new Dictionary<string, EndpointTableEntry>();
-            _objectTable = new Dictionary<Identity, ReferenceTableEntry>();
-        }
-
-        internal void clear()
+        internal void Clear()
         {
             lock (this)
             {
@@ -819,7 +762,7 @@ namespace IceInternal
             }
         }
 
-        internal Endpoint[] getAdapterEndpoints(string adapter, int ttl, out bool cached)
+        internal Endpoint[]? GetAdapterEndpoints(string adapter, int ttl, out bool cached)
         {
             if (ttl == 0) // Locator cache disabled.
             {
@@ -829,11 +772,10 @@ namespace IceInternal
 
             lock (this)
             {
-                EndpointTableEntry entry = null;
-                if (_adapterEndpointsTable.TryGetValue(adapter, out entry))
+                if (_adapterEndpointsTable.TryGetValue(adapter, out (long Time, Endpoint[] Endpoints) entry))
                 {
-                    cached = checkTTL(entry.time, ttl);
-                    return entry.endpoints;
+                    cached = CheckTTL(entry.Time, ttl);
+                    return entry.Endpoints;
 
                 }
                 cached = false;
@@ -841,30 +783,28 @@ namespace IceInternal
             }
         }
 
-        internal void addAdapterEndpoints(string adapter, Endpoint[] endpoints)
+        internal void AddAdapterEndpoints(string adapter, Endpoint[] endpoints)
         {
             lock (this)
             {
-                _adapterEndpointsTable[adapter] =
-                    new EndpointTableEntry(Time.currentMonotonicTimeMillis(), endpoints);
+                _adapterEndpointsTable[adapter] = (Time.currentMonotonicTimeMillis(), endpoints);
             }
         }
 
-        internal Endpoint[] removeAdapterEndpoints(string adapter)
+        internal Endpoint[]? RemoveAdapterEndpoints(string adapter)
         {
             lock (this)
             {
-                EndpointTableEntry entry = null;
-                if (_adapterEndpointsTable.TryGetValue(adapter, out entry))
+                if (_adapterEndpointsTable.TryGetValue(adapter, out (long Time, Endpoint[] Endpoints) entry))
                 {
                     _adapterEndpointsTable.Remove(adapter);
-                    return entry.endpoints;
+                    return entry.Endpoints;
                 }
                 return null;
             }
         }
 
-        internal Reference getObjectReference(Identity id, int ttl, out bool cached)
+        internal Reference? GetObjectReference(Identity id, int ttl, out bool cached)
         {
             if (ttl == 0) // Locator cache disabled.
             {
@@ -874,40 +814,38 @@ namespace IceInternal
 
             lock (this)
             {
-                ReferenceTableEntry entry = null;
-                if (_objectTable.TryGetValue(id, out entry))
+                if (_objectTable.TryGetValue(id, out (long Time, Reference Reference) entry))
                 {
-                    cached = checkTTL(entry.time, ttl);
-                    return entry.reference;
+                    cached = CheckTTL(entry.Time, ttl);
+                    return entry.Reference;
                 }
                 cached = false;
                 return null;
             }
         }
 
-        internal void addObjectReference(Identity id, Reference reference)
+        internal void AddObjectReference(Identity id, Reference reference)
         {
             lock (this)
             {
-                _objectTable[id] = new ReferenceTableEntry(Time.currentMonotonicTimeMillis(), reference);
+                _objectTable[id] = (Time.currentMonotonicTimeMillis(), reference);
             }
         }
 
-        internal Reference removeObjectReference(Identity id)
+        internal Reference? RemoveObjectReference(Identity id)
         {
             lock (this)
             {
-                ReferenceTableEntry entry = null;
-                if (_objectTable.TryGetValue(id, out entry))
+                if (_objectTable.TryGetValue(id, out (long Time, Reference Reference) entry))
                 {
                     _objectTable.Remove(id);
-                    return entry.reference;
+                    return entry.Reference;
                 }
                 return null;
             }
         }
 
-        private bool checkTTL(long time, int ttl)
+        private bool CheckTTL(long time, int ttl)
         {
             Debug.Assert(ttl != 0);
             if (ttl < 0) // TTL = infinite
@@ -920,32 +858,22 @@ namespace IceInternal
             }
         }
 
-        private sealed class EndpointTableEntry
+        private readonly struct TableEntry<T>
         {
-            public EndpointTableEntry(long time, Endpoint[] endpoints)
+            public TableEntry(long time, T value)
             {
-                this.time = time;
-                this.endpoints = endpoints;
+                Time = time;
+                Value = value;
             }
 
-            public long time;
-            public Endpoint[] endpoints;
+            public readonly long Time;
+            public readonly T Value;
         }
 
-        private sealed class ReferenceTableEntry
-        {
-            public ReferenceTableEntry(long time, Reference reference)
-            {
-                this.time = time;
-                this.reference = reference;
-            }
-
-            public long time;
-            public Reference reference;
-        }
-
-        private Dictionary<string, EndpointTableEntry> _adapterEndpointsTable;
-        private Dictionary<Identity, ReferenceTableEntry> _objectTable;
+        private readonly Dictionary<string, (long Time, Endpoint[] Endpoints)> _adapterEndpointsTable =
+            new Dictionary<string, (long Time, Endpoint[] Endpoints)>();
+        private readonly Dictionary<Identity, (long Time, Reference Reference)> _objectTable =
+            new Dictionary<Identity, (long Time, Reference Reference)>();
     }
 
 }

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -780,7 +780,7 @@ namespace IceInternal
                 {
                     IPAddress addr = IPAddress.Parse(host);
                     if ((addr.AddressFamily == AddressFamily.InterNetwork && protocol != EnableIPv6) ||
-                       (addr.AddressFamily == AddressFamily.InterNetworkV6 && protocol != EnableIPv4))
+                        (addr.AddressFamily == AddressFamily.InterNetworkV6 && protocol != EnableIPv4))
                     {
                         addresses.Add(new IPEndPoint(addr, port));
                         return addresses;

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -422,7 +422,7 @@ namespace IceInternal
                 // the retry interval is 0. This method can be called with the
                 // connection locked so we can't just retry here.
                 //
-                communicator_.RetryQueue().add(this, proxy_.IceHandleException(exc, handler_, mode_, _sent, ref _cnt));
+                communicator_.AddRetryTask(this, proxy_.IceHandleException(exc, handler_, mode_, _sent, ref _cnt));
                 return false;
             }
             catch (Ice.Exception ex)
@@ -455,7 +455,7 @@ namespace IceInternal
                 // connection to be done.
                 //
                 proxy_.IceUpdateRequestHandler(handler_, null); // Clear request handler and always retry.
-                communicator_.RetryQueue().add(this, 0);
+                communicator_.AddRetryTask(this, 0);
             }
             catch (Ice.Exception ex)
             {
@@ -559,7 +559,7 @@ namespace IceInternal
                         int interval = proxy_.IceHandleException(ex, handler_, mode_, _sent, ref _cnt);
                         if (interval > 0)
                         {
-                            communicator_.RetryQueue().add(this, interval);
+                            communicator_.AddRetryTask(this, interval);
                             return;
                         }
                         else if (observer_ != null)

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -30,9 +30,9 @@ namespace Ice
     {
         public static void RegisterPluginFactory(string name, IPluginFactory factory, bool loadOnInit)
         {
-            if (!_factories.ContainsKey(name))
+            if (!_pluginFactories.ContainsKey(name))
             {
-                _factories[name] = factory;
+                _pluginFactories[name] = factory;
                 if (loadOnInit)
                 {
                     _loadOnInitialization.Add(name);
@@ -42,7 +42,7 @@ namespace Ice
 
         public void InitializePlugins()
         {
-            if (_initialized)
+            if (_pluginsInitialized)
             {
                 InitializationException ex = new InitializationException();
                 ex.reason = "plug-ins already initialized";
@@ -82,7 +82,7 @@ namespace Ice
                 throw;
             }
 
-            _initialized = true;
+            _pluginsInitialized = true;
         }
 
         public string[] GetPlugins()
@@ -321,7 +321,7 @@ namespace Ice
             // property value.
             //
             IPluginFactory? pluginFactory;
-            if (!_factories.TryGetValue(name, out pluginFactory))
+            if (!_pluginFactories.TryGetValue(name, out pluginFactory))
             {
                 //
                 // Extract the assembly name and the class name.
@@ -421,9 +421,9 @@ namespace Ice
         }
 
         private readonly List<(string Name, IPlugin Plugin)> _plugins = new List<(string Name, IPlugin Plugin)>();
-        private bool _initialized;
+        private bool _pluginsInitialized;
 
-        private static Dictionary<string, IPluginFactory> _factories = new Dictionary<string, IPluginFactory>();
+        private static Dictionary<string, IPluginFactory> _pluginFactories = new Dictionary<string, IPluginFactory>();
         private static List<string> _loadOnInitialization = new List<string>();
     }
 }

--- a/csharp/src/Ice/ProtocolInstance.cs
+++ b/csharp/src/Ice/ProtocolInstance.cs
@@ -35,10 +35,10 @@ namespace IceInternal
         public int MessageSizeMax => Communicator.MessageSizeMax;
         public INetworkProxy? NetworkProxy => Communicator.NetworkProxy;
 
-        public IEndpointFactory? GetEndpointFactory(short type) => Communicator.EndpointFactoryManager().get(type);
+        public IEndpointFactory? GetEndpointFactory(short type) => Communicator.GetEndpointFactory(type);
         public void Resolve(string host, int port, Ice.EndpointSelectionType type, IPEndpoint endpt,
                             IEndpointConnectors callback) =>
-            Communicator.EndpointHostResolver().resolve(host, port, type, endpt, callback);
+            Communicator.Resolve(host, port, type, endpt, callback);
         public void setSndBufSizeWarn(short type, int size) => Communicator.SetSndBufSizeWarn(type, size);
         public void setRcvBufSizeWarn(short type, int size) => Communicator.SetRcvBufSizeWarn(type, size);
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -437,7 +437,7 @@ namespace Ice
         {
             get
             {
-                return IceReference.getRouterInfo()?.getRouter();
+                return IceReference.getRouterInfo()?.Router;
             }
         }
 
@@ -449,7 +449,7 @@ namespace Ice
         {
             get
             {
-                return IceReference.getLocatorInfo()?.getLocator();
+                return IceReference.getLocatorInfo()?.Locator;
             }
         }
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1147,14 +1147,14 @@ namespace IceInternal
 
             if (encodingVersion is EncodingVersion encodingVersionValue)
             {
-                if (_locatorInfo != null && !_locatorInfo.getLocator().EncodingVersion.Equals(encodingVersionValue))
+                if (_locatorInfo != null && !_locatorInfo.Locator.EncodingVersion.Equals(encodingVersionValue))
                 {
                     if (reference == this)
                     {
                         reference = (RoutableReference)Clone();
                     }
-                    reference._locatorInfo = _communicator.LocatorManager().get(
-                        _locatorInfo.getLocator().Clone(encodingVersion: encodingVersionValue));
+                    reference._locatorInfo = _communicator.GetLocatorInfo(
+                        _locatorInfo.Locator.Clone(encodingVersion: encodingVersionValue));
                 }
             }
 
@@ -1179,7 +1179,7 @@ namespace IceInternal
 
             if (locator != null)
             {
-                LocatorInfo locatorInfo = _communicator.LocatorManager().get(locator);
+                LocatorInfo locatorInfo = _communicator.GetLocatorInfo(locator);
                 if (!locatorInfo.Equals(_locatorInfo))
                 {
                     if (reference == this)
@@ -1223,7 +1223,7 @@ namespace IceInternal
 
             if (router != null)
             {
-                RouterInfo routerInfo = _communicator.RouterManager().get(router);
+                RouterInfo routerInfo = _communicator.GetRouterInfo(router);
                 if (!routerInfo.Equals(_routerInfo))
                 {
                     if (reference == this)
@@ -1346,8 +1346,7 @@ namespace IceInternal
 
             if (_routerInfo != null)
             {
-                var h = _routerInfo.getRouter();
-                Dictionary<string, string> routerProperties = h.IceReference.ToProperty(prefix + ".Router");
+                Dictionary<string, string> routerProperties = _routerInfo.Router.IceReference.ToProperty(prefix + ".Router");
                 foreach (KeyValuePair<string, string> entry in routerProperties)
                 {
                     properties[entry.Key] = entry.Value;
@@ -1356,8 +1355,7 @@ namespace IceInternal
 
             if (_locatorInfo != null)
             {
-                var h = _locatorInfo.getLocator();
-                Dictionary<string, string> locatorProperties = h.IceReference.ToProperty(prefix + ".Locator");
+                Dictionary<string, string> locatorProperties = _locatorInfo.Locator.IceReference.ToProperty(prefix + ".Locator");
                 foreach (KeyValuePair<string, string> entry in locatorProperties)
                 {
                     properties[entry.Key] = entry.Value;
@@ -1484,7 +1482,7 @@ namespace IceInternal
 
         public override IRequestHandler getRequestHandler(IObjectPrx proxy)
         {
-            return _communicator.RequestHandlerFactory().getRequestHandler(this, proxy);
+            return _communicator.GetRequestHandler(this, proxy);
         }
 
         public void getConnection(GetConnectionCallback callback)
@@ -1495,7 +1493,7 @@ namespace IceInternal
                 // If we route, we send everything to the router's client
                 // proxy endpoints.
                 //
-                _routerInfo.getClientEndpoints(new RouterEndpointsCallback(this, callback));
+                _routerInfo.GetClientEndpoints(new RouterEndpointsCallback(this, callback));
             }
             else
             {
@@ -1511,7 +1509,7 @@ namespace IceInternal
                 _cb = cb;
             }
 
-            public void setEndpoints(Endpoint[] endpoints, bool cached)
+            public void SetEndpoints(Endpoint[] endpoints, bool cached)
             {
                 if (endpoints.Length == 0)
                 {
@@ -1522,7 +1520,7 @@ namespace IceInternal
                 _ir.createConnection(_ir.applyOverrides(endpoints), new ConnectionCallback(_ir, _cb, cached));
             }
 
-            public void setException(LocalException ex)
+            public void SetException(LocalException ex)
             {
                 _cb.setException(ex);
             }
@@ -1558,7 +1556,7 @@ namespace IceInternal
                 catch (LocalException ex)
                 {
                     Debug.Assert(_ir._locatorInfo != null);
-                    _ir._locatorInfo.clearCache(_ir);
+                    _ir._locatorInfo.ClearCache(_ir);
                     if (_cached)
                     {
                         TraceLevels traceLevels = _ir._communicator.TraceLevels;
@@ -1589,7 +1587,7 @@ namespace IceInternal
 
             if (_locatorInfo != null)
             {
-                _locatorInfo.getEndpoints(this, _locatorCacheTimeout, new LocatorEndpointsCallback(this, callback));
+                _locatorInfo.GetEndpoints(this, _locatorCacheTimeout, new LocatorEndpointsCallback(this, callback));
             }
             else
             {
@@ -1793,9 +1791,9 @@ namespace IceInternal
                 // (if any) to the new connection, so that callbacks from the
                 // router can be received over this new connection.
                 //
-                if (_rr._routerInfo != null && _rr._routerInfo.getAdapter() != null)
+                if (_rr._routerInfo != null && _rr._routerInfo.Adapter != null)
                 {
-                    connection.SetAdapter(_rr._routerInfo.getAdapter());
+                    connection.SetAdapter(_rr._routerInfo.Adapter);
                 }
                 _callback.setConnection(connection, compress);
             }

--- a/csharp/src/Ice/ThreadPool.cs
+++ b/csharp/src/Ice/ThreadPool.cs
@@ -565,7 +565,7 @@ namespace IceInternal
                                                {
                                                    try
                                                    {
-                                                       _communicator.ObjectAdapterFactory().shutdown();
+                                                       _communicator.Shutdown();
                                                    }
                                                    catch (Ice.CommunicatorDestroyedException)
                                                    {

--- a/csharp/src/Ice/Timer.cs
+++ b/csharp/src/Ice/Timer.cs
@@ -8,12 +8,12 @@
 // scheduling and cancelling timers.
 //
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
 namespace IceInternal
 {
-    using System.Diagnostics;
-    using System.Threading;
-    using System.Collections.Generic;
-
     public interface ITimerTask
     {
         void RunTimerTask();

--- a/csharp/src/IceSSL/Plugin.cs
+++ b/csharp/src/IceSSL/Plugin.cs
@@ -74,7 +74,7 @@ namespace IceSSL
             // SSL based on TCP
             //
             Instance instance = new Instance(_engine, SSLEndpointType.value, "ssl");
-            facade.addEndpointFactory(new EndpointFactoryI(instance, Ice.TCPEndpointType.value));
+            facade.AddEndpointFactory(new EndpointFactoryI(instance, TCPEndpointType.value));
         }
 
         public void initialize()

--- a/csharp/src/IceSSL/SSLEngine.cs
+++ b/csharp/src/IceSSL/SSLEngine.cs
@@ -16,7 +16,7 @@ namespace IceSSL
     {
         internal SSLEngine(IceInternal.IProtocolPluginFacade facade)
         {
-            _communicator = facade.getCommunicator();
+            _communicator = facade.Communicator;
             _logger = _communicator.Logger;
             _facade = facade;
             _securityTraceLevel = _communicator.GetPropertyAsInt("IceSSL.Trace.Security") ?? 0;
@@ -105,7 +105,7 @@ namespace IceSSL
                     throw new InvalidOperationException("IceSSL: certificate verifier already installed");
                 }
 
-                Type cls = _facade.findType(certVerifierClass);
+                Type? cls = _facade.FindType(certVerifierClass);
                 if (cls == null)
                 {
                     throw new InvalidOperationException(
@@ -140,7 +140,7 @@ namespace IceSSL
                     throw new InvalidOperationException("IceSSL: password callback already installed");
                 }
 
-                Type cls = _facade.findType(passwordCallbackClass);
+                Type? cls = _facade.FindType(passwordCallbackClass);
                 if (cls == null)
                 {
                     throw new InvalidOperationException(
@@ -409,7 +409,7 @@ namespace IceSSL
 
         internal Ice.Communicator communicator()
         {
-            return _facade.getCommunicator();
+            return _facade.Communicator;
         }
 
         internal int securityTraceLevel()

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -390,7 +390,7 @@ public class Client : Test.TestHelper
                 IObjectPrx.Parse("dummy", session.communicator());
                 test(false);
             }
-            catch (Ice.CommunicatorDestroyedException)
+            catch (CommunicatorDestroyedException)
             {
             }
             Console.Out.WriteLine("ok");

--- a/csharp/test/Ice/background/PluginI.cs
+++ b/csharp/test/Ice/background/PluginI.cs
@@ -11,10 +11,10 @@ internal class Plugin : Ice.IPlugin
         IceInternal.IProtocolPluginFacade facade = IceInternal.Util.getProtocolPluginFacade(_communicator);
         for (short s = 0; s < 100; ++s)
         {
-            IceInternal.IEndpointFactory factory = facade.getEndpointFactory(s);
+            IceInternal.IEndpointFactory? factory = facade.GetEndpointFactory(s);
             if (factory != null)
             {
-                facade.addEndpointFactory(new EndpointFactory(factory));
+                facade.AddEndpointFactory(new EndpointFactory(factory));
             }
         }
     }


### PR DESCRIPTION
Merge some classes that were only used by Communicator into Communicator definition

- EndpointHostResolverThread
- LocatorManager
- ObjectAdapterFactory
- RequestHandlerFactory
- RetryQueue
- RouterManager

There is also `OutgoingConnectionFactory` that we can merge in but I didn't, the connection factory class has a large set of methods, we will need to rename most of this methods, for example communicator.RemoveAdapter will be confusing at to what it does.