### PR TITLE
Update implementation of IcePing, IcePingAsync and other

### DIFF
--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -871,7 +871,14 @@ namespace IceInternal
             base.Abort(ex);
         }
 
-        protected internal void Invoke(bool synchronous)
+        // Called by IceInvokeAsync
+        internal void Invoke(string operation, Dictionary<string, string>? context, bool synchronous)
+        {
+            Observer = ObserverHelper.get(Proxy, operation, context);
+            Invoke(synchronous);
+        }
+
+        protected void Invoke(bool synchronous)
         {
             Synchronous = synchronous;
             Ice.InvocationMode mode = Proxy.IceReference.GetMode();

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -51,11 +51,13 @@ namespace Ice
         public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context = null)
             : base(proxy.Communicator)
         {
+            Protocol.CheckSupportedProtocol(Protocol.GetCompatibleProtocol(proxy.IceReference.GetProtocol()));
+
             Identity = proxy.Identity;
             Facet = proxy.Facet;
             Operation = operation;
             IsIdempotent = idempotent;
-            _payloadEncoding = proxy.EncodingVersion;
+            _payloadEncoding = Protocol.GetCompatibleEncoding(proxy.EncodingVersion);
 
             WriteSpan(Protocol.RequestHeader.AsSpan());
             Identity.IceWrite(this);
@@ -113,7 +115,7 @@ namespace Ice
         {
             if (payload.Count == 0)
             {
-                WriteEmptyEncapsulation(proxy.EncodingVersion);
+                WriteEmptyEncapsulation(_payloadEncoding);
             }
             else
             {

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -424,7 +424,7 @@ namespace Ice.ami
                     i.IceIsAAsync("::Test::TestIntf").Wait();
                     test(false);
                 }
-                catch (AggregateException)
+                catch (Ice.NoEndpointException)
                 {
                 }
 
@@ -618,7 +618,14 @@ namespace Ice.ami
                         t1 = p.IcePingAsync(cancel: cs1.Token);
                         t2 = p.IcePingAsync(cancel: cs2.Token);
                         cs3.Cancel();
-                        t3 = p.IcePingAsync(cancel: cs3.Token);
+                        try
+                        {
+                            t3 = p.IcePingAsync(cancel: cs3.Token);
+                        }
+                        catch (InvocationCanceledException)
+                        {
+                            // expected
+                        }
                         cs1.Cancel();
                         cs2.Cancel();
                         try
@@ -645,20 +652,6 @@ namespace Ice.ami
                                 return ex is InvocationCanceledException;
                             });
                         }
-
-                        try
-                        {
-                            t3.Wait();
-                            test(false);
-                        }
-                        catch (AggregateException ae)
-                        {
-                            ae.Handle(ex =>
-                            {
-                                return ex is InvocationCanceledException;
-                            });
-                        }
-
                     }
                     finally
                     {

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -8,19 +8,14 @@ using Ice;
 
 public class BlobjectI : IObject
 {
-    public async ValueTask<OutputStream> DispatchAsync(InputStream inputStream, Current current)
+    public ValueTask<OutputStream> DispatchAsync(InputStream inputStream, Current current)
     {
+        var request = new IncomingRequestFrame(inputStream, current); // Temporary
+
         Debug.Assert(current.Connection != null);
-
-        var incomingRequestFrame = new IncomingRequestFrame(inputStream, current);
-
-        var prx = current.Connection.CreateProxy(current.Id, IObjectPrx.Factory).Clone(facet: current.Facet,
+        var proxy = current.Connection.CreateProxy(current.Id, IObjectPrx.Factory).Clone(facet: current.Facet,
             oneway: current.IsOneway);
 
-        var requestFrame = new OutgoingRequestFrame(prx, current.Operation, current.IsIdempotent, current.Context,
-            incomingRequestFrame.TakePayload());
-
-        IncomingResponseFrame responseFrame = await prx.InvokeAsync(requestFrame);
-        return new OutgoingResponseFrame(current, responseFrame.ReplyStatus, responseFrame.TakePayload());
+        return proxy.ForwardAsync(request);
     }
 }

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -21,44 +21,44 @@ namespace Ice.invoke
             output.Flush();
 
             {
-                var requestFrame = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
-                var responseFrame = oneway.Invoke(requestFrame);
-                test(responseFrame.ReplyStatus == ReplyStatus.OK);
+                var request = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
+                var response = oneway.Invoke(request);
+                test(response.ReplyStatus == ReplyStatus.OK);
 
-                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false);
-                requestFrame.StartParameters();
-                requestFrame.WriteString(testString);
-                requestFrame.EndParameters();
-                responseFrame = cl.Invoke(requestFrame);
-                test(responseFrame.ReplyStatus == ReplyStatus.OK);
-                responseFrame.InputStream.StartEncapsulation();
-                string s = responseFrame.InputStream.ReadString();
+                request = new OutgoingRequestFrame(cl, "opString", idempotent: false);
+                request.StartParameters();
+                request.WriteString(testString);
+                request.EndParameters();
+                response = cl.Invoke(request);
+                var result = response.ReadResult();
+                test(result.ResultType == ResultType.Success);
+                string s = result.InputStream.ReadString();
                 test(s.Equals(testString));
-                s = responseFrame.InputStream.ReadString();
-                responseFrame.InputStream.EndEncapsulation();
+                s = result.InputStream.ReadString();
+                result.InputStream.EndEncapsulation();
                 test(s.Equals(testString));
             }
 
             for (int i = 0; i < 2; ++i)
             {
-                Dictionary<string, string> ctx = null;
+                Dictionary<string, string>? ctx = null;
                 if (i == 1)
                 {
                     ctx = new Dictionary<string, string>();
                     ctx["raise"] = "";
                 }
 
-                var requestFrame = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false, context: ctx);
-                var responseFrame = cl.Invoke(requestFrame);
-                test(responseFrame.ReplyStatus == ReplyStatus.UserException);
-                responseFrame.InputStream.StartEncapsulation();
+                var request = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false, context: ctx);
+                var response = cl.Invoke(request);
+                var result = response.ReadResult();
+                test(result.ResultType == ResultType.Failure);
                 try
                 {
-                    responseFrame.InputStream.ThrowException();
+                    result.InputStream.ThrowException();
                 }
                 catch (Test.MyException)
                 {
-                    responseFrame.InputStream.EndEncapsulation();
+                    result.InputStream.EndEncapsulation();
                 }
                 catch (Exception)
                 {
@@ -72,44 +72,44 @@ namespace Ice.invoke
             output.Flush();
 
             {
-                var requestFrame = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
+                var request = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
                 try
                 {
-                    oneway.InvokeAsync(requestFrame).Wait();
+                    oneway.InvokeAsync(request).Wait();
                 }
                 catch (Exception)
                 {
                     test(false);
                 }
 
-                requestFrame = new OutgoingRequestFrame(cl, "opString", idempotent: false);
-                requestFrame.StartParameters();
-                requestFrame.WriteString(testString);
-                requestFrame.EndParameters();
+                request = new OutgoingRequestFrame(cl, "opString", idempotent: false);
+                request.StartParameters();
+                request.WriteString(testString);
+                request.EndParameters();
 
-                var responseFrame = cl.InvokeAsync(requestFrame).Result;
-                test(responseFrame.ReplyStatus == 0);
-                responseFrame.InputStream.StartEncapsulation();
-                string s = responseFrame.InputStream.ReadString();
+                var response = cl.InvokeAsync(request).Result;
+                var result = response.ReadResult();
+                test(result.ResultType == ResultType.Success);
+                string s = result.InputStream.ReadString();
                 test(s.Equals(testString));
-                s = responseFrame.InputStream.ReadString();
-                responseFrame.InputStream.EndEncapsulation();
+                s = result.InputStream.ReadString();
+                result.InputStream.EndEncapsulation();
                 test(s.Equals(testString));
             }
 
             {
-                var requestFrame = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false);
-                var responseFrame = cl.InvokeAsync(requestFrame).Result;
-                test(responseFrame.ReplyStatus == ReplyStatus.UserException);
+                var request = OutgoingRequestFrame.Empty(cl, "opException", idempotent: false);
+                var response = cl.InvokeAsync(request).Result;
+                var result = response.ReadResult();
+                test(result.ResultType == ResultType.Failure);
 
-                responseFrame.InputStream.StartEncapsulation();
                 try
                 {
-                    responseFrame.InputStream.ThrowException();
+                    result.InputStream.ThrowException();
                 }
                 catch (Test.MyException)
                 {
-                    responseFrame.InputStream.EndEncapsulation();
+                    result.InputStream.EndEncapsulation();
                 }
                 catch (Exception)
                 {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -940,8 +940,8 @@ namespace Ice.proxy
                 // Server 2.0 proxy doesn't support 1.0 version.
             }
 
-            // 1.3 isn't supported but since a 1.3 proxy supports 1.1, the
-            // call will use the 1.1 protocol
+            // 1.3 isn't supported but since a 1.3 proxy supports 1.0, the
+            // call will use the 1.0 protocol
             ref13 = "test -p 1.3:" + helper.getTestEndpoint(0);
             cl13 = Test.IMyClassPrx.Parse(ref13, communicator);
             cl13.IcePing();


### PR DESCRIPTION
built-operations to use IceInvokeAsync.

This PR proposes a new style for the implementation of generated proxy methods:
- the IceI_ private methods are replaced by a private method per operation with the same name and signature as the Async overload, except with an additional "bool synchronous" parameter.
- this generated private method (represented in this PR by the private IceIsAAsync, IcePingAsync etc.) builds an outgoing request frame, then calls IceInvokeAsync, then awaits the resulting task, then reads the return value from the incoming response frame. 
- the awaiting is performed in a static local function. This is to ensure that synchronous exceptions are reported immediately (and not during await) for application code like:
```
    Task<string> task = prx.IceIdAsync(); // does not await task immediately
    taskList.Add(task);
    ...
    // await all task in taskList
```
See https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions.
