### PR TITLE
Rework servant dispatch

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2649,12 +2649,18 @@ Slice::Gen::DispatcherVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << "global::System.Threading.Tasks.Task<global::Ice.OutputStream?>? "
         << getUnqualified("Ice.IObject", ns)
         << ".Dispatch(global::IceInternal.Incoming incoming, global::Ice.Current current)";
-    _out << sb;
+    _out.inc();
+    _out << nl << " => Dispatch(this, incoming, current);";
+    _out.dec();
 
+    _out << sp;
+    _out << nl << "protected static global::System.Threading.Tasks.Task<global::Ice.OutputStream?>? "
+        << "Dispatch(" << fixId(name) << " servant, "
+        << "global::IceInternal.Incoming incoming, global::Ice.Current current)";
+    _out << sb;
     _out << nl << "incoming.StartOver();";
     _out << nl << "switch(current.Operation)";
     _out << sb;
-
     StringList allOpNames;
     allOpNames.push_back("ice_id");
     allOpNames.push_back("ice_ids");
@@ -2665,7 +2671,7 @@ Slice::Gen::DispatcherVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         _out << nl << "case \"" << opName << "\":";
         _out << sb;
-        _out << nl << "return (this as " << getUnqualified("Ice.IObjectOperations", ns)
+        _out << nl << "return (servant as " << getUnqualified("Ice.IObjectOperations", ns)
              << " ?? _defaultObjectOperations).IceD_" << opName << "(incoming, current);";
         _out << eb;
     }
@@ -2677,7 +2683,7 @@ Slice::Gen::DispatcherVisitor::visitClassDefStart(const ClassDefPtr& p)
         _out << sb;
         _out << nl << "return " << getUnqualified(getNamespace(cl) + "." + interfaceName(cl), ns)
              << ".IceD_" << operationName(op)
-             << "(this, incoming, current);";
+             << "(servant, incoming, current);";
         _out << eb;
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2963,7 +2963,7 @@ Slice::Gen::DispatcherVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out << nl << "=> " << fixId(name) << ".IceDispatch(servant, incoming, current);";
     _out.dec();
 
-    // ObjectAdapter extension methods to Add a servant dispatcher
+    // ObjectAdapter extension methods to Add a servant
     string oa = getUnqualified("Ice.ObjectAdapter", ns);
 
     _out << sp;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2680,7 +2680,6 @@ Slice::Gen::DispatcherVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     for(const auto& op : p->allOperations())
     {
-        ClassDefPtr cl = ClassDefPtr::dynamicCast(op->container());
         _out << nl << "case \"" << op->name() << "\":";
         _out << sb;
         _out << nl << "return servant.IceD_" << op->name() << "(incoming, current);";

--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -147,7 +147,8 @@ namespace Glacier2
                     throw new SessionNotExistException();
                 }
                 Debug.Assert(_category != null);
-                return InternalObjectAdapter().Add(servant, new Ice.Identity(Guid.NewGuid().ToString(), _category));
+                return InternalObjectAdapter().Add(servant, IObjectPrx.Factory,
+                    new Ice.Identity(Guid.NewGuid().ToString(), _category));
             }
         }
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -3,7 +3,6 @@
 //
 
 using IceInternal;
-using IceMX; // for generated extensions
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -1466,7 +1465,7 @@ namespace Ice
                     throw new CommunicatorDestroyedException();
                 }
 
-                if (!_adminFacets.TryGetValue(facet, out var result))
+                if (!_adminFacets.TryGetValue(facet, out IObject result))
                 {
                     return null;
                 }
@@ -1642,7 +1641,7 @@ namespace Ice
                     throw new CommunicatorDestroyedException();
                 }
 
-                if (!_adminFacets.TryGetValue(facet, out var result))
+                if (!_adminFacets.TryGetValue(facet, out IObject result))
                 {
                     throw new NotRegisteredException("facet", facet);
                 }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -101,8 +101,7 @@ namespace Ice
         private ObjectAdapter? _adminAdapter;
         private readonly bool _adminEnabled = false;
         private readonly HashSet<string> _adminFacetFilter = new HashSet<string>();
-        private readonly Dictionary<string, (object servant, Disp disp)> _adminFacets =
-            new Dictionary<string, (object servant, Disp disp)>();
+        private readonly Dictionary<string, IObject> _adminFacets = new Dictionary<string, IObject>();
         private Identity? _adminIdentity;
         private AsyncIOThread? _asyncIOThread;
         private readonly IceInternal.ThreadPool _clientThreadPool;
@@ -463,9 +462,7 @@ namespace Ice
                     string processFacetName = "Process";
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(processFacetName))
                     {
-                        IProcess process = new IceInternal.Process(this);
-                        Disp disp = process.Dispatch;
-                        _adminFacets.Add(processFacetName, (process, disp));
+                        _adminFacets.Add(processFacetName, new IceInternal.Process(this));
                     }
 
                     //
@@ -476,9 +473,7 @@ namespace Ice
                     {
                         ILoggerAdminLogger loggerAdminLogger = new LoggerAdminLogger(this, Logger);
                         Logger = loggerAdminLogger;
-                        ILoggerAdmin servant = loggerAdminLogger.GetFacet();
-                        Disp disp = servant.Dispatch;
-                        _adminFacets.Add(loggerFacetName, (servant, disp));
+                        _adminFacets.Add(loggerFacetName, loggerAdminLogger.GetFacet());
                     }
 
                     //
@@ -488,9 +483,7 @@ namespace Ice
                     PropertiesAdmin? propsAdmin = null;
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(propertiesFacetName))
                     {
-                        propsAdmin = new PropertiesAdmin(this);
-                        Disp disp = propsAdmin.Dispatch;
-                        _adminFacets.Add(propertiesFacetName, (propsAdmin, disp));
+                        _adminFacets.Add(propertiesFacetName, new PropertiesAdmin(this));
                     }
 
                     //
@@ -501,9 +494,7 @@ namespace Ice
                     {
                         var communicatorObserver = new CommunicatorObserverI(this, Logger);
                         Observer = communicatorObserver;
-                        MetricsAdminI metricsAdmin = communicatorObserver.GetFacet();
-                        Disp disp = metricsAdmin.Dispatch;
-                        _adminFacets.Add(metricsFacetName, (metricsAdmin, disp));
+                        _adminFacets.Add(metricsFacetName, communicatorObserver.GetFacet());
 
                         //
                         // Make sure the admin plugin receives property updates.
@@ -617,7 +608,7 @@ namespace Ice
             }
         }
 
-        public void AddAdminFacet(object servant, Disp disp, string facet)
+        public void AddAdminFacet(IObject servant, string facet)
         {
             lock (this)
             {
@@ -635,11 +626,11 @@ namespace Ice
                 {
                     throw new ArgumentException($"A facet `{facet}' is already registered", nameof(facet));
                 }
-                _adminFacets.Add(facet, (servant, disp));
+                _adminFacets.Add(facet, servant);
                 if (_adminAdapter != null)
                 {
-                    Debug.Assert(_adminIdentity != null); // TODO: check
-                    _adminAdapter.Add(disp, _adminIdentity.Value, facet);
+                    Debug.Assert(_adminIdentity != null); // TODO: check it's true
+                    _adminAdapter.Add(servant, _adminIdentity.Value, facet);
                 }
             }
         }
@@ -1465,7 +1456,7 @@ namespace Ice
         /// </param>
         /// <returns>The servant associated with this Admin facet, or
         /// null if no facet is registered with the given name.</returns>
-        public (object servant, Disp disp) FindAdminFacet(string facet)
+        public IObject? FindAdminFacet(string facet)
         {
             lock (this)
             {
@@ -1474,9 +1465,9 @@ namespace Ice
                     throw new CommunicatorDestroyedException();
                 }
 
-                if (!_adminFacets.TryGetValue(facet, out (object servant, Disp disp) result))
+                if (!_adminFacets.TryGetValue(facet, out var result))
                 {
-                    return default;
+                    return null;
                 }
                 return result;
             }
@@ -1489,7 +1480,7 @@ namespace Ice
         /// servants of the Admin object.
         ///
         /// </returns>
-        public Dictionary<string, (object servant, Disp disp)> FindAllAdminFacets()
+        public Dictionary<string, IObject> FindAllAdminFacets()
         {
             lock (this)
             {
@@ -1497,7 +1488,7 @@ namespace Ice
                 {
                     throw new CommunicatorDestroyedException();
                 }
-                return new Dictionary<string, (object servant, Disp disp)>(_adminFacets);
+                return new Dictionary<string, IObject>(_adminFacets); // TODO, return a read-only collection
             }
         }
 
@@ -1641,7 +1632,7 @@ namespace Ice
         /// <param name="facet">The name of the Admin facet.
         /// </param>
         /// <returns>The servant associated with this Admin facet.</returns>
-        public (object servant, Disp disp) RemoveAdminFacet(string facet)
+        public IObject? RemoveAdminFacet(string facet)
         {
             lock (this)
             {
@@ -1650,7 +1641,7 @@ namespace Ice
                     throw new CommunicatorDestroyedException();
                 }
 
-                if (!_adminFacets.TryGetValue(facet, out (object servant, Disp disp) result))
+                if (!_adminFacets.TryGetValue(facet, out var result))
                 {
                     throw new NotRegisteredException("facet", facet);
                 }
@@ -2285,12 +2276,12 @@ namespace Ice
             lock (this)
             {
                 Debug.Assert(_adminAdapter != null);
-                foreach (KeyValuePair<string, (object servant, Disp disp)> entry in _adminFacets)
+                foreach (KeyValuePair<string, IObject> entry in _adminFacets)
                 {
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(entry.Key))
                     {
                         Debug.Assert(_adminIdentity != null); // TODO: check
-                        _adminAdapter.Add(entry.Value.disp, _adminIdentity.Value, entry.Key);
+                        _adminAdapter.Add(entry.Value, _adminIdentity.Value, entry.Key);
                     }
                 }
             }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -483,7 +483,8 @@ namespace Ice
                     PropertiesAdmin? propsAdmin = null;
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(propertiesFacetName))
                     {
-                        _adminFacets.Add(propertiesFacetName, new PropertiesAdmin(this));
+                        propsAdmin = new PropertiesAdmin(this);
+                        _adminFacets.Add(propertiesFacetName, propsAdmin);
                     }
 
                     //

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -3,6 +3,7 @@
 //
 
 using IceInternal;
+using IceMX; // for generated extensions
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -463,7 +464,7 @@ namespace Ice
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(processFacetName))
                     {
                         IProcess process = new IceInternal.Process(this);
-                        Disp disp = (current, incoming) => IProcess.Dispatch(process, current, incoming);
+                        Disp disp = process.Dispatch;
                         _adminFacets.Add(processFacetName, (process, disp));
                     }
 
@@ -476,7 +477,7 @@ namespace Ice
                         ILoggerAdminLogger loggerAdminLogger = new LoggerAdminLogger(this, Logger);
                         Logger = loggerAdminLogger;
                         ILoggerAdmin servant = loggerAdminLogger.GetFacet();
-                        Disp disp = (incoming, current) => ILoggerAdmin.Dispatch(servant, incoming, current);
+                        Disp disp = servant.Dispatch;
                         _adminFacets.Add(loggerFacetName, (servant, disp));
                     }
 
@@ -488,7 +489,7 @@ namespace Ice
                     if (_adminFacetFilter.Count == 0 || _adminFacetFilter.Contains(propertiesFacetName))
                     {
                         propsAdmin = new PropertiesAdmin(this);
-                        Disp disp = (current, incoming) => IPropertiesAdmin.Dispatch(propsAdmin, current, incoming);
+                        Disp disp = propsAdmin.Dispatch;
                         _adminFacets.Add(propertiesFacetName, (propsAdmin, disp));
                     }
 
@@ -501,8 +502,7 @@ namespace Ice
                         var communicatorObserver = new CommunicatorObserverI(this, Logger);
                         Observer = communicatorObserver;
                         MetricsAdminI metricsAdmin = communicatorObserver.GetFacet();
-                        Disp disp = (current, incoming) =>
-                                        IceMX.IMetricsAdmin.Dispatch(metricsAdmin, current, incoming);
+                        Disp disp = metricsAdmin.Dispatch;
                         _adminFacets.Add(metricsFacetName, (metricsAdmin, disp));
 
                         //
@@ -615,21 +615,6 @@ namespace Ice
                 Destroy();
                 throw;
             }
-        }
-
-        /// <summary>
-        /// Add a new facet to the Admin object.
-        /// Adding a servant with a facet that is already registered
-        /// throws AlreadyRegisteredException.
-        ///
-        /// </summary>
-        /// <param name="servant">The servant that implements the new Admin facet.
-        /// </param>
-        /// <param name="facet">The name of the new Admin facet.</param>
-        public void AddAdminFacet<T>(T servant, string facet, ServantDispatch<T> servantDispatch)
-        {
-            Disp disp = (incoming, current) => servantDispatch(servant, incoming, current);
-            AddAdminFacet(servant, disp, facet);
         }
 
         public void AddAdminFacet(object servant, Disp disp, string facet)

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -955,14 +955,15 @@ namespace Ice
         /// from the client.
         ///
         /// </summary>
-        /// <param name="id">The identity for which a proxy is to be created.
+        /// <param name="identity">The identity for which a proxy is to be created.
         ///
         /// </param>
         /// <returns>A proxy that matches the given identity and uses this
         /// connection.
         ///
         /// </returns>
-        public IObjectPrx CreateProxy(Identity id) => new ObjectPrx(_communicator.CreateReference(id, this));
+        public T CreateProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx
+            => factory(_communicator.CreateReference(identity, this));
 
         public void SetAdapterAndServantManager(ObjectAdapter adapter, ServantManager servantManager)
         {

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -193,7 +193,7 @@ namespace Ice
         public abstract Task<Ice.Object_Ice_invokeResult> IceInvokeAsync(byte[] inEncaps, Current current);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Task<OutputStream> Dispatch(Incoming incoming, Current current)
+        public Task<OutputStream?>? Dispatch(Incoming incoming, Current current)
         {
             incoming.StartOver();
             byte[] inEncaps = incoming.ReadParamEncaps();

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -5,6 +5,7 @@
 using IceInternal;
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Ice
@@ -27,7 +28,8 @@ namespace Ice
         // See Dispatcher.
         public Task<OutputStream?>? Dispatch(Incoming inS, Current current)
         {
-            // TODO: should we implement a real dispatch with an ObjectOperations<IObject>?
+            // TODO: switch to abstract method
+            Debug.Assert(false);
             return null;
         }
 

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -197,10 +197,6 @@ namespace Ice
         }
     }
 
-    public interface IInterfaceTraits<T>
-    {
-        Task<OutputStream?>? Dispatch(T servant, Incoming incoming, Current current);
-    }
     public class Object<T> : IObject
     {
         private static readonly string _typeId = typeof(T).GetIceTypeId()!;

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -406,7 +406,7 @@ namespace Ice
         /// AlreadyRegisteredException.</summary>
         /// <param name="dispatcher">The dispatcher to add.</param>
         /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
-        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
+        /// pass INamePrx.Factory for this parameter. See <see cref="CreateProxy"/>.</param>
         /// <param name="identity">The identity of the Ice object that is handled by the dispatcher. When null, the
         /// ObjectAdapter creates a new unique identity with a UUID name and empty category.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
@@ -437,7 +437,7 @@ namespace Ice
         /// AlreadyRegisteredException.</summary>
         /// <param name="dispatcher">The dispatcher to add.</param>
         /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
-        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
+        /// pass INamePrx.Factory for this parameter. See <see cref="CreateProxy"/>.</param>
         /// <param name="identity">The stringified identity of the Ice object that is handled by the dispatcher.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
@@ -480,9 +480,7 @@ namespace Ice
         /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         public void Add(Disp dispatcher, string identity, string facet = "")
-        {
-            Add(dispatcher, Identity.Parse(identity), facet);
-        }
+            => Add(dispatcher, Identity.Parse(identity), facet);
 
         public void Add(IObject servant, string identity, string facet = "")
             => Add(servant.Dispatch, identity, facet);
@@ -547,10 +545,7 @@ namespace Ice
         /// Removing an identity that is not in the map throws
         /// NotRegisteredException.</param>
         /// <returns>The removed dispatcher.</returns>
-        public Disp Remove(string identity, string facet = "")
-        {
-            return Remove(Identity.Parse(identity), facet);
-        }
+        public Disp Remove(string identity, string facet = "") => Remove(Identity.Parse(identity), facet);
 
         public Disp Remove(Identity identity, string facet = "")
         {
@@ -578,10 +573,7 @@ namespace Ice
         /// dispatchers of the removed Ice object.
         ///
         /// </returns>
-        public Dictionary<string, Disp> RemoveAllFacets(string identity)
-        {
-            return RemoveAllFacets(Identity.Parse(identity));
-        }
+        public Dictionary<string, Disp> RemoveAllFacets(string identity) => RemoveAllFacets(Identity.Parse(identity));
 
         public Dictionary<string, Disp> RemoveAllFacets(Identity identity)
         {
@@ -656,9 +648,7 @@ namespace Ice
         ///
         /// </returns>
         public Dictionary<string, Disp> FindAllFacets(string identity)
-        {
-            return FindAllFacets(Identity.Parse(identity));
-        }
+            => FindAllFacets(Identity.Parse(identity));
 
         /// <summary>
         /// Find all facets with the given identity in the Active Servant
@@ -819,9 +809,7 @@ namespace Ice
         ///
         /// </returns>
         public T CreateProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
-        {
-            return CreateProxy(Identity.Parse(identity), factory);
-        }
+            => CreateProxy(Identity.Parse(identity), factory);
 
         /// <summary>
         /// Create a proxy for the object with the given identity.
@@ -864,9 +852,7 @@ namespace Ice
         ///
         /// </returns>
         public T CreateDirectProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
-        {
-            return CreateDirectProxy(Identity.Parse(identity), factory);
-        }
+            => CreateDirectProxy(Identity.Parse(identity), factory);
 
         /// <summary>
         /// Create a direct proxy for the object with the given identity.
@@ -905,9 +891,7 @@ namespace Ice
         ///
         /// </returns>
         public T CreateIndirectProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
-        {
-            return CreateIndirectProxy(Identity.Parse(identity), factory);
-        }
+            => CreateIndirectProxy(Identity.Parse(identity), factory);
 
         /// <summary>
         /// Create an indirect proxy for the object with the given identity.

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -400,18 +400,18 @@ namespace Ice
         }
 
         /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
-        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
-        /// </summary>
-        /// <param name="servant">The servant to add.</param>
+        /// Add a dispatcher to this object adapter's Active Servant Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
         /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
         /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the servant. When null, the
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher. When null, the
         /// ObjectAdapter creates a new unique identity with a UUID name and empty category.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
-        public T Add<T>(Disp servant, ProxyFactory<T> proxyFactory, Identity? identity = null, string facet = "")
+        public T Add<T>(Disp dispatcher, ProxyFactory<T> proxyFactory, Identity? identity = null, string facet = "")
             where T : class, IObjectPrx
         {
             lock (this)
@@ -420,118 +420,133 @@ namespace Ice
                 checkForDeactivation();
                 checkIdentity(identity.Value);
 
-                _servantManager.AddServant(servant, identity.Value, facet);
+                _servantManager.AddServant(dispatcher, identity.Value, facet);
 
                 return newProxy(identity.Value, proxyFactory, facet);
             }
         }
 
-        /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
-        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
-        /// </summary>
-        /// <param name="servant">The servant to add.</param>
-        /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
-        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
-        /// <param name="identity">The stringified identity of the Ice object that is handled by the servant.</param>
-        /// <param name="facet">The facet. An empty facet means the default facet.</param>
-        /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
-        public T Add<T>(Disp servant, ProxyFactory<T> proxyFactory, string identity, string facet = "")
+        public T Add<T>(IObject servant, ProxyFactory<T> proxyFactory, Identity? identity = null, string facet = "")
             where T : class, IObjectPrx
-        {
-            return Add(servant, proxyFactory, Identity.Parse(identity), facet);
-        }
+            => Add(servant.Dispatch, proxyFactory, identity, facet);
 
         /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
-        /// identities. Adding a servant with an identity that is already in the map throws
+        /// Add a dispatcher to this object adapter's Active Servant Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map throws
         /// AlreadyRegisteredException.</summary>
-        /// <param name="servant">The servant to add.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the servant.</param>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
+        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
+        /// <param name="identity">The stringified identity of the Ice object that is handled by the dispatcher.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
-        public void Add(Disp servant, Identity identity, string facet = "")
+        /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
+        public T Add<T>(Disp dispatcher, ProxyFactory<T> proxyFactory, string identity, string facet = "")
+            where T : class, IObjectPrx
+            => Add(dispatcher, proxyFactory, Identity.Parse(identity), facet);
+
+        public T Add<T>(IObject servant, ProxyFactory<T> proxyFactory, string identity, string facet = "")
+            where T : class, IObjectPrx
+            => Add(servant.Dispatch, proxyFactory, identity, facet);
+
+        /// <summary>
+        /// Add a dispatcher to this object adapter's Active Servant Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        public void Add(Disp dispatcher, Identity identity, string facet = "")
         {
             lock (this)
             {
                 checkForDeactivation();
                 checkIdentity(identity);
 
-                _servantManager.AddServant(servant, identity, facet);
+                _servantManager.AddServant(dispatcher, identity, facet);
             }
         }
 
-        /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
-        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
-        /// </summary>
-        /// <param name="servant">The servant to add.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the servant.</param>
-        /// <param name="facet">The facet. An empty facet means the default facet.</param>
-        public void Add(Disp servant, string identity, string facet = "")
-        {
-            Add(servant, Identity.Parse(identity), facet);
-        }
+        public void Add(IObject servant, Identity identity, string facet = "")
+            => Add(servant.Dispatch, identity, facet);
 
         /// <summary>
-        /// Add a default servant to handle requests for a specific
+        /// Add a dispatcher to this object adapter's Active Servant Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map throws AlreadyRegisteredException.
+        /// </summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        public void Add(Disp dispatcher, string identity, string facet = "")
+        {
+            Add(dispatcher, Identity.Parse(identity), facet);
+        }
+
+        public void Add(IObject servant, string identity, string facet = "")
+            => Add(servant.Dispatch, identity, facet);
+
+        /// <summary>
+        /// Add a default dispatcher to handle requests for a specific
         /// category.
-        /// Adding a default servant for a category for
-        /// which a default servant is already registered throws
+        /// Adding a default dispatcher for a category for
+        /// which a default dispatcher is already registered throws
         /// AlreadyRegisteredException. To dispatch operation
-        /// calls on servants, the object adapter tries to find a servant
+        /// calls on dispatchers, the object adapter tries to find a dispatcher
         /// for a given Ice object identity and facet in the following
         /// order:
         ///
         ///
         ///
-        /// The object adapter tries to find a servant for the identity
+        /// The object adapter tries to find a dispatcher for the identity
         /// and facet in the Active Servant Map.
         ///
-        /// If no servant has been found in the Active Servant Map, the
-        /// object adapter tries to find a default servant for the category
+        /// If no dispatcher has been found in the Active Servant Map, the
+        /// object adapter tries to find a default dispatcher for the category
         /// component of the identity.
         ///
-        /// If no servant has been found by any of the preceding steps,
-        /// the object adapter tries to find a default servant for an empty
+        /// If no dispatcher has been found by any of the preceding steps,
+        /// the object adapter tries to find a default dispatcher for an empty
         /// category, regardless of the category contained in the identity.
         ///
-        /// If no servant has been found by any of the preceding steps,
+        /// If no dispatcher has been found by any of the preceding steps,
         /// the object adapter gives up and the caller receives
         /// ObjectNotExistException or FacetNotExistException.
         ///
         ///
         ///
         /// </summary>
-        /// <param name="servant">The default servant.
+        /// <param name="dispatcher">The default dispatcher.
         ///
         /// </param>
-        /// <param name="category">The category for which the default servant is
+        /// <param name="category">The category for which the default dispatcher is
         /// registered. An empty category means it will handle all categories.
         ///
         /// </param>
-        public void AddDefaultServant(Disp servant, string category)
+        public void AddDefaultServant(Disp dispatcher, string category)
         {
             lock (this)
             {
                 checkForDeactivation();
 
-                _servantManager.AddDefaultServant(servant, category);
+                _servantManager.AddDefaultServant(dispatcher, category);
             }
         }
 
+        public void AddDefaultServant(IObject servant, string category)
+            => AddDefaultServant(servant.Dispatch, category);
+
         /// <summary>
-        /// Remove a servant (that is, the default facet) from the object
+        /// Remove a dispatcher (that is, the default facet) from the object
         /// adapter's Active Servant Map.
         /// </summary>
         /// <param name="identity">The identity of the Ice object that is implemented by
-        /// the servant. If the servant implements multiple Ice objects,
+        /// the dispatcher. If the dispatcher implements multiple Ice objects,
         /// remove has to be called for all those Ice objects.
         /// Removing an identity that is not in the map throws
         /// NotRegisteredException.</param>
-        /// <returns>The removed servant.</returns>
+        /// <returns>The removed dispatcher.</returns>
         public Disp Remove(string identity, string facet = "")
         {
             return Remove(Identity.Parse(identity), facet);
@@ -560,7 +575,7 @@ namespace Ice
         ///
         /// </param>
         /// <returns>A collection containing all the facet names and
-        /// servants of the removed Ice object.
+        /// dispatchers of the removed Ice object.
         ///
         /// </returns>
         public Dictionary<string, Disp> RemoveAllFacets(string identity)
@@ -580,16 +595,16 @@ namespace Ice
         }
 
         /// <summary>
-        /// Remove the default servant for a specific category.
+        /// Remove the default dispatcher for a specific category.
         /// Attempting
-        /// to remove a default servant for a category that is not
+        /// to remove a default dispatcher for a category that is not
         /// registered throws NotRegisteredException.
         ///
         /// </summary>
-        /// <param name="category">The category of the default servant to remove.
+        /// <param name="category">The category of the default dispatcher to remove.
         ///
         /// </param>
-        /// <returns>The default servant.
+        /// <returns>The default dispatcher.
         ///
         /// </returns>
         public Disp RemoveDefaultServant(string category)
@@ -603,17 +618,17 @@ namespace Ice
         }
 
         /// <summary>
-        /// Look up a servant in this object adapter's Active Servant Map
+        /// Look up a dispatcher in this object adapter's Active Servant Map
         /// by the identity of the Ice object it implements.
-        /// This operation only tries to look up a servant in
-        /// the Active Servant Map. It does not attempt to find a servant
+        /// This operation only tries to look up a dispatcher in
+        /// the Active Servant Map. It does not attempt to find a dispatcher
         /// by using any installed ServantLocator.
         ///
         /// </summary>
-        /// <param name="identity">The identity of the Ice object for which the servant should be returned.</param>
+        /// <param name="identity">The identity of the Ice object for which the dispatcher should be returned.</param>
         /// <param name="facet">Optinoal facet of the Ice object.</param>
-        /// <returns>The servant associated with the
-        /// given identity, or null if no such servant has been found.
+        /// <returns>The dispatcher associated with the
+        /// given identity, or null if no such dispatcher has been found.
         ///
         /// </returns>
         public Disp Find(Identity identity, string facet = "")
@@ -636,7 +651,7 @@ namespace Ice
         ///
         /// </param>
         /// <returns>A collection containing all the facet names and
-        /// servants that have been found, or an empty map if there is no
+        /// dispatchers that have been found, or an empty map if there is no
         /// facet for the given identity.
         ///
         /// </returns>
@@ -654,7 +669,7 @@ namespace Ice
         ///
         /// </param>
         /// <returns>A collection containing all the facet names and
-        /// servants that have been found, or an empty map if there is no
+        /// dispatchers that have been found, or an empty map if there is no
         /// facet for the given identity.
         ///
         /// </returns>
@@ -670,12 +685,12 @@ namespace Ice
         }
 
         /// <summary>
-        /// Find the default servant for a specific category.
+        /// Find the default dispatcher for a specific category.
         /// </summary>
-        /// <param name="category">The category of the default servant to find.
+        /// <param name="category">The category of the default dispatcher to find.
         ///
         /// </param>
-        /// <returns>The default servant or null if no default servant was
+        /// <returns>The default dispatcher or null if no default dispatcher was
         /// registered for the category.
         ///
         /// </returns>
@@ -691,30 +706,30 @@ namespace Ice
 
         /// <summary>
         /// Add a Servant Locator to this object adapter.
-        /// Adding a servant
-        /// locator for a category for which a servant locator is already
+        /// Adding a dispatcher
+        /// locator for a category for which a dispatcher locator is already
         /// registered throws AlreadyRegisteredException. To dispatch
-        /// operation calls on servants, the object adapter tries to find a
-        /// servant for a given Ice object identity and facet in the
+        /// operation calls on dispatchers, the object adapter tries to find a
+        /// dispatcher for a given Ice object identity and facet in the
         /// following order:
         ///
         ///
         ///
-        /// The object adapter tries to find a servant for the identity
+        /// The object adapter tries to find a dispatcher for the identity
         /// and facet in the Active Servant Map.
         ///
-        /// If no servant has been found in the Active Servant Map,
-        /// the object adapter tries to find a servant locator for the
+        /// If no dispatcher has been found in the Active Servant Map,
+        /// the object adapter tries to find a dispatcher locator for the
         /// category component of the identity. If a locator is found, the
-        /// object adapter tries to find a servant using this locator.
+        /// object adapter tries to find a dispatcher using this locator.
         ///
-        /// If no servant has been found by any of the preceding steps,
+        /// If no dispatcher has been found by any of the preceding steps,
         /// the object adapter tries to find a locator for an empty category,
         /// regardless of the category contained in the identity. If a
-        /// locator is found, the object adapter tries to find a servant
+        /// locator is found, the object adapter tries to find a dispatcher
         /// using this locator.
         ///
-        /// If no servant has been found by any of the preceding steps,
+        /// If no dispatcher has been found by any of the preceding steps,
         /// the object adapter gives up and the caller receives
         /// ObjectNotExistException or FacetNotExistException.
         ///
@@ -728,7 +743,7 @@ namespace Ice
         ///
         /// </param>
         /// <param name="category">The category for which the Servant Locator can
-        /// locate servants, or an empty string if the Servant Locator does
+        /// locate dispatchers, or an empty string if the Servant Locator does
         /// not belong to any specific category.
         ///
         /// </param>
@@ -746,7 +761,7 @@ namespace Ice
         /// Remove a Servant Locator from this object adapter.
         /// </summary>
         /// <param name="category">The category for which the Servant Locator can
-        /// locate servants, or an empty string if the Servant Locator does
+        /// locate dispatchers, or an empty string if the Servant Locator does
         /// not belong to any specific category.
         ///
         /// </param>
@@ -768,7 +783,7 @@ namespace Ice
         /// Find a Servant Locator installed with this object adapter.
         /// </summary>
         /// <param name="category">The category for which the Servant Locator can
-        /// locate servants, or an empty string if the Servant Locator does
+        /// locate dispatchers, or an empty string if the Servant Locator does
         /// not belong to any specific category.
         ///
         /// </param>
@@ -1103,7 +1118,7 @@ namespace Ice
             if (r.IsWellKnown())
             {
                 //
-                // Check the active servant map to see if the well-known
+                // Check the active dispatcher map to see if the well-known
                 // proxy is for a local object.
                 //
                 return _servantManager.HasServant(r.GetIdentity());

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -11,7 +11,15 @@ using IceInternal;
 
 namespace Ice
 {
+    // TODO: rename Disp to Dispatcher and fix the Dispatcher signature
+    /// <summary>When an ObjectAdapter receives a request, it finds the dispatcher associated with the target object
+    /// and then forwards the request to that dispatcher. This dispatcher then executes the request and returns
+    /// the response.</summary>
     public delegate Task<OutputStream?>? Disp(Incoming inS, Current current);
+
+    /// <summary>A ServantDispatch represents the Dispatch method of a generated servant interface.
+    /// See CreateDispatcher.</summary>
+    public delegate Task<OutputStream?>? ServantDispatch<T>(T servant, Incoming inS, Current current);
 
     public sealed class ObjectAdapter
     {
@@ -93,7 +101,7 @@ namespace Ice
 
             try
             {
-                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", "")));
+                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", ""), IObjectPrx.Factory));
             }
             catch (LocalException)
             {
@@ -398,66 +406,86 @@ namespace Ice
             }
         }
 
+        /// <summary>Combine a servant and servant dispatch to form a Dispatcher.</summary>
+        /// <param name="servant">The servant.</param>
+        /// <param name="servantDispatch">The servant's static Dispatch method.</param>
+        /// <returns>A dispatcher.</returns>
+        public static Disp CreateDispatcher<T>(T servant, ServantDispatch<T> servantDispatch)
+            => (incoming, current) => servantDispatch(servant, incoming, current);
+
         /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note
-        /// that one servant can implement several Ice objects by registering
-        /// the servant with multiple identities. Adding a servant with an
-        /// identity that is in the map already throws AlreadyRegisteredException.
-        ///
-        /// </summary>
-        /// <param name="disp">The dispatcher object to add.
-        ///
-        /// </param>
-        /// <param name="id">The identity of the Ice object that is implemented by
-        /// the servant.
-        ///
-        /// </param>
-        /// <param name="facet">The facet. An empty facet means the default facet.
-        ///
-        /// </param>
-        /// <returns>A proxy that matches the given identity and this object
-        /// adapter.
-        ///
-        /// </returns>
-        public IObjectPrx Add(Disp disp, string id, string facet = "")
+        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map already throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
+        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
+        public T Add<T>(Disp dispatcher, ProxyFactory<T> proxyFactory, string identity, string facet = "")
+            where T : class, IObjectPrx
         {
-            return Add(disp, Identity.Parse(id), facet);
+            return Add(dispatcher, proxyFactory, Identity.Parse(identity), facet);
         }
 
         /// <summary>
-        /// Add a servant to this object adapter's Active Servant Map.
-        /// Note
-        /// that one servant can implement several Ice objects by registering
-        /// the servant with multiple identities. Adding a servant with an
-        /// identity that is in the map already throws AlreadyRegisteredException.
-        ///
-        /// </summary>
-        /// <param name="disp">The dispatcher object to add.
-        ///
-        /// </param>
-        /// <param name="id">The identity of the Ice object that is implemented by
-        /// the servant.
-        ///
-        /// </param>
-        /// <param name="facet">The facet. An empty facet means the default facet.
-        ///
-        /// </param>
-        /// <returns>A proxy that matches the given identity and this object
-        /// adapter.
-        ///
-        /// </returns>
-        public IObjectPrx Add(Disp disp, Identity? id = null, string facet = "")
+        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map already throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
+        /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher. When null, the
+        /// ObjectAdapter creates a new unique identity with a UUID name and empty category.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
+        public T Add<T>(Disp dispatcher, ProxyFactory<T> proxyFactory, Identity? identity = null, string facet = "")
+            where T : class, IObjectPrx
         {
             lock (this)
             {
-                id = id ?? new Identity(Guid.NewGuid().ToString(), "");
+                identity = identity ?? new Identity(Guid.NewGuid().ToString(), "");
                 checkForDeactivation();
-                checkIdentity(id.Value);
+                checkIdentity(identity.Value);
 
-                _servantManager.AddServant(disp, id.Value, facet);
+                _servantManager.AddServant(dispatcher, identity.Value, facet);
 
-                return newProxy(id.Value, facet);
+                return newProxy(identity.Value, proxyFactory, facet);
+            }
+        }
+
+        /// <summary>
+        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map already throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        public void Add(Disp dispatcher, string identity, string facet = "")
+        {
+            Add(dispatcher, Identity.Parse(identity), facet);
+        }
+
+         /// <summary>
+        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
+        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
+        /// identities. Adding a dispatcher with an identity that is already in the map already throws
+        /// AlreadyRegisteredException.</summary>
+        /// <param name="dispatcher">The dispatcher to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="facet">The facet. An empty facet means the default facet.</param>
+        public void Add(Disp dispatcher, Identity identity, string facet = "")
+        {
+            lock (this)
+            {
+                checkForDeactivation();
+                checkIdentity(identity);
+
+                _servantManager.AddServant(dispatcher, identity, facet);
             }
         }
 
@@ -512,25 +540,25 @@ namespace Ice
         /// Remove a servant (that is, the default facet) from the object
         /// adapter's Active Servant Map.
         /// </summary>
-        /// <param name="id">The identity of the Ice object that is implemented by
+        /// <param name="identity">The identity of the Ice object that is implemented by
         /// the servant. If the servant implements multiple Ice objects,
         /// remove has to be called for all those Ice objects.
         /// Removing an identity that is not in the map throws
         /// NotRegisteredException.</param>
         /// <returns>The removed servant.</returns>
-        public Disp Remove(string id, string facet = "")
+        public Disp Remove(string identity, string facet = "")
         {
-            return Remove(Identity.Parse(id), facet);
+            return Remove(Identity.Parse(identity), facet);
         }
 
-        public Disp Remove(Identity ident, string facet = "")
+        public Disp Remove(Identity identity, string facet = "")
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(ident);
+                checkIdentity(identity);
 
-                return _servantManager.RemoveServant(ident, facet);
+                return _servantManager.RemoveServant(identity, facet);
             }
         }
 
@@ -542,26 +570,26 @@ namespace Ice
         /// is not in the map throws NotRegisteredException.
         ///
         /// </summary>
-        /// <param name="id">The identity of the Ice object to be removed.
+        /// <param name="identity">The identity of the Ice object to be removed.
         ///
         /// </param>
         /// <returns>A collection containing all the facet names and
         /// servants of the removed Ice object.
         ///
         /// </returns>
-        public Dictionary<string, Disp> RemoveAllFacets(string id)
+        public Dictionary<string, Disp> RemoveAllFacets(string identity)
         {
-            return RemoveAllFacets(Identity.Parse(id));
+            return RemoveAllFacets(Identity.Parse(identity));
         }
 
-        public Dictionary<string, Disp> RemoveAllFacets(Identity ident)
+        public Dictionary<string, Disp> RemoveAllFacets(Identity identity)
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(ident);
+                checkIdentity(identity);
 
-                return _servantManager.RemoveAllFacets(ident);
+                return _servantManager.RemoveAllFacets(identity);
             }
         }
 
@@ -596,20 +624,20 @@ namespace Ice
         /// by using any installed ServantLocator.
         ///
         /// </summary>
-        /// <param name="ident">The identity of the Ice object for which the servant should be returned.</param>
+        /// <param name="identity">The identity of the Ice object for which the servant should be returned.</param>
         /// <param name="facet">Optinoal facet of the Ice object.</param>
         /// <returns>The dispatcher associated with the
         /// given identity, or null if no such servant has been found.
         ///
         /// </returns>
-        public Disp Find(Identity ident, string facet = "")
+        public Disp Find(Identity identity, string facet = "")
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(ident);
+                checkIdentity(identity);
 
-                return _servantManager.FindServant(ident, facet);
+                return _servantManager.FindServant(identity, facet);
             }
         }
 
@@ -617,7 +645,7 @@ namespace Ice
         /// Find all facets with the given identity in the Active Servant
         /// Map.
         /// </summary>
-        /// <param name="id">The identity of the Ice object for which the facets
+        /// <param name="identity">The identity of the Ice object for which the facets
         /// should be returned.
         ///
         /// </param>
@@ -626,16 +654,16 @@ namespace Ice
         /// facet for the given identity.
         ///
         /// </returns>
-        public Dictionary<string, Disp> FindAllFacets(string id)
+        public Dictionary<string, Disp> FindAllFacets(string identity)
         {
-            return FindAllFacets(Identity.Parse(id));
+            return FindAllFacets(Identity.Parse(identity));
         }
 
         /// <summary>
         /// Find all facets with the given identity in the Active Servant
         /// Map.
         /// </summary>
-        /// <param name="id">The identity of the Ice object for which the facets
+        /// <param name="identity">The identity of the Ice object for which the facets
         /// should be returned.
         ///
         /// </param>
@@ -644,14 +672,14 @@ namespace Ice
         /// facet for the given identity.
         ///
         /// </returns>
-        public Dictionary<string, Disp> FindAllFacets(Identity id)
+        public Dictionary<string, Disp> FindAllFacets(Identity identity)
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(id);
+                checkIdentity(identity);
 
-                return _servantManager.FindAllFacets(id);
+                return _servantManager.FindAllFacets(identity);
             }
         }
 
@@ -783,15 +811,15 @@ namespace Ice
         /// proxy containing this object adapter's published endpoints.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateProxy(string id)
+        public T CreateProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
-            return CreateProxy(Identity.Parse(id));
+            return CreateProxy(Identity.Parse(identity), factory);
         }
 
         /// <summary>
@@ -805,20 +833,20 @@ namespace Ice
         /// proxy containing this object adapter's published endpoints.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateProxy(Identity id)
+        public T CreateProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(id);
+                checkIdentity(identity);
 
-                return newProxy(id, "");
+                return newProxy(identity, factory, "");
             }
         }
 
@@ -828,15 +856,15 @@ namespace Ice
         /// endpoints.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateDirectProxy(string id)
+        public T CreateDirectProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
-            return CreateDirectProxy(Identity.Parse(id));
+            return CreateDirectProxy(Identity.Parse(identity), factory);
         }
 
         /// <summary>
@@ -845,20 +873,20 @@ namespace Ice
         /// endpoints.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateDirectProxy(Identity id)
+        public T CreateDirectProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(id);
+                checkIdentity(identity);
 
-                return newDirectProxy(id, "");
+                return newDirectProxy(identity, factory, "");
             }
         }
 
@@ -869,15 +897,15 @@ namespace Ice
         /// value contains only the object identity.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateIndirectProxy(string id)
+        public T CreateIndirectProxy<T>(string identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
-            return CreateIndirectProxy(Identity.Parse(id));
+            return CreateIndirectProxy(Identity.Parse(identity), factory);
         }
 
         /// <summary>
@@ -887,20 +915,20 @@ namespace Ice
         /// value contains only the object identity.
         ///
         /// </summary>
-        /// <param name="id">The object's identity.
+        /// <param name="identity">The object's identity.
         ///
         /// </param>
         /// <returns>A proxy for the object with the given identity.
         ///
         /// </returns>
-        public IObjectPrx CreateIndirectProxy(Identity id)
+        public T CreateIndirectProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx
         {
             lock (this)
             {
                 checkForDeactivation();
-                checkIdentity(id);
+                checkIdentity(identity);
 
-                return newIndirectProxy(id, "", _id);
+                return newIndirectProxy(identity, factory, "", _id);
             }
         }
 
@@ -1005,7 +1033,7 @@ namespace Ice
 
             try
             {
-                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", "")));
+                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", ""), IObjectPrx.Factory));
             }
             catch (LocalException)
             {
@@ -1063,7 +1091,7 @@ namespace Ice
 
             try
             {
-                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", "")));
+                UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", ""), IObjectPrx.Factory));
             }
             catch (LocalException)
             {
@@ -1416,34 +1444,36 @@ namespace Ice
             }
         }
 
-        private IObjectPrx newProxy(Identity ident, string facet)
+        private T newProxy<T>(Identity identity, ProxyFactory<T> factory, string facet) where T : class, IObjectPrx
         {
             if (_id.Length == 0)
             {
-                return newDirectProxy(ident, facet);
+                return newDirectProxy(identity, factory, facet);
             }
             else if (_replicaGroupId.Length == 0)
             {
-                return newIndirectProxy(ident, facet, _id);
+                return newIndirectProxy(identity, factory, facet, _id);
             }
             else
             {
-                return newIndirectProxy(ident, facet, _replicaGroupId);
+                return newIndirectProxy(identity, factory, facet, _replicaGroupId);
             }
         }
 
         //
         // Create a reference and return a proxy for this reference.
         //
-        private IObjectPrx newDirectProxy(Identity ident, string facet) =>
-            new ObjectPrx(_communicator!.CreateReference(ident, facet, _reference!, _publishedEndpoints));
+        private T newDirectProxy<T>(Identity identity, ProxyFactory<T> factory, string facet)
+            where T : class, IObjectPrx
+            => factory(_communicator!.CreateReference(identity, facet, _reference!, _publishedEndpoints));
 
         //
         // Create a reference with the adapter id and return a
         // proxy for the reference.
         //
-        private IObjectPrx newIndirectProxy(Identity ident, string facet, string id) =>
-            new ObjectPrx(_communicator!.CreateReference(ident, facet, _reference!, id));
+        private T newIndirectProxy<T>(Identity identity, ProxyFactory<T> factory, string facet, string id)
+            where T : class, IObjectPrx
+            => factory(_communicator!.CreateReference(identity, facet, _reference!, id));
 
         private void checkForDeactivation()
         {

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -11,7 +11,7 @@ using IceInternal;
 
 namespace Ice
 {
-    // TODO: rename Disp to Dispatcher or Servant and fix its signature
+    // TODO: rename Disp to Dispatcher and fix its signature
     public delegate Task<OutputStream?>? Disp(Incoming inS, Current current);
 
     public sealed class ObjectAdapter

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -11,10 +11,7 @@ using IceInternal;
 
 namespace Ice
 {
-    // TODO: rename Disp to Dispatcher and fix the Dispatcher signature
-    /// <summary>When an ObjectAdapter receives a request, it finds the dispatcher associated with the target object
-    /// and then forwards the request to that dispatcher. This dispatcher then executes the request and returns
-    /// the response.</summary>
+    // TODO: rename Disp to Dispatcher or Servant and fix its signature
     public delegate Task<OutputStream?>? Disp(Incoming inS, Current current);
 
     public sealed class ObjectAdapter
@@ -403,14 +400,14 @@ namespace Ice
         }
 
         /// <summary>
-        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
-        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
-        /// identities. Adding a dispatcher with an identity that is already in the map already throws
-        /// AlreadyRegisteredException.</summary>
-        /// <param name="servant">The dispatcher to add.</param>
+        /// Add a servant to this object adapter's Active Servant Map.
+        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
+        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
+        /// </summary>
+        /// <param name="servant">The servant to add.</param>
         /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
         /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher. When null, the
+        /// <param name="identity">The identity of the Ice object that is handled by the servant. When null, the
         /// ObjectAdapter creates a new unique identity with a UUID name and empty category.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
@@ -430,14 +427,14 @@ namespace Ice
         }
 
         /// <summary>
-        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
-        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
-        /// identities. Adding a dispatcher with an identity that is already in the map already throws
-        /// AlreadyRegisteredException.</summary>
-        /// <param name="servant">The dispatcher to add.</param>
+        /// Add a servant to this object adapter's Active Servant Map.
+        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
+        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
+        /// </summary>
+        /// <param name="servant">The servant to add.</param>
         /// <param name="proxyFactory">The proxy factory used to manufacture the returned proxy. You should in general
         /// pass INamePrx.Factory for this parameter. See CreateProxy.</param>
-        /// <param name="identity">The stringified identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="identity">The stringified identity of the Ice object that is handled by the servant.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         /// <returns>A proxy associated with this object adapter, object identity and facet.</returns>
         public T Add<T>(Disp servant, ProxyFactory<T> proxyFactory, string identity, string facet = "")
@@ -447,12 +444,12 @@ namespace Ice
         }
 
         /// <summary>
-        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
-        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
-        /// identities. Adding a dispatcher with an identity that is already in the map already throws
+        /// Add a servant to this object adapter's Active Servant Map.
+        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
+        /// identities. Adding a servant with an identity that is already in the map throws
         /// AlreadyRegisteredException.</summary>
-        /// <param name="servant">The dispatcher to add.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// <param name="servant">The servant to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the servant.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         public void Add(Disp servant, Identity identity, string facet = "")
         {
@@ -466,12 +463,12 @@ namespace Ice
         }
 
         /// <summary>
-        /// Add a dispatcher to this object adapter's Active Dispatcher Map.
-        /// Note that a single dispatcher can handle several Ice objects by registering the dispatcher with multiple
-        /// identities. Adding a dispatcher with an identity that is already in the map already throws
-        /// AlreadyRegisteredException.</summary>
-        /// <param name="servant">The dispatcher to add.</param>
-        /// <param name="identity">The identity of the Ice object that is handled by the dispatcher.</param>
+        /// Add a servant to this object adapter's Active Servant Map.
+        /// Note that a single servant can handle several Ice objects by registering the servant with multiple
+        /// identities. Adding a servant with an identity that is already in the map throws AlreadyRegisteredException.
+        /// </summary>
+        /// <param name="servant">The servant to add.</param>
+        /// <param name="identity">The identity of the Ice object that is handled by the servant.</param>
         /// <param name="facet">The facet. An empty facet means the default facet.</param>
         public void Add(Disp servant, string identity, string facet = "")
         {
@@ -615,7 +612,7 @@ namespace Ice
         /// </summary>
         /// <param name="identity">The identity of the Ice object for which the servant should be returned.</param>
         /// <param name="facet">Optinoal facet of the Ice object.</param>
-        /// <returns>The dispatcher associated with the
+        /// <returns>The servant associated with the
         /// given identity, or null if no such servant has been found.
         ///
         /// </returns>

--- a/csharp/src/Ice/ice.csproj
+++ b/csharp/src/Ice/ice.csproj
@@ -47,9 +47,6 @@
         <Compile Update="generated\RouterF.cs">
           <SliceCompileSource>..\..\..\slice\Ice\RouterF.ice</SliceCompileSource>
         </Compile>
-        <Compile Update="generated\.#Identity.cs">
-          <SliceCompileSource>..\..\..\slice\Ice\.#Identity.ice</SliceCompileSource>
-        </Compile>
     </ItemGroup>
     <ItemGroup />
 </Project>

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -86,8 +86,7 @@ namespace IceDiscovery
             _multicastAdapter.Add(lookup, "IceDiscovery/Lookup");
 
             var lookupReply = new LookupReply(lookup);
-            _replyAdapter.AddDefaultServant(
-                (current, incoming) => ILookupReply.Dispatch(lookupReply, current, incoming), "");
+            _replyAdapter.AddDefaultServant(lookupReply.Dispatch, "");
             lookup.SetLookupReply(_replyAdapter.CreateProxy("dummy", ILookupReplyPrx.Factory)
                 .Clone(invocationMode: InvocationMode.Datagram));
 

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -74,7 +74,7 @@ namespace IceDiscovery
             // Setup locatory registry.
             //
             var locatorRegistry = new LocatorRegistry(_communicator);
-            ILocatorRegistryPrx locatorRegistryPrx = _locatorAdapter.Add(locatorRegistry);
+            ILocatorRegistryPrx locatorRegistryPrx = _locatorAdapter.Add(locatorRegistry, ILocatorRegistryPrx.Factory);
 
             ILookupPrx lookupPrx = ILookupPrx.Parse("IceDiscovery/Lookup -d:" + lookupEndpoints, _communicator).Clone(
                 clearRouter: true, collocationOptimized: false); // No colloc optimization or router for the multicast proxy!
@@ -86,14 +86,14 @@ namespace IceDiscovery
             _multicastAdapter.Add(lookup, "IceDiscovery/Lookup");
 
             var lookupReply = new LookupReply(lookup);
-            _replyAdapter.AddDefaultServant(lookupReply.Dispatch, "");
+            _replyAdapter.AddDefaultServant(lookupReply, "");
             lookup.SetLookupReply(_replyAdapter.CreateProxy("dummy", ILookupReplyPrx.Factory)
                 .Clone(invocationMode: InvocationMode.Datagram));
 
             //
             // Setup locator on the communicator.
             //
-            _locator = _locatorAdapter.Add(new Locator(lookup, locatorRegistryPrx));
+            _locator = _locatorAdapter.Add(new Locator(lookup, locatorRegistryPrx), ILocatorPrx.Factory);
             _defaultLocator = _communicator.GetDefaultLocator();
             _communicator.SetDefaultLocator(_locator);
 

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -85,11 +85,11 @@ namespace IceDiscovery
             var lookup = new Lookup(locatorRegistry, lookupPrx, _communicator);
             _multicastAdapter.Add(lookup, "IceDiscovery/Lookup");
 
-            LookupReplyTraits lookupT = default;
             var lookupReply = new LookupReply(lookup);
             _replyAdapter.AddDefaultServant(
-                (current, incoming) => lookupT.Dispatch(lookupReply, current, incoming), "");
-            lookup.SetLookupReply(ILookupReplyPrx.UncheckedCast(_replyAdapter.CreateProxy("dummy")).Clone(invocationMode: InvocationMode.Datagram));
+                (current, incoming) => ILookupReply.Dispatch(lookupReply, current, incoming), "");
+            lookup.SetLookupReply(_replyAdapter.CreateProxy("dummy", ILookupReplyPrx.Factory)
+                .Clone(invocationMode: InvocationMode.Datagram));
 
             //
             // Setup locator on the communicator.

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -689,7 +689,7 @@ namespace IceLocatorDiscovery
             // No colloc optimization or router for the multicast proxy!
             lookupPrx = lookupPrx.Clone(clearRouter: false, collocationOptimized: false);
 
-            ILocatorPrx voidLo = _locatorAdapter.Add(new VoidLocatorI());
+            ILocatorPrx voidLo = _locatorAdapter.Add(new VoidLocatorI(), ILocatorPrx.Factory);
 
             string instanceName = _communicator.GetProperty($"{_name}.InstanceName") ?? "";
             var id = new Identity("Locator", instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString());
@@ -700,7 +700,8 @@ namespace IceLocatorDiscovery
             _communicator.SetDefaultLocator(_locatorPrx);
 
             ILookupReply lookupReplyI = new LookupReplyI(_locator);
-            _locator.SetLookupReply(_replyAdapter.Add(lookupReplyI).Clone(invocationMode: InvocationMode.Datagram));
+            _locator.SetLookupReply(_replyAdapter.Add(lookupReplyI, ILookupReplyPrx.Factory)
+                .Clone(invocationMode: InvocationMode.Datagram));
 
             _replyAdapter.Activate();
             _locatorAdapter.Activate();

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -696,8 +696,7 @@ namespace IceLocatorDiscovery
 
             _defaultLocator = _communicator.GetDefaultLocator();
             _locator = new LocatorI(_name, lookupPrx, _communicator, instanceName, voidLo);
-            _locatorPrx = ILocatorPrx.UncheckedCast(
-                _locatorAdapter.Add((current, incoming) => _locator.Dispatch(current, incoming)));
+            _locatorPrx = _locatorAdapter.Add(_locator.Dispatch, ILocatorPrx.Factory);
             _communicator.SetDefaultLocator(_locatorPrx);
 
             ILookupReply lookupReplyI = new LookupReplyI(_locator);

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -297,7 +297,7 @@ namespace IceBox
                 //
                 // Start Admin (if enabled) and/or deprecated IceBox.ServiceManager OA
                 //
-                _communicator.AddAdminFacet(this, "IceBox.ServiceManager", IServiceManager.Dispatch);
+                _communicator.AddAdminFacet(this, this.Dispatch, "IceBox.ServiceManager");
                 _communicator.GetAdmin();
                 if (adapter != null)
                 {

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -279,11 +279,11 @@ namespace IceBox
                         // Add all facets created on shared communicator to the IceBox communicator
                         // but renamed <prefix>.<facet-name>, except for the Process facet which is
                         // never added.
-                        foreach (KeyValuePair<string, (object servant, Disp disp)> p in _sharedCommunicator.FindAllAdminFacets())
+                        foreach (KeyValuePair<string, IObject> p in _sharedCommunicator.FindAllAdminFacets())
                         {
                             if (!p.Key.Equals("Process"))
                             {
-                                _communicator.AddAdminFacet(p.Value.servant, p.Value.disp, facetNamePrefix + p.Key);
+                                _communicator.AddAdminFacet(p.Value, facetNamePrefix + p.Key);
                             }
                         }
                     }
@@ -297,7 +297,7 @@ namespace IceBox
                 //
                 // Start Admin (if enabled) and/or deprecated IceBox.ServiceManager OA
                 //
-                _communicator.AddAdminFacet(this, this.Dispatch, "IceBox.ServiceManager");
+                _communicator.AddAdminFacet(this, "IceBox.ServiceManager");
                 _communicator.GetAdmin();
                 if (adapter != null)
                 {
@@ -488,11 +488,11 @@ namespace IceBox
                         // Add all facets created on the service communicator to the IceBox communicator
                         // but renamed IceBox.Service.<service>.<facet-name>, except for the Process facet
                         // which is never added
-                        foreach (KeyValuePair<string, (object servant, Disp disp)> p in communicator.FindAllAdminFacets())
+                        foreach (KeyValuePair<string, IObject> p in communicator.FindAllAdminFacets())
                         {
                             if (!p.Key.Equals("Process"))
                             {
-                                _communicator.AddAdminFacet(p.Value.servant, p.Value.disp, serviceFacetNamePrefix + p.Key);
+                                _communicator.AddAdminFacet(p.Value, serviceFacetNamePrefix + p.Key);
                             }
                         }
                     }

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -297,7 +297,7 @@ namespace IceBox
                 //
                 // Start Admin (if enabled) and/or deprecated IceBox.ServiceManager OA
                 //
-                _communicator.AddAdminFacet<IServiceManager, ServiceManagerTraits>(this, "IceBox.ServiceManager");
+                _communicator.AddAdminFacet(this, "IceBox.ServiceManager", IServiceManager.Dispatch);
                 _communicator.GetAdmin();
                 if (adapter != null)
                 {

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -222,9 +222,9 @@ public class Client : Test.TestHelper
                 callbackReceiverImpl = new CallbackReceiver();
                 callbackReceiver = callbackReceiverImpl;
                 Identity callbackReceiverIdent = new Identity("callbackReceiver", category);
-                twowayR = adapter.Add(callbackReceiver, callbackReceiverIdent);
+                twowayR = adapter.Add(callbackReceiver, ICallbackReceiverPrx.Factory, callbackReceiverIdent);
                 Identity fakeCallbackReceiverIdent = new Identity("callbackReceiver", "dummy");
-                fakeTwowayR = adapter.Add(callbackReceiver, fakeCallbackReceiverIdent);
+                fakeTwowayR = adapter.Add(callbackReceiver, ICallbackReceiverPrx.Factory, fakeCallbackReceiverIdent);
                 Console.Out.WriteLine("ok");
             }
 

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -32,7 +32,7 @@ namespace Ice.acm
             }
             communicator.SetProperty($"{name}.ThreadPool.Size", "2");
             ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(name, $"{protocol} -h \"{host}\"");
-            return current.Adapter.Add(new RemoteObjectAdapter(adapter));
+            return current.Adapter.Add(new RemoteObjectAdapter(adapter), IRemoteObjectAdapterPrx.Factory);
         }
 
         public void
@@ -45,7 +45,7 @@ namespace Ice.acm
         public RemoteObjectAdapter(ObjectAdapter adapter)
         {
             _adapter = adapter;
-            _testIntf = _adapter.Add(new TestIntf(), "test");
+            _testIntf = _adapter.Add(new TestIntf(), ITestIntfPrx.Factory, "test");
             _adapter.Activate();
         }
 

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -80,7 +80,8 @@ namespace Ice
                     var prx = IObjectPrx.Parse("dummy:tcp -h localhost -p 12346 -t 20000:tcp -h localhost -p 12347 -t 10000", communicator);
                     adapter.SetPublishedEndpoints(prx.Endpoints);
                     test(adapter.GetPublishedEndpoints().Length == 2);
-                    test(Collections.Equals(adapter.CreateProxy(new Identity("dummy", "")).Endpoints, prx.Endpoints));
+                    test(Collections.Equals(adapter.CreateProxy(new Identity("dummy", ""), IObjectPrx.Factory).Endpoints,
+                        prx.Endpoints));
                     test(Collections.Equals(adapter.GetPublishedEndpoints(), prx.Endpoints));
                     adapter.RefreshPublishedEndpoints();
                     test(adapter.GetPublishedEndpoints().Length == 1);

--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -3,7 +3,6 @@
 //
 
 using System.Text;
-using Ice.adapterDeactivation.Test; // for extension methods
 
 namespace Ice.adapterDeactivation
 {

--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -63,7 +63,7 @@ namespace Ice.adapterDeactivation
             if (current.Id.Name.Equals("router"))
             {
                 cookie = null;
-                return _router.Dispatch;
+                return (_router as IObject).Dispatch;
             }
 
             test(current.Id.Category.Length == 0);
@@ -72,7 +72,7 @@ namespace Ice.adapterDeactivation
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return testI.Dispatch;
+            return (testI as IObject).Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -3,6 +3,7 @@
 //
 
 using System.Text;
+using Ice.adapterDeactivation.Test; // for extension methods
 
 namespace Ice.adapterDeactivation
 {
@@ -62,7 +63,7 @@ namespace Ice.adapterDeactivation
             if (current.Id.Name.Equals("router"))
             {
                 cookie = null;
-                return (incoming, current) => IRouter.Dispatch(_router, incoming, current);
+                return _router.Dispatch;
             }
 
             test(current.Id.Category.Length == 0);
@@ -71,7 +72,7 @@ namespace Ice.adapterDeactivation
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return (incoming, current) => Test.ITestIntf.Dispatch(testI, incoming, current);
+            return testI.Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -62,8 +62,7 @@ namespace Ice.adapterDeactivation
             if (current.Id.Name.Equals("router"))
             {
                 cookie = null;
-                RouterTraits routerT = default;
-                return (incoming, current) => routerT.Dispatch(_router, incoming, current);
+                return (incoming, current) => IRouter.Dispatch(_router, incoming, current);
             }
 
             test(current.Id.Category.Length == 0);
@@ -71,9 +70,8 @@ namespace Ice.adapterDeactivation
 
             cookie = new Cookie();
 
-            var testT = default(Test.TestIntfTraits);
             var testI = new TestIntf();
-            return (incoming, current) => testT.Dispatch(testI, incoming, current);
+            return (incoming, current) => Test.ITestIntf.Dispatch(testI, incoming, current);
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -16,10 +16,10 @@ namespace Ice.admin
         {
             if (builtInFacets && !filtered)
             {
-                test(com.FindAdminFacet("Properties").servant != null);
-                test(com.FindAdminFacet("Process").servant != null);
-                test(com.FindAdminFacet("Logger").servant != null);
-                test(com.FindAdminFacet("Metrics").servant != null);
+                test(com.FindAdminFacet("Properties") != null);
+                test(com.FindAdminFacet("Process") != null);
+                test(com.FindAdminFacet("Logger") != null);
+                test(com.FindAdminFacet("Metrics") != null);
             }
 
             var f1 = new TestFacet();
@@ -28,15 +28,15 @@ namespace Ice.admin
 
             if (!filtered)
             {
-                com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
-                com.AddAdminFacet(f2, f2.Dispatch, "Facet2");
-                com.AddAdminFacet(f3, f3.Dispatch, "Facet3");
+                com.AddAdminFacet(f1, "Facet1");
+                com.AddAdminFacet(f2, "Facet2");
+                com.AddAdminFacet(f3, "Facet3");
             }
             else
             {
                 try
                 {
-                    com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
+                    com.AddAdminFacet(f1, "Facet1");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -45,7 +45,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f2, f2.Dispatch, "Facet2");
+                    com.AddAdminFacet(f2, "Facet2");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -54,7 +54,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f3, f3.Dispatch, "Facet3");
+                    com.AddAdminFacet(f3, "Facet3");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -64,19 +64,19 @@ namespace Ice.admin
 
             if (!filtered)
             {
-                test(com.FindAdminFacet("Facet1").servant == f1);
-                test(com.FindAdminFacet("Facet2").servant == f2);
-                test(com.FindAdminFacet("Facet3").servant == f3);
+                test(com.FindAdminFacet("Facet1") == f1);
+                test(com.FindAdminFacet("Facet2") == f2);
+                test(com.FindAdminFacet("Facet3") == f3);
             }
             else
             {
-                test(com.FindAdminFacet("Facet1").servant == null);
-                test(com.FindAdminFacet("Facet2").servant == null);
-                test(com.FindAdminFacet("Facet3").servant == null);
+                test(com.FindAdminFacet("Facet1") == null);
+                test(com.FindAdminFacet("Facet2") == null);
+                test(com.FindAdminFacet("Facet3") == null);
             }
-            test(com.FindAdminFacet("Bogus").servant == null);
+            test(com.FindAdminFacet("Bogus") == null);
 
-            Dictionary<string, (object servant, Disp disp)> facetMap = com.FindAllAdminFacets();
+            Dictionary<string, IObject> facetMap = com.FindAllAdminFacets();
             if (builtInFacets)
             {
                 test(facetMap.Count == 7);
@@ -99,7 +99,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
+                    com.AddAdminFacet(f1, "Facet1");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -390,7 +390,7 @@ namespace Ice.admin
 
                 var remoteLogger = new RemoteLogger();
 
-                IRemoteLoggerPrx myProxy = adapter.Add(remoteLogger);
+                IRemoteLoggerPrx myProxy = adapter.Add(remoteLogger, IRemoteLoggerPrx.Factory);
 
                 adapter.Activate();
 

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -28,15 +28,15 @@ namespace Ice.admin
 
             if (!filtered)
             {
-                com.AddAdminFacet<ITestFacet, TestFacetTraits>(f1, "Facet1");
-                com.AddAdminFacet<ITestFacet, TestFacetTraits>(f2, "Facet2");
-                com.AddAdminFacet<ITestFacet, TestFacetTraits>(f3, "Facet3");
+                com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
+                com.AddAdminFacet(f2, "Facet2", ITestFacet.Dispatch);
+                com.AddAdminFacet(f3, "Facet3", ITestFacet.Dispatch);
             }
             else
             {
                 try
                 {
-                    com.AddAdminFacet<ITestFacet, TestFacetTraits>(f1, "Facet1");
+                    com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
                     test(false);
                 }
                 catch (ArgumentException)
@@ -45,7 +45,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet<ITestFacet, TestFacetTraits>(f2, "Facet2");
+                    com.AddAdminFacet(f2, "Facet2", ITestFacet.Dispatch);
                     test(false);
                 }
                 catch (ArgumentException)
@@ -54,7 +54,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet<ITestFacet, TestFacetTraits>(f3, "Facet3");
+                    com.AddAdminFacet(f3, "Facet3", ITestFacet.Dispatch);
                     test(false);
                 }
                 catch (ArgumentException)
@@ -99,7 +99,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet<ITestFacet, TestFacetTraits>(f1, "Facet1");
+                    com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
                     test(false);
                 }
                 catch (ArgumentException)

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -28,15 +28,15 @@ namespace Ice.admin
 
             if (!filtered)
             {
-                com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
-                com.AddAdminFacet(f2, "Facet2", ITestFacet.Dispatch);
-                com.AddAdminFacet(f3, "Facet3", ITestFacet.Dispatch);
+                com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
+                com.AddAdminFacet(f2, f2.Dispatch, "Facet2");
+                com.AddAdminFacet(f3, f3.Dispatch, "Facet3");
             }
             else
             {
                 try
                 {
-                    com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
+                    com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -45,7 +45,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f2, "Facet2", ITestFacet.Dispatch);
+                    com.AddAdminFacet(f2, f2.Dispatch, "Facet2");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -54,7 +54,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f3, "Facet3", ITestFacet.Dispatch);
+                    com.AddAdminFacet(f3, f3.Dispatch, "Facet3");
                     test(false);
                 }
                 catch (ArgumentException)
@@ -99,7 +99,7 @@ namespace Ice.admin
 
                 try
                 {
-                    com.AddAdminFacet(f1, "Facet1", ITestFacet.Dispatch);
+                    com.AddAdminFacet(f1, f1.Dispatch, "Facet1");
                     test(false);
                 }
                 catch (ArgumentException)

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -83,7 +83,7 @@ namespace Ice.admin
             try
             {
                 var testFacet = new TestFacet();
-                communicator.AddAdminFacet(testFacet, testFacet.Dispatch, "TestFacet");
+                communicator.AddAdminFacet(testFacet, "TestFacet");
             }
             catch (System.ArgumentException)
             {
@@ -94,7 +94,7 @@ namespace Ice.admin
             // Set the callback on the admin facet.
             //
             var servant = new RemoteCommunicator(communicator);
-            var propFacet = communicator.FindAdminFacet("Properties").servant;
+            var propFacet = communicator.FindAdminFacet("Properties");
 
             if (propFacet != null)
             {
@@ -103,7 +103,7 @@ namespace Ice.admin
                 admin.AddUpdateCallback(servant.updated);
             }
 
-            return current.Adapter.Add(servant);
+            return current.Adapter.Add(servant, IRemoteCommunicatorPrx.Factory);
         }
 
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -82,7 +82,7 @@ namespace Ice.admin
             //
             try
             {
-                communicator.AddAdminFacet<ITestFacet, TestFacetTraits>(new TestFacet(), "TestFacet");
+                communicator.AddAdminFacet(new TestFacet(), "TestFacet", ITestFacet.Dispatch);
             }
             catch (System.ArgumentException)
             {

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -82,7 +82,8 @@ namespace Ice.admin
             //
             try
             {
-                communicator.AddAdminFacet(new TestFacet(), "TestFacet", ITestFacet.Dispatch);
+                var testFacet = new TestFacet();
+                communicator.AddAdminFacet(testFacet, testFacet.Dispatch, "TestFacet");
             }
             catch (System.ArgumentException)
             {

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -898,7 +898,7 @@ namespace Ice.ami
                 {
                     ObjectAdapter adapter = communicator.CreateObjectAdapter("");
                     PingReplyI replyI = new PingReplyI();
-                    var reply = adapter.Add(replyI);
+                    var reply = adapter.Add(replyI, IPingReplyPrx.Factory);
                     adapter.Activate();
 
                     p.GetConnection().SetAdapter(adapter);

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -98,7 +98,7 @@ namespace Ice.ami
         }
 
         Test.ITestIntfPrx self(Current current) =>
-            Test.ITestIntfPrx.UncheckedCast(current.Adapter.CreateProxy(current.Id));
+            current.Adapter.CreateProxy(current.Id, Test.ITestIntfPrx.Factory);
 
         public Task
         startDispatchAsync(Ice.Current current)

--- a/csharp/test/Ice/background/Server.cs
+++ b/csharp/test/Ice/background/Server.cs
@@ -19,14 +19,14 @@ public class Server : TestHelper
         FindAdapterByIdAsync(string adapter, Current current)
         {
             _controller.checkCallPause(current);
-            return Task.FromResult(current.Adapter.CreateDirectProxy("dummy"));
+            return Task.FromResult(current.Adapter.CreateDirectProxy("dummy", IObjectPrx.Factory));
         }
 
         public Task<IObjectPrx>
         FindObjectByIdAsync(Identity id, Current current)
         {
             _controller.checkCallPause(current);
-            return Task.FromResult(current.Adapter.CreateDirectProxy(id));
+            return Task.FromResult(current.Adapter.CreateDirectProxy(id, IObjectPrx.Factory));
         }
 
         public ILocatorRegistryPrx GetRegistry(Current current) => null;

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -874,7 +874,7 @@ namespace Ice.binding
                         continue; // IP version not supported.
                     }
 
-                    var prx = oa.CreateProxy("dummy");
+                    var prx = oa.CreateProxy("dummy", IObjectPrx.Factory);
                     try
                     {
                         prx.Clone(collocationOptimized: false).IcePing();

--- a/csharp/test/Ice/binding/RemoteCommunicatorI.cs
+++ b/csharp/test/Ice/binding/RemoteCommunicatorI.cs
@@ -25,7 +25,7 @@ namespace Ice.binding
 
                     communicator.SetProperty(name + ".ThreadPool.Size", "1");
                     ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(name, endpoints);
-                    return current.Adapter.Add(new RemoteObjectAdapter(adapter));
+                    return current.Adapter.Add(new RemoteObjectAdapter(adapter), IRemoteObjectAdapterPrx.Factory);
                 }
                 catch (SocketException)
                 {

--- a/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
+++ b/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
@@ -11,7 +11,7 @@ namespace Ice.binding
         public RemoteObjectAdapter(ObjectAdapter adapter)
         {
             _adapter = adapter;
-            _testIntf = _adapter.Add(new TestIntf(), "test");
+            _testIntf = _adapter.Add(new TestIntf(), ITestIntfPrx.Factory, "test");
             _adapter.Activate();
         }
 

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -16,8 +16,7 @@ namespace Ice.defaultServant
             oa.Activate();
 
             var servantI = new MyObject();
-            var servantT = default(MyObjectTraits);
-            Disp servantD = (incoming, current) => servantT.Dispatch(servantI, incoming, current);
+            Disp servantD = (incoming, current) => IMyObject.Dispatch(servantI, incoming, current);
 
             //
             // Register default servant with category "foo"
@@ -44,13 +43,13 @@ namespace Ice.defaultServant
             for (int idx = 0; idx < 5; ++idx)
             {
                 identity = new Identity(names[idx], identity.Category);
-                prx = IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+                prx = oa.CreateProxy(identity, IMyObjectPrx.Factory);
                 prx.IcePing();
                 test(prx.getName() == names[idx]);
             }
 
             identity = new Identity("ObjectNotExist", identity.Category);
-            prx = IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+            prx = oa.CreateProxy(identity, IMyObjectPrx.Factory);
             try
             {
                 prx.IcePing();
@@ -72,7 +71,7 @@ namespace Ice.defaultServant
             }
 
             identity = new Identity("FacetNotExist", identity.Category);
-            prx = IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+            prx = oa.CreateProxy(identity, IMyObjectPrx.Factory);
             try
             {
                 prx.IcePing();
@@ -97,7 +96,7 @@ namespace Ice.defaultServant
             for (int idx = 0; idx < 5; idx++)
             {
                 identity = new Identity(names[idx], identity.Category);
-                prx = Test.IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+                prx = oa.CreateProxy(identity, Test.IMyObjectPrx.Factory);
 
                 try
                 {
@@ -122,7 +121,7 @@ namespace Ice.defaultServant
 
             oa.RemoveDefaultServant("foo");
             identity =  new Identity(identity.Name, "foo");
-            prx = IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+            prx = oa.CreateProxy(identity, IMyObjectPrx.Factory);
             try
             {
                 prx.IcePing();
@@ -148,7 +147,7 @@ namespace Ice.defaultServant
             for (int idx = 0; idx < 5; ++idx)
             {
                 identity = new Identity(names[idx], identity.Category);
-                prx = IMyObjectPrx.UncheckedCast(oa.CreateProxy(identity));
+                prx = oa.CreateProxy(identity, IMyObjectPrx.Factory);
                 prx.IcePing();
                 test(prx.getName() == names[idx]);
             }

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -16,7 +16,7 @@ namespace Ice.defaultServant
             oa.Activate();
 
             var servantI = new MyObject();
-            Disp servantD = (incoming, current) => IMyObject.Dispatch(servantI, incoming, current);
+            Disp servantD = servantI.Dispatch;
 
             //
             // Register default servant with category "foo"

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -16,7 +16,7 @@ namespace Ice.defaultServant
             oa.Activate();
 
             var servantI = new MyObject();
-            Disp servantD = servantI.Dispatch;
+            Disp servantD = (servantI as IObject).Dispatch;
 
             //
             // Register default servant with category "foo"

--- a/csharp/test/Ice/defaultServant/MyObjectI.cs
+++ b/csharp/test/Ice/defaultServant/MyObjectI.cs
@@ -4,7 +4,7 @@
 
 namespace Ice.defaultServant
 {
-    public sealed class MyObject : Object<Test.IMyObject>, Test.IMyObject
+    public sealed class MyObject : ObjectOperations<Test.IMyObject>, Test.IMyObject
     {
         public override void
         IcePing(Current current)

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -12,7 +12,8 @@ public class BlobjectI : Ice.BlobjectAsync
     IceInvokeAsync(byte[] inEncaps, Ice.Current current)
     {
         Debug.Assert(current.Connection != null);
-        var prx = current.Connection.CreateProxy(current.Id).Clone(facet: current.Facet, oneway: current.RequestId == 0);
+        var prx = current.Connection.CreateProxy(current.Id, IObjectPrx.Factory)
+            .Clone(facet: current.Facet, oneway: current.RequestId == 0);
         return prx.InvokeAsync(current.Operation, current.Mode, inEncaps, current.Context);
     }
 }

--- a/csharp/test/Ice/echo/Server.cs
+++ b/csharp/test/Ice/echo/Server.cs
@@ -22,7 +22,7 @@ public class Server : TestHelper
         communicator.SetProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
         BlobjectI blob = new BlobjectI();
-        adapter.AddDefaultServant((incoming, current) => blob.Dispatch(incoming, current), "");
+        adapter.AddDefaultServant(blob.Dispatch, "");
         adapter.Add(new Echo(), "__echo");
         adapter.Activate();
         communicator.WaitForShutdown();

--- a/csharp/test/Ice/echo/Server.cs
+++ b/csharp/test/Ice/echo/Server.cs
@@ -22,7 +22,7 @@ public class Server : TestHelper
         communicator.SetProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
         BlobjectI blob = new BlobjectI();
-        adapter.AddDefaultServant(blob.Dispatch, "");
+        adapter.AddDefaultServant(blob, "");
         adapter.Add(new Echo(), "__echo");
         adapter.Activate();
         communicator.WaitForShutdown();

--- a/csharp/test/Ice/inheritance/InitialI.cs
+++ b/csharp/test/Ice/inheritance/InitialI.cs
@@ -12,10 +12,10 @@ namespace Ice.inheritance
     {
         public InitialI(Ice.ObjectAdapter adapter)
         {
-            _ia = adapter.Add(new IA());
-            _ib1 = adapter.Add(new IB1());
-            _ib2 = adapter.Add(new IB2());
-            _ic = adapter.Add(new IC());
+            _ia = adapter.Add(new IA(),IIAPrx.Factory);
+            _ib1 = adapter.Add(new IB1(), IIB1Prx.Factory);
+            _ib2 = adapter.Add(new IB2(), IIB2Prx.Factory);
+            _ic = adapter.Add(new IC(), IICPrx.Factory);
         }
 
         public IIAPrx iaop(Current current) => _ia;

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -16,7 +16,7 @@ namespace Ice.interceptor
 
     public class Client : TestHelper
     {
-        private void runTest(Test.IMyObjectPrx prx, Interceptor<IMyObject> interceptor)
+        private void runTest(Test.IMyObjectPrx prx, Interceptor interceptor)
         {
             var output = getWriter();
             output.Write("testing simple interceptor... ");
@@ -101,7 +101,7 @@ namespace Ice.interceptor
             output.WriteLine("ok");
         }
 
-        private void runAmdTest(IMyObjectPrx prx, Interceptor<IMyObject> interceptor)
+        private void runAmdTest(IMyObjectPrx prx, Interceptor interceptor)
         {
             var output = getWriter();
             output.Write("testing simple interceptor... ");
@@ -203,9 +203,9 @@ namespace Ice.interceptor
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA2", "tcp -h localhost");
 
             var myObject = new MyObject();
-            var interceptor = new Interceptor<IMyObject>(myObject, myObject.Dispatch);
+            var interceptor = new Interceptor(myObject);
 
-            var prx = oa.Add(interceptor.Dispatch, IMyObjectPrx.Factory);
+            var prx = oa.Add(interceptor, IMyObjectPrx.Factory);
 
             var output = getWriter();
 

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -16,7 +16,7 @@ namespace Ice.interceptor
 
     public class Client : TestHelper
     {
-        private void runTest(Test.IMyObjectPrx prx, Interceptor<IMyObject, MyObjectTraits> interceptor)
+        private void runTest(Test.IMyObjectPrx prx, Interceptor<IMyObject> interceptor)
         {
             var output = getWriter();
             output.Write("testing simple interceptor... ");
@@ -101,7 +101,7 @@ namespace Ice.interceptor
             output.WriteLine("ok");
         }
 
-        private void runAmdTest(IMyObjectPrx prx, Interceptor<IMyObject, MyObjectTraits> interceptor)
+        private void runAmdTest(IMyObjectPrx prx, Interceptor<IMyObject> interceptor)
         {
             var output = getWriter();
             output.Write("testing simple interceptor... ");
@@ -202,9 +202,9 @@ namespace Ice.interceptor
 
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA2", "tcp -h localhost");
 
-            var interceptor = new Interceptor<IMyObject, MyObjectTraits>(new MyObject());
+            var interceptor = new Interceptor<IMyObject>(new MyObject(), IMyObject.Dispatch);
 
-            var prx = IMyObjectPrx.UncheckedCast(oa.Add((incoming, current) => interceptor.Dispatch(incoming, current)));
+            var prx = oa.Add(interceptor.Dispatch, IMyObjectPrx.Factory);
 
             var output = getWriter();
 

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -202,7 +202,8 @@ namespace Ice.interceptor
 
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA2", "tcp -h localhost");
 
-            var interceptor = new Interceptor<IMyObject>(new MyObject(), IMyObject.Dispatch);
+            var myObject = new MyObject();
+            var interceptor = new Interceptor<IMyObject>(myObject, myObject.Dispatch);
 
             var prx = oa.Add(interceptor.Dispatch, IMyObjectPrx.Factory);
 

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -8,7 +8,7 @@ namespace Ice.interceptor
 {
     internal sealed class Interceptor<T>
     {
-        internal Interceptor(T servant, Ice.ServantDispatch<T> servantDisp)
+        internal Interceptor(T servant, Disp servantDisp)
         {
             _servant = servant;
             _servantDisp = servantDisp;
@@ -54,7 +54,7 @@ namespace Ice.interceptor
                     {
                         try
                         {
-                            var t = _servantDisp(_servant, incoming, current);
+                            var t = _servantDisp(incoming, current);
                             if (t != null && t.IsFaulted)
                             {
                                 throw t.Exception.InnerException;
@@ -80,11 +80,11 @@ namespace Ice.interceptor
                     // Retry the dispatch to ensure that abandoning the result of the dispatch
                     // works fine and is thread-safe
                     //
-                    _servantDisp(_servant, incoming, current);
-                    _servantDisp(_servant, incoming, current);
+                    _servantDisp(incoming, current);
+                    _servantDisp(incoming, current);
                 }
 
-                var task = _servantDisp(_servant, incoming, current);
+                var task = _servantDisp(incoming, current);
                 _lastStatus = task != null;
 
                 if (current.Context.TryGetValue("raiseAfterDispatch", out context))
@@ -132,7 +132,7 @@ namespace Ice.interceptor
         }
 
         private readonly T _servant;
-        private readonly Ice.ServantDispatch<T> _servantDisp;
+        private readonly Disp _servantDisp;
         private string _lastOperation;
         private bool _lastStatus = false;
     }

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -579,11 +579,11 @@ namespace Ice.location
             test(helloPrx.GetConnection() == null);
 
             // Ensure that calls on the indirect proxy (with adapter ID) is collocated
-            helloPrx = IHelloPrx.CheckedCast(adapter.CreateIndirectProxy(id));
+            helloPrx = IHelloPrx.CheckedCast(adapter.CreateIndirectProxy(id, IObjectPrx.Factory));
             test(helloPrx != null && helloPrx.GetConnection() == null);
 
             // Ensure that calls on the direct proxy is collocated
-            helloPrx = IHelloPrx.CheckedCast(adapter.CreateDirectProxy(id));
+            helloPrx = IHelloPrx.CheckedCast(adapter.CreateDirectProxy(id, IObjectPrx.Factory));
             test(helloPrx != null && helloPrx.GetConnection() == null);
 
             output.WriteLine("ok");

--- a/csharp/test/Ice/location/Server.cs
+++ b/csharp/test/Ice/location/Server.cs
@@ -30,7 +30,7 @@ namespace Ice.location
             var obj = new ServerManager(registry, this);
             adapter.Add(obj, "ServerManager");
             registry.addObject(adapter.CreateProxy("ServerManager", IObjectPrx.Factory));
-            var registryPrx = adapter.Add(registry, "registry");
+            var registryPrx = adapter.Add(registry, ILocatorRegistryPrx.Factory, "registry");
             adapter.Add(new ServerLocator(registry, registryPrx), "locator");
 
             adapter.Activate();

--- a/csharp/test/Ice/location/Server.cs
+++ b/csharp/test/Ice/location/Server.cs
@@ -29,7 +29,7 @@ namespace Ice.location
             var registry = new ServerLocatorRegistry();
             var obj = new ServerManager(registry, this);
             adapter.Add(obj, "ServerManager");
-            registry.addObject(adapter.CreateProxy("ServerManager"));
+            registry.addObject(adapter.CreateProxy("ServerManager", IObjectPrx.Factory));
             var registryPrx = adapter.Add(registry, "registry");
             adapter.Add(new ServerLocator(registry, registryPrx), "locator");
 

--- a/csharp/test/Ice/location/ServerManagerI.cs
+++ b/csharp/test/Ice/location/ServerManagerI.cs
@@ -65,8 +65,8 @@ namespace Ice.location
                     adapter2.SetLocator(locator);
 
                     var testI = new TestIntf(adapter, adapter2, _registry);
-                    _registry.addObject(adapter.Add(testI, "test"));
-                    _registry.addObject(adapter.Add(testI, "test2"));
+                    _registry.addObject(adapter.Add(testI, Ice.IObjectPrx.Factory, "test"));
+                    _registry.addObject(adapter.Add(testI, Ice.IObjectPrx.Factory, "test2"));
                     adapter.Add(testI, "test3");
 
                     adapter.Activate();

--- a/csharp/test/Ice/location/TestI.cs
+++ b/csharp/test/Ice/location/TestI.cs
@@ -19,22 +19,20 @@ namespace Ice.location
 
         public void shutdown(Current current) => _adapter1.Communicator.Shutdown();
 
-        public IHelloPrx getHello(Current current) =>
-            IHelloPrx.UncheckedCast(_adapter1.CreateIndirectProxy("hello"));
+        public IHelloPrx getHello(Current current) => _adapter1.CreateIndirectProxy("hello", IHelloPrx.Factory);
 
-        public IHelloPrx getReplicatedHello(Current current) =>
-            IHelloPrx.UncheckedCast(_adapter1.CreateProxy("hello"));
+        public IHelloPrx getReplicatedHello(Current current) => _adapter1.CreateProxy("hello", IHelloPrx.Factory);
 
         public void migrateHello(Current current)
         {
             var id = Identity.Parse("hello");
             try
             {
-                _registry.addObject(_adapter2.Add(_adapter1.Remove(id), id), current);
+                _registry.addObject(_adapter2.Add(_adapter1.Remove(id), IObjectPrx.Factory, id), current);
             }
             catch (NotRegisteredException)
             {
-                _registry.addObject(_adapter1.Add(_adapter2.Remove(id), id), current);
+                _registry.addObject(_adapter1.Add(_adapter2.Remove(id), IObjectPrx.Factory, id), current);
             }
         }
 

--- a/csharp/test/Ice/location/TestI.cs
+++ b/csharp/test/Ice/location/TestI.cs
@@ -14,7 +14,7 @@ namespace Ice.location
             _adapter2 = adapter2;
             _registry = registry;
 
-            _registry.addObject(_adapter1.Add(new Hello(), "hello"));
+            _registry.addObject(_adapter1.Add(new Hello(), IObjectPrx.Factory, "hello"));
         }
 
         public void shutdown(Current current) => _adapter1.Communicator.Shutdown();

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -414,7 +414,7 @@ public class AllTests : Test.AllTests
         test(serverProps != null && serverMetrics != null);
 
         UpdateCallbackI update = new UpdateCallbackI(serverProps);
-        ((INativePropertiesAdmin)communicator.FindAdminFacet("Properties").servant).AddUpdateCallback(update.updated);
+        ((INativePropertiesAdmin)communicator.FindAdminFacet("Properties")).AddUpdateCallback(update.updated);
 
         output.WriteLine("ok");
 

--- a/csharp/test/Ice/objects/Collocated.cs
+++ b/csharp/test/Ice/objects/Collocated.cs
@@ -19,7 +19,7 @@ namespace Ice.objects
             adapter.Add(new Initial(adapter), "initial");
             adapter.Add(new F2(), "F21");
             var uoet = new UnexpectedObjectExceptionTest();
-            adapter.Add((incoming, current) => uoet.Dispatch(incoming, current), "uoet");
+            adapter.Add(uoet.Dispatch, "uoet");
             Test.AllTests.allTests(this);
         }
 

--- a/csharp/test/Ice/objects/Server.cs
+++ b/csharp/test/Ice/objects/Server.cs
@@ -19,7 +19,7 @@ namespace Ice.objects
             adapter.Add(new Initial(adapter), "initial");
             adapter.Add(new F2(), "F21");
             var uoet = new UnexpectedObjectExceptionTest();
-            adapter.Add((incoming, current) => uoet.Dispatch(incoming, current), "uoet");
+            adapter.Add(uoet.Dispatch, "uoet");
             adapter.Activate();
             serverReady();
             communicator.WaitForShutdown();

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -19,7 +19,7 @@ namespace Ice.operations
             communicator.SetProperty("TestAdapter.AdapterId", "test");
             communicator.SetProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            var prx = adapter.Add(new MyDerivedClass(), "test");
+            var prx = adapter.Add(new MyDerivedClass(), IMyDerivedClassPrx.Factory, "test");
             //adapter.activate(); // Don't activate OA to ensure collocation is used.
 
             if (prx.GetConnection() != null)

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -252,9 +252,9 @@ namespace Ice.operations.AMD
         opMyClassAsync(Test.IMyClassPrx p1, Current current)
         {
             var p2 = p1;
-            var p3 = Test.IMyClassPrx.UncheckedCast(current.Adapter.CreateProxy("noSuchIdentity"));
+            var p3 = current.Adapter.CreateProxy("noSuchIdentity", Test.IMyClassPrx.Factory);
             return Task.FromResult(new Test.IMyClass.OpMyClassReturnValue(
-                Test.IMyClassPrx.UncheckedCast(current.Adapter.CreateProxy(current.Id)), p2, p3));
+                current.Adapter.CreateProxy(current.Id, Test.IMyClassPrx.Factory), p2, p3));
         }
 
         public Task<Test.IMyClass.OpMyEnumReturnValue>

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -188,9 +188,9 @@ namespace Ice.operations
 
         public Test.IMyClass.OpMyClassReturnValue opMyClass(Test.IMyClassPrx p1, Current current) =>
             new Test.IMyClass.OpMyClassReturnValue(
-                Test.IMyClassPrx.UncheckedCast(current.Adapter.CreateProxy(current.Id)),
+                current.Adapter.CreateProxy(current.Id, Test.IMyClassPrx.Factory),
                 p1,
-                Test.IMyClassPrx.UncheckedCast(current.Adapter.CreateProxy("noSuchIdentity")));
+                current.Adapter.CreateProxy("noSuchIdentity", Test.IMyClassPrx.Factory));
 
         public Test.IMyClass.OpMyEnumReturnValue
         opMyEnum(Test.MyEnum p1, Current current)

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -392,7 +392,7 @@ namespace Ice.proxy
 
             if (b1.GetConnection() != null) // not colloc-optimized target
             {
-                b2 = b1.GetConnection().CreateProxy(Identity.Parse("fixed"));
+                b2 = b1.GetConnection().CreateProxy(Identity.Parse("fixed"), IObjectPrx.Factory);
                 string str = b2.ToString();
                 test(b2.ToString() == str);
                 string str2 = b1.Clone(b2.Identity).Clone(secure: b2.IsSecure).ToString();

--- a/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Ice.proxy.AMD
 {
-    public sealed class MyDerivedClass : Object<Test.IMyDerivedClass>, Test.IMyDerivedClass
+    public sealed class MyDerivedClass : ObjectOperations<Test.IMyDerivedClass>, Test.IMyDerivedClass
     {
         public Task<IObjectPrx> echoAsync(IObjectPrx obj, Current c) => Task.FromResult(obj);
 

--- a/csharp/test/Ice/proxy/MyDerivedClassI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassI.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Ice.proxy
 {
-    public sealed class MyDerivedClass : Object<Test.IMyDerivedClass>, Test.IMyDerivedClass
+    public sealed class MyDerivedClass : ObjectOperations<Test.IMyDerivedClass>, Test.IMyDerivedClass
     {
 
         public IObjectPrx echo(IObjectPrx obj, Current c) => obj;

--- a/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
@@ -67,7 +67,7 @@ namespace Ice.servantLocator.AMD
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return testI.Dispatch;
+            return (testI as IObject).Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
@@ -65,8 +65,7 @@ namespace Ice.servantLocator.AMD
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            Test.TestIntfTraits testT = default;
-            return (current, incoming) => testT.Dispatch(testI, current, incoming);
+            return (current, incoming) => Test.ITestIntf.Dispatch(testI, current, incoming);
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice.servantLocator.AMD.Test; // for extension methods
+
 namespace Ice.servantLocator.AMD
 {
     public sealed class ServantLocator : IServantLocator
@@ -65,7 +67,7 @@ namespace Ice.servantLocator.AMD
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return (current, incoming) => Test.ITestIntf.Dispatch(testI, current, incoming);
+            return testI.Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorI.cs
@@ -67,7 +67,7 @@ namespace Ice.servantLocator
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return (current, incoming) => ITestIntf.Dispatch(testI, current, incoming);
+            return testI.Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorI.cs
@@ -67,7 +67,7 @@ namespace Ice.servantLocator
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            return testI.Dispatch;
+            return (testI as IObject).Dispatch;
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorI.cs
@@ -67,8 +67,7 @@ namespace Ice.servantLocator
             cookie = new Cookie();
 
             var testI = new TestIntf();
-            TestIntfTraits testT = default;
-            return (current, incoming) => testT.Dispatch(testI, current, incoming);
+            return (current, incoming) => ITestIntf.Dispatch(testI, current, incoming);
         }
 
         public void Finished(Current current, Disp servant, object cookie)

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -764,7 +764,7 @@ public class AllTests : Test.AllTests
             }
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("");
-            IRelayPrx relay = adapter.Add(new Relay());
+            IRelayPrx relay = adapter.Add(new Relay(), IRelayPrx.Factory);
             adapter.Activate();
             testPrx.GetConnection().SetAdapter(adapter);
 

--- a/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
@@ -86,7 +86,7 @@ public sealed class TestIntf : ITestIntf
     public Task
     relayKnownPreservedAsBaseAsync(IRelayPrx r, Ice.Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.knownPreservedAsBase();
         test(false);
         return null;
@@ -95,7 +95,7 @@ public sealed class TestIntf : ITestIntf
     public Task
     relayKnownPreservedAsKnownPreservedAsync(IRelayPrx r, Ice.Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.knownPreservedAsKnownPreserved();
         test(false);
         return null;
@@ -127,7 +127,7 @@ public sealed class TestIntf : ITestIntf
     public Task
     relayUnknownPreservedAsBaseAsync(IRelayPrx r, Ice.Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.unknownPreservedAsBase();
         test(false);
         return null;
@@ -136,7 +136,7 @@ public sealed class TestIntf : ITestIntf
     public Task
     relayUnknownPreservedAsKnownPreservedAsync(IRelayPrx r, Ice.Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.unknownPreservedAsKnownPreserved();
         test(false);
         return null;

--- a/csharp/test/Ice/slicing/exceptions/TestI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestI.cs
@@ -65,14 +65,14 @@ public sealed class TestIntf : ITestIntf
 
     public void relayKnownPreservedAsBase(IRelayPrx r, Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.knownPreservedAsBase();
         test(false);
     }
 
     public void relayKnownPreservedAsKnownPreserved(IRelayPrx r, Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.knownPreservedAsKnownPreserved();
         test(false);
     }
@@ -101,14 +101,14 @@ public sealed class TestIntf : ITestIntf
 
     public void relayUnknownPreservedAsBase(IRelayPrx r, Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.unknownPreservedAsBase();
         test(false);
     }
 
     public void relayUnknownPreservedAsKnownPreserved(IRelayPrx r, Ice.Current current)
     {
-        IRelayPrx p = IRelayPrx.UncheckedCast(current.Connection.CreateProxy(r.Identity));
+        IRelayPrx p = current.Connection.CreateProxy(r.Identity, IRelayPrx.Factory);
         p.unknownPreservedAsKnownPreserved();
         test(false);
     }

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -384,7 +384,7 @@ namespace Ice.timeout
                 var adapter = communicator.CreateObjectAdapter("TimeoutCollocated");
                 adapter.Activate();
 
-                var proxy = adapter.Add(new Timeout()).Clone(invocationTimeout: 100);
+                var proxy = adapter.Add(new Timeout(), ITimeoutPrx.Factory).Clone(invocationTimeout: 100);
                 try
                 {
                     proxy.sleep(500);

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -59,7 +59,8 @@ namespace Ice.udp
             communicator.SetProperty("ReplyAdapter.Endpoints", "udp");
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ReplyAdapter");
             PingReplyI replyI = new PingReplyI();
-            IPingReplyPrx reply = adapter.Add(replyI).Clone(invocationMode: InvocationMode.Datagram);
+            IPingReplyPrx reply = adapter.Add(replyI, IPingReplyPrx.Factory)
+                .Clone(invocationMode: InvocationMode.Datagram);
             adapter.Activate();
 
             Console.Out.Write("testing udp... ");
@@ -84,7 +85,7 @@ namespace Ice.udp
                 // If the 3 datagrams were not received within the 2 seconds, we try again to
                 // receive 3 new datagrams using a new object. We give up after 5 retries.
                 replyI = new PingReplyI();
-                reply = adapter.Add(replyI).Clone(invocationMode: InvocationMode.Datagram);
+                reply = adapter.Add(replyI, IPingReplyPrx.Factory).Clone(invocationMode: InvocationMode.Datagram);
             }
             test(ret == true);
 
@@ -177,7 +178,7 @@ namespace Ice.udp
                     break;
                 }
                 replyI = new PingReplyI();
-                reply = adapter.Add(replyI).Clone(invocationMode: InvocationMode.Datagram);
+                reply = adapter.Add(replyI, IPingReplyPrx.Factory).Clone(invocationMode: InvocationMode.Datagram);
             }
             if (!ret)
             {
@@ -205,7 +206,7 @@ namespace Ice.udp
                     break; // Success
                 }
                 replyI = new PingReplyI();
-                reply = adapter.Add(replyI).Clone(invocationMode: InvocationMode.Datagram);
+                reply = adapter.Add(replyI, IPingReplyPrx.Factory).Clone(invocationMode: InvocationMode.Datagram);
             }
             test(ret);
             Console.Out.WriteLine("ok");

--- a/csharp/test/Ice/udp/TestIntfI.cs
+++ b/csharp/test/Ice/udp/TestIntfI.cs
@@ -43,14 +43,14 @@ namespace Ice.udp
                 try
                 {
                     byte[] seq = new byte[32 * 1024];
-                    Test.ITestIntfPrx.UncheckedCast(current.Connection.CreateProxy(id)).sendByteSeq(seq, null);
+                    current.Connection.CreateProxy(id, Test.ITestIntfPrx.Factory).sendByteSeq(seq, null);
                 }
                 catch (Ice.DatagramLimitException)
                 {
                     // Expected.
                 }
 
-                Test.IPingReplyPrx.UncheckedCast(current.Connection.CreateProxy(id)).reply();
+                current.Connection.CreateProxy(id, Test.IPingReplyPrx.Factory).reply();
             }
             catch (LocalException)
             {

--- a/csharp/test/IceBox/admin/TestServiceI.cs
+++ b/csharp/test/IceBox/admin/TestServiceI.cs
@@ -14,13 +14,13 @@ public class TestService : IService
         //
         // Install a custom admin facet.
         //
-        serviceManagerCommunicator.AddAdminFacet(facet, facet.Dispatch, "TestFacet");
+        serviceManagerCommunicator.AddAdminFacet(facet, "TestFacet");
 
         //
         // The TestFacetI servant also implements PropertiesAdminUpdateCallback.
         // Set the callback on the admin facet.
         //
-        object propFacet = serviceManagerCommunicator.FindAdminFacet("IceBox.Service.TestService.Properties").servant;
+        Ice.IObject? propFacet = serviceManagerCommunicator.FindAdminFacet("IceBox.Service.TestService.Properties");
         if (propFacet != null)
         {
             var admin = (Ice.INativePropertiesAdmin)propFacet;

--- a/csharp/test/IceBox/admin/TestServiceI.cs
+++ b/csharp/test/IceBox/admin/TestServiceI.cs
@@ -14,7 +14,7 @@ public class TestService : IService
         //
         // Install a custom admin facet.
         //
-        serviceManagerCommunicator.AddAdminFacet(facet, "TestFacet", ITestFacet.Dispatch);
+        serviceManagerCommunicator.AddAdminFacet(facet, facet.Dispatch, "TestFacet");
 
         //
         // The TestFacetI servant also implements PropertiesAdminUpdateCallback.

--- a/csharp/test/IceBox/admin/TestServiceI.cs
+++ b/csharp/test/IceBox/admin/TestServiceI.cs
@@ -14,7 +14,7 @@ public class TestService : IService
         //
         // Install a custom admin facet.
         //
-        serviceManagerCommunicator.AddAdminFacet<ITestFacet, TestFacetTraits>(facet, "TestFacet");
+        serviceManagerCommunicator.AddAdminFacet(facet, "TestFacet", ITestFacet.Dispatch);
 
         //
         // The TestFacetI servant also implements PropertiesAdminUpdateCallback.

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -86,7 +86,7 @@ internal sealed class ServerFactory : IServerFactory
         Ice.Communicator communicator = new Ice.Communicator(props);
         Ice.ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints("ServerAdapter", "ssl");
         var server = new SSLServer(communicator);
-        var prx = adapter.Add(server);
+        var prx = adapter.Add(server, IServerPrx.Factory);
         _servers[prx.Identity] = server;
         adapter.Activate();
         return prx;

--- a/csharp/test/Slice/escape/Client.cs
+++ b/csharp/test/Slice/escape/Client.cs
@@ -111,16 +111,16 @@ public class Client : Test.TestHelper
 
             Console.Out.Write("testing operation name... ");
             Console.Out.Flush();
-            var p = IdecimalPrx.UncheckedCast(adapter.CreateProxy("test"));
+            var p = adapter.CreateProxy("test", IdecimalPrx.Factory);
             p.@default();
             Console.Out.WriteLine("ok");
 
             Console.Out.Write("testing System as module name... ");
             Console.Out.Flush();
-            @abstract.System.ITestPrx t1 = @abstract.System.ITestPrx.UncheckedCast(adapter.CreateProxy("test1"));
+            @abstract.System.ITestPrx t1 = adapter.CreateProxy("test1", @abstract.System.ITestPrx.Factory);
             t1.op();
 
-            System.ITestPrx t2 = System.ITestPrx.UncheckedCast(adapter.CreateProxy("test2"));
+            System.ITestPrx t2 = adapter.CreateProxy("test2", System.ITestPrx.Factory);
 
             t2.op();
             Console.Out.WriteLine("ok");


### PR DESCRIPTION
With this PR, servant dispatch relies on a Dispatch method on the base interface IObject. This Dispatch method is explicitly implemented in derived generated interfaces. See https://github.com/dotnet/roslyn/issues/39940. This also works with multiple inheritance, like in Java.

This way, internally, Ice can easily create a dispatcher from a servant: it's simply servant.Dispatch. This eliminates the need for generated extension methods for server-side interfaces.

This PR also reorganizes the generated dispatch code with:
- a public instance Dispatch from IObject that calls a static Dispatch (below)
- a protected static Dispatch in each generated interface with the actual operation-switch implementation, that sends the request to the correct method `IceD_<opName>`
- for each operation, a protected instance `IceD_<opName>` that unmarshals the operation parameters before calling the application method; later, it marshals the return value.

`<opName>` in `IceD_<opName`  is the exact Slice operation name, without change in capitalization. This way several Slice interfaces in an inheritance tree can be compiled with different normalize-case settings.

Finally, this PR makes most methods that create proxies typed. The caller just needs to specify the desired proxy type with a `<proxy interface>.Factory` parameter. For example:
```
// before
var locator = ILocatorPrx.UncheckedCast(adapter.CreateProxy(identity));
// with PR:
var locator = adapter.CreateProxy(identity, ILocatorPrx.Factory);
```

This `<proxy interface>.Factory` parameter is already use by `Communicator.GetPropertyAsProxy`.


 