### PR TITLE
Removed NotRegisteredException in C#

### DIFF
--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -29,46 +29,6 @@ namespace Ice
     }
 
     /// <summary>
-    /// An attempt was made to find or deregister something that is not
-    /// registered with the Ice run time or Ice locator.
-    /// This exception is raised if an attempt is made to remove a servant,
-    /// servant locator, facet, class factory, plug-in, object adapter,
-    /// object, or user exception factory that is not currently registered.
-    ///
-    /// It's also raised if the Ice locator can't find an object or object
-    /// adapter when resolving an indirect proxy or when an object adapter
-    /// is activated.
-    /// </summary>
-    public class NotRegisteredException : System.Exception
-    {
-        public string KindOfObject;
-        public string Id;
-        public NotRegisteredException()
-        {
-            KindOfObject = "";
-            Id = "";
-        }
-
-        public NotRegisteredException(System.Exception ex) : base("", ex)
-        {
-            KindOfObject = "";
-            Id = "";
-        }
-
-        public NotRegisteredException(string kindOfObject, string id)
-        {
-            KindOfObject = kindOfObject;
-            Id = id;
-        }
-
-        public NotRegisteredException(string kindOfObject, string id, System.Exception ex) : base("", ex)
-        {
-            KindOfObject = kindOfObject;
-            Id = id;
-        }
-    }
-
-    /// <summary>
     /// This exception is raised if the Communicator has been destroyed.
     /// </summary>
     public class CommunicatorDestroyedException : System.Exception
@@ -101,24 +61,6 @@ namespace Ice
     }
 
     /// <summary>
-    /// This exception is raised if an ObjectAdapter cannot be activated.
-    /// This happens if the Locator detects another active ObjectAdapter with
-    /// the same adapter id.
-    /// </summary>
-    public class ObjectAdapterIdInUseException : System.Exception
-    {
-        public string Id;
-
-        public ObjectAdapterIdInUseException() => Id = "";
-
-        public ObjectAdapterIdInUseException(System.Exception ex) : base("", ex) => Id = "";
-
-        public ObjectAdapterIdInUseException(string id) => Id = id;
-
-        public ObjectAdapterIdInUseException(string id, System.Exception ex) : base("", ex) => Id = id;
-    }
-
-    /// <summary>
     /// This exception is raised if no suitable endpoint is available.
     /// </summary>
     public class NoEndpointException : System.Exception
@@ -147,16 +89,6 @@ namespace Ice
         public SocketException(System.Exception ex) : base("", ex)
         {
         }
-    }
-
-    /// <summary>
-    /// This exception indicates file errors.
-    /// </summary>
-    public class FileException : System.Exception
-    {
-        public string Path;
-
-        public FileException(System.Exception ex) : base("", ex) => Path = "";
     }
 
     /// <summary>

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1345,7 +1345,7 @@ namespace Ice
                     {
                         Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat,
                             $"could not update the endpoints of object adapter `{_id}' " +
-                            $" with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
+                            $"with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
                     }
                 }
                 throw;

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1324,42 +1324,6 @@ namespace Ice
                     locatorRegistry.SetReplicatedAdapterDirectProxy(_id, _replicaGroupId, proxy);
                 }
             }
-            catch (AdapterNotFoundException)
-            {
-                if (Communicator.TraceLevels.Location >= 1)
-                {
-                    var s = new StringBuilder();
-                    s.Append($"could not update object adapter `{_id}' endpoints with the locator registry:\n");
-                    s.Append("the object adapter is not known to the locator registry");
-                    Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat, s.ToString());
-                }
-
-                throw new NotRegisteredException("object adapter", _id);
-            }
-            catch (InvalidReplicaGroupIdException)
-            {
-                if (Communicator.TraceLevels.Location >= 1)
-                {
-                    var s = new StringBuilder();
-                    s.Append($"could not update object adapter `{_id}' endpoints with the locator registry:\n");
-                    s.Append($"the replica group `{_replicaGroupId}' is not known to the locator registry");
-                    Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat, s.ToString());
-                }
-
-                throw new NotRegisteredException("replica group", _replicaGroupId);
-            }
-            catch (AdapterAlreadyActiveException)
-            {
-                if (Communicator.TraceLevels.Location >= 1)
-                {
-                    var s = new StringBuilder();
-                    s.Append($"could not update object adapter `{_id}' endpoints with the locator registry:\n");
-                    s.Append("the object adapter endpoints are already set");
-                    Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat, s.ToString());
-                }
-
-                throw new ObjectAdapterIdInUseException(_id);
-            }
             catch (ObjectAdapterDeactivatedException)
             {
                 // Expected if collocated call and OA is deactivated, ignore.
@@ -1368,14 +1332,21 @@ namespace Ice
             {
                 // Ignore
             }
-            catch (System.Exception e)
+            catch (System.Exception ex)
             {
                 if (Communicator.TraceLevels.Location >= 1)
                 {
-                    var s = new StringBuilder();
-                    s.Append($"could not update object adapter `{_id}' endpoints with the locator registry:\n");
-                    s.Append(e.ToString());
-                    Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat, s.ToString());
+                    if (_replicaGroupId.Length == 0)
+                    {
+                        Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat,
+                            $"could not update the endpoints of object adapter `{_id}' in the locator registry:\n{ex}");
+                    }
+                    else
+                    {
+                        Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat,
+                            $"could not update the endpoints of object adapter `{_id}' " +
+                            $" with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
+                    }
                 }
                 throw;
             }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1332,7 +1332,7 @@ namespace Ice
             {
                 // Ignore
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
                 if (Communicator.TraceLevels.Location >= 1)
                 {

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -108,30 +108,17 @@ namespace Ice.admin
                 }
             }
 
-            try
-            {
-                com.RemoveAdminFacet("Bogus");
-                test(false);
-            }
-            catch (NotRegisteredException)
-            {
-                // Expected
-            }
+            var facet = com.RemoveAdminFacet("Bogus");
+            test(facet == null);
 
             if (!filtered)
             {
-                com.RemoveAdminFacet("Facet1");
+                facet = com.RemoveAdminFacet("Facet1");
+                test(facet == f1);
                 com.RemoveAdminFacet("Facet2");
                 com.RemoveAdminFacet("Facet3");
-                try
-                {
-                    com.RemoveAdminFacet("Facet1");
-                    test(false);
-                }
-                catch (NotRegisteredException)
-                {
-                    // Expected
-                }
+                facet = com.RemoveAdminFacet("Facet1");
+                test(facet == null);
             }
         }
 

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -190,10 +190,8 @@ namespace Ice.location
                 @base.IcePing();
                 test(false);
             }
-            catch (NotRegisteredException ex)
+            catch (ObjectNotFoundException)
             {
-                test(ex.KindOfObject.Equals("object"));
-                test(ex.Id.Equals("unknown/unknown"));
             }
             output.WriteLine("ok");
 
@@ -205,10 +203,8 @@ namespace Ice.location
                 @base.IcePing();
                 test(false);
             }
-            catch (NotRegisteredException ex)
+            catch (AdapterNotFoundException)
             {
-                test(ex.KindOfObject.Equals("object adapter"));
-                test(ex.Id.Equals("TestAdapterUnknown"));
             }
             output.WriteLine("ok");
 
@@ -289,7 +285,7 @@ namespace Ice.location
                     {
                         t.Wait();
                     }
-                    catch (AggregateException ex) when (ex.InnerException is Ice.NotRegisteredException)
+                    catch (AggregateException ex) when (ex.InnerException is AdapterNotFoundException)
                     {
                     }
                 }));
@@ -312,10 +308,8 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter3", communicator).IcePing();
                 test(false);
             }
-            catch (NotRegisteredException ex)
+            catch (AdapterNotFoundException)
             {
-                test(ex.KindOfObject == "object adapter");
-                test(ex.Id.Equals("TestAdapter3"));
             }
             registry.SetAdapterDirectProxy("TestAdapter3", locator.FindAdapterById("TestAdapter"));
             try
@@ -335,17 +329,18 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter3", communicator).Clone(locatorCacheTimeout: 0).IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
+
             try
             {
                 IObjectPrx.Parse("test@TestAdapter3", communicator).IcePing();
-                test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
+
             registry.SetAdapterDirectProxy("TestAdapter3", locator.FindAdapterById("TestAdapter"));
             try
             {
@@ -365,10 +360,8 @@ namespace Ice.location
                 IObjectPrx.Parse("test3", communicator).IcePing();
                 test(false);
             }
-            catch (NotRegisteredException ex)
+            catch (AdapterNotFoundException)
             {
-                test(ex.KindOfObject == "object adapter");
-                test(ex.Id.Equals("TestUnknown"));
             }
             registry.addObject(IObjectPrx.Parse("test3@TestAdapter4", communicator)); // Update
             registry.SetAdapterDirectProxy("TestAdapter4",
@@ -378,7 +371,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test3", communicator).IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
             registry.SetAdapterDirectProxy("TestAdapter4", locator.FindAdapterById("TestAdapter"));
@@ -407,7 +400,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter4", communicator).Clone(locatorCacheTimeout: 0).IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
             try
@@ -415,7 +408,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test@TestAdapter4", communicator).IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
             try
@@ -423,7 +416,7 @@ namespace Ice.location
                 IObjectPrx.Parse("test3", communicator).IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (ConnectionRefusedException)
             {
             }
             registry.addObject(IObjectPrx.Parse("test3@TestAdapter", communicator));
@@ -543,7 +536,7 @@ namespace Ice.location
                 obj2.IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (AdapterNotFoundException)
             {
             }
             try
@@ -551,7 +544,7 @@ namespace Ice.location
                 obj3.IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (AdapterNotFoundException)
             {
             }
             try
@@ -559,7 +552,7 @@ namespace Ice.location
                 obj5.IcePing();
                 test(false);
             }
-            catch (System.Exception)
+            catch (AdapterNotFoundException)
             {
             }
             output.WriteLine("ok");

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -229,10 +229,9 @@ public class AllTests : Test.AllTests
             IObjectPrx.Parse("unknown/unknown", communicator).IcePing();
             test(false);
         }
-        catch (NotRegisteredException ex)
+        catch (ObjectNotFoundException)
         {
-            test(ex.KindOfObject.Equals("object"));
-            test(ex.Id.Equals("unknown/unknown"));
+            // expected
         }
         Console.Out.WriteLine("ok");
 
@@ -243,10 +242,9 @@ public class AllTests : Test.AllTests
             IObjectPrx.Parse("test @ TestAdapterUnknown", communicator).IcePing();
             test(false);
         }
-        catch (NotRegisteredException ex)
+        catch (AdapterNotFoundException)
         {
-            test(ex.KindOfObject.Equals("object adapter"));
-            test(ex.Id.Equals("TestAdapterUnknown"));
+            // expected
         }
         Console.Out.WriteLine("ok");
 


### PR DESCRIPTION
Also removed `FileException` and `ObjectAdapterIdInUseException`.

With this PR, various Ice remote exceptions defined in `Locator.ice` that used to be converted into the removed local exceptions (mostly `NotRegisteredException`) are simply not converted now.

This PR makes `AddAdminFacet` and `RemoveAdminFacet` more consistent the corresponds `ObjectAdapter` methods.