### PR TITLE
Removed remaining ice_id methods in C#

### DIFF
--- a/csharp/src/Ice/Communicator-EndpointHostResolver.cs
+++ b/csharp/src/Ice/Communicator-EndpointHostResolver.cs
@@ -184,7 +184,7 @@ namespace Ice
                 {
                     if (r.Observer != null)
                     {
-                        r.Observer.Failed(ex.ice_id());
+                        r.Observer.Failed(ex.GetType().FullName);
                         r.Observer.Detach();
                     }
                     r.Callback.Exception(ex);
@@ -204,7 +204,7 @@ namespace Ice
                 var ex = new CommunicatorDestroyedException();
                 if (entry.Observer != null)
                 {
-                    entry.Observer.Failed(ex.ice_id());
+                    entry.Observer.Failed(ex.GetType().FullName);
                     entry.Observer.Detach();
                 }
                 entry.Callback.Exception(ex);

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -1904,7 +1904,7 @@ namespace Ice
                          _exception is ObjectAdapterDeactivatedException ||
                          (_exception is ConnectionLostException && _state >= StateClosing)))
                     {
-                        _observer.Failed(_exception.ice_id());
+                        _observer.Failed(_exception.GetType().FullName);
                     }
                 }
             }

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -1012,7 +1012,7 @@ namespace IceInternal
             {
                 if (_observer != null)
                 {
-                    _observer.Failed(ex.ice_id());
+                    _observer.Failed(ex.GetType().FullName);
                     _observer.Detach();
                 }
                 _factory.HandleConnectionException(ex, _hasMore || _iter < _connectors.Count);

--- a/csharp/src/Ice/Exception.cs
+++ b/csharp/src/Ice/Exception.cs
@@ -10,7 +10,7 @@ namespace IceInternal
 {
     internal class Ex
     {
-        // UOE = UnknownObjectException as in unknow class. TODO: fix/remove.
+        // UOE = UnknownObjectException as in unknown class. TODO: fix/remove.
         internal static void ThrowUOE(Type expectedType, Ice.AnyClass v)
         {
             // If the object is an unknown sliced object, we didn't find an
@@ -55,9 +55,6 @@ namespace Ice
         /// <param name="ex">The inner exception.</param>
         public Exception(System.Exception ex) : base("", ex) { }
 
-        // TODO: temporary, should be removed:
-        public abstract string ice_id();
-
         /// <summary>
         /// Initializes a new instance of the exception with serialized data.
         /// </summary>
@@ -90,7 +87,6 @@ namespace Ice
         /// <param name="info">Holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">Contains contextual information about the source or destination.</param>
         protected LocalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-
     }
 }
 

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -25,14 +25,7 @@ namespace IceInternal
                 if (unhandledException)
                 {
                     System.Exception realEx = exc.InnerException ?? exc;
-                    if (realEx is Ice.LocalException iceLocalEx)
-                    {
-                        dispatchObserver.Failed(iceLocalEx.ice_id()); // TODO: refactor
-                    }
-                    else
-                    {
-                        dispatchObserver.Failed(realEx.GetType().FullName);
-                    }
+                    dispatchObserver.Failed(realEx.GetType().FullName);
                 }
                 else
                 {

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -17,8 +17,6 @@ namespace Ice
         public InitializationException(string reason) => Reason = reason;
 
         public InitializationException(string reason, System.Exception ex) : base(ex) => Reason = reason;
-
-        public override string ice_id() => "::Ice::InitializationException";
     }
 
     /// <summary>
@@ -59,8 +57,6 @@ namespace Ice
             KindOfObject = kindOfObject;
             Id = id;
         }
-
-        public override string ice_id() => "::Ice::NotRegisteredException";
     }
 
     /// <summary>
@@ -81,7 +77,6 @@ namespace Ice
 
         public TwowayOnlyException(string operation, System.Exception ex) : base(ex) => Operation = operation;
 
-        public override string ice_id() => "::Ice::TwowayOnlyException";
     }
 
     /// <summary>
@@ -96,8 +91,6 @@ namespace Ice
         public CommunicatorDestroyedException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::CommunicatorDestroyedException";
     }
 
     /// <summary>
@@ -116,7 +109,6 @@ namespace Ice
 
         public ObjectAdapterDeactivatedException(string name, System.Exception ex) : base(ex) => Name = name;
 
-        public override string ice_id() => "::Ice::ObjectAdapterDeactivatedException";
     }
 
     /// <summary>
@@ -135,8 +127,6 @@ namespace Ice
         public ObjectAdapterIdInUseException(string id) => Id = id;
 
         public ObjectAdapterIdInUseException(string id, System.Exception ex) : base(ex) => Id = id;
-
-        public override string ice_id() => "::Ice::ObjectAdapterIdInUseException";
     }
 
     /// <summary>
@@ -154,7 +144,6 @@ namespace Ice
 
         public NoEndpointException(string proxy, System.Exception ex) : base(ex) => Proxy = proxy;
 
-        public override string ice_id() => "::Ice::NoEndpointException";
     }
 
     /// <summary>
@@ -176,7 +165,6 @@ namespace Ice
 
         public SyscallException(int error, System.Exception ex) : base(ex) => Error = error;
 
-        public override string ice_id() => "::Ice::SyscallException";
     }
 
     /// <summary>
@@ -199,8 +187,6 @@ namespace Ice
         public SocketException(int error, System.Exception ex) : base(error, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::SocketException";
     }
 
     /// <summary>
@@ -218,7 +204,6 @@ namespace Ice
 
         public FileException(int error, string path, System.Exception ex) : base(error, ex) => Path = path;
 
-        public override string ice_id() => "::Ice::FileException";
     }
 
     /// <summary>
@@ -241,8 +226,6 @@ namespace Ice
         public ConnectFailedException(int error, System.Exception ex) : base(error, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectFailedException";
     }
 
     /// <summary>
@@ -266,8 +249,6 @@ namespace Ice
         public ConnectionRefusedException(int error, System.Exception ex) : base(error, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectionRefusedException";
     }
 
     /// <summary>
@@ -290,8 +271,6 @@ namespace Ice
         public ConnectionLostException(int error, System.Exception ex) : base(error, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectionLostException";
     }
 
     /// <summary>
@@ -327,8 +306,6 @@ namespace Ice
             Error = error;
             Host = host;
         }
-
-        public override string ice_id() => "::Ice::DNSException";
     }
 
     /// <summary>
@@ -343,8 +320,6 @@ namespace Ice
         public TimeoutException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::TimeoutException";
     }
 
     /// <summary>
@@ -360,8 +335,6 @@ namespace Ice
         public ConnectTimeoutException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectTimeoutException";
     }
 
     /// <summary>
@@ -377,8 +350,6 @@ namespace Ice
         public CloseTimeoutException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::CloseTimeoutException";
     }
 
     /// <summary>
@@ -395,8 +366,6 @@ namespace Ice
         public ConnectionTimeoutException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectionTimeoutException";
     }
 
     /// <summary>
@@ -412,8 +381,6 @@ namespace Ice
         public InvocationTimeoutException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::InvocationTimeoutException";
     }
 
     /// <summary>
@@ -429,8 +396,6 @@ namespace Ice
         public InvocationCanceledException(System.Exception ex) : base(ex)
         {
         }
-
-        public override string ice_id() => "::Ice::InvocationCanceledException";
     }
 
     /// <summary>
@@ -448,8 +413,6 @@ namespace Ice
         public ProtocolException(string reason) => Reason = reason;
 
         public ProtocolException(string reason, System.Exception ex) : base(ex) => Reason = reason;
-
-        public override string ice_id() => "::Ice::ProtocolException";
     }
 
     /// <summary>
@@ -467,8 +430,6 @@ namespace Ice
         public BadMagicException(string reason, byte[] badMagic) : base(reason) => BadMagic = badMagic;
 
         public BadMagicException(string reason, byte[] badMagic, System.Exception ex) : base(reason, ex) => BadMagic = badMagic;
-
-        public override string ice_id() => "::Ice::BadMagicException";
     }
 
     /// <summary>
@@ -491,8 +452,6 @@ namespace Ice
             Bad = bad;
             Supported = supported;
         }
-
-        public override string ice_id() => "::Ice::UnsupportedProtocolException";
     }
 
     /// <summary>
@@ -526,8 +485,6 @@ namespace Ice
             Bad = bad;
             Supported = supported;
         }
-
-        public override string ice_id() => "::Ice::UnsupportedEncodingException";
     }
 
     /// <summary>
@@ -550,8 +507,6 @@ namespace Ice
         public UnknownMessageException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::UnknownMessageException";
     }
 
     /// <summary>
@@ -575,8 +530,6 @@ namespace Ice
         public ConnectionNotValidatedException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ConnectionNotValidatedException";
     }
 
     /// <summary>
@@ -600,8 +553,6 @@ namespace Ice
         public UnknownRequestIdException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::UnknownRequestIdException";
     }
 
     /// <summary>
@@ -624,8 +575,6 @@ namespace Ice
         public UnknownReplyStatusException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::UnknownReplyStatusException";
     }
 
     /// <summary>
@@ -656,8 +605,6 @@ namespace Ice
         public CloseConnectionException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::CloseConnectionException";
     }
 
     /// <summary>
@@ -679,8 +626,6 @@ namespace Ice
         public ConnectionManuallyClosedException(bool graceful) => Graceful = graceful;
 
         public ConnectionManuallyClosedException(bool graceful, System.Exception ex) : base(ex) => Graceful = graceful;
-
-        public override string ice_id() => "::Ice::ConnectionManuallyClosedException";
     }
 
     /// <summary>
@@ -704,8 +649,6 @@ namespace Ice
         public IllegalMessageSizeException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::IllegalMessageSizeException";
     }
 
     /// <summary>
@@ -728,8 +671,6 @@ namespace Ice
         public CompressionException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::CompressionException";
     }
 
     /// <summary>
@@ -754,8 +695,6 @@ namespace Ice
         public DatagramLimitException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::DatagramLimitException";
     }
 
     /// <summary>
@@ -778,8 +717,6 @@ namespace Ice
         public MarshalException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::MarshalException";
     }
 
     /// <summary>
@@ -802,8 +739,6 @@ namespace Ice
         public ProxyUnmarshalException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::ProxyUnmarshalException";
     }
 
     /// <summary>
@@ -826,8 +761,6 @@ namespace Ice
         public UnmarshalOutOfBoundsException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::UnmarshalOutOfBoundsException";
     }
 
     /// <summary>
@@ -845,8 +778,6 @@ namespace Ice
         public NoClassFactoryException(string reason, string type) : base(reason) => Type = type;
 
         public NoClassFactoryException(string reason, string type, System.Exception ex) : base(reason, ex) => Type = type;
-
-        public override string ice_id() => "::Ice::NoClassFactoryException";
     }
 
     /// <summary>
@@ -886,8 +817,6 @@ namespace Ice
             Type = type;
             ExpectedType = expectedType;
         }
-
-        public override string ice_id() => "::Ice::UnexpectedObjectException";
     }
 
     /// <summary>
@@ -912,8 +841,6 @@ namespace Ice
         public MemoryLimitException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::MemoryLimitException";
     }
 
     /// <summary>
@@ -937,8 +864,6 @@ namespace Ice
         public EncapsulationException(string reason, System.Exception ex) : base(reason, ex)
         {
         }
-
-        public override string ice_id() => "::Ice::EncapsulationException";
     }
 
     /// <summary>
@@ -959,8 +884,6 @@ namespace Ice
 
         public FeatureNotSupportedException(string unsupportedFeature, System.Exception ex) : base(ex) =>
             UnsupportedFeature = unsupportedFeature;
-
-        public override string ice_id() => "::Ice::FeatureNotSupportedException";
     }
 
     /// <summary>
@@ -978,7 +901,5 @@ namespace Ice
         public SecurityException(string reason) => Reason = reason;
 
         public SecurityException(string reason, System.Exception ex) : base(ex) => Reason = reason;
-
-        public override string ice_id() => "::Ice::SecurityException";
     }
 }

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -255,20 +255,9 @@ namespace IceInternal
             {
                 _ex = ex;
 
-                string typeId;
-                if (ex is RemoteException remoteException)
-                {
-                    typeId = remoteException.TypeId;
-                }
-                else
-                {
-                    // TODO: we assume all non-RemoteExceptions are LocalExceptions
-                    typeId = ((Ice.LocalException)ex).ice_id();
-                }
-
                 if (ChildObserver != null)
                 {
-                    ChildObserver.Failed(typeId);
+                    ChildObserver.Failed(ex.GetType().FullName);
                     ChildObserver.Detach();
                     ChildObserver = null;
                 }
@@ -276,7 +265,7 @@ namespace IceInternal
 
                 if (Observer != null)
                 {
-                    Observer.Failed(typeId);
+                    Observer.Failed(ex.GetType().FullName);
                 }
                 bool invoke = _completionCallback.HandleException(ex, this);
                 if (!invoke && Observer != null)
@@ -391,18 +380,7 @@ namespace IceInternal
         {
             if (ChildObserver != null)
             {
-                string typeId;
-                if (exc is RemoteException remoteException)
-                {
-                    typeId = remoteException.TypeId;
-                }
-                else
-                {
-                    // TODO: we assume all non-RemoteExceptions are LocalExceptions
-                    typeId = ((Ice.LocalException)exc).ice_id();
-                }
-
-                ChildObserver.Failed(typeId);
+                ChildObserver.Failed(exc.GetType().FullName);
                 ChildObserver.Detach();
                 ChildObserver = null;
             }
@@ -551,7 +529,7 @@ namespace IceInternal
                     {
                         if (ChildObserver != null)
                         {
-                            ChildObserver.Failed(ex.ice_id());
+                            ChildObserver.Failed(ex.GetType().FullName);
                             ChildObserver.Detach();
                             ChildObserver = null;
                         }

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -22,10 +22,6 @@ namespace Ice
         protected SlicedData? IceSlicedData { get; set; }
         internal SlicedData? SlicedData => IceSlicedData;
 
-        // Most derived type Id for this exception
-        internal string TypeId
-            => IceSlicedData != null ? IceSlicedData.Value.Slices[0].TypeId! : GetType().GetIceTypeId()!;
-
         internal RemoteException(SlicedData slicedData) => IceSlicedData = slicedData;
 
         /// <summary>Creates a default-initialized remote exception.</summary>
@@ -66,8 +62,10 @@ namespace Ice
             Debug.Assert(IceSlicedData.HasValue);
             if (!ostr.WriteSlicedData(IceSlicedData.Value))
             {
+                 // Most derived type Id for this exception
+                string typeId = IceSlicedData.Value.Slices[0].TypeId!;
                 throw new MarshalException(
-                    $"Failed to marshal a fully sliced {nameof(RemoteException)} with type ID `{TypeId}'");
+                    $"Failed to marshal a fully sliced {nameof(RemoteException)} with type ID `{typeId}'");
             }
         }
         internal void Write(OutputStream ostr) => IceWrite(ostr, true);

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -629,9 +629,9 @@ public class AllTests : Test.AllTests
             }
             test(cm1.Failures == 2 && sm1.Failures >= 2);
 
-            checkFailure(clientMetrics, "Connection", cm1.Id, "::Ice::TimeoutException", 1, output);
-            checkFailure(clientMetrics, "Connection", cm1.Id, "::Ice::ConnectTimeoutException", 1, output);
-            checkFailure(serverMetrics, "Connection", sm1.Id, "::Ice::ConnectionLostException", 0, output);
+            checkFailure(clientMetrics, "Connection", cm1.Id, "Ice.TimeoutException", 1, output);
+            checkFailure(clientMetrics, "Connection", cm1.Id, "Ice.ConnectTimeoutException", 1, output);
+            checkFailure(serverMetrics, "Connection", sm1.Id, "Ice.ConnectionLostException", 0, output);
 
             IMetricsPrx m = metrics.Clone(connectionTimeout: 500, connectionId: "Con1");
             m.IcePing();
@@ -698,7 +698,7 @@ public class AllTests : Test.AllTests
             m1 = clientMetrics.GetMetricsView("View").ReturnValue["ConnectionEstablishment"][0];
             test(m1.Id.Equals(hostAndPort) && m1.Total == 3 && m1.Failures == 2);
 
-            checkFailure(clientMetrics, "ConnectionEstablishment", m1.Id, "::Ice::ConnectTimeoutException", 2, output);
+            checkFailure(clientMetrics, "ConnectionEstablishment", m1.Id, "Ice.ConnectTimeoutException", 2, output);
 
             System.Action c = () => { connect(metrics); };
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "parent", "Communicator", c, output);
@@ -764,7 +764,7 @@ public class AllTests : Test.AllTests
                  (!dnsException || m1.Failures == 2));
             if (dnsException)
             {
-                checkFailure(clientMetrics, "EndpointLookup", m1.Id, "::Ice::DNSException", 2, output);
+                checkFailure(clientMetrics, "EndpointLookup", m1.Id, "Ice.DNSException", 2, output);
             }
 
             c = () => { connect(prx); };
@@ -851,12 +851,11 @@ public class AllTests : Test.AllTests
 
         dm1 = (IceMX.DispatchMetrics)map["opWithLocalException"];
         test(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);
-        checkFailure(serverMetrics, "Dispatch", dm1.Id, "::Ice::SyscallException", 1, output);
+        checkFailure(serverMetrics, "Dispatch", dm1.Id, "Ice.SyscallException", 1, output);
         test(dm1.Size == 39 && dm1.ReplySize > 7); // Reply contains the exception stack depending on the OS.
 
         dm1 = (IceMX.DispatchMetrics)map["opWithRequestFailedException"];
         test(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 1);
-        // checkFailure(serverMetrics, "Dispatch", dm1.Id, "::Ice::ObjectNotExistException", 1, output);
         test(dm1.Size == 47 && dm1.ReplySize == 40);
 
         dm1 = (IceMX.DispatchMetrics)map["opWithUnknownException"];
@@ -1042,7 +1041,7 @@ public class AllTests : Test.AllTests
         rim1 = (IceMX.ChildInvocationMetrics)(collocated ? im1.Collocated[0] : im1.Remotes[0]);
         test(rim1.Current == 0 && rim1.Total == 2 && rim1.Failures == 0);
         test(rim1.Size == 78 && rim1.ReplySize > 7);
-        checkFailure(clientMetrics, "Invocation", im1.Id, "::Ice::UnhandledException", 2, output);
+        checkFailure(clientMetrics, "Invocation", im1.Id, "Ice.UnhandledException", 2, output);
 
         im1 = (IceMX.InvocationMetrics)map["opWithRequestFailedException"];
         test(im1.Current <= 1 && im1.Total == 2 && im1.Failures == 2 && im1.Retry == 0);
@@ -1050,7 +1049,7 @@ public class AllTests : Test.AllTests
         rim1 = (IceMX.ChildInvocationMetrics)(collocated ? im1.Collocated[0] : im1.Remotes[0]);
         test(rim1.Current == 0 && rim1.Total == 2 && rim1.Failures == 0);
         test(rim1.Size == 94 && rim1.ReplySize == 80);
-        checkFailure(clientMetrics, "Invocation", im1.Id, "::Ice::ObjectNotExistException", 2, output);
+        checkFailure(clientMetrics, "Invocation", im1.Id, "Ice.ObjectNotExistException", 2, output);
 
         im1 = (IceMX.InvocationMetrics)map["opWithUnknownException"];
         test(im1.Current <= 1 && im1.Total == 2 && im1.Failures == 2 && im1.Retry == 0);
@@ -1058,7 +1057,7 @@ public class AllTests : Test.AllTests
         rim1 = (IceMX.ChildInvocationMetrics)(collocated ? im1.Collocated[0] : im1.Remotes[0]);
         test(rim1.Current == 0 && rim1.Total == 2 && rim1.Failures == 0);
         test(rim1.Size == 82 && rim1.ReplySize > 7);
-        checkFailure(clientMetrics, "Invocation", im1.Id, "::Ice::UnhandledException", 2, output);
+        checkFailure(clientMetrics, "Invocation", im1.Id, "Ice.UnhandledException", 2, output);
 
         if (!collocated)
         {
@@ -1068,7 +1067,7 @@ public class AllTests : Test.AllTests
             test(rim1.Current == 0);
             test(rim1.Total == 4);
             test(rim1.Failures == 4);
-            checkFailure(clientMetrics, "Invocation", im1.Id, "::Ice::ConnectionLostException", 2, output);
+            checkFailure(clientMetrics, "Invocation", im1.Id, "Ice.ConnectionLostException", 2, output);
         }
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -48,7 +48,7 @@ namespace Ice.operations.AMD
         //
         // Override the Object "pseudo" operations to verify the operation mode.
         //
-        public bool ice_isA(string id, Current current)
+        public bool IceIsA(string id, Current current)
         {
             test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds().Contains(id);
@@ -56,13 +56,13 @@ namespace Ice.operations.AMD
 
         public void IcePing(Current current) => test(current.IsIdempotent);
 
-        public string[] ice_ids(Current current)
+        public string[] IceIds(Current current)
         {
             test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds();
         }
 
-        public string ice_id(Current current)
+        public string IceId(Current current)
         {
             test(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetIceTypeId();

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -108,29 +108,6 @@ namespace Ice.operations
                 _d = d;
             }
 
-            public void IcePing()
-            {
-                called();
-            }
-
-            public void ice_isA(bool r)
-            {
-                test(r);
-                called();
-            }
-
-            public void ice_ids(string[] ids)
-            {
-                test(ids.Length == 3);
-                called();
-            }
-
-            public void ice_id(string id)
-            {
-                test(id.Equals("::Test::MyDerivedClass"));
-                called();
-            }
-
             public void opVoid()
             {
                 called();


### PR DESCRIPTION
This small PR removes the local exception `ice_id` methods and changes the semantics of the exceptionName parameter given to `IObserver.Failed` in Instrumentation. With this PR, exceptionName receives the full name of the C# exception class, whereas it currently receives the Slice type-ID of the remote or local exception.