### PR TITLE
C# - Use Bzip2 low level API to avoid extra allocations

### DIFF
--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -314,7 +314,7 @@ namespace IceInternal
                         rc = "BZ_UNEXPECTED_EOF";
                         break;
                     }
-                case BzOutbufFull:
+                case BzOutbuffFull:
                     {
                         rc = "BZ_OUTBUFF_FULL";
                         break;
@@ -399,7 +399,7 @@ namespace IceInternal
             int compressedLen = compressed.Length - (int)bzStream.AvailOut;
             compressedHandle.Free();
             _compressEnd(ref bzStream);
-            if (rc == BzOutbufFull)
+            if (rc == BzOutbuffFull)
             {
                 return null;
             }
@@ -478,7 +478,7 @@ namespace IceInternal
         private const int BzDataErrorMagic = -5;
         private const int BzIoError = -6;
         private const int BzUnexpectedEof = -7;
-        private const int BzOutbufFull = -8;
+        private const int BzOutbuffFull = -8;
         private const int BzConfigError = -9;
     }
 

--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -414,10 +414,12 @@ namespace IceInternal
                 return null;
             }
 
-            // Copy the header from the uncompressed stream to the compressed one.
-            byte[] header = stream.GetBytes(0, headerSize + 4);
-            var r = new Ice.OutputStream(stream.Communicator, stream.Encoding, header);
-
+            // Copy the header from the uncompressed stream to the compressed one,
+            // we use headerSize + 4 to ensure there is room for the size of the
+            // uncompressed stream in the first segment.
+            Debug.Assert(data.Count > 0 && data[0].Count > headerSize + 4);
+            var r = new Ice.OutputStream(stream.Communicator, stream.Encoding,
+                data[0].Slice(0, headerSize + 4).ToArray());
             // Add the size of the uncompressed stream before the message body.
             r.RewriteInt(stream.Size, new Ice.OutputStream.Position(0, headerSize));
             r.WritePayload(new ArraySegment<byte>(compressed, 0, compressedLen));

--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -8,19 +8,41 @@ using System.Runtime.InteropServices;
 
 namespace IceInternal
 {
+    // Map Bzip2 bz_stream struct to a C# struct
+    // for using with the Bzip2 low level API.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct BZStream
+    {
+        internal IntPtr NextIn;
+        internal uint AvailIn;
+        internal uint TotalInLo32;
+        internal uint TotalInHi32;
+
+        internal IntPtr NextOut;
+        internal uint AvailOut;
+        internal uint TotalOutLo32;
+        internal uint TotalOutHi32;
+
+        internal IntPtr State;
+        internal IntPtr BzAlloc;
+        internal IntPtr BzFree;
+        internal IntPtr Opaque;
+    }
+
     internal static class SafeNativeMethods
     {
         [DllImport("bzip2.dll", EntryPoint = "BZ2_bzlibVersion", ExactSpelling = true)]
         internal static extern IntPtr WindowsBZ2_bzlibVersion();
 
-        [DllImport("bzip2.dll", EntryPoint = "BZ2_bzBuffToBuffCompress", ExactSpelling = true)]
-        internal static extern int WindowsBZ2_bzBuffToBuffCompress(byte[] dest,
-                                                                   ref int destLen,
-                                                                   byte[] source,
-                                                                   int sourceLen,
-                                                                   int blockSize100k,
-                                                                   int verbosity,
-                                                                   int workFactor);
+        [DllImport("bzip2.dll", EntryPoint = "BZ2_bzCompressInit", ExactSpelling = true)]
+        internal static extern int WindowsBZ2_bzCompressInit(ref BZStream stream, int blockSize100k, int verbosity,
+                                                             int workFactor);
+
+        [DllImport("bzip2.dll", EntryPoint = "BZ2_bzCompress", ExactSpelling = true)]
+        internal static extern int WindowsBZ2_bzCompress(ref BZStream stream, int action);
+
+        [DllImport("bzip2.dll", EntryPoint = "BZ2_bzCompressEnd", ExactSpelling = true)]
+        internal static extern int WindowsBZ2_bzCompressEnd(ref BZStream stream);
 
         [DllImport("bzip2.dll", EntryPoint = "BZ2_bzBuffToBuffDecompress", ExactSpelling = true)]
         internal static extern int WindowsBZ2_bzBuffToBuffDecompress(byte[] dest,
@@ -33,14 +55,15 @@ namespace IceInternal
         [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzlibVersion", ExactSpelling = true)]
         internal static extern IntPtr UnixBZ2_1_bzlibVersion();
 
-        [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzBuffToBuffCompress", ExactSpelling = true)]
-        internal static extern int UnixBZ2_1_bzBuffToBuffCompress(byte[] dest,
-                                                                  ref int destLen,
-                                                                  byte[] source,
-                                                                  int sourceLen,
-                                                                  int blockSize100k,
-                                                                  int verbosity,
-                                                                  int workFactor);
+        [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzCompressInit", ExactSpelling = true)]
+        internal static extern int UnixBZ2_1_bzCompressInit(ref BZStream stream, int blockSize100k, int verbosity,
+                                                            int workFactor);
+
+        [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzCompress", ExactSpelling = true)]
+        internal static extern int UnixBZ2_1_bzCompress(ref BZStream stream, int action);
+
+        [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzCompressEnd", ExactSpelling = true)]
+        internal static extern int UnixBZ2_1_bzCompressEnd(ref BZStream stream);
 
         [DllImport("libbz2.so.1", EntryPoint = "BZ2_bzBuffToBuffDecompress", ExactSpelling = true)]
         internal static extern int UnixBZ2_1_bzBuffToBuffDecompress(byte[] dest,
@@ -53,14 +76,15 @@ namespace IceInternal
         [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzlibVersion", ExactSpelling = true)]
         internal static extern IntPtr UnixBZ2_10_bzlibVersion();
 
-        [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzBuffToBuffCompress", ExactSpelling = true)]
-        internal static extern int UnixBZ2_10_bzBuffToBuffCompress(byte[] dest,
-                                                                   ref int destLen,
-                                                                   byte[] source,
-                                                                   int sourceLen,
-                                                                   int blockSize100k,
-                                                                   int verbosity,
-                                                                   int workFactor);
+        [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzCompressInit", ExactSpelling = true)]
+        internal static extern int UnixBZ2_10_bzCompressInit(ref BZStream stream, int blockSize100k, int verbosity,
+                                                             int workFactor);
+
+        [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzCompress", ExactSpelling = true)]
+        internal static extern int UnixBZ2_10_bzCompress(ref BZStream stream, int action);
+
+        [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzCompressEnd", ExactSpelling = true)]
+        internal static extern int UnixBZ2_10_bzCompressEnd(ref BZStream stream);
 
         [DllImport("libbz2.so.1.0", EntryPoint = "BZ2_bzBuffToBuffDecompress", ExactSpelling = true)]
         internal static extern int UnixBZ2_10_bzBuffToBuffDecompress(byte[] dest,
@@ -73,14 +97,15 @@ namespace IceInternal
         [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzlibVersion", ExactSpelling = true)]
         internal static extern IntPtr MacOSBZ2_bzlibVersion();
 
-        [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzBuffToBuffCompress", ExactSpelling = true)]
-        internal static extern int MacOSBZ2_bzBuffToBuffCompress(byte[] dest,
-                                                                 ref int destLen,
-                                                                 byte[] source,
-                                                                 int sourceLen,
-                                                                 int blockSize100k,
-                                                                 int verbosity,
-                                                                 int workFactor);
+        [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzCompressInit", ExactSpelling = true)]
+        internal static extern int MacOSBZ2_bzCompressInit(ref BZStream stream, int blockSize100k, int verbosity,
+                                                             int workFactor);
+
+        [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzCompress", ExactSpelling = true)]
+        internal static extern int MacOSBZ2_bzCompress(ref BZStream stream, int action);
+
+        [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzCompressEnd", ExactSpelling = true)]
+        internal static extern int MacOSBZ2_bzCompressEnd(ref BZStream stream);
 
         [DllImport("libbz2.dylib", EntryPoint = "BZ2_bzBuffToBuffDecompress", ExactSpelling = true)]
         internal static extern int MacOSBZ2_bzBuffToBuffDecompress(byte[] dest,
@@ -105,8 +130,20 @@ namespace IceInternal
                                            int sourceLen,
                                            int small,
                                            int verbosity);
+
+    internal delegate int BZCompressInit(ref BZStream stream, int blockSize100k, int verbosity, int workFactor);
+    internal delegate int BZCompress(ref BZStream stream, int action);
+    internal delegate int BZCompressEnd(ref BZStream stream);
+
     public class BZip2
     {
+        private const int BzRun = 0;
+        private const int BzFinish = 2;
+
+        private const int BzOk = 0;
+        private const int BzRunOk = 1;
+        private const int BzFinishOk = 3;
+
         static BZip2()
         {
             //
@@ -144,7 +181,7 @@ namespace IceInternal
             }
             catch (EntryPointNotFoundException)
             {
-                Console.Error.WriteLine("warning: found " + _bzlibName + " but entry point BZ2_bzlibVersion is missing.");
+                Console.Error.WriteLine($"warning: found {_bzlibName} but entry point BZ2_bzlibVersion is missing.");
             }
             catch (TypeLoadException)
             {
@@ -157,81 +194,81 @@ namespace IceInternal
                 {
                     lib = ex.FileName; // Future-proof: we'll do the right thing if the FileName member is non-empty.
                 }
-                Console.Error.Write("warning: " + lib + " could not be loaded (likely due to 32/64-bit mismatch).");
+                Console.Error.Write($"warning: {lib} could not be loaded (likely due to 32/64-bit mismatch).");
                 if (IntPtr.Size == 8)
                 {
-                    Console.Error.Write(" Make sure the directory containing the 64-bit " + lib + " is in your PATH.");
+                    Console.Error.Write($" Make sure the directory containing the 64-bit {lib} is in your PATH.");
                 }
                 Console.Error.WriteLine();
             }
 
             if (AssemblyUtil.IsWindows)
             {
-                _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                   int verbosity, int workFactor) =>
-                    {
-                        return SafeNativeMethods.WindowsBZ2_bzBuffToBuffCompress(dest, ref destLen, source, sourceLen,
-                                                                                 blockSize100k, verbosity, workFactor);
-                    };
-
                 _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
                                      int verbosity) =>
                     {
                         return SafeNativeMethods.WindowsBZ2_bzBuffToBuffDecompress(dest, ref destLen, source, sourceLen,
                                                                                    small, verbosity);
                     };
+
+                _compressInit = (ref BZStream stream, int blockSize100k, int verbosity, int workFactor) =>
+                    SafeNativeMethods.WindowsBZ2_bzCompressInit(ref stream, blockSize100k, verbosity, workFactor);
+
+                _compress = (ref BZStream stream, int action) =>
+                    SafeNativeMethods.WindowsBZ2_bzCompress(ref stream, action);
+
+                _compressEnd = (ref BZStream stream) => SafeNativeMethods.WindowsBZ2_bzCompressEnd(ref stream);
             }
             else if (AssemblyUtil.IsMacOS)
             {
-                _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                   int verbosity, int workFactor) =>
-                    {
-                        return SafeNativeMethods.MacOSBZ2_bzBuffToBuffCompress(dest, ref destLen, source, sourceLen,
-                                                                               blockSize100k, verbosity, workFactor);
-                    };
-
                 _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
                                      int verbosity) =>
                     {
                         return SafeNativeMethods.MacOSBZ2_bzBuffToBuffDecompress(dest, ref destLen, source, sourceLen,
                                                                                  small, verbosity);
                     };
+                _compressInit = (ref BZStream stream, int blockSize100k, int verbosity, int workFactor) =>
+                    SafeNativeMethods.MacOSBZ2_bzCompressInit(ref stream, blockSize100k, verbosity, workFactor);
+
+                _compress = (ref BZStream stream, int action) =>
+                    SafeNativeMethods.MacOSBZ2_bzCompress(ref stream, action);
+
+                _compressEnd = (ref BZStream stream) => SafeNativeMethods.MacOSBZ2_bzCompressEnd(ref stream);
             }
             else
             {
                 if (_bzlibName == "libbz2.so.1.0")
                 {
-                    _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                       int verbosity, int workFactor) =>
-                        {
-                            return SafeNativeMethods.UnixBZ2_10_bzBuffToBuffCompress(dest, ref destLen, source,
-                                                                                     sourceLen, blockSize100k,
-                                                                                     verbosity, workFactor);
-                        };
-
                     _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
                                          int verbosity) =>
                         {
                             return SafeNativeMethods.UnixBZ2_10_bzBuffToBuffDecompress(dest, ref destLen, source,
                                                                                        sourceLen, small, verbosity);
                         };
+
+                    _compressInit = (ref BZStream stream, int blockSize100k, int verbosity, int workFactor) =>
+                        SafeNativeMethods.UnixBZ2_10_bzCompressInit(ref stream, blockSize100k, verbosity, workFactor);
+
+                    _compress = (ref BZStream stream, int action) =>
+                        SafeNativeMethods.UnixBZ2_10_bzCompress(ref stream, action);
+
+                    _compressEnd = (ref BZStream stream) => SafeNativeMethods.UnixBZ2_10_bzCompressEnd(ref stream);
                 }
                 else
                 {
-                    _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                       int verbosity, int workFactor) =>
-                        {
-                            return SafeNativeMethods.UnixBZ2_1_bzBuffToBuffCompress(dest, ref destLen, source,
-                                                                                    sourceLen, blockSize100k, verbosity,
-                                                                                    workFactor);
-                        };
-
                     _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
                                          int verbosity) =>
                         {
                             return SafeNativeMethods.UnixBZ2_1_bzBuffToBuffDecompress(dest, ref destLen, source,
                                                                                       sourceLen, small, verbosity);
                         };
+                    _compressInit = (ref BZStream stream, int blockSize100k, int verbosity, int workFactor) =>
+                        SafeNativeMethods.UnixBZ2_1_bzCompressInit(ref stream, blockSize100k, verbosity, workFactor);
+
+                    _compress = (ref BZStream stream, int action) =>
+                        SafeNativeMethods.UnixBZ2_1_bzCompress(ref stream, action);
+
+                    _compressEnd = (ref BZStream stream) => SafeNativeMethods.UnixBZ2_1_bzCompressEnd(ref stream);
                 }
             }
         }
@@ -242,47 +279,47 @@ namespace IceInternal
 
             switch (error)
             {
-                case BZ_SEQUENCE_ERROR:
+                case BzSequenceError:
                     {
                         rc = "BZ_SEQUENCE_ERROR";
                         break;
                     }
-                case BZ_PARAM_ERROR:
+                case BzParamError:
                     {
                         rc = "BZ_PARAM_ERROR";
                         break;
                     }
-                case BZ_MEM_ERROR:
+                case BzMemError:
                     {
                         rc = "BZ_MEM_ERROR";
                         break;
                     }
-                case BZ_DATA_ERROR:
+                case BzDataError:
                     {
                         rc = "BZ_DATA_ERROR";
                         break;
                     }
-                case BZ_DATA_ERROR_MAGIC:
+                case BzDataErrorMagic:
                     {
                         rc = "BZ_DATA_ERROR_MAGIC";
                         break;
                     }
-                case BZ_IO_ERROR:
+                case BzIoError:
                     {
                         rc = "BZ_IO_ERROR";
                         break;
                     }
-                case BZ_UNEXPECTED_EOF:
+                case BzUnexpectedEof:
                     {
                         rc = "BZ_UNEXPECTED_EOF";
                         break;
                     }
-                case BZ_OUTBUFF_FULL:
+                case BzOutbufFull:
                     {
                         rc = "BZ_OUTBUFF_FULL";
                         break;
                     }
-                case BZ_CONFIG_ERROR:
+                case BzConfigError:
                     {
                         rc = "BZ_CONFIG_ERROR";
                         break;
@@ -301,49 +338,89 @@ namespace IceInternal
         public static Ice.OutputStream? Compress(Ice.OutputStream stream, int headerSize, int compressionLevel)
         {
             Debug.Assert(Supported());
-            //
+            var bzStream = new BZStream();
+            bzStream.BzAlloc = IntPtr.Zero;
+            bzStream.BzFree = IntPtr.Zero;
+            bzStream.Opaque = IntPtr.Zero;
+
+            _compressInit(ref bzStream, compressionLevel, 0, 0);
             // Compress the message body, but not the header.
-            //
             int uncompressedLen = stream.Size - headerSize;
 
-            // TODO: Avoid copy the data using bzip2 low level API, feeding segments instead of allocating
-            // a new array to hold the whole input.
-            byte[] data = stream.GetBytes(headerSize, uncompressedLen);
+            byte[] compressed = new byte[(int)((uncompressedLen * 1.01) + 600)];
 
-            int compressedLen = (int)((uncompressedLen * 1.01) + 600);
-            byte[] compressed = new byte[compressedLen];
+            // Prevent GC from moving the byte array, this allow to take the object address
+            // and pass it to bzip2 calls.
+            var compressedHandle = GCHandle.Alloc(compressed, GCHandleType.Pinned);
+            bzStream.NextOut = compressedHandle.AddrOfPinnedObject();
+            bzStream.AvailOut = (uint) compressed.Length;
+            System.Collections.Generic.IList<ArraySegment<byte>> data = stream.GetUnderlyingBuffer();
 
-            int rc = _compressBuffer(compressed, ref compressedLen, data, uncompressedLen, compressionLevel, 0, 0);
-            if (rc == BZ_OUTBUFF_FULL)
+            int rc = BzOk;
+            for (int i = 0; i < data.Count; ++i)
+            {
+                ArraySegment<byte> segment = data[i];
+                var outHandle = GCHandle.Alloc(segment.Array, GCHandleType.Pinned);
+
+                if (i == 0)
+                {
+                    bzStream.NextIn = outHandle.AddrOfPinnedObject() + headerSize;
+                    bzStream.AvailIn = (uint)(segment.Count - headerSize);
+                }
+                else
+                {
+                    bzStream.NextIn = outHandle.AddrOfPinnedObject();
+                    bzStream.AvailIn = (uint)segment.Count;
+                }
+                Debug.Assert(bzStream.AvailIn > 0);
+
+                do
+                {
+                    rc = _compress(ref bzStream, BzRun);
+                }
+                while (rc == BzRunOk && bzStream.AvailIn > 0);
+
+                if (rc == BzRunOk && i + 1 == data.Count)
+                {
+                    do
+                    {
+                        rc = _compress(ref bzStream, BzFinish);
+                    }
+                    while (rc == BzFinishOk);
+                }
+                outHandle.Free();
+
+                if (rc < 0)
+                {
+                    break;
+                }
+            }
+
+            int compressedLen = compressed.Length - (int)bzStream.AvailOut;
+            compressedHandle.Free();
+            _compressEnd(ref bzStream);
+            if (rc == BzOutbufFull)
             {
                 return null;
             }
             else if (rc < 0)
             {
-                throw new Ice.CompressionException($"BZ2_bzBuffToBuffCompress failed {GetBZ2Error(rc)}");
+                throw new Ice.CompressionException($"Bzip2 compress failed {GetBZ2Error(rc)}");
             }
 
-            //
-            // Don't bother if the compressed data is larger than the
-            // uncompressed data.
-            //
+            // Don't bother if the compressed data is larger than the uncompressed data.
             if (compressedLen >= uncompressedLen)
             {
                 return null;
             }
 
-            //
-            // Copy the header from the uncompressed stream to the
-            // compressed one.
-            //
+            // Copy the header from the uncompressed stream to the compressed one.
             byte[] header = stream.GetBytes(0, headerSize + 4);
             var r = new Ice.OutputStream(stream.Communicator, stream.Encoding, header);
-            //
-            // Add the size of the uncompressed stream before the
-            // message body.
-            //
+
+            // Add the size of the uncompressed stream before the message body.
             r.RewriteInt(stream.Size, new Ice.OutputStream.Position(0, headerSize));
-            r.WriteSpan(compressed.AsSpan(0, compressedLen));
+            r.WritePayload(new ArraySegment<byte>(compressed, 0, compressedLen));
             return r;
         }
 
@@ -388,18 +465,21 @@ namespace IceInternal
         private static readonly bool _bzlibInstalled;
         private static readonly string _bzlibName;
 
-        private static readonly CompressBuffer _compressBuffer;
+        private static readonly BZCompressInit _compressInit;
+        private static readonly BZCompress _compress;
+        private static readonly BZCompressEnd _compressEnd;
+
         private static readonly DecompressBuffer _decompressBuffer;
 
-        private const int BZ_SEQUENCE_ERROR = -1;
-        private const int BZ_PARAM_ERROR = -2;
-        private const int BZ_MEM_ERROR = -3;
-        private const int BZ_DATA_ERROR = -4;
-        private const int BZ_DATA_ERROR_MAGIC = -5;
-        private const int BZ_IO_ERROR = -6;
-        private const int BZ_UNEXPECTED_EOF = -7;
-        private const int BZ_OUTBUFF_FULL = -8;
-        private const int BZ_CONFIG_ERROR = -9;
+        private const int BzSequenceError = -1;
+        private const int BzParamError = -2;
+        private const int BzMemError = -3;
+        private const int BzDataError = -4;
+        private const int BzDataErrorMagic = -5;
+        private const int BzIoError = -6;
+        private const int BzUnexpectedEof = -7;
+        private const int BzOutbufFull = -8;
+        private const int BzConfigError = -9;
     }
 
 }

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -365,45 +365,6 @@ namespace Ice
             RewriteInt(Distance(start) - 4, start);
         }
 
-        /// <summary>Get an array of bytes from the stream contents starting at the given
-        /// offset and with the given length. This method always returns a copy of the
-        /// internal data.</summary>
-        /// <param name="offset">The zero-based byte offset into the stream.</param>
-        /// <param name="count">The number of bytes to retrive.</param>
-        /// <returns>A array of bytes with the requested size</returns>
-        internal byte[] GetBytes(int offset, int count)
-        {
-            Debug.Assert(count <= offset + Size);
-            byte[] data = new byte[count];
-            int i = 0;
-            int remaining = 0;
-            for (; i < _segmentList.Count && offset > 0; i++)
-            {
-                ArraySegment<byte> segment = _segmentList[i];
-                if (segment.Count > offset)
-                {
-                    remaining = Math.Min(count, segment.Count - offset);
-                    Buffer.BlockCopy(segment.Array, segment.Offset + offset, data, 0, remaining);
-                    i++;
-                    break;
-                }
-                else
-                {
-                    offset -= segment.Count;
-                }
-            }
-
-            offset = remaining;
-            for (; i < _segmentList.Count && offset < count; i++)
-            {
-                ArraySegment<byte> segment = _segmentList[i];
-                remaining = Math.Min(segment.Count, count - offset);
-                Buffer.BlockCopy(segment.Array, segment.Offset, data, offset, remaining);
-                offset += remaining;
-            }
-            return data;
-        }
-
         /// <summary>
         /// Write the header information for an optional value.
         /// </summary>

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1353,7 +1353,7 @@ namespace Ice
         /// ensures there is no gaps, the size and capacity of the stream are adjusted to the
         /// sum of all segment counts, and the tail is advanced to the end of the new segment.</summary>
         /// <param name="payload">The array segment payload to write into the stream.</param>
-        protected void WritePayload(ArraySegment<byte> payload)
+        internal void WritePayload(ArraySegment<byte> payload)
         {
             Debug.Assert(_tail.Segment == _segmentList.Count - 1, "Current segment is not the last segment");
 


### PR DESCRIPTION
This PR reworks Bzip2 compression usage to use the low level API and avoid the extra allocations