### PR TITLE
Convert Protocol to enum and refactor Encoding struct in C#

### DIFF
--- a/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
+++ b/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
@@ -107,11 +107,11 @@ namespace Ice
                     // and ask the factory to read the endpoint data from that stream to create
                     // the actual endpoint.
                     //
-                    var os = new OutputStream(this, Util.CurrentProtocolEncoding);
+                    var os = new OutputStream(this, Ice1Definitions.Encoding);
                     os.WriteShort(ue.Type());
                     ue.StreamWrite(os);
                     // TODO avoid copy OutputStream buffers
-                    var iss = new InputStream(this, Util.CurrentProtocolEncoding, new Buffer(os.ToArray()), true);
+                    var iss = new InputStream(this, Ice1Definitions.Encoding, new Buffer(os.ToArray()), true);
                     iss.Pos = 0;
                     iss.ReadShort(); // type
                     iss.StartEndpointEncapsulation();

--- a/csharp/src/Ice/Communicator-LocatorManager.cs
+++ b/csharp/src/Ice/Communicator-LocatorManager.cs
@@ -38,13 +38,10 @@ namespace Ice
                 if (proxy != null)
                 {
                     Reference r = proxy.IceReference;
-                    if (_ref.IsWellKnown() && !EncodingDefinitions.IsSupported(_ref.GetEncoding(), r.GetEncoding()))
+                    if (_ref.IsWellKnown() && _ref.GetEncoding() != r.GetEncoding())
                     {
-                        //
-                        // If a well-known proxy and the returned
-                        // proxy encoding isn't supported, we're done:
+                        // If a well-known proxy and the returned proxy encoding don't match we're done:
                         // there's no compatible endpoint we can use.
-                        //
                     }
                     else if (!r.IsIndirect())
                     {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -15,13 +15,6 @@ using System.Threading;
 
 namespace Ice
 {
-    public enum ToStringMode
-    {
-        Unicode,
-        ASCII,
-        Compat
-    }
-
     internal sealed class BufSizeWarnInfo
     {
         // Whether send size warning has been emitted
@@ -761,7 +754,7 @@ namespace Ice
             InvocationMode mode = InvocationMode.Twoway;
             bool secure = false;
             Encoding encoding = DefaultsAndOverrides.DefaultEncoding;
-            Protocol protocol = Util.Protocol_1_0;
+            Protocol protocol = Protocol.Ice1;
             string adapter;
 
             while (true)
@@ -931,7 +924,7 @@ namespace Ice
                                 throw new FormatException($"no argument provided for -p option `{s}'");
                             }
 
-                            protocol = Util.StringToProtocol(argument);
+                            protocol = ProtocolExtensions.Parse(argument);
                             break;
                         }
 
@@ -1123,7 +1116,11 @@ namespace Ice
             {
                 byte major = s.ReadByte();
                 byte minor = s.ReadByte();
-                protocol = new Protocol(major, minor);
+                if (minor != 0)
+                {
+                    throw new ProxyUnmarshalException($"received proxy with protocol set to {major}.{minor}");
+                }
+                protocol = (Protocol)major;
 
                 major = s.ReadByte();
                 minor = s.ReadByte();
@@ -1131,7 +1128,7 @@ namespace Ice
             }
             else
             {
-                protocol = Util.Protocol_1_0;
+                protocol = Protocol.Ice1;
                 encoding = Util.Encoding_1_0;
             }
 
@@ -1802,7 +1799,7 @@ namespace Ice
                 "", // Facet
                 ((Endpoint)connection.Endpoint).Datagram() ? InvocationMode.Datagram : InvocationMode.Twoway,
                 ((Endpoint)connection.Endpoint).Secure(),
-                Util.Protocol_1_0,
+                Protocol.Ice1,
                 DefaultsAndOverrides.DefaultEncoding,
                 connection,
                 -1,

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1112,7 +1112,7 @@ namespace Ice
 
             Protocol protocol;
             Encoding encoding;
-            if (!s.Encoding.Equals(Util.Encoding_1_0))
+            if (!s.Encoding.Equals(Encoding.V1_0))
             {
                 byte major = s.ReadByte();
                 byte minor = s.ReadByte();
@@ -1129,7 +1129,7 @@ namespace Ice
             else
             {
                 protocol = Protocol.Ice1;
-                encoding = Util.Encoding_1_0;
+                encoding = Encoding.V1_0;
             }
 
             Endpoint[] endpoints;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1110,27 +1110,17 @@ namespace Ice
 
             bool secure = s.ReadBool();
 
-            Protocol protocol;
-            Encoding encoding;
-            if (!s.Encoding.Equals(Encoding.V1_0))
+            byte major = s.ReadByte();
+            byte minor = s.ReadByte();
+            if (minor != 0)
             {
-                byte major = s.ReadByte();
-                byte minor = s.ReadByte();
-                if (minor != 0)
-                {
-                    throw new ProxyUnmarshalException($"received proxy with protocol set to {major}.{minor}");
-                }
-                protocol = (Protocol)major;
+                throw new ProxyUnmarshalException($"received proxy with protocol set to {major}.{minor}");
+            }
+            var protocol = (Protocol)major;
 
-                major = s.ReadByte();
-                minor = s.ReadByte();
-                encoding = new Encoding(major, minor);
-            }
-            else
-            {
-                protocol = Protocol.Ice1;
-                encoding = Encoding.V1_0;
-            }
+            major = s.ReadByte();
+            minor = s.ReadByte();
+            var encoding = new Encoding(major, minor);
 
             Endpoint[] endpoints;
             string adapterId = "";

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -913,7 +913,7 @@ namespace Ice
                                 throw new FormatException($"no argument provided for -e option in `{s}'");
                             }
 
-                            encoding = Util.StringToEncoding(argument);
+                            encoding = Encoding.Parse(argument);
                             break;
                         }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -574,10 +574,7 @@ namespace Ice
                 {
                     Debug.Assert(Os != null);
                     Os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                    Os.WriteByte((byte)Protocol.Ice1);
-                    Os.WriteByte(0);
-                    Os.WriteByte(Util.CurrentProtocolEncoding.Major);
-                    Os.WriteByte(Util.CurrentProtocolEncoding.Minor);
+                    Os.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                     Os.WriteByte(Ice1Definitions.ValidateConnectionMessage);
                     Os.WriteByte(0);
                     Os.WriteInt(Ice1Definitions.HeaderSize); // Message size.
@@ -2037,10 +2034,7 @@ namespace Ice
                 //
                 var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                os.WriteByte((byte)Protocol.Ice1);
-                os.WriteByte(0);
-                os.WriteByte(Util.CurrentProtocolEncoding.Major);
-                os.WriteByte(Util.CurrentProtocolEncoding.Minor);
+                os.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                 os.WriteByte(Ice1Definitions.CloseConnectionMessage);
                 os.WriteByte(_compressionSupported ? (byte)1 : (byte)0);
                 os.WriteInt(Ice1Definitions.HeaderSize); // Message size.
@@ -2070,10 +2064,7 @@ namespace Ice
             {
                 var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                os.WriteByte((byte)Protocol.Ice1);
-                os.WriteByte(0);
-                os.WriteByte(Util.CurrentProtocolEncoding.Major);
-                os.WriteByte(Util.CurrentProtocolEncoding.Minor);
+                os.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                 os.WriteByte(Ice1Definitions.ValidateConnectionMessage);
                 os.WriteByte(0);
                 os.WriteInt(Ice1Definitions.HeaderSize); // Message size.
@@ -2120,10 +2111,7 @@ namespace Ice
                     if (_writeStream.Size == 0)
                     {
                         _writeStream.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                        _writeStream.WriteByte((byte)Protocol.Ice1);
-                        _writeStream.WriteByte(0);
-                        _writeStream.WriteByte(Util.CurrentProtocolEncoding.Major);
-                        _writeStream.WriteByte(Util.CurrentProtocolEncoding.Minor);
+                        _writeStream.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                         _writeStream.WriteByte(Ice1Definitions.ValidateConnectionMessage);
                         _writeStream.WriteByte(0); // Compression status (always zero for validate connection).
                         _writeStream.WriteInt(Ice1Definitions.HeaderSize); // Message size.

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -1735,10 +1735,10 @@ namespace Ice
             }
             _nextRequestId = 1;
             _messageSizeMax = adapter != null ? adapter.MessageSizeMax : communicator.MessageSizeMax;
-            _readStream = new InputStream(communicator, Util.CurrentProtocolEncoding);
+            _readStream = new InputStream(communicator, Ice1Definitions.Encoding);
             _readHeader = false;
             _readStreamPos = -1;
-            _writeStream = new OutputStream(communicator, Util.CurrentProtocolEncoding);
+            _writeStream = new OutputStream(communicator, Ice1Definitions.Encoding);
             _writeBuffer = new List<ArraySegment<byte>>();
             _writeBufferSize = 0;
             _writeBufferOffset = 0;
@@ -2032,7 +2032,7 @@ namespace Ice
                 //
                 // Before we shut down, we send a close connection message.
                 //
-                var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
+                var os = new OutputStream(_communicator, Ice1Definitions.Encoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
                 os.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                 os.WriteByte(Ice1Definitions.CloseConnectionMessage);
@@ -2062,7 +2062,7 @@ namespace Ice
 
             if (!_endpoint.Datagram())
             {
-                var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
+                var os = new OutputStream(_communicator, Ice1Definitions.Encoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
                 os.WriteSpan(Ice1Definitions.PostMagic.AsSpan());
                 os.WriteByte(Ice1Definitions.ValidateConnectionMessage);
@@ -2452,7 +2452,7 @@ namespace Ice
         {
             Debug.Assert(_state > StateNotValidated && _state < StateClosed);
 
-            info.Stream = new InputStream(_communicator, Util.CurrentProtocolEncoding);
+            info.Stream = new InputStream(_communicator, Ice1Definitions.Encoding);
             _readStream.Swap(info.Stream);
             _readStream.Resize(Ice1Definitions.HeaderSize);
             _readStream.Pos = 0;

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -574,8 +574,8 @@ namespace Ice
                 {
                     Debug.Assert(Os != null);
                     Os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                    Os.WriteByte(Util.CurrentProtocol.Major);
-                    Os.WriteByte(Util.CurrentProtocol.Minor);
+                    Os.WriteByte((byte)Protocol.Ice1);
+                    Os.WriteByte(0);
                     Os.WriteByte(Util.CurrentProtocolEncoding.Major);
                     Os.WriteByte(Util.CurrentProtocolEncoding.Minor);
                     Os.WriteByte(Ice1Definitions.ValidateConnectionMessage);
@@ -1052,12 +1052,20 @@ namespace Ice
 
                                 byte major = _readStream.ReadByte();
                                 byte minor = _readStream.ReadByte();
-                                var pv = new Protocol(major, minor);
-                                Protocol.CheckSupportedProtocol(pv);
+                                if (major != 1 || minor != 0)
+                                {
+                                    // These bytes can only be set to 1.0.
+                                    throw new ProtocolException(
+                                        $"received ice1 protocol frame with protocol set to {major}.{minor}");
+                                }
                                 major = _readStream.ReadByte();
                                 minor = _readStream.ReadByte();
-                                var ev = new Encoding(major, minor);
-                                Protocol.CheckSupportedProtocolEncoding(ev);
+                                if (major != 1 || minor != 0)
+                                {
+                                    // These bytes can only be set to 1.0.
+                                    throw new ProtocolException(
+                                        $"received ice1 protocol frame with protocol encoding set to {major}.{minor}");
+                                }
 
                                 _readStream.ReadByte(); // messageType
                                 _readStream.ReadByte(); // compress
@@ -2029,8 +2037,8 @@ namespace Ice
                 //
                 var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                os.WriteByte(Util.CurrentProtocol.Major);
-                os.WriteByte(Util.CurrentProtocol.Minor);
+                os.WriteByte((byte)Protocol.Ice1);
+                os.WriteByte(0);
                 os.WriteByte(Util.CurrentProtocolEncoding.Major);
                 os.WriteByte(Util.CurrentProtocolEncoding.Minor);
                 os.WriteByte(Ice1Definitions.CloseConnectionMessage);
@@ -2062,8 +2070,8 @@ namespace Ice
             {
                 var os = new OutputStream(_communicator, Util.CurrentProtocolEncoding);
                 os.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                os.WriteByte(Util.CurrentProtocol.Major);
-                os.WriteByte(Util.CurrentProtocol.Minor);
+                os.WriteByte((byte)Protocol.Ice1);
+                os.WriteByte(0);
                 os.WriteByte(Util.CurrentProtocolEncoding.Major);
                 os.WriteByte(Util.CurrentProtocolEncoding.Minor);
                 os.WriteByte(Ice1Definitions.ValidateConnectionMessage);
@@ -2112,8 +2120,8 @@ namespace Ice
                     if (_writeStream.Size == 0)
                     {
                         _writeStream.WriteSpan(Ice1Definitions.Magic.AsSpan());
-                        _writeStream.WriteByte(Util.CurrentProtocol.Major);
-                        _writeStream.WriteByte(Util.CurrentProtocol.Minor);
+                        _writeStream.WriteByte((byte)Protocol.Ice1);
+                        _writeStream.WriteByte(0);
                         _writeStream.WriteByte(Util.CurrentProtocolEncoding.Major);
                         _writeStream.WriteByte(Util.CurrentProtocolEncoding.Minor);
                         _writeStream.WriteByte(Ice1Definitions.ValidateConnectionMessage);
@@ -2181,12 +2189,20 @@ namespace Ice
 
                     byte major = _readStream.ReadByte();
                     byte minor = _readStream.ReadByte();
-                    var pv = new Protocol(major, minor);
-                    Protocol.CheckSupportedProtocol(pv);
+                    if (major != 1 || minor != 0)
+                    {
+                        // These bytes can only be set to 1.0.
+                        throw new ProtocolException(
+                            $"received ice1 protocol frame with protocol set to {major}.{minor}");
+                    }
                     major = _readStream.ReadByte();
                     minor = _readStream.ReadByte();
-                    var ev = new Encoding(major, minor);
-                    Protocol.CheckSupportedProtocolEncoding(ev);
+                    if (major != 1 || minor != 0)
+                    {
+                        // These bytes can only be set to 1.0.
+                        throw new ProtocolException(
+                            $"received ice1 protocol frame with protocol encoding set to {major}.{minor}");
+                    }
 
                     byte messageType = _readStream.ReadByte();
                     if (messageType != Ice1Definitions.ValidateConnectionMessage)

--- a/csharp/src/Ice/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/DefaultsAndOverrides.cs
@@ -173,7 +173,7 @@ namespace IceInternal
             val = communicator.GetProperty("Ice.Default.Encoding");
             if (val == null)
             {
-                DefaultEncoding = Ice.Util.CurrentEncoding;
+                DefaultEncoding = Encoding.Latest;
             }
             else
             {

--- a/csharp/src/Ice/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/DefaultsAndOverrides.cs
@@ -178,7 +178,7 @@ namespace IceInternal
             else
             {
                 DefaultEncoding = Encoding.Parse(val);
-                EncodingDefinitions.CheckSupportedEncoding(DefaultEncoding);
+                DefaultEncoding.CheckSupported();
             }
 
             bool slicedFormat = communicator.GetPropertyAsInt("Ice.Default.SlicedFormat") > 0;

--- a/csharp/src/Ice/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/DefaultsAndOverrides.cs
@@ -170,9 +170,16 @@ namespace IceInternal
 
             DefaultPreferSecure = communicator.GetPropertyAsInt("Ice.Default.PreferSecure") > 0;
 
-            val = communicator.GetProperty("Ice.Default.Encoding") ?? Ice.Util.EncodingToString(Ice.Util.CurrentEncoding);
-            DefaultEncoding = Ice.Util.StringToEncoding(val);
-            EncodingDefinitions.CheckSupportedEncoding(DefaultEncoding);
+            val = communicator.GetProperty("Ice.Default.Encoding");
+            if (val == null)
+            {
+                DefaultEncoding = Ice.Util.CurrentEncoding;
+            }
+            else
+            {
+                DefaultEncoding = Encoding.Parse(val);
+                EncodingDefinitions.CheckSupportedEncoding(DefaultEncoding);
+            }
 
             bool slicedFormat = communicator.GetPropertyAsInt("Ice.Default.SlicedFormat") > 0;
             DefaultFormat = slicedFormat ? Ice.FormatType.SlicedFormat : Ice.FormatType.CompactFormat;

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
+
 namespace Ice
 {
     [System.Serializable]
@@ -9,6 +11,28 @@ namespace Ice
     {
         public readonly byte Major;
         public readonly byte Minor;
+
+        public static Encoding Parse(string str)
+        {
+            (byte major, byte minor) = Util.ParseMajorMinorVersion(str, throwOnFailure: true).Value;
+            return new Encoding(major, minor);
+        }
+        public static bool TryParse(string str, out Encoding encoding)
+        {
+            var result = Util.ParseMajorMinorVersion(str, throwOnFailure: false);
+            if (result != null)
+            {
+                encoding = new Encoding(result.Value.Major, result.Value.Minor);
+            }
+            else
+            {
+                encoding = default;
+            }
+            return result != null;
+        }
+
+        public static bool operator ==(Encoding lhs, Encoding rhs) => Equals(lhs, rhs);
+        public static bool operator !=(Encoding lhs, Encoding rhs) => !Equals(lhs, rhs);
 
         public Encoding(byte major, byte minor)
         {
@@ -29,7 +53,6 @@ namespace Ice
             return other is Encoding value && Equals(value);
         }
 
-        public static bool operator ==(Encoding lhs, Encoding rhs) => Equals(lhs, rhs);
-        public static bool operator !=(Encoding lhs, Encoding rhs) => !Equals(lhs, rhs);
+        public override string ToString() => string.Format("{0}.{1}", Major, Minor);
     }
 }

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -14,13 +14,13 @@ namespace Ice
     {
         // The encodings known to the Ice runtime. Don't reference them from other static variables!
 
-        /// <summary>Version 1.0 of the Ice encoding.</summary>
+        /// <summary>Version 1.0 of the Ice encoding, supported by Ice 1.0 to Ice 3.7.</summary>
         public static readonly Encoding V1_0 = new Encoding(1, 0);
 
-        /// <summary>Version 1.1 of the Ice encoding.</summary>
+        /// <summary>Version 1.1 of the Ice encoding, supported since Ice 3.5.</summary>
         public static readonly Encoding V1_1 = new Encoding(1, 1);
 
-        /// <summary>Version 2.0 of the Ice encoding.</summary>
+        /// <summary>Version 2.0 of the Ice encoding, supported since Ice 4.0.</summary>
         public static readonly Encoding V2_0 = new Encoding(2, 0);
 
         /// <summary>The most recent version of the Ice encoding.</summary>
@@ -104,9 +104,8 @@ namespace Ice
 
         internal void CheckSupported()
         {
-            // For now, we claim to support 1.0 and 1.1.
-            // TODO: add 2.0, remove 1.0
-            if (this != V1_0 && this != V1_1)
+            // TODO: add 2.0
+            if (this != V1_1)
             {
                 throw new UnsupportedEncodingException("", this, V1_1);
             }

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -6,23 +6,44 @@ using System;
 
 namespace Ice
 {
+    /// <summary>The Ice encoding defines how Slice constructs are marshaled to and later unmarshaled from sequences
+    /// of bytes. An Encoding struct holds a version of the Ice encoding.</summary>
     [System.Serializable]
     public readonly struct Encoding : System.IEquatable<Encoding>
     {
         // The encodings known to the Ice runtime. Don't reference them from other static variables!
 
+        /// <summary>Version 1.0 of the Ice encoding.</summary>
         public static readonly Encoding V1_0 = new Encoding(1, 0);
+
+        /// <summary>Version 1.1 of the Ice encoding.</summary>
         public static readonly Encoding V1_1 = new Encoding(1, 1);
+
+        /// <summary>Version 1.2 of the Ice encoding.</summary>
         public static readonly Encoding V2_0 = new Encoding(2, 0);
 
+        /// <summary>The most recent version of the Ice encoding.</summary>
+        public static readonly Encoding Latest = new Encoding(1, 1); // for now, will upgrade to 2.0
+
+        /// <summary>The major version number of this version of the Ice encoding.</summary>
         public readonly byte Major;
+
+        /// <summary>The minor version number of this version of the Ice encoding.</summary>
         public readonly byte Minor;
 
+        /// <summary>Parses a string into an Encoding.</summary>
+        /// <param name="str">The string to parse.</param>
+        /// <returns>A new encoding.</returns>
         public static Encoding Parse(string str)
         {
             (byte major, byte minor) = Util.ParseMajorMinorVersion(str, throwOnFailure: true)!.Value;
             return new Encoding(major, minor);
         }
+
+        /// <summary>Attempts to parse a string into an Encoding.</summary>
+        /// <param name="str">The string to parse.</param>
+        /// <param name="encoding">The resulting encoding.</param>
+        /// <returns>True if the parsing succeeded and encoding contains the result; otherwise, false.</returns>
         public static bool TryParse(string str, out Encoding encoding)
         {
             var result = Util.ParseMajorMinorVersion(str, throwOnFailure: false);
@@ -40,6 +61,9 @@ namespace Ice
         public static bool operator ==(Encoding lhs, Encoding rhs) => Equals(lhs, rhs);
         public static bool operator !=(Encoding lhs, Encoding rhs) => !Equals(lhs, rhs);
 
+        /// <summary>Constructs a new Encoding.</summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
         public Encoding(byte major, byte minor)
         {
             Major = major;
@@ -67,7 +91,7 @@ namespace Ice
             // TODO: add 2.0, remove 1.0
             if (this != V1_0 && this != V1_1)
             {
-                throw new UnsupportedEncodingException("", this, Util.CurrentEncoding);
+                throw new UnsupportedEncodingException("", this, V1_1);
             }
         }
     }

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -9,12 +9,18 @@ namespace Ice
     [System.Serializable]
     public readonly struct Encoding : System.IEquatable<Encoding>
     {
+        // The encodings known to the Ice runtime. Don't reference them from other static variables!
+
+        public static readonly Encoding V1_0 = new Encoding(1, 0);
+        public static readonly Encoding V1_1 = new Encoding(1, 1);
+        public static readonly Encoding V2_0 = new Encoding(2, 0);
+
         public readonly byte Major;
         public readonly byte Minor;
 
         public static Encoding Parse(string str)
         {
-            (byte major, byte minor) = Util.ParseMajorMinorVersion(str, throwOnFailure: true).Value;
+            (byte major, byte minor) = Util.ParseMajorMinorVersion(str, throwOnFailure: true)!.Value;
             return new Encoding(major, minor);
         }
         public static bool TryParse(string str, out Encoding encoding)
@@ -54,5 +60,15 @@ namespace Ice
         }
 
         public override string ToString() => string.Format("{0}.{1}", Major, Minor);
+
+        internal void CheckSupported()
+        {
+            // For now, we claim to support 1.0 and 1.1.
+            // TODO: add 2.0, remove 1.0
+            if (this != V1_0 && this != V1_1)
+            {
+                throw new UnsupportedEncodingException("", this, Util.CurrentEncoding);
+            }
+        }
     }
 }

--- a/csharp/src/Ice/EncodingDefinitions.cs
+++ b/csharp/src/Ice/EncodingDefinitions.cs
@@ -16,8 +16,5 @@ namespace Ice
         internal const byte FLAG_HAS_INDIRECTION_TABLE = 1 << 3;
         internal const byte FLAG_HAS_SLICE_SIZE = 1 << 4;
         internal const byte FLAG_IS_LAST_SLICE = 1 << 5;
-
-        internal static bool IsSupported(Encoding version, Encoding supported) =>
-            version.Major == supported.Major && version.Minor <= supported.Minor;
     }
 }

--- a/csharp/src/Ice/EncodingDefinitions.cs
+++ b/csharp/src/Ice/EncodingDefinitions.cs
@@ -6,9 +6,6 @@ namespace Ice
 {
     internal static class EncodingDefinitions
     {
-        internal const byte EncodingMajor = 1;
-        internal const byte EncodingMinor = 1;
-
         internal const byte OPTIONAL_END_MARKER = 0xFF;
 
         // TODO: replace by enum
@@ -19,14 +16,6 @@ namespace Ice
         internal const byte FLAG_HAS_INDIRECTION_TABLE = 1 << 3;
         internal const byte FLAG_HAS_SLICE_SIZE = 1 << 4;
         internal const byte FLAG_IS_LAST_SLICE = 1 << 5;
-
-        internal static void CheckSupportedEncoding(Encoding v)
-        {
-            if (v.Major != EncodingMajor || v.Minor > EncodingMinor)
-            {
-                throw new UnsupportedEncodingException("", v, Util.CurrentEncoding);
-            }
-        }
 
         internal static bool IsSupported(Encoding version, Encoding supported) =>
             version.Major == supported.Major && version.Minor <= supported.Minor;

--- a/csharp/src/Ice/IEndpoint.cs
+++ b/csharp/src/Ice/IEndpoint.cs
@@ -178,7 +178,7 @@ namespace Ice
         public Encoding RawEncoding;
         public byte[]? RawBytes;
 
-        protected OpaqueEndpointInfo() => RawEncoding = new Encoding();
+        protected OpaqueEndpointInfo() => RawEncoding = default;
 
         protected OpaqueEndpointInfo(EndpointInfo? underlying,
                                      int timeout,

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -7,6 +7,10 @@ namespace Ice
     // Definitions for the ice1 protocol.
     internal static class Ice1Definitions
     {
+        // The encoding of the header for ice1 frames. It is nominally 1.0, but in practice it is identical to 1.1
+        // for the subset of the encoding used by the ice1 headers.
+        internal static readonly Encoding Encoding = new Encoding(1, 1);
+
         // Size of an ice1 frame or message header:
         // Magic number (4 bytes)
         // Post magic (4 bytes)
@@ -20,7 +24,7 @@ namespace Ice
 
         // 4-bytes after magic that provide the protocol version (always 1.0 for an ice1 frame) and the
         // encoding of the frame header (always 1.0 with the an ice1 frame).
-        internal static readonly byte[] PostMagic = new byte[] { 0x01, 0x00, 0x01, 0x00 };
+        internal static readonly byte[] PostMagic = new byte[] { 1, 0, 1, 0 };
 
         // The Ice protocol message types
         internal const byte RequestMessage = 0;

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -7,36 +7,22 @@ namespace Ice
     // Definitions for the ice1 protocol.
     internal static class Ice1Definitions
     {
-        //
-        // Size of the ice1 protocol header
-        //
+        // Size of an ice1 frame or message header:
         // Magic number (4 bytes)
-        // Protocol version major (Byte)
-        // Protocol version minor (Byte)
-        // Encoding version major (Byte)
-        // Encoding version minor (Byte)
+        // Post magic (4 bytes)
         // Message type (Byte)
         // Compression status (Byte)
-        // Message size (Int)
-        //
+        // Message size (Int - 4 bytes)
         internal const int HeaderSize = 14;
 
-        //
         // The magic number at the front of each message
-        //
         internal static readonly byte[] Magic = new byte[] { 0x49, 0x63, 0x65, 0x50 }; // 'I', 'c', 'e', 'P'
 
-        //
-        // The current Ice protocol and encoding version
-        //
-        internal const byte ProtocolMajor = 1;
-        internal const byte ProtocolMinor = 0;
-        internal const byte ProtocolEncodingMajor = 1;
-        internal const byte ProtocolEncodingMinor = 0;
+        // 4-bytes after magic that provide the protocol version (always 1.0 for an ice1 frame) and the
+        // encoding of the frame header (always 1.0 with the an ice1 frame).
+        internal static readonly byte[] PostMagic = new byte[] { 0x01, 0x00, 0x01, 0x00 };
 
-        //
         // The Ice protocol message types
-        //
         internal const byte RequestMessage = 0;
         internal const byte RequestBatchMessage = 1;
         internal const byte ReplyMessage = 2;
@@ -46,8 +32,7 @@ namespace Ice
         internal static readonly byte[] RequestHeader = new byte[]
         {
             Magic[0], Magic[1], Magic[2], Magic[3],
-            ProtocolMajor, ProtocolMinor,
-            ProtocolEncodingMajor, ProtocolEncodingMinor,
+            PostMagic[0], PostMagic[1], PostMagic[2], PostMagic[3],
             RequestMessage,
             0, // Compression status.
             0, 0, 0, 0, // Message size (placeholder).
@@ -57,8 +42,7 @@ namespace Ice
         internal static readonly byte[] RequestBatchHeader = new byte[]
         {
             Magic[0], Magic[1], Magic[2], Magic[3],
-            ProtocolMajor, ProtocolMinor,
-            ProtocolEncodingMajor, ProtocolEncodingMinor,
+            PostMagic[0], PostMagic[1], PostMagic[2], PostMagic[3],
             RequestBatchMessage,
             0, // Compression status.
             0, 0, 0, 0, // Message size (placeholder).
@@ -68,8 +52,7 @@ namespace Ice
         internal static readonly byte[] ReplyHeader = new byte[]
         {
             Magic[0], Magic[1], Magic[2], Magic[3],
-            ProtocolMajor, ProtocolMinor,
-            ProtocolEncodingMajor, ProtocolEncodingMinor,
+            PostMagic[0], PostMagic[1], PostMagic[2], PostMagic[3],
             ReplyMessage,
             0, // Compression status.
             0, 0, 0, 0 // Message size (placeholder).

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -9,7 +9,7 @@ namespace Ice
     {
         // The encoding of the header for ice1 frames. It is nominally 1.0, but in practice it is identical to 1.1
         // for the subset of the encoding used by the ice1 headers.
-        internal static readonly Encoding Encoding = new Encoding(1, 1);
+        internal static readonly Encoding Encoding = Encoding.V1_1;
 
         // Size of an ice1 frame or message header:
         // Magic number (4 bytes)

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -165,7 +165,7 @@ namespace Ice
             Debug.Assert(_mainEncaps == null && _endpointEncaps == null);
             (Encoding Encoding, int Size) encapsHeader = ReadEncapsulationHeader();
             _mainEncaps = new Encaps(_limit, Encoding, encapsHeader.Size);
-            Debug.Assert(!encapsHeader.Encoding.Equals(Util.Encoding_1_0));
+            Debug.Assert(!encapsHeader.Encoding.Equals(Encoding.V1_0));
             Encoding = encapsHeader.Encoding;
             _limit = Pos + encapsHeader.Size - 6;
 
@@ -213,7 +213,7 @@ namespace Ice
 
         /// <summary>Verifies if this InputStream can read data encoded using its current encoding.
         /// Throws Ice.UnsupportedEncodingException if it cannot.</summary>
-        public void CheckIsReadable() => EncodingDefinitions.CheckSupportedEncoding(Encoding);
+        public void CheckIsReadable() => Encoding.CheckSupported();
 
         /// <summary>Go to the end of the current main encapsulation, if we are in one.</summary>
         public void SkipCurrentEncapsulation()
@@ -233,7 +233,7 @@ namespace Ice
         public Encoding SkipEmptyEncapsulation()
         {
             (Encoding Encoding, int Size) encapsHeader = ReadEncapsulationHeader();
-            if (encapsHeader.Encoding.Equals(Util.Encoding_1_0))
+            if (encapsHeader.Encoding.Equals(Encoding.V1_0))
             {
                 if (encapsHeader.Size != 6)
                 {
@@ -1212,7 +1212,7 @@ namespace Ice
         /// <returns>The enumerator.</returns>
         public int ReadEnum(int maxValue)
         {
-            if (Encoding.Equals(Util.Encoding_1_0))
+            if (Encoding.Equals(Encoding.V1_0))
             {
                 if (maxValue < 127)
                 {

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -164,8 +164,8 @@ namespace Ice
         {
             Debug.Assert(_mainEncaps == null && _endpointEncaps == null);
             (Encoding Encoding, int Size) encapsHeader = ReadEncapsulationHeader();
+            Debug.Assert(encapsHeader.Encoding == Encoding.V1_1); // TODO: temporary
             _mainEncaps = new Encaps(_limit, Encoding, encapsHeader.Size);
-            Debug.Assert(!encapsHeader.Encoding.Equals(Encoding.V1_0));
             Encoding = encapsHeader.Encoding;
             _limit = Pos + encapsHeader.Size - 6;
 
@@ -233,19 +233,10 @@ namespace Ice
         public Encoding SkipEmptyEncapsulation()
         {
             (Encoding Encoding, int Size) encapsHeader = ReadEncapsulationHeader();
-            if (encapsHeader.Encoding.Equals(Encoding.V1_0))
-            {
-                if (encapsHeader.Size != 6)
-                {
-                    throw new EncapsulationException();
-                }
-            }
-            else
-            {
-                // Skip the optional content of the encapsulation if we are expecting an
-                // empty encapsulation.
-                _buf.B.Position(_buf.B.Position() + encapsHeader.Size - 6);
-            }
+            Debug.Assert(encapsHeader.Encoding == Encoding.V1_1); // TODO: temporary
+            // Skip the optional content of the encapsulation if we are expecting an
+            // empty encapsulation.
+            _buf.B.Position(_buf.B.Position() + encapsHeader.Size - 6);
             return encapsHeader.Encoding;
         }
 
@@ -1212,25 +1203,9 @@ namespace Ice
         /// <returns>The enumerator.</returns>
         public int ReadEnum(int maxValue)
         {
-            if (Encoding.Equals(Encoding.V1_0))
-            {
-                if (maxValue < 127)
-                {
-                    return ReadByte();
-                }
-                else if (maxValue < 32767)
-                {
-                    return ReadShort();
-                }
-                else
-                {
-                    return ReadInt();
-                }
-            }
-            else
-            {
-                return ReadSize();
-            }
+            // TODO: eliminate maxValue
+            Debug.Assert(Encoding == Encoding.V1_1); // TODO: temporary
+            return ReadSize();
         }
 
         /// <summary>

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -477,7 +477,7 @@ namespace IceInternal
 
         public IObjectPrx? GetProxy() => _proxy;
 
-        public string GetEncoding() => Ice.Util.EncodingToString(_proxy.Encoding);
+        public string GetEncoding() => _proxy.Encoding.ToString();
 
         public string GetIdentity()
         {

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -692,18 +692,6 @@ namespace Ice
         public Protocol Bad;
         public Protocol Supported;
 
-        public UnsupportedProtocolException()
-        {
-            Bad = new Protocol();
-            Supported = new Protocol();
-        }
-
-        public UnsupportedProtocolException(System.Exception ex) : base(ex)
-        {
-            Bad = new Protocol();
-            Supported = new Protocol();
-        }
-
         public UnsupportedProtocolException(string reason, Protocol bad, Protocol supported) : base(reason)
         {
             Bad = bad;

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -717,14 +717,14 @@ namespace Ice
 
         public UnsupportedEncodingException()
         {
-            Bad = new Encoding();
-            Supported = new Encoding();
+            Bad = default;
+            Supported = default;
         }
 
         public UnsupportedEncodingException(System.Exception ex) : base(ex)
         {
-            Bad = new Encoding();
-            Supported = new Encoding();
+            Bad = default;
+            Supported = default;
         }
 
         public UnsupportedEncodingException(string reason, Encoding bad, Encoding supported) : base(reason)

--- a/csharp/src/Ice/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/OpaqueEndpointI.cs
@@ -14,7 +14,7 @@ namespace IceInternal
         public OpaqueEndpointI(List<string> args)
         {
             _type = -1;
-            _rawEncoding = Ice.Util.Encoding_1_0;
+            _rawEncoding = Ice.Encoding.V1_0;
             _rawBytes = System.Array.Empty<byte>();
 
             InitWithOptions(args);

--- a/csharp/src/Ice/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/OpaqueEndpointI.cs
@@ -14,7 +14,7 @@ namespace IceInternal
         public OpaqueEndpointI(List<string> args)
         {
             _type = -1;
-            _rawEncoding = Ice.Encoding.V1_0;
+            _rawEncoding = Ice.Encoding.V1_1;
             _rawBytes = System.Array.Empty<byte>();
 
             InitWithOptions(args);

--- a/csharp/src/Ice/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/OpaqueEndpointI.cs
@@ -59,7 +59,7 @@ namespace IceInternal
         public override string ToString()
         {
             string val = System.Convert.ToBase64String(_rawBytes);
-            return "opaque -t " + _type + " -e " + Ice.Util.EncodingToString(_rawEncoding) + " -v " + val;
+            return "opaque -t " + _type + " -e " + _rawEncoding.ToString() + " -v " + val;
         }
 
         private sealed class InfoI : Ice.OpaqueEndpointInfo
@@ -263,7 +263,7 @@ namespace IceInternal
             {
                 s += " -t " + _type;
             }
-            s += " -e " + Ice.Util.EncodingToString(_rawEncoding);
+            s += " -e " + _rawEncoding.ToString();
             if (_rawBytes.Length > 0)
             {
                 s += " -v " + System.Convert.ToBase64String(_rawBytes);
@@ -404,7 +404,7 @@ namespace IceInternal
 
                         try
                         {
-                            _rawEncoding = Ice.Util.StringToEncoding(argument);
+                            _rawEncoding = Ice.Encoding.Parse(argument);
                         }
                         catch (FormatException ex)
                         {

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -625,7 +625,7 @@ namespace IceInternal
         public void Prepare(string operation, bool idempotent, Dictionary<string, string>? context)
         {
             Debug.Assert(Os != null);
-            Protocol.CheckSupportedProtocol(Proxy.IceReference.GetProtocol());
+            Proxy.IceReference.GetProtocol().CheckSupported();
 
             IsIdempotent = idempotent;
 

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -212,8 +212,8 @@ namespace IceInternal
             _doneInSent = false;
             _alreadySent = false;
             State = 0;
-            Os = os ?? new Ice.OutputStream(communicator, Ice.Util.CurrentProtocolEncoding);
-            Is = iss ?? new Ice.InputStream(communicator, Ice.Util.CurrentProtocolEncoding);
+            Os = os ?? new Ice.OutputStream(communicator, Ice.Ice1Definitions.Encoding);
+            Is = iss ?? new Ice.InputStream(communicator, Ice.Ice1Definitions.Encoding);
             _completionCallback = completionCallback;
             if (_completionCallback != null)
             {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -51,7 +51,7 @@ namespace Ice
         public OutgoingRequestFrame(IObjectPrx proxy, string operation, bool idempotent, Context? context = null)
             : base(proxy.Communicator)
         {
-            Protocol.CheckSupportedProtocol(proxy.IceReference.GetProtocol());
+            proxy.IceReference.GetProtocol().CheckSupported();
 
             Identity = proxy.Identity;
             Facet = proxy.Facet;

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -34,7 +34,7 @@ namespace Ice
         /// written later on with StartReturnValue/EndReturnValue.</summary>
         /// <param name="current">The current parameter holds decoded header data and other information about the
         /// request for which this method creates a response.</param>
-        public OutgoingResponseFrame(Current current) : base(current.Adapter.Communicator, Util.CurrentProtocolEncoding)
+        public OutgoingResponseFrame(Current current) : base(current.Adapter.Communicator, Ice1Definitions.Encoding)
         {
             RequestId = current.RequestId;
             _payloadEncoding = current.Encoding;

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -413,12 +413,6 @@ namespace Ice
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
 
-            if (Encoding.Equals(Encoding.V1_0))
-            {
-                // TODO: eliminate this block and return value
-                return false; // Tagged members aren't supported with the 1.0 encoding.
-            }
-
             int v = (int)format;
             if (tag < 30)
             {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -411,6 +411,7 @@ namespace Ice
         /// <param name="format">The optional format of the value.</param>
         public bool WriteOptional(int tag, OptionalFormat format)
         {
+            // TODO: eliminate return value, which was used for 1.0 encoding.
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
 
             int v = (int)format;

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -161,7 +161,7 @@ namespace Ice
         public void StartEncapsulation(Encoding encoding, FormatType? format = null)
         {
             Debug.Assert(_mainEncaps == null && _endpointEncaps == null);
-            EncodingDefinitions.CheckSupportedEncoding(encoding);
+            encoding.CheckSupported();
 
             _mainEncaps = new Encaps(Encoding, _format, _tail);
 
@@ -413,7 +413,7 @@ namespace Ice
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
 
-            if (Encoding.Equals(Util.Encoding_1_0))
+            if (Encoding.Equals(Encoding.V1_0))
             {
                 // TODO: eliminate this block and return value
                 return false; // Tagged members aren't supported with the 1.0 encoding.
@@ -1461,7 +1461,7 @@ namespace Ice
         internal void StartEndpointEncapsulation(Encoding encoding)
         {
             Debug.Assert(_endpointEncaps == null);
-            EncodingDefinitions.CheckSupportedEncoding(encoding);
+            encoding.CheckSupported();
 
             _endpointEncaps = new Encaps(Encoding, _format, _tail);
             Encoding = encoding;
@@ -1488,7 +1488,7 @@ namespace Ice
         /// <param name="encoding">The encoding version of the encapsulation.</param>
         internal void WriteEmptyEncapsulation(Encoding encoding)
         {
-            EncodingDefinitions.CheckSupportedEncoding(encoding);
+            encoding.CheckSupported();
             WriteEncapsulationHeader(6, encoding);
         }
 

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using System;
 using System.Globalization;
 
 namespace Ice

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -45,10 +45,10 @@ namespace Ice
                 case "ice2":
                     return Protocol.Ice2;
                 default:
-                    (byte Major, byte Minor)? result = Util.ParseMajorMinorVersion(str, throwOnFailure: false);
-                    if (result != null && result.Value.Minor == 0)
+                    // Parse as a Major.Minor encoding:
+                    if (Encoding.TryParse(str, out Encoding encoding) && encoding.Minor == 0)
                     {
-                        return (Protocol)result.Value.Major;
+                        return (Protocol)encoding.Major;
                     }
                     byte value = byte.Parse(str, CultureInfo.InvariantCulture);
                     return (Protocol)value;

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -2,56 +2,58 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
+
 namespace Ice
 {
-    [System.Serializable]
-    public readonly struct Protocol : System.IEquatable<Protocol>
+    /// <summary>Represents a version of the Ice protocol. A Protocol can hold a byte value that does not correspond
+    /// to any of its enumerators, and such protocol is not supported by this Ice runtime. It is possible to marshal
+    /// and unmarshal a proxy that uses an unsupported protocol, but it is not possible to call an operation with such
+    /// a proxy.</summary>
+    public enum Protocol : byte { Ice1 = 1, Ice2 = 2 }
+
+    internal static class ProtocolExtensions
     {
-        public readonly byte Major;
-        public readonly byte Minor;
-
-        public Protocol(byte major, byte minor)
+        /// <summary>Checks if this protocol is supported by the Ice runtime. If not supported, throws
+        /// UnsupportedProtocolException.</summary>
+        /// <param name="protocol">The protocol.</param>
+        internal static void CheckSupported(this Protocol protocol)
         {
-            Major = major;
-            Minor = minor;
-        }
-
-        public override int GetHashCode() => System.HashCode.Combine(Major, Minor);
-
-        public bool Equals(Protocol other) => Major.Equals(other.Major) && Minor.Equals(other.Minor);
-
-        public override bool Equals(object? other)
-        {
-            if (ReferenceEquals(this, other))
+            // For now, we support only ice1
+            if (protocol != Protocol.Ice1)
             {
-                return true;
-            }
-            return other is Protocol value && Equals(value);
-        }
-
-        public static bool operator ==(Protocol lhs, Protocol rhs) => Equals(lhs, rhs);
-
-        public static bool operator !=(Protocol lhs, Protocol rhs) => !Equals(lhs, rhs);
-
-        // TODO: move these static methods somewhere else (or remove them).
-
-        internal static void CheckSupportedProtocol(Protocol v)
-        {
-            if (v.Major != Ice1Definitions.ProtocolMajor || v.Minor > Ice1Definitions.ProtocolMinor)
-            {
-                throw new UnsupportedProtocolException("", v, Util.CurrentProtocol);
+                throw new UnsupportedProtocolException("", protocol, Protocol.Ice1);
             }
         }
 
-        internal static void CheckSupportedProtocolEncoding(Encoding v)
+        /// <summary>Parses a protocol string in the stringified proxy format into a Protocol.</summary>
+        /// <param name="str">The string to parse.</param>
+        /// <returns>The parsed protocol, or throws an exception if the string cannot be parsed.</returns>
+        internal static Protocol Parse(string str)
         {
-            if (v.Major != Ice1Definitions.ProtocolEncodingMajor || v.Minor > Ice1Definitions.ProtocolEncodingMinor)
+            switch (str)
             {
-                throw new UnsupportedEncodingException("", v, Util.CurrentProtocolEncoding);
+                case "ice1":
+                    return Protocol.Ice1;
+                case "ice2":
+                    return Protocol.Ice2;
+                default:
+                    try
+                    {
+                        Util.StringToMajorMinor(str, out byte major, out byte minor);
+                        if (minor == 0)
+                        {
+                            return (Protocol)major;
+                        }
+                        // else invalid format
+                    }
+                    catch (FormatException)
+                    {
+                        // ignored, try again below
+                    }
+                    byte value = byte.Parse(str);
+                    return (Protocol)value;
             }
         }
-
-        internal static bool IsSupported(Protocol version, Protocol supported) =>
-            version.Major == supported.Major && version.Minor <= supported.Minor;
     }
 }

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Globalization;
 
 namespace Ice
 {
@@ -38,20 +39,12 @@ namespace Ice
                 case "ice2":
                     return Protocol.Ice2;
                 default:
-                    try
+                    (byte Major, byte Minor)? result = Util.ParseMajorMinorVersion(str, throwOnFailure: false);
+                    if (result != null && result.Value.Minor == 0)
                     {
-                        Util.StringToMajorMinor(str, out byte major, out byte minor);
-                        if (minor == 0)
-                        {
-                            return (Protocol)major;
-                        }
-                        // else invalid format
+                        return (Protocol)result.Value.Major;
                     }
-                    catch (FormatException)
-                    {
-                        // ignored, try again below
-                    }
-                    byte value = byte.Parse(str);
+                    byte value = byte.Parse(str, CultureInfo.InvariantCulture);
                     return (Protocol)value;
             }
         }

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -11,7 +11,13 @@ namespace Ice
     /// to any of its enumerators, and such protocol is not supported by this Ice runtime. It is possible to marshal
     /// and unmarshal a proxy that uses an unsupported protocol, but it is not possible to call an operation with such
     /// a proxy.</summary>
-    public enum Protocol : byte { Ice1 = 1, Ice2 = 2 }
+    public enum Protocol : byte
+    {
+        /// <summary>The ice1 protocol supported by all Ice versions since Ice 1.0.</summary>
+        Ice1 = 1,
+        /// <summary>The ice2 protocol introduced in Ice 4.0.</summary>
+        Ice2 = 2
+    }
 
     internal static class ProtocolExtensions
     {

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -137,8 +137,8 @@ namespace IceInternal
 
             if (!s.Encoding.Equals(Ice.Util.Encoding_1_0))
             {
-                s.WriteByte(_protocol.Major);
-                s.WriteByte(_protocol.Minor);
+                s.WriteByte((byte)_protocol);
+                s.WriteByte(0);
                 s.WriteByte(_encoding.Major);
                 s.WriteByte(_encoding.Minor);
             }
@@ -236,16 +236,16 @@ namespace IceInternal
                 s.Append(" -s");
             }
 
-            if (!_protocol.Equals(Ice.Util.Protocol_1_0))
+            s.Append(" -p ");
+            if (Communicator.ToStringMode >= ToStringMode.Compat)
             {
-                //
-                // We only print the protocol if it's not 1.0. It's fine as
-                // long as we don't add Ice.Default.Protocol, a
-                // stringified proxy will convert back to the same proxy with
-                // stringToProxy.
-                //
-                s.Append(" -p ");
-                s.Append(Ice.Util.ProtocolToString(_protocol));
+                // x.0 style
+                s.Append(_protocol.ToString("D"));
+                s.Append(".0");
+            }
+            else
+            {
+                s.Append(_protocol.ToString().ToLower());
             }
 
             //

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -135,13 +135,10 @@ namespace IceInternal
 
             s.WriteBool(Secure);
 
-            if (!s.Encoding.Equals(Encoding.V1_0))
-            {
-                s.WriteByte((byte)_protocol);
-                s.WriteByte(0);
-                s.WriteByte(_encoding.Major);
-                s.WriteByte(_encoding.Minor);
-            }
+            s.WriteByte((byte)_protocol);
+            s.WriteByte(0);
+            s.WriteByte(_encoding.Major);
+            s.WriteByte(_encoding.Minor);
 
             // Derived class writes the remainder of the reference.
         }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -254,7 +254,7 @@ namespace IceInternal
             // stringToProxy (and won't use Ice.Default.Encoding).
             //
             s.Append(" -e ");
-            s.Append(Ice.Util.EncodingToString(_encoding));
+            s.Append(_encoding.ToString());
 
             return s.ToString();
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -135,7 +135,7 @@ namespace IceInternal
 
             s.WriteBool(Secure);
 
-            if (!s.Encoding.Equals(Ice.Util.Encoding_1_0))
+            if (!s.Encoding.Equals(Encoding.V1_0))
             {
                 s.WriteByte((byte)_protocol);
                 s.WriteByte(0);

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -171,7 +171,7 @@ namespace IceUtilInternal
                                     }
                                     sb.Append(octal);
                                 }
-                                else if (i < 32 || i == 127 || toStringMode == Ice.ToStringMode.ASCII)
+                                else if (i < 32 || i == 127 || (toStringMode & Ice.ToStringMode.ASCII) != 0)
                                 {
                                     // append \\unnnn
                                     sb.Append("\\u");
@@ -238,13 +238,13 @@ namespace IceUtilInternal
                 for (int i = 0; i < s.Length; i++)
                 {
                     char c = s[i];
-                    if (toStringMode == Ice.ToStringMode.Unicode || !char.IsSurrogate(c))
+                    if ((toStringMode & Ice.ToStringMode.Unicode) != 0 || !char.IsSurrogate(c))
                     {
                         EncodeChar(c, result, special, toStringMode);
                     }
                     else
                     {
-                        Debug.Assert(toStringMode == Ice.ToStringMode.ASCII && char.IsSurrogate(c));
+                        Debug.Assert((toStringMode & Ice.ToStringMode.ASCII) != 0 && char.IsSurrogate(c));
                         if (i + 1 == s.Length)
                         {
                             throw new System.ArgumentException("High surrogate without low surrogate");

--- a/csharp/src/Ice/ToStringMode.cs
+++ b/csharp/src/Ice/ToStringMode.cs
@@ -1,0 +1,36 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+
+namespace Ice
+{
+    /// <summary>The output mode or format for ToString on an Ice proxy or Ice identity.</summary>
+    public enum ToStringMode
+    {
+        /// <summary>Characters with ordinal values greater than 127 are kept as-is in the resulting string.
+        /// Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.).</summary>
+        Unicode = 1,
+
+        /// <summary>Characters with ordinal values greater than 127 are encoded as universal character names in
+        /// the resulting string: \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters.
+        /// Non-printable ASCII characters with ordinal values 127 and below are encoded as \\t, \\n (etc.)
+        /// or \\unnnn.</summary>
+        ASCII = 2,
+
+        /// <summary>Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using
+        /// octal escapes. Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or
+        /// an octal escape. Use this mode to generate strings compatible with Ice 3.7 and earlier Ice versions.
+        /// </summary>
+        Compat = 4,
+
+        /// <summary>Generates Unicode-style stringified proxies and identities in a format compatible with Ice 3.7.
+        /// </summary>
+        CompatUnicode = Compat | Unicode,
+
+        /// <summary>Generates ASCII-style stringified proxies and identities in a format compatible with Ice 3.7.
+        /// </summary>
+        CompatASCII = Compat | ASCII
+    }
+}

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -219,11 +219,7 @@ namespace IceInternal
             if (replyStatus == ReplyStatus.OK || replyStatus == ReplyStatus.UserException)
             {
                 Ice.Encoding v = str.SkipEncapsulation();
-                if (!v.Equals(Encoding.V1_0))
-                {
-                    s.Write("\nencoding = ");
-                    s.Write(v.ToString());
-                }
+                s.Write("\nencoding = ");
             }
         }
 
@@ -276,11 +272,8 @@ namespace IceInternal
                 }
 
                 Ice.Encoding v = str.SkipEncapsulation();
-                if (!v.Equals(Encoding.V1_0))
-                {
-                    s.Write("\nencoding = ");
-                    s.Write(v.ToString());
-                }
+                s.Write("\nencoding = ");
+                s.Write(v.ToString());
             }
             catch (System.IO.IOException)
             {

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -222,7 +222,7 @@ namespace IceInternal
                 if (!v.Equals(Ice.Util.Encoding_1_0))
                 {
                     s.Write("\nencoding = ");
-                    s.Write(Ice.Util.EncodingToString(v));
+                    s.Write(v.ToString());
                 }
             }
         }
@@ -279,7 +279,7 @@ namespace IceInternal
                 if (!v.Equals(Ice.Util.Encoding_1_0))
                 {
                     s.Write("\nencoding = ");
-                    s.Write(Ice.Util.EncodingToString(v));
+                    s.Write(v.ToString());
                 }
             }
             catch (System.IO.IOException)

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -219,7 +219,7 @@ namespace IceInternal
             if (replyStatus == ReplyStatus.OK || replyStatus == ReplyStatus.UserException)
             {
                 Ice.Encoding v = str.SkipEncapsulation();
-                if (!v.Equals(Ice.Util.Encoding_1_0))
+                if (!v.Equals(Encoding.V1_0))
                 {
                     s.Write("\nencoding = ");
                     s.Write(v.ToString());
@@ -276,7 +276,7 @@ namespace IceInternal
                 }
 
                 Ice.Encoding v = str.SkipEncapsulation();
-                if (!v.Equals(Ice.Util.Encoding_1_0))
+                if (!v.Equals(Encoding.V1_0))
                 {
                     s.Write("\nencoding = ");
                     s.Write(v.ToString());

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -258,10 +258,7 @@ namespace IceInternal
             base.StreamWriteImpl(s);
             if (s.Encoding.Equals(Encoding.V1_0))
             {
-                s.WriteByte((byte)Protocol.Ice1);
-                s.WriteByte(0);
-                s.WriteByte(Encoding.V1_0.Major);
-                s.WriteByte(Encoding.V1_0.Minor);
+                s.WriteSpan(Ice1Definitions.PostMagic);
             }
             // Not transmitted.
             //s.writeBool(_connect);

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -32,13 +32,6 @@ namespace IceInternal
         public UdpEndpoint(TransportInstance instance, Ice.InputStream s) :
             base(instance, s)
         {
-            if (s.Encoding.Equals(Encoding.V1_0))
-            {
-                s.ReadByte();
-                s.ReadByte();
-                s.ReadByte();
-                s.ReadByte();
-            }
             // Not transmitted.
             //_connect = s.readBool();
             _connect = false;
@@ -256,10 +249,6 @@ namespace IceInternal
         public override void StreamWriteImpl(Ice.OutputStream s)
         {
             base.StreamWriteImpl(s);
-            if (s.Encoding.Equals(Encoding.V1_0))
-            {
-                s.WriteSpan(Ice1Definitions.ProtocolBytes);
-            }
             // Not transmitted.
             //s.writeBool(_connect);
             s.WriteBool(_compress);

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -1,6 +1,7 @@
 //
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
+
 using Ice;
 using System;
 using System.Collections.Generic;
@@ -322,7 +323,7 @@ namespace IceInternal
 
                 try
                 {
-                    Ice.Encoding v = Ice.Util.StringToEncoding(argument);
+                    Ice.Encoding v = Encoding.Parse(argument);
                     if (v.Major != 1 || v.Minor != 0)
                     {
                         Instance.Logger.Warning($"deprecated udp endpoint option: {option}");

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -1,6 +1,7 @@
 //
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
+using Ice;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -256,8 +257,8 @@ namespace IceInternal
             base.StreamWriteImpl(s);
             if (s.Encoding.Equals(Ice.Util.Encoding_1_0))
             {
-                s.WriteByte(Ice.Util.Protocol_1_0.Major);
-                s.WriteByte(Ice.Util.Protocol_1_0.Minor);
+                s.WriteByte((byte)Protocol.Ice1);
+                s.WriteByte(0);
                 s.WriteByte(Ice.Util.Encoding_1_0.Major);
                 s.WriteByte(Ice.Util.Encoding_1_0.Minor);
             }

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -32,7 +32,7 @@ namespace IceInternal
         public UdpEndpoint(TransportInstance instance, Ice.InputStream s) :
             base(instance, s)
         {
-            if (s.Encoding.Equals(Ice.Util.Encoding_1_0))
+            if (s.Encoding.Equals(Encoding.V1_0))
             {
                 s.ReadByte();
                 s.ReadByte();
@@ -256,12 +256,12 @@ namespace IceInternal
         public override void StreamWriteImpl(Ice.OutputStream s)
         {
             base.StreamWriteImpl(s);
-            if (s.Encoding.Equals(Ice.Util.Encoding_1_0))
+            if (s.Encoding.Equals(Encoding.V1_0))
             {
                 s.WriteByte((byte)Protocol.Ice1);
                 s.WriteByte(0);
-                s.WriteByte(Ice.Util.Encoding_1_0.Major);
-                s.WriteByte(Ice.Util.Encoding_1_0.Minor);
+                s.WriteByte(Encoding.V1_0.Major);
+                s.WriteByte(Encoding.V1_0.Minor);
             }
             // Not transmitted.
             //s.writeBool(_connect);

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -258,7 +258,7 @@ namespace IceInternal
             base.StreamWriteImpl(s);
             if (s.Encoding.Equals(Encoding.V1_0))
             {
-                s.WriteSpan(Ice1Definitions.PostMagic);
+                s.WriteSpan(Ice1Definitions.ProtocolBytes);
             }
             // Not transmitted.
             //s.writeBool(_connect);

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -89,9 +89,6 @@ namespace Ice
             }
         }
 
-        public static readonly Encoding CurrentEncoding =
-            new Encoding(EncodingDefinitions.EncodingMajor, EncodingDefinitions.EncodingMinor);
-
         private static readonly object _processLoggerMutex = new object();
         private static ILogger? _processLogger = null;
     }

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -60,17 +60,6 @@ namespace Ice
         public static int IntVersion() => 40000; // AABBCC, with AA=major, BB=minor, CC=patch
 
         /// <summary>
-        /// Converts a string to a protocol version.
-        /// </summary>
-        /// <param name="version">The string to convert.</param>
-        /// <returns>The converted protocol version.</returns>
-        public static Protocol StringToProtocol(string version)
-        {
-            StringToMajorMinor(version, out byte major, out byte minor);
-            return new Protocol(major, minor);
-        }
-
-        /// <summary>
         /// Converts a string to an encoding version.
         /// </summary>
         /// <param name="version">The string to convert.</param>
@@ -82,20 +71,13 @@ namespace Ice
         }
 
         /// <summary>
-        /// Converts a protocol version to a string.
-        /// </summary>
-        /// <param name="v">The protocol version to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static string ProtocolToString(Protocol v) => MajorMinorToString(v.Major, v.Minor);
-
-        /// <summary>
         /// Converts an encoding version to a string.
         /// </summary>
         /// <param name="v">The encoding version to convert.</param>
         /// <returns>The converted string.</returns>
         public static string EncodingToString(Encoding v) => MajorMinorToString(v.Major, v.Minor);
 
-        private static void StringToMajorMinor(string str, out byte major, out byte minor)
+        internal static void StringToMajorMinor(string str, out byte major, out byte minor)
         {
             int pos = str.IndexOf('.');
             if (pos == -1)
@@ -128,17 +110,12 @@ namespace Ice
 
         private static string MajorMinorToString(byte major, byte minor) => string.Format("{0}.{1}", major, minor);
 
-        public static readonly Protocol CurrentProtocol =
-            new Protocol(Ice1Definitions.ProtocolMajor, Ice1Definitions.ProtocolMinor);
-
         public static readonly Encoding CurrentProtocolEncoding =
             new Encoding(Ice1Definitions.ProtocolEncodingMajor,
                                 Ice1Definitions.ProtocolEncodingMinor);
 
         public static readonly Encoding CurrentEncoding =
             new Encoding(EncodingDefinitions.EncodingMajor, EncodingDefinitions.EncodingMinor);
-
-        public static readonly Protocol Protocol_1_0 = new Protocol(1, 0);
 
         public static readonly Encoding Encoding_1_0 = new Encoding(1, 0);
         public static readonly Encoding Encoding_1_1 = new Encoding(1, 1);

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -92,9 +92,6 @@ namespace Ice
         public static readonly Encoding CurrentEncoding =
             new Encoding(EncodingDefinitions.EncodingMajor, EncodingDefinitions.EncodingMinor);
 
-        public static readonly Encoding Encoding_1_0 = new Encoding(1, 0);
-        public static readonly Encoding Encoding_1_1 = new Encoding(1, 1);
-
         private static readonly object _processLoggerMutex = new object();
         private static ILogger? _processLogger = null;
     }

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -59,36 +59,6 @@ namespace Ice
         /// <returns>The Ice version.</returns>
         public static int IntVersion() => 40000; // AABBCC, with AA=major, BB=minor, CC=patch
 
-        internal static (byte Major, byte Minor)? ParseMajorMinorVersion(string str, bool throwOnFailure)
-        {
-            int pos = str.IndexOf('.');
-            if (pos == -1)
-            {
-                if (throwOnFailure)
-                {
-                    throw new FormatException($"malformed major.minor value `{str}'");
-                }
-                return null;
-            }
-
-            string majStr = str[..pos];
-            string minStr = str[(pos + 1)..];
-            try
-            {
-                byte major = byte.Parse(majStr, CultureInfo.InvariantCulture);
-                byte minor = byte.Parse(minStr, CultureInfo.InvariantCulture);
-                return (major, minor);
-            }
-            catch (FormatException)
-            {
-                if (throwOnFailure)
-                {
-                    throw new FormatException($"malformed major.minor value `{str}'");
-                }
-                return null;
-            }
-        }
-
         private static readonly object _processLoggerMutex = new object();
         private static ILogger? _processLogger = null;
     }

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -110,9 +110,7 @@ namespace Ice
 
         private static string MajorMinorToString(byte major, byte minor) => string.Format("{0}.{1}", major, minor);
 
-        public static readonly Encoding CurrentProtocolEncoding =
-            new Encoding(Ice1Definitions.ProtocolEncodingMajor,
-                                Ice1Definitions.ProtocolEncodingMinor);
+        public static readonly Encoding CurrentProtocolEncoding = new Encoding(1, 1);
 
         public static readonly Encoding CurrentEncoding =
             new Encoding(EncodingDefinitions.EncodingMajor, EncodingDefinitions.EncodingMinor);

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -110,8 +110,6 @@ namespace Ice
 
         private static string MajorMinorToString(byte major, byte minor) => string.Format("{0}.{1}", major, minor);
 
-        public static readonly Encoding CurrentProtocolEncoding = new Encoding(1, 1);
-
         public static readonly Encoding CurrentEncoding =
             new Encoding(EncodingDefinitions.EncodingMajor, EncodingDefinitions.EncodingMinor);
 

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -527,7 +527,7 @@ namespace Ice.location
             output.Flush();
             hello = IHelloPrx.Parse("hello", communicator);
             count = locator.getRequestCount();
-            IObjectPrx.Parse("test@TestAdapter", communicator).Clone(encoding: Util.Encoding_1_1).IcePing();
+            IObjectPrx.Parse("test@TestAdapter", communicator).Clone(encoding: Encoding.V1_1).IcePing();
             test(count == locator.getRequestCount());
             output.WriteLine("ok");
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -1072,7 +1072,8 @@ public class AllTests : Test.AllTests
         }
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);
-        testAttribute(clientMetrics, clientProps, update, "Invocation", "id", "metrics -t -e 1.1 [op]", op, output);
+        testAttribute(clientMetrics, clientProps, update, "Invocation", "id", "metrics -t -p ice1 -e 1.1 [op]", op,
+            output);
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "operation", "op", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "identity", "metrics", op, output);
@@ -1080,7 +1081,7 @@ public class AllTests : Test.AllTests
         testAttribute(clientMetrics, clientProps, update, "Invocation", "encoding", "1.1", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "mode", "twoway", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "proxy",
-                      "metrics -t -e 1.1:" + endpoint + " -t " + timeout, op, output);
+                      "metrics -t -p ice1 -e 1.1:" + endpoint + " -t " + timeout, op, output);
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry1", "test", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry2", "", op, output);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -555,7 +555,7 @@ namespace Ice.proxy
                 endpointSelectionType: EndpointSelectionType.Ordered,
                 locatorCacheTimeout: 100,
                 invocationTimeout: 1234,
-                encoding: new Encoding(1, 0),
+                encoding: Encoding.V1_0,
                 locator: locator);
 
             Dictionary<string, string> proxyProps = b1.ToProperty("Test");

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -237,11 +237,23 @@ namespace Ice.proxy
             b1 = IObjectPrx.Parse("test -e 6.5", communicator);
             test(b1.Encoding.Major == 6 && b1.Encoding.Minor == 5);
 
-            b1 = IObjectPrx.Parse("test -p 1.0 -e 1.0", communicator);
-            test(b1.ToString().Equals("test -t -e 1.0"));
+            b1 = IObjectPrx.Parse("test -p ice1 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p ice1 -e 1.0"));
 
-            b1 = IObjectPrx.Parse("test -p 6.5 -e 1.0", communicator);
-            test(b1.ToString().Equals("test -t -p 6.5 -e 1.0"));
+            b1 = IObjectPrx.Parse("test -p 1.0 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p ice1 -e 1.0"));
+
+            b1 = IObjectPrx.Parse("test -p ice2 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p ice2 -e 1.0"));
+
+            b1 = IObjectPrx.Parse("test -p 2.0 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p ice2 -e 1.0"));
+
+            b1 = IObjectPrx.Parse("test -p 6 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p 6 -e 1.0"));
+
+            b1 = IObjectPrx.Parse("test -p 6.0 -e 1.0", communicator);
+            test(b1.ToString().Equals("test -t -p 6 -e 1.0"));
 
             try
             {
@@ -549,7 +561,7 @@ namespace Ice.proxy
             Dictionary<string, string> proxyProps = b1.ToProperty("Test");
             test(proxyProps.Count == 21);
 
-            test(proxyProps["Test"].Equals("test -t -e 1.0"));
+            test(proxyProps["Test"].Equals("test -t -p ice1 -e 1.0"));
             test(proxyProps["Test.CollocationOptimized"].Equals("1"));
             test(proxyProps["Test.ConnectionCached"].Equals("1"));
             test(proxyProps["Test.PreferSecure"].Equals("0"));
@@ -558,7 +570,7 @@ namespace Ice.proxy
             test(proxyProps["Test.InvocationTimeout"].Equals("1234"));
 
             test(proxyProps["Test.Locator"].Equals(
-                        "locator -t -e " + Util.EncodingToString(Util.CurrentEncoding)));
+                        "locator -t -p ice1 -e " + Util.EncodingToString(Util.CurrentEncoding)));
             // Locator collocation optimization is always disabled.
             //test(proxyProps["Test.Locator.CollocationOptimized"].Equals("1"));
             test(proxyProps["Test.Locator.ConnectionCached"].Equals("0"));
@@ -568,7 +580,7 @@ namespace Ice.proxy
             test(proxyProps["Test.Locator.InvocationTimeout"].Equals("1500"));
 
             test(proxyProps["Test.Locator.Router"].Equals(
-                        "router -t -e " + Util.EncodingToString(Util.CurrentEncoding)));
+                        "router -t -p ice1 -e " + Util.EncodingToString(Util.CurrentEncoding)));
             test(proxyProps["Test.Locator.Router.CollocationOptimized"].Equals("0"));
             test(proxyProps["Test.Locator.Router.ConnectionCached"].Equals("1"));
             test(proxyProps["Test.Locator.Router.PreferSecure"].Equals("1"));
@@ -913,24 +925,13 @@ namespace Ice.proxy
 
             output.WriteLine("ok");
 
-            ref13 = "test -p 1.3:" + helper.getTestEndpoint(0);
-            cl13 = Test.IMyClassPrx.Parse(ref13, communicator);
-            try
-            {
-                cl13.IcePing();
-            }
-            catch (UnsupportedProtocolException)
-            {
-                // expected
-            }
-
             output.Write("testing protocol versioning... ");
             output.Flush();
-            ref21 = "test -p 2.1:" + helper.getTestEndpoint(0);
-            cl21 = Test.IMyClassPrx.Parse(ref21, communicator);
+            string ref3 = "test -p 3:" + helper.getTestEndpoint(0);
+            var cl3 = Test.IMyClassPrx.Parse(ref3, communicator);
             try
             {
-                cl21.IcePing();
+                cl3.IcePing();
                 test(false);
             }
             catch (UnsupportedProtocolException)
@@ -1066,12 +1067,12 @@ namespace Ice.proxy
             var p1 = IObjectPrx.Parse("test -e 1.1:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMeouAAAQJwAAAA==",
                 communicator);
             string pstr = p1.ToString();
-            test(pstr.Equals("test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
+            test(pstr.Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
 
             // Opaque endpoint encoded with 1.1 encoding.
             var p2 = IObjectPrx.Parse("test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==",
                 communicator);
-            test(p2.ToString().Equals("test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
+            test(p2.ToString().Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
 
             if ((communicator.GetPropertyAsInt("IPv6") ?? 0) == 0)
             {
@@ -1084,7 +1085,7 @@ namespace Ice.proxy
                     "opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==:" +
                     "opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMusuAAAQJwAAAA==", communicator);
                 pstr = p1.ToString();
-                test(pstr.Equals("test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000"));
+                test(pstr.Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000"));
 
                 // Test that an SSL endpoint and a nonsense endpoint get written back out as an opaque endpoint.
                 p1 = IObjectPrx.Parse("test -e 1.1:opaque -e 1.1 -t 2 -v CTEyNy4wLjAuMREnAAD/////AA==:opaque -e 1.1 -t 99 -v abch",
@@ -1092,12 +1093,12 @@ namespace Ice.proxy
                 pstr = p1.ToString();
                 if (ssl)
                 {
-                    test(pstr.Equals("test -t -e 1.1:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.1 -v abch"));
+                    test(pstr.Equals("test -t -p ice1 -e 1.1:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.1 -v abch"));
                 }
                 else if (tcp)
                 {
                     test(pstr.Equals(
-                        "test -t -e 1.1:opaque -t 2 -e 1.1 -v CTEyNy4wLjAuMREnAAD/////AA==:opaque -t 99 -e 1.1 -v abch"));
+                        "test -t -p ice1 -e 1.1:opaque -t 2 -e 1.1 -v CTEyNy4wLjAuMREnAAD/////AA==:opaque -t 99 -e 1.1 -v abch"));
                 }
             }
 

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -229,7 +229,7 @@ namespace Ice.proxy
             b1 = IObjectPrx.Parse("test -s", communicator);
             test(b1.IsSecure);
 
-            test(b1.Encoding.Equals(Util.CurrentEncoding));
+            test(b1.Encoding.Equals(Encoding.Latest));
 
             b1 = IObjectPrx.Parse("test -e 1.0", communicator);
             test(b1.Encoding.Major == 1 && b1.Encoding.Minor == 0);
@@ -570,7 +570,7 @@ namespace Ice.proxy
             test(proxyProps["Test.InvocationTimeout"].Equals("1234"));
 
             test(proxyProps["Test.Locator"].Equals(
-                        "locator -t -p ice1 -e " + Util.CurrentEncoding.ToString()));
+                        "locator -t -p ice1 -e " + Encoding.Latest.ToString()));
             // Locator collocation optimization is always disabled.
             //test(proxyProps["Test.Locator.CollocationOptimized"].Equals("1"));
             test(proxyProps["Test.Locator.ConnectionCached"].Equals("0"));
@@ -580,7 +580,7 @@ namespace Ice.proxy
             test(proxyProps["Test.Locator.InvocationTimeout"].Equals("1500"));
 
             test(proxyProps["Test.Locator.Router"].Equals(
-                        "router -t -p ice1 -e " + Util.CurrentEncoding.ToString()));
+                        "router -t -p ice1 -e " + Encoding.Latest.ToString()));
             test(proxyProps["Test.Locator.Router.CollocationOptimized"].Equals("0"));
             test(proxyProps["Test.Locator.Router.ConnectionCached"].Equals("1"));
             test(proxyProps["Test.Locator.Router.PreferSecure"].Equals("1"));

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -570,7 +570,7 @@ namespace Ice.proxy
             test(proxyProps["Test.InvocationTimeout"].Equals("1234"));
 
             test(proxyProps["Test.Locator"].Equals(
-                        "locator -t -p ice1 -e " + Util.EncodingToString(Util.CurrentEncoding)));
+                        "locator -t -p ice1 -e " + Util.CurrentEncoding.ToString()));
             // Locator collocation optimization is always disabled.
             //test(proxyProps["Test.Locator.CollocationOptimized"].Equals("1"));
             test(proxyProps["Test.Locator.ConnectionCached"].Equals("0"));
@@ -580,7 +580,7 @@ namespace Ice.proxy
             test(proxyProps["Test.Locator.InvocationTimeout"].Equals("1500"));
 
             test(proxyProps["Test.Locator.Router"].Equals(
-                        "router -t -p ice1 -e " + Util.EncodingToString(Util.CurrentEncoding)));
+                        "router -t -p ice1 -e " + Util.CurrentEncoding.ToString()));
             test(proxyProps["Test.Locator.Router.CollocationOptimized"].Equals("0"));
             test(proxyProps["Test.Locator.Router.ConnectionCached"].Equals("1"));
             test(proxyProps["Test.Locator.Router.PreferSecure"].Equals("1"));

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -555,13 +555,13 @@ namespace Ice.proxy
                 endpointSelectionType: EndpointSelectionType.Ordered,
                 locatorCacheTimeout: 100,
                 invocationTimeout: 1234,
-                encoding: Encoding.V1_0,
+                encoding: Encoding.V2_0,
                 locator: locator);
 
             Dictionary<string, string> proxyProps = b1.ToProperty("Test");
             test(proxyProps.Count == 21);
 
-            test(proxyProps["Test"].Equals("test -t -p ice1 -e 1.0"));
+            test(proxyProps["Test"].Equals("test -t -p ice1 -e 2.0"));
             test(proxyProps["Test.CollocationOptimized"].Equals("1"));
             test(proxyProps["Test.ConnectionCached"].Equals("1"));
             test(proxyProps["Test.PreferSecure"].Equals("0"));
@@ -1064,15 +1064,10 @@ namespace Ice.proxy
             }
 
             // Legal TCP endpoint expressed as opaque endpoint
-            var p1 = IObjectPrx.Parse("test -e 1.1:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMeouAAAQJwAAAA==",
-                communicator);
-            string pstr = p1.ToString();
-            test(pstr.Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
-
             // Opaque endpoint encoded with 1.1 encoding.
-            var p2 = IObjectPrx.Parse("test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==",
+            var p1 = IObjectPrx.Parse("test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==",
                 communicator);
-            test(p2.ToString().Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
+            test(p1.ToString().Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
 
             if ((communicator.GetPropertyAsInt("IPv6") ?? 0) == 0)
             {
@@ -1084,7 +1079,7 @@ namespace Ice.proxy
                 p1 = IObjectPrx.Parse("test -e 1.1:" + "" +
                     "opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==:" +
                     "opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMusuAAAQJwAAAA==", communicator);
-                pstr = p1.ToString();
+                var pstr = p1.ToString();
                 test(pstr.Equals("test -t -p ice1 -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000"));
 
                 // Test that an SSL endpoint and a nonsense endpoint get written back out as an opaque endpoint.


### PR DESCRIPTION
This PR converts Protocol into an enum, and moves most protocol and encoding related functions and static variables out of Util and into Protocol and Encoding.

