### PR TITLE
Remove Ice.Exception, Ice.LocalException and Ice.SyscallException in C#

### DIFF
--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -403,7 +403,7 @@ namespace Glacier2
                             typeIdNamespaces: _typeIdNamespaces);
                     }
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     lock (_mutex)
                     {

--- a/csharp/src/Ice/AsyncIOThread.cs
+++ b/csharp/src/Ice/AsyncIOThread.cs
@@ -110,15 +110,9 @@ namespace IceInternal
                     {
                         cb();
                     }
-                    catch (Ice.LocalException ex)
-                    {
-                        string s = "exception in asynchronous IO thread:\n" + ex;
-                        _communicator.Logger.Error(s);
-                    }
                     catch (System.Exception ex)
                     {
-                        string s = "unknown exception in asynchronous IO thread:\n" + ex;
-                        _communicator.Logger.Error(s);
+                        _communicator.Logger.Error($"exception in asynchronous IO thread:\n{ex}");
                     }
                 }
                 queue.Clear();

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -30,7 +30,7 @@ namespace IceInternal
 
         public int SendAsyncRequest(ProxyOutgoingAsyncBase outAsync) => outAsync.InvokeCollocated(this);
 
-        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex)
+        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex)
         {
             lock (this)
             {
@@ -222,7 +222,7 @@ namespace IceInternal
                     }
                 }
             }
-            catch (Ice.LocalException ex)
+            catch (System.Exception ex)
             {
                 HandleException(requestId, ex, false);
             }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -277,7 +277,7 @@ namespace IceInternal
             }
         }
 
-        private void HandleException(int requestId, Ice.Exception ex, bool amd)
+        private void HandleException(int requestId, System.Exception ex, bool amd)
         {
             if (requestId == 0)
             {

--- a/csharp/src/Ice/Communicator-EndpointHostResolver.cs
+++ b/csharp/src/Ice/Communicator-EndpointHostResolver.cs
@@ -98,7 +98,7 @@ namespace Ice
                         return;
                     }
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     callback.Exception(ex);
                     return;
@@ -180,7 +180,7 @@ namespace Ice
 
                     r.Callback.Connectors(r.Endpoint.Connectors(addrs, networkProxy));
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     if (r.Observer != null)
                     {

--- a/csharp/src/Ice/Communicator-LocatorManager.cs
+++ b/csharp/src/Ice/Communicator-LocatorManager.cs
@@ -16,7 +16,7 @@ namespace Ice
         public interface IGetEndpointsCallback
         {
             void SetEndpoints(Endpoint[] endpoints, bool cached);
-            void SetException(LocalException ex);
+            void SetException(System.Exception ex);
         }
 
         private class RequestCallback
@@ -80,7 +80,7 @@ namespace Ice
                 {
                     locatorInfo.GetEndpointsException(_ref, exc); // This throws.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     if (_callback != null)
                     {
@@ -483,7 +483,7 @@ namespace Ice
             {
                 throw;
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 Communicator communicator = reference.GetCommunicator();
                 if (communicator.TraceLevels.Location >= 1)
@@ -502,10 +502,6 @@ namespace Ice
                     communicator.Logger.Trace(communicator.TraceLevels.LocationCat, s.ToString());
                 }
                 throw;
-            }
-            catch (System.Exception)
-            {
-                Debug.Assert(false);
             }
         }
 

--- a/csharp/src/Ice/Communicator-RetryQueue.cs
+++ b/csharp/src/Ice/Communicator-RetryQueue.cs
@@ -29,7 +29,7 @@ namespace Ice
             _communicator.RemoveRetryTask(this);
         }
 
-        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex)
+        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex)
         {
             Debug.Assert(_outAsync == outAsync);
             if (_communicator.CancelRetryTask(this))

--- a/csharp/src/Ice/Communicator-RouterManager.cs
+++ b/csharp/src/Ice/Communicator-RouterManager.cs
@@ -13,13 +13,13 @@ namespace Ice
         public interface GetClientEndpointsCallback
         {
             void setEndpoints(Endpoint[] endpoints);
-            void setException(Ice.LocalException ex);
+            void setException(System.Exception ex);
         }
 
         public interface AddProxyCallback
         {
             void addedProxy();
-            void SetException(Ice.LocalException ex);
+            void SetException(System.Exception ex);
         }
 
         internal RouterInfo(IRouterPrx router) => Router = router;
@@ -87,8 +87,7 @@ namespace Ice
                     }
                     catch (System.AggregateException ae)
                     {
-                        Debug.Assert(ae.InnerException is LocalException);
-                        callback.setException((LocalException)ae.InnerException);
+                        callback.setException(ae.InnerException);
                     }
                 },
                 System.Threading.Tasks.TaskScheduler.Current);
@@ -151,8 +150,7 @@ namespace Ice
                     }
                     catch (System.AggregateException ae)
                     {
-                        Debug.Assert(ae.InnerException is LocalException);
-                        callback.SetException((LocalException)ae.InnerException);
+                        callback.SetException(ae.InnerException);
                     }
                 },
                 System.Threading.Tasks.TaskScheduler.Current);

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -682,7 +682,7 @@ namespace Ice
                 {
                     _adminAdapter.Activate();
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     //
                     // We cleanup _adminAdapter, however this error is not recoverable
@@ -1427,7 +1427,7 @@ namespace Ice
             {
                 adminAdapter.Activate();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 // We cleanup _adminAdapter, however this error is not recoverable
                 // (can't call again getAdmin() after fixing the problem)
@@ -1678,7 +1678,7 @@ namespace Ice
             //
             // There is no point in retrying an operation that resulted in a
             // MarshalException. This must have been raised locally (because if
-            // it happened in a server it would result in an UnknownLocalException
+            // it happened in a server it would result in an UnknownSystem.Exception
             // instead), which means there was a problem in this process that will
             // not change if we try again.
             //
@@ -1964,7 +1964,7 @@ namespace Ice
 
                     throw new InitializationException("Locator knows nothing about server `" + serverId + "'");
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     if (TraceLevels.Location >= 1)
                     {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1678,7 +1678,7 @@ namespace Ice
             //
             // There is no point in retrying an operation that resulted in a
             // MarshalException. This must have been raised locally (because if
-            // it happened in a server it would result in an UnknownSystem.Exception
+            // it happened in a server it would result in an UnknownLocalException
             // instead), which means there was a problem in this process that will
             // not change if we try again.
             //

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -45,7 +45,7 @@ namespace IceInternal
             return outAsync.InvokeRemote(_connection, _compress, !outAsync.IsOneway);
         }
 
-        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex)
+        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex)
         {
             lock (this)
             {
@@ -130,7 +130,7 @@ namespace IceInternal
             FlushRequests();
         }
 
-        public void SetException(Ice.LocalException ex)
+        public void SetException(System.Exception ex)
         {
             lock (this)
             {
@@ -237,7 +237,7 @@ namespace IceInternal
                 _flushing = true;
             }
 
-            Ice.LocalException? exception = null;
+            System.Exception? exception = null;
             foreach (ProxyOutgoingAsyncBase outAsync in _requests)
             {
                 try
@@ -256,7 +256,7 @@ namespace IceInternal
 
                     outAsync.RetryException();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     exception = ex;
                     if (outAsync.Exception(ex))
@@ -308,7 +308,7 @@ namespace IceInternal
 
         private Connection? _connection;
         private bool _compress;
-        private LocalException? _exception;
+        private System.Exception? _exception;
         private bool _initialized;
         private bool _flushing;
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -73,7 +73,7 @@ namespace Ice
         public interface IStartCallback
         {
             void ConnectionStartCompleted(Connection connection);
-            void ConnectionStartFailed(Connection connection, LocalException ex);
+            void ConnectionStartFailed(Connection connection, System.Exception ex);
         }
 
         private class TimeoutCallback : ITimerTask
@@ -112,7 +112,7 @@ namespace Ice
                     SetState(StateHolding);
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 lock (this)
                 {
@@ -164,7 +164,7 @@ namespace Ice
                     SetState(StateHolding);
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 lock (this)
                 {
@@ -468,7 +468,7 @@ namespace Ice
                     var message = new OutgoingMessage(og, os, compress, requestId);
                     status = SendMessage(message);
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     SetState(StateClosed, ex);
                     Debug.Assert(_exception != null);
@@ -594,7 +594,7 @@ namespace Ice
                     {
                         throw ex.Get();
                     }
-                    catch (LocalException ee)
+                    catch (System.Exception ee)
                     {
                         if (Exception(ee))
                         {
@@ -680,7 +680,7 @@ namespace Ice
             }
         }
 
-        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, LocalException ex)
+        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex)
         {
             //
             // NOTE: This isn't called from a thread pool thread.
@@ -873,7 +873,7 @@ namespace Ice
                     }
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 SetState(StateClosed, ex);
                 return false;
@@ -904,7 +904,7 @@ namespace Ice
                     }
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 SetState(StateClosed, ex);
             }
@@ -1115,7 +1115,7 @@ namespace Ice
                         SetState(StateClosed, ex);
                         return;
                     }
-                    catch (LocalException ex)
+                    catch (System.Exception ex)
                     {
                         if (_endpoint.Datagram())
                         {
@@ -1250,7 +1250,7 @@ namespace Ice
                             {
                                 InitiateShutdown();
                             }
-                            catch (Ice.LocalException ex)
+                            catch (System.Exception ex)
                             {
                                 SetState(StateClosed, ex);
                             }
@@ -1466,7 +1466,7 @@ namespace Ice
                         InitiateShutdown();
                     }
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     SetState(StateClosed, ex);
                 }
@@ -1501,14 +1501,14 @@ namespace Ice
                         InitiateShutdown();
                     }
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     SetState(StateClosed, ex);
                 }
             }
         }
 
-        private void InvokeException(LocalException ex, int invokeNum)
+        private void InvokeException(System.Exception ex, int invokeNum)
         {
             // Fatal exception while invoking a request. Since sendResponse/sendNoResponse isn't
             // called in case of a fatal exception we decrement _dispatchCount here.
@@ -1666,26 +1666,15 @@ namespace Ice
                 _compressionLevel = 9;
             }
 
-            try
+            if (adapter != null)
             {
-                if (adapter != null)
-                {
-                    ThreadPool = adapter.ThreadPool;
-                }
-                else
-                {
-                    ThreadPool = communicator.ClientThreadPool();
-                }
-                ThreadPool.Initialize(this);
+                ThreadPool = adapter.ThreadPool;
             }
-            catch (LocalException)
+            else
             {
-                throw;
+                ThreadPool = communicator.ClientThreadPool();
             }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
-            }
+            ThreadPool.Initialize(this);
         }
 
         private const int StateNotInitialized = 0;
@@ -1697,7 +1686,7 @@ namespace Ice
         private const int StateClosed = 6;
         private const int StateFinished = 7;
 
-        private void SetState(int state, LocalException ex)
+        private void SetState(int state, System.Exception ex)
         {
             //
             // If setState() is called with an exception, then only closed
@@ -1855,7 +1844,7 @@ namespace Ice
                         }
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 _logger.Error("unexpected connection exception:\n" + ex + "\n" + _transceiver.ToString());
             }
@@ -1917,7 +1906,7 @@ namespace Ice
                 {
                     InitiateShutdown();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     SetState(StateClosed, ex);
                 }
@@ -1979,7 +1968,7 @@ namespace Ice
                 {
                     SendMessage(new OutgoingMessage(os, false));
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     SetState(StateClosed, ex);
                     Debug.Assert(_exception != null);
@@ -2218,7 +2207,7 @@ namespace Ice
                     }
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 SetState(StateClosed, ex);
             }
@@ -2476,7 +2465,7 @@ namespace Ice
                         }
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 if (_endpoint.Datagram())
                 {
@@ -2570,7 +2559,7 @@ namespace Ice
                     SendResponse(responseFrame, compressionStatus);
                 }
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 InvokeException(ex, invokeNum);
             }
@@ -2667,7 +2656,7 @@ namespace Ice
             {
                 _info = _transceiver.GetInfo();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 _info = new ConnectionInfo();
             }
@@ -2808,7 +2797,7 @@ namespace Ice
                 return false;
             }
 
-            internal void Completed(LocalException ex)
+            internal void Completed(System.Exception ex)
             {
                 if (OutAsync != null)
                 {
@@ -2860,7 +2849,7 @@ namespace Ice
 
         private readonly Dictionary<int, OutgoingAsyncBase> _asyncRequests = new Dictionary<int, OutgoingAsyncBase>();
 
-        private LocalException? _exception;
+        private System.Exception? _exception;
 
         private readonly int _messageSizeMax;
 

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -39,7 +39,7 @@ namespace IceInternal
         public interface ICreateConnectionCallback
         {
             void SetConnection(Connection connection, bool compress);
-            void SetException(LocalException ex);
+            void SetException(System.Exception ex);
         }
 
         public void Destroy()
@@ -163,7 +163,7 @@ namespace IceInternal
                     return;
                 }
             }
-            catch (Ice.LocalException ex)
+            catch (System.Exception ex)
             {
                 callback.SetException(ex);
                 return;
@@ -507,13 +507,13 @@ namespace IceInternal
                     connection = new Ice.Connection(_communicator, _monitor, transceiver, ci.Connector,
                                                     ci.Endpoint.Compress(false), null);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                     try
                     {
                         transceiver.Close();
                     }
-                    catch (Ice.LocalException)
+                    catch (System.Exception)
                     {
                         // Ignore
                     }
@@ -592,7 +592,7 @@ namespace IceInternal
             }
         }
 
-        private void FinishGetConnection(List<ConnectorInfo> connectors, Ice.LocalException ex, ConnectCallback cb)
+        private void FinishGetConnection(List<ConnectorInfo> connectors, System.Exception ex, ConnectCallback cb)
         {
             var failedCallbacks = new HashSet<ConnectCallback>();
             if (cb != null)
@@ -641,7 +641,7 @@ namespace IceInternal
             }
         }
 
-        private void HandleConnectionException(Ice.LocalException ex, bool hasMore)
+        private void HandleConnectionException(System.Exception ex, bool hasMore)
         {
             TraceLevels traceLevels = _communicator.TraceLevels;
             if (traceLevels.Network >= 2)
@@ -719,7 +719,7 @@ namespace IceInternal
             }
         }
 
-        internal void HandleException(Ice.LocalException ex, bool hasMore)
+        internal void HandleException(System.Exception ex, bool hasMore)
         {
             TraceLevels traceLevels = _communicator.TraceLevels;
             if (traceLevels.Network >= 2)
@@ -793,7 +793,7 @@ namespace IceInternal
                 _factory.FinishGetConnection(_connectors, _current, connection, this);
             }
 
-            public void ConnectionStartFailed(Ice.Connection connection, Ice.LocalException ex)
+            public void ConnectionStartFailed(Ice.Connection connection, System.Exception ex)
             {
                 if (ConnectionStartFailedImpl(ex))
                 {
@@ -829,7 +829,7 @@ namespace IceInternal
                 }
             }
 
-            public void Exception(Ice.LocalException ex)
+            public void Exception(System.Exception ex)
             {
                 _factory.HandleException(ex, _hasMore || _endpointsIter < _endpoints.Count);
                 if (_endpointsIter < _endpoints.Count)
@@ -862,7 +862,7 @@ namespace IceInternal
                 _factory.DecPendingConnectCount(); // Must be called last.
             }
 
-            public void SetException(Ice.LocalException ex)
+            public void SetException(System.Exception ex)
             {
                 //
                 // Callback from the factory: connection establishment failed.
@@ -898,7 +898,7 @@ namespace IceInternal
                     //
                     _factory.IncPendingConnectCount();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     _callback.SetException(ex);
                     return;
@@ -915,7 +915,7 @@ namespace IceInternal
                     _currentEndpoint = _endpoints[_endpointsIter++];
                     _currentEndpoint.ConnectorsAsync(_selType, this);
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Exception(ex);
                 }
@@ -944,7 +944,7 @@ namespace IceInternal
                     _callback.SetConnection(connection, compress);
                     _factory.DecPendingConnectCount(); // Must be called last.
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     _callback.SetException(ex);
                     _factory.DecPendingConnectCount(); // Must be called last.
@@ -984,7 +984,7 @@ namespace IceInternal
                         Ice.Connection connection = _factory.CreateConnection(_current.Connector.Connect(), _current);
                         connection.Start(this);
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         if (_factory._communicator.TraceLevels.Network >= 2)
                         {
@@ -1008,7 +1008,7 @@ namespace IceInternal
                 }
             }
 
-            private bool ConnectionStartFailedImpl(Ice.LocalException ex)
+            private bool ConnectionStartFailedImpl(System.Exception ex)
             {
                 if (_observer != null)
                 {
@@ -1274,7 +1274,7 @@ namespace IceInternal
             {
                 completedSynchronously = _acceptor.StartAccept(callback, this);
             }
-            catch (Ice.LocalException ex)
+            catch (System.Exception ex)
             {
                 _acceptorException = ex;
                 completedSynchronously = true;
@@ -1294,7 +1294,7 @@ namespace IceInternal
                 }
                 _acceptor.FinishAccept();
             }
-            catch (Ice.LocalException ex)
+            catch (System.Exception ex)
             {
                 _acceptorException = null;
                 _communicator.Logger.Error($"couldn't accept connection:\n{ex}\n{_acceptor}");
@@ -1381,7 +1381,7 @@ namespace IceInternal
                         // Ignore socket exceptions.
                         return;
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         // Warn about other Ice local exceptions.
                         if (_warn)
@@ -1397,13 +1397,13 @@ namespace IceInternal
                     {
                         connection = new Ice.Connection(_communicator, _monitor, transceiver, null, _endpoint, _adapter);
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         try
                         {
                             transceiver.Close();
                         }
-                        catch (Ice.LocalException)
+                        catch (System.Exception)
                         {
                             // Ignore
                         }
@@ -1477,7 +1477,7 @@ namespace IceInternal
             }
         }
 
-        public void ConnectionStartFailed(Ice.Connection connection, Ice.LocalException ex)
+        public void ConnectionStartFailed(Ice.Connection connection, System.Exception ex)
         {
             lock (this)
             {
@@ -1551,7 +1551,7 @@ namespace IceInternal
                     {
                         _transceiver.Close();
                     }
-                    catch (LocalException)
+                    catch (System.Exception)
                     {
                         // Ignore
                     }
@@ -1561,14 +1561,7 @@ namespace IceInternal
                 _monitor.Destroy();
                 _connections.Clear();
 
-                if (ex is Ice.LocalException)
-                {
-                    throw;
-                }
-                else
-                {
-                    throw new Ice.SyscallException(ex);
-                }
+                throw;
             }
         }
 
@@ -1720,7 +1713,7 @@ namespace IceInternal
             _acceptor.Close();
         }
 
-        private void Warning(Ice.LocalException ex) =>
+        private void Warning(System.Exception ex) =>
             _communicator.Logger.Warning($"connection exception:\n{ex}\n{_acceptor}");
 
         private readonly Ice.Communicator _communicator;
@@ -1739,7 +1732,7 @@ namespace IceInternal
 
         private int _state;
         private bool _acceptorStarted;
-        private Ice.LocalException? _acceptorException;
+        private System.Exception? _acceptorException;
     }
 
 }

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -34,7 +34,7 @@ namespace IceInternal
         public int SendAsyncRequest(ProxyOutgoingAsyncBase outAsync) =>
             outAsync.InvokeRemote(_connection, _compress, !outAsync.IsOneway);
 
-        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex) =>
+        public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex) =>
             _connection.AsyncRequestCanceled(outAsync, ex);
 
         public Reference GetReference() => _reference;

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -24,7 +24,7 @@ namespace IceInternal
                     return newHandler;
                 }
             }
-            catch (Ice.Exception)
+            catch (System.Exception)
             {
                 // Ignore
             }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -10,7 +10,7 @@ namespace IceInternal
     public interface IEndpointConnectors
     {
         void Connectors(List<IConnector> connectors);
-        void Exception(Ice.LocalException ex);
+        void Exception(System.Exception ex);
     }
 
     public abstract class Endpoint : Ice.IEndpoint, IComparable<Endpoint>, IEquatable<Endpoint>

--- a/csharp/src/Ice/Exception.cs
+++ b/csharp/src/Ice/Exception.cs
@@ -33,45 +33,13 @@ namespace IceInternal
                 $"requested {requested} bytes, maximum allowed is {maximum} bytes (see Ice.MessageSizeMax)");
         }
     }
-}
 
-namespace Ice
-{
-    /// <summary>
-    /// Base class for Ice run-time exceptions.
-    /// </summary>
-    [Serializable]
-    public abstract class LocalException : System.Exception
-    {
-        /// <summary>
-        /// Creates a default-initialized Ice run-time exception.
-        /// </summary>
-        public LocalException() { }
-
-        /// <summary>
-        /// Creates a default-initialized Ice run-time exception and sets the InnerException
-        /// property to the passed exception.
-        /// </summary>
-        /// <param name="ex">The inner exception.</param>
-        public LocalException(System.Exception ex) : base("", ex) { }
-
-        /// <summary>
-        /// Initializes a new instance of the exception with serialized data.
-        /// </summary>
-        /// <param name="info">Holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">Contains contextual information about the source or destination.</param>
-        protected LocalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-    }
-}
-
-namespace IceInternal
-{
     public class RetryException : Exception
     {
-        internal RetryException(Ice.LocalException ex) => _ex = ex;
+        internal RetryException(System.Exception ex) => _ex = ex;
 
-        internal Ice.LocalException Get() => _ex;
+        internal System.Exception Get() => _ex;
 
-        private readonly Ice.LocalException _ex;
+        private readonly System.Exception _ex;
     }
 }

--- a/csharp/src/Ice/Exception.cs
+++ b/csharp/src/Ice/Exception.cs
@@ -38,36 +38,10 @@ namespace IceInternal
 namespace Ice
 {
     /// <summary>
-    /// Base class for Ice exceptions.
-    /// </summary>
-    [Serializable]
-    public abstract class Exception : System.Exception
-    {
-        /// <summary>
-        /// Creates a default-initialized exception.
-        /// </summary>
-        public Exception() { }
-
-        /// <summary>
-        /// Creates a default-initialized exception and sets the InnerException
-        /// property to the passed exception.
-        /// </summary>
-        /// <param name="ex">The inner exception.</param>
-        public Exception(System.Exception ex) : base("", ex) { }
-
-        /// <summary>
-        /// Initializes a new instance of the exception with serialized data.
-        /// </summary>
-        /// <param name="info">Holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">Contains contextual information about the source or destination.</param>
-        protected Exception(SerializationInfo info, StreamingContext context) : base(info, context) { }
-    }
-
-    /// <summary>
     /// Base class for Ice run-time exceptions.
     /// </summary>
     [Serializable]
-    public abstract class LocalException : Exception
+    public abstract class LocalException : System.Exception
     {
         /// <summary>
         /// Creates a default-initialized Ice run-time exception.
@@ -79,7 +53,7 @@ namespace Ice
         /// property to the passed exception.
         /// </summary>
         /// <param name="ex">The inner exception.</param>
-        public LocalException(System.Exception ex) : base(ex) { }
+        public LocalException(System.Exception ex) : base("", ex) { }
 
         /// <summary>
         /// Initializes a new instance of the exception with serialized data.

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -447,8 +447,7 @@ namespace Ice
             // count isn't reached.
             //
             // TODO: revisit retry logic
-            if (ex is ObjectNotExistException || ex is CloseConnectionException ||
-                ((ex is RequestFailedException || ex is LocalException) && (!sent || idempotent)))
+            if (ex is ObjectNotExistException || ex is CloseConnectionException || !sent || idempotent)
             {
                 try
                 {

--- a/csharp/src/Ice/IRequestHandler.cs
+++ b/csharp/src/Ice/IRequestHandler.cs
@@ -6,7 +6,7 @@ namespace IceInternal
 {
     public interface ICancellationHandler
     {
-        void AsyncRequestCanceled(OutgoingAsyncBase outAsync, Ice.LocalException ex);
+        void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex);
     }
 
     public interface IRequestHandler : ICancellationHandler

--- a/csharp/src/Ice/ITransceiver.cs
+++ b/csharp/src/Ice/ITransceiver.cs
@@ -23,7 +23,7 @@ namespace IceInternal
         /// <returns>Returns SocketOperation.Write, SocketOperation.Read or SocketOperation.None indicating
         /// whenever the operation needs to write more data, read more data or it is done.</returns>
         int Initialize(ref ArraySegment<byte> readBuffer, IList<ArraySegment<byte>> writeBuffer);
-        int Closing(bool initiator, Ice.LocalException? ex);
+        int Closing(bool initiator, System.Exception? ex);
         void Close();
         void Destroy();
 

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -60,7 +60,7 @@ namespace IceInternal
                         }
                     }
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
             }

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -457,7 +457,7 @@ namespace IceInternal
                     {
                         os.Append(_proxy.Clone(endpoints: _emptyEndpoints)).Append(" [").Append(_operation).Append(']');
                     }
-                    catch (Ice.Exception)
+                    catch (System.Exception)
                     {
                         // Either a fixed proxy or the communicator is destroyed.
                         os.Append(_proxy.Identity.ToString(_proxy.Communicator.ToStringMode));

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -7,16 +7,16 @@ namespace Ice
     /// <summary>
     /// This exception is raised when a failure occurs during initialization.
     /// </summary>
-    public class InitializationException : LocalException
+    public class InitializationException : System.Exception
     {
         public string Reason;
 
         public InitializationException() => Reason = "";
 
-        public InitializationException(System.Exception ex) : base(ex) => Reason = "";
+        public InitializationException(System.Exception ex) : base("", ex) => Reason = "";
         public InitializationException(string reason) => Reason = reason;
 
-        public InitializationException(string reason, System.Exception ex) : base(ex) => Reason = reason;
+        public InitializationException(string reason, System.Exception ex) : base("", ex) => Reason = reason;
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ namespace Ice
     /// adapter when resolving an indirect proxy or when an object adapter
     /// is activated.
     /// </summary>
-    public class NotRegisteredException : LocalException
+    public class NotRegisteredException : System.Exception
     {
         public string KindOfObject;
         public string Id;
@@ -40,7 +40,7 @@ namespace Ice
             Id = "";
         }
 
-        public NotRegisteredException(System.Exception ex) : base(ex)
+        public NotRegisteredException(System.Exception ex) : base("", ex)
         {
             KindOfObject = "";
             Id = "";
@@ -52,7 +52,7 @@ namespace Ice
             Id = id;
         }
 
-        public NotRegisteredException(string kindOfObject, string id, System.Exception ex) : base(ex)
+        public NotRegisteredException(string kindOfObject, string id, System.Exception ex) : base("", ex)
         {
             KindOfObject = kindOfObject;
             Id = id;
@@ -62,13 +62,13 @@ namespace Ice
     /// <summary>
     /// This exception is raised if the Communicator has been destroyed.
     /// </summary>
-    public class CommunicatorDestroyedException : LocalException
+    public class CommunicatorDestroyedException : System.Exception
     {
         public CommunicatorDestroyedException()
         {
         }
 
-        public CommunicatorDestroyedException(System.Exception ex) : base(ex)
+        public CommunicatorDestroyedException(System.Exception ex) : base("", ex)
         {
         }
     }
@@ -77,17 +77,17 @@ namespace Ice
     /// This exception is raised if an attempt is made to use a deactivated
     /// ObjectAdapter.
     /// </summary>
-    public class ObjectAdapterDeactivatedException : LocalException
+    public class ObjectAdapterDeactivatedException : System.Exception
     {
         public string Name;
 
         public ObjectAdapterDeactivatedException() => Name = "";
 
-        public ObjectAdapterDeactivatedException(System.Exception ex) : base(ex) => Name = "";
+        public ObjectAdapterDeactivatedException(System.Exception ex) : base("", ex) => Name = "";
 
         public ObjectAdapterDeactivatedException(string name) => Name = name;
 
-        public ObjectAdapterDeactivatedException(string name, System.Exception ex) : base(ex) => Name = name;
+        public ObjectAdapterDeactivatedException(string name, System.Exception ex) : base("", ex) => Name = name;
 
     }
 
@@ -96,33 +96,33 @@ namespace Ice
     /// This happens if the Locator detects another active ObjectAdapter with
     /// the same adapter id.
     /// </summary>
-    public class ObjectAdapterIdInUseException : LocalException
+    public class ObjectAdapterIdInUseException : System.Exception
     {
         public string Id;
 
         public ObjectAdapterIdInUseException() => Id = "";
 
-        public ObjectAdapterIdInUseException(System.Exception ex) : base(ex) => Id = "";
+        public ObjectAdapterIdInUseException(System.Exception ex) : base("", ex) => Id = "";
 
         public ObjectAdapterIdInUseException(string id) => Id = id;
 
-        public ObjectAdapterIdInUseException(string id, System.Exception ex) : base(ex) => Id = id;
+        public ObjectAdapterIdInUseException(string id, System.Exception ex) : base("", ex) => Id = id;
     }
 
     /// <summary>
     /// This exception is raised if no suitable endpoint is available.
     /// </summary>
-    public class NoEndpointException : LocalException
+    public class NoEndpointException : System.Exception
     {
         public string Proxy;
 
         public NoEndpointException() => Proxy = "";
 
-        public NoEndpointException(System.Exception ex) : base(ex) => Proxy = "";
+        public NoEndpointException(System.Exception ex) : base("", ex) => Proxy = "";
 
         public NoEndpointException(string proxy) => Proxy = proxy;
 
-        public NoEndpointException(string proxy, System.Exception ex) : base(ex) => Proxy = proxy;
+        public NoEndpointException(string proxy, System.Exception ex) : base("", ex) => Proxy = proxy;
 
     }
 
@@ -133,17 +133,17 @@ namespace Ice
     /// exception. For details on the cause, SyscallException.error
     /// should be inspected.
     /// </summary>
-    public class SyscallException : LocalException
+    public class SyscallException : System.Exception
     {
         public int Error;
 
         public SyscallException() => Error = 0;
 
-        public SyscallException(System.Exception ex) : base(ex) => Error = 0;
+        public SyscallException(System.Exception ex) : base("", ex) => Error = 0;
 
         public SyscallException(int error) => Error = error;
 
-        public SyscallException(int error, System.Exception ex) : base(ex) => Error = error;
+        public SyscallException(int error, System.Exception ex) : base("", ex) => Error = error;
 
     }
 
@@ -258,7 +258,7 @@ namespace Ice
     /// For details on the cause,
     /// DNSException.error should be inspected.
     /// </summary>
-    public class DNSException : LocalException
+    public class DNSException : System.Exception
     {
         public int Error;
         public string Host;
@@ -269,7 +269,7 @@ namespace Ice
             Host = "";
         }
 
-        public DNSException(System.Exception ex) : base(ex)
+        public DNSException(System.Exception ex) : base("", ex)
         {
             Error = 0;
             Host = "";
@@ -281,7 +281,7 @@ namespace Ice
             Host = host;
         }
 
-        public DNSException(int error, string host, System.Exception ex) : base(ex)
+        public DNSException(int error, string host, System.Exception ex) : base("", ex)
         {
             Error = error;
             Host = host;
@@ -291,13 +291,13 @@ namespace Ice
     /// <summary>
     /// This exception indicates a timeout condition.
     /// </summary>
-    public class TimeoutException : LocalException
+    public class TimeoutException : System.Exception
     {
         public TimeoutException()
         {
         }
 
-        public TimeoutException(System.Exception ex) : base(ex)
+        public TimeoutException(System.Exception ex) : base("", ex)
         {
         }
     }
@@ -367,13 +367,13 @@ namespace Ice
     /// This exception indicates that an asynchronous invocation failed
     /// because it was canceled explicitly by the user.
     /// </summary>
-    public class InvocationCanceledException : LocalException
+    public class InvocationCanceledException : System.Exception
     {
         public InvocationCanceledException()
         {
         }
 
-        public InvocationCanceledException(System.Exception ex) : base(ex)
+        public InvocationCanceledException(System.Exception ex) : base("", ex)
         {
         }
     }
@@ -382,17 +382,17 @@ namespace Ice
     /// A generic exception base for all kinds of protocol error
     /// conditions.
     /// </summary>
-    public class ProtocolException : LocalException
+    public class ProtocolException : System.Exception
     {
         public string Reason;
 
         public ProtocolException() => Reason = "";
 
-        public ProtocolException(System.Exception ex) : base(ex) => Reason = "";
+        public ProtocolException(System.Exception ex) : base("", ex) => Reason = "";
 
         public ProtocolException(string reason) => Reason = reason;
 
-        public ProtocolException(string reason, System.Exception ex) : base(ex) => Reason = reason;
+        public ProtocolException(string reason, System.Exception ex) : base("", ex) => Reason = reason;
     }
 
     /// <summary>
@@ -591,7 +591,7 @@ namespace Ice
     /// This exception is raised by an operation call if the application
     /// closes the connection locally using Connection.close.
     /// </summary>
-    public class ConnectionManuallyClosedException : LocalException
+    public class ConnectionManuallyClosedException : System.Exception
     {
         public bool Graceful;
 
@@ -599,13 +599,13 @@ namespace Ice
         {
         }
 
-        public ConnectionManuallyClosedException(System.Exception ex) : base(ex)
+        public ConnectionManuallyClosedException(System.Exception ex) : base("", ex)
         {
         }
 
         public ConnectionManuallyClosedException(bool graceful) => Graceful = graceful;
 
-        public ConnectionManuallyClosedException(bool graceful, System.Exception ex) : base(ex) => Graceful = graceful;
+        public ConnectionManuallyClosedException(bool graceful, System.Exception ex) : base("", ex) => Graceful = graceful;
     }
 
     /// <summary>
@@ -852,17 +852,17 @@ namespace Ice
     /// unsupported feature string contains the name of the unsupported
     /// feature
     /// </summary>
-    public class FeatureNotSupportedException : LocalException
+    public class FeatureNotSupportedException : System.Exception
     {
         public string UnsupportedFeature;
 
         public FeatureNotSupportedException() => UnsupportedFeature = "";
 
-        public FeatureNotSupportedException(System.Exception ex) : base(ex) => UnsupportedFeature = "";
+        public FeatureNotSupportedException(System.Exception ex) : base("", ex) => UnsupportedFeature = "";
 
         public FeatureNotSupportedException(string unsupportedFeature) => UnsupportedFeature = unsupportedFeature;
 
-        public FeatureNotSupportedException(string unsupportedFeature, System.Exception ex) : base(ex) =>
+        public FeatureNotSupportedException(string unsupportedFeature, System.Exception ex) : base("", ex) =>
             UnsupportedFeature = unsupportedFeature;
     }
 
@@ -870,16 +870,16 @@ namespace Ice
     /// This exception indicates a failure in a security subsystem,
     /// such as the IceSSL plug-in.
     /// </summary>
-    public class SecurityException : LocalException
+    public class SecurityException : System.Exception
     {
         public string Reason;
 
         public SecurityException() => Reason = "";
 
-        public SecurityException(System.Exception ex) : base(ex) => Reason = "";
+        public SecurityException(System.Exception ex) : base("", ex) => Reason = "";
 
         public SecurityException(string reason) => Reason = reason;
 
-        public SecurityException(string reason, System.Exception ex) : base(ex) => Reason = reason;
+        public SecurityException(string reason, System.Exception ex) : base("", ex) => Reason = reason;
     }
 }

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -127,44 +127,15 @@ namespace Ice
     }
 
     /// <summary>
-    /// This exception is raised if a system error occurred in the server
-    /// or client process.
-    /// There are many possible causes for such a system
-    /// exception. For details on the cause, SyscallException.error
-    /// should be inspected.
-    /// </summary>
-    public class SyscallException : System.Exception
-    {
-        public int Error;
-
-        public SyscallException() => Error = 0;
-
-        public SyscallException(System.Exception ex) : base("", ex) => Error = 0;
-
-        public SyscallException(int error) => Error = error;
-
-        public SyscallException(int error, System.Exception ex) : base("", ex) => Error = error;
-
-    }
-
-    /// <summary>
     /// This exception indicates socket errors.
     /// </summary>
-    public class SocketException : SyscallException
+    public class SocketException : System.Exception
     {
         public SocketException()
         {
         }
 
-        public SocketException(System.Exception ex) : base(ex)
-        {
-        }
-
-        public SocketException(int error) : base(error)
-        {
-        }
-
-        public SocketException(int error, System.Exception ex) : base(error, ex)
+        public SocketException(System.Exception ex) : base("", ex)
         {
         }
     }
@@ -172,18 +143,11 @@ namespace Ice
     /// <summary>
     /// This exception indicates file errors.
     /// </summary>
-    public class FileException : SyscallException
+    public class FileException : System.Exception
     {
         public string Path;
 
-        public FileException() => Path = "";
-
-        public FileException(System.Exception ex) : base(ex) => Path = "";
-
-        public FileException(int error, string path) : base(error) => Path = path;
-
-        public FileException(int error, string path, System.Exception ex) : base(error, ex) => Path = path;
-
+        public FileException(System.Exception ex) : base("", ex) => Path = "";
     }
 
     /// <summary>
@@ -196,14 +160,6 @@ namespace Ice
         }
 
         public ConnectFailedException(System.Exception ex) : base(ex)
-        {
-        }
-
-        public ConnectFailedException(int error) : base(error)
-        {
-        }
-
-        public ConnectFailedException(int error, System.Exception ex) : base(error, ex)
         {
         }
     }
@@ -221,14 +177,6 @@ namespace Ice
         public ConnectionRefusedException(System.Exception ex) : base(ex)
         {
         }
-
-        public ConnectionRefusedException(int error) : base(error)
-        {
-        }
-
-        public ConnectionRefusedException(int error, System.Exception ex) : base(error, ex)
-        {
-        }
     }
 
     /// <summary>
@@ -241,14 +189,6 @@ namespace Ice
         }
 
         public ConnectionLostException(System.Exception ex) : base(ex)
-        {
-        }
-
-        public ConnectionLostException(int error) : base(error)
-        {
-        }
-
-        public ConnectionLostException(int error, System.Exception ex) : base(error, ex)
         {
         }
     }

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -91,13 +91,12 @@ namespace IceInternal
                         }
                         catch (AggregateException ae)
                         {
-                            Debug.Assert(ae.InnerException is LocalException);
-                            DeadRemoteLogger(remoteLogger, _logger, (LocalException)ae.InnerException, "init");
+                            DeadRemoteLogger(remoteLogger, _logger, ae.InnerException, "init");
                         }
                     },
                     System.Threading.Tasks.TaskScheduler.Current);
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 DeadRemoteLogger(remoteLogger, _logger, ex, "init");
                 throw;
@@ -289,7 +288,7 @@ namespace IceInternal
             }
         }
 
-        internal void DeadRemoteLogger(IRemoteLoggerPrx remoteLogger, ILogger logger, LocalException ex,
+        internal void DeadRemoteLogger(IRemoteLoggerPrx remoteLogger, ILogger logger, System.Exception ex,
                                        string operation)
         {
             //

--- a/csharp/src/Ice/LoggerAdminLogger.cs
+++ b/csharp/src/Ice/LoggerAdminLogger.cs
@@ -169,16 +169,15 @@ namespace IceInternal
                                     {
                                         // expected if there are outstanding calls during communicator destruction
                                     }
-                                    if (ae.InnerException is Ice.LocalException)
-                                    {
-                                        _loggerAdmin.DeadRemoteLogger(p, _localLogger,
-                                                                      (Ice.LocalException)ae.InnerException, "log");
-                                    }
+
+                                    _loggerAdmin.DeadRemoteLogger(p, _localLogger,
+                                                                  ae.InnerException, "log");
+
                                 }
                             },
                             System.Threading.Tasks.TaskScheduler.Current);
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         _loggerAdmin.DeadRemoteLogger(p, _localLogger, ex, "log");
                     }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -856,7 +856,7 @@ namespace Ice
             {
                 UpdateLocatorRegistry(locatorInfo, CreateDirectProxy(new Identity("dummy", ""), IObjectPrx.Factory));
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 lock (_mutex)
                 {

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -155,7 +155,7 @@ namespace IceInternal
                     {
                         throw _cancellationException;
                     }
-                    catch (Ice.LocalException)
+                    catch (System.Exception)
                     {
                         _cancellationException = null;
                         throw;
@@ -306,7 +306,7 @@ namespace IceInternal
             }
         }
 
-        protected void Cancel(Ice.LocalException ex)
+        protected void Cancel(System.Exception ex)
         {
             ICancellationHandler handler;
             {
@@ -350,7 +350,7 @@ namespace IceInternal
         private bool _doneInSent;
         private bool _alreadySent;
         private System.Exception? _ex;
-        private LocalException? _cancellationException;
+        private System.Exception? _cancellationException;
         private ICancellationHandler? _cancellationHandler;
         private readonly IOutgoingAsyncCompletionCallback _completionCallback;
 

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -437,7 +437,7 @@ namespace IceInternal
                 Proxy.IceUpdateRequestHandler(Handler, null); // Clear request handler and always retry.
                 Communicator.AddRetryTask(this, 0);
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 if (Exception(ex))
                 {
@@ -447,7 +447,7 @@ namespace IceInternal
         }
 
         public void Retry() => InvokeImpl(false);
-        public void Abort(Ice.Exception ex)
+        public void Abort(System.Exception ex)
         {
             Debug.Assert(ChildObserver == null);
             if (ExceptionImpl(ex))
@@ -526,7 +526,7 @@ namespace IceInternal
                     {
                         Proxy.IceUpdateRequestHandler(Handler, null); // Clear request handler and always retry.
                     }
-                    catch (Ice.Exception ex)
+                    catch (System.Exception ex)
                     {
                         if (ChildObserver != null)
                         {
@@ -547,7 +547,7 @@ namespace IceInternal
                     }
                 }
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 //
                 // If called from the user thread we re-throw, the exception
@@ -815,7 +815,7 @@ namespace IceInternal
             return handler.InvokeAsyncRequest(this, Synchronous);
         }
 
-        public new void Abort(Ice.Exception ex)
+        public new void Abort(System.Exception ex)
         {
             Ice.InvocationMode mode = Proxy.IceReference.GetMode();
 
@@ -878,7 +878,7 @@ namespace IceInternal
                 }
                 Invoke(synchronous);
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 Abort(ex);
             }

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -229,7 +229,7 @@ namespace Ice
                 {
                     return handler.GetConnection();
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
             }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -17,7 +17,7 @@ namespace IceInternal
         public interface IGetConnectionCallback
         {
             void SetConnection(Connection connection, bool compress);
-            void SetException(LocalException ex);
+            void SetException(System.Exception ex);
         }
 
         public InvocationMode GetMode() => _mode;
@@ -1368,7 +1368,7 @@ namespace IceInternal
                 }
             }
 
-            public void setException(LocalException ex) => _cb.SetException(ex);
+            public void setException(System.Exception ex) => _cb.SetException(ex);
 
             private readonly RoutableReference _ir;
             private readonly IGetConnectionCallback _cb;
@@ -1411,7 +1411,7 @@ namespace IceInternal
                 _ir.CreateConnection(_ir.ApplyOverrides(endpoints), new ConnectionCallback(_ir, _cb, cached));
             }
 
-            public void SetException(LocalException ex) => _cb.SetException(ex);
+            public void SetException(System.Exception ex) => _cb.SetException(ex);
 
             private readonly RoutableReference _ir;
             private readonly IGetConnectionCallback _cb;
@@ -1428,7 +1428,7 @@ namespace IceInternal
 
             public void SetConnection(Connection connection, bool compress) => _cb.SetConnection(connection, compress);
 
-            public void SetException(LocalException exc)
+            public void SetException(System.Exception exc)
             {
                 try
                 {
@@ -1438,7 +1438,7 @@ namespace IceInternal
                 {
                     _cb.SetException(ex); // No need to retry if there's no endpoints.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Debug.Assert(_ir._locatorInfo != null);
                     _ir._locatorInfo.ClearCache(_ir);
@@ -1683,7 +1683,7 @@ namespace IceInternal
                 _callback.SetConnection(connection, compress);
             }
 
-            public void SetException(LocalException ex)
+            public void SetException(System.Exception ex)
             {
                 if (_exception == null)
                 {
@@ -1705,7 +1705,7 @@ namespace IceInternal
             private readonly Endpoint[]? _endpoints;
             private readonly IGetConnectionCallback _callback;
             private int _i = 0;
-            private LocalException? _exception = null;
+            private System.Exception? _exception = null;
         }
 
         protected void CreateConnection(Endpoint[] allEndpoints, IGetConnectionCallback callback)

--- a/csharp/src/Ice/TcpTransceiver.cs
+++ b/csharp/src/Ice/TcpTransceiver.cs
@@ -19,7 +19,7 @@ namespace IceInternal
 
         // If we are initiating the connection closure, wait for the peer
         // to close the TCP/IP connection. Otherwise, close immediately.
-        public int Closing(bool initiator, Ice.LocalException? ex) =>
+        public int Closing(bool initiator, System.Exception? ex) =>
             initiator ? SocketOperation.Read : SocketOperation.None;
 
         public void Close() => _stream.Close();

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -181,10 +181,6 @@ namespace IceInternal
                         throw new Ice.SocketException(ex);
                     }
                 }
-                catch (System.Exception e)
-                {
-                    throw new SyscallException(e);
-                }
             }
             return SocketOperation.None;
         }
@@ -264,10 +260,6 @@ namespace IceInternal
                     {
                         throw new Ice.SocketException(e);
                     }
-                }
-                catch (System.Exception e)
-                {
-                    throw new SyscallException(e);
                 }
             }
 

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -49,7 +49,7 @@ namespace IceInternal
             return SocketOperation.None;
         }
 
-        public int Closing(bool initiator, LocalException? ex)
+        public int Closing(bool initiator, System.Exception? ex)
         {
             //
             // Nothing to do.
@@ -704,7 +704,7 @@ namespace IceInternal
                     }
                 }
             }
-            catch (Ice.LocalException)
+            catch (System.Exception)
             {
                 _fd = null;
                 throw;
@@ -740,7 +740,7 @@ namespace IceInternal
                 SetBufSize(-1, -1);
                 Network.SetBlock(_fd, false);
             }
-            catch (Ice.LocalException)
+            catch (System.Exception)
             {
                 if (_readEventArgs != null)
                 {

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -141,7 +141,7 @@ namespace IceInternal
                 _callback.Connectors(l);
             }
 
-            public void Exception(Ice.LocalException ex) => _callback.Exception(ex);
+            public void Exception(System.Exception ex) => _callback.Exception(ex);
 
             private readonly TransportInstance _instance;
             private readonly string _host;

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -202,7 +202,7 @@ namespace IceInternal
                 _state = StateOpened;
                 _nextState = StateOpened;
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 if (_instance.TraceLevel >= 2)
                 {
@@ -228,7 +228,7 @@ namespace IceInternal
             return SocketOperation.None;
         }
 
-        public int Closing(bool initiator, LocalException? reason)
+        public int Closing(bool initiator, System.Exception? reason)
         {
             if (_instance.TraceLevel >= 1)
             {

--- a/csharp/src/IceDiscovery/Lookup.cs
+++ b/csharp/src/IceDiscovery/Lookup.cs
@@ -268,7 +268,7 @@ namespace IceDiscovery
                     Debug.Assert(reply != null);
                     reply.FoundObjectByIdAsync(id, proxy);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     // Ignore.
                 }
@@ -293,7 +293,7 @@ namespace IceDiscovery
                     Debug.Assert(reply != null);
                     reply.FoundAdapterByIdAsync(adapterId, proxy, isReplicaGroup);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     // Ignore.
                 }
@@ -318,7 +318,7 @@ namespace IceDiscovery
                         request.Invoke(_domainId, _lookups);
                         _timer.Schedule(request, _timeout);
                     }
-                    catch (LocalException)
+                    catch (System.Exception)
                     {
                         request.Finished(null);
                         _objectRequests.Remove(id);
@@ -346,7 +346,7 @@ namespace IceDiscovery
                         request.Invoke(_domainId, _lookups);
                         _timer.Schedule(request, _timeout);
                     }
-                    catch (LocalException)
+                    catch (System.Exception)
                     {
                         request.Finished(null);
                         _adapterRequests.Remove(adapterId);
@@ -403,7 +403,7 @@ namespace IceDiscovery
                         _timer.Schedule(request, _timeout);
                         return;
                     }
-                    catch (Ice.LocalException)
+                    catch (System.Exception)
                     {
                     }
                 }
@@ -460,7 +460,7 @@ namespace IceDiscovery
                         _timer.Schedule(request, _timeout);
                         return;
                     }
-                    catch (LocalException)
+                    catch (System.Exception)
                     {
                     }
                 }

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -434,7 +434,7 @@ namespace IceLocatorDiscovery
                             }
                             _timer.Schedule(this, _timeout);
                         }
-                        catch (LocalException ex)
+                        catch (System.Exception ex)
                         {
                             if (_traceLevel > 0)
                             {
@@ -557,7 +557,7 @@ namespace IceLocatorDiscovery
                         _timer.Schedule(this, _timeout);
                         return;
                     }
-                    catch (Ice.LocalException)
+                    catch (System.Exception)
                     {
                     }
                     _pendingRetryCount = 0;

--- a/csharp/src/IceSSL/Endpoint.cs
+++ b/csharp/src/IceSSL/Endpoint.cs
@@ -104,7 +104,7 @@ namespace IceSSL
                 _callback.Connectors(l);
             }
 
-            public void Exception(Ice.LocalException ex) => _callback.Exception(ex);
+            public void Exception(System.Exception ex) => _callback.Exception(ex);
 
             private readonly Instance _instance;
             private readonly string _host;

--- a/csharp/src/IceSSL/Transceiver.cs
+++ b/csharp/src/IceSSL/Transceiver.cs
@@ -81,7 +81,7 @@ namespace IceSSL
             return IceInternal.SocketOperation.None;
         }
 
-        public int Closing(bool initiator, LocalException? ex) => _delegate.Closing(initiator, ex);
+        public int Closing(bool initiator, System.Exception? ex) => _delegate.Closing(initiator, ex);
 
         public void Close()
         {
@@ -142,10 +142,6 @@ namespace IceSSL
             {
                 throw new ConnectionLostException(ex);
             }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
-            }
         }
 
         public void FinishRead(ref ArraySegment<byte> buffer, ref int offset)
@@ -174,10 +170,6 @@ namespace IceSSL
                 Debug.Assert(ret > 0);
                 offset += ret;
             }
-            catch (LocalException)
-            {
-                throw;
-            }
             catch (IOException ex)
             {
                 if (IceInternal.Network.ConnectionLost(ex))
@@ -193,10 +185,6 @@ namespace IceSSL
             catch (ObjectDisposedException ex)
             {
                 throw new ConnectionLostException(ex);
-            }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
             }
         }
 
@@ -245,10 +233,6 @@ namespace IceSSL
             {
                 throw new Ice.ConnectionLostException(ex);
             }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
-            }
         }
 
         public void FinishWrite(IList<ArraySegment<byte>> buffer, ref int offset)
@@ -296,10 +280,6 @@ namespace IceSSL
             catch (ObjectDisposedException ex)
             {
                 throw new ConnectionLostException(ex);
-            }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
             }
         }
 
@@ -403,10 +383,6 @@ namespace IceSSL
             {
                 throw new Ice.SecurityException(ex.Message, ex);
             }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
-            }
 
             Debug.Assert(_writeResult != null);
             return _writeResult.CompletedSynchronously;
@@ -443,10 +419,6 @@ namespace IceSSL
             catch (AuthenticationException ex)
             {
                 throw new SecurityException(ex.Message, ex);
-            }
-            catch (System.Exception ex)
-            {
-                throw new SyscallException(ex);
             }
         }
 

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -343,7 +343,7 @@ public class Client : Test.TestHelper
                   }
                   // If we use the glacier router, the exact exception reason gets
                   // lost.
-                  catch(Ice.UnknownSystem.Exception ex)
+                  catch(Ice.UnknownLocalException ex)
                   {
                   Console.Out.WriteLine("ok");
                   }

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -343,7 +343,7 @@ public class Client : Test.TestHelper
                   }
                   // If we use the glacier router, the exact exception reason gets
                   // lost.
-                  catch(Ice.UnknownLocalException ex)
+                  catch(Ice.UnknownSystem.Exception ex)
                   {
                   Console.Out.WriteLine("ok");
                   }
@@ -357,7 +357,7 @@ public class Client : Test.TestHelper
                 {
                     router.DestroySession();
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     test(false);
                 }
@@ -422,7 +422,7 @@ public class Client : Test.TestHelper
                     process.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     Console.Out.WriteLine("ok");
                 }

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -418,7 +418,7 @@ public class Client : Test.TestHelper
                 process.IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 Console.Out.WriteLine("ok");
             }

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -170,7 +170,7 @@ namespace Ice
                         communicator.CreateObjectAdapterWithEndpoints("Adpt2", helper.getTestEndpoint(10));
                         test(false);
                     }
-                    catch (LocalException)
+                    catch (System.Exception)
                     {
                         // Expected can't re-use the same endpoint.
                     }
@@ -190,7 +190,7 @@ namespace Ice
                     obj.Clone(connectionTimeout: 100).IcePing(); // Use timeout to speed up testing on Windows
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     output.WriteLine("ok");
                 }

--- a/csharp/test/Ice/adapterDeactivation/Servant.cs
+++ b/csharp/test/Ice/adapterDeactivation/Servant.cs
@@ -45,6 +45,7 @@ namespace Ice.adapterDeactivation
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/admin/Client.cs
+++ b/csharp/test/Ice/admin/Client.cs
@@ -17,7 +17,7 @@ namespace Ice
                     using var communicator = initialize(ref args);
                     AllTests.allTests(this);
                 }
-                catch(Exception ex)
+                catch(System.Exception ex)
                 {
                     System.Console.WriteLine(ex.ToString());
                 }

--- a/csharp/test/Ice/background/AllTests.cs
+++ b/csharp/test/Ice/background/AllTests.cs
@@ -161,7 +161,7 @@ public class AllTests
                     _background.opAsync();
                     Thread.Sleep(1);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
             }
@@ -342,7 +342,7 @@ public class AllTests
         {
             background.op();
         }
-        catch (LocalException ex)
+        catch (System.Exception ex)
         {
             System.Console.Out.WriteLine(ex);
             test(false);
@@ -471,7 +471,7 @@ public class AllTests
         {
             background.op();
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -504,14 +504,16 @@ public class AllTests
                 sentSynchronously = value;
             }));
             test(!sentSynchronously);
+            bool called = false;
             try
             {
                 t.Wait();
-                test(false);
+                called = true;
             }
-            catch (AggregateException ex) when (ex.InnerException is System.Exception)
+            catch (AggregateException ex)
             {
             }
+            test(!called);
             test(t.IsCompleted);
 
             OpAMICallback cbEx = new OpAMICallback();
@@ -565,7 +567,7 @@ public class AllTests
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -578,14 +580,14 @@ public class AllTests
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -601,14 +603,14 @@ public class AllTests
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -618,7 +620,7 @@ public class AllTests
                 background.GetCachedConnection()!.Close(ConnectionClose.Forcefully);
                 background.op();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -657,7 +659,7 @@ public class AllTests
         {
             background.op();
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -707,7 +709,7 @@ public class AllTests
                 background.op();
                 configuration.readReady(true);
             }
-            catch (LocalException ex)
+            catch (System.Exception ex)
             {
                 Console.Error.WriteLine(ex);
                 test(false);
@@ -791,7 +793,7 @@ public class AllTests
             background.op();
             ctl.writeReady(true);
         }
-        catch (LocalException ex)
+        catch (System.Exception ex)
         {
             Console.Error.WriteLine(ex);
             test(false);
@@ -820,7 +822,7 @@ public class AllTests
         {
             background.op();
         }
-        catch (LocalException ex)
+        catch (System.Exception ex)
         {
             Console.Error.WriteLine(ex);
             test(false);
@@ -899,7 +901,7 @@ public class AllTests
             background.op();
             configuration.writeReady(true);
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -911,7 +913,7 @@ public class AllTests
             background.op();
             configuration.readReady(true);
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -1147,7 +1149,7 @@ public class AllTests
             background.op();
             ctl.writeReady(true);
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -1159,7 +1161,7 @@ public class AllTests
             background.op();
             ctl.readReady(true);
         }
-        catch (LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -1201,7 +1203,7 @@ public class AllTests
             {
                 background.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -1212,7 +1214,7 @@ public class AllTests
             {
                 background.op();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             configuration.writeException(null);

--- a/csharp/test/Ice/background/AllTests.cs
+++ b/csharp/test/Ice/background/AllTests.cs
@@ -16,6 +16,7 @@ public class AllTests
     {
         if (!b)
         {
+            Debug.Assert(false);
             throw new System.Exception();
         }
     }
@@ -71,9 +72,9 @@ public class AllTests
 
         public void noResponse() => test(false);
 
-        public void exception(Ice.Exception ex) => _response.called();
+        public void exception(System.Exception ex) => _response.called();
 
-        public void noException(Ice.Exception ex)
+        public void noException(System.Exception ex)
         {
             Console.Error.WriteLine(ex);
             test(false);
@@ -312,7 +313,7 @@ public class AllTests
                         p.Wait();
                         cb.responseNoOp();
                     }
-                    catch (Ice.Exception ex)
+                    catch (System.Exception ex)
                     {
                         cb.noException(ex);
                     }
@@ -360,14 +361,16 @@ public class AllTests
             }
             IBackgroundPrx prx = (i == 1 || i == 3) ? background : background.Clone(oneway: true);
 
+            bool called = false;
             try
             {
                 prx.op();
-                test(false);
+                called = true;
             }
-            catch (Ice.Exception)
+            catch (System.Exception)
             {
             }
+            test(!called);
 
             var sentSynchronously = false;
             var t = prx.opAsync(progress: new Progress<bool>(value =>
@@ -375,14 +378,16 @@ public class AllTests
                 sentSynchronously = value;
             }));
             test(!sentSynchronously);
+
             try
             {
                 t.Wait();
-                test(false);
+                called = true;
             }
-            catch (AggregateException ex) when (ex.InnerException is Ice.Exception)
+            catch (AggregateException ex)
             {
             }
+            test(!called);
             test(t.IsCompleted);
 
             OpAMICallback cbEx = new OpAMICallback();
@@ -398,9 +403,9 @@ public class AllTests
                 {
                     p.Wait();
                 }
-                catch (AggregateException ex) when (ex.InnerException is Ice.Exception)
+                catch (AggregateException ex)
                 {
-                    cbEx.exception((Ice.Exception)ex.InnerException);
+                    cbEx.exception(ex.InnerException);
                 }
             });
             cbEx.checkException(true);
@@ -426,7 +431,7 @@ public class AllTests
                 {
                     background.IcePing();
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     test(false);
                 }
@@ -439,7 +444,7 @@ public class AllTests
                 {
                     background.IcePing();
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
             }
@@ -504,7 +509,7 @@ public class AllTests
                 t.Wait();
                 test(false);
             }
-            catch (AggregateException ex) when (ex.InnerException is Ice.Exception)
+            catch (AggregateException ex) when (ex.InnerException is System.Exception)
             {
             }
             test(t.IsCompleted);
@@ -519,9 +524,9 @@ public class AllTests
             {
                 t.Wait();
             }
-            catch (AggregateException ex) when (ex.InnerException is Ice.Exception)
+            catch (AggregateException ex)
             {
-                cbEx.exception((Ice.Exception)ex.InnerException);
+                cbEx.exception(ex.InnerException);
             }
             cbEx.checkException(true);
             test(t.IsCompleted);
@@ -1037,7 +1042,7 @@ public class AllTests
                 p.Wait();
                 cb.response();
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 cb.exception(ex);
             }
@@ -1058,7 +1063,7 @@ public class AllTests
                 p.Wait();
                 cb2.response();
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 cb2.noException(ex);
             }
@@ -1076,9 +1081,8 @@ public class AllTests
             try
             {
                 p.Wait();
-                cbWP.noResponse();
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 cbWP.noException(ex);
             }
@@ -1095,9 +1099,8 @@ public class AllTests
             try
             {
                 p.Wait();
-                cbWP.noResponse();
             }
-            catch (Ice.Exception ex)
+            catch (System.Exception ex)
             {
                 cbWP.noException(ex);
             }

--- a/csharp/test/Ice/background/Configuration.cs
+++ b/csharp/test/Ice/background/Configuration.cs
@@ -4,7 +4,7 @@
 
 internal class Configuration
 {
-    public void connectorsException(Ice.LocalException? ex)
+    public void connectorsException(System.Exception? ex)
     {
         lock (this)
         {
@@ -23,7 +23,7 @@ internal class Configuration
         }
     }
 
-    public void connectException(Ice.LocalException? ex)
+    public void connectException(System.Exception? ex)
     {
         lock (this)
         {
@@ -42,7 +42,7 @@ internal class Configuration
         }
     }
 
-    public void initializeException(Ice.LocalException? ex)
+    public void initializeException(System.Exception? ex)
     {
         lock (this)
         {
@@ -69,7 +69,7 @@ internal class Configuration
         }
     }
 
-    public void readException(Ice.LocalException? ex)
+    public void readException(System.Exception? ex)
     {
         lock (this)
         {
@@ -109,7 +109,7 @@ internal class Configuration
         }
     }
 
-    public void writeException(Ice.LocalException? ex)
+    public void writeException(System.Exception? ex)
     {
         lock (this)
         {
@@ -156,13 +156,13 @@ internal class Configuration
         return _instance;
     }
 
-    private Ice.LocalException? _connectorsException;
-    private Ice.LocalException? _connectException;
-    private Ice.LocalException? _initializeException;
+    private System.Exception? _connectorsException;
+    private System.Exception? _connectException;
+    private System.Exception? _initializeException;
     private int _readReadyCount;
-    private Ice.LocalException? _readException;
+    private System.Exception? _readException;
     private int _writeReadyCount;
-    private Ice.LocalException? _writeException;
+    private System.Exception? _writeException;
     private bool _buffered;
 
     private static Configuration _instance = new Configuration();

--- a/csharp/test/Ice/background/EndpointI.cs
+++ b/csharp/test/Ice/background/EndpointI.cs
@@ -135,7 +135,7 @@ internal class Endpoint : IceInternal.Endpoint
             _callback.Connectors(connectors);
         }
 
-        public void Exception(Ice.LocalException exception)
+        public void Exception(System.Exception exception)
         {
             _callback.Exception(exception);
         }
@@ -150,7 +150,7 @@ internal class Endpoint : IceInternal.Endpoint
             _configuration.checkConnectorsException();
             _endpoint.ConnectorsAsync(selType, new ConnectorsCallback(cb));
         }
-        catch (Ice.LocalException ex)
+        catch (System.Exception ex)
         {
             cb.Exception(ex);
         }

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -28,7 +28,7 @@ internal class Transceiver : IceInternal.ITransceiver
         return IceInternal.SocketOperation.None;
     }
 
-    public int Closing(bool initiator, Ice.LocalException? ex) => _transceiver.Closing(initiator, ex);
+    public int Closing(bool initiator, System.Exception? ex) => _transceiver.Closing(initiator, ex);
 
     public void Close() => _transceiver.Close();
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -241,7 +241,7 @@ namespace Ice.binding
                         {
                             proxies[i].IcePing();
                         }
-                        catch (LocalException)
+                        catch (System.Exception)
                         {
                         }
                     }
@@ -265,7 +265,7 @@ namespace Ice.binding
                         {
                             a.getTestIntf().GetConnection().Close(ConnectionClose.GracefullyWithWait);
                         }
-                        catch (LocalException)
+                        catch (System.Exception)
                         {
                             // Expected if adapter is down.
                         }

--- a/csharp/test/Ice/dictMapping/Twoways.cs
+++ b/csharp/test/Ice/dictMapping/Twoways.cs
@@ -12,6 +12,7 @@ namespace Ice.dictMapping
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -167,7 +167,7 @@ public class AllTests : Test.AllTests
                     }
                     catch (AggregateException ex)
                     {
-                        exceptAbortI(ex.InnerException as System.Exception, output);
+                        exceptAbortI(ex.InnerException, output);
                     }
                     output.WriteLine("ok");
                 }
@@ -207,7 +207,7 @@ public class AllTests : Test.AllTests
                     }
                     catch (AggregateException ex)
                     {
-                        exceptAbortI(ex.InnerException as System.Exception, output);
+                        exceptAbortI(ex.InnerException, output);
                     }
                     output.WriteLine("ok");
                 }

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -43,7 +43,7 @@ public class AllTests : Test.AllTests
         private bool _called;
     }
 
-    private static void exceptAbortI(Ice.Exception ex, TextWriter output)
+    private static void exceptAbortI(System.Exception ex, TextWriter output)
     {
         try
         {
@@ -167,7 +167,7 @@ public class AllTests : Test.AllTests
                     }
                     catch (AggregateException ex)
                     {
-                        exceptAbortI(ex.InnerException as Ice.Exception, output);
+                        exceptAbortI(ex.InnerException as System.Exception, output);
                     }
                     output.WriteLine("ok");
                 }
@@ -207,7 +207,7 @@ public class AllTests : Test.AllTests
                     }
                     catch (AggregateException ex)
                     {
-                        exceptAbortI(ex.InnerException as Ice.Exception, output);
+                        exceptAbortI(ex.InnerException as System.Exception, output);
                     }
                     output.WriteLine("ok");
                 }

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -226,7 +226,7 @@ public class AllTests : Test.AllTests
             obj.IcePing();
             test(false);
         }
-        catch (Ice.LocalException)
+        catch (System.Exception)
         {
             output.WriteLine("ok");
         }

--- a/csharp/test/Ice/hold/AllTests.cs
+++ b/csharp/test/Ice/hold/AllTests.cs
@@ -58,7 +58,7 @@ namespace Ice
                 }
 
                 public void
-                exception(Ice.Exception ex)
+                exception(System.Exception ex)
                 {
                 }
 

--- a/csharp/test/Ice/hold/HoldI.cs
+++ b/csharp/test/Ice/hold/HoldI.cs
@@ -10,6 +10,7 @@ namespace Ice.hold
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -18,6 +18,7 @@ namespace Ice.interceptor
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/interceptor/MyObjectI.cs
+++ b/csharp/test/Ice/interceptor/MyObjectI.cs
@@ -13,6 +13,7 @@ namespace Ice.interceptor
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -72,7 +72,7 @@ namespace Ice.invoke
                 {
                     result.InputStream.EndEncapsulation();
                 }
-                catch (Exception)
+                catch (System.Exception)
                 {
                     test(false);
                 }
@@ -89,7 +89,7 @@ namespace Ice.invoke
                 {
                     oneway.InvokeAsync(request, oneway: true).Wait();
                 }
-                catch (Exception)
+                catch (System.Exception)
                 {
                     test(false);
                 }
@@ -123,7 +123,7 @@ namespace Ice.invoke
                 {
                     result.InputStream.EndEncapsulation();
                 }
-                catch (Exception)
+                catch (System.Exception)
                 {
                     test(false);
                 }

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -91,7 +91,7 @@ namespace Ice.location
             {
                 obj2.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -105,7 +105,7 @@ namespace Ice.location
             {
                 obj6.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -119,7 +119,7 @@ namespace Ice.location
             {
                 obj3.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -127,7 +127,7 @@ namespace Ice.location
             {
                 obj2.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -137,7 +137,7 @@ namespace Ice.location
             {
                 obj2.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -145,7 +145,7 @@ namespace Ice.location
             {
                 obj3.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -155,7 +155,7 @@ namespace Ice.location
             {
                 obj2.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -165,7 +165,7 @@ namespace Ice.location
             {
                 obj3.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -176,7 +176,7 @@ namespace Ice.location
                 obj5 = Test.ITestIntfPrx.CheckedCast(base5);
                 obj5.IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -325,7 +325,7 @@ namespace Ice.location
                                                 IObjectPrx.Parse($"dummy:{helper.getTestEndpoint(99)}", communicator));
                 IObjectPrx.Parse("test@TestAdapter3", communicator).IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -335,7 +335,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter3", communicator).Clone(locatorCacheTimeout: 0).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
@@ -343,7 +343,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter3", communicator).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             registry.SetAdapterDirectProxy("TestAdapter3", locator.FindAdapterById("TestAdapter"));
@@ -351,7 +351,7 @@ namespace Ice.location
             {
                 IObjectPrx.Parse("test@TestAdapter3", communicator).IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -378,7 +378,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test3", communicator).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             registry.SetAdapterDirectProxy("TestAdapter4", locator.FindAdapterById("TestAdapter"));
@@ -386,7 +386,7 @@ namespace Ice.location
             {
                 IObjectPrx.Parse("test3", communicator).IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -397,7 +397,7 @@ namespace Ice.location
             {
                 IObjectPrx.Parse("test3", communicator).IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -407,7 +407,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter4", communicator).Clone(locatorCacheTimeout: 0).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
@@ -415,7 +415,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter4", communicator).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
@@ -423,7 +423,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test3", communicator).IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             registry.addObject(IObjectPrx.Parse("test3@TestAdapter", communicator));
@@ -431,7 +431,7 @@ namespace Ice.location
             {
                 IObjectPrx.Parse("test3", communicator).IcePing();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -483,7 +483,7 @@ namespace Ice.location
                         System.Threading.Thread.Sleep(10);
                     }
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     // Expected to fail once they endpoints have been updated in the background.
                 }
@@ -495,7 +495,7 @@ namespace Ice.location
                         System.Threading.Thread.Sleep(10);
                     }
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     // Expected to fail once they endpoints have been updated in the background.
                 }
@@ -543,7 +543,7 @@ namespace Ice.location
                 obj2.IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
@@ -551,7 +551,7 @@ namespace Ice.location
                 obj3.IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             try
@@ -559,7 +559,7 @@ namespace Ice.location
                 obj5.IcePing();
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -54,7 +54,7 @@ public class AllTests : Test.AllTests
             }
         }
 
-        public void exception(Ice.Exception ex)
+        public void exception(System.Exception ex)
         {
             response();
         }

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -851,7 +851,7 @@ public class AllTests : Test.AllTests
 
         dm1 = (IceMX.DispatchMetrics)map["opWithLocalException"];
         test(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);
-        checkFailure(serverMetrics, "Dispatch", dm1.Id, "Ice.SyscallException", 1, output);
+        checkFailure(serverMetrics, "Dispatch", dm1.Id, "Ice.InitializationException", 1, output);
         test(dm1.Size == 39 && dm1.ReplySize > 7); // Reply contains the exception stack depending on the OS.
 
         dm1 = (IceMX.DispatchMetrics)map["opWithRequestFailedException"];

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -274,7 +274,7 @@ public class AllTests : Test.AllTests
         {
             proxy.IcePing();
         }
-        catch (Ice.LocalException)
+        catch (System.Exception)
         {
         }
 
@@ -689,7 +689,7 @@ public class AllTests : Test.AllTests
             catch (Ice.ConnectTimeoutException)
             {
             }
-            catch (Ice.LocalException)
+            catch (System.Exception)
             {
                 test(false);
             }
@@ -732,7 +732,7 @@ public class AllTests : Test.AllTests
                 prx.IcePing();
                 prx.GetConnection().Close(ConnectionClose.GracefullyWithWait);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
             }
 
@@ -750,7 +750,7 @@ public class AllTests : Test.AllTests
             {
                 dnsException = true;
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 // Some DNS servers don't fail on unknown DNS names.
             }

--- a/csharp/test/Ice/metrics/MetricsAMDI.cs
+++ b/csharp/test/Ice/metrics/MetricsAMDI.cs
@@ -39,7 +39,7 @@ public sealed class Metrics : IMetrics
     opWithRequestFailedExceptionAsync(Ice.Current current) => throw new Ice.ObjectNotExistException();
 
     public ValueTask
-    opWithLocalExceptionAsync(Ice.Current current) => throw new Ice.SyscallException();
+    opWithLocalExceptionAsync(Ice.Current current) => throw new Ice.InitializationException();
 
     public ValueTask
     opWithUnknownExceptionAsync(Ice.Current current) => throw new ArgumentOutOfRangeException();

--- a/csharp/test/Ice/metrics/MetricsI.cs
+++ b/csharp/test/Ice/metrics/MetricsI.cs
@@ -32,7 +32,7 @@ public sealed class Metrics : IMetrics
 
     public void opWithRequestFailedException(Ice.Current current) => throw new Ice.ObjectNotExistException();
 
-    public void opWithLocalException(Ice.Current current) => throw new Ice.SyscallException();
+    public void opWithLocalException(Ice.Current current) => throw new Ice.InitializationException();
 
     public void opWithUnknownException(Ice.Current current) => throw new ArgumentOutOfRangeException();
 

--- a/csharp/test/Ice/networkProxy/AllTests.cs
+++ b/csharp/test/Ice/networkProxy/AllTests.cs
@@ -59,7 +59,7 @@ public class AllTests : Test.AllTests
                 testPrx.IcePing();
                 test(false);
             }
-            catch (Ice.LocalException)
+            catch (System.Exception)
             {
             }
         }

--- a/csharp/test/Ice/operations/Client.cs
+++ b/csharp/test/Ice/operations/Client.cs
@@ -25,7 +25,7 @@ namespace Ice.operations
                 myClass.Clone(connectionTimeout: 100).IcePing(); // Use timeout to speed up testing on Windows
                 test(false);
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                  Console.Out.WriteLine("ok");
             }

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -24,6 +24,7 @@ namespace Ice.operations
 
             if (prx.GetConnection() != null)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
             AllTests.allTests(this);

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -17,6 +17,7 @@ namespace Ice.operations.AMD
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -15,6 +15,7 @@ namespace Ice.operations
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/operations/OnewaysAMI.cs
+++ b/csharp/test/Ice/operations/OnewaysAMI.cs
@@ -14,6 +14,7 @@ namespace Ice.operations
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -14,6 +14,7 @@ namespace Ice.operations
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -16,6 +16,7 @@ namespace Ice.operations
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/plugin/BasePlugin.cs
+++ b/csharp/test/Ice/plugin/BasePlugin.cs
@@ -14,6 +14,7 @@ public abstract class BasePlugin : Ice.IPlugin
     {
         if (!b)
         {
+            System.Diagnostics.Debug.Assert(false);
             throw new System.Exception();
         }
     }

--- a/csharp/test/Ice/plugin/BasePluginFail.cs
+++ b/csharp/test/Ice/plugin/BasePluginFail.cs
@@ -19,6 +19,7 @@ public abstract class BasePluginFail : Ice.IPlugin
     {
         if (!b)
         {
+            System.Diagnostics.Debug.Assert(false);
             throw new System.Exception();
         }
     }

--- a/csharp/test/Ice/plugin/PluginInitializeFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginInitializeFailFactory.cs
@@ -16,6 +16,7 @@ public class PluginInitializeFailFactory : Ice.IPluginFactory
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/seqMapping/Custom.cs
+++ b/csharp/test/Ice/seqMapping/Custom.cs
@@ -84,7 +84,7 @@ namespace Ice.seqMapping
                 }
                 return true;
             }
-            catch (Exception)
+            catch (System.Exception)
             {
                 return false;
             }

--- a/csharp/test/Ice/seqMapping/Twoways.cs
+++ b/csharp/test/Ice/seqMapping/Twoways.cs
@@ -13,6 +13,7 @@ namespace Ice.seqMapping
         {
             if (!b)
             {
+                System.Diagnostics.Debug.Assert(false);
                 throw new System.Exception();
             }
         }

--- a/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
@@ -14,6 +14,7 @@ public sealed class TestIntf : ITestIntf
     {
         if (!b)
         {
+            System.Diagnostics.Debug.Assert(false);
             throw new System.Exception();
         }
     }

--- a/csharp/test/Ice/slicing/exceptions/TestI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestI.cs
@@ -12,6 +12,7 @@ public sealed class TestIntf : ITestIntf
     {
         if (!b)
         {
+            System.Diagnostics.Debug.Assert(false);
             throw new System.Exception();
         }
     }

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -34,7 +34,7 @@ namespace Ice.timeout
             {
                 allTestsWithController(helper, controller);
             }
-            catch (Exception)
+            catch (System.Exception)
             {
                 // Ensure the adapter is not in the holding state when an unexpected exception occurs to prevent
                 // the test from hanging on exit in case a connection which disables timeouts is still opened.

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -234,7 +234,7 @@ namespace Ice.timeout
                 {
                     _ = connection.GetConnectionInfo(); // getInfo() doesn't throw in the closing state.
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                     test(false);
                 }

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -143,7 +143,7 @@ namespace Ice.udp
                 catch (DatagramLimitException)
                 {
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.Out.WriteLine(ex);
                     test(false);

--- a/csharp/test/Ice/udp/TestIntfI.cs
+++ b/csharp/test/Ice/udp/TestIntfI.cs
@@ -20,7 +20,7 @@ namespace Ice.udp
             {
                 reply.reply();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 Debug.Assert(false);
             }
@@ -32,7 +32,7 @@ namespace Ice.udp
             {
                 reply.reply();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 Debug.Assert(false);
             }
@@ -58,7 +58,7 @@ namespace Ice.udp
 
                 current.Connection.CreateProxy(id, Test.IPingReplyPrx.Factory).reply();
             }
-            catch (LocalException)
+            catch (System.Exception)
             {
                 Debug.Assert(false);
             }

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -215,7 +215,7 @@ public class AllTests : Test.AllTests
                     IObjectPrx.Parse("controller0@control0", comm).IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 comm.Destroy();

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -21,6 +21,7 @@ public class AllTests
     {
         if (!b)
         {
+            System.Diagnostics.Debug.Assert(false);
             throw new System.Exception();
         }
     }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -149,7 +149,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -180,7 +180,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -211,7 +211,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -240,7 +240,7 @@ public class AllTests
                     server.noCert();
                     test(!((IceSSL.ConnectionInfo)server.GetConnection().GetConnectionInfo()).Verified);
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -264,7 +264,7 @@ public class AllTests
                     server.noCert();
                     test(((IceSSL.ConnectionInfo)server.GetConnection().GetConnectionInfo()).Verified);
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -285,7 +285,7 @@ public class AllTests
                 {
                     server.noCert();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -308,7 +308,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -393,7 +393,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -425,7 +425,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -447,7 +447,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -474,7 +474,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -495,7 +495,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -531,7 +531,7 @@ public class AllTests
                         {
                             server.IcePing();
                         }
-                        catch (Ice.LocalException ex)
+                        catch (System.Exception ex)
                         {
                             //
                             // macOS catalina does not check the certificate common name
@@ -586,7 +586,7 @@ public class AllTests
                         {
                             server.IcePing();
                         }
-                        catch (Ice.LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -670,7 +670,7 @@ public class AllTests
                         {
                             server.IcePing();
                         }
-                        catch(Ice.LocalException)
+                        catch(System.Exception)
                         {
                             test(false);
                         }
@@ -753,7 +753,7 @@ public class AllTests
                             IceSSL.ConnectionInfo info = (IceSSL.ConnectionInfo)server.GetConnection().GetConnectionInfo();
                             test(!info.Verified);
                         }
-                        catch (LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -779,7 +779,7 @@ public class AllTests
                         {
                             server.IcePing();
                         }
-                        catch (LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -836,7 +836,7 @@ public class AllTests
                         test(info.Certs!.Length == 1);
                         test(!info.Verified);
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         Console.WriteLine(ex.ToString());
                         test(false);
@@ -856,7 +856,7 @@ public class AllTests
                         test(info.Certs!.Length == 1);
                         test(!info.Verified);
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         Console.WriteLine(ex.ToString());
                         test(false);
@@ -876,7 +876,7 @@ public class AllTests
                         info = (IceSSL.ConnectionInfo)server.GetConnection().GetConnectionInfo();
                         test(info.Certs!.Length == 1); // Like the SChannel transport, .NET never sends the root.
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         Console.WriteLine(ex.ToString());
                         test(false);
@@ -903,7 +903,7 @@ public class AllTests
                             test(info.Certs!.Length == 2);
                             test(info.Verified);
                         }
-                        catch (LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -934,7 +934,7 @@ public class AllTests
                         {
                             // Chain length too long
                         }
-                        catch (Ice.LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -970,7 +970,7 @@ public class AllTests
                                 test(info.Certs!.Length == 3);
                                 test(info.Verified);
                             }
-                            catch (Ice.LocalException ex)
+                            catch (System.Exception ex)
                             {
                                 Console.WriteLine(ex.ToString());
                                 test(false);
@@ -1015,7 +1015,7 @@ public class AllTests
                                 test(info.Certs!.Length == 4);
                                 test(info.Verified);
                             }
-                            catch (Ice.LocalException ex)
+                            catch (System.Exception ex)
                             {
                                 Console.WriteLine(ex.ToString());
                                 test(false);
@@ -1051,7 +1051,7 @@ public class AllTests
                             {
                                 // Expected
                             }
-                            catch (LocalException ex)
+                            catch (System.Exception ex)
                             {
                                 Console.WriteLine(ex.ToString());
                                 test(false);
@@ -1068,7 +1068,7 @@ public class AllTests
                             {
                                 server.GetConnection();
                             }
-                            catch (LocalException ex)
+                            catch (System.Exception ex)
                             {
                                 Console.WriteLine(ex.ToString());
                                 test(false);
@@ -1112,7 +1112,7 @@ public class AllTests
                     Debug.Assert(info.Cipher != null);
                     server.checkCipher(info.Cipher);
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1136,7 +1136,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1189,7 +1189,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1210,7 +1210,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     if (ex.ToString().IndexOf("no protocols available") < 0) // Expected if TLS1.1 is disabled (RHEL8)
                     {
@@ -1236,7 +1236,7 @@ public class AllTests
                     fact.destroyServer(server);
                     comm.Destroy();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1265,7 +1265,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.Out.Write(ex.ToString());
                     test(false);
@@ -1291,7 +1291,7 @@ public class AllTests
                 {
                     // Expected.
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.Out.Write(ex.ToString());
                     test(false);
@@ -1324,7 +1324,7 @@ public class AllTests
                     {
                         server.IcePing();
                     }
-                    catch (LocalException ex)
+                    catch (System.Exception ex)
                     {
                         Console.WriteLine(ex.ToString());
                         test(false);
@@ -1350,7 +1350,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1375,7 +1375,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1444,7 +1444,7 @@ public class AllTests
                 {
                     comm.InitializePlugins();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1482,7 +1482,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1504,7 +1504,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1523,7 +1523,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1544,7 +1544,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1566,7 +1566,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1584,7 +1584,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1605,7 +1605,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1623,7 +1623,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1644,7 +1644,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1663,7 +1663,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1682,7 +1682,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1701,7 +1701,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1719,7 +1719,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1739,7 +1739,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1760,7 +1760,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1778,7 +1778,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1798,7 +1798,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1822,7 +1822,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1844,7 +1844,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1870,7 +1870,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1892,7 +1892,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1911,7 +1911,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1932,7 +1932,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -1950,7 +1950,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -1978,7 +1978,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -2000,7 +2000,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -2019,7 +2019,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -2040,7 +2040,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -2059,7 +2059,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -2083,7 +2083,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -2105,7 +2105,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -2124,7 +2124,7 @@ public class AllTests
                     server.IcePing();
                     test(false);
                 }
-                catch (Ice.LocalException)
+                catch (System.Exception)
                 {
                 }
                 fact.destroyServer(server);
@@ -2142,7 +2142,7 @@ public class AllTests
                 {
                     server.IcePing();
                 }
-                catch (Ice.LocalException ex)
+                catch (System.Exception ex)
                 {
                     Console.WriteLine(ex.ToString());
                     test(false);
@@ -2233,7 +2233,7 @@ public class AllTests
                         {
                             server.IcePing();
                         }
-                        catch (Ice.LocalException ex)
+                        catch (System.Exception ex)
                         {
                             Console.WriteLine(ex.ToString());
                             test(false);
@@ -2326,7 +2326,7 @@ public class AllTests
                         // Expected, by default we don't check for system CAs.
                         break;
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         if ((ex is Ice.ConnectTimeoutException) ||
                            (ex is Ice.SocketException) ||
@@ -2373,7 +2373,7 @@ public class AllTests
                         test(info.Verified);
                         break;
                     }
-                    catch (Ice.LocalException ex)
+                    catch (System.Exception ex)
                     {
                         if ((ex is Ice.ConnectTimeoutException) ||
                            (ex is Ice.SocketException) ||

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -18,7 +18,7 @@ internal sealed class SSLServer : IServer
             IceSSL.ConnectionInfo info = (IceSSL.ConnectionInfo)current.Connection.GetConnectionInfo();
             test(info.Certs == null);
         }
-        catch (Ice.LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -35,7 +35,7 @@ internal sealed class SSLServer : IServer
                  info.Certs[0].Subject.Equals(subjectDN) &&
                  info.Certs[0].Issuer.Equals(issuerDN));
         }
-        catch (Ice.LocalException)
+        catch (System.Exception)
         {
             test(false);
         }
@@ -49,7 +49,7 @@ internal sealed class SSLServer : IServer
             IceSSL.ConnectionInfo info = (IceSSL.ConnectionInfo)current.Connection.GetConnectionInfo();
             test(info.Cipher.Equals(cipher));
         }
-        catch (Ice.LocalException)
+        catch (System.Exception)
         {
             test(false);
         }


### PR DESCRIPTION
This PR removes the `Ice.Exception` and `Ice.LocalException` classes in C# and replaces the corresponding objects by `System.Exception` objects.

It also removes the `Ice.SyscallException` class which was used only for the pattern:
```
try
{

}
catch (System.Exception ex) // last catch
{
    throw new SyscallException(ex);
}
```