### PR TITLE
Replace C# ProtocolException and derived exception classes by

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2055,8 +2055,8 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
         _out << nl << "if(value < 0 || value > " << p->maxValue() << ")";
     }
     _out << sb;
-    _out << nl << "throw new Ice.MarshalException($\"invalid enumerator value `{value}' for " << fixId(p->scoped())
-         << "\");";
+    _out << nl << "throw new Ice.InvalidDataException($\"invalid enumerator value `{value}' for "
+        << fixId(p->scoped()) << "\");";
     _out << eb;
     _out << nl << "return (" << name << ") value;";
     _out << eb;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1135,7 +1135,7 @@ namespace Ice
             {
                 if (facetPath.Length > 1)
                 {
-                    throw new ProxyUnmarshalException();
+                    throw new InvalidDataException($"invalid facet path length: {facetPath.Length}");
                 }
                 facet = facetPath[0];
             }
@@ -1147,7 +1147,7 @@ namespace Ice
             int mode = s.ReadByte();
             if (mode < 0 || mode > (int)InvocationMode.Last)
             {
-                throw new ProxyUnmarshalException();
+                throw new InvalidDataException($"invalid invocation mode: {mode}");
             }
 
             bool secure = s.ReadBool();
@@ -1156,7 +1156,7 @@ namespace Ice
             byte minor = s.ReadByte();
             if (minor != 0)
             {
-                throw new ProxyUnmarshalException($"received proxy with protocol set to {major}.{minor}");
+                throw new InvalidDataException($"received proxy with protocol set to {major}.{minor}");
             }
             var protocol = (Protocol)major;
 
@@ -1705,7 +1705,7 @@ namespace Ice
             //
             // There is no point in retrying an operation that resulted in a
             // MarshalException. This must have been raised locally (because if
-            // it happened in a server it would result in an UnknownLocalException
+            // it happened in a server it would result in a remote exception
             // instead), which means there was a problem in this process that will
             // not change if we try again.
             //
@@ -1858,7 +1858,7 @@ namespace Ice
             {
                 // First attempt corresponds to no cs:namespace metadata in the
                 // enclosing top-level module
-                string className = TypeToClass(typeId);
+                string className = TypeIdToClassName(typeId);
                 Type? classType = AssemblyUtil.FindType(className);
 
                 // If this fails, look for helper classes in the typeIdNamespaces namespace(s)
@@ -2064,13 +2064,13 @@ namespace Ice
             }
         }
 
-        private static string TypeToClass(string id)
+        private static string TypeIdToClassName(string typeId)
         {
-            if (!id.StartsWith("::", StringComparison.Ordinal))
+            if (!typeId.StartsWith("::", StringComparison.Ordinal))
             {
-                throw new MarshalException("expected type id but received `" + id + "'");
+                throw new InvalidDataException($"`{typeId}' is not a valid Ice type ID");
             }
-            return id.Substring(2).Replace("::", ".");
+            return typeId.Substring(2).Replace("::", ".");
         }
 
         private void AddAllAdminFacets()

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -249,7 +249,7 @@ namespace IceInternal
                 }
                 catch (RetryException ex)
                 {
-                    exception = ex.Get();
+                    exception = ex.InnerException;
 
                     // Remove the request handler before retrying.
                     _reference.GetCommunicator().RemoveRequestHandler(_reference, this);

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -2028,14 +2028,14 @@ namespace Ice
                     if (messageType != Ice1Definitions.ValidateConnectionMessage)
                     {
                         throw new InvalidDataException(@$"received ice1 frame with message type `{messageType
-                            }' before receiving frame with ValidateConnectionMessage");
+                            }' before receiving the validate connection message");
                     }
 
                     int size = InputStream.ReadInt(_readBuffer.Slice(10, 4));
                     if (size != Ice1Definitions.HeaderSize)
                     {
                         throw new InvalidDataException(
-                            $"received an ice1 frame with ValidateConnectionMessage and a size of `{size}' bytes");
+                            $"received an ice1 frame with validate connection type and a size of `{size}' bytes");
                     }
                 }
             }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -401,7 +401,7 @@ namespace Ice
             lock (this)
             {
                 //
-                // If the exception is closed before we even have a chance
+                // If the exception is thrown before we even have a chance
                 // to send our request, we always try to send the request
                 // again.
                 //
@@ -573,16 +573,9 @@ namespace Ice
                 }
                 catch (RetryException ex)
                 {
-                    try
+                    if (Exception(ex.InnerException))
                     {
-                        throw ex.Get();
-                    }
-                    catch (System.Exception ee)
-                    {
-                        if (Exception(ee))
-                        {
-                            InvokeExceptionAsync();
-                        }
+                        InvokeExceptionAsync();
                     }
                 }
                 catch (Exception ex)
@@ -954,19 +947,21 @@ namespace Ice
                                     //
                                     // This situation is possible for small UDP packets.
                                     //
-                                    throw new IllegalMessageSizeException();
+                                    throw new InvalidDataException(
+                                        $"received packet with only {_readBufferOffset} bytes");
                                 }
 
                                 Ice1Definitions.CheckHeader(_readBuffer.AsSpan(0, 8));
                                 int size = InputStream.ReadInt(_readBuffer.Slice(10, 4));
                                 if (size < Ice1Definitions.HeaderSize)
                                 {
-                                    throw new IllegalMessageSizeException();
+                                    throw new InvalidDataException($"received ice1 frame with only {size} bytes");
                                 }
 
                                 if (size > _messageSizeMax)
                                 {
-                                    Ex.ThrowMemoryLimitException(size, _messageSizeMax);
+                                    throw new Ice.InvalidDataException(
+                                        $"frame with {size} bytes exceeds Ice.MessageSizeMax value");
                                 }
 
                                 if (_endpoint.Datagram() && size > _readBufferOffset)
@@ -2032,13 +2027,15 @@ namespace Ice
                     byte messageType = _readBuffer[8];
                     if (messageType != Ice1Definitions.ValidateConnectionMessage)
                     {
-                        throw new ConnectionNotValidatedException();
+                        throw new InvalidDataException(@$"received ice1 frame with message type `{messageType
+                            }' before receiving frame with ValidateConnectionMessage");
                     }
 
                     int size = InputStream.ReadInt(_readBuffer.Slice(10, 4));
                     if (size != Ice1Definitions.HeaderSize)
                     {
-                        throw new IllegalMessageSizeException();
+                        throw new InvalidDataException(
+                            $"received an ice1 frame with ValidateConnectionMessage and a size of `{size}' bytes");
                     }
                 }
             }
@@ -2383,8 +2380,10 @@ namespace Ice
                                 info.InvokeNum = info.Stream.ReadInt();
                                 if (info.InvokeNum < 0)
                                 {
+                                    var invokeNum = info.InvokeNum;
                                     info.InvokeNum = 0;
-                                    throw new UnmarshalOutOfBoundsException();
+                                    throw new InvalidDataException(
+                                        $"received ice1 RequestBatchMessage with {invokeNum} batch requests");
                                 }
                                 info.Adapter = _adapter;
                                 info.MessageDispatchCount += info.InvokeNum;
@@ -2440,7 +2439,8 @@ namespace Ice
                         {
                             TraceUtil.Trace("received unknown message\n(invalid, closing connection)",
                                             info.Stream, _logger, _traceLevels);
-                            throw new UnknownMessageException();
+                            throw new InvalidDataException(
+                                $"received ice1 frame with unknown message type `{messageType}'");
                         }
                 }
             }

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -30,7 +30,7 @@ namespace Ice
             string[] facetPath = request.ReadStringArray();
             if (facetPath.Length > 1)
             {
-                throw new MarshalException();
+                throw new InvalidDataException($"invalid facet path length: {facetPath.Length}");
             }
             Facet = facetPath.Length == 0 ? "" : facetPath[0];
             Operation = request.ReadString();

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -107,7 +107,8 @@ namespace Ice
             // TODO: add 2.0
             if (this != V1_1)
             {
-                throw new UnsupportedEncodingException("", this, V1_1);
+                throw new NotSupportedException(
+                    $"Ice encoding `{ToString()}' is not supported by this Ice runtime");
             }
         }
     }

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -108,7 +108,7 @@ namespace Ice
             if (this != V1_1)
             {
                 throw new NotSupportedException(
-                    $"Ice encoding `{ToString()}' is not supported by this Ice runtime");
+                    $"Ice encoding `{ToString()}' is not supported by this Ice runtime ({Util.StringVersion()})");
             }
         }
     }

--- a/csharp/src/Ice/Exception.cs
+++ b/csharp/src/Ice/Exception.cs
@@ -8,38 +8,11 @@ using System.Runtime.Serialization;
 
 namespace IceInternal
 {
-    internal class Ex
-    {
-        // UOE = UnknownObjectException as in unknown class. TODO: fix/remove.
-        internal static void ThrowUOE(Type expectedType, Ice.AnyClass v)
-        {
-            // If the object is an unknown sliced object, we didn't find an
-            // class factory, in this case raise a NoClassFactoryException
-            // instead.
-            if (v is Ice.UnknownSlicedClass usv)
-            {
-                throw new Ice.NoClassFactoryException("", usv.TypeId ?? "");
-            }
-
-            string typeId = Ice.TypeExtensions.GetIceTypeId(v.GetType())!;
-            string expectedTypeId = Ice.TypeExtensions.GetIceTypeId(expectedType)!;
-            throw new Ice.UnexpectedObjectException(
-                $"expected element of type `{expectedTypeId}' but received `{typeId}'", typeId, expectedTypeId);
-        }
-
-        internal static void ThrowMemoryLimitException(int requested, int maximum)
-        {
-            throw new Ice.MemoryLimitException(
-                $"requested {requested} bytes, maximum allowed is {maximum} bytes (see Ice.MessageSizeMax)");
-        }
-    }
-
     public class RetryException : Exception
     {
-        internal RetryException(System.Exception ex) => _ex = ex;
-
-        internal System.Exception Get() => _ex;
-
-        private readonly System.Exception _ex;
+        internal RetryException(Exception innerException)
+            : base("", innerException)
+        {
+        }
     }
 }

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -65,7 +65,7 @@ namespace Ice
         {
             if (current.IsIdempotent)
             {
-                throw new MarshalException(
+                throw new InvalidDataException(
                         $@"idempotent mistmatch for operation `{current.Operation
                         }': received request marked idempotent for a non-idempotent operation");
             }

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -71,23 +71,28 @@ namespace Ice
             Debug.Assert(header.Length >= 8);
             if (header[0] != Magic[0] || header[1] != Magic[1] || header[2] != Magic[2] || header[3] != Magic[3])
             {
-                throw new BadMagicException("Received incorrect magic bytes in ice1 header",
-                    header.Slice(0, 4).ToArray());
+                throw new InvalidDataException(
+                    $"received incorrect magic bytes in header of ice1 frame: {BytesToString(header.Slice(0, 4))}");
             }
 
             header = header.Slice(4);
 
             if (header[0] != ProtocolBytes[0] || header[1] != ProtocolBytes[1])
             {
-                throw new ProtocolException(
-                    $"received ice1 protocol frame with protocol set to {header[0]}.{header[1]}");
+                throw new InvalidDataException(
+                    $"received ice1 protocol frame with protocol set to {BytesToString(header.Slice(0, 2))}");
             }
 
             if (header[2] != ProtocolBytes[2] || header[3] != ProtocolBytes[3])
             {
-                throw new ProtocolException(
-                    $"received ice1 protocol frame with protocol encoding set to {header[2]}.{header[3]}");
+                throw new InvalidDataException(
+                    $"received ice1 protocol frame with protocol encoding set to {BytesToString(header.Slice(2, 2))}");
             }
+        }
+
+        private static string BytesToString(Span<byte> bytes)
+        {
+            return BitConverter.ToString(bytes.ToArray());
         }
     }
 }

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -90,9 +90,6 @@ namespace Ice
             }
         }
 
-        private static string BytesToString(Span<byte> bytes)
-        {
-            return BitConverter.ToString(bytes.ToArray());
-        }
+        private static string BytesToString(Span<byte> bytes) => BitConverter.ToString(bytes.ToArray());
     }
 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -69,7 +69,7 @@ namespace Ice
                 if (value < 0 || value > _buffer.Count)
                 {
                     throw new ArgumentOutOfRangeException(nameof(Pos),
-                        "the position value is outside the buffer bounds.");
+                        "the position value is outside the buffer bounds");
                 }
                 _pos = value;
             }

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -246,6 +246,50 @@ namespace Ice
         }
     }
 
+    /// <summary>This exception reports that data (bytes) received by Ice are not in an expected format.</summary>
+    [Serializable]
+    public class InvalidDataException : Exception
+    {
+        public InvalidDataException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidDataException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected InvalidDataException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    /// <summary>This exception reports an error that occurred while marshaling data into a sequence of bytes.</summary>
+    [Serializable]
+    public class MarshalException : Exception
+    {
+        public MarshalException(string message)
+            : base(message)
+        {
+        }
+
+        public MarshalException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected MarshalException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    //
+    // TODO: all remaining exceptions below need to be refactored
+    //
+
     /// <summary>
     /// This exception indicates a timeout condition.
     /// </summary>
@@ -337,185 +381,6 @@ namespace Ice
     }
 
     /// <summary>
-    /// A generic exception base for all kinds of protocol error
-    /// conditions.
-    /// </summary>
-    public class ProtocolException : Exception
-    {
-        public string Reason;
-
-        public ProtocolException() => Reason = "";
-
-        public ProtocolException(Exception ex) : base("", ex) => Reason = "";
-
-        public ProtocolException(string reason) => Reason = reason;
-
-        public ProtocolException(string reason, Exception ex) : base("", ex) => Reason = reason;
-    }
-
-    /// <summary>
-    /// This exception indicates that a message did not start with the expected
-    /// magic number ('I', 'c', 'e', 'P').
-    /// </summary>
-    public class BadMagicException : ProtocolException
-    {
-        public byte[] BadMagic;
-
-        public BadMagicException() => BadMagic = System.Array.Empty<byte>();
-
-        public BadMagicException(Exception ex) : base(ex) => BadMagic = System.Array.Empty<byte>();
-
-        public BadMagicException(string reason, byte[] badMagic) : base(reason) => BadMagic = badMagic;
-
-        public BadMagicException(string reason, byte[] badMagic, Exception ex) : base(reason, ex) => BadMagic = badMagic;
-    }
-
-    /// <summary>
-    /// This exception indicates an unsupported protocol version.
-    /// </summary>
-    public class UnsupportedProtocolException : ProtocolException
-    {
-
-        public Protocol Bad;
-        public Protocol Supported;
-
-        public UnsupportedProtocolException(string reason, Protocol bad, Protocol supported) : base(reason)
-        {
-            Bad = bad;
-            Supported = supported;
-        }
-
-        public UnsupportedProtocolException(string reason, Protocol bad, Protocol supported, Exception ex) : base(reason, ex)
-        {
-            Bad = bad;
-            Supported = supported;
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates an unsupported data encoding version.
-    /// </summary>
-    public class UnsupportedEncodingException : ProtocolException
-    {
-        public Encoding Bad;
-        public Encoding Supported;
-
-        public UnsupportedEncodingException()
-        {
-            Bad = default;
-            Supported = default;
-        }
-
-        public UnsupportedEncodingException(Exception ex) : base(ex)
-        {
-            Bad = default;
-            Supported = default;
-        }
-
-        public UnsupportedEncodingException(string reason, Encoding bad, Encoding supported) : base(reason)
-        {
-            Bad = bad;
-            Supported = supported;
-        }
-
-        public UnsupportedEncodingException(string reason, Encoding bad, Encoding supported, Exception ex) : base(reason, ex)
-        {
-            Bad = bad;
-            Supported = supported;
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates that an unknown protocol message has been received.
-    /// </summary>
-    public class UnknownMessageException : ProtocolException
-    {
-        public UnknownMessageException()
-        {
-        }
-
-        public UnknownMessageException(Exception ex) : base(ex)
-        {
-        }
-
-        public UnknownMessageException(string reason) : base(reason)
-        {
-        }
-
-        public UnknownMessageException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised if a message is received over a connection
-    /// that is not yet validated.
-    /// </summary>
-    public class ConnectionNotValidatedException : ProtocolException
-    {
-        public ConnectionNotValidatedException()
-        {
-        }
-
-        public ConnectionNotValidatedException(Exception ex) : base(ex)
-        {
-        }
-
-        public ConnectionNotValidatedException(string reason) : base(reason)
-        {
-        }
-
-        public ConnectionNotValidatedException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates that a response for an unknown request ID has been
-    /// received.
-    /// </summary>
-    public class UnknownRequestIdException : ProtocolException
-    {
-        public UnknownRequestIdException()
-        {
-        }
-
-        public UnknownRequestIdException(Exception ex) : base(ex)
-        {
-        }
-
-        public UnknownRequestIdException(string reason) : base(reason)
-        {
-        }
-
-        public UnknownRequestIdException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates that an unknown reply status has been received.
-    /// </summary>
-    public class UnknownReplyStatusException : ProtocolException
-    {
-        public UnknownReplyStatusException()
-        {
-        }
-
-        public UnknownReplyStatusException(Exception ex) : base(ex)
-        {
-        }
-
-        public UnknownReplyStatusException(string reason) : base(reason)
-        {
-        }
-
-        public UnknownReplyStatusException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
     /// This exception indicates that the connection has been gracefully shut down by the
     /// server.
     /// The operation call that caused this exception has not been
@@ -526,21 +391,9 @@ namespace Ice
     /// retry limit has been reached, then this exception is propagated to
     /// the application code.
     /// </summary>
-    public class CloseConnectionException : ProtocolException
+    public class CloseConnectionException : Exception
     {
         public CloseConnectionException()
-        {
-        }
-
-        public CloseConnectionException(Exception ex) : base(ex)
-        {
-        }
-
-        public CloseConnectionException(string reason) : base(reason)
-        {
-        }
-
-        public CloseConnectionException(string reason, Exception ex) : base(reason, ex)
         {
         }
     }
@@ -553,230 +406,6 @@ namespace Ice
     {
         public bool Graceful;
 
-        public ConnectionManuallyClosedException()
-        {
-        }
-
-        public ConnectionManuallyClosedException(Exception ex) : base("", ex)
-        {
-        }
-
         public ConnectionManuallyClosedException(bool graceful) => Graceful = graceful;
-
-        public ConnectionManuallyClosedException(bool graceful, Exception ex) : base("", ex) => Graceful = graceful;
-    }
-
-    /// <summary>
-    /// This exception indicates that a message size is less
-    /// than the minimum required size.
-    /// </summary>
-    public class IllegalMessageSizeException : ProtocolException
-    {
-        public IllegalMessageSizeException()
-        {
-        }
-
-        public IllegalMessageSizeException(Exception ex) : base(ex)
-        {
-        }
-
-        public IllegalMessageSizeException(string reason) : base(reason)
-        {
-        }
-
-        public IllegalMessageSizeException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates a problem with compressing or uncompressing data.
-    /// </summary>
-    public class CompressionException : ProtocolException
-    {
-        public CompressionException()
-        {
-        }
-
-        public CompressionException(Exception ex) : base(ex)
-        {
-        }
-
-        public CompressionException(string reason) : base(reason)
-        {
-        }
-
-        public CompressionException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised for errors during marshaling or unmarshaling data.
-    /// </summary>
-    public class MarshalException : ProtocolException
-    {
-        public MarshalException()
-        {
-        }
-
-        public MarshalException(Exception ex) : base(ex)
-        {
-        }
-
-        public MarshalException(string reason) : base(reason)
-        {
-        }
-
-        public MarshalException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised if inconsistent data is received while unmarshaling a proxy.
-    /// </summary>
-    public class ProxyUnmarshalException : MarshalException
-    {
-        public ProxyUnmarshalException()
-        {
-        }
-
-        public ProxyUnmarshalException(Exception ex) : base(ex)
-        {
-        }
-
-        public ProxyUnmarshalException(string reason) : base(reason)
-        {
-        }
-
-        public ProxyUnmarshalException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised if an out-of-bounds condition occurs during unmarshaling.
-    /// </summary>
-    public class UnmarshalOutOfBoundsException : MarshalException
-    {
-        public UnmarshalOutOfBoundsException()
-        {
-        }
-
-        public UnmarshalOutOfBoundsException(Exception ex) : base(ex)
-        {
-        }
-
-        public UnmarshalOutOfBoundsException(string reason) : base(reason)
-        {
-        }
-
-        public UnmarshalOutOfBoundsException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised if no suitable class factory was found during
-    /// unmarshaling of a Slice class instance.
-    /// </summary>
-    public class NoClassFactoryException : MarshalException
-    {
-        public string Type;
-
-        public NoClassFactoryException() => Type = "";
-
-        public NoClassFactoryException(Exception ex) : base(ex) => Type = "";
-
-        public NoClassFactoryException(string reason, string type) : base(reason) => Type = type;
-
-        public NoClassFactoryException(string reason, string type, Exception ex) : base(reason, ex) => Type = type;
-    }
-
-    /// <summary>
-    /// This exception is raised if the type of an unmarshaled Slice class instance does
-    /// not match its expected type.
-    /// This can happen if client and server are compiled with mismatched Slice
-    /// definitions or if a class of the wrong type is passed as a parameter
-    /// or return value using dynamic invocation. This exception can also be
-    /// raised if IceStorm is used to send Slice class instances and
-    /// an operation is subscribed to the wrong topic.
-    /// </summary>
-    public class UnexpectedObjectException : MarshalException
-    {
-        public string Type;
-        public string ExpectedType;
-
-        public UnexpectedObjectException()
-        {
-            Type = "";
-            ExpectedType = "";
-        }
-
-        public UnexpectedObjectException(Exception ex) : base(ex)
-        {
-            Type = "";
-            ExpectedType = "";
-        }
-
-        public UnexpectedObjectException(string reason, string type, string expectedType) : base(reason)
-        {
-            Type = type;
-            ExpectedType = expectedType;
-        }
-
-        public UnexpectedObjectException(string reason, string type, string expectedType, Exception ex) : base(reason, ex)
-        {
-            Type = type;
-            ExpectedType = expectedType;
-        }
-    }
-
-    /// <summary>
-    /// This exception is raised when Ice receives a request or reply
-    /// message whose size exceeds the limit specified by the
-    /// Ice.MessageSizeMax property.
-    /// </summary>
-    public class MemoryLimitException : MarshalException
-    {
-        public MemoryLimitException()
-        {
-        }
-
-        public MemoryLimitException(Exception ex) : base(ex)
-        {
-        }
-
-        public MemoryLimitException(string reason) : base(reason)
-        {
-        }
-
-        public MemoryLimitException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
-    }
-
-    /// <summary>
-    /// This exception indicates a malformed data encapsulation.
-    /// </summary>
-    public class EncapsulationException : MarshalException
-    {
-
-        public EncapsulationException()
-        {
-        }
-
-        public EncapsulationException(Exception ex) : base(ex)
-        {
-        }
-
-        public EncapsulationException(string reason) : base(reason)
-        {
-        }
-
-        public EncapsulationException(string reason, Exception ex) : base(reason, ex)
-        {
-        }
     }
 }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1344,8 +1344,8 @@ namespace Ice
                     else
                     {
                         Communicator.Logger.Trace(Communicator.TraceLevels.LocationCat,
-                            $"could not update the endpoints of object adapter `{_id}' " +
-                            $"with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
+                            @$"could not update the endpoints of object adapter `{_id
+                                }' with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
                     }
                 }
                 throw;

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -758,7 +758,8 @@ namespace IceInternal
                             {
                                 if (facetPath.Length > 1)
                                 {
-                                    throw new Ice.MarshalException();
+                                    throw new Ice.InvalidDataException(
+                                        $"invalid facet path length: {facetPath.Length}");
                                 }
                                 facet = facetPath[0];
                             }
@@ -788,7 +789,8 @@ namespace IceInternal
 
                     default:
                         {
-                            throw new Ice.UnknownReplyStatusException();
+                            throw new InvalidDataException(
+                                $"received ice1 response frame with unknown reply status `{replyStatus}'");
                         }
                 }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -470,7 +470,7 @@ namespace Ice
             }
             catch (System.Exception ex)
             {
-                throw new MarshalException("cannot serialize object:", ex);
+                throw new MarshalException("cannot serialize object", ex);
             }
         }
 
@@ -1463,7 +1463,7 @@ namespace Ice
             Debug.Assert(v.Length >= 6);
             if (v.Length < 6)
             {
-                throw new EncapsulationException();
+                throw new ArgumentException($"encapsulation has only {v.Length} bytes", nameof(v));
             }
             WriteSpan(v.AsSpan());
         }

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -21,14 +21,15 @@ namespace Ice
     internal static class ProtocolExtensions
     {
         /// <summary>Checks if this protocol is supported by the Ice runtime. If not supported, throws
-        /// UnsupportedProtocolException.</summary>
+        /// NotSupportedException.</summary>
         /// <param name="protocol">The protocol.</param>
         internal static void CheckSupported(this Protocol protocol)
         {
             // For now, we support only ice1
             if (protocol != Protocol.Ice1)
             {
-                throw new UnsupportedProtocolException("", protocol, Protocol.Ice1);
+                throw new System.NotSupportedException(
+                    $"Ice protocol `{protocol.ToString().ToLower()}' is not supported by this Ice runtime");
             }
         }
 

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -28,8 +28,8 @@ namespace Ice
             // For now, we support only ice1
             if (protocol != Protocol.Ice1)
             {
-                throw new System.NotSupportedException(
-                    $"Ice protocol `{protocol.ToString().ToLower()}' is not supported by this Ice runtime");
+                throw new System.NotSupportedException(@$"Ice protocol `{protocol.ToString().ToLower()
+                    }' is not supported by this Ice runtime ({Util.StringVersion()})");
             }
         }
 

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -83,7 +83,7 @@ namespace Ice
                  // Most derived type Id for this exception
                 string typeId = IceSlicedData.Value.Slices[0].TypeId!;
                 throw new MarshalException(
-                    $"Failed to marshal a fully sliced {nameof(RemoteException)} with type ID `{typeId}'");
+                    $"failed to marshal a fully sliced {nameof(RemoteException)} with type ID `{typeId}'");
             }
         }
         internal void Write(OutputStream ostr) => IceWrite(ostr, true);

--- a/csharp/src/Ice/UnknownSlicedClass.cs
+++ b/csharp/src/Ice/UnknownSlicedClass.cs
@@ -42,7 +42,7 @@ namespace Ice
             {
                 // Could be for example attempting to marshal this instance into a compact-format encapsulation.
                 throw new MarshalException(
-                    $"Failed to marshal an {nameof(UnknownSlicedClass)} with type ID {TypeId}");
+                    $"failed to marshal an {nameof(UnknownSlicedClass)} with type ID `{TypeId}'");
             }
         }
         internal UnknownSlicedClass()

--- a/csharp/src/Ice/VectoredBufferExtensions.cs
+++ b/csharp/src/Ice/VectoredBufferExtensions.cs
@@ -84,8 +84,8 @@ namespace Ice
         public static ArraySegment<byte> GetSegment(this IList<ArraySegment<byte>> src, int srcOffset, int count)
         {
             Debug.Assert(src.GetByteCount() >= srcOffset + count,
-                $"requested {count} bytes starting at offset {srcOffset} but there is only " +
-                $"{src.GetByteCount() - srcOffset} bytes remaining.");
+                @$"requested {count} bytes starting at offset {srcOffset
+                    } but there is only {src.GetByteCount() - srcOffset} bytes remaining.");
 
             // Skip offset bytes into the source segment list
             int srcIndex = 0;

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -405,9 +405,8 @@ namespace IceBox
                 }
                 catch (System.Exception ex)
                 {
-                    throw new LoadException(
-                        $"IceBox.ServiceManager: unable to load service '{entryPoint}': error loading assembly " +
-                        $"`{assemblyName}'", ex);
+                    throw new LoadException(@$"IceBox.ServiceManager: unable to load service `{entryPoint
+                        }': error loading assembly `{assemblyName}'", ex);
                 }
 
                 //
@@ -420,9 +419,8 @@ namespace IceBox
                 }
                 catch (System.Exception ex)
                 {
-                    throw new LoadException(
-                        $"IceBox.ServiceManager: unable to load service `{entryPoint}': cannot find the service " +
-                        $"class `{className}'", ex);
+                    throw new LoadException(@$"IceBox.ServiceManager: unable to load service `{entryPoint
+                        }': cannot find the service class `{className}'", ex);
                 }
                 Debug.Assert(c != null);
 
@@ -580,7 +578,8 @@ namespace IceBox
                         }
                         catch (System.Exception ex)
                         {
-                            _logger.Warning($"IceBox.ServiceManager: exception while stopping service {info.Name}:\n{ex}");
+                            _logger.Warning(
+                                $"IceBox.ServiceManager: exception while stopping service {info.Name}:\n{ex}");
                         }
                     }
 
@@ -773,8 +772,8 @@ namespace IceBox
                 }
                 catch (System.Exception ex)
                 {
-                    _logger.Warning("IceBox.ServiceManager: exception while shutting down communicator for service " +
-                        $"`{service}'\n{ex}");
+                    _logger.Warning(@$"IceBox.ServiceManager: exception while shutting down communicator for service `{
+                        service}'\n{ex}");
                 }
 
                 RemoveAdminFacets("IceBox.Service." + service + ".");
@@ -844,5 +843,4 @@ namespace IceBox
         private readonly Dictionary<IServiceObserverPrx, bool> _observers = new Dictionary<IServiceObserverPrx, bool>();
         private readonly int _traceServiceObserver = 0;
     }
-
 }

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -319,7 +319,7 @@ namespace Ice.exceptions
                     thrower.throwMemoryLimitException(Array.Empty<byte>());
                     test(false);
                 }
-                catch (MemoryLimitException)
+                catch (InvalidDataException)
                 {
                 }
                 catch (System.Exception)
@@ -351,7 +351,7 @@ namespace Ice.exceptions
                     {
                         thrower2.throwMemoryLimitException(new byte[2 * 1024 * 1024]); // 2MB(no limits)
                     }
-                    catch (MemoryLimitException)
+                    catch (InvalidDataException)
                     {
                     }
                     var thrower3 = IThrowerPrx.Parse("thrower:" + helper.getTestEndpoint(2), communicator);

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -273,10 +273,10 @@ namespace Ice
                         uoet.op();
                         test(false);
                     }
-                    catch (UnexpectedObjectException ex)
+                    catch (InvalidDataException ex)
                     {
-                        test(ex.Type.Equals("::Test::AlsoEmpty"));
-                        test(ex.ExpectedType.Equals("::Test::Empty"));
+                        test(ex.Message.Contains("Test.AlsoEmpty"));
+                        test(ex.Message.Contains("Test.Empty"));
                     }
                     catch (System.Exception ex)
                     {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -904,25 +904,10 @@ namespace Ice.proxy
                 cl13.IcePing();
                 test(false);
             }
-            catch (UnsupportedEncodingException)
+            catch (NotSupportedException)
             {
                 // expected
             }
-
-            output.Write("testing encoding versioning... ");
-            output.Flush();
-            string ref21 = "test -e 2.1:" + helper.getTestEndpoint(0);
-            Test.IMyClassPrx cl21 = Test.IMyClassPrx.Parse(ref21, communicator);
-            try
-            {
-                cl21.IcePing();
-                test(false);
-            }
-            catch (UnsupportedEncodingException)
-            {
-                // expected
-            }
-
             output.WriteLine("ok");
 
             output.Write("testing protocol versioning... ");
@@ -934,7 +919,7 @@ namespace Ice.proxy
                 cl3.IcePing();
                 test(false);
             }
-            catch (UnsupportedProtocolException)
+            catch (NotSupportedException)
             {
                 // expected
             }

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -186,9 +186,9 @@ public class AllTests : Test.AllTests
             testPrx.SBSUnknownDerivedAsSBaseCompact();
             test(false);
         }
-        catch (Ice.NoClassFactoryException)
+        catch (Ice.InvalidDataException ex)
         {
-            // Expected.
+            test(ex.Message.Contains("::Test::SBSUnknownDerived"));
         }
         catch (System.Exception ex)
         {
@@ -214,7 +214,7 @@ public class AllTests : Test.AllTests
         }
         catch (AggregateException ae)
         {
-            test(ae.InnerException is Ice.NoClassFactoryException);
+            test(ae.InnerException is Ice.InvalidDataException);
         }
         output.WriteLine("ok");
 
@@ -228,10 +228,6 @@ public class AllTests : Test.AllTests
                 test((o as Ice.UnknownSlicedClass).TypeId.Equals("::Test::SUnknown"));
                 test((o as Ice.UnknownSlicedClass).GetSlicedData() != null);
                 testPrx.checkSUnknown(o);
-            }
-            catch (Ice.NoClassFactoryException)
-            {
-                test(false);
             }
             catch (System.Exception ex)
             {

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -1045,10 +1045,6 @@ public class AllTests
                                 server.GetConnection();
                                 test(false);
                             }
-                            catch (ProtocolException)
-                            {
-                                // Expected
-                            }
                             catch (ConnectionLostException)
                             {
                                 // Expected


### PR DESCRIPTION
InvalidDataException and MarshalException.

InvalidDataException reports any and all problems with bytes received by Ice, including various mismatches that may not be an encoding issue.

And MarshalException is now purely about marshaling (serializing/encoding) errors. There is currently only a handful of such errors. For example, a failure to serialize a C# object before sending it "over the wire" as a sequence of bytes.