### PR TITLE
Change the semantics of oneway proxies

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2370,11 +2370,6 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
              << epar;
         _out << sb;
 
-        if(operation->returnsData())
-        {
-            _out << nl << "IceCheckTwowayOnly(\"" << operation->name() << "\");";
-        }
-
         string resultT = resultType(operation, ns, false);
 
         _out << nl << "var completed = new global::IceInternal.OperationTaskCompletionCallback<"
@@ -2386,6 +2381,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
         _out.inc();
         _out << nl << '"' << operation->name() << '"' << ",";
         _out << nl << "idempotent: " << (isIdempotent(operation) ? "true" : "false") << ",";
+        _out << nl << "oneway: " << (operation->returnsData() ? "false" : "IsOneway") << ",";
         _out << nl << opFormatTypeToString(operation, ns) << ",";
         _out << nl << "context,";
         _out << nl << "synchronous";

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -42,7 +42,7 @@ namespace IceInternal
                 }
             }
             Debug.Assert(_connection != null);
-            return outAsync.InvokeRemote(_connection, _compress, _response);
+            return outAsync.InvokeRemote(_connection, _compress, !outAsync.IsOneway);
         }
 
         public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex)
@@ -182,7 +182,6 @@ namespace IceInternal
         public ConnectRequestHandler(Reference @ref, Ice.IObjectPrx proxy)
         {
             _reference = @ref;
-            _response = _reference.GetMode() == Ice.InvocationMode.Twoway;
             _proxy = proxy;
             _initialized = false;
             _flushing = false;
@@ -243,7 +242,7 @@ namespace IceInternal
             {
                 try
                 {
-                    if ((outAsync.InvokeRemote(_connection, _compress, _response) & OutgoingAsyncBase.AsyncStatusInvokeSentCallback) != 0)
+                    if ((outAsync.InvokeRemote(_connection, _compress, !outAsync.IsOneway) & OutgoingAsyncBase.AsyncStatusInvokeSentCallback) != 0)
                     {
                         outAsync.InvokeSentAsync();
                     }
@@ -303,7 +302,6 @@ namespace IceInternal
         }
 
         private readonly Reference _reference;
-        private readonly bool _response;
 
         private IObjectPrx? _proxy;
         private readonly HashSet<IObjectPrx> _proxies = new HashSet<IObjectPrx>();

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -32,7 +32,7 @@ namespace IceInternal
         }
 
         public int SendAsyncRequest(ProxyOutgoingAsyncBase outAsync) =>
-            outAsync.InvokeRemote(_connection, _compress, _response);
+            outAsync.InvokeRemote(_connection, _compress, !outAsync.IsOneway);
 
         public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex) =>
             _connection.AsyncRequestCanceled(outAsync, ex);
@@ -44,13 +44,12 @@ namespace IceInternal
         public ConnectionRequestHandler(Reference @ref, Ice.Connection connection, bool compress)
         {
             _reference = @ref;
-            _response = _reference.GetMode() == Ice.InvocationMode.Twoway;
             _connection = connection;
             _compress = compress;
         }
 
         private readonly Reference _reference;
-        private readonly bool _response;
+
         private readonly Ice.Connection _connection;
         private readonly bool _compress;
     }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -362,7 +362,6 @@ namespace Ice
         }
 
         /// <summary>
-
         /// Reads a sequence size and make sure there is enough space in the underlying buffer to read the sequence.
         /// This validation is performed to make sure we do not allocate a large container based on an invalid encoded
         /// size.

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -60,26 +60,6 @@ namespace Ice
     }
 
     /// <summary>
-    /// The operation can only be invoked with a twoway request.
-    /// This exception is raised if an attempt is made to invoke an
-    /// operation with ice_oneway or ice_datagram and the operation has a return value,
-    /// out-parameters, or an exception specification.
-    /// </summary>
-    public class TwowayOnlyException : LocalException
-    {
-        public string Operation;
-
-        public TwowayOnlyException() => Operation = "";
-
-        public TwowayOnlyException(System.Exception ex) : base(ex) => Operation = "";
-
-        public TwowayOnlyException(string operation) => Operation = operation;
-
-        public TwowayOnlyException(string operation, System.Exception ex) : base(ex) => Operation = operation;
-
-    }
-
-    /// <summary>
     /// This exception is raised if the Communicator has been destroyed.
     /// </summary>
     public class CommunicatorDestroyedException : LocalException

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -382,15 +382,6 @@ namespace Ice.ami
                     });
                 }
 
-                try
-                {
-                    p.Clone(oneway: true).opWithResultAsync();
-                    test(false);
-                }
-                catch (TwowayOnlyException)
-                {
-                }
-
                 //
                 // Check that CommunicatorDestroyedException is raised directly.
                 //

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -712,9 +712,11 @@ namespace Ice.binding
                 try
                 {
                     testUDP.getAdapterName();
+                    test(false);
                 }
-                catch (TwowayOnlyException)
+                catch (System.InvalidOperationException)
                 {
+                    // expected
                 }
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -22,8 +22,20 @@ namespace Ice.invoke
 
             {
                 var request = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
-                var response = oneway.Invoke(request);
+
+                // Whether the proxy is oneway or not does not matter for Invoke's oneway parameter.
+
+                var response = cl.Invoke(request, oneway: true);
                 test(response.ReplyStatus == ReplyStatus.OK);
+
+                response = cl.Invoke(request, oneway: false);
+                test(response.ReplyStatus == ReplyStatus.UserException);
+
+                response = oneway.Invoke(request, oneway: true);
+                test(response.ReplyStatus == ReplyStatus.OK);
+
+                response = oneway.Invoke(request, oneway: false);
+                test(response.ReplyStatus == ReplyStatus.UserException);
 
                 request = new OutgoingRequestFrame(cl, "opString", idempotent: false);
                 request.StartParameters();
@@ -75,7 +87,7 @@ namespace Ice.invoke
                 var request = OutgoingRequestFrame.Empty(oneway, "opOneway", idempotent: false);
                 try
                 {
-                    oneway.InvokeAsync(request).Wait();
+                    oneway.InvokeAsync(request, oneway: true).Wait();
                 }
                 catch (Exception)
                 {

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -13,8 +13,11 @@ namespace Ice.invoke
         {
             if (current.Operation.Equals("opOneway"))
             {
-                Debug.Assert(current.IsOneway);
-                // TODO: replace by shared "fake" empty
+                if (!current.IsOneway)
+                {
+                    // If called two-way, return exception to caller.
+                    throw new Test.MyException();
+                }
                 return OutgoingResponseFrame.Empty(current);
             }
             else if (current.Operation.Equals("opString"))

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -735,11 +735,10 @@ namespace Ice.operations.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask
-        opNonmutatingAsync(Current current)
+        public ValueTask opOnewayAsync(Current current)
         {
-            test(current.IsIdempotent);
-            return new ValueTask(Task.CompletedTask);
+            // "return" exception when called two-way, otherwise succeeds.
+            throw new Test.SomeException();
         }
 
         public ValueTask

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -648,7 +648,8 @@ namespace Ice.operations
 
         public void opIdempotent(Current current) => test(current.IsIdempotent);
 
-        public void opNonmutating(Current current) => test(current.IsIdempotent);
+        // "return" exception when called two-way, otherwise succeeds.
+        public void opOneway(Current current) => throw new Test.SomeException();
 
         public void opDerived(Current current)
         {

--- a/csharp/test/Ice/operations/Oneways.cs
+++ b/csharp/test/Ice/operations/Oneways.cs
@@ -20,16 +20,8 @@ namespace Ice.operations
             p.IcePing();
             p.opVoid();
             p.opIdempotent();
-            p.opNonmutating();
-
-            try
-            {
-                p.opByte(0xff, 0x0f);
-                test(false);
-            }
-            catch (TwowayOnlyException)
-            {
-            }
+            p.opOneway();
+            p.opByte(0xff, 0x0f);
         }
     }
 }

--- a/csharp/test/Ice/operations/OnewaysAMI.cs
+++ b/csharp/test/Ice/operations/OnewaysAMI.cs
@@ -83,38 +83,9 @@ namespace Ice.operations
                 cb.check();
             }
 
-            {
-                try
-                {
-                    p.IceIsAAsync("::Test::MyClass");
-                    test(false);
-                }
-                catch (TwowayOnlyException)
-                {
-                }
-            }
-
-            {
-                try
-                {
-                    p.IceIdAsync();
-                    test(false);
-                }
-                catch (TwowayOnlyException)
-                {
-                }
-            }
-
-            {
-                try
-                {
-                    p.IceIdsAsync();
-                    test(false);
-                }
-                catch (TwowayOnlyException)
-                {
-                }
-            }
+            bool b = p.IceIsAAsync("::Test::MyClass").Result;
+            string id = p.IceIdAsync().Result;
+            string[] ids = p.IceIdsAsync().Result;
 
             {
                 Callback cb = new Callback();
@@ -138,7 +109,7 @@ namespace Ice.operations
 
             {
                 Callback cb = new Callback();
-                p.opNonmutatingAsync(progress: new Progress<bool>(
+                p.opOnewayAsync(progress: new Progress<bool>(
                     sentSynchronously =>
                     {
                         cb.sent(sentSynchronously);
@@ -146,16 +117,7 @@ namespace Ice.operations
                 cb.check();
             }
 
-            {
-                try
-                {
-                    p.opByteAsync(0xff, 0x0f);
-                    test(false);
-                }
-                catch (TwowayOnlyException)
-                {
-                }
-            }
+            var _ = p.opByteAsync(0xff, 0x0f).Result;
         }
     }
 }

--- a/csharp/test/Ice/operations/Test.ice
+++ b/csharp/test/Ice/operations/Test.ice
@@ -236,7 +236,7 @@ interface MyClass
 
     idempotent void opIdempotent();
 
-    ["nonmutating"] idempotent void opNonmutating();
+    void opOneway();
 
     byte opByte1(byte opByte1);
     short opShort1(short opShort1);

--- a/csharp/test/Ice/operations/TestAMD.ice
+++ b/csharp/test/Ice/operations/TestAMD.ice
@@ -90,6 +90,8 @@ dictionary<string, DoubleS> StringDoubleSD;
 dictionary<string, StringS> StringStringSD;
 dictionary<MyEnum, MyEnumS> MyEnumMyEnumSD;
 
+exception SomeException {}
+
 ["amd"] interface MyClass
 {
     void shutdown();
@@ -234,7 +236,7 @@ dictionary<MyEnum, MyEnumS> MyEnumMyEnumSD;
 
     idempotent void opIdempotent();
 
-    ["nonmutating"] idempotent void opNonmutating();
+    void opOneway();
 
     byte opByte1(byte opByte1);
     short opShort1(short opShort1);

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1477,8 +1477,14 @@ namespace Ice.operations
                 p.opIdempotent();
             }
 
+            try
             {
-                p.opNonmutating();
+                p.opOneway();
+                test(false);
+            }
+            catch (Test.SomeException)
+            {
+                // expected
             }
 
             {

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -1708,8 +1708,14 @@ namespace Ice.operations
                 p.opIdempotentAsync().Wait();
             }
 
+            try
             {
-                p.opNonmutatingAsync().Wait();
+                p.opOnewayAsync().Wait();
+                test(false);
+            }
+            catch (System.AggregateException ex)
+            {
+                test(ex.InnerException is Test.SomeException);
             }
 
             {

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -68,6 +68,16 @@ namespace Ice.udp
             var obj = ITestIntfPrx.Parse("test:" + helper.getTestEndpoint(0, "udp"),
                                         communicator).Clone(invocationMode: InvocationMode.Datagram);
 
+            try
+            {
+                int val = obj.getValue();
+                test(false);
+            }
+            catch (System.InvalidOperationException)
+            {
+                // expected
+            }
+
             int nRetry = 5;
             bool ret = false;
             while (nRetry-- > 0)

--- a/csharp/test/Ice/udp/Test.ice
+++ b/csharp/test/Ice/udp/Test.ice
@@ -19,6 +19,7 @@ sequence<byte> ByteSeq;
 
 interface TestIntf
 {
+    int getValue();
     void ping(PingReply* reply);
     void sendByteSeq(ByteSeq seq, PingReply* reply);
     void pingBiDir(Ice::Identity id);

--- a/csharp/test/Ice/udp/TestIntfI.cs
+++ b/csharp/test/Ice/udp/TestIntfI.cs
@@ -8,6 +8,12 @@ namespace Ice.udp
 {
     public sealed class TestIntf : Test.ITestIntf
     {
+        public int getValue(Current current)
+        {
+            Debug.Assert(false); // a two-way operation cannot be reached through UDP
+            return 42;
+        }
+
         public void ping(Test.IPingReplyPrx reply, Current current)
         {
             try


### PR DESCRIPTION
This small PR changes the semantics of oneway proxies (only in C# for now).

Old semantics: can only be used to make oneway calls
New semantics: oneway-capable operations are sent oneway, other operations are sent twoway

This PR also removes the exception `Ice.TwowayOnlyException`, and throws `System.InvalidOperationException` in the event you try to call a twoway operation on a Datagram proxy.

