### PR TITLE
Move request handler from proxy class to reference

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2268,9 +2268,8 @@ Slice::Gen::ProxyVisitor::visitClassDefEnd(const ClassDefPtr& p)
     {
         _out << "new ";
     }
-    _out << name << " UncheckedCast("
-         << getUnqualified("Ice.IObjectPrx", ns) << " prx) =>  "
-         << "new _" << p->name() << "Prx(prx.IceReference, prx.RequestHandler);";
+    _out << name << " UncheckedCast(" << getUnqualified("Ice.IObjectPrx", ns) << " prx) => new _" << p->name()
+        << "Prx(prx.IceReference);";
 
     _out << sp;
     _out << nl << "public static ";
@@ -2286,7 +2285,7 @@ Slice::Gen::ProxyVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out << nl << "if(prx.IceIsA(global::Ice.TypeExtensions.GetIceTypeId(typeof(" << interfaceName(p)
          << "Prx))!, context))";
     _out << sb;
-    _out << nl << "return new _" << p->name() << "Prx(prx.IceReference, prx.RequestHandler);";
+    _out << nl << "return new _" << p->name() << "Prx(prx.IceReference);";
     _out << eb;
     _out << nl << "else";
     _out << sb;
@@ -2306,22 +2305,26 @@ Slice::Gen::ProxyVisitor::visitClassDefEnd(const ClassDefPtr& p)
          << name;
     _out << sb;
 
-    _out << nl << "internal _" << p->name() << "Prx("
+    _out << nl << "private _" << p->name() << "Prx("
          << "global::System.Runtime.Serialization.SerializationInfo info, "
-         << "global::System.Runtime.Serialization.StreamingContext context) : base(info, context)";
+         << "global::System.Runtime.Serialization.StreamingContext context)";
+    _out.inc();
+    _out << nl << ": base(info, context)";
+    _out.dec();
     _out << sb;
     _out << eb;
 
     _out << sp;
-    _out << nl << "internal _" << p->name() << "Prx("
-         << "IceInternal.Reference reference, "
-         << "IceInternal.IRequestHandler? requestHandler = null) : base(reference, requestHandler)";
+    _out << nl << "internal _" << p->name() << "Prx(global::IceInternal.Reference reference)";
+    _out.inc();
+    _out << nl << ": base(reference)";
+    _out.dec();
     _out << sb;
     _out << eb;
 
     _out << sp;
-    _out << nl << "public override " << getUnqualified("Ice.IObjectPrx", ns)
-         << " Clone(global::IceInternal.Reference reference) => new _" << p->name() << "Prx(reference);";
+    _out << nl << getUnqualified("Ice.IObjectPrx", ns) << " " << getUnqualified("Ice.IObjectPrx", ns)
+        << ".IceClone(global::IceInternal.Reference reference) => new _" << p->name() << "Prx(reference);";
 
     _out << eb;
 }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -64,8 +64,6 @@ namespace IceInternal
             }
         }
 
-        public Reference GetReference() => _reference;
-
         public Ice.Connection? GetConnection() => null;
 
         public int InvokeAsyncRequest(OutgoingAsync outAsync, bool synchronous)

--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using IceInternal;
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -208,7 +210,7 @@ namespace Ice
             }
         }
 
-        private ObjectAdapter? FindObjectAdapter(IObjectPrx proxy)
+        private ObjectAdapter? FindObjectAdapter(Reference reference)
         {
             List<ObjectAdapter> adapters;
             lock (this)
@@ -225,7 +227,7 @@ namespace Ice
             {
                 try
                 {
-                    if (adapter.IsLocal(proxy))
+                    if (adapter.IsLocal(reference))
                     {
                         return adapter;
                     }

--- a/csharp/src/Ice/Communicator-RequestHandlerFactory.cs
+++ b/csharp/src/Ice/Communicator-RequestHandlerFactory.cs
@@ -3,7 +3,6 @@
 //
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using IceInternal;
 
 namespace Ice

--- a/csharp/src/Ice/Communicator-RequestHandlerFactory.cs
+++ b/csharp/src/Ice/Communicator-RequestHandlerFactory.cs
@@ -10,12 +10,11 @@ namespace Ice
 {
     public sealed partial class Communicator
     {
-        internal IRequestHandler GetRequestHandler(RoutableReference rf, IObjectPrx proxy)
+        internal IRequestHandler GetRequestHandler(RoutableReference rf)
         {
-            Debug.Assert(ReferenceEquals(rf, proxy.IceReference));
             if (rf.GetCollocationOptimized())
             {
-                ObjectAdapter? adapter = FindObjectAdapter(proxy);
+                ObjectAdapter? adapter = FindObjectAdapter(rf);
                 if (adapter != null)
                 {
                     return rf.SetRequestHandler(new CollocatedRequestHandler(rf, adapter));
@@ -30,7 +29,7 @@ namespace Ice
                 {
                     if (!_handlers.TryGetValue(rf, out handler))
                     {
-                        handler = new ConnectRequestHandler(rf, proxy);
+                        handler = new ConnectRequestHandler(rf);
                         _handlers.Add(rf, handler);
                         connect = true;
                     }
@@ -38,7 +37,7 @@ namespace Ice
             }
             else
             {
-                handler = new ConnectRequestHandler(rf, proxy);
+                handler = new ConnectRequestHandler(rf);
                 connect = true;
             }
 

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -11,13 +11,18 @@ namespace IceInternal
 {
     public class ConnectRequestHandler : IRequestHandler, Reference.IGetConnectionCallback, RouterInfo.AddProxyCallback
     {
-        public IRequestHandler Connect(Ice.IObjectPrx proxy)
+        public IRequestHandler Connect(RoutableReference reference)
         {
+            Debug.Assert(reference == _reference); // not ReferenceEquals, see Communicator.GetRequestHandler
             lock (this)
             {
                 if (!Initialized())
                 {
-                    _proxies.Add(proxy);
+                    if (_reference.IsRequestHandlerCached)
+                    {
+                        _referenceList ??= new List<RoutableReference>();
+                        _referenceList.Add(reference);
+                    }
                 }
                 return _requestHandler;
             }
@@ -77,15 +82,13 @@ namespace IceInternal
             _connection.AsyncRequestCanceled(outAsync, ex);
         }
 
-        public Reference GetReference() => _reference;
-
         public Ice.Connection? GetConnection()
         {
             lock (this)
             {
                 //
                 // First check for the connection, it's important otherwise the user could first get a connection
-                // and then the exception if he tries to obtain the proxy cached connection mutiple times (the
+                // and then the exception if he tries to obtain the proxy cached connection multiple times (the
                 // exception can be set after the connection is set if the flush of pending requests fails).
                 //
                 if (_connection != null)
@@ -146,7 +149,7 @@ namespace IceInternal
             //
             try
             {
-                _reference.GetCommunicator().RemoveRequestHandler(_reference, this);
+                _reference.GetCommunicator().RemoveConnectRequestHandler(_reference, this);
             }
             catch (Ice.CommunicatorDestroyedException)
             {
@@ -165,7 +168,7 @@ namespace IceInternal
             lock (this)
             {
                 _flushing = false;
-                _proxies.Clear();
+                _referenceList = null;
                 _proxy = null; // Break cyclic reference count.
                 Monitor.PulseAll(this);
             }
@@ -179,9 +182,9 @@ namespace IceInternal
         //
         public void addedProxy() => FlushRequests();
 
-        public ConnectRequestHandler(Reference @ref, Ice.IObjectPrx proxy)
+        public ConnectRequestHandler(RoutableReference routableReference, Ice.IObjectPrx proxy)
         {
-            _reference = @ref;
+            _reference = routableReference;
             _proxy = proxy;
             _initialized = false;
             _flushing = false;
@@ -252,7 +255,7 @@ namespace IceInternal
                     exception = ex.InnerException;
 
                     // Remove the request handler before retrying.
-                    _reference.GetCommunicator().RemoveRequestHandler(_reference, this);
+                    _reference.GetCommunicator().RemoveConnectRequestHandler(_reference, this);
 
                     outAsync.RetryException();
                 }
@@ -273,12 +276,15 @@ namespace IceInternal
             // request handler to use the more efficient connection request
             // handler.
             //
-            if (_reference.GetCacheConnection() && exception == null)
+            if (_reference.IsRequestHandlerCached && exception == null)
             {
-                _requestHandler = new ConnectionRequestHandler(_reference, _connection, _compress);
-                foreach (Ice.IObjectPrx prx in _proxies)
+                _requestHandler = new ConnectionRequestHandler(_connection, _compress);
+                if (_referenceList != null)
                 {
-                    prx.IceUpdateRequestHandler(this, _requestHandler);
+                    foreach (var reference in _referenceList)
+                    {
+                        reference.UpdateRequestHandler(this, _requestHandler);
+                    }
                 }
             }
 
@@ -293,18 +299,20 @@ namespace IceInternal
                 // Only remove once all the requests are flushed to
                 // guarantee serialization.
                 //
-                _reference.GetCommunicator().RemoveRequestHandler(_reference, this);
+                _reference.GetCommunicator().RemoveConnectRequestHandler(_reference, this);
 
-                _proxies.Clear();
+                _referenceList = null;
                 _proxy = null; // Break cyclic reference count.
                 Monitor.PulseAll(this);
             }
         }
 
-        private readonly Reference _reference;
+        private readonly RoutableReference _reference;
 
         private IObjectPrx? _proxy;
-        private readonly HashSet<IObjectPrx> _proxies = new HashSet<IObjectPrx>();
+
+        // References to update upon initialization
+        private List<RoutableReference>? _referenceList;
 
         private Connection? _connection;
         private bool _compress;

--- a/csharp/src/Ice/ConnectRequestHandler.cs
+++ b/csharp/src/Ice/ConnectRequestHandler.cs
@@ -119,10 +119,8 @@ namespace IceInternal
             //
             // If this proxy is for a non-local object, and we are using a router, then
             // add this proxy to the router info object.
-            //
-            Debug.Assert(_proxy != null);
             RouterInfo? ri = _reference.GetRouterInfo();
-            if (ri != null && !ri.AddProxy(_proxy, this))
+            if (ri != null && !ri.AddProxy(IObjectPrx.Factory(_reference), this))
             {
                 return; // The request handler will be initialized once addProxy returns.
             }
@@ -169,7 +167,6 @@ namespace IceInternal
             {
                 _flushing = false;
                 _referenceList = null;
-                _proxy = null; // Break cyclic reference count.
                 Monitor.PulseAll(this);
             }
         }
@@ -182,10 +179,9 @@ namespace IceInternal
         //
         public void addedProxy() => FlushRequests();
 
-        public ConnectRequestHandler(RoutableReference routableReference, Ice.IObjectPrx proxy)
+        public ConnectRequestHandler(RoutableReference routableReference)
         {
             _reference = routableReference;
-            _proxy = proxy;
             _initialized = false;
             _flushing = false;
             _requestHandler = this;
@@ -302,14 +298,11 @@ namespace IceInternal
                 _reference.GetCommunicator().RemoveConnectRequestHandler(_reference, this);
 
                 _referenceList = null;
-                _proxy = null; // Break cyclic reference count.
                 Monitor.PulseAll(this);
             }
         }
 
         private readonly RoutableReference _reference;
-
-        private IObjectPrx? _proxy;
 
         // References to update upon initialization
         private List<RoutableReference>? _referenceList;

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -37,18 +37,13 @@ namespace IceInternal
         public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex) =>
             _connection.AsyncRequestCanceled(outAsync, ex);
 
-        public Reference GetReference() => _reference;
-
         public Ice.Connection GetConnection() => _connection;
 
-        public ConnectionRequestHandler(Reference @ref, Ice.Connection connection, bool compress)
+        public ConnectionRequestHandler(Ice.Connection connection, bool compress)
         {
-            _reference = @ref;
             _connection = connection;
             _compress = compress;
         }
-
-        private readonly Reference _reference;
 
         private readonly Ice.Connection _connection;
         private readonly bool _compress;

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -30,14 +30,19 @@ namespace Ice
     /// </summary>
     public interface IObjectPrx : IEquatable<IObjectPrx>
     {
-        public Reference IceReference { get; }
-
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<IObjectPrx?> IceReader = (istr) => istr.ReadProxy(Factory);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<IObjectPrx?> IceWriter = (ostr, value) => ostr.WriteProxy(value);
 
-        public IRequestHandler? RequestHandler { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Reference IceReference { get; }
 
-        public IObjectPrx Clone(Reference reference);
+        // IceClone is re-implemented by all generated proxy classes
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected IObjectPrx IceClone(Reference reference) => new ObjectPrx(reference);
+        internal IObjectPrx Clone(Reference reference) => IceClone(reference);
 
         /// <summary>
         /// Returns the communicator that created this proxy.
@@ -217,7 +222,7 @@ namespace Ice
         /// Returns whether this proxy caches connections.
         /// </summary>
         /// <returns>True if this proxy caches connections; false, otherwise.</returns>
-        public bool IsConnectionCached => IceReference.GetCacheConnection();
+        public bool IsConnectionCached => IceReference.IsRequestHandlerCached;
 
         /// <summary>
         /// Returns how this proxy selects endpoints (randomly or ordered).
@@ -371,7 +376,7 @@ namespace Ice
         public int IceHandleException(System.Exception ex, IRequestHandler? handler, bool idempotent, bool sent,
                                       ref int cnt)
         {
-            IceUpdateRequestHandler(handler, null); // Clear the request handler
+            IceReference.UpdateRequestHandler(handler, null); // Clear the request handler
 
             // We only retry after failing with a DispatchException or a local exception.
             //
@@ -402,62 +407,6 @@ namespace Ice
             else
             {
                 throw ex; // Retry could break at-most-once semantics, don't retry.
-            }
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public IRequestHandler IceGetRequestHandler()
-        {
-            if (IceReference.GetCacheConnection())
-            {
-                lock (this)
-                {
-                    if (RequestHandler != null)
-                    {
-                        return RequestHandler;
-                    }
-                }
-            }
-            return IceReference.GetRequestHandler(this);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public IRequestHandler
-        IceSetRequestHandler(IRequestHandler handler)
-        {
-            if (IceReference.GetCacheConnection())
-            {
-                lock (this)
-                {
-                    if (RequestHandler == null)
-                    {
-                        RequestHandler = handler;
-                    }
-                    return RequestHandler;
-                }
-            }
-            return handler;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void IceUpdateRequestHandler(IRequestHandler? previous, IRequestHandler? handler)
-        {
-            if (IceReference.GetCacheConnection() && previous != null)
-            {
-                lock (this)
-                {
-                    if (RequestHandler != null && RequestHandler != handler)
-                    {
-                        //
-                        // Update the request handler only if "previous" is the same
-                        // as the current request handler. This is called after
-                        // connection binding by the connect request handler. We only
-                        // replace the request handler if the current handler is the
-                        // connect request handler.
-                        //
-                        RequestHandler = RequestHandler.Update(previous, handler);
-                    }
-                }
             }
         }
 
@@ -496,43 +445,20 @@ namespace Ice
             => (await task.ConfigureAwait(false)).ReadReturnValue(reader);
     }
 
-    // The base class for all proxies. It's a publically visible Ice-internal class. Applications should
-    // not use it directly.
+    // The base class for all proxies. It's a publicly visible Ice-internal class. Applications should not use it
+    // directly.
     [Serializable]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ObjectPrx : IObjectPrx, ISerializable
     {
-        public Reference IceReference { get; private set; }
-        public IRequestHandler? RequestHandler { get; set; }
-
-        public virtual IObjectPrx Clone(Reference reference) => new ObjectPrx(reference);
-
-        public ObjectPrx(Reference reference, IRequestHandler? requestHandler = null)
-        {
-            IceReference = reference ?? throw new ArgumentNullException(nameof(reference));
-            RequestHandler = requestHandler;
-        }
-
-        protected ObjectPrx(SerializationInfo info, StreamingContext context)
-        {
-            if (!(context.Context is Communicator communicator))
-            {
-                throw new ArgumentException("cannot deserialize proxy: Ice.Communicator not found in StreamingContext",
-                    nameof(context));
-            }
-            IceReference = communicator.CreateReference(info.GetString("proxy"), null);
-        }
+        public Reference IceReference { get; }
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context) =>
             info.AddValue("proxy", ToString());
 
         /// <summary>Returns the stringified form of this proxy.</summary>
         /// <returns>The stringified proxy.</returns>
-        public override string ToString()
-        {
-            Debug.Assert(IceReference != null);
-            return IceReference.ToString();
-        }
+        public override string ToString() => IceReference.ToString();
 
         /// <summary>Returns a hash code for this proxy.</summary>
         /// <returns>The hash code.</returns>
@@ -544,10 +470,23 @@ namespace Ice
         /// <returns>True if this proxy is equal to other; otherwise, false.</returns>
         public override bool Equals(object? other) => Equals(other as IObjectPrx);
 
+        // Implements IEquatable<IObjectPrx>:
         /// <summary>Returns whether this proxy equals the given proxy. Two proxies are equal if they are equal in all
         /// respects, that is, if their object identity, endpoints timeout settings, and so on are all equal.</summary>
         /// <param name="other">The proxy to compare this proxy with.</param>
         /// <returns>True if this proxy is equal to other; otherwise, false.</returns>
         public bool Equals(IObjectPrx? other) => other != null && IceReference.Equals(other.IceReference);
+
+        protected internal ObjectPrx(Reference reference) => IceReference = reference;
+
+        protected ObjectPrx(SerializationInfo info, StreamingContext context)
+        {
+            if (!(context.Context is Communicator communicator))
+            {
+                throw new ArgumentException("cannot deserialize proxy: Ice.Communicator not found in StreamingContext",
+                    nameof(context));
+            }
+            IceReference = communicator.CreateReference(info.GetString("proxy"), null);
+        }
     }
 }

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -376,7 +376,7 @@ namespace Ice
         public int IceHandleException(System.Exception ex, IRequestHandler? handler, bool idempotent, bool sent,
                                       ref int cnt)
         {
-            IceReference.UpdateRequestHandler(handler, null); // Clear the request handler
+            (IceReference as RoutableReference)?.UpdateRequestHandler(handler, null); // Clear the request handler
 
             // We only retry after failing with a DispatchException or a local exception.
             //

--- a/csharp/src/Ice/IRequestHandler.cs
+++ b/csharp/src/Ice/IRequestHandler.cs
@@ -15,8 +15,6 @@ namespace IceInternal
 
         int SendAsyncRequest(ProxyOutgoingAsyncBase @out);
 
-        Reference GetReference();
-
         Ice.Connection? GetConnection();
     }
 }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -999,12 +999,10 @@ namespace Ice
             }
         }
 
-        internal bool IsLocal(IObjectPrx proxy)
+        internal bool IsLocal(Reference r)
         {
             // NOTE: it's important that IsLocal() doesn't perform any blocking operations as
             // it can be called for AMI invocations if the proxy has no delegate set yet.
-
-            Reference r = proxy.IceReference;
             if (r.IsWellKnown())
             {
                 lock (_mutex)

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -419,7 +419,9 @@ namespace IceInternal
                 // require could end up waiting for the flush of the
                 // connection to be done.
                 //
-                Proxy.IceReference.UpdateRequestHandler(Handler, null); // Clear request handler and always retry.
+
+                // Clear request handler and always retry.
+                (Proxy.IceReference as RoutableReference)?.UpdateRequestHandler(Handler, null);
                 Communicator.AddRetryTask(this, 0);
             }
             catch (System.Exception ex)
@@ -485,7 +487,7 @@ namespace IceInternal
                     try
                     {
                         _sent = false;
-                        Handler = Proxy.IceReference.GetRequestHandlerUsingCache(Proxy);
+                        Handler = Proxy.IceReference.GetRequestHandler(Proxy);
                         int status = Handler.SendAsyncRequest(this);
                         if ((status & AsyncStatusSent) != 0)
                         {
@@ -509,7 +511,8 @@ namespace IceInternal
                     }
                     catch (RetryException)
                     {
-                        Proxy.IceReference.UpdateRequestHandler(Handler, null); // Clear request handler and always retry.
+                        // Clear request handler and always retry.
+                        (Proxy.IceReference as RoutableReference)?.UpdateRequestHandler(Handler, null);
                     }
                     catch (System.Exception ex)
                     {

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -419,7 +419,7 @@ namespace IceInternal
                 // require could end up waiting for the flush of the
                 // connection to be done.
                 //
-                Proxy.IceUpdateRequestHandler(Handler, null); // Clear request handler and always retry.
+                Proxy.IceReference.UpdateRequestHandler(Handler, null); // Clear request handler and always retry.
                 Communicator.AddRetryTask(this, 0);
             }
             catch (System.Exception ex)
@@ -485,7 +485,7 @@ namespace IceInternal
                     try
                     {
                         _sent = false;
-                        Handler = Proxy.IceGetRequestHandler();
+                        Handler = Proxy.IceReference.GetRequestHandlerUsingCache(Proxy);
                         int status = Handler.SendAsyncRequest(this);
                         if ((status & AsyncStatusSent) != 0)
                         {
@@ -509,7 +509,7 @@ namespace IceInternal
                     }
                     catch (RetryException)
                     {
-                        Proxy.IceUpdateRequestHandler(Handler, null); // Clear request handler and always retry.
+                        Proxy.IceReference.UpdateRequestHandler(Handler, null); // Clear request handler and always retry.
                     }
                     catch (System.Exception ex)
                     {

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -487,7 +487,7 @@ namespace IceInternal
                     try
                     {
                         _sent = false;
-                        Handler = Proxy.IceReference.GetRequestHandler(Proxy);
+                        Handler = Proxy.IceReference.GetRequestHandler();
                         int status = Handler.SendAsyncRequest(this);
                         if ((status & AsyncStatusSent) != 0)
                         {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -215,26 +215,7 @@ namespace Ice
         /// an established connection).</returns>
         /// <exception name="CollocationOptimizationException">If the proxy uses collocation optimization and denotes a
         /// collocated object.</exception>
-        public static Connection? GetCachedConnection(this IObjectPrx prx)
-        {
-            IRequestHandler? handler;
-            lock (prx)
-            {
-                handler = prx.RequestHandler;
-            }
-
-            if (handler != null)
-            {
-                try
-                {
-                    return handler.GetConnection();
-                }
-                catch (System.Exception)
-                {
-                }
-            }
-            return null;
-        }
+        public static Connection? GetCachedConnection(this IObjectPrx prx) => prx.IceReference.GetCachedConnection();
 
         /// <summary>Sends a request synchronously.</summary>
         /// <param name="proxy">The proxy for the target Ice object.</param>

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -266,7 +266,7 @@ namespace IceInternal
 
         public abstract Dictionary<string, string> ToProperty(string prefix);
 
-        internal abstract IRequestHandler GetRequestHandler(IObjectPrx proxy);
+        internal abstract IRequestHandler GetRequestHandler();
         internal abstract Ice.Connection? GetCachedConnection();
 
         public static bool operator ==(Reference? lhs, Reference? rhs)
@@ -759,7 +759,7 @@ namespace IceInternal
         public override Dictionary<string, string> ToProperty(string prefix)
             => throw new NotSupportedException("cannot convert a fixed proxy to property dictionary");
 
-        internal override IRequestHandler GetRequestHandler(IObjectPrx proxy) => _requestHandler;
+        internal override IRequestHandler GetRequestHandler() => _requestHandler;
 
         internal override Ice.Connection? GetCachedConnection() => _requestHandler.GetConnection();
 
@@ -1675,7 +1675,7 @@ namespace IceInternal
             }
         }
 
-        internal override IRequestHandler GetRequestHandler(IObjectPrx proxy)
+        internal override IRequestHandler GetRequestHandler()
         {
             if (IsRequestHandlerCached)
             {
@@ -1688,7 +1688,7 @@ namespace IceInternal
                     }
                 }
             }
-            return Communicator.GetRequestHandler(this, proxy);
+            return Communicator.GetRequestHandler(this);
         }
 
         internal override Ice.Connection? GetCachedConnection()

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -447,11 +447,7 @@ namespace IceInternal
             return reference;
         }
 
-        internal virtual Reference Clone()
-        {
-            var clone = (MemberwiseClone() as Reference)!;
-            return clone;
-        }
+        internal virtual Reference Clone() => (MemberwiseClone() as Reference)!;
 
         // Creates a new clone of this unless `clone` is already a real clone (meaning "not this")
         // Returns the clone.

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -548,7 +548,7 @@ namespace IceInternal
 
         // Creates a new clone of this unless `clone` is already a real clone (meaning "not this")
         // Returns the clone.
-        protected internal T Clone<T>(T clone) where T : Reference
+        private protected T Clone<T>(T clone) where T : Reference
         {
             if (ReferenceEquals(this, clone))
             {


### PR DESCRIPTION
This PR moves the request handler from ObjectPrx (`RequestHandler` property, with access synchronized using `this`) to Reference (`_requestHandler` field, with access synchronized using `_requestHandlerMutex`).

It also replaces abstract method `Reference.GetCacheConnection` and field `RoutableReference._cacheConnection` by property `Reference.IsRequestHandlerCached`, and simplifies internal `Clone` methods.



