### PR TITLE
C# - minor fix for input stream enumerator implementation

### DIFF
--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2139,7 +2139,6 @@ namespace Ice
 
         private sealed class Enumerator<T> : IEnumerator<T>
         {
-            private T _current;
             public T Current
             {
                 get
@@ -2151,8 +2150,10 @@ namespace Ice
                     return _current;
                 }
             }
+
             object IEnumerator.Current => Current!;
 
+            private T _current;
             private readonly InputStream _ins;
             private readonly InputStreamReader<T> _read;
             private int _pos;
@@ -2175,6 +2176,7 @@ namespace Ice
             {
                 if (++_pos > _size)
                 {
+                    _pos = _size + 1;
                     return false;
                 }
                 else


### PR DESCRIPTION
This tiny PR fixes InputStrem.Enumerator implementation to ensure the Current element is not accessed before it is initialized and suppress the warning of Current not be initialized in the constructor.