### PR TITLE
Removed Outgoing Frame ctors with payloadWriter action

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2801,21 +2801,16 @@ Slice::Gen::DispatcherVisitor::writeReturnValueStruct(const OperationPtr& operat
              << (getUnqualified("Ice.Current", ns) + " current")
              << epar;
         _out << sb;
-        _out << nl << "ResponseFrame = new global::Ice.OutgoingResponseFrame(current";
-
+        _out << nl << "ResponseFrame = new global::Ice.OutgoingResponseFrame(current);";
+        _out << nl << "ResponseFrame.StartReturnValue(";
         if (operation->format() != DefaultFormat)
         {
-            _out << ", " << opFormatTypeToString(operation, ns);
+            _out << opFormatTypeToString(operation, ns);
         }
-        _out << ",";
-        _out.inc();
-        _out << nl << "outputStream =>";
-        _out << sb;
-        writeMarshalParams(operation, requiredOutParams, taggedOutParams, "outputStream");
-        _out << eb;
         _out << ");";
+        writeMarshalParams(operation, requiredOutParams, taggedOutParams, "ResponseFrame");
+        _out << nl << "ResponseFrame.EndReturnValue();";
         _out << eb;
-        _out.dec();
         _out << eb;
     }
 }
@@ -2943,7 +2938,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
         {
             if (amd)
             {
-                _out << nl << "return new global::Ice.OutgoingResponseFrame(current);";
+                _out << nl << "return global::Ice.OutgoingResponseFrame.Empty(current);";
             }
             else
             {
@@ -2952,21 +2947,15 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
         }
         else
         {
-            _out << nl << "var responseFrame = new global::Ice.OutgoingResponseFrame(current";
+            _out << nl << "var responseFrame = new global::Ice.OutgoingResponseFrame(current);";
+            _out << nl << "responseFrame.StartReturnValue(";
             if (operation->format() != DefaultFormat)
             {
-                _out << ", " << opFormatTypeToString(operation, ns);
+                _out << opFormatTypeToString(operation, ns);
             }
-            _out << ",";
-            _out.inc();
-            _out << nl << "outputStream =>";
-            // It's not possible to skip the braces because writeMarshalParams always outputs a semicolon after each
-            // statement.
-            _out << sb;
-            writeMarshalParams(operation, requiredOutParams, taggedOutParams, "outputStream");
-            _out << eb;
             _out << ");";
-            _out.dec();
+            writeMarshalParams(operation, requiredOutParams, taggedOutParams, "responseFrame");
+            _out << nl << "responseFrame.EndReturnValue();";
             if (amd)
             {
                 _out << nl << "return responseFrame;";

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -81,7 +81,7 @@ namespace Ice
         {
             // TODO: for oneway requests, we should reuse the same fake response frame, not
             // create a new one each time.
-            return IceFromResult(new OutgoingResponseFrame(current));
+            return IceFromResult(OutgoingResponseFrame.Empty(current));
         }
 
         protected ValueTask<OutputStream> IceD_ice_pingAsync(InputStream istr, Current current)
@@ -98,8 +98,10 @@ namespace Ice
             string id = istr.ReadString();
             istr.EndEncapsulation();
             bool ret = IceIsA(id, current);
-            var responseFrame = new OutgoingResponseFrame(current, format: null,
-                outputStream => outputStream.WriteBool(ret));
+            var responseFrame = new OutgoingResponseFrame(current);
+            responseFrame.StartReturnValue();
+            responseFrame.WriteBool(ret);
+            responseFrame.EndReturnValue();
             return IceFromResult(responseFrame);
         }
 
@@ -108,8 +110,10 @@ namespace Ice
             istr.CheckIsReadable();
             istr.EndEncapsulation();
             string ret = IceId(current);
-            var responseFrame = new OutgoingResponseFrame(current, format: null,
-                outputStream => outputStream.WriteString(ret));
+            var responseFrame = new OutgoingResponseFrame(current);
+            responseFrame.StartReturnValue();
+            responseFrame.WriteString(ret);
+            responseFrame.EndReturnValue();
             return IceFromResult(responseFrame);
         }
 
@@ -118,8 +122,10 @@ namespace Ice
             istr.CheckIsReadable();
             istr.EndEncapsulation();
             string[] ret = IceIds(current);
-            var responseFrame = new OutgoingResponseFrame(current, format: null,
-                outputStream => outputStream.WriteStringSeq(ret));
+            var responseFrame = new OutgoingResponseFrame(current);
+            responseFrame.StartReturnValue();
+            responseFrame.WriteStringSeq(ret);
+            responseFrame.EndReturnValue();
             return IceFromResult(responseFrame);
         }
     }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -30,6 +30,12 @@ namespace Ice
         private EncodingVersion _payloadEncoding; // TODO: move to OutputStream
 
         /// <summary>Creates a new outgoing request frame with no parameters.</summary>
+        /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
+        /// encoding and context of this proxy to create the request frame.</param>
+        /// <param name="operation">The operation to invoke on the target Ice object.</param>
+        /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
+        /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
+        /// proxy and the communicator's current context (if any).</param>
         public static OutgoingRequestFrame Empty(IObjectPrx proxy, string operation, bool idempotent,
                                                  Context? context = null)
             => new OutgoingRequestFrame(proxy, operation, idempotent, context, ArraySegment<byte>.Empty);
@@ -122,7 +128,7 @@ namespace Ice
             StartEncapsulation(_payloadEncoding, format);
         }
 
-         /// <summary>Marks the end of the parameters.</summary>
+        /// <summary>Marks the end of the parameters.</summary>
         public void EndParameters()
         {
             EndEncapsulation();

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -27,79 +27,39 @@ namespace Ice
         /// <summary>The request context. Its initial value is computed when the request frame is created.</summary>
         public Context Context { get; }
 
-        /// <summary>Creates a new outgoing request frame.</summary>
+        private EncodingVersion _payloadEncoding; // TODO: move to OutputStream
+
+        /// <summary>Creates a new outgoing request frame with no parameters.</summary>
+        public static OutgoingRequestFrame Empty(IObjectPrx proxy, string operation, bool idempotent,
+                                                 Context? context = null)
+            => new OutgoingRequestFrame(proxy, operation, idempotent, context, ArraySegment<byte>.Empty);
+
+        /// <summary>Creates a new outgoing request frame. This frame is incomplete and its payload needs to be
+        /// provided using StartParameters/EndParameters.</summary>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
         /// encoding and context of this proxy to create the request frame.</param>
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
-        /// <param name="format">The Slice format (Compact or Sliced) used by the encapsulation.</param>
-        /// <param name="payloadWriter">An action that writes the contents of the payload.</param>
-        public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context,
-                                    FormatType? format, Action<OutputStream> payloadWriter)
-            : this(proxy.Communicator, proxy.Identity, proxy.Facet, operation, idempotent, proxy.Context, context)
+        public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context = null)
+            : base(proxy.Communicator)
         {
-            StartEncapsulation(proxy.EncodingVersion, format);
-            payloadWriter(this);
-            EndEncapsulation();
-        }
-
-        /// <summary>Creates a new outgoing request frame with a null format.</summary>
-        /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
-        /// encoding and context of this proxy to create the request frame.</param>
-        /// <param name="operation">The operation to invoke on the target Ice object.</param>
-        /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
-        /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
-        /// proxy and the communicator's current context (if any).</param>
-        /// <param name="payloadWriter">An action that writes the contents of the payload.</param>
-        public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context,
-                                    Action<OutputStream> payloadWriter)
-            : this(proxy, operation, idempotent, context, format:null, payloadWriter)
-        {
-        }
-
-        /// <summary>Creates a new outgoing request frame with the given payload.</summary>
-        /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet
-        /// and context of this proxy to create the request frame.</param>
-        /// <param name="operation">The operation to invoke on the target Ice object.</param>
-        /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
-        /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
-        /// proxy and the communicator's current context (if any).</param>
-        /// <param name="payload">The payload of this request frame, which represents the marshaled in-parameters.
-        /// </param>
-        public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context = null,
-                                    ArraySegment<byte>? payload = null)
-            : this(proxy.Communicator, proxy.Identity, proxy.Facet, operation, idempotent, proxy.Context, context)
-        {
-            if (payload == null || payload.Value.Count == 0)
-            {
-                WriteEmptyEncapsulation(proxy.EncodingVersion);
-            }
-            else
-            {
-                WritePayload(payload.Value);
-            }
-        }
-
-        private OutgoingRequestFrame(Communicator communicator, Identity identity, string facet, string operation,
-                                     bool idempotent, Context? prxContext, Context? context)
-            : base(communicator)
-        {
-            Identity = identity;
-            Facet = facet;
+            Identity = proxy.Identity;
+            Facet = proxy.Facet;
             Operation = operation;
             IsIdempotent = idempotent;
+            _payloadEncoding = proxy.EncodingVersion;
 
             WriteSpan(Protocol.RequestHeader.AsSpan());
-            identity.IceWrite(this);
-            if (facet.Length == 0)
+            Identity.IceWrite(this);
+            if (Facet.Length == 0)
             {
                 WriteStringSeq(Array.Empty<string>());
             }
             else
             {
-                WriteStringSeq(new string[]{ facet });
+                WriteStringSeq(new string[]{ Facet });
             }
 
             WriteString(operation);
@@ -112,10 +72,17 @@ namespace Ice
             }
             else
             {
-                 Context = new Context(prxContext) ?? new Dictionary<string, string>();
+                if (proxy.Context != null)
+                {
+                    Context = new Context(proxy.Context);
+                }
+                else
+                {
+                    Context = new Context();
+                }
 
                 // TODO: simplify implicit context
-                var implicitContext = (ImplicitContext?)communicator.GetImplicitContext();
+                var implicitContext = (ImplicitContext?)proxy.Communicator.GetImplicitContext();
                 if (implicitContext != null)
                 {
                     Context = implicitContext.Combine(Context);
@@ -123,6 +90,42 @@ namespace Ice
             }
 
             ContextHelper.Write(this, Context);
+        }
+
+        /// <summary>Creates a new outgoing request frame with the given payload.</summary>
+        /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet
+        /// and context of this proxy to create the request frame.</param>
+        /// <param name="operation">The operation to invoke on the target Ice object.</param>
+        /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
+        /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
+        /// proxy and the communicator's current context (if any).</param>
+        /// <param name="payload">The payload of this request frame, which represents the marshaled in-parameters.
+        /// </param>
+        public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context,
+                                    ArraySegment<byte> payload)
+            : this(proxy, operation, idempotent, context)
+        {
+            if (payload.Count == 0)
+            {
+                WriteEmptyEncapsulation(proxy.EncodingVersion);
+            }
+            else
+            {
+                WritePayload(payload);
+            }
+        }
+
+        /// <summary>Starts writing the parameters for this request.</summary>
+        /// <param name="format">The format for the payload, SlicedFormat or CompactFormat.</param>
+        public void StartParameters(FormatType? format = null)
+        {
+            StartEncapsulation(_payloadEncoding, format);
+        }
+
+         /// <summary>Marks the end of the parameters.</summary>
+        public void EndParameters()
+        {
+            EndEncapsulation();
         }
     }
 }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -27,7 +27,7 @@ namespace Ice
         /// <summary>The request context. Its initial value is computed when the request frame is created.</summary>
         public Context Context { get; }
 
-        private EncodingVersion _payloadEncoding; // TODO: move to OutputStream
+        private readonly EncodingVersion _payloadEncoding; // TODO: move to OutputStream
 
         /// <summary>Creates a new outgoing request frame with no parameters.</summary>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
@@ -122,16 +122,12 @@ namespace Ice
         }
 
         /// <summary>Starts writing the parameters for this request.</summary>
-        /// <param name="format">The format for the payload, SlicedFormat or CompactFormat.</param>
+        /// <param name="format">The format for the parameters, null (meaning keep communicator's setting), SlicedFormat
+        /// or CompactFormat.</param>
         public void StartParameters(FormatType? format = null)
-        {
-            StartEncapsulation(_payloadEncoding, format);
-        }
+            => StartEncapsulation(_payloadEncoding, format);
 
         /// <summary>Marks the end of the parameters.</summary>
-        public void EndParameters()
-        {
-            EndEncapsulation();
-        }
+        public void EndParameters() => EndEncapsulation();
     }
 }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -22,7 +22,7 @@ namespace Ice
         /// <summary>The response context. Always null with Ice1.</summary>
         public Context? Context { get; }
 
-        private EncodingVersion _payloadEncoding; // TODO: move to OutputStream
+        private readonly EncodingVersion _payloadEncoding; // TODO: move to OutputStream
 
         /// <summary>Creates a new outgoing request frame with an OK reply status and a void return value.</summary>
         /// <param name="current">The current parameter holds decoded header data and other information about the
@@ -160,7 +160,8 @@ namespace Ice
         }
 
         /// <summary>Starts writing the return value for a successful response.</summary>
-        /// <param name="format">The format for the payload, SlicedFormat or CompactFormat.</param>
+        /// <param name="format">The format for the return value, null (meaning keep communicator's setting),
+        /// SlicedFormat or CompactFormat.</param>
         public void StartReturnValue(FormatType? format = null)
         {
             WriteByte((byte)ReplyStatus.OK);
@@ -168,9 +169,6 @@ namespace Ice
         }
 
         /// <summary>Marks the end of the return value.</summary>
-        public void EndReturnValue()
-        {
-            EndEncapsulation();
-        }
+        public void EndReturnValue() => EndEncapsulation();
     }
 }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -25,6 +25,8 @@ namespace Ice
         private EncodingVersion _payloadEncoding; // TODO: move to OutputStream
 
         /// <summary>Creates a new outgoing request frame with an OK reply status and a void return value.</summary>
+        /// <param name="current">The current parameter holds decoded header data and other information about the
+        /// request for which this method creates a response.</param>
         public static OutgoingResponseFrame Empty(Current current)
             => new OutgoingResponseFrame(current, ReplyStatus.OK, ArraySegment<byte>.Empty);
 

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -21,13 +21,14 @@ namespace Ice.invoke
             output.Flush();
 
             {
-                var requestFrame = new OutgoingRequestFrame(oneway, "opOneway", idempotent: false);
+                var requestFrame = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
                 var responseFrame = oneway.Invoke(requestFrame);
                 test(responseFrame.ReplyStatus == ReplyStatus.OK);
 
-                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false, context : null,
-                    outputStream => outputStream.WriteString(testString));
-
+                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteString(testString);
+                requestFrame.EndParameters();
                 responseFrame = cl.Invoke(requestFrame);
                 test(responseFrame.ReplyStatus == ReplyStatus.OK);
                 responseFrame.InputStream.StartEncapsulation();
@@ -47,7 +48,7 @@ namespace Ice.invoke
                     ctx["raise"] = "";
                 }
 
-                var requestFrame = new OutgoingRequestFrame(cl, "opException", idempotent: false, context: ctx);
+                var requestFrame = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false, context: ctx);
                 var responseFrame = cl.Invoke(requestFrame);
                 test(responseFrame.ReplyStatus == ReplyStatus.UserException);
                 responseFrame.InputStream.StartEncapsulation();
@@ -71,7 +72,7 @@ namespace Ice.invoke
             output.Flush();
 
             {
-                var requestFrame = new OutgoingRequestFrame(oneway, "opOneway", idempotent: false);
+                var requestFrame = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
                 try
                 {
                     oneway.InvokeAsync(requestFrame).Wait();
@@ -81,8 +82,10 @@ namespace Ice.invoke
                     test(false);
                 }
 
-                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false, context: null,
-                    outputStream => outputStream.WriteString(testString));
+                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteString(testString);
+                requestFrame.EndParameters();
 
                 var responseFrame = cl.InvokeAsync(requestFrame).Result;
                 test(responseFrame.ReplyStatus == 0);
@@ -95,7 +98,7 @@ namespace Ice.invoke
             }
 
             {
-                var requestFrame = new OutgoingRequestFrame(cl, "opException", idempotent: false);
+                var requestFrame = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false);
                 var responseFrame = cl.InvokeAsync(requestFrame).Result;
                 test(responseFrame.ReplyStatus == ReplyStatus.UserException);
 

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -15,17 +15,16 @@ namespace Ice.invoke
             {
                 Debug.Assert(current.IsOneway);
                 // TODO: replace by shared "fake" empty
-                return new OutgoingResponseFrame(current);
+                return OutgoingResponseFrame.Empty(current);
             }
             else if (current.Operation.Equals("opString"))
             {
                 string s = istr.ReadString();
-                var responseFrame = new OutgoingResponseFrame(current,
-                    outputStream =>
-                    {
-                        outputStream.WriteString(s);
-                        outputStream.WriteString(s);
-                    });
+                var responseFrame = new OutgoingResponseFrame(current);
+                responseFrame.StartReturnValue();
+                responseFrame.WriteString(s);
+                responseFrame.WriteString(s);
+                responseFrame.EndReturnValue();
                 return responseFrame;
             }
             else if (current.Operation.Equals("opException"))
@@ -40,23 +39,22 @@ namespace Ice.invoke
             else if (current.Operation.Equals("shutdown"))
             {
                 current.Adapter.Communicator.Shutdown();
-                return new OutgoingResponseFrame(current);
+                return OutgoingResponseFrame.Empty(current);
             }
             else if (current.Operation.Equals("ice_isA"))
             {
                 string s = istr.ReadString();
-                var responseFrame = new OutgoingResponseFrame(current,
-                    outputStream =>
-                    {
-                        if (s.Equals("::Test::MyClass"))
-                        {
-                            outputStream.WriteBool(true);
-                        }
-                        else
-                        {
-                            outputStream.WriteBool(false);
-                        }
-                    });
+                var responseFrame = new OutgoingResponseFrame(current);
+                responseFrame.StartReturnValue();
+                if (s.Equals("::Test::MyClass"))
+                {
+                    responseFrame.WriteBool(true);
+                }
+                else
+                {
+                    responseFrame.WriteBool(false);
+                }
+                responseFrame.EndReturnValue();
                 return responseFrame;
             }
             else

--- a/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
+++ b/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
@@ -8,10 +8,14 @@ namespace Ice.objects
 {
     public sealed class UnexpectedObjectExceptionTest : IObject
     {
-        public async ValueTask<OutputStream> DispatchAsync(InputStream istr, Current current)
+        public ValueTask<OutputStream> DispatchAsync(InputStream istr, Current current)
         {
             var ae = new Test.AlsoEmpty();
-            return new OutgoingResponseFrame(current, outputStream => outputStream.WriteClass(ae));
+            var responseFrame = new OutgoingResponseFrame(current);
+            responseFrame.StartReturnValue();
+            responseFrame.WriteClass(ae);
+            responseFrame.EndReturnValue();
+            return new ValueTask<OutputStream>(responseFrame);
         }
     }
 }

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -1724,7 +1724,6 @@ namespace Ice.optional
 
                 requestFrame = new OutgoingRequestFrame(initial, "opStringIntDict", idempotent: false);
                 requestFrame.StartParameters();
-
                 requestFrame.WriteOptional(2, OptionalFormat.FSize);
                 OutputStream.Position pos = requestFrame.StartSize();
                 requestFrame.Write(p1);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -375,14 +375,13 @@ namespace Ice.optional
 
             initial.opVoid();
 
-            var requestFrame = new OutgoingRequestFrame(initial, "opVoid", idempotent: false, context: null,
-                outputStream =>
-                {
-                    outputStream.WriteOptional(1, OptionalFormat.F4);
-                    outputStream.WriteInt(15);
-                    outputStream.WriteOptional(1, OptionalFormat.VSize);
-                    outputStream.WriteString("test");
-                });
+            var requestFrame = new OutgoingRequestFrame(initial, "opVoid", idempotent: false);
+            requestFrame.StartParameters();
+            requestFrame.WriteOptional(1, OptionalFormat.F4);
+            requestFrame.WriteInt(15);
+            requestFrame.WriteOptional(1, OptionalFormat.VSize);
+            requestFrame.WriteString("test");
+            requestFrame.EndParameters();
 
             test(initial.Invoke(requestFrame).ReplyStatus == 0);
 
@@ -536,8 +535,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opByte(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opByte", idempotent: false, context: null,
-                    outputStream => outputStream.WriteByte(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opByte", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteByte(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -569,8 +570,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opBool(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opBool", idempotent: false, context: null,
-                    outputStream => outputStream.WriteBool(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opBool", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteBool(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -602,8 +605,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opShort(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opShort", idempotent: false, context: null,
-                    outputStream => outputStream.WriteShort(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opShort", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteShort(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -635,8 +640,9 @@ namespace Ice.optional
                 (p2, p3) = initial.opInt(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opInt", idempotent: false, context: null,
-                    outputStream => outputStream.WriteInt(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opInt", idempotent: false);
+                requestFrame.StartParameters(); requestFrame.WriteInt(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -668,8 +674,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opLong(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opLong", idempotent: false, context: null,
-                    outputStream => outputStream.WriteLong(1, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opLong", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteLong(1, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -701,8 +709,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opFloat(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opFloat", idempotent: false, context: null,
-                    outputStream => outputStream.WriteFloat(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opFloat", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteFloat(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -734,8 +744,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opDouble(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opDouble", idempotent: false, context: null,
-                    outputStream => outputStream.WriteDouble(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opDouble", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteDouble(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -769,8 +781,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opString(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opString", idempotent: false, context: null,
-                    outputStream => outputStream.WriteString(2, p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opString", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteString(2, p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -802,8 +816,10 @@ namespace Ice.optional
                 (p2, p3) = initial.opMyEnum(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opMyEnum", idempotent: false, context: null,
-                    outputStream => outputStream.WriteEnum(2, (int?)p1));
+                requestFrame = new OutgoingRequestFrame(initial, "opMyEnum", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteEnum(2, (int?)p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -837,13 +853,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opSmallStruct(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opSmallStruct", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(1);
-                        p1.Value.IceWrite(outputStream);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opSmallStruct", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(1);
+                p1.Value.IceWrite(requestFrame);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -881,13 +896,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opFixedStruct(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opFixedStruct", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(4);
-                        p1.Value.IceWrite(outputStream);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opFixedStruct", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(4);
+                p1.Value.IceWrite(requestFrame);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -930,14 +944,13 @@ namespace Ice.optional
                 (p2, p3) = initial.opVarStruct(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opVarStruct", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        p1.Value.IceWrite(outputStream);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opVarStruct", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                p1.Value.IceWrite(requestFrame);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -997,12 +1010,11 @@ namespace Ice.optional
                 (p2, p3) = initial.opOneOptional(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opOneOptional", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.Class);
-                        outputStream.WriteClass(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opOneOptional", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.Class);
+                requestFrame.WriteClass(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1036,14 +1048,13 @@ namespace Ice.optional
                 (p2, p3) = initial.opOneOptionalProxy(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opOneOptionalProxy", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        outputStream.WriteProxy(p1);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opOneOptionalProxy", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                requestFrame.WriteProxy(p1);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1075,12 +1086,11 @@ namespace Ice.optional
                 (p2, p3) = initial.opByteSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opByteSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteByteSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opByteSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteByteSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1114,12 +1124,11 @@ namespace Ice.optional
                 (p2, p3) = initial.opBoolSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opBoolSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteBoolSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opBoolSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteBoolSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1154,13 +1163,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opShortSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opShortSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 2 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.WriteShortSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opShortSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 2 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.WriteShortSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1196,13 +1204,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opIntSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opIntSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.WriteIntSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opIntSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.WriteIntSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1238,13 +1245,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opLongSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opLongSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 8 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.WriteLongSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opLongSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 8 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.WriteLongSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1280,13 +1286,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opFloatSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opFloatSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.WriteFloatSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opFloatSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.WriteFloatSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1322,13 +1327,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opDoubleSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opDoubleSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 8 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.WriteDoubleSeq(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opDoubleSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 8 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.WriteDoubleSeq(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1364,14 +1368,13 @@ namespace Ice.optional
                 (p2, p3) = initial.opStringSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opStringSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        outputStream.WriteStringSeq(p1);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opStringSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                requestFrame.WriteStringSeq(p1);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1407,13 +1410,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opSmallStructSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opSmallStructSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length + (p1.Length > 254 ? 5 : 1));
-                        outputStream.Write(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opSmallStructSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length + (p1.Length > 254 ? 5 : 1));
+                requestFrame.Write(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1455,13 +1457,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opSmallStructList(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opSmallStructList", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Count + (p1.Count > 254 ? 5 : 1));
-                        outputStream.Write(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opSmallStructList", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Count + (p1.Count > 254 ? 5 : 1));
+                requestFrame.Write(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1499,13 +1500,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opFixedStructSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opFixedStructSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
-                        outputStream.Write(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opFixedStructSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Length * 4 + (p1.Length > 254 ? 5 : 1));
+                requestFrame.Write(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1547,13 +1547,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opFixedStructList(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opFixedStructList", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Count * 4 + (p1.Count > 254 ? 5 : 1));
-                        outputStream.Write(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opFixedStructList", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Count * 4 + (p1.Count > 254 ? 5 : 1));
+                requestFrame.Write(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1591,14 +1590,13 @@ namespace Ice.optional
                 (p2, p3) = initial.opVarStructSeq(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opVarStructSeq", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        outputStream.Write(p1);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opVarStructSeq", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                requestFrame.Write(p1);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1637,17 +1635,16 @@ namespace Ice.optional
                 (p2, p3) = initial.opSerializable(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opSerializable", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSerializable(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opSerializable", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSerializable(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
                 test(responseFrame.InputStream.ReadOptional(1, OptionalFormat.VSize));
-                var sc = (Test.SerializableClass) responseFrame.InputStream.ReadSerializable();
+                var sc = (Test.SerializableClass)responseFrame.InputStream.ReadSerializable();
                 test(sc.Equals(p1));
                 test(responseFrame.InputStream.ReadOptional(3, OptionalFormat.VSize));
                 sc = (Test.SerializableClass)responseFrame.InputStream.ReadSerializable();
@@ -1680,13 +1677,12 @@ namespace Ice.optional
                 (p2, p3) = initial.opIntIntDict(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opIntIntDict", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.VSize);
-                        outputStream.WriteSize(p1.Count * 8 + (p1.Count > 254 ? 5 : 1));
-                        outputStream.Write(p1);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opIntIntDict", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.VSize);
+                requestFrame.WriteSize(p1.Count * 8 + (p1.Count > 254 ? 5 : 1));
+                requestFrame.Write(p1);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1726,14 +1722,14 @@ namespace Ice.optional
                 (p2, p3) = initial.opStringIntDict(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opStringIntDict", idempotent: false, context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        outputStream.Write(p1);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opStringIntDict", idempotent: false);
+                requestFrame.StartParameters();
+
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                requestFrame.Write(p1);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();
@@ -1773,15 +1769,13 @@ namespace Ice.optional
                 (p2, p3) = initial.opIntOneOptionalDict(null);
                 test(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = new OutgoingRequestFrame(initial, "opIntOneOptionalDict", idempotent: false,
-                    context: null,
-                    outputStream =>
-                    {
-                        outputStream.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = outputStream.StartSize();
-                        outputStream.Write(p1);
-                        outputStream.EndSize(pos);
-                    });
+                requestFrame = new OutgoingRequestFrame(initial, "opIntOneOptionalDict", idempotent: false);
+                requestFrame.StartParameters();
+                requestFrame.WriteOptional(2, OptionalFormat.FSize);
+                OutputStream.Position pos = requestFrame.StartSize();
+                requestFrame.Write(p1);
+                requestFrame.EndSize(pos);
+                requestFrame.EndParameters();
 
                 var responseFrame = initial.Invoke(requestFrame);
                 responseFrame.InputStream.StartEncapsulation();


### PR DESCRIPTION
Using a payloadWriter delegate is more elegant but creates an extra class and extra heap allocation for all the parameters, which is not worth since the primary user of this API is the generated code.

I switched back to use Start/End and added a static Empty method.