### PR TITLE
User exceptions are now always marshaled with the Sliced format.

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2916,11 +2916,6 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     }
     _out << nl << "istr.EndEncapsulation();";
 
-    if(operation->format() != DefaultFormat)
-    {
-        _out << nl << "current.Format = " << opFormatTypeToString(operation, ns) << ";";
-    }
-
     // The 'this.' is necessary only when the operation name matches one of our local variable (current, istr etc.)
 
     if(operation->hasMarshaledResult())

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -18,7 +18,6 @@ namespace Ice
         public int RequestId { get; }
         public bool IsOneway => RequestId == 0;
         public EncodingVersion Encoding { get; }
-        public FormatType? Format { get ; set; } // TODO: temporary, until exceptions are always sliced
 
         internal Current(ObjectAdapter adapter, Identity id, string facet, string operation, OperationMode mode,
             Dictionary<string, string> ctx, int requestId, Connection? connection, EncodingVersion encoding)

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1191,6 +1191,7 @@ namespace Ice
         public void WriteException(UserException v)
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null && _current == null);
+            Debug.Assert(_format != null && _format == FormatType.SlicedFormat);
             Push(InstanceType.Exception);
             v.Write(this);
             Pop(null);

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -20,8 +20,6 @@ namespace IceInternal
         /// <returns>An <see cref="Ice.OutputStream"/> that holds the new frame.</returns>
         public static Ice.OutputStream StartResponseFrame(Ice.Current current, Ice.FormatType? format = null)
         {
-            Debug.Assert(format == current.Format); // temporary
-
             var ostr = new Ice.OutputStream(current.Adapter.Communicator, Ice.Util.CurrentProtocolEncoding);
             ostr.WriteBlob(Protocol.replyHdr);
             ostr.WriteInt(current.RequestId);
@@ -56,7 +54,8 @@ namespace IceInternal
             ostr.WriteBlob(Protocol.replyHdr);
             ostr.WriteInt(current.RequestId);
             ostr.WriteByte(ReplyStatus.replyUserException);
-            ostr.StartEncapsulation(current.Encoding, current.Format);
+            // Exceptions are always marshaled in the sliced format:
+            ostr.StartEncapsulation(current.Encoding, FormatType.SlicedFormat);
             return ostr;
         }
 
@@ -141,9 +140,8 @@ namespace IceInternal
             catch (Ice.UserException ex)
             {
                 ostr.WriteByte(ReplyStatus.replyUserException);
-                // TODO: always send exception in sliced format?
-                // ostr.StartEncapsulation(current.Encoding, Ice.FormatType.SlicedFormat);
-                ostr.StartEncapsulation(current.Encoding, current.Format);
+                // Exceptions are always marshaled in the sliced format:
+                ostr.StartEncapsulation(current.Encoding, FormatType.SlicedFormat);
                 ostr.WriteException(ex);
                 ostr.EndEncapsulation();
             }

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -74,7 +74,6 @@ namespace Ice.invoke
             InputStream inS = new InputStream(communicator, inParams);
             inS.StartEncapsulation();
             OutputStream outS = new OutputStream(communicator);
-            outS.StartEncapsulation();
             if (current.Operation.Equals("opOneway"))
             {
                 return Task.FromResult(new Object_Ice_invokeResult(true, new byte[0]));
@@ -82,6 +81,7 @@ namespace Ice.invoke
             else if (current.Operation.Equals("opString"))
             {
                 string s = inS.ReadString();
+                outS.StartEncapsulation();
                 outS.WriteString(s);
                 outS.WriteString(s);
                 outS.EndEncapsulation();
@@ -90,6 +90,7 @@ namespace Ice.invoke
             else if (current.Operation.Equals("opException"))
             {
                 Test.MyException ex = new Test.MyException();
+                outS.StartEncapsulation(current.Encoding, FormatType.SlicedFormat);
                 outS.WriteException(ex);
                 outS.EndEncapsulation();
                 return Task.FromResult(new Object_Ice_invokeResult(false, outS.Finished()));
@@ -102,6 +103,7 @@ namespace Ice.invoke
             else if (current.Operation.Equals("ice_isA"))
             {
                 string s = inS.ReadString();
+                outS.StartEncapsulation();
                 if (s.Equals("::Test::MyClass"))
                 {
                     outS.WriteBool(true);

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -847,7 +847,7 @@ public class AllTests : Test.AllTests
 
         dm1 = (IceMX.DispatchMetrics)map["opWithUserException"];
         test(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 1);
-        test(dm1.Size == 38 && dm1.ReplySize == 23);
+        test(dm1.Size == 38 && dm1.ReplySize == 27);
 
         dm1 = (IceMX.DispatchMetrics)map["opWithLocalException"];
         test(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);
@@ -1033,7 +1033,7 @@ public class AllTests : Test.AllTests
         test(collocated ? im1.Collocated.Length == 1 : im1.Remotes.Length == 1);
         rim1 = (IceMX.ChildInvocationMetrics)(collocated ? im1.Collocated[0] : im1.Remotes[0]);
         test(rim1.Current == 0 && rim1.Total == 2 && rim1.Failures == 0);
-        test(rim1.Size == 76 && rim1.ReplySize == 46);
+        test(rim1.Size == 76 && rim1.ReplySize == 54);
         test(im1.UserException == 2);
 
         im1 = (IceMX.InvocationMetrics)map["opWithLocalException"];

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -714,14 +714,12 @@ public class AllTests : Test.AllTests
             }
             catch (Base)
             {
-                test(false);
+                // Exceptions are always marshaled in sliced format; format:compact applies only to in-parameters and
+                // return values.
             }
             catch (Ice.UnknownUserException)
             {
-                //
-                // A MarshalException is raised for the compact format because the
-                // most-derived type is unknown and the exception cannot be sliced.
-                //
+                test(false);
             }
             catch (Ice.OperationNotExistException)
             {

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -529,7 +529,7 @@ namespace Ice.stream
 
             {
                 ostr = new OutputStream(communicator);
-                ostr.StartEncapsulation();
+                ostr.StartEncapsulation(ostr.Encoding, FormatType.SlicedFormat);
                 var ex = new Test.MyException();
 
                 var c = new Test.MyClass();


### PR DESCRIPTION
This PR changes the marshaling of user exceptions to always use the Sliced format.

The compact format optimization is not important for exceptions. Once we remove checked exceptions from Slice, mismatches between the exception definitions compiled in the client and server are more likely, which makes the compact format undesirable for exceptions.