### PR TITLE
Replace OperationMode by idempotent bool in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -59,6 +59,14 @@ sliceModeToIceMode(Operation::Mode opMode, string ns)
 }
 
 string
+sliceModeToIdempotent(Operation::Mode opMode)
+{
+    assert(opMode != Operation::Nonmutating); // TODO: can we just eliminate this enumerator?
+
+    return opMode == Operation::Normal ? "false" : "true";
+}
+
+string
 opFormatTypeToString(const OperationPtr& op, string ns)
 {
     switch (op->format())
@@ -2904,7 +2912,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
         << " current)";
     _out << sb;
 
-    _out << nl << "IceCheckMode(" << sliceModeToIceMode(operation->mode(), ns) << ", current.Mode);";
+    _out << nl << "IceCheckIdempotent(" << sliceModeToIdempotent(operation->mode()) << ", current);";
 
     // Even when the parameters are empty, we verify we could read the data. Note that EndEncapsulation
     // skips tagged members, and needs to understand them.

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -28,11 +28,11 @@ using namespace IceUtilInternal;
 namespace
 {
 
-string
-sliceModeToIdempotent(Operation::Mode opMode)
+bool
+isIdempotent(const OperationPtr& operation)
 {
     // TODO: eliminate Nonmutating enumerator in the parser together with the nonmutating metadata.
-    return opMode == Operation::Normal ? "false" : "true";
+    return operation->mode() != Operation::Normal;
 }
 
 string
@@ -2475,7 +2475,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
         _out << nl << "outAsync.Invoke(";
         _out.inc();
         _out << nl << '"' << operation->name() << '"' << ",";
-        _out << nl << "idempotent: " << sliceModeToIdempotent(operation->sendMode()) << ",";
+        _out << nl << "idempotent: " << (isIdempotent(operation) ? "true" : "false") << ",";
         _out << nl << opFormatTypeToString(operation, ns) << ",";
         _out << nl << "context,";
         _out << nl << "synchronous";
@@ -2881,7 +2881,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
         << " current)";
     _out << sb;
 
-    if (operation->mode() == Operation::Normal) // = non-idempotent
+    if (!isIdempotent(operation))
     {
          _out << nl << "IceCheckNonIdempotent(current);";
     }

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -13,20 +13,20 @@ namespace Ice
         public Identity Id { get; }
         public string Facet { get; }
         public string Operation { get; }
-        public OperationMode Mode { get; }
+        public bool IsIdempotent { get; }
         public Dictionary<string, string> Context { get; }
         public int RequestId { get; }
         public bool IsOneway => RequestId == 0;
         public EncodingVersion Encoding { get; }
 
-        internal Current(ObjectAdapter adapter, Identity id, string facet, string operation, OperationMode mode,
+        internal Current(ObjectAdapter adapter, Identity id, string facet, string operation, bool idempotent,
             Dictionary<string, string> ctx, int requestId, Connection? connection, EncodingVersion encoding)
         {
             Adapter = adapter;
             Id = id;
             Facet = facet;
             Operation = operation;
-            Mode = mode;
+            IsIdempotent = idempotent;
             Context = ctx;
             RequestId = requestId;
             Connection = connection;

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -61,17 +61,16 @@ namespace Ice
         // The following protected static methods with Ice-prefixes are Ice-internal helper methods used by
         // generated servants.
 
-        protected static void IceCheckIdempotent(bool expected, Current current)
+        // The generated code calls this method to ensure that when an operation is _not_ declared idempotent, the
+        // request is not marked idempotent (which would mean the caller incorrectly believes this operation is
+        // idempotent).
+        protected static void IceCheckNonIdempotent(Current current)
         {
-            // TODO: if we expect idempotent = true (because the implementation was made idempotent), is it really
-            // a problem to receive a non-idempotent request?
-            if (expected != current.IsIdempotent)
+            if (current.IsIdempotent)
             {
-                string expectedStr = expected ? "idempotent" : "non-idempotent";
-                string receivedStr = current.IsIdempotent ? "idempotent" : "non-idempotent";
                 throw new MarshalException(
-                        $@"idempotent mistmatch for operation {current.Operation
-                        }: expected = {expectedStr} received = {receivedStr}");
+                        $@"idempotent mistmatch for operation `{current.Operation
+                        }': received request marked idempotent for a non-idempotent operation");
             }
         }
 

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -61,19 +61,17 @@ namespace Ice
         // The following protected static methods with Ice-prefixes are Ice-internal helper methods used by
         // generated servants.
 
-        protected static void IceCheckMode(OperationMode expected, OperationMode received)
+        protected static void IceCheckIdempotent(bool expected, Current current)
         {
-            if (expected != received)
+            // TODO: if we expect idempotent = true (because the implementation was made idempotent), is it really
+            // a problem to receive a non-idempotent request?
+            if (expected != current.IsIdempotent)
             {
-                if (expected == OperationMode.Idempotent && received == OperationMode.Nonmutating)
-                {
-                    // Fine: typically an old client still using the deprecated nonmutating keyword or metadata.
-                }
-                else
-                {
-                    throw new MarshalException(
-                        $"unexpected operation mode. expected = {expected} received = {received}");
-                }
+                string expectedStr = expected ? "idempotent" : "non-idempotent";
+                string receivedStr = current.IsIdempotent ? "idempotent" : "non-idempotent";
+                throw new MarshalException(
+                        $@"idempotent mistmatch for operation {current.Operation
+                        }: expected = {expectedStr} received = {receivedStr}");
             }
         }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1191,7 +1191,7 @@ namespace Ice
         public void WriteException(UserException v)
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null && _current == null);
-            Debug.Assert(_format != null && _format == FormatType.SlicedFormat);
+            Debug.Assert(_format == FormatType.SlicedFormat);
             Push(InstanceType.Exception);
             v.Write(this);
             Pop(null);

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -171,11 +171,16 @@ namespace IceInternal
             }
             string facet = facetPath.Length == 0 ? "" : facetPath[0];
             string operation = requestFrame.ReadString();
-            byte mode = requestFrame.ReadByte();
+            var mode = requestFrame.ReadByte();
+            if (mode > 2)
+            {
+                throw new Ice.MarshalException();
+            }
+            bool idempotent = mode > 0;
             var context = requestFrame.ReadContext();
             Ice.EncodingVersion encoding = requestFrame.StartEncapsulation();
 
-            return new Ice.Current(adapter, identity, facet, operation, (Ice.OperationMode)mode, context,
+            return new Ice.Current(adapter, identity, facet, operation, idempotent, context,
                 requestId, connection, encoding);
         }
 

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -174,7 +174,8 @@ namespace IceInternal
             var mode = requestFrame.ReadByte();
             if (mode > 2)
             {
-                throw new Ice.MarshalException();
+                throw new Ice.MarshalException(
+                    $"received invalid operation mode `{mode}' with operation `{operation}'");
             }
             bool idempotent = mode > 0;
             var context = requestFrame.ReadContext();

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -100,7 +100,7 @@ namespace Ice
         {
             IceCheckAsyncTwowayOnly("ice_isA");
             var os = new OutgoingAsyncT<bool>(this, completed);
-            os.Invoke("ice_isA", OperationMode.Nonmutating, null, context, synchronous,
+            os.Invoke("ice_isA", idempotent: true, null, context, synchronous,
                 write: (OutputStream os) => os.WriteString(id),
                 read: (InputStream iss) => iss.ReadBool());
         }
@@ -143,7 +143,7 @@ namespace Ice
         private void IceI_IcePing(Dictionary<string, string>? context, IOutgoingAsyncCompletionCallback completed, bool synchronous)
         {
             var os = new OutgoingAsyncT<object>(this, completed);
-            os.Invoke("ice_ping", OperationMode.Nonmutating, null, context, synchronous);
+            os.Invoke("ice_ping", idempotent: true, null, context, synchronous);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Ice
         {
             IceCheckAsyncTwowayOnly("ice_ids");
             new OutgoingAsyncT<string[]>(this, completed).Invoke("ice_ids",
-                                                         OperationMode.Nonmutating,
+                                                         idempotent: true,
                                                          null,
                                                          context,
                                                          synchronous,
@@ -240,7 +240,7 @@ namespace Ice
                                  bool synchronous)
         {
             var os = new OutgoingAsyncT<string>(this, completed);
-            os.Invoke("ice_id", OperationMode.Nonmutating, null, context, synchronous,
+            os.Invoke("ice_id", idempotent: true, null, context, synchronous,
                       read: (InputStream iss) => iss.ReadString());
         }
 
@@ -458,7 +458,7 @@ namespace Ice
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public int IceHandleException(Exception ex, IRequestHandler? handler, OperationMode mode, bool sent,
+        public int IceHandleException(Exception ex, IRequestHandler? handler, bool idempotent, bool sent,
                                       ref int cnt)
         {
             IceUpdateRequestHandler(handler, null); // Clear the request handler
@@ -479,7 +479,7 @@ namespace Ice
             // also always be retried if the retry count isn't reached.
             //
             if (ex is LocalException && (!sent ||
-                                        mode == OperationMode.Nonmutating || mode == OperationMode.Idempotent ||
+                                        idempotent ||
                                         ex is CloseConnectionException ||
                                         ex is ObjectNotExistException))
             {
@@ -595,13 +595,13 @@ namespace Ice
         {
         }
 
-        public void Invoke(string operation, OperationMode mode, byte[] inParams,
+        public void Invoke(string operation, bool idempotent, byte[] inParams,
                            Dictionary<string, string>? context, bool synchronous)
         {
             try
             {
                 Debug.Assert(Os != null);
-                Prepare(operation, mode, context);
+                Prepare(operation, idempotent, context);
                 if (inParams == null || inParams.Length == 0)
                 {
                     Os.WriteEmptyEncapsulation(Encoding);
@@ -964,7 +964,7 @@ namespace Ice
         /// </summary>
         /// <param name="prx">The proxy to invoke the operation.</param>
         /// <param name="operation">The name of the operation to invoke.</param>
-        /// <param name="mode">The operation mode (normal or idempotent).</param>
+        /// <param name="idempotent">True if this operation is idempotent, and false otherwise.</param>
         /// <param name="inEncaps">The encoded in-parameters for the operation.</param>
         /// <param name="outEncaps">The encoded out-paramaters and return value
         /// for the operation. The return value follows any out-parameters.</param>
@@ -976,14 +976,14 @@ namespace Ice
         /// it throws it directly.</returns>
         public static bool Invoke(this IObjectPrx prx,
                                   string operation,
-                                  OperationMode mode,
+                                  bool idempotent,
                                   byte[] inEncaps,
                                   out byte[]? outEncaps,
                                   Dictionary<string, string>? context = null)
         {
             try
             {
-                Object_Ice_invokeResult result = prx.IceI_ice_invokeAsync(operation, mode, inEncaps, context, null, CancellationToken.None, true).Result;
+                Object_Ice_invokeResult result = prx.IceI_ice_invokeAsync(operation, idempotent, inEncaps, context, null, CancellationToken.None, true).Result;
                 outEncaps = result.OutEncaps;
                 return result.ReturnValue;
             }
@@ -998,7 +998,7 @@ namespace Ice
         /// </summary>
         /// <param name="prx">The proxy to invoke the operation.</param>
         /// <param name="operation">The name of the operation to invoke.</param>
-        /// <param name="mode">The operation mode (normal or idempotent).</param>
+        /// <param name="idempotent">True if this operation is idempotent, and false otherwise.</param>
         /// <param name="inEncaps">The encoded in-parameters for the operation.</param>
         /// <param name="context">The context dictionary for the invocation.</param>
         /// <param name="progress">Sent progress provider.</param>
@@ -1007,17 +1007,17 @@ namespace Ice
         public static Task<Object_Ice_invokeResult>
         InvokeAsync(this IObjectPrx prx,
                     string operation,
-                    OperationMode mode,
+                    bool idempotent,
                     byte[] inEncaps,
                     Dictionary<string, string>? context = null,
                     IProgress<bool>? progress = null,
                     CancellationToken cancel = new CancellationToken()) =>
-            prx.IceI_ice_invokeAsync(operation, mode, inEncaps, context, progress, cancel, false);
+            prx.IceI_ice_invokeAsync(operation, idempotent, inEncaps, context, progress, cancel, false);
 
         private static Task<Object_Ice_invokeResult>
         IceI_ice_invokeAsync(this IObjectPrx prx,
                              string operation,
-                             OperationMode mode,
+                             bool idempotent,
                              byte[] inEncaps,
                              Dictionary<string, string>? context,
                              IProgress<bool>? progress,
@@ -1025,17 +1025,17 @@ namespace Ice
                              bool synchronous)
         {
             var completed = new InvokeTaskCompletionCallback(progress, cancel);
-            prx.IceI_ice_invoke(operation, mode, inEncaps, context, completed, synchronous);
+            prx.IceI_ice_invoke(operation, idempotent, inEncaps, context, completed, synchronous);
             return completed.Task;
         }
 
         private static void IceI_ice_invoke(this IObjectPrx prx,
                                      string operation,
-                                     OperationMode mode,
+                                     bool idempotent,
                                      byte[] inEncaps,
                                      Dictionary<string, string>? context,
                                      IOutgoingAsyncCompletionCallback completed,
                                      bool synchronous) =>
-            new InvokeOutgoingAsyncT(prx, completed).Invoke(operation, mode, inEncaps, context, synchronous);
+            new InvokeOutgoingAsyncT(prx, completed).Invoke(operation, idempotent, inEncaps, context, synchronous);
     }
 }

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -353,7 +353,7 @@ namespace Ice
 
         /// <summary>Returns whether or not an operation invoked on this proxy returns a response.</summary>
         /// <returns>True if invoking an operation on this proxy does not return a response. This corresponds to
-        /// several <see cref="InvocationMode"> enumerators, such as Oneway and Datagram. Otherwise,
+        /// several <see cref="InvocationMode"/> enumerators, such as Oneway and Datagram. Otherwise,
         /// returns false.</returns>
         public bool IsOneway => IceReference.GetMode() != InvocationMode.Twoway;
 

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -331,22 +331,22 @@ namespace IceInternal
             try
             {
                 byte mode = str.ReadByte();
-                s.Write("\nmode = " + (int)mode + ' ');
-                switch ((Ice.OperationMode)mode)
+                s.Write("\noperation mode = " + (int)mode + ' ');
+                switch (mode)
                 {
-                    case Ice.OperationMode.Normal:
+                    case 0:
                         {
-                            s.Write("(normal)");
+                            s.Write("(non-idempotent)");
                             break;
                         }
 
-                    case Ice.OperationMode.Nonmutating:
+                    case 1:
                         {
-                            s.Write("(nonmutating)");
+                            s.Write("(idempotent/nonmutating)");
                             break;
                         }
 
-                    case Ice.OperationMode.Idempotent:
+                    case 2:
                         {
                             s.Write("(idempotent)");
                             break;

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -44,8 +44,7 @@ namespace IceLocatorDiscovery
             if (_locatorPrx == null || !_locatorPrx.Equals(l))
             {
                 _locatorPrx = l;
-                l.InvokeAsync(_operation, _idempotent ? OperationMode.Idempotent : OperationMode.Normal,
-                    _inParams, _context).ContinueWith(
+                l.InvokeAsync(_operation, _idempotent, _inParams, _context).ContinueWith(
                     (task) =>
                     {
                         try

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -27,13 +27,13 @@ namespace IceLocatorDiscovery
     {
         public Request(LocatorI locator,
                        string operation,
-                       OperationMode mode,
+                       bool idempotent,
                        byte[] inParams,
                        Dictionary<string, string>? context)
         {
             _locator = locator;
             _operation = operation;
-            _mode = mode;
+            _idempotent = idempotent;
             _inParams = inParams;
             _context = context;
         }
@@ -44,7 +44,8 @@ namespace IceLocatorDiscovery
             if (_locatorPrx == null || !_locatorPrx.Equals(l))
             {
                 _locatorPrx = l;
-                l.InvokeAsync(_operation, _mode, _inParams, _context).ContinueWith(
+                l.InvokeAsync(_operation, _idempotent ? OperationMode.Idempotent : OperationMode.Normal,
+                    _inParams, _context).ContinueWith(
                     (task) =>
                     {
                         try
@@ -101,7 +102,7 @@ namespace IceLocatorDiscovery
 
         private readonly LocatorI _locator;
         private readonly string _operation;
-        private readonly OperationMode _mode;
+        private readonly bool _idempotent;
         private readonly Dictionary<string, string>? _context;
         private readonly byte[] _inParams;
 
@@ -207,7 +208,7 @@ namespace IceLocatorDiscovery
         {
             lock (this)
             {
-                var request = new Request(this, current.Operation, current.Mode, inParams, current.Context);
+                var request = new Request(this, current.Operation, current.IsIdempotent, inParams, current.Context);
                 Invoke(null, request);
                 return request.Task;
             }

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -14,6 +14,7 @@ public class BlobjectI : Ice.BlobjectAsync
         Debug.Assert(current.Connection != null);
         var prx = current.Connection.CreateProxy(current.Id, IObjectPrx.Factory)
             .Clone(facet: current.Facet, oneway: current.RequestId == 0);
-        return prx.InvokeAsync(current.Operation, current.Mode, inEncaps, current.Context);
+        return prx.InvokeAsync(current.Operation,
+            current.IsIdempotent ? OperationMode.Idempotent : OperationMode.Normal, inEncaps, current.Context);
     }
 }

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -14,7 +14,6 @@ public class BlobjectI : Ice.BlobjectAsync
         Debug.Assert(current.Connection != null);
         var prx = current.Connection.CreateProxy(current.Id, IObjectPrx.Factory)
             .Clone(facet: current.Facet, oneway: current.RequestId == 0);
-        return prx.InvokeAsync(current.Operation,
-            current.IsIdempotent ? OperationMode.Idempotent : OperationMode.Normal, inEncaps, current.Context);
+        return prx.InvokeAsync(current.Operation, current.IsIdempotent, inEncaps, current.Context);
     }
 }

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -22,7 +22,7 @@ namespace Ice.invoke
 
             {
                 byte[] inEncaps, outEncaps;
-                if (!oneway.Invoke("opOneway", OperationMode.Normal, null, out outEncaps))
+                if (!oneway.Invoke("opOneway", idempotent: false, null, out outEncaps))
                 {
                     test(false);
                 }
@@ -33,7 +33,7 @@ namespace Ice.invoke
                 outS.EndEncapsulation();
                 inEncaps = outS.Finished();
 
-                if (cl.Invoke("opString", OperationMode.Normal, inEncaps, out outEncaps))
+                if (cl.Invoke("opString", idempotent: false, inEncaps, out outEncaps))
                 {
                     InputStream inS = new InputStream(communicator, outEncaps);
                     inS.StartEncapsulation();
@@ -59,7 +59,7 @@ namespace Ice.invoke
                     ctx["raise"] = "";
                 }
 
-                if (cl.Invoke("opException", OperationMode.Normal, null, out outEncaps, ctx))
+                if (cl.Invoke("opException", idempotent: false, null, out outEncaps, ctx))
                 {
                     test(false);
                 }
@@ -90,7 +90,7 @@ namespace Ice.invoke
             {
                 try
                 {
-                    oneway.InvokeAsync("opOneway", OperationMode.Normal, null).Wait();
+                    oneway.InvokeAsync("opOneway", idempotent: false, null).Wait();
                 }
                 catch (Exception)
                 {
@@ -104,7 +104,7 @@ namespace Ice.invoke
                 byte[] inEncaps = outS.Finished();
 
                 // begin_ice_invoke with no callback
-                var result = cl.InvokeAsync("opString", OperationMode.Normal, inEncaps).Result;
+                var result = cl.InvokeAsync("opString", idempotent: false, inEncaps).Result;
                 if (result.ReturnValue)
                 {
                     InputStream inS = new InputStream(communicator, result.OutEncaps);
@@ -122,7 +122,7 @@ namespace Ice.invoke
             }
 
             {
-                var result = cl.InvokeAsync("opException", OperationMode.Normal, null).Result;
+                var result = cl.InvokeAsync("opException", idempotent: false, null).Result;
                 if (result.ReturnValue)
                 {
                     test(false);

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -50,21 +50,21 @@ namespace Ice.operations.AMD
         //
         public bool ice_isA(string id, Current current)
         {
-            test(current.Mode == Ice.OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds().Contains(id);
         }
 
-        public void IcePing(Current current) => test(current.Mode == OperationMode.Nonmutating);
+        public void IcePing(Current current) => test(current.IsIdempotent);
 
         public string[] ice_ids(Current current)
         {
-            test(current.Mode == OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds();
         }
 
         public string ice_id(Current current)
         {
-            test(current.Mode == Ice.OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetIceTypeId();
         }
 
@@ -84,7 +84,7 @@ namespace Ice.operations.AMD
 
         public ValueTask opVoidAsync(Current current)
         {
-            test(current.Mode == OperationMode.Normal);
+            test(!current.IsIdempotent);
 
             while (_opVoidThread != null)
             {
@@ -731,14 +731,14 @@ namespace Ice.operations.AMD
         public ValueTask
         opIdempotentAsync(Current current)
         {
-            test(current.Mode == OperationMode.Idempotent);
+            test(current.IsIdempotent);
             return new ValueTask(Task.CompletedTask);
         }
 
         public ValueTask
         opNonmutatingAsync(Current current)
         {
-            test(current.Mode == OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return new ValueTask(Task.CompletedTask);
         }
 

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -25,21 +25,21 @@ namespace Ice.operations
 
         public bool IceIsA(string id, Current current)
         {
-            test(current.Mode == OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds().Contains(id);
         }
 
-        public void IcePing(Current current) => test(current.Mode == OperationMode.Nonmutating);
+        public void IcePing(Current current) => test(current.IsIdempotent);
 
         public string[] IceIds(Current current)
         {
-            test(current.Mode == OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds();
         }
 
         public string IceId(Current current)
         {
-            test(current.Mode == OperationMode.Nonmutating);
+            test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetIceTypeId()!;
         }
 
@@ -47,7 +47,7 @@ namespace Ice.operations
 
         public bool supportsCompress(Current current) => IceInternal.BZip2.Supported();
 
-        public void opVoid(Current current) => test(current.Mode == OperationMode.Normal);
+        public void opVoid(Current current) => test(!current.IsIdempotent);
 
         public (bool, bool) opBool(bool p1, bool p2, Current current) => (p2, p1);
 
@@ -646,9 +646,9 @@ namespace Ice.operations
             return (p2, p3);
         }
 
-        public void opIdempotent(Current current) => test(current.Mode == OperationMode.Idempotent);
+        public void opIdempotent(Current current) => test(current.IsIdempotent);
 
-        public void opNonmutating(Current current) => test(current.Mode == OperationMode.Nonmutating);
+        public void opNonmutating(Current current) => test(current.IsIdempotent);
 
         public void opDerived(Current current)
         {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -319,7 +319,7 @@ namespace Ice.optional
             os.EndEncapsulation();
             byte[] inEncaps = os.Finished();
             byte[] outEncaps;
-            test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+            test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
             InputStream istr = new InputStream(communicator, outEncaps);
             istr.StartEncapsulation();
             ReadClassCallbackI cb = new ReadClassCallbackI();
@@ -332,7 +332,7 @@ namespace Ice.optional
             os.WriteClass(mo1);
             os.EndEncapsulation();
             inEncaps = os.Finished();
-            test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+            test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
             istr = new InputStream(communicator, outEncaps);
             istr.StartEncapsulation();
             istr.ReadClass(cb.invoke);
@@ -383,7 +383,7 @@ namespace Ice.optional
             ostr.WriteString("test");
             ostr.EndEncapsulation();
             var inEncaps = ostr.Finished();
-            test(initial.Invoke("opVoid", OperationMode.Normal, inEncaps, out outEncaps));
+            test(initial.Invoke("opVoid", idempotent: false, inEncaps, out outEncaps));
 
             output.WriteLine("ok");
 
@@ -419,7 +419,7 @@ namespace Ice.optional
             os.WriteClass(mc);
             os.EndEncapsulation();
             inEncaps = os.Finished();
-            test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+            test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
             istr = new InputStream(communicator, outEncaps);
             istr.StartEncapsulation();
             istr.ReadClass(cb.invoke);
@@ -457,7 +457,7 @@ namespace Ice.optional
                 os.WriteClass(b);
                 os.EndEncapsulation();
                 inEncaps = os.Finished();
-                test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+                test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
                 istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 istr.ReadClass(cb.invoke);
@@ -529,7 +529,7 @@ namespace Ice.optional
 
                     /*
                     factory.setEnabled(true);
-                    test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+                    test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
                     istr = new InputStream(communicator, outEncaps);
                     istr.StartEncapsulation();
                     istr.ReadClass(cb.invoke);
@@ -544,7 +544,7 @@ namespace Ice.optional
                     os.WriteClass(d);
                     os.EndEncapsulation();
                     inEncaps = os.Finished();
-                    test(initial.Invoke("pingPong", OperationMode.Normal, inEncaps, out outEncaps));
+                    test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
                     istr = new InputStream(communicator, outEncaps);
                     istr.StartEncapsulation();
                     istr.ReadClass(cb.invoke);
@@ -569,7 +569,7 @@ namespace Ice.optional
                     os.WriteClass(new DClassWriter());
                     os.EndEncapsulation();
                     inEncaps = os.Finished();
-                    test(initial.Invoke("opClassAndUnknownOptional", OperationMode.Normal, inEncaps,
+                    test(initial.Invoke("opClassAndUnknownOptional", idempotent: false, inEncaps,
                                             out outEncaps));
 
                     var istr = new InputStream(communicator, outEncaps);
@@ -607,7 +607,7 @@ namespace Ice.optional
                 ostr.WriteByte(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opByte", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opByte", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadByte(1) == 56);
@@ -644,7 +644,7 @@ namespace Ice.optional
                 ostr.WriteBool(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opBool", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opBool", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadBool(1) == true);
@@ -681,7 +681,7 @@ namespace Ice.optional
                 ostr.WriteShort(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opShort", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opShort", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadShort(1) == 56);
@@ -718,7 +718,7 @@ namespace Ice.optional
                 ostr.WriteInt(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opInt", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opInt", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadInt(1) == 56);
@@ -755,7 +755,7 @@ namespace Ice.optional
                 ostr.WriteLong(1, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opLong", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opLong", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadLong(2) == 56);
@@ -792,7 +792,7 @@ namespace Ice.optional
                 ostr.WriteFloat(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opFloat", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opFloat", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadFloat(1) == 1.0f);
@@ -829,7 +829,7 @@ namespace Ice.optional
                 ostr.WriteDouble(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opDouble", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opDouble", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadDouble(1) == 1.0);
@@ -868,7 +868,7 @@ namespace Ice.optional
                 ostr.WriteString(2, p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opString", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opString", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadString(1) == "test");
@@ -905,7 +905,7 @@ namespace Ice.optional
                 ostr.WriteEnum(2, (int?)p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opMyEnum", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opMyEnum", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.Size));
@@ -946,7 +946,7 @@ namespace Ice.optional
                 p1.Value.IceWrite(ostr);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opSmallStruct", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opSmallStruct", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -991,7 +991,7 @@ namespace Ice.optional
                 p1.Value.IceWrite(ostr);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opFixedStruct", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opFixedStruct", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1042,7 +1042,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opVarStruct", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opVarStruct", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.FSize));
@@ -1086,7 +1086,7 @@ namespace Ice.optional
                 ostr.WriteClass(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opOneOptional", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opOneOptional", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.Class));
@@ -1128,7 +1128,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opOneOptionalProxy", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opOneOptionalProxy", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(IObjectPrx.Equals(istr.ReadProxy(1, IObjectPrx.Factory), p1));
@@ -1166,7 +1166,7 @@ namespace Ice.optional
                 ostr.WriteByteSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opByteSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opByteSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1206,7 +1206,7 @@ namespace Ice.optional
                 ostr.WriteBoolSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opBoolSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opBoolSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1248,7 +1248,7 @@ namespace Ice.optional
                 ostr.WriteShortSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opShortSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opShortSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1291,7 +1291,7 @@ namespace Ice.optional
                 ostr.WriteIntSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opIntSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opIntSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1334,7 +1334,7 @@ namespace Ice.optional
                 ostr.WriteLongSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opLongSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opLongSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1377,7 +1377,7 @@ namespace Ice.optional
                 ostr.WriteFloatSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opFloatSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opFloatSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1420,7 +1420,7 @@ namespace Ice.optional
                 ostr.WriteDoubleSeq(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opDoubleSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opDoubleSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1464,7 +1464,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opStringSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opStringSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.FSize));
@@ -1507,7 +1507,7 @@ namespace Ice.optional
                 ostr.Write(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opSmallStructSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opSmallStructSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1556,7 +1556,7 @@ namespace Ice.optional
                 ostr.Write(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opSmallStructList", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opSmallStructList", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1601,7 +1601,7 @@ namespace Ice.optional
                 ostr.Write(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opFixedStructSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opFixedStructSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1650,7 +1650,7 @@ namespace Ice.optional
                 ostr.Write(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opFixedStructList", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opFixedStructList", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1696,7 +1696,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opVarStructSeq", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opVarStructSeq", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.FSize));
@@ -1741,7 +1741,7 @@ namespace Ice.optional
                 ostr.WriteSerializable(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opSerializable", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opSerializable", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1786,7 +1786,7 @@ namespace Ice.optional
                 ostr.Write(p1);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opIntIntDict", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opIntIntDict", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.VSize));
@@ -1834,7 +1834,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opStringIntDict", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opStringIntDict", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.FSize));
@@ -1903,7 +1903,7 @@ namespace Ice.optional
                 ostr.EndSize(pos);
                 ostr.EndEncapsulation();
                 inEncaps = ostr.Finished();
-                initial.Invoke("opIntOneOptionalDict", OperationMode.Normal, inEncaps, out outEncaps);
+                initial.Invoke("opIntOneOptionalDict", idempotent: false, inEncaps, out outEncaps);
                 var istr = new InputStream(communicator, outEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadOptional(1, OptionalFormat.FSize));

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -917,7 +917,7 @@ namespace Ice.proxy
                 inEncaps[4] = version.Major;
                 inEncaps[5] = version.Minor;
                 byte[] outEncaps;
-                cl.Invoke("ice_ping", OperationMode.Normal, inEncaps, out outEncaps);
+                cl.Invoke("ice_ping", idempotent: false, inEncaps, out outEncaps);
                 test(false);
             }
             catch (UnknownLocalException ex)
@@ -936,7 +936,7 @@ namespace Ice.proxy
                 inEncaps[4] = version.Major;
                 inEncaps[5] = version.Minor;
                 byte[] outEncaps;
-                cl.Invoke("ice_ping", OperationMode.Normal, inEncaps, out outEncaps);
+                cl.Invoke("ice_ping", idempotent: false, inEncaps, out outEncaps);
                 test(false);
             }
             catch (UnknownLocalException ex)


### PR DESCRIPTION
This PR replaces OperationMode by a simpler idempotent bool parameter or IsIdempotent property in C#.

It also relaxes the idempotent checking performed by the generated code during dispatch: it now requires that a request be marked non-idempotent only if the corresponding operation was declared non-idempotent when generating the code for the operation. 

For example, a request marked non-idempotent can be dispatched on an operation declared idempotent - it's safe, and it allows a server to increase its guarantee (from non-idempotent to idempotent) without breaking existing clients.

See also https://github.com/zeroc-ice/ice/issues/370.