### PR TITLE
Change IObjectPrx.IsOneway to match all oneway invocation modes

### DIFF
--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -695,7 +695,7 @@ namespace IceInternal
                 }
             }
         }
-        public override bool Sent() => base.SentImpl(!Proxy.IsTwoway); // done = true if it's not a two-way proxy
+        public override bool Sent() => base.SentImpl(Proxy.IsOneway); // done = true if it's not a two-way proxy
 
         public override bool Response()
         {
@@ -705,7 +705,7 @@ namespace IceInternal
             // with the connection locked. Therefore, it must not invoke
             // any user callbacks.
             //
-            Debug.Assert(Proxy.IsTwoway); // Can only be called for twoways.
+            Debug.Assert(!Proxy.IsOneway); // Can only be called for twoways.
 
             if (ChildObserver != null)
             {
@@ -855,7 +855,7 @@ namespace IceInternal
         public override int InvokeCollocated(CollocatedRequestHandler handler)
         {
             // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
-            if (!Proxy.IsTwoway || Proxy.IceReference.GetInvocationTimeout() != -1)
+            if (Proxy.IsOneway || Proxy.IceReference.GetInvocationTimeout() != -1)
             {
                 // Disable caching by marking the streams as cached!
                 State |= StateCachedBuffers;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -351,17 +351,11 @@ namespace Ice
         /// <returns>True if the proxy uses collocation optimization; false, otherwise.</returns>
         public bool IsCollocationOptimized => IceReference.GetCollocationOptimized();
 
-        /// <summary>
-        /// Returns whether this proxy uses twoway invocations.
-        /// </summary>
-        /// <returns>True if this proxy uses twoway invocations; false, otherwise.</returns>
-        public bool IsTwoway => IceReference.GetMode() == InvocationMode.Twoway;
-
-        /// <summary>
-        /// Returns whether this proxy uses oneway invocations.
-        /// </summary>
-        /// <returns>True if this proxy uses oneway invocations; false, otherwise.</returns>
-        public bool IsOneway => IceReference.GetMode() == InvocationMode.Oneway;
+        /// <summary>Returns whether or not an operation invoked on this proxy returns a response.</summary>
+        /// <returns>True if invoking an operation on this proxy does not return a response. This corresponds to
+        /// several <see cref="InvocationMode"> enumerators, such as Oneway and Datagram. Otherwise,
+        /// returns false.</returns>
+        public bool IsOneway => IceReference.GetMode() != InvocationMode.Twoway;
 
         public InvocationMode InvocationMode => IceReference.GetMode();
 
@@ -443,7 +437,7 @@ namespace Ice
             // operation.
             //
 
-            if (!IsTwoway)
+            if (IsOneway)
             {
                 throw new TwowayOnlyException(name);
             }
@@ -457,9 +451,9 @@ namespace Ice
             // operation.
             //
 
-            if (!IsTwoway)
+            if (IsOneway)
             {
-                throw new ArgumentException("`" + name + "' can only be called with a twoway proxy");
+                throw new ArgumentException($"`{name}' can only be called with a twoway proxy");
             }
         }
 

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -213,9 +213,9 @@ namespace Ice.proxy
             {
             }
             b1 = IObjectPrx.Parse("test", communicator);
-            test(b1.IsTwoway);
+            test(!b1.IsOneway);
             b1 = IObjectPrx.Parse("test -t", communicator);
-            test(b1.IsTwoway);
+            test(!b1.IsOneway);
             b1 = IObjectPrx.Parse("test -o", communicator);
             test(b1.IsOneway);
             b1 = IObjectPrx.Parse("test -O", communicator);
@@ -587,8 +587,9 @@ namespace Ice.proxy
 
             test(baseProxy.Clone(facet: "facet").Facet.Equals("facet"));
             test(baseProxy.Clone(adapterId: "id").AdapterId.Equals("id"));
-            test(baseProxy.Clone(invocationMode: InvocationMode.Twoway).IsTwoway);
+            test(!baseProxy.Clone(invocationMode: InvocationMode.Twoway).IsOneway);
             test(baseProxy.Clone(invocationMode: InvocationMode.Oneway).IsOneway);
+            test(baseProxy.Clone(invocationMode: InvocationMode.Datagram).IsOneway);
             test(baseProxy.Clone(invocationMode: InvocationMode.BatchOneway).InvocationMode == InvocationMode.BatchOneway);
             test(baseProxy.Clone(invocationMode: InvocationMode.Datagram).InvocationMode == InvocationMode.Datagram);
             test(baseProxy.Clone(invocationMode: InvocationMode.BatchDatagram).InvocationMode == InvocationMode.BatchDatagram);


### PR DESCRIPTION
This tiny PR changes the semantics of IsOneway and removes IsTwoway.

IsOneway no longer corresponds to the Oneway invocation mode but to all oneway invocation modes (currently all invocation modes except Twoway). And IsTwoway is no longer needed - it's just not-IsOneway.