### PR TITLE
Remove MarshalException

### DIFF
--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -397,7 +397,7 @@ namespace Ice
 
                 if (rc != BzRunOk)
                 {
-                    throw new MarshalException($"bzip2 compression failed: {GetBZ2Error(rc)}");
+                    throw new TransportException($"bzip2 compression failed: {GetBZ2Error(rc)}");
                 }
 
                 do
@@ -408,7 +408,7 @@ namespace Ice
 
                 if (rc != BzStreamEnd)
                 {
-                    throw new MarshalException($"bzip2 compression failed: {GetBZ2Error(rc)}");
+                    throw new TransportException($"bzip2 compression failed: {GetBZ2Error(rc)}");
                 }
 
                 int compressedLen = compressed.Length - (int)bzStream.AvailOut;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1707,18 +1707,6 @@ namespace Ice
             }
 
             //
-            // There is no point in retrying an operation that resulted in a
-            // MarshalException. This must have been raised locally (because if
-            // it happened in a server it would result in a remote exception
-            // instead), which means there was a problem in this process that will
-            // not change if we try again.
-            //
-            if (ex is MarshalException)
-            {
-                throw ex;
-            }
-
-            //
             // Don't retry if the communicator is destroyed, object adapter is deactivated,
             // or connection is manually closed.
             //

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -361,26 +361,6 @@ namespace Ice
         }
     }
 
-    /// <summary>This exception reports an error that occurred while marshaling data into a sequence of bytes.</summary>
-    [Serializable]
-    public class MarshalException : Exception
-    {
-        public MarshalException(string message)
-            : base(message)
-        {
-        }
-
-        public MarshalException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected MarshalException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-    }
-
     /// <summary>This is a purely Ice-internal exception used for retries.</summary>
     [Serializable]
     public class RetryException : Exception

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -78,13 +78,7 @@ namespace Ice
             Debug.Assert(firstSlice);
             // This implementation can only be called on a plain RemoteException with IceSlicedData set.
             Debug.Assert(IceSlicedData.HasValue);
-            if (!ostr.WriteSlicedData(IceSlicedData.Value))
-            {
-                 // Most derived type Id for this exception
-                string typeId = IceSlicedData.Value.Slices[0].TypeId!;
-                throw new MarshalException(
-                    $"failed to marshal a fully sliced {nameof(RemoteException)} with type ID `{typeId}'");
-            }
+            ostr.WriteSlicedData(IceSlicedData.Value);
         }
         internal void Write(OutputStream ostr) => IceWrite(ostr, true);
     }

--- a/csharp/src/Ice/SlicedData.cs
+++ b/csharp/src/Ice/SlicedData.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Ice
 {
-    ///<summary>SlicedData holds the sliced-off unknown slices of a class or remote exception.</summary>
+    ///<summary>SlicedData holds the sliced-off unknown slices of a class or remote exception. Each SlicedData value
+    /// holds at least one slice.</summary>
     public readonly struct SlicedData
     {
         /// <summary>The Ice encoding of the "unknown" slices held by this SlicedData. These slices can only be
@@ -19,6 +21,7 @@ namespace Ice
 
         internal SlicedData(Encoding encoding, IReadOnlyList<SliceInfo> slices)
         {
+            Debug.Assert(slices.Count >= 1);
             Encoding = encoding;
             Slices = slices;
         }

--- a/csharp/src/Ice/UnknownSlicedClass.cs
+++ b/csharp/src/Ice/UnknownSlicedClass.cs
@@ -38,12 +38,7 @@ namespace Ice
         {
             Debug.Assert(firstSlice);
             Debug.Assert(_slicedData.HasValue); // Can only be called on an instance previously filled by IceRead.
-            if (!ostr.WriteSlicedData(_slicedData.Value))
-            {
-                // Could be for example attempting to marshal this instance into a compact-format encapsulation.
-                throw new MarshalException(
-                    $"failed to marshal an {nameof(UnknownSlicedClass)} with type ID `{TypeId}'");
-            }
+            ostr.WriteSlicedData(_slicedData.Value);
         }
         internal UnknownSlicedClass()
         {


### PR DESCRIPTION
This small PR removes Ice.MarshalException, and replaces its throwing by:
- TransportException for bzip2 errors
- NotSupportedException when failing to marshal a fully sliced exception or class instance

And an exception thrown by C# object serialization is no longer wrapped in Ice exception.