### PR TITLE
Remove checked exceptions in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2379,16 +2379,6 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
     string cancel = getEscapedParamName(operation, "cancel");
     string progress = getEscapedParamName(operation, "progress");
 
-    ExceptionList throws = operation->throws();
-    //
-    // Arrange exceptions into most-derived to least-derived order. If we don't
-    // do this, a base exception handler can appear before a derived exception
-    // handler, causing compiler warnings and resulting in the base exception
-    // being marshaled instead of the derived exception.
-    //
-    throws.sort(Slice::DerivedToBaseCompare());
-    throws.unique();
-
     {
         //
         // Write the synchronous version of the operation.
@@ -2481,31 +2471,6 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
             _out << nl << "write: (" << getUnqualified("Ice.OutputStream", ns) << " ostr) =>";
             _out << sb;
             writeMarshalParams(operation, requiredInParams, taggedInParams);
-            _out << eb;
-        }
-
-        if(throws.size() > 0)
-        {
-            _out << ",";
-            _out << nl << "userException: (" << getUnqualified("Ice.UserException", ns) << " ex) =>";
-            _out << sb;
-            _out << nl << "try";
-            _out << sb;
-            _out << nl << "throw ex;";
-            _out << eb;
-
-            for(const auto& ex : throws)
-            {
-                _out << nl << "catch(" << getUnqualified(ex, ns) << ")";
-                _out << sb;
-                _out << nl << "throw;";
-                _out << eb;
-            }
-
-            _out << nl << "catch(" << getUnqualified("Ice.UserException", ns) << ")";
-            _out << sb;
-            _out << eb;
-
             _out << eb;
         }
 

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -97,18 +97,10 @@ namespace Ice
 
             static async Task<bool> AwaitResponseAsync(Task<IncomingResponseFrame> task)
             {
-                try
-                {
-                    InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
-                    bool returnValue = istr.ReadBool();
-                    istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
-                    return returnValue;
-                }
-                catch (UserException userException)
-                {
-                    // TODO: remove this try/catch block once we eliminate checked exceptions.
-                    throw new UnknownUserException(userException);
-                }
+                InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
+                bool returnValue = istr.ReadBool();
+                istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
+                return returnValue;
             }
         }
 
@@ -148,17 +140,7 @@ namespace Ice
             return IsOneway ? task : AwaitResponseAsync(task);
 
             static async Task AwaitResponseAsync(Task<IncomingResponseFrame> task)
-            {
-                try
-                {
-                    (await task.ConfigureAwait(false)).ReadVoidReturnValue();
-                }
-                catch (UserException userException)
-                {
-                    // TODO: remove this try/catch block once we eliminate checked exceptions.
-                    throw new UnknownUserException(userException);
-                }
-            }
+                => (await task.ConfigureAwait(false)).ReadVoidReturnValue();
         }
 
         /// <summary>
@@ -200,18 +182,10 @@ namespace Ice
 
             static async Task<string[]> AwaitResponseAsync(Task<IncomingResponseFrame> task)
             {
-                try
-                {
-                    InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
-                    string[] returnValue = istr.ReadStringArray();
-                    istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
-                    return returnValue;
-                }
-                catch (UserException userException)
-                {
-                    // TODO: remove this try/catch block once we eliminate checked exceptions.
-                    throw new UnknownUserException(userException);
-                }
+                InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
+                string[] returnValue = istr.ReadStringArray();
+                istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
+                return returnValue;
             }
         }
 
@@ -252,18 +226,10 @@ namespace Ice
 
             static async Task<string> AwaitResponseAsync(Task<IncomingResponseFrame> task)
             {
-                try
-                {
-                    InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
-                    string returnValue = istr.ReadString();
-                    istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
-                    return returnValue;
-                }
-                catch (UserException userException)
-                {
-                    // TODO: remove this try/catch block once we eliminate checked exceptions.
-                    throw new UnknownUserException(userException);
-                }
+                InputStream istr = (await task.ConfigureAwait(false)).ReadReturnValue();
+                string returnValue = istr.ReadString();
+                istr.EndEncapsulation(); // TODO: need a better name, like maybe Done()
+                return returnValue;
             }
         }
 

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -928,24 +928,18 @@ namespace IceInternal
         public override void ThrowUserException()
         {
             Debug.Assert(Is != null);
+            Is.StartEncapsulation();
             try
             {
-                Is.StartEncapsulation();
                 Is.ThrowException();
             }
-            catch (Ice.UserException ex)
+            finally
             {
                 Is.EndEncapsulation();
-                if (UserException != null)
-                {
-                    UserException.Invoke(ex);
-                }
-                throw new Ice.UnknownUserException(ex.ice_id());
             }
         }
 
         protected readonly Ice.Encoding Encoding;
-        protected System.Action<Ice.UserException>? UserException;
     }
 
     public class OutgoingAsyncT<T> : OutgoingAsync
@@ -964,11 +958,9 @@ namespace IceInternal
                            Dictionary<string, string>? context,
                            bool synchronous,
                            System.Action<Ice.OutputStream>? write = null,
-                           System.Action<Ice.UserException>? userException = null,
                            System.Func<Ice.InputStream, T>? read = null)
         {
             Read = read;
-            UserException = userException;
             base.Invoke(operation, idempotent, format, context, synchronous, write);
         }
 

--- a/csharp/test/Ice/assemblies/Core.ice
+++ b/csharp/test/Ice/assemblies/Core.ice
@@ -1,8 +1,7 @@
 module Core
 {
-
-exception ArgumentException
-{
-}
-
+    struct Data
+    {
+        int x;
+    }
 }

--- a/csharp/test/Ice/assemblies/User.ice
+++ b/csharp/test/Ice/assemblies/User.ice
@@ -3,14 +3,12 @@
 
 module User
 {
+    class UserInfo
+    {
+    }
 
-class UserInfo
-{
-}
-
-interface Registry
-{
-    UserInfo getUserInfo(string id) throws Core::ArgumentException;
-}
-
+    interface Registry
+    {
+        UserInfo getUserInfo(string id, Core::Data data);
+    }
 }

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -268,7 +268,7 @@ namespace Ice.exceptions
 
             if (thrower.supportsUndeclaredExceptions())
             {
-                output.Write("catching unknown user exception... ");
+                output.Write("catching undeclared user exception... ");
                 output.Flush();
 
                 try
@@ -276,7 +276,7 @@ namespace Ice.exceptions
                     thrower.throwUndeclaredA(1);
                     test(false);
                 }
-                catch (UnknownUserException)
+                catch (A)
                 {
                 }
                 catch (Exception)
@@ -289,7 +289,7 @@ namespace Ice.exceptions
                     thrower.throwUndeclaredB(1, 2);
                     test(false);
                 }
-                catch (UnknownUserException)
+                catch (B)
                 {
                 }
                 catch (Exception)
@@ -302,7 +302,7 @@ namespace Ice.exceptions
                     thrower.throwUndeclaredC(1, 2, 3);
                     test(false);
                 }
-                catch (UnknownUserException)
+                catch (C)
                 {
                 }
                 catch (Exception)
@@ -519,7 +519,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching exact types with AMI mapping... ");
+            output.Write("catching exact types with AMI... ");
             output.Flush();
 
             {
@@ -640,7 +640,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching derived types with new AMI mapping... ");
+            output.Write("catching derived types with AMI... ");
             output.Flush();
 
             {
@@ -720,7 +720,7 @@ namespace Ice.exceptions
 
             if (thrower.supportsUndeclaredExceptions())
             {
-                output.Write("catching unknown user exception with new AMI mapping... ");
+                output.Write("catching undeclared user exception with AMI... ");
                 output.Flush();
 
                 {
@@ -735,7 +735,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (A)
                         {
                         }
                         catch (Exception)
@@ -757,7 +757,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (B)
                         {
                         }
                         catch (Exception)
@@ -779,7 +779,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (C)
                         {
                         }
                         catch (Exception)
@@ -792,7 +792,7 @@ namespace Ice.exceptions
                 output.WriteLine("ok");
             }
 
-            output.Write("catching object not exist exception with new AMI mapping... ");
+            output.Write("catching object not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -822,7 +822,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching object not exist exception with new AMI mapping... ");
+            output.Write("catching object not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -851,7 +851,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching operation not exist exception with new AMI mapping... ");
+            output.Write("catching operation not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -880,7 +880,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching unknown local exception with new AMI mapping... ");
+            output.Write("catching unknown local exception with AMI... ");
             output.Flush();
 
             {
@@ -935,7 +935,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching unknown non-Ice exception with new AMI mapping... ");
+            output.Write("catching unknown non-Ice exception with AMI... ");
             output.Flush();
 
             {
@@ -964,7 +964,7 @@ namespace Ice.exceptions
 
             if (thrower.supportsUndeclaredExceptions())
             {
-                output.Write("catching unknown user exception with new AMI mapping... ");
+                output.Write("catching undeclared user exception with AMI... ");
                 output.Flush();
 
                 {
@@ -979,7 +979,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (A)
                         {
                         }
                         catch (Exception)
@@ -1001,7 +1001,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (B)
                         {
                         }
                         catch (Exception)
@@ -1023,7 +1023,7 @@ namespace Ice.exceptions
                         {
                             throw exc.InnerException;
                         }
-                        catch (UnknownUserException)
+                        catch (C)
                         {
                         }
                         catch (Exception)
@@ -1036,7 +1036,7 @@ namespace Ice.exceptions
                 output.WriteLine("ok");
             }
 
-            output.Write("catching object not exist exception with new AMI mapping... ");
+            output.Write("catching object not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -1066,7 +1066,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching facet not exist exception with new AMI mapping... ");
+            output.Write("catching facet not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -1095,7 +1095,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching operation not exist exception with new AMI mapping... ");
+            output.Write("catching operation not exist exception with AMI... ");
             output.Flush();
 
             {
@@ -1124,7 +1124,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching unknown local exception with new AMI mapping... ");
+            output.Write("catching unknown local exception with AMI... ");
             output.Flush();
 
             {
@@ -1179,7 +1179,7 @@ namespace Ice.exceptions
 
             output.WriteLine("ok");
 
-            output.Write("catching unknown non-Ice exception with new AMI mapping... ");
+            output.Write("catching unknown non-Ice exception with AMI... ");
             output.Flush();
 
             {

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -247,7 +247,7 @@ namespace Ice.interceptor
                     prx.IcePing(ctx);
                     test(false);
                 }
-                catch (UnknownUserException) when (e.kind.Equals("user"))
+                catch (Test.InvalidInputException) when (e.kind.Equals("user"))
                 {
                 }
                 catch (ObjectNotExistException) when (e.kind.Equals("notExist"))


### PR DESCRIPTION
This small PR removes checked Slice user exceptions from C#. 

With this PR, when an invocation fails with a user exception, the caller gets the user exception (if the Ice runtime can unmarshal it) whether or not this user exception is in the operation's exception specification. In Ice 3.7 and before, the caller would get UnknownUserException for user exceptions not listed in the exception specification (taking inheritance into account, just like in Java).

This PR does not update slice2cs to issue a warning for ignored exception specifications - this is for a future commit in the shared parser.