### PR TITLE
Update remote exceptions to use Message from System.Exception

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1567,7 +1567,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     _out << sp;
 
-    // TODO: remove this parameter-less constructor used by unmarshaling code.
+    // Parameterless constructor - all exceptions derived from System.Exception should provide such a constructor.
     emitGeneratedCodeAttribute();
     _out << nl << "public " << name << "()";
     _out << sb;

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -783,8 +783,7 @@ namespace IceInternal
                     case ReplyStatus.UnknownLocalException:
                     case ReplyStatus.UnknownUserException:
                         {
-                            string unknown = Is.ReadString();
-                            throw new UnhandledException(Ice.Identity.Empty, "", "", unknown);
+                            throw new UnhandledException(Is.ReadString(), Ice.Identity.Empty, "", "");
                         }
 
                     default:

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -123,14 +123,7 @@ namespace Ice
                 else
                 {
                     WriteByte((byte)ReplyStatus.UnknownLocalException);
-                    if (requestFailedException.IceMessage.Length > 0)
-                    {
-                        WriteString(requestFailedException.IceMessage);
-                    }
-                    else
-                    {
-                        WriteString(requestFailedException.ToString());
-                    }
+                    WriteString(requestFailedException.Message);
                 }
             }
             else

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -19,22 +19,35 @@ namespace Ice
         /// in a remote server.</summary>
         public bool ConvertToUnhandled { get; set; } = false;
 
+        /// <summary>When true, a custom message was provided to the constructor. Otherwise, false.</summary>
+        protected bool HasCustomMessage { get; } = false;
+
         protected SlicedData? IceSlicedData { get; set; }
+
         internal SlicedData? SlicedData => IceSlicedData;
 
         internal RemoteException(SlicedData slicedData) => IceSlicedData = slicedData;
 
-        /// <summary>Creates a default-initialized remote exception.</summary>
+        /// <summary>Constructs a remote exception with the default system message.</summary>
         protected RemoteException()
         {
         }
 
-        /// <summary>Creates a default-initialized remote exception and sets the InnerException property to the passed
-        /// exception.</summary>
-        /// <param name="innerException">The inner exception.</param>
-        protected RemoteException(System.Exception innerException)
-            : base("", innerException)
+        /// <summary>Constructs a remote exception with the provided message.</summary>
+        /// <param name="message">Message that describes the exception.</param>
+        protected RemoteException(string message)
+            : base(message)
         {
+            HasCustomMessage = true;
+        }
+
+        /// <summary>Constructs a remote exception with the provided message and inner exception.</summary>
+        /// <param name="message">Message that describes the exception.</param>
+        /// <param name="innerException">The inner exception.</param>
+        protected RemoteException(string message, System.Exception innerException)
+            : base(message, innerException)
+        {
+            HasCustomMessage = true;
         }
 
         /// <summary>Initializes a new instance of the remote exception with serialized data.</summary>

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -13,18 +13,23 @@ namespace Ice
     [Serializable]
     public class RemoteException : System.Exception
     {
+        public override string Message => _hasCustomMessage || DefaultMessage == null ? base.Message : DefaultMessage;
+
         /// <summary>When true, if this exception is thrown from the implementation of an operation, Ice will convert
         /// it into an Ice.UnhandledException. When false, Ice marshals this remote exception as-is. true is the
         /// default for exceptions unmarshaled by Ice, while false is the default for exceptions that did not originate
         /// in a remote server.</summary>
         public bool ConvertToUnhandled { get; set; } = false;
 
-        /// <summary>When true, a custom message was provided to the constructor. Otherwise, false.</summary>
-        protected bool HasCustomMessage { get; } = false;
+        /// <summary>When DefaultMessage is not null and the application does construct the exception with a constructor
+        /// that takes a message parameter, Message returns DefaultMessage. This property should be overridden in
+        /// derived partial exception classes that provide a custom default message.</summary>
+        protected virtual string? DefaultMessage => null;
 
         protected SlicedData? IceSlicedData { get; set; }
-
         internal SlicedData? SlicedData => IceSlicedData;
+
+        private readonly bool _hasCustomMessage = false;
 
         internal RemoteException(SlicedData slicedData) => IceSlicedData = slicedData;
 
@@ -38,7 +43,7 @@ namespace Ice
         protected RemoteException(string message)
             : base(message)
         {
-            HasCustomMessage = true;
+            _hasCustomMessage = true;
         }
 
         /// <summary>Constructs a remote exception with the provided message and inner exception.</summary>
@@ -47,7 +52,7 @@ namespace Ice
         protected RemoteException(string message, System.Exception innerException)
             : base(message, innerException)
         {
-            HasCustomMessage = true;
+            _hasCustomMessage = true;
         }
 
         /// <summary>Initializes a new instance of the remote exception with serialized data.</summary>

--- a/csharp/src/Ice/RequestFailedException.cs
+++ b/csharp/src/Ice/RequestFailedException.cs
@@ -10,20 +10,9 @@ namespace Ice
 
     public partial class RequestFailedException
     {
-        protected virtual string DefaultMessage
+        protected override string DefaultMessage
             => Facet.Length == 0 ? $"request for operation `{Operation}' on Ice object `{Id}' failed"
                 : $"request for operation `{Operation}' on Ice object `{Id}' with facet `{Facet}' failed";
-
-        public override string Message => HasCustomMessage ? base.Message : DefaultMessage;
-
-        public RequestFailedException(string message, Identity id, string facet, string operation,
-                                      Exception innerException)
-            : base(message, innerException)
-        {
-            Id = id;
-            Facet = facet;
-            Operation = operation;
-        }
     }
 
     public partial class ObjectNotExistException

--- a/csharp/src/Ice/RequestFailedException.cs
+++ b/csharp/src/Ice/RequestFailedException.cs
@@ -10,58 +10,54 @@ namespace Ice
 
     public partial class RequestFailedException
     {
-        protected virtual string DefaultIceMessage
+        protected virtual string DefaultMessage
             => Facet.Length == 0 ? $"request for operation `{Operation}' on Ice object `{Id}' failed"
                 : $"request for operation `{Operation}' on Ice object `{Id}' with facet `{Facet}' failed";
 
-        public override string Message => IceMessage.Length > 0 ? IceMessage : DefaultIceMessage;
+        public override string Message => HasCustomMessage ? base.Message : DefaultMessage;
 
-        public RequestFailedException(Identity id, string facet, string operation,
-                                      System.Exception innerException)
-            : base(innerException)
+        public RequestFailedException(string message, Identity id, string facet, string operation,
+                                      Exception innerException)
+            : base(message, innerException)
         {
             Id = id;
             Facet = facet;
             Operation = operation;
-            IceMessage = "";
         }
     }
 
     public partial class ObjectNotExistException
     {
-        protected override string DefaultIceMessage
+        protected override string DefaultMessage
             => $"could not find servant for Ice object `{Id}'" + (Facet.Length > 0 ? $" with facet `{Facet}'" : "") +
                 $" while attempting to call operation `{Operation}'";
-
-        public ObjectNotExistException(Identity id, string facet, string operation)
-            : base(id, facet, operation, "")
-        {
-        }
     }
 
     public partial class OperationNotExistException
     {
-        protected override string DefaultIceMessage
+        protected override string DefaultMessage
             => $"could not find operation `{Operation}' for Ice object `{Id}'" +
                 (Facet.Length > 0 ? $" with facet `{Facet}'" : "");
-
-        public OperationNotExistException(Identity id, string facet, string operation)
-            : base(id, facet, operation, "")
-        {
-        }
     }
 
     public partial class UnhandledException
     {
-        public UnhandledException(Identity id, string facet, string operation, System.Exception innerException)
-            : base(id, facet, operation, innerException)
+        public UnhandledException(Identity id, string facet, string operation, Exception innerException)
+            : base(CustomMessage(id, facet, operation, innerException), id, facet, operation, innerException)
         {
-            IceMessage = $"unhandled exception while calling `{Operation}' on Ice object `{Id}'";
-            if (Facet.Length > 0)
+        }
+
+        private static string CustomMessage(Identity id, string facet, string operation, Exception innerException)
+        {
+            string message = $"unhandled exception while calling `{operation}' on Ice object `{id}'";
+            if (facet.Length > 0)
             {
-                IceMessage += $" with facet `{Facet}'";
+                message += $" with facet `{facet}'";
             }
-            IceMessage += $":\n {innerException}";
+            // Since this custom message will be sent "over the wire", we don't include the stack trace of the inner
+            // exception since it can include sensitive information. The stack trace is of course available locally.
+            message += $":\n{innerException.Message}";
+            return message;
         }
     }
 }

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -386,6 +386,7 @@ namespace Ice.exceptions
                 catch (ObjectNotExistException ex)
                 {
                     test(ex.Id.Equals(id));
+                    test(ex.Message.Contains("servant")); // verify we don't get system message
                 }
                 catch (System.Exception)
                 {
@@ -409,6 +410,7 @@ namespace Ice.exceptions
                 catch (ObjectNotExistException ex)
                 {
                     test(ex.Facet.Equals("no such facet"));
+                    test(ex.Message.Contains("with facet")); // verify we don't get system message
                 }
             }
             catch (System.Exception)
@@ -430,6 +432,7 @@ namespace Ice.exceptions
             catch (OperationNotExistException ex)
             {
                 test(ex.Operation.Equals("noSuchOperation"));
+                test(ex.Message.Contains("could not find operation")); // verify we don't get system message
             }
             catch (System.Exception)
             {
@@ -446,8 +449,9 @@ namespace Ice.exceptions
                 thrower.throwLocalException();
                 test(false);
             }
-            catch (UnhandledException)
+            catch (UnhandledException ex)
             {
+                 test(ex.Message.Contains("unhandled exception")); // verify we get custom message
             }
             catch (System.Exception)
             {
@@ -476,7 +480,7 @@ namespace Ice.exceptions
                 thrower.throwNonIceException();
                 test(false);
             }
-            catch (UnhandledException)
+            catch (UnhandledException ex)
             {
             }
             catch (System.Exception)

--- a/slice/Ice/RequestFailedException.ice
+++ b/slice/Ice/RequestFailedException.ice
@@ -26,7 +26,6 @@ module Ice
         Identity id;
         string facet;
         string operation;
-        string message; // TODO: switch to an optional string
     }
 
     // A dispatch exception is an exception that occurs during the server-side request dispatch before the operation


### PR DESCRIPTION
Before this PR, Ice ignored System.Exception.Message and set it to "".

This PR adds support for message in RemoteException and generated derived exceptions.

This PR also removes the message member of `RequestFailedException`, which is "replaced" by this System.Exception message.