### PR TITLE
Removed various obsolete cpp macros

### DIFF
--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -39,12 +39,12 @@ class ICE_API FactoryTable : private IceUtil::noncopyable
 {
 public:
 
-    void addExceptionFactory(const ::std::string&, ICE_IN(ICE_DELEGATE(::Ice::UserExceptionFactory)));
-    ICE_DELEGATE(::Ice::UserExceptionFactory) getExceptionFactory(const ::std::string&) const;
+    void addExceptionFactory(const ::std::string&, ICE_IN(::Ice::UserExceptionFactory));
+    ::Ice::UserExceptionFactory getExceptionFactory(const ::std::string&) const;
     void removeExceptionFactory(const ::std::string&);
 
-    void addValueFactory(const ::std::string&, ICE_IN(ICE_DELEGATE(::Ice::ValueFactory)));
-    ICE_DELEGATE(::Ice::ValueFactory) getValueFactory(const ::std::string&) const;
+    void addValueFactory(const ::std::string&, ICE_IN(::Ice::ValueFactory));
+    ::Ice::ValueFactory getValueFactory(const ::std::string&) const;
     void removeValueFactory(const ::std::string&);
 
     void addTypeId(int, const ::std::string&);
@@ -55,11 +55,11 @@ private:
 
     IceUtil::Mutex _m;
 
-    typedef ::std::pair< ICE_DELEGATE(::Ice::UserExceptionFactory), int> EFPair;
+    typedef ::std::pair< ::Ice::UserExceptionFactory, int> EFPair;
     typedef ::std::map< ::std::string, EFPair> EFTable;
     EFTable _eft;
 
-    typedef ::std::pair< ICE_DELEGATE(::Ice::ValueFactory), int> VFPair;
+    typedef ::std::pair< ::Ice::ValueFactory, int> VFPair;
     typedef ::std::map< ::std::string, VFPair> VFTable;
     VFTable _vft;
 

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -39,11 +39,11 @@ class ICE_API FactoryTable : private IceUtil::noncopyable
 {
 public:
 
-    void addExceptionFactory(const ::std::string&, ICE_IN(::Ice::UserExceptionFactory));
+    void addExceptionFactory(const ::std::string&, ::Ice::UserExceptionFactory);
     ::Ice::UserExceptionFactory getExceptionFactory(const ::std::string&) const;
     void removeExceptionFactory(const ::std::string&);
 
-    void addValueFactory(const ::std::string&, ICE_IN(::Ice::ValueFactory));
+    void addValueFactory(const ::std::string&, ::Ice::ValueFactory);
     ::Ice::ValueFactory getValueFactory(const ::std::string&) const;
     void removeValueFactory(const ::std::string&);
 

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -344,7 +344,7 @@ createIconvStringConverter(const std::string& internalCodeWithDefault = "")
         internalCode = nl_langinfo(CODESET);
     }
 
-    return ICE_MAKE_SHARED(IceInternal::IconvStringConverter<charT>, internalCode);
+    return std::make_shared<IceInternal::IconvStringConverter<charT>>(internalCode);
 }
 
 }

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -334,7 +334,7 @@ namespace Ice
  * @throws IconvInitializationException If the code is not supported.
  */
 template<typename charT>
-ICE_HANDLE<IceUtil::BasicStringConverter<charT> >
+std::shared_ptr<IceUtil::BasicStringConverter<charT> >
 createIconvStringConverter(const std::string& internalCodeWithDefault = "")
 {
     std::string internalCode = internalCodeWithDefault;

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -676,7 +676,7 @@ ICE_API Identity stringToIdentity(const std::string& str);
  * @param mode Affects the handling of non-ASCII characters and non-printable ASCII characters.
  * @return The stringified identity.
  */
-ICE_API std::string identityToString(const Identity& id, ToStringMode mode = ICE_ENUM(ToStringMode, Unicode));
+ICE_API std::string identityToString(const Identity& id, ToStringMode mode = ToStringMode::Unicode);
 
 }
 

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -987,7 +987,7 @@ public:
      * the stream will attempt to instantiate the exception using static type information.
      * @throws UserException The user exception that was unmarshaled.
      */
-    void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory = ICE_NULLPTR);
+    void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory = nullptr);
 
     /**
      * Skips one optional value with the given format.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -987,7 +987,7 @@ public:
      * the stream will attempt to instantiate the exception using static type information.
      * @throws UserException The user exception that was unmarshaled.
      */
-    void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory = nullptr);
+    void throwException(ICE_IN(UserExceptionFactory) factory = nullptr);
 
     /**
      * Skips one optional value with the given format.
@@ -1095,7 +1095,7 @@ private:
         virtual ~EncapsDecoder();
 
         virtual void read(PatchFunc, void*) = 0;
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory))) = 0;
+        virtual void throwException(ICE_IN(UserExceptionFactory)) = 0;
 
         virtual void startInstance(SliceType) = 0;
         virtual SlicedDataPtr endInstance(bool) = 0;
@@ -1170,7 +1170,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)));
+        virtual void throwException(ICE_IN(UserExceptionFactory));
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);
@@ -1205,7 +1205,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)));
+        virtual void throwException(ICE_IN(UserExceptionFactory));
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -987,7 +987,7 @@ public:
      * the stream will attempt to instantiate the exception using static type information.
      * @throws UserException The user exception that was unmarshaled.
      */
-    void throwException(ICE_IN(UserExceptionFactory) factory = nullptr);
+    void throwException(UserExceptionFactory factory = nullptr);
 
     /**
      * Skips one optional value with the given format.
@@ -1095,7 +1095,7 @@ private:
         virtual ~EncapsDecoder();
 
         virtual void read(PatchFunc, void*) = 0;
-        virtual void throwException(ICE_IN(UserExceptionFactory)) = 0;
+        virtual void throwException(UserExceptionFactory) = 0;
 
         virtual void startInstance(SliceType) = 0;
         virtual SlicedDataPtr endInstance(bool) = 0;
@@ -1170,7 +1170,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(UserExceptionFactory));
+        virtual void throwException(UserExceptionFactory);
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);
@@ -1205,7 +1205,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(UserExceptionFactory));
+        virtual void throwException(UserExceptionFactory);
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -115,7 +115,7 @@ template<class MetricsType> class MetricsMapT : public MetricsMapI, private IceU
 public:
 
     typedef MetricsType T;
-    typedef ICE_INTERNAL_HANDLE<MetricsType> TPtr;
+    typedef std::shared_ptr<MetricsType> TPtr;
 
     ICE_DEFINE_PTR(MetricsMapTPtr, MetricsMapT);
 
@@ -591,7 +591,7 @@ public:
     registerSubMap(const std::string& map, const std::string& subMap, IceMX::MetricsMap MetricsType::* member)
     {
         bool updated;
-        ICE_HANDLE<MetricsMapFactoryT<MetricsType> > factory;
+        std::shared_ptr<MetricsMapFactoryT<MetricsType> > factory;
         {
             Lock sync(*this);
             std::map<std::string, MetricsMapFactoryPtr>::const_iterator p = _factories.find(map);

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -351,7 +351,7 @@ public:
         {
             return std::pair<MetricsMapIPtr, SubMapMember>(ICE_GET_SHARED_FROM_THIS(p->second.second->clone()), p->second.first);
         }
-        return std::pair<MetricsMapIPtr, SubMapMember>(MetricsMapIPtr(ICE_NULLPTR), static_cast<SubMapMember>(0));
+        return std::pair<MetricsMapIPtr, SubMapMember>(MetricsMapIPtr(nullptr), static_cast<SubMapMember>(0));
     }
 
     EntryTPtr
@@ -364,7 +364,7 @@ public:
         {
             if(!(*p)->match(helper, false))
             {
-                return ICE_NULLPTR;
+                return nullptr;
             }
         }
 
@@ -372,7 +372,7 @@ public:
         {
             if((*p)->match(helper, true))
             {
-                return ICE_NULLPTR;
+                return nullptr;
             }
         }
 
@@ -404,7 +404,7 @@ public:
         }
         catch(const std::exception&)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         //
@@ -413,7 +413,7 @@ public:
         Lock sync(*this);
         if(_destroyed)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         if(previous && previous->_object->id == key)
@@ -523,7 +523,7 @@ public:
     registerSubMap(const std::string& subMap, IceMX::MetricsMap MetricsType::* member)
     {
         _subMaps[subMap] = std::pair<IceMX::MetricsMap MetricsType::*,
-                                     MetricsMapFactoryPtr>(member, ICE_MAKE_SHARED(MetricsMapFactoryT<SubMapMetricsType>, ICE_NULLPTR));
+                                     MetricsMapFactoryPtr>(member, ICE_MAKE_SHARED(MetricsMapFactoryT<SubMapMetricsType>, nullptr));
     }
 
 private:

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -349,7 +349,7 @@ public:
             _subMaps.find(subMapName);
         if(p != _subMaps.end())
         {
-            return std::pair<MetricsMapIPtr, SubMapMember>(ICE_GET_SHARED_FROM_THIS(p->second.second->clone()), p->second.first);
+            return std::pair<MetricsMapIPtr, SubMapMember>(p->second.second->clone()->shared_from_this(), p->second.first);
         }
         return std::pair<MetricsMapIPtr, SubMapMember>(MetricsMapIPtr(nullptr), static_cast<SubMapMember>(0));
     }
@@ -425,7 +425,7 @@ public:
         typename std::map<std::string, EntryTPtr>::const_iterator p = _objects.find(key);
         if(p == _objects.end())
         {
-            TPtr t = ICE_MAKE_SHARED(T);
+            TPtr t = std::make_shared<T>();
             t->id = key;
 
             p = _objects.insert(typename std::map<std::string, EntryTPtr>::value_type(
@@ -440,7 +440,7 @@ private:
 
     virtual MetricsMapIPtr clone() const
     {
-        return ICE_MAKE_SHARED(MetricsMapT<MetricsType>, *this);
+        return std::make_shared<MetricsMapT<MetricsType>>(*this);
     }
 
     void detached(EntryTPtr entry)
@@ -516,14 +516,14 @@ public:
     virtual MetricsMapIPtr
     create(const std::string& mapPrefix, const Ice::PropertiesPtr& properties)
     {
-        return ICE_MAKE_SHARED(MetricsMapT<MetricsType>, mapPrefix, properties, _subMaps);
+        return std::make_shared<MetricsMapT<MetricsType>>(mapPrefix, properties, _subMaps);
     }
 
     template<class SubMapMetricsType> void
     registerSubMap(const std::string& subMap, IceMX::MetricsMap MetricsType::* member)
     {
         _subMaps[subMap] = std::pair<IceMX::MetricsMap MetricsType::*,
-                                     MetricsMapFactoryPtr>(member, ICE_MAKE_SHARED(MetricsMapFactoryT<SubMapMetricsType>, nullptr));
+                                     MetricsMapFactoryPtr>(member, std::make_shared<MetricsMapFactoryT<SubMapMetricsType>>(nullptr));
     }
 
 private:
@@ -577,7 +577,7 @@ public:
         MetricsMapFactoryPtr factory;
         {
             Lock sync(*this);
-            factory = ICE_MAKE_SHARED(MetricsMapFactoryT<MetricsType>, updater);
+            factory = std::make_shared<MetricsMapFactoryT<MetricsType>>(updater);
             _factories[map] = factory;
             updated = addOrUpdateMap(map, factory);
         }

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -322,7 +322,7 @@ public:
 };
 ICE_DEFINE_PTR(UpdaterPtr, Updater);
 
-template<typename T> class UpdaterT ICE_FINAL : public Updater
+template<typename T> class UpdaterT final : public Updater
 {
 public:
 
@@ -439,7 +439,7 @@ public:
                 return *p;
             }
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     template<typename ObserverImpl, typename ObserverMetricsType> ICE_INTERNAL_HANDLE<ObserverImpl>
@@ -457,7 +457,7 @@ public:
 
         if(metricsObjects.empty())
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         ICE_INTERNAL_HANDLE<ObserverImpl> obsv = ICE_MAKE_SHARED(ObserverImpl);
@@ -501,7 +501,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!_metrics)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         typename ObserverImplType::EntrySeqType metricsObjects;
@@ -516,7 +516,7 @@ public:
 
         if(metricsObjects.empty())
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         ObserverImplPtrType obsv = ICE_MAKE_SHARED(ObserverImplType);
@@ -536,7 +536,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!_metrics)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         typename ObserverImplType::EntrySeqType metricsObjects;
@@ -551,7 +551,7 @@ public:
         if(metricsObjects.empty())
         {
             old->detach();
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         ObserverImplPtrType obsv = ICE_MAKE_SHARED(ObserverImplType);

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -460,7 +460,7 @@ public:
             return nullptr;
         }
 
-        ICE_INTERNAL_HANDLE<ObserverImpl> obsv = ICE_MAKE_SHARED(ObserverImpl);
+        ICE_INTERNAL_HANDLE<ObserverImpl> obsv = std::make_shared<ObserverImpl>();
         obsv->init(helper, metricsObjects);
         return obsv;
     }
@@ -519,7 +519,7 @@ public:
             return nullptr;
         }
 
-        ObserverImplPtrType obsv = ICE_MAKE_SHARED(ObserverImplType);
+        ObserverImplPtrType obsv = std::make_shared<ObserverImplType>();
         obsv->init(helper, metricsObjects);
         return obsv;
     }
@@ -554,7 +554,7 @@ public:
             return nullptr;
         }
 
-        ObserverImplPtrType obsv = ICE_MAKE_SHARED(ObserverImplType);
+        ObserverImplPtrType obsv = std::make_shared<ObserverImplType>();
         obsv->init(helper, metricsObjects, old.get());
         return obsv;
     }

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -31,7 +31,7 @@ public:
 
     virtual std::string operator()(const std::string&) const = 0;
 
-    virtual void initMetrics(const ICE_INTERNAL_HANDLE<T>&) const
+    virtual void initMetrics(const std::shared_ptr<T>&) const
     {
         // To be overriden in specialization to initialize state attributes
     }
@@ -339,7 +339,7 @@ public:
 
 private:
 
-    const ICE_HANDLE<T> _updater;
+    const std::shared_ptr<T> _updater;
     void (T::*_fn)();
 };
 
@@ -442,7 +442,7 @@ public:
         return nullptr;
     }
 
-    template<typename ObserverImpl, typename ObserverMetricsType> ICE_INTERNAL_HANDLE<ObserverImpl>
+    template<typename ObserverImpl, typename ObserverMetricsType> std::shared_ptr<ObserverImpl>
     getObserver(const std::string& mapName, const MetricsHelperT<ObserverMetricsType>& helper)
     {
         std::vector<typename IceInternal::MetricsMapT<ObserverMetricsType>::EntryTPtr> metricsObjects;
@@ -460,7 +460,7 @@ public:
             return nullptr;
         }
 
-        ICE_INTERNAL_HANDLE<ObserverImpl> obsv = std::make_shared<ObserverImpl>();
+        std::shared_ptr<ObserverImpl> obsv = std::make_shared<ObserverImpl>();
         obsv->init(helper, metricsObjects);
         return obsv;
     }

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -177,7 +177,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(ICE_IN(std::vector<Byte>) inEncaps, std::vector<Byte>& outEncaps,
+    virtual bool ice_invoke(std::vector<Byte> inEncaps, std::vector<Byte>& outEncaps,
                             const Current& current) = 0;
 
     /// \cond INTERNAL
@@ -206,7 +206,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(ICE_IN(std::pair<const Byte*, const Byte*>) inEncaps, std::vector<Byte>& outEncaps,
+    virtual bool ice_invoke(std::pair<const Byte*, const Byte*> inEncaps, std::vector<Byte>& outEncaps,
                             const Current& current) = 0;
 
     /// \cond INTERNAL

--- a/cpp/include/Ice/ObserverHelper.h
+++ b/cpp/include/Ice/ObserverHelper.h
@@ -32,7 +32,7 @@ public:
 
     operator bool() const
     {
-        return _observer != ICE_NULLPTR;
+        return _observer != nullptr;
     }
 
     T* operator->() const
@@ -139,7 +139,7 @@ public:
         {
             return _observer->getRemoteObserver(con, endpt, requestId, size);
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     ::Ice::Instrumentation::ChildInvocationObserverPtr
@@ -149,7 +149,7 @@ public:
         {
             return _observer->getCollocatedObserver(adapter, requestId, size);
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     void

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -1001,7 +1001,7 @@ private:
 
     public:
 
-        Encaps() : format(ICE_ENUM(FormatType, DefaultFormat)), encoder(0), previous(0)
+        Encaps() : format(FormatType::DefaultFormat), encoder(0), previous(0)
         {
             // Inlined for performance reasons.
         }

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -586,7 +586,7 @@ struct GetOptionalFormat;
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F1);
+    static const OptionalFormat value = OptionalFormat::F1;
 };
 
 /**
@@ -596,7 +596,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 2, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F2);
+    static const OptionalFormat value = OptionalFormat::F2;
 };
 
 /**
@@ -606,7 +606,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 2, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 4, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F4);
+    static const OptionalFormat value = OptionalFormat::F4;
 };
 
 /**
@@ -616,7 +616,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 4, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 8, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F8);
+    static const OptionalFormat value = OptionalFormat::F8;
 };
 
 /**
@@ -626,7 +626,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 8, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat value = OptionalFormat::VSize;
 };
 
 /**
@@ -636,7 +636,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, false>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryClass, 1, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, Class);
+    static const OptionalFormat value = OptionalFormat::Class;
 };
 
 /**
@@ -646,7 +646,7 @@ struct GetOptionalFormat<StreamHelperCategoryClass, 1, false>
 template<int minWireSize>
 struct GetOptionalFormat<StreamHelperCategoryEnum, minWireSize, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, Size);
+    static const OptionalFormat value = OptionalFormat::Size;
 };
 
 /**
@@ -685,7 +685,7 @@ struct StreamOptionalHelper
 template<typename T>
 struct StreamOptionalHelper<T, StreamHelperCategoryStruct, true>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v)
@@ -709,7 +709,7 @@ struct StreamOptionalHelper<T, StreamHelperCategoryStruct, true>
 template<typename T>
 struct StreamOptionalHelper<T, StreamHelperCategoryStruct, false>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, FSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
     template<class S> static inline void
     write(S* stream, const T& v)
@@ -753,7 +753,7 @@ struct StreamOptionalContainerHelper;
 template<typename T, int sz>
 struct StreamOptionalContainerHelper<T, false, sz>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, FSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int)
@@ -777,7 +777,7 @@ struct StreamOptionalContainerHelper<T, false, sz>
 template<typename T, int sz>
 struct StreamOptionalContainerHelper<T, true, sz>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int n)
@@ -809,7 +809,7 @@ struct StreamOptionalContainerHelper<T, true, sz>
 template<typename T>
 struct StreamOptionalContainerHelper<T, true, 1>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int)

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -292,8 +292,5 @@ typedef long long Int64;
 #define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()
 #define ICE_CHECKED_CAST(T, ...) Ice::checkedCast<T>(__VA_ARGS__)
 #define ICE_UNCHECKED_CAST(T, ...) Ice::uncheckedCast<T>(__VA_ARGS__)
-#define ICE_DELEGATE(T) T
-#define ICE_IN(...) __VA_ARGS__
-#define ICE_SET_EXCEPTION_FROM_CLONE(T, V)  T = V
 
 #endif

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -293,7 +293,6 @@ typedef long long Int64;
 #define ICE_MAKE_SHARED(T, ...) ::std::make_shared<T>(__VA_ARGS__)
 #define ICE_DEFINE_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
 #define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
-#define ICE_SHARED_FROM_THIS shared_from_this()
 #define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()
 #define ICE_GET_SHARED_FROM_THIS(p) p->shared_from_this()
 #define ICE_CHECKED_CAST(T, ...) Ice::checkedCast<T>(__VA_ARGS__)

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -292,9 +292,6 @@ typedef long long Int64;
 #define ICE_PROXY_HANDLE ::std::shared_ptr
 #define ICE_MAKE_SHARED(T, ...) ::std::make_shared<T>(__VA_ARGS__)
 #define ICE_DEFINE_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
-#define ICE_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
-#define ICE_SCOPED_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
-#define nullptr nullptr
 #define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
 #define ICE_SHARED_FROM_THIS shared_from_this()
 #define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -287,14 +287,9 @@ typedef long long Int64;
 
 #include <memory>
 #include <future>
-#define ICE_HANDLE ::std::shared_ptr
-#define ICE_INTERNAL_HANDLE ::std::shared_ptr
-#define ICE_PROXY_HANDLE ::std::shared_ptr
-#define ICE_MAKE_SHARED(T, ...) ::std::make_shared<T>(__VA_ARGS__)
 #define ICE_DEFINE_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
 #define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
 #define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()
-#define ICE_GET_SHARED_FROM_THIS(p) p->shared_from_this()
 #define ICE_CHECKED_CAST(T, ...) Ice::checkedCast<T>(__VA_ARGS__)
 #define ICE_UNCHECKED_CAST(T, ...) Ice::uncheckedCast<T>(__VA_ARGS__)
 #define ICE_DELEGATE(T) T

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -100,10 +100,6 @@
 #   define ICE_CPLUSPLUS __cplusplus
 #endif
 
-#define ICE_NOEXCEPT noexcept
-#define ICE_NOEXCEPT_FALSE noexcept(false)
-#define ICE_FINAL final
-
 //
 // Does the C++ compiler library provide std::codecvt_utf8 and
 // std::codecvt_utf8_utf16?
@@ -298,7 +294,7 @@ typedef long long Int64;
 #define ICE_DEFINE_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
 #define ICE_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
 #define ICE_SCOPED_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
-#define ICE_NULLPTR nullptr
+#define nullptr nullptr
 #define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
 #define ICE_SHARED_FROM_THIS shared_from_this()
 #define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()

--- a/cpp/include/IceUtil/CtrlCHandler.h
+++ b/cpp/include/IceUtil/CtrlCHandler.h
@@ -39,7 +39,7 @@ public:
      * Only a single CtrlCHandler object can exist in a process at a give time.
      * @param cb The callback function to invoke when a signal is received.
      */
-    explicit CtrlCHandler(CtrlCHandlerCallback cb = ICE_NULLPTR);
+    explicit CtrlCHandler(CtrlCHandlerCallback cb = nullptr);
 
      /**
      * Unregisters the callback function.

--- a/cpp/include/IceUtil/Exception.h
+++ b/cpp/include/IceUtil/Exception.h
@@ -52,7 +52,7 @@ public:
      * Returns a description of this exception.
      * @return The description.
      */
-    virtual const char* what() const ICE_NOEXCEPT;
+    virtual const char* what() const noexcept;
 
     /**
      * Returns a shallow polymorphic copy of this exception.

--- a/cpp/include/IceUtil/StringUtil.h
+++ b/cpp/include/IceUtil/StringUtil.h
@@ -68,7 +68,7 @@ ICE_API bool match(const std::string&, const std::string&, bool = false);
 //
 ICE_API std::string lastErrorToString();
 #ifdef _WIN32
-ICE_API std::string errorToString(int, LPCVOID = ICE_NULLPTR);
+ICE_API std::string errorToString(int, LPCVOID = nullptr);
 #else
 ICE_API std::string errorToString(int);
 #endif

--- a/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
@@ -119,8 +119,8 @@ Init::createObjects()
     if(!_adapter)
     {
         _adapter = _communicator->createObjectAdapter(""); // colloc-only adapter
-        _adapter->add(ICE_MAKE_SHARED(NullPermissionsVerifier), _nullPVId);
-        _adapter->add(ICE_MAKE_SHARED(NullSSLPermissionsVerifier), _nullSSLPVId);
+        _adapter->add(std::make_shared<NullPermissionsVerifier>(), _nullPVId);
+        _adapter->add(std::make_shared<NullSSLPermissionsVerifier>(), _nullSSLPVId);
         _adapter->activate();
     }
 }

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -227,11 +227,11 @@ SessionHelperI::destroy()
         // We destroy the communicator to trigger the immediate
         // failure of the connection establishment.
         //
-        destroyThread = new DestroyCommunicator(ICE_SHARED_FROM_THIS, _threadCB);
+        destroyThread = new DestroyCommunicator(shared_from_this(), _threadCB);
     }
     else
     {
-        destroyThread = new DestroyInternal(ICE_SHARED_FROM_THIS, _callback, _threadCB);
+        destroyThread = new DestroyInternal(shared_from_this(), _callback, _threadCB);
         _connected = false;
         _session = nullptr;
     }
@@ -376,14 +376,14 @@ void
 SessionHelperI::connect(const map<string, string>& context)
 {
     IceUtil::Mutex::Lock sync(_mutex);
-    connectImpl(ICE_MAKE_SHARED(ConnectStrategySecureConnection, context));
+    connectImpl(std::make_shared<ConnectStrategySecureConnection>(context));
 }
 
 void
 SessionHelperI::connect(const string& user, const string& password, const map<string, string>& context)
 {
     IceUtil::Mutex::Lock sync(_mutex);
-    connectImpl(ICE_MAKE_SHARED(ConnectStrategyUserPassword, user, password, context));
+    connectImpl(std::make_shared<ConnectStrategyUserPassword>(user, password, context));
 }
 
 void
@@ -643,7 +643,7 @@ void
 SessionHelperI::connectImpl(const ConnectStrategyPtr& factory)
 {
     assert(!_destroy);
-    IceUtil::ThreadPtr thread = new ConnectThread(_callback, ICE_SHARED_FROM_THIS, factory, _finder);
+    IceUtil::ThreadPtr thread = new ConnectThread(_callback, shared_from_this(), factory, _finder);
     _threadCB->add(this, thread);
     thread->start();
 }
@@ -757,11 +757,11 @@ SessionHelperI::connected(const Glacier2::RouterPrxPtr& router, const Glacier2::
         // connected() is only called from the ConnectThread so it is ok to
         // call destroyInternal here.
         //
-        destroyInternal(new Disconnected(ICE_SHARED_FROM_THIS, _callback));
+        destroyInternal(new Disconnected(shared_from_this(), _callback));
     }
     else
     {
-        dispatchCallback(new Connected(_callback, ICE_SHARED_FROM_THIS), conn);
+        dispatchCallback(new Connected(_callback, shared_from_this()), conn);
     }
 }
 
@@ -1053,8 +1053,8 @@ Glacier2::SessionFactoryHelper::connect()
     map<string, string> context;
     {
         IceUtil::Mutex::Lock sync(_mutex);
-        session = ICE_MAKE_SHARED(SessionHelperI,
-                                  ICE_MAKE_SHARED(SessionThreadCallback, ICE_SHARED_FROM_THIS),
+        session = std::make_shared<SessionHelperI>(
+                                  std::make_shared<SessionThreadCallback>(shared_from_this()),
                                   _callback,
                                   createInitData(),
                                   getRouterFinderStr(),
@@ -1072,8 +1072,8 @@ Glacier2::SessionFactoryHelper::connect(const string& user,  const string& passw
     map<string, string> context;
     {
         IceUtil::Mutex::Lock sync(_mutex);
-        session = ICE_MAKE_SHARED(SessionHelperI,
-                                  ICE_MAKE_SHARED(SessionThreadCallback, ICE_SHARED_FROM_THIS),
+        session = std::make_shared<SessionHelperI>(
+                                  std::make_shared<SessionThreadCallback>(shared_from_this()),
                                   _callback,
                                   createInitData(),
                                   getRouterFinderStr(),

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -143,7 +143,7 @@ public:
     virtual void run()
     {
         _session->destroyInternal(_disconnected);
-        _session = ICE_NULLPTR;
+        _session = nullptr;
 
         //
         // Join the connect thread to free resources.
@@ -175,7 +175,7 @@ public:
     virtual void run()
     {
         _session->destroyCommunicator();
-        _session = ICE_NULLPTR;
+        _session = nullptr;
 
         //
         // Join the connect thread to free resources.
@@ -233,9 +233,9 @@ SessionHelperI::destroy()
     {
         destroyThread = new DestroyInternal(ICE_SHARED_FROM_THIS, _callback, _threadCB);
         _connected = false;
-        _session = ICE_NULLPTR;
+        _session = nullptr;
     }
-    _threadCB = ICE_NULLPTR;
+    _threadCB = nullptr;
 
     //
     // Run destroy in a thread because it can block.
@@ -324,7 +324,7 @@ Glacier2::SessionCallback::~SessionCallback()
 namespace
 {
 
-class ConnectStrategySecureConnection ICE_FINAL : public ConnectStrategy
+class ConnectStrategySecureConnection final : public ConnectStrategy
 {
 
 public:
@@ -345,7 +345,7 @@ private:
     const map<string, string> _context;
 };
 
-class ConnectStrategyUserPassword ICE_FINAL : public ConnectStrategy
+class ConnectStrategyUserPassword final : public ConnectStrategy
 {
 
 public:
@@ -395,7 +395,7 @@ SessionHelperI::destroyInternal(const Ice::DispatcherCallPtr& disconnected)
     {
         IceUtil::Mutex::Lock sync(_mutex);
         router = _router;
-        _router = ICE_NULLPTR;
+        _router = nullptr;
         _connected = false;
 
         communicator = _communicator;
@@ -436,7 +436,7 @@ SessionHelperI::destroyInternal(const Ice::DispatcherCallPtr& disconnected)
     {
         communicator->destroy();
     }
-    dispatchCallback(disconnected, ICE_NULLPTR);
+    dispatchCallback(disconnected, nullptr);
 }
 
 void
@@ -552,7 +552,7 @@ public:
                 IceUtil::Mutex::Lock sync(_session->_mutex);
                 _session->_destroy = true;
             }
-            _session->dispatchCallback(new ConnectFailed(_callback, _session, ex), ICE_NULLPTR);
+            _session->dispatchCallback(new ConnectFailed(_callback, _session, ex), nullptr);
             return;
         }
 
@@ -627,7 +627,7 @@ public:
     virtual void run()
     {
         _session->dispatchCallback(_call, _conn);
-        _session = ICE_NULLPTR;
+        _session = nullptr;
     }
 
 private:

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -482,7 +482,7 @@ public:
         _callback(callback),
         _session(session)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+        _ex = ex.ice_clone();
     }
 
     virtual void

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -741,7 +741,7 @@ SessionHelperI::connected(const Glacier2::RouterPrxPtr& router, const Glacier2::
             {
                 Ice::ConnectionPtr connection = _router->ice_getCachedConnection();
                 assert(connection);
-                connection->setACM(acmTimeout, IceUtil::None, Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                connection->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
                 auto self = shared_from_this();
                 connection->setCloseCallback([self](Ice::ConnectionPtr)
                 {
@@ -1125,7 +1125,7 @@ string
 Glacier2::SessionFactoryHelper::createProxyStr(const Ice::Identity& ident)
 {
     ostringstream os;
-    os << "\"" << identityToString(ident, Ice::ICE_ENUM(ToStringMode, Unicode)) << "\":" << _protocol
+    os << "\"" << identityToString(ident, Ice::ToStringMode::Unicode) << "\":" << _protocol
        << " -p " << getPortInternal() << " -h \"" << _routerHost << "\"";
 
     if(_timeout > 0)

--- a/cpp/src/Ice/ACM.cpp
+++ b/cpp/src/Ice/ACM.cpp
@@ -15,8 +15,8 @@ using namespace IceInternal;
 
 IceInternal::ACMConfig::ACMConfig(bool server) :
     timeout(IceUtil::Time::seconds(60)),
-    heartbeat(ICE_ENUM(ACMHeartbeat, HeartbeatOnDispatch)),
-    close(server ? ICE_ENUM(ACMClose, CloseOnInvocation) : ICE_ENUM(ACMClose, CloseOnInvocationAndIdle))
+    heartbeat(ACMHeartbeat::HeartbeatOnDispatch),
+    close(server ? ACMClose::CloseOnInvocation : ACMClose::CloseOnInvocationAndIdle)
 {
 }
 
@@ -47,8 +47,8 @@ IceInternal::ACMConfig::ACMConfig(const Ice::PropertiesPtr& p,
     }
 
     int hb = p->getPropertyAsIntWithDefault(prefix + ".Heartbeat", static_cast<int>(dflt.heartbeat));
-    if(hb >= static_cast<int>(ICE_ENUM(ACMHeartbeat, HeartbeatOff)) &&
-       hb <= static_cast<int>(ICE_ENUM(ACMHeartbeat, HeartbeatAlways)))
+    if(hb >= static_cast<int>(ACMHeartbeat::HeartbeatOff) &&
+       hb <= static_cast<int>(ACMHeartbeat::HeartbeatAlways))
     {
         heartbeat = static_cast<Ice::ACMHeartbeat>(hb);
     }
@@ -59,8 +59,8 @@ IceInternal::ACMConfig::ACMConfig(const Ice::PropertiesPtr& p,
     }
 
     int cl = p->getPropertyAsIntWithDefault(prefix + ".Close", static_cast<int>(dflt.close));
-    if(cl >= static_cast<int>(ICE_ENUM(ACMClose, CloseOff)) &&
-       cl <= static_cast<int>(ICE_ENUM(ACMClose, CloseOnIdleForceful)))
+    if(cl >= static_cast<int>(ACMClose::CloseOff) &&
+       cl <= static_cast<int>(ACMClose::CloseOnIdleForceful))
     {
         close = static_cast<Ice::ACMClose>(cl);
     }

--- a/cpp/src/Ice/ACM.cpp
+++ b/cpp/src/Ice/ACM.cpp
@@ -107,8 +107,8 @@ IceInternal::FactoryACMMonitor::destroy()
     //
     if(!_connections.empty())
     {
-        _instance->timer()->cancel(ICE_SHARED_FROM_THIS);
-        _instance->timer()->schedule(ICE_SHARED_FROM_THIS, IceUtil::Time());
+        _instance->timer()->cancel(shared_from_this());
+        _instance->timer()->schedule(shared_from_this(), IceUtil::Time());
     }
 
     _instance = 0;
@@ -135,7 +135,7 @@ IceInternal::FactoryACMMonitor::add(const ConnectionIPtr& connection)
     if(_connections.empty())
     {
         _connections.insert(connection);
-        _instance->timer()->scheduleRepeated(ICE_SHARED_FROM_THIS, _config.timeout / 2);
+        _instance->timer()->scheduleRepeated(shared_from_this(), _config.timeout / 2);
     }
     else
     {
@@ -184,7 +184,7 @@ IceInternal::FactoryACMMonitor::acm(const IceUtil::Optional<int>& timeout,
     {
         config.heartbeat = *heartbeat;
     }
-    return ICE_MAKE_SHARED(ConnectionACMMonitor, ICE_SHARED_FROM_THIS, _instance->timer(), config);
+    return std::make_shared<ConnectionACMMonitor>(shared_from_this(), _instance->timer(), config);
 }
 
 Ice::ACM
@@ -231,7 +231,7 @@ IceInternal::FactoryACMMonitor::runTimerTask()
 
         if(_connections.empty())
         {
-            _instance->timer()->cancel(ICE_SHARED_FROM_THIS);
+            _instance->timer()->cancel(shared_from_this());
             return;
         }
     }
@@ -304,7 +304,7 @@ IceInternal::ConnectionACMMonitor::add(const ConnectionIPtr& connection)
     _connection = connection;
     if(_config.timeout != IceUtil::Time())
     {
-        _timer->scheduleRepeated(ICE_SHARED_FROM_THIS, _config.timeout / 2);
+        _timer->scheduleRepeated(shared_from_this(), _config.timeout / 2);
     }
 }
 
@@ -318,7 +318,7 @@ IceInternal::ConnectionACMMonitor::remove(ICE_MAYBE_UNUSED const ConnectionIPtr&
     assert(_connection == connection);
     if(_config.timeout != IceUtil::Time())
     {
-        _timer->cancel(ICE_SHARED_FROM_THIS);
+        _timer->cancel(shared_from_this());
     }
     _connection = 0;
 }

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -150,10 +150,10 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         if(_response)
         {
             requestId = ++_requestId;
-            _asyncRequests.insert(make_pair(requestId, ICE_GET_SHARED_FROM_THIS(outAsync)));
+            _asyncRequests.insert(make_pair(requestId, outAsync->shared_from_this()));
         }
 
-        _sendAsyncRequests.insert(make_pair(ICE_GET_SHARED_FROM_THIS(outAsync), requestId));
+        _sendAsyncRequests.insert(make_pair(outAsync->shared_from_this(), requestId));
     }
     catch(...)
     {
@@ -166,7 +166,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
     if(!synchronous || !_response || _reference->getInvocationTimeout() > 0)
     {
         // Don't invoke from the user thread if async or invocation timeout is set
-        _adapter->getThreadPool()->dispatch(new InvokeAllAsync(ICE_GET_SHARED_FROM_THIS(outAsync),
+        _adapter->getThreadPool()->dispatch(new InvokeAllAsync(outAsync->shared_from_this(),
                                                                outAsync->getOs(),
                                                                ICE_SHARED_FROM_THIS,
                                                                requestId,
@@ -174,7 +174,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
     }
     else if(_dispatcher)
     {
-        _adapter->getThreadPool()->dispatchFromThisThread(new InvokeAllAsync(ICE_GET_SHARED_FROM_THIS(outAsync),
+        _adapter->getThreadPool()->dispatchFromThisThread(new InvokeAllAsync(outAsync->shared_from_this(),
                                                                              outAsync->getOs(),
                                                                              ICE_SHARED_FROM_THIS,
                                                                              requestId,
@@ -288,7 +288,7 @@ CollocatedRequestHandler::sentAsync(OutgoingAsyncBase* outAsync)
 {
     {
         Lock sync(*this);
-        if(_sendAsyncRequests.erase(ICE_GET_SHARED_FROM_THIS(outAsync)) == 0)
+        if(_sendAsyncRequests.erase(outAsync->shared_from_this()) == 0)
         {
             return false; // The request timed-out.
         }

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -80,7 +80,7 @@ CollocatedRequestHandler::~CollocatedRequestHandler()
 RequestHandlerPtr
 CollocatedRequestHandler::update(const RequestHandlerPtr& previousHandler, const RequestHandlerPtr& newHandler)
 {
-    return previousHandler.get() == this ? newHandler : ICE_SHARED_FROM_THIS;
+    return previousHandler.get() == this ? newHandler : shared_from_this();
 }
 
 AsyncStatus
@@ -145,7 +145,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         //
         // This will throw if the request is canceled
         //
-        outAsync->cancelable(ICE_SHARED_FROM_THIS);
+        outAsync->cancelable(shared_from_this());
 
         if(_response)
         {
@@ -168,7 +168,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         // Don't invoke from the user thread if async or invocation timeout is set
         _adapter->getThreadPool()->dispatch(new InvokeAllAsync(outAsync->shared_from_this(),
                                                                outAsync->getOs(),
-                                                               ICE_SHARED_FROM_THIS,
+                                                               shared_from_this(),
                                                                requestId,
                                                                batchRequestNum));
     }
@@ -176,7 +176,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
     {
         _adapter->getThreadPool()->dispatchFromThisThread(new InvokeAllAsync(outAsync->shared_from_this(),
                                                                              outAsync->getOs(),
-                                                                             ICE_SHARED_FROM_THIS,
+                                                                             shared_from_this(),
                                                                              requestId,
                                                                              batchRequestNum));
     }
@@ -188,7 +188,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         // if a retry occurs.
         //
 
-        CollocatedRequestHandlerPtr self(ICE_SHARED_FROM_THIS);
+        CollocatedRequestHandlerPtr self(shared_from_this());
         if(sentAsync(outAsync))
         {
             invokeAll(outAsync->getOs(), requestId, batchRequestNum);

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -131,11 +131,11 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
         }
         else
         {
-            if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, Yes))
+            if(compressBatch == CompressBatch::Yes)
             {
                 compress = true;
             }
-            else if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, No))
+            else if(compressBatch == CompressBatch::No)
             {
                 compress = false;
             }

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -185,7 +185,7 @@ CommunicatorFlushBatchAsync::check(bool userThread)
 }
 
 void
-Ice::CommunicatorI::destroy() ICE_NOEXCEPT
+Ice::CommunicatorI::destroy() noexcept
 {
     if(_instance)
     {
@@ -194,7 +194,7 @@ Ice::CommunicatorI::destroy() ICE_NOEXCEPT
 }
 
 void
-Ice::CommunicatorI::shutdown() ICE_NOEXCEPT
+Ice::CommunicatorI::shutdown() noexcept
 {
     try
     {
@@ -207,7 +207,7 @@ Ice::CommunicatorI::shutdown() ICE_NOEXCEPT
 }
 
 void
-Ice::CommunicatorI::waitForShutdown() ICE_NOEXCEPT
+Ice::CommunicatorI::waitForShutdown() noexcept
 {
     try
     {
@@ -220,7 +220,7 @@ Ice::CommunicatorI::waitForShutdown() ICE_NOEXCEPT
 }
 
 bool
-Ice::CommunicatorI::isShutdown() const ICE_NOEXCEPT
+Ice::CommunicatorI::isShutdown() const noexcept
 {
     try
     {
@@ -271,7 +271,7 @@ Ice::CommunicatorI::identityToString(const Identity& ident) const
 ObjectAdapterPtr
 Ice::CommunicatorI::createObjectAdapter(const string& name)
 {
-    return _instance->objectAdapterFactory()->createObjectAdapter(name, ICE_NULLPTR);
+    return _instance->objectAdapterFactory()->createObjectAdapter(name, nullptr);
 }
 
 ObjectAdapterPtr
@@ -284,7 +284,7 @@ Ice::CommunicatorI::createObjectAdapterWithEndpoints(const string& name, const s
     }
 
     getProperties()->setProperty(oaName + ".Endpoints", endpoints);
-    return _instance->objectAdapterFactory()->createObjectAdapter(oaName, ICE_NULLPTR);
+    return _instance->objectAdapterFactory()->createObjectAdapter(oaName, nullptr);
 }
 
 ObjectAdapterPtr
@@ -312,25 +312,25 @@ Ice::CommunicatorI::addObjectFactory(const ::Ice::ObjectFactoryPtr& factory, con
 }
 
 ::Ice::ObjectFactoryPtr
-Ice::CommunicatorI::findObjectFactory(const string& id) const ICE_NOEXCEPT
+Ice::CommunicatorI::findObjectFactory(const string& id) const noexcept
 {
     return _instance->findObjectFactory(id);
 }
 
 PropertiesPtr
-Ice::CommunicatorI::getProperties() const ICE_NOEXCEPT
+Ice::CommunicatorI::getProperties() const noexcept
 {
     return _instance->initializationData().properties;
 }
 
 LoggerPtr
-Ice::CommunicatorI::getLogger() const ICE_NOEXCEPT
+Ice::CommunicatorI::getLogger() const noexcept
 {
     return _instance->initializationData().logger;
 }
 
 Ice::Instrumentation::CommunicatorObserverPtr
-Ice::CommunicatorI::getObserver() const ICE_NOEXCEPT
+Ice::CommunicatorI::getObserver() const noexcept
 {
     return _instance->initializationData().observer;
 }
@@ -360,7 +360,7 @@ Ice::CommunicatorI::setDefaultLocator(const LocatorPrxPtr& locator)
 }
 
 Ice::ImplicitContextPtr
-Ice::CommunicatorI::getImplicitContext() const ICE_NOEXCEPT
+Ice::CommunicatorI::getImplicitContext() const noexcept
 {
     return _instance->getImplicitContext();
 }
@@ -372,7 +372,7 @@ Ice::CommunicatorI::getPluginManager() const
 }
 
 ValueFactoryManagerPtr
-Ice::CommunicatorI::getValueFactoryManager() const ICE_NOEXCEPT
+Ice::CommunicatorI::getValueFactoryManager() const noexcept
 {
     return _instance->initializationData().valueFactoryManager;
 }

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -122,7 +122,7 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
 
     try
     {
-        OutgoingAsyncBasePtr flushBatch = ICE_MAKE_SHARED(FlushBatch, ICE_SHARED_FROM_THIS, _instance, _observer);
+        OutgoingAsyncBasePtr flushBatch = std::make_shared<FlushBatch>(shared_from_this(), _instance, _observer);
         bool compress;
         int batchRequestNum = con->getBatchRequestQueue()->swap(flushBatch->getOs(), compress);
         if(batchRequestNum == 0)
@@ -153,8 +153,8 @@ void
 CommunicatorFlushBatchAsync::invoke(const string& operation, CompressBatch compressBatch)
 {
     _observer.attach(_instance.get(), operation);
-    _instance->outgoingConnectionFactory()->flushAsyncBatchRequests(ICE_SHARED_FROM_THIS, compressBatch);
-    _instance->objectAdapterFactory()->flushAsyncBatchRequests(ICE_SHARED_FROM_THIS, compressBatch);
+    _instance->outgoingConnectionFactory()->flushAsyncBatchRequests(shared_from_this(), compressBatch);
+    _instance->objectAdapterFactory()->flushAsyncBatchRequests(shared_from_this(), compressBatch);
     check(true);
 }
 
@@ -459,7 +459,7 @@ Ice::CommunicatorI::findAllAdminFacets()
 CommunicatorIPtr
 Ice::CommunicatorI::create(const InitializationData& initData)
 {
-    Ice::CommunicatorIPtr communicator = ICE_MAKE_SHARED(CommunicatorI);
+    Ice::CommunicatorIPtr communicator = std::make_shared<CommunicatorI>();
     try
     {
         const_cast<InstancePtr&>(communicator->_instance) = new Instance(communicator, initData);
@@ -493,7 +493,7 @@ Ice::CommunicatorI::finishSetup(int& argc, const char* argv[])
 {
     try
     {
-        _instance->finishSetup(argc, argv, ICE_SHARED_FROM_THIS);
+        _instance->finishSetup(argc, argv, shared_from_this());
     }
     catch(...)
     {

--- a/cpp/src/Ice/CommunicatorI.h
+++ b/cpp/src/Ice/CommunicatorI.h
@@ -56,10 +56,10 @@ class CommunicatorI : public Communicator
 {
 public:
 
-    virtual void destroy() ICE_NOEXCEPT;
-    virtual void shutdown() ICE_NOEXCEPT;
-    virtual void waitForShutdown() ICE_NOEXCEPT;
-    virtual bool isShutdown() const ICE_NOEXCEPT;
+    virtual void destroy() noexcept;
+    virtual void shutdown() noexcept;
+    virtual void waitForShutdown() noexcept;
+    virtual bool isShutdown() const noexcept;
 
     virtual ObjectPrxPtr stringToProxy(const std::string&) const;
     virtual std::string proxyToString(const ObjectPrxPtr&) const;
@@ -75,13 +75,13 @@ public:
     virtual ObjectAdapterPtr createObjectAdapterWithRouter(const std::string&, const RouterPrxPtr&);
 
     virtual void addObjectFactory(const ObjectFactoryPtr&, const std::string&);
-    virtual ObjectFactoryPtr findObjectFactory(const std::string&) const ICE_NOEXCEPT;
+    virtual ObjectFactoryPtr findObjectFactory(const std::string&) const noexcept;
 
-    virtual ImplicitContextPtr getImplicitContext() const ICE_NOEXCEPT;
+    virtual ImplicitContextPtr getImplicitContext() const noexcept;
 
-    virtual PropertiesPtr getProperties() const ICE_NOEXCEPT;
-    virtual LoggerPtr getLogger() const ICE_NOEXCEPT;
-    virtual Ice::Instrumentation::CommunicatorObserverPtr getObserver() const ICE_NOEXCEPT;
+    virtual PropertiesPtr getProperties() const noexcept;
+    virtual LoggerPtr getLogger() const noexcept;
+    virtual Ice::Instrumentation::CommunicatorObserverPtr getObserver() const noexcept;
 
     virtual RouterPrxPtr getDefaultRouter() const;
     virtual void setDefaultRouter(const RouterPrxPtr&);
@@ -91,7 +91,7 @@ public:
 
     virtual PluginManagerPtr getPluginManager() const;
 
-    virtual ValueFactoryManagerPtr getValueFactoryManager() const ICE_NOEXCEPT;
+    virtual ValueFactoryManagerPtr getValueFactoryManager() const noexcept;
 
 #ifdef ICE_SWIFT
     virtual dispatch_queue_t getClientDispatchQueue() const;

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -170,7 +170,7 @@ ConnectRequestHandler::setException(const Ice::LocalException& ex)
         Lock sync(*this);
         assert(!_flushing && !_initialized && !_exception);
         _flushing = true; // Ensures request handler is removed before processing new requests.
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
     }
 
     //
@@ -282,7 +282,7 @@ ConnectRequestHandler::flushRequests()
         }
         catch(const RetryException& ex)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.get()->ice_clone());
+            exception = ex.get()->ice_clone();
 
             // Remove the request handler before retrying.
             _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
@@ -291,7 +291,7 @@ ConnectRequestHandler::flushRequests()
         }
         catch(const Ice::LocalException& ex)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.ice_clone());
+            exception = ex.ice_clone();
 
             if(req->exception(ex))
             {

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -107,7 +107,7 @@ ConnectRequestHandler::getConnection()
     {
         _exception->ice_throw();
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::ConnectionIPtr
@@ -330,7 +330,7 @@ ConnectRequestHandler::flushRequests()
         _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
 
         _proxies.clear();
-        _proxy = ICE_NULLPTR; // Break cyclic reference count.
+        _proxy = nullptr; // Break cyclic reference count.
         notifyAll();
     }
 }

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -33,13 +33,13 @@ ConnectRequestHandler::connect(const Ice::ObjectPrxPtr& proxy)
     {
         _proxies.insert(proxy);
     }
-    return _requestHandler ? _requestHandler : ICE_SHARED_FROM_THIS;
+    return _requestHandler ? _requestHandler : shared_from_this();
 }
 
 RequestHandlerPtr
 ConnectRequestHandler::update(const RequestHandlerPtr& previousHandler, const RequestHandlerPtr& newHandler)
 {
-    return previousHandler.get() == this ? newHandler : ICE_SHARED_FROM_THIS;
+    return previousHandler.get() == this ? newHandler : shared_from_this();
 }
 
 AsyncStatus
@@ -49,7 +49,7 @@ ConnectRequestHandler::sendAsyncRequest(const ProxyOutgoingAsyncBasePtr& out)
         Lock sync(*this);
         if(!_initialized)
         {
-            out->cancelable(ICE_SHARED_FROM_THIS); // This will throw if the request is canceled
+            out->cancelable(shared_from_this()); // This will throw if the request is canceled
         }
 
         if(!initialized())
@@ -152,7 +152,7 @@ ConnectRequestHandler::setConnection(const Ice::ConnectionIPtr& connection, bool
     // add this proxy to the router info object.
     //
     RouterInfoPtr ri = _reference->getRouterInfo();
-    if(ri && !ri->addProxy(_proxy, ICE_SHARED_FROM_THIS))
+    if(ri && !ri->addProxy(_proxy, shared_from_this()))
     {
         return; // The request handler will be initialized once addProxy returns.
     }
@@ -180,7 +180,7 @@ ConnectRequestHandler::setException(const Ice::LocalException& ex)
     //
     try
     {
-        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
     }
     catch(const Ice::CommunicatorDestroyedException&)
     {
@@ -285,7 +285,7 @@ ConnectRequestHandler::flushRequests()
             ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.get()->ice_clone());
 
             // Remove the request handler before retrying.
-            _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+            _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
 
             req->retryException(*exception);
         }
@@ -309,10 +309,10 @@ ConnectRequestHandler::flushRequests()
     //
     if(_reference->getCacheConnection() && !exception)
     {
-        _requestHandler = ICE_MAKE_SHARED(ConnectionRequestHandler, _reference, _connection, _compress);
+        _requestHandler = std::make_shared<ConnectionRequestHandler>(_reference, _connection, _compress);
         for(set<Ice::ObjectPrxPtr>::const_iterator p = _proxies.begin(); p != _proxies.end(); ++p)
         {
-            (*p)->_updateRequestHandler(ICE_SHARED_FROM_THIS, _requestHandler);
+            (*p)->_updateRequestHandler(shared_from_this(), _requestHandler);
         }
     }
 
@@ -327,7 +327,7 @@ ConnectRequestHandler::flushRequests()
         // Only remove once all the requests are flushed to
         // guarantee serialization.
         //
-        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
 
         _proxies.clear();
         _proxy = nullptr; // Break cyclic reference count.

--- a/cpp/src/Ice/ConnectRequestHandler.h
+++ b/cpp/src/Ice/ConnectRequestHandler.h
@@ -21,7 +21,7 @@
 namespace IceInternal
 {
 
-class ConnectRequestHandler ICE_FINAL : public RequestHandler,
+class ConnectRequestHandler final : public RequestHandler,
                                         public Reference::GetConnectionCallback,
                                         public RouterInfo::AddProxyCallback,
                                         public IceUtil::Monitor<IceUtil::Mutex>

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -602,7 +602,7 @@ IceInternal::OutgoingConnectionFactory::createConnection(const TransceiverPtr& t
         }
 
         connection = ConnectionI::create(_communicator, _instance, _monitor, transceiver, ci.connector,
-                                         ci.endpoint->compress(false), ICE_NULLPTR);
+                                         ci.endpoint->compress(false), nullptr);
     }
     catch(const Ice::LocalException&)
     {
@@ -1359,7 +1359,7 @@ IceInternal::IncomingConnectionFactory::finishAsync(SocketOperation)
     }
     catch(const LocalException& ex)
     {
-        _acceptorException.reset(ICE_NULLPTR);
+        _acceptorException.reset(nullptr);
 
         Error out(_instance->initializationData().logger);
         out << "couldn't accept connection:\n" << ex << '\n' << _acceptor->toString();

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -95,7 +95,7 @@ public:
         {
             Error out(_instance->initializationData().logger);
             out << "acceptor creation failed:\n" << ex << '\n' << _factory->toString();
-            _instance->timer()->schedule(ICE_SHARED_FROM_THIS, IceUtil::Time::seconds(1));
+            _instance->timer()->schedule(shared_from_this(), IceUtil::Time::seconds(1));
         }
     }
 
@@ -883,7 +883,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::connectionStartComplete
     }
 
     connection->activate();
-    _factory->finishGetConnection(_connectors, *_iter, connection, ICE_SHARED_FROM_THIS);
+    _factory->finishGetConnection(_connectors, *_iter, connection, shared_from_this());
 }
 
 void
@@ -976,7 +976,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::nextEndpoint()
     try
     {
         assert(_endpointsIter != _endpoints.end());
-        (*_endpointsIter)->connectors_async(_selType, ICE_SHARED_FROM_THIS);
+        (*_endpointsIter)->connectors_async(_selType, shared_from_this());
 
     }
     catch(const Ice::LocalException& ex)
@@ -995,7 +995,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::getConnection()
         // connection.
         //
         bool compress;
-        Ice::ConnectionIPtr connection = _factory->getConnection(_connectors, ICE_SHARED_FROM_THIS, compress);
+        Ice::ConnectionIPtr connection = _factory->getConnection(_connectors, shared_from_this(), compress);
         if(!connection)
         {
             //
@@ -1043,7 +1043,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::nextConnector()
                     << _iter->connector->toString();
             }
             Ice::ConnectionIPtr connection = _factory->createConnection(_iter->connector->connect(), *_iter);
-            connection->start(ICE_SHARED_FROM_THIS);
+            connection->start(shared_from_this());
         }
         catch(const Ice::LocalException& ex)
         {
@@ -1109,7 +1109,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::removeConnectors(const 
 void
 IceInternal::OutgoingConnectionFactory::ConnectCallback::removeFromPending()
 {
-    _factory->removeFromPending(ICE_SHARED_FROM_THIS, _connectors);
+    _factory->removeFromPending(shared_from_this(), _connectors);
 }
 
 bool
@@ -1130,7 +1130,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::connectionStartFailedIm
     _factory->handleConnectionException(ex, _hasMore || _iter != _connectors.end() - 1);
     if(dynamic_cast<const Ice::CommunicatorDestroyedException*>(&ex)) // No need to continue.
     {
-        _factory->finishGetConnection(_connectors, ex, ICE_SHARED_FROM_THIS);
+        _factory->finishGetConnection(_connectors, ex, shared_from_this());
     }
     else if(++_iter != _connectors.end()) // Try the next connector.
     {
@@ -1138,7 +1138,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::connectionStartFailedIm
     }
     else
     {
-        _factory->finishGetConnection(_connectors, ex, ICE_SHARED_FROM_THIS);
+        _factory->finishGetConnection(_connectors, ex, shared_from_this());
     }
     return false;
 }
@@ -1366,7 +1366,7 @@ IceInternal::IncomingConnectionFactory::finishAsync(SocketOperation)
         if(_acceptorStarted)
         {
             _acceptorStarted = false;
-            if(_adapter->getThreadPool()->finish(ICE_SHARED_FROM_THIS, true))
+            if(_adapter->getThreadPool()->finish(shared_from_this(), true))
             {
                 closeAcceptor();
             }
@@ -1440,7 +1440,7 @@ IceInternal::IncomingConnectionFactory::message(ThreadPoolCurrent& current)
 
                 assert(_acceptorStarted);
                 _acceptorStarted = false;
-                if(_adapter->getThreadPool()->finish(ICE_SHARED_FROM_THIS, true))
+                if(_adapter->getThreadPool()->finish(shared_from_this(), true))
                 {
                     closeAcceptor();
                 }
@@ -1491,7 +1491,7 @@ IceInternal::IncomingConnectionFactory::message(ThreadPoolCurrent& current)
 
     assert(connection);
 
-    connection->start(ICE_SHARED_FROM_THIS);
+    connection->start(shared_from_this());
 }
 
 void
@@ -1511,7 +1511,7 @@ IceInternal::IncomingConnectionFactory::finished(ThreadPoolCurrent&, bool close)
         //
         if(!_acceptorStopped)
         {
-            _instance->timer()->schedule(ICE_MAKE_SHARED(StartAcceptor, ICE_SHARED_FROM_THIS, _instance),
+            _instance->timer()->schedule(std::make_shared<StartAcceptor>(shared_from_this(), _instance),
                                          IceUtil::Time::seconds(1));
         }
         return;
@@ -1535,7 +1535,7 @@ IceInternal::IncomingConnectionFactory::finished(ThreadPoolCurrent&, bool close)
 void
 IceInternal::IncomingConnectionFactory::finish()
 {
-    unregisterForBackgroundNotification(ICE_SHARED_FROM_THIS);
+    unregisterForBackgroundNotification(shared_from_this());
 }
 #endif
 
@@ -1649,7 +1649,7 @@ IceInternal::IncomingConnectionFactory::stopAcceptor()
 
     _acceptorStopped = true;
     _acceptorStarted = false;
-    if(_adapter->getThreadPool()->finish(ICE_SHARED_FROM_THIS, true))
+    if(_adapter->getThreadPool()->finish(shared_from_this(), true))
     {
         closeAcceptor();
     }
@@ -1690,7 +1690,7 @@ IceInternal::IncomingConnectionFactory::initialize()
             // The notification center will call back on the factory to
             // start the acceptor if necessary.
             //
-            registerForBackgroundNotification(ICE_SHARED_FROM_THIS);
+            registerForBackgroundNotification(shared_from_this());
 #else
             createAcceptor();
 #endif
@@ -1746,7 +1746,7 @@ IceInternal::IncomingConnectionFactory::setState(State state)
                     Trace out(_instance->initializationData().logger, _instance->traceLevels()->networkCat);
                     out << "accepting " << _endpoint->protocol() << " connections at " << _acceptor->toString();
                 }
-                _adapter->getThreadPool()->_register(ICE_SHARED_FROM_THIS, SocketOperationRead);
+                _adapter->getThreadPool()->_register(shared_from_this(), SocketOperationRead);
             }
 
             for(const auto& conn : _connections)
@@ -1769,7 +1769,7 @@ IceInternal::IncomingConnectionFactory::setState(State state)
                     Trace out(_instance->initializationData().logger, _instance->traceLevels()->networkCat);
                     out << "holding " << _endpoint->protocol() << " connections at " << _acceptor->toString();
                 }
-                _adapter->getThreadPool()->unregister(ICE_SHARED_FROM_THIS, SocketOperationRead);
+                _adapter->getThreadPool()->unregister(shared_from_this(), SocketOperationRead);
             }
 
             for(const auto& conn : _connections)
@@ -1791,7 +1791,7 @@ IceInternal::IncomingConnectionFactory::setState(State state)
                 // however.
                 //
                 _acceptorStarted = false;
-                if(_adapter->getThreadPool()->finish(ICE_SHARED_FROM_THIS, true))
+                if(_adapter->getThreadPool()->finish(shared_from_this(), true))
                 {
                     closeAcceptor();
                 }
@@ -1799,7 +1799,7 @@ IceInternal::IncomingConnectionFactory::setState(State state)
             else
             {
 #if TARGET_OS_IPHONE != 0
-                _adapter->getThreadPool()->dispatch(new FinishCall(ICE_SHARED_FROM_THIS));
+                _adapter->getThreadPool()->dispatch(new FinishCall(shared_from_this()));
 #endif
                 state = StateFinished;
             }
@@ -1843,10 +1843,10 @@ IceInternal::IncomingConnectionFactory::createAcceptor()
             out << "listening for " << _endpoint->protocol() << " connections\n" << _acceptor->toDetailedString();
         }
 
-        _adapter->getThreadPool()->initialize(ICE_SHARED_FROM_THIS);
+        _adapter->getThreadPool()->initialize(shared_from_this());
         if(_state == StateActive)
         {
-            _adapter->getThreadPool()->_register(ICE_SHARED_FROM_THIS, SocketOperationRead);
+            _adapter->getThreadPool()->_register(shared_from_this(), SocketOperationRead);
         }
 
         _acceptorStarted = true;

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1339,7 +1339,7 @@ IceInternal::IncomingConnectionFactory::startAsync(SocketOperation)
     }
     catch(const Ice::LocalException& ex)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_acceptorException, ex.ice_clone());
+        _acceptorException = ex.ice_clone();
         _acceptor->getNativeInfo()->completed(SocketOperationRead);
     }
     return true;

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2192,7 +2192,7 @@ Ice::ConnectionI::setState(State state, const LocalException& ex)
         // If we are in closed state, an exception must be set.
         //
         assert(_state != StateClosed);
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
         //
         // We don't warn if we are not validated.
         //

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -194,7 +194,7 @@ ConnectionFlushBatchAsync::invoke(const string& operation, Ice::CompressBatch co
             {
                 compress = false;
             }
-            status = _connection->sendAsyncRequest(ICE_SHARED_FROM_THIS, compress, false, batchRequestNum);
+            status = _connection->sendAsyncRequest(shared_from_this(), compress, false, batchRequestNum);
         }
 
         if(status & AsyncStatusSent)
@@ -419,7 +419,7 @@ Ice::ConnectionI::start(const StartCallbackPtr& callback)
         exception(ex);
         if(callback)
         {
-            callback->connectionStartFailed(ICE_SHARED_FROM_THIS, ex);
+            callback->connectionStartFailed(shared_from_this(), ex);
             return;
         }
         else
@@ -431,7 +431,7 @@ Ice::ConnectionI::start(const StartCallbackPtr& callback)
 
     if(callback)
     {
-        callback->connectionStartCompleted(ICE_SHARED_FROM_THIS);
+        callback->connectionStartCompleted(shared_from_this());
     }
 }
 
@@ -707,7 +707,7 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
     // Notify the request that it's cancelable with this connection.
     // This will throw if the request is canceled.
     //
-    out->cancelable(ICE_SHARED_FROM_THIS);
+    out->cancelable(shared_from_this());
     Int requestId = 0;
     if(response)
     {
@@ -790,7 +790,7 @@ Ice::ConnectionI::flushBatchRequestsAsync(CompressBatch compress,
         {
         }
     };
-    auto outAsync = make_shared<ConnectionFlushBatchLambda>(ICE_SHARED_FROM_THIS, _instance, ex, sent);
+    auto outAsync = make_shared<ConnectionFlushBatchLambda>(shared_from_this(), _instance, ex, sent);
     outAsync->invoke(flushBatchRequests_name, compress);
     return [outAsync]() { outAsync->cancel(); };
 }
@@ -844,7 +844,7 @@ public:
             _os.write(headerSize); // Message size.
             _os.i = _os.b.begin();
 
-            AsyncStatus status = _connection->sendAsyncRequest(ICE_SHARED_FROM_THIS, false, false, 0);
+            AsyncStatus status = _connection->sendAsyncRequest(shared_from_this(), false, false, 0);
             if(status & AsyncStatusSent)
             {
                 _sentSynchronously = true;
@@ -901,7 +901,7 @@ Ice::ConnectionI::heartbeatAsync(::std::function<void(::std::exception_ptr)> ex,
         {
         }
     };
-    auto outAsync = make_shared<HeartbeatLambda>(ICE_SHARED_FROM_THIS, _communicator, _instance, ex, sent);
+    auto outAsync = make_shared<HeartbeatLambda>(shared_from_this(), _communicator, _instance, ex, sent);
     outAsync->invoke();
     return [outAsync]() { outAsync->cancel(); };
 }
@@ -945,7 +945,7 @@ Ice::ConnectionI::setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)) callback)
                 const ConnectionIPtr _connection;
                 const ICE_DELEGATE(CloseCallback) _callback;
             };
-            _threadPool->dispatch(new CallbackWorkItem(ICE_SHARED_FROM_THIS, move(callback)));
+            _threadPool->dispatch(new CallbackWorkItem(shared_from_this(), move(callback)));
         }
     }
     else
@@ -959,7 +959,7 @@ Ice::ConnectionI::closeCallback(const ICE_DELEGATE(CloseCallback)& callback)
 {
     try
     {
-        callback(ICE_SHARED_FROM_THIS);
+        callback(shared_from_this());
     }
     catch(const std::exception& ex)
     {
@@ -990,7 +990,7 @@ Ice::ConnectionI::setACM(const IceUtil::Optional<int>& timeout,
 
     if(_state == StateActive)
     {
-        _monitor->remove(ICE_SHARED_FROM_THIS);
+        _monitor->remove(shared_from_this());
     }
     _monitor = _monitor->acm(timeout, close, heartbeat);
 
@@ -1005,7 +1005,7 @@ Ice::ConnectionI::setACM(const IceUtil::Optional<int>& timeout,
 
     if(_state == StateActive)
     {
-        _monitor->add(ICE_SHARED_FROM_THIS);
+        _monitor->add(shared_from_this());
     }
 }
 
@@ -1249,7 +1249,7 @@ Ice::ConnectionI::setAdapter(const ObjectAdapterPtr& adapter)
     {
         // Go through the adapter to set the adapter and servant manager on this connection
         // to ensure the object adapter is still active.
-        dynamic_cast<ObjectAdapterI*>(adapter.get())->setAdapterOnConnection(ICE_SHARED_FROM_THIS);
+        dynamic_cast<ObjectAdapterI*>(adapter.get())->setAdapterOnConnection(shared_from_this());
     }
     else
     {
@@ -1561,7 +1561,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     // satisfied before continuing.
                     //
                     scheduleTimeout(newOp);
-                    _threadPool->update(ICE_SHARED_FROM_THIS, current.operation, newOp);
+                    _threadPool->update(shared_from_this(), current.operation, newOp);
                     return;
                 }
 
@@ -1575,7 +1575,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     return;
                 }
 
-                _threadPool->unregister(ICE_SHARED_FROM_THIS, current.operation);
+                _threadPool->unregister(shared_from_this(), current.operation);
 
                 //
                 // We start out in holding state.
@@ -1623,7 +1623,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                 if(_state < StateClosed)
                 {
                     scheduleTimeout(newOp);
-                    _threadPool->update(ICE_SHARED_FROM_THIS, current.operation, newOp);
+                    _threadPool->update(shared_from_this(), current.operation, newOp);
                 }
             }
 
@@ -1680,7 +1680,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
 
 // dispatchFromThisThread dispatches to the correct DispatchQueue
 #ifdef ICE_SWIFT
-    _threadPool->dispatchFromThisThread(new DispatchCall(ICE_SHARED_FROM_THIS, startCB, sentCBs, compress, requestId,
+    _threadPool->dispatchFromThisThread(new DispatchCall(shared_from_this(), startCB, sentCBs, compress, requestId,
                                                          invokeNum, servantManager, adapter, outAsync,
                                                          heartbeatCallback, current.stream));
 #else
@@ -1691,7 +1691,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
     }
     else
     {
-        _threadPool->dispatchFromThisThread(new DispatchCall(ICE_SHARED_FROM_THIS, startCB, sentCBs, compress, requestId,
+        _threadPool->dispatchFromThisThread(new DispatchCall(shared_from_this(), startCB, sentCBs, compress, requestId,
                                                              invokeNum, servantManager, adapter, outAsync,
                                                              heartbeatCallback, current.stream));
 
@@ -1713,7 +1713,7 @@ ConnectionI::dispatch(const StartCallbackPtr& startCB, const vector<OutgoingMess
     //
     if(startCB)
     {
-        startCB->connectionStartCompleted(ICE_SHARED_FROM_THIS);
+        startCB->connectionStartCompleted(shared_from_this());
         ++dispatchedCount;
     }
 
@@ -1758,7 +1758,7 @@ ConnectionI::dispatch(const StartCallbackPtr& startCB, const vector<OutgoingMess
     {
         try
         {
-            heartbeatCallback(ICE_SHARED_FROM_THIS);
+            heartbeatCallback(shared_from_this());
         }
         catch(const std::exception& ex)
         {
@@ -1847,7 +1847,7 @@ Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
 
 // dispatchFromThisThread dispatches to the correct DispatchQueue
 #ifdef __APPLE__
-    _threadPool->dispatchFromThisThread(new FinishCall(ICE_SHARED_FROM_THIS, close));
+    _threadPool->dispatchFromThisThread(new FinishCall(shared_from_this(), close));
 #else
     if(!_dispatcher) // Optimization, call finish() directly if there's no dispatcher.
     {
@@ -1855,7 +1855,7 @@ Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
     }
     else
     {
-        _threadPool->dispatchFromThisThread(new FinishCall(ICE_SHARED_FROM_THIS, close));
+        _threadPool->dispatchFromThisThread(new FinishCall(shared_from_this(), close));
     }
 #endif
 }
@@ -1909,7 +1909,7 @@ Ice::ConnectionI::finish(bool close)
     {
         assert(_exception);
 
-        _startCallback->connectionStartFailed(ICE_SHARED_FROM_THIS, *_exception);
+        _startCallback->connectionStartFailed(shared_from_this(), *_exception);
         _startCallback = 0;
     }
 
@@ -2277,7 +2277,7 @@ Ice::ConnectionI::setState(State state)
                 {
                     return;
                 }
-                _threadPool->_register(ICE_SHARED_FROM_THIS, SocketOperationRead);
+                _threadPool->_register(shared_from_this(), SocketOperationRead);
                 break;
             }
 
@@ -2293,7 +2293,7 @@ Ice::ConnectionI::setState(State state)
                 }
                 if(_state == StateActive)
                 {
-                    _threadPool->unregister(ICE_SHARED_FROM_THIS, SocketOperationRead);
+                    _threadPool->unregister(shared_from_this(), SocketOperationRead);
                 }
                 break;
             }
@@ -2324,7 +2324,7 @@ Ice::ConnectionI::setState(State state)
                 // Don't need to close now for connections so only close the transceiver
                 // if the selector request it.
                 //
-                if(_threadPool->finish(ICE_SHARED_FROM_THIS, false))
+                if(_threadPool->finish(shared_from_this(), false))
                 {
                     _transceiver->close();
                 }
@@ -2359,11 +2359,11 @@ Ice::ConnectionI::setState(State state)
             {
                 _acmLastActivity = IceUtil::Time::now(IceUtil::Time::Monotonic);
             }
-            _monitor->add(ICE_SHARED_FROM_THIS);
+            _monitor->add(shared_from_this());
         }
         else if(_state == StateActive)
         {
-            _monitor->remove(ICE_SHARED_FROM_THIS);
+            _monitor->remove(shared_from_this());
         }
     }
 
@@ -2447,7 +2447,7 @@ Ice::ConnectionI::initiateShutdown()
             if(op)
             {
                 scheduleTimeout(op);
-                _threadPool->_register(ICE_SHARED_FROM_THIS, op);
+                _threadPool->_register(shared_from_this(), op);
             }
         }
     }
@@ -2491,7 +2491,7 @@ Ice::ConnectionI::initialize(SocketOperation operation)
     if(s != SocketOperationNone)
     {
         scheduleTimeout(s);
-        _threadPool->update(ICE_SHARED_FROM_THIS, operation, s);
+        _threadPool->update(shared_from_this(), operation, s);
         return false;
     }
 
@@ -2537,7 +2537,7 @@ Ice::ConnectionI::validate(SocketOperation operation)
                 if(op)
                 {
                     scheduleTimeout(op);
-                    _threadPool->update(ICE_SHARED_FROM_THIS, operation, op);
+                    _threadPool->update(shared_from_this(), operation, op);
                     return false;
                 }
             }
@@ -2566,7 +2566,7 @@ Ice::ConnectionI::validate(SocketOperation operation)
                 if(op)
                 {
                     scheduleTimeout(op);
-                    _threadPool->update(ICE_SHARED_FROM_THIS, operation, op);
+                    _threadPool->update(shared_from_this(), operation, op);
                     return false;
                 }
             }
@@ -2915,7 +2915,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
 
     _writeStream.swap(*_sendStreams.back().stream);
     scheduleTimeout(op);
-    _threadPool->_register(ICE_SHARED_FROM_THIS, op);
+    _threadPool->_register(shared_from_this(), op);
     return AsyncStatusQueued;
 }
 
@@ -3425,7 +3425,7 @@ Ice::ConnectionI::initConnectionInfo() const
     }
     catch(const Ice::LocalException&)
     {
-        _info = ICE_MAKE_SHARED(ConnectionInfo);
+        _info = std::make_shared<ConnectionInfo>();
     }
 
     Ice::ConnectionInfoPtr info = _info;
@@ -3490,7 +3490,7 @@ ConnectionI::reap()
 {
     if(_monitor)
     {
-        _monitor->reap(ICE_SHARED_FROM_THIS);
+        _monitor->reap(shared_from_this());
     }
     if(_observer)
     {

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -484,7 +484,7 @@ Ice::ConnectionI::destroy(DestructionReason reason)
 }
 
 void
-Ice::ConnectionI::close(ConnectionClose mode) ICE_NOEXCEPT
+Ice::ConnectionI::close(ConnectionClose mode) noexcept
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
 
@@ -1010,7 +1010,7 @@ Ice::ConnectionI::setACM(const IceUtil::Optional<int>& timeout,
 }
 
 ACM
-Ice::ConnectionI::getACM() ICE_NOEXCEPT
+Ice::ConnectionI::getACM() noexcept
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     ACM acm;
@@ -1270,14 +1270,14 @@ Ice::ConnectionI::setAdapter(const ObjectAdapterPtr& adapter)
 }
 
 ObjectAdapterPtr
-Ice::ConnectionI::getAdapter() const ICE_NOEXCEPT
+Ice::ConnectionI::getAdapter() const noexcept
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     return _adapter;
 }
 
 EndpointPtr
-Ice::ConnectionI::getEndpoint() const ICE_NOEXCEPT
+Ice::ConnectionI::getEndpoint() const noexcept
 {
     return _endpoint; // No mutex protection necessary, _endpoint is immutable.
 }
@@ -1982,10 +1982,10 @@ Ice::ConnectionI::finish(bool close)
     if(_closeCallback)
     {
         closeCallback(_closeCallback);
-        _closeCallback = ICE_NULLPTR;
+        _closeCallback = nullptr;
     }
 
-    _heartbeatCallback = ICE_NULLPTR;
+    _heartbeatCallback = nullptr;
 
     //
     // This must be done last as this will cause waitUntilFinished() to return (and communicator
@@ -2003,7 +2003,7 @@ Ice::ConnectionI::finish(bool close)
 }
 
 string
-Ice::ConnectionI::toString() const ICE_NOEXCEPT
+Ice::ConnectionI::toString() const noexcept
 {
     return _desc; // No mutex lock, _desc is immutable.
 }
@@ -2033,13 +2033,13 @@ Ice::ConnectionI::timedOut()
 }
 
 string
-Ice::ConnectionI::type() const ICE_NOEXCEPT
+Ice::ConnectionI::type() const noexcept
 {
     return _type; // No mutex lock, _type is immutable.
 }
 
 Ice::Int
-Ice::ConnectionI::timeout() const ICE_NOEXCEPT
+Ice::ConnectionI::timeout() const noexcept
 {
     return _endpoint->timeout(); // No mutex lock, _endpoint is immutable.
 }

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -144,14 +144,14 @@ private:
 typedef IceUtil::Handle<ConnectionFlushBatchAsync> ConnectionFlushBatchAsyncPtr;
 
 ConnectionState connectionStateMap[] = {
-    ICE_ENUM(ConnectionState, ConnectionStateValidating),   // StateNotInitialized
-    ICE_ENUM(ConnectionState, ConnectionStateValidating),   // StateNotValidated
-    ICE_ENUM(ConnectionState, ConnectionStateActive),       // StateActive
-    ICE_ENUM(ConnectionState, ConnectionStateHolding),      // StateHolding
-    ICE_ENUM(ConnectionState, ConnectionStateClosing),      // StateClosing
-    ICE_ENUM(ConnectionState, ConnectionStateClosing),      // StateClosingPending
-    ICE_ENUM(ConnectionState, ConnectionStateClosed),       // StateClosed
-    ICE_ENUM(ConnectionState, ConnectionStateClosed),       // StateFinished
+    ConnectionState::ConnectionStateValidating,   // StateNotInitialized
+    ConnectionState::ConnectionStateValidating,   // StateNotValidated
+    ConnectionState::ConnectionStateActive,       // StateActive
+    ConnectionState::ConnectionStateHolding,      // StateHolding
+    ConnectionState::ConnectionStateClosing,      // StateClosing
+    ConnectionState::ConnectionStateClosing,      // StateClosingPending
+    ConnectionState::ConnectionStateClosed,       // StateClosed
+    ConnectionState::ConnectionStateClosed,       // StateFinished
 };
 
 }
@@ -186,11 +186,11 @@ ConnectionFlushBatchAsync::invoke(const string& operation, Ice::CompressBatch co
         }
         else
         {
-            if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, Yes))
+            if(compressBatch == CompressBatch::Yes)
             {
                 compress = true;
             }
-            else if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, No))
+            else if(compressBatch == CompressBatch::No)
             {
                 compress = false;
             }
@@ -488,17 +488,17 @@ Ice::ConnectionI::close(ConnectionClose mode) noexcept
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
 
-    if(mode == ICE_SCOPED_ENUM(ConnectionClose, Forcefully))
+    if(mode == ConnectionClose::Forcefully)
     {
         setState(StateClosed, ConnectionManuallyClosedException(__FILE__, __LINE__, false));
     }
-    else if(mode == ICE_SCOPED_ENUM(ConnectionClose, Gracefully))
+    else if(mode == ConnectionClose::Gracefully)
     {
         setState(StateClosing, ConnectionManuallyClosedException(__FILE__, __LINE__, true));
     }
     else
     {
-        assert(mode == ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        assert(mode == ConnectionClose::GracefullyWithWait);
 
         //
         // Wait until all outstanding requests have been completed.
@@ -636,11 +636,11 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
     // per timeout period because the monitor() method is still only
     // called every (timeout / 2) period.
     //
-    if(acm.heartbeat == ICE_ENUM(ACMHeartbeat, HeartbeatAlways) ||
-       (acm.heartbeat != ICE_ENUM(ACMHeartbeat, HeartbeatOff) &&
+    if(acm.heartbeat == ACMHeartbeat::HeartbeatAlways ||
+       (acm.heartbeat != ACMHeartbeat::HeartbeatOff &&
         _writeStream.b.empty() && now >= (_acmLastActivity + acm.timeout / 4)))
     {
-        if(acm.heartbeat != ICE_ENUM(ACMHeartbeat, HeartbeatOnDispatch) || _dispatchCount > 0)
+        if(acm.heartbeat != ACMHeartbeat::HeartbeatOnDispatch || _dispatchCount > 0)
         {
             sendHeartbeatNow();
         }
@@ -657,10 +657,10 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
         return;
     }
 
-    if(acm.close != ICE_ENUM(ACMClose, CloseOff) && now >= (_acmLastActivity + acm.timeout))
+    if(acm.close != ACMClose::CloseOff && now >= (_acmLastActivity + acm.timeout))
     {
-        if(acm.close == ICE_ENUM(ACMClose, CloseOnIdleForceful) ||
-           (acm.close != ICE_ENUM(ACMClose, CloseOnIdle) && !_asyncRequests.empty()))
+        if(acm.close == ACMClose::CloseOnIdleForceful ||
+           (acm.close != ACMClose::CloseOnIdle && !_asyncRequests.empty()))
         {
             //
             // Close the connection if we didn't receive a heartbeat in
@@ -668,7 +668,7 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
             //
             setState(StateClosed, ConnectionTimeoutException(__FILE__, __LINE__));
         }
-        else if(acm.close != ICE_ENUM(ACMClose, CloseOnInvocation) &&
+        else if(acm.close != ACMClose::CloseOnInvocation &&
                 _dispatchCount == 0 && _batchRequestQueue->isEmpty() && _asyncRequests.empty())
         {
             //
@@ -1015,8 +1015,8 @@ Ice::ConnectionI::getACM() noexcept
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     ACM acm;
     acm.timeout = 0;
-    acm.close = ICE_ENUM(ACMClose, CloseOff);
-    acm.heartbeat = ICE_ENUM(ACMHeartbeat, HeartbeatOff);
+    acm.close = ACMClose::CloseOff;
+    acm.heartbeat = ACMHeartbeat::HeartbeatOff;
     return _monitor ? _monitor->getACM() : acm;
 }
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -63,7 +63,7 @@ public:
     DispatchCall(const ConnectionIPtr& connection, const ConnectionI::StartCallbackPtr& startCB,
                  const vector<ConnectionI::OutgoingMessage>& sentCBs, Byte compress, Int requestId,
                  Int invokeNum, const ServantManagerPtr& servantManager, const ObjectAdapterPtr& adapter,
-                 const OutgoingAsyncBasePtr& outAsync, const ICE_DELEGATE(HeartbeatCallback)& heartbeatCallback,
+                 const OutgoingAsyncBasePtr& outAsync, const HeartbeatCallback& heartbeatCallback,
                  InputStream& stream) :
         DispatchWorkItem(connection),
         _connection(connection),
@@ -99,7 +99,7 @@ private:
     const ServantManagerPtr _servantManager;
     const ObjectAdapterPtr _adapter;
     const OutgoingAsyncBasePtr _outAsync;
-    const ICE_DELEGATE(HeartbeatCallback) _heartbeatCallback;
+    const HeartbeatCallback _heartbeatCallback;
     InputStream _stream;
 };
 
@@ -907,7 +907,7 @@ Ice::ConnectionI::heartbeatAsync(::std::function<void(::std::exception_ptr)> ex,
 }
 
 void
-Ice::ConnectionI::setHeartbeatCallback(ICE_IN(ICE_DELEGATE(HeartbeatCallback)) callback)
+Ice::ConnectionI::setHeartbeatCallback(ICE_IN(HeartbeatCallback) callback)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     if(_state >= StateClosed)
@@ -918,7 +918,7 @@ Ice::ConnectionI::setHeartbeatCallback(ICE_IN(ICE_DELEGATE(HeartbeatCallback)) c
 }
 
 void
-Ice::ConnectionI::setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)) callback)
+Ice::ConnectionI::setCloseCallback(ICE_IN(CloseCallback) callback)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     if(_state >= StateClosed)
@@ -929,7 +929,7 @@ Ice::ConnectionI::setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)) callback)
             {
             public:
 
-                CallbackWorkItem(const ConnectionIPtr& connection, ICE_IN(ICE_DELEGATE(CloseCallback)) callback) :
+                CallbackWorkItem(const ConnectionIPtr& connection, ICE_IN(CloseCallback) callback) :
                     _connection(connection),
                     _callback(move(callback))
                 {
@@ -943,7 +943,7 @@ Ice::ConnectionI::setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)) callback)
             private:
 
                 const ConnectionIPtr _connection;
-                const ICE_DELEGATE(CloseCallback) _callback;
+                const CloseCallback _callback;
             };
             _threadPool->dispatch(new CallbackWorkItem(shared_from_this(), move(callback)));
         }
@@ -955,7 +955,7 @@ Ice::ConnectionI::setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)) callback)
 }
 
 void
-Ice::ConnectionI::closeCallback(const ICE_DELEGATE(CloseCallback)& callback)
+Ice::ConnectionI::closeCallback(const CloseCallback& callback)
 {
     try
     {
@@ -1418,7 +1418,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
     ServantManagerPtr servantManager;
     ObjectAdapterPtr adapter;
     OutgoingAsyncBasePtr outAsync;
-    ICE_DELEGATE(HeartbeatCallback) heartbeatCallback;
+    HeartbeatCallback heartbeatCallback;
     int dispatchCount = 0;
 
     ThreadPoolMessage<ConnectionI> msg(current, *this);
@@ -1703,7 +1703,7 @@ void
 ConnectionI::dispatch(const StartCallbackPtr& startCB, const vector<OutgoingMessage>& sentCBs,
                       Byte compress, Int requestId, Int invokeNum, const ServantManagerPtr& servantManager,
                       const ObjectAdapterPtr& adapter, const OutgoingAsyncBasePtr& outAsync,
-                      const ICE_DELEGATE(HeartbeatCallback)& heartbeatCallback, InputStream& stream)
+                      const HeartbeatCallback& heartbeatCallback, InputStream& stream)
 {
     int dispatchedCount = 0;
 
@@ -3070,7 +3070,7 @@ Ice::ConnectionI::doUncompress(InputStream& compressed, InputStream& uncompresse
 SocketOperation
 Ice::ConnectionI::parseMessage(InputStream& stream, Int& invokeNum, Int& requestId, Byte& compress,
                                ServantManagerPtr& servantManager, ObjectAdapterPtr& adapter,
-                               OutgoingAsyncBasePtr& outAsync, ICE_DELEGATE(HeartbeatCallback)& heartbeatCallback,
+                               OutgoingAsyncBasePtr& outAsync, HeartbeatCallback& heartbeatCallback,
                                int& dispatchCount)
 {
     assert(_state > StateNotValidated && _state < StateClosed);

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -907,7 +907,7 @@ Ice::ConnectionI::heartbeatAsync(::std::function<void(::std::exception_ptr)> ex,
 }
 
 void
-Ice::ConnectionI::setHeartbeatCallback(ICE_IN(HeartbeatCallback) callback)
+Ice::ConnectionI::setHeartbeatCallback(HeartbeatCallback callback)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     if(_state >= StateClosed)
@@ -918,7 +918,7 @@ Ice::ConnectionI::setHeartbeatCallback(ICE_IN(HeartbeatCallback) callback)
 }
 
 void
-Ice::ConnectionI::setCloseCallback(ICE_IN(CloseCallback) callback)
+Ice::ConnectionI::setCloseCallback(CloseCallback callback)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     if(_state >= StateClosed)
@@ -929,7 +929,7 @@ Ice::ConnectionI::setCloseCallback(ICE_IN(CloseCallback) callback)
             {
             public:
 
-                CallbackWorkItem(const ConnectionIPtr& connection, ICE_IN(CloseCallback) callback) :
+                CallbackWorkItem(const ConnectionIPtr& connection, CloseCallback callback) :
                     _connection(connection),
                     _callback(move(callback))
                 {

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -159,8 +159,8 @@ public:
                             ::std::function<void(::std::exception_ptr)>,
                             ::std::function<void(bool)> = nullptr);
 
-    virtual void setCloseCallback(ICE_IN(CloseCallback));
-    virtual void setHeartbeatCallback(ICE_IN(HeartbeatCallback));
+    virtual void setCloseCallback(CloseCallback);
+    virtual void setHeartbeatCallback(HeartbeatCallback);
 
     virtual void heartbeat();
 

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -136,7 +136,7 @@ public:
     void activate();
     void hold();
     void destroy(DestructionReason);
-    virtual void close(ConnectionClose) ICE_NOEXCEPT; // From Connection.
+    virtual void close(ConnectionClose) noexcept; // From Connection.
 
     bool isActiveOrHolding() const;
     bool isFinished() const;
@@ -170,7 +170,7 @@ public:
     virtual void setACM(const IceUtil::Optional<int>&,
                         const IceUtil::Optional<ACMClose>&,
                         const IceUtil::Optional<ACMHeartbeat>&);
-    virtual ACM getACM() ICE_NOEXCEPT;
+    virtual ACM getACM() noexcept;
 
     virtual void asyncRequestCanceled(const IceInternal::OutgoingAsyncBasePtr&, const LocalException&);
 
@@ -183,8 +183,8 @@ public:
     IceInternal::ConnectorPtr connector() const;
 
     virtual void setAdapter(const ObjectAdapterPtr&); // From Connection.
-    virtual ObjectAdapterPtr getAdapter() const ICE_NOEXCEPT; // From Connection.
-    virtual EndpointPtr getEndpoint() const ICE_NOEXCEPT; // From Connection.
+    virtual ObjectAdapterPtr getAdapter() const noexcept; // From Connection.
+    virtual EndpointPtr getEndpoint() const noexcept; // From Connection.
     virtual ObjectPrxPtr createProxy(const Identity& ident) const; // From Connection.
 
     void setAdapterAndServantManager(const ObjectAdapterPtr&, const IceInternal::ServantManagerPtr&);
@@ -199,13 +199,13 @@ public:
 
     virtual void message(IceInternal::ThreadPoolCurrent&);
     virtual void finished(IceInternal::ThreadPoolCurrent&, bool);
-    virtual std::string toString() const ICE_NOEXCEPT; // From Connection and EvantHandler.
+    virtual std::string toString() const noexcept; // From Connection and EvantHandler.
     virtual IceInternal::NativeInfoPtr getNativeInfo();
 
     void timedOut();
 
-    virtual std::string type() const ICE_NOEXCEPT; // From Connection.
-    virtual Ice::Int timeout() const ICE_NOEXCEPT; // From Connection.
+    virtual std::string type() const noexcept; // From Connection.
+    virtual Ice::Int timeout() const noexcept; // From Connection.
     virtual ConnectionInfoPtr getInfo() const; // From Connection
 
     virtual void setBufferSize(Ice::Int rcvSize, Ice::Int sndSize); // From Connection

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -159,8 +159,8 @@ public:
                             ::std::function<void(::std::exception_ptr)>,
                             ::std::function<void(bool)> = nullptr);
 
-    virtual void setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)));
-    virtual void setHeartbeatCallback(ICE_IN(ICE_DELEGATE(HeartbeatCallback)));
+    virtual void setCloseCallback(ICE_IN(CloseCallback));
+    virtual void setHeartbeatCallback(ICE_IN(HeartbeatCallback));
 
     virtual void heartbeat();
 
@@ -215,10 +215,10 @@ public:
     void dispatch(const StartCallbackPtr&, const std::vector<OutgoingMessage>&, Byte, Int, Int,
                   const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&,
                   const IceInternal::OutgoingAsyncBasePtr&,
-                  const ICE_DELEGATE(HeartbeatCallback)&, Ice::InputStream&);
+                  const HeartbeatCallback&, Ice::InputStream&);
     void finish(bool);
 
-    void closeCallback(const ICE_DELEGATE(CloseCallback)&);
+    void closeCallback(const CloseCallback&);
 
     virtual ~ConnectionI();
 
@@ -266,7 +266,7 @@ private:
 
     IceInternal::SocketOperation parseMessage(Ice::InputStream&, Int&, Int&, Byte&,
                                               IceInternal::ServantManagerPtr&, ObjectAdapterPtr&,
-                                              IceInternal::OutgoingAsyncBasePtr&, ICE_DELEGATE(HeartbeatCallback)&, int&);
+                                              IceInternal::OutgoingAsyncBasePtr&, HeartbeatCallback&, int&);
 
     void invokeAll(Ice::InputStream&, Int, Int, Byte,
                    const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&);
@@ -341,8 +341,8 @@ private:
     bool _initialized;
     bool _validated;
 
-    ICE_DELEGATE(CloseCallback) _closeCallback;
-    ICE_DELEGATE(HeartbeatCallback) _heartbeatCallback;
+    CloseCallback _closeCallback;
+    HeartbeatCallback _heartbeatCallback;
 };
 
 }

--- a/cpp/src/Ice/ConnectionRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectionRequestHandler.cpp
@@ -45,7 +45,7 @@ ConnectionRequestHandler::update(const RequestHandlerPtr& previousHandler, const
     {
         // Ignore.
     }
-    return ICE_SHARED_FROM_THIS;
+    return shared_from_this();
 }
 
 AsyncStatus

--- a/cpp/src/Ice/ConnectionRequestHandler.h
+++ b/cpp/src/Ice/ConnectionRequestHandler.h
@@ -12,7 +12,7 @@
 namespace IceInternal
 {
 
-class ConnectionRequestHandler ICE_FINAL : public RequestHandler
+class ConnectionRequestHandler final : public RequestHandler
                                , public std::enable_shared_from_this<ConnectionRequestHandler>
 {
 public:

--- a/cpp/src/Ice/DefaultsAndOverrides.cpp
+++ b/cpp/src/Ice/DefaultsAndOverrides.cpp
@@ -102,11 +102,11 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
     value = properties->getPropertyWithDefault("Ice.Default.EndpointSelection", "Random");
     if(value == "Random")
     {
-        defaultEndpointSelection = ICE_ENUM(EndpointSelectionType, Random);
+        defaultEndpointSelection = EndpointSelectionType::Random;
     }
     else if(value == "Ordered")
     {
-        defaultEndpointSelection = ICE_ENUM(EndpointSelectionType, Ordered);
+        defaultEndpointSelection = EndpointSelectionType::Ordered;
     }
     else
     {
@@ -153,5 +153,5 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
 
     bool slicedFormat = properties->getPropertyAsIntWithDefault("Ice.Default.SlicedFormat", 0) > 0;
     const_cast<FormatType&>(defaultFormat) = slicedFormat ?
-        ICE_ENUM(FormatType, SlicedFormat) : ICE_ENUM(FormatType, CompactFormat);
+        FormatType::SlicedFormat : FormatType::CompactFormat;
 }

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -66,7 +66,7 @@ IceInternal::EndpointFactoryManager::get(Short type) const
             return _factories[i];
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 EndpointIPtr
@@ -168,7 +168,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
         return ue; // Endpoint is opaque, but we don't have a factory for its type.
     }
 
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 EndpointIPtr

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -140,7 +140,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
     //
     if(protocol == "opaque")
     {
-        EndpointIPtr ue = ICE_MAKE_SHARED(OpaqueEndpointI, v);
+        EndpointIPtr ue = std::make_shared<OpaqueEndpointI>(v);
         if(!v.empty())
         {
             throw EndpointParseException(__FILE__, __LINE__, "unrecognized argument `" + v.front() + "' in endpoint `" +
@@ -194,7 +194,7 @@ IceInternal::EndpointFactoryManager::read(InputStream* s) const
     //
     if(!e)
     {
-        e = ICE_MAKE_SHARED(OpaqueEndpointI, type, s);
+        e = std::make_shared<OpaqueEndpointI>(type, s);
     }
 
     s->endEncapsulation();

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -21,7 +21,7 @@ IceInternal::EndpointI::streamWrite(Ice::OutputStream* s) const
 }
 
 string
-IceInternal::EndpointI::toString() const ICE_NOEXCEPT
+IceInternal::EndpointI::toString() const noexcept
 {
     //
     // WARNING: Certain features, such as proxy validation in Glacier2,

--- a/cpp/src/Ice/EndpointI.h
+++ b/cpp/src/Ice/EndpointI.h
@@ -152,7 +152,7 @@ public:
     //
     virtual std::string options() const = 0;
 
-    virtual std::string toString() const ICE_NOEXCEPT;
+    virtual std::string toString() const noexcept;
     void initWithOptions(std::vector<std::string>&);
 
 protected:
@@ -172,19 +172,19 @@ public:
     }
 
     virtual Ice::Short
-    type() const ICE_NOEXCEPT
+    type() const noexcept
     {
         return _endpoint->type();
     }
 
     virtual bool
-    datagram() const ICE_NOEXCEPT
+    datagram() const noexcept
     {
         return _endpoint->datagram();
     }
 
     virtual bool
-    secure() const ICE_NOEXCEPT
+    secure() const noexcept
     {
         return _endpoint->secure();
     }

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -100,7 +100,7 @@ Ice::UserException::ice_clone() const
 Ice::SlicedDataPtr
 Ice::UserException::ice_getSlicedData() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -306,7 +306,7 @@ void
 Ice::IllegalIdentityException::ice_print(ostream& out) const
 {
     Exception::ice_print(out);
-    out << ":\nillegal identity: `" << identityToString(id, ICE_ENUM(ToStringMode, Unicode)) << "'";
+    out << ":\nillegal identity: `" << identityToString(id, ToStringMode::Unicode) << "'";
 }
 
 void
@@ -319,7 +319,7 @@ Ice::IllegalServantException::ice_print(ostream& out) const
 static void
 printFailedRequestData(ostream& out, const RequestFailedException& ex)
 {
-    out << ":\nidentity: `" << identityToString(ex.id, ICE_ENUM(ToStringMode, Unicode)) << "'";
+    out << ":\nidentity: `" << identityToString(ex.id, ToStringMode::Unicode) << "'";
     out << "\nfacet: " << ex.facet;
     out << "\noperation: " << ex.operation;
 }

--- a/cpp/src/Ice/FactoryTable.cpp
+++ b/cpp/src/Ice/FactoryTable.cpp
@@ -12,7 +12,7 @@ using namespace std;
 // If the factory is present already, increment its reference count.
 //
 void
-IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(::Ice::UserExceptionFactory) f)
+IceInternal::FactoryTable::addExceptionFactory(const string& t, ::Ice::UserExceptionFactory f)
 {
     IceUtil::Mutex::Lock lock(_m);
     assert(f);
@@ -62,7 +62,7 @@ IceInternal::FactoryTable::removeExceptionFactory(const string& t)
 // Add a factory to the value factory table.
 //
 void
-IceInternal::FactoryTable::addValueFactory(const string& t, ICE_IN(::Ice::ValueFactory) f)
+IceInternal::FactoryTable::addValueFactory(const string& t, ::Ice::ValueFactory f)
 {
     IceUtil::Mutex::Lock lock(_m);
     assert(f);

--- a/cpp/src/Ice/FactoryTable.cpp
+++ b/cpp/src/Ice/FactoryTable.cpp
@@ -12,7 +12,7 @@ using namespace std;
 // If the factory is present already, increment its reference count.
 //
 void
-IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(ICE_DELEGATE(::Ice::UserExceptionFactory)) f)
+IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(::Ice::UserExceptionFactory) f)
 {
     IceUtil::Mutex::Lock lock(_m);
     assert(f);
@@ -30,12 +30,12 @@ IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(ICE_DELEG
 //
 // Return the exception factory for a given type ID
 //
-ICE_DELEGATE(::Ice::UserExceptionFactory)
+::Ice::UserExceptionFactory
 IceInternal::FactoryTable::getExceptionFactory(const string& t) const
 {
     IceUtil::Mutex::Lock lock(_m);
     EFTable::const_iterator i = _eft.find(t);
-    return i != _eft.end() ? i->second.first : ICE_DELEGATE(::Ice::UserExceptionFactory)();
+    return i != _eft.end() ? i->second.first : ::Ice::UserExceptionFactory();
 }
 
 //
@@ -62,7 +62,7 @@ IceInternal::FactoryTable::removeExceptionFactory(const string& t)
 // Add a factory to the value factory table.
 //
 void
-IceInternal::FactoryTable::addValueFactory(const string& t, ICE_IN(ICE_DELEGATE(::Ice::ValueFactory)) f)
+IceInternal::FactoryTable::addValueFactory(const string& t, ICE_IN(::Ice::ValueFactory) f)
 {
     IceUtil::Mutex::Lock lock(_m);
     assert(f);
@@ -80,12 +80,12 @@ IceInternal::FactoryTable::addValueFactory(const string& t, ICE_IN(ICE_DELEGATE(
 //
 // Return the value factory for a given type ID
 //
-ICE_DELEGATE(::Ice::ValueFactory)
+::Ice::ValueFactory
 IceInternal::FactoryTable::getValueFactory(const string& t) const
 {
     IceUtil::Mutex::Lock lock(_m);
     VFTable::const_iterator i = _vft.find(t);
-    return i != _vft.end() ? i->second.first : ICE_DELEGATE(::Ice::ValueFactory)();
+    return i != _vft.end() ? i->second.first : ::Ice::ValueFactory();
 }
 
 //

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -174,7 +174,7 @@ IceInternal::IPEndpointI::expandHost(EndpointIPtr& publish) const
     vector<Address> addrs = getAddresses(_host,
                                          _port,
                                          _instance->protocolSupport(),
-                                         Ice::ICE_ENUM(EndpointSelectionType, Ordered),
+                                         Ice::EndpointSelectionType::Ordered,
                                          _instance->preferIPv6(),
                                          true);
 
@@ -618,7 +618,7 @@ IceInternal::EndpointHostResolver::run()
 
         if(threadObserver)
         {
-            threadObserver->stateChanged(ICE_ENUM(ThreadState, ThreadStateIdle), ICE_ENUM(ThreadState, ThreadStateInUseForOther));
+            threadObserver->stateChanged(ThreadState::ThreadStateIdle, ThreadState::ThreadStateInUseForOther);
         }
 
         try
@@ -645,8 +645,8 @@ IceInternal::EndpointHostResolver::run()
 
             if(threadObserver)
             {
-                threadObserver->stateChanged(ICE_ENUM(ThreadState, ThreadStateInUseForOther),
-                                             ICE_ENUM(ThreadState, ThreadStateIdle));
+                threadObserver->stateChanged(ThreadState::ThreadStateInUseForOther,
+                                             ThreadState::ThreadStateIdle);
             }
 
         }
@@ -654,8 +654,8 @@ IceInternal::EndpointHostResolver::run()
         {
             if(threadObserver)
             {
-                threadObserver->stateChanged(ICE_ENUM(ThreadState, ThreadStateInUseForOther),
-                                             ICE_ENUM(ThreadState, ThreadStateIdle));
+                threadObserver->stateChanged(ThreadState::ThreadStateInUseForOther,
+                                             ThreadState::ThreadStateIdle);
             }
             if(r.observer)
             {
@@ -693,7 +693,7 @@ IceInternal::EndpointHostResolver::updateObserver()
     {
         _observer.attach(obsv->getThreadObserver("Communicator",
                                                  name(),
-                                                 ICE_ENUM(ThreadState, ThreadStateIdle),
+                                                 ThreadState::ThreadStateIdle,
                                                  _observer.get()));
     }
 }

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -53,25 +53,25 @@ IceInternal::IPEndpointInfoI::~IPEndpointInfoI()
 }
 
 Ice::Short
-IceInternal::IPEndpointInfoI::type() const ICE_NOEXCEPT
+IceInternal::IPEndpointInfoI::type() const noexcept
 {
     return _endpoint->type();
 }
 
 bool
-IceInternal::IPEndpointInfoI::datagram() const ICE_NOEXCEPT
+IceInternal::IPEndpointInfoI::datagram() const noexcept
 {
     return _endpoint->datagram();
 }
 
 bool
-IceInternal::IPEndpointInfoI::secure() const ICE_NOEXCEPT
+IceInternal::IPEndpointInfoI::secure() const noexcept
 {
     return _endpoint->secure();
 }
 
 Ice::EndpointInfoPtr
-IceInternal::IPEndpointI::getInfo() const ICE_NOEXCEPT
+IceInternal::IPEndpointI::getInfo() const noexcept
 {
     Ice::IPEndpointInfoPtr info = ICE_MAKE_SHARED(IPEndpointInfoI, ICE_SHARED_FROM_CONST_THIS(IPEndpointI));
     fillEndpointInfo(info.get());

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -73,7 +73,7 @@ IceInternal::IPEndpointInfoI::secure() const noexcept
 Ice::EndpointInfoPtr
 IceInternal::IPEndpointI::getInfo() const noexcept
 {
-    Ice::IPEndpointInfoPtr info = ICE_MAKE_SHARED(IPEndpointInfoI, ICE_SHARED_FROM_CONST_THIS(IPEndpointI));
+    Ice::IPEndpointInfoPtr info = std::make_shared<IPEndpointInfoI>(ICE_SHARED_FROM_CONST_THIS(IPEndpointI));
     fillEndpointInfo(info.get());
     return info;
 }

--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -27,9 +27,9 @@ public:
     IPEndpointInfoI(const EndpointIPtr&);
     virtual ~IPEndpointInfoI();
 
-    virtual Ice::Short type() const ICE_NOEXCEPT;
-    virtual bool datagram() const ICE_NOEXCEPT;
-    virtual bool secure() const ICE_NOEXCEPT;
+    virtual Ice::Short type() const noexcept;
+    virtual bool datagram() const noexcept;
+    virtual bool secure() const noexcept;
 
 private:
 
@@ -43,7 +43,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Short type() const;
     virtual const std::string& protocol() const;
     virtual bool secure() const;

--- a/cpp/src/Ice/ImplicitContextI.cpp
+++ b/cpp/src/Ice/ImplicitContextI.cpp
@@ -110,11 +110,11 @@ ImplicitContextI::create(const std::string& kind)
     }
     else if(kind == "Shared")
     {
-        return ICE_MAKE_SHARED(SharedImplicitContext);
+        return std::make_shared<SharedImplicitContext>();
     }
     else if(kind == "PerThread")
     {
-        return ICE_MAKE_SHARED(PerThreadImplicitContext);
+        return std::make_shared<PerThreadImplicitContext>();
     }
     else
     {

--- a/cpp/src/Ice/Incoming.cpp
+++ b/cpp/src/Ice/Incoming.cpp
@@ -45,7 +45,7 @@ IceInternal::IncomingBase::IncomingBase(Instance* instance, ResponseHandler* res
                                         bool response, Byte compress, Int requestId) :
     _response(response),
     _compress(compress),
-    _format(Ice::ICE_ENUM(FormatType, DefaultFormat)),
+    _format(Ice::FormatType::DefaultFormat),
     _os(instance, Ice::currentProtocolEncoding),
     _responseHandler(responseHandler)
 {

--- a/cpp/src/Ice/IncomingAsync.cpp
+++ b/cpp/src/Ice/IncomingAsync.cpp
@@ -46,7 +46,7 @@ Init init;
 IceInternal::IncomingAsync::IncomingAsync(Incoming& in) :
     IncomingBase(in),
     _responseSent(false),
-    _responseHandlerCopy(ICE_GET_SHARED_FROM_THIS(_responseHandler))
+    _responseHandlerCopy(_responseHandler->shared_from_this())
 {
 }
 

--- a/cpp/src/Ice/Initialize.cpp
+++ b/cpp/src/Ice/Initialize.cpp
@@ -337,7 +337,7 @@ Ice::getProcessLogger()
 {
     IceUtilInternal::MutexPtrLock<IceUtil::Mutex> lock(globalMutex);
 
-    if(processLogger == ICE_NULLPTR)
+    if(processLogger == nullptr)
     {
        //
        // TODO: Would be nice to be able to use process name as prefix by default.
@@ -406,7 +406,7 @@ Ice::CommunicatorHolder::~CommunicatorHolder()
 
 Ice::CommunicatorHolder::operator bool() const
 {
-    return _communicator != ICE_NULLPTR;
+    return _communicator != nullptr;
 }
 
 const Ice::CommunicatorPtr&

--- a/cpp/src/Ice/Initialize.cpp
+++ b/cpp/src/Ice/Initialize.cpp
@@ -161,13 +161,13 @@ Ice::stringSeqToArgs(const StringSeq& args, int& argc, const wchar_t* argv[])
 PropertiesPtr
 Ice::createProperties()
 {
-    return ICE_MAKE_SHARED(PropertiesI);
+    return std::make_shared<PropertiesI>();
 }
 
 PropertiesPtr
 Ice::createProperties(StringSeq& args, const PropertiesPtr& defaults)
 {
-    return ICE_MAKE_SHARED(PropertiesI, args, defaults);
+    return std::make_shared<PropertiesI>(args, defaults);
 }
 
 PropertiesPtr
@@ -342,7 +342,7 @@ Ice::getProcessLogger()
        //
        // TODO: Would be nice to be able to use process name as prefix by default.
        //
-       processLogger = ICE_MAKE_SHARED(LoggerI, "", "", true);
+       processLogger = std::make_shared<LoggerI>("", "", true);
     }
     return processLogger;
 }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1208,7 +1208,7 @@ Ice::InputStream::readEnum(Int maxValue)
 }
 
 void
-Ice::InputStream::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::throwException(ICE_IN(UserExceptionFactory) factory)
 {
     initEncaps();
     _currentEncaps->decoder->throwException(factory);
@@ -1713,7 +1713,7 @@ Ice::InputStream::EncapsDecoder10::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(UserExceptionFactory) factory)
 {
     assert(_sliceType == NoSlice);
 
@@ -1735,7 +1735,7 @@ Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(ICE_DELEGATE(UserExcept
     //
     startSlice();
     const string mostDerivedId = _typeId;
-    ICE_DELEGATE(UserExceptionFactory) exceptionFactory = factory;
+    UserExceptionFactory exceptionFactory = factory;
     while(true)
     {
         //
@@ -2039,7 +2039,7 @@ Ice::InputStream::EncapsDecoder11::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(UserExceptionFactory) factory)
 {
     assert(!_current);
 
@@ -2050,7 +2050,7 @@ Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(ICE_DELEGATE(UserExcept
     //
     startSlice();
     const string mostDerivedId = _current->typeId;
-    ICE_DELEGATE(UserExceptionFactory) exceptionFactory = factory;
+    UserExceptionFactory exceptionFactory = factory;
     while(true)
     {
         //

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1272,37 +1272,37 @@ Ice::InputStream::skipOptional(OptionalFormat type)
 {
     switch(type)
     {
-        case ICE_SCOPED_ENUM(OptionalFormat, F1):
+        case OptionalFormat::F1:
         {
             skip(1);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F2):
+        case OptionalFormat::F2:
         {
             skip(2);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F4):
+        case OptionalFormat::F4:
         {
             skip(4);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F8):
+        case OptionalFormat::F8:
         {
             skip(8);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, Size):
+        case OptionalFormat::Size:
         {
             skipSize();
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, VSize):
+        case OptionalFormat::VSize:
         {
             skip(static_cast<size_t>(readSize()));
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, FSize):
+        case OptionalFormat::FSize:
         {
             Int sz;
             read(sz);
@@ -1313,7 +1313,7 @@ Ice::InputStream::skipOptional(OptionalFormat type)
             skip(static_cast<size_t>(sz));
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, Class):
+        case OptionalFormat::Class:
         {
             read(0, 0);
             break;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1208,7 +1208,7 @@ Ice::InputStream::readEnum(Int maxValue)
 }
 
 void
-Ice::InputStream::throwException(ICE_IN(UserExceptionFactory) factory)
+Ice::InputStream::throwException(UserExceptionFactory factory)
 {
     initEncaps();
     _currentEncaps->decoder->throwException(factory);
@@ -1713,7 +1713,7 @@ Ice::InputStream::EncapsDecoder10::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(UserExceptionFactory) factory)
+Ice::InputStream::EncapsDecoder10::throwException(UserExceptionFactory factory)
 {
     assert(_sliceType == NoSlice);
 
@@ -2039,7 +2039,7 @@ Ice::InputStream::EncapsDecoder11::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(UserExceptionFactory) factory)
+Ice::InputStream::EncapsDecoder11::throwException(UserExceptionFactory factory)
 {
     assert(!_current);
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -2269,7 +2269,7 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
     //
     // Preserve this slice.
     //
-    SliceInfoPtr info = ICE_MAKE_SHARED(SliceInfo);
+    SliceInfoPtr info = std::make_shared<SliceInfo>();
     info->typeId = _current->typeId;
     info->compactId = _current->compactId;
     info->hasOptionalMembers = _current->sliceFlags & FLAG_HAS_OPTIONAL_MEMBERS;
@@ -2407,7 +2407,7 @@ Ice::InputStream::EncapsDecoder11::readInstance(Int index, PatchFunc patchFunc, 
             v = newInstance(Object::ice_staticId());
             if(!v)
             {
-                v = ICE_MAKE_SHARED(UnknownSlicedValue, mostDerivedId);
+                v = std::make_shared<UnknownSlicedValue>(mostDerivedId);
             }
 
             break;
@@ -2474,5 +2474,5 @@ Ice::InputStream::EncapsDecoder11::readSlicedData()
             addPatchEntry(*p, &patchHandle<Value>, &instances[j++]);
         }
     }
-    return ICE_MAKE_SHARED(SlicedData, _current->slices);
+    return std::make_shared<SlicedData>(_current->slices);
 }

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1084,7 +1084,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                     throw InitializationException(__FILE__, __LINE__, "Both syslog and file logger cannot be enabled.");
                 }
 
-                _initData.logger = ICE_MAKE_SHARED(SysLoggerI,
+                _initData.logger = std::make_shared<SysLoggerI>(
                                                    _initData.properties->getProperty("Ice.ProgramName"),
                                                    _initData.properties->getPropertyWithDefault("Ice.SyslogFacility", "LOG_USER"));
             }
@@ -1094,7 +1094,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 #ifdef ICE_SWIFT
             if(!_initData.logger && _initData.properties->getPropertyAsInt("Ice.UseOSLog") > 0)
             {
-                _initData.logger = ICE_MAKE_SHARED(OSLogLoggerI,
+                _initData.logger = std::make_shared<OSLogLoggerI>(
                                                    _initData.properties->getProperty("Ice.ProgramName"));
             }
             else
@@ -1103,7 +1103,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 #ifdef ICE_USE_SYSTEMD
             if(_initData.properties->getPropertyAsInt("Ice.UseSystemdJournal") > 0)
             {
-                _initData.logger = ICE_MAKE_SHARED(SystemdJournalI,
+                _initData.logger = std::make_shared<SystemdJournalI>(
                                                    _initData.properties->getProperty("Ice.ProgramName"));
             }
             else
@@ -1115,7 +1115,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                 {
                     sz = 0;
                 }
-                _initData.logger = ICE_MAKE_SHARED(LoggerI, _initData.properties->getProperty("Ice.ProgramName"),
+                _initData.logger = std::make_shared<LoggerI>(_initData.properties->getProperty("Ice.ProgramName"),
                                                    logfile, true, static_cast<size_t>(sz));
             }
             else
@@ -1123,7 +1123,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                 _initData.logger = getProcessLogger();
                 if(ICE_DYNAMIC_CAST(LoggerI, _initData.logger))
                 {
-                    _initData.logger = ICE_MAKE_SHARED(LoggerI, _initData.properties->getProperty("Ice.ProgramName"), "", logStdErrConvert);
+                    _initData.logger = std::make_shared<LoggerI>(_initData.properties->getProperty("Ice.ProgramName"), "", logStdErrConvert);
                 }
             }
         }
@@ -1255,18 +1255,18 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 
         _dynamicLibraryList = new DynamicLibraryList;
 
-        _pluginManager = ICE_MAKE_SHARED(PluginManagerI, communicator, _dynamicLibraryList);
+        _pluginManager = std::make_shared<PluginManagerI>(communicator, _dynamicLibraryList);
 
         if(!_initData.valueFactoryManager)
         {
-            _initData.valueFactoryManager = ICE_MAKE_SHARED(ValueFactoryManagerI);
+            _initData.valueFactoryManager = std::make_shared<ValueFactoryManagerI>();
         }
 
         _objectFactoryMapHint = _objectFactoryMap.end();
 
         _outgoingConnectionFactory = new OutgoingConnectionFactory(communicator, this);
 
-        _objectAdapterFactory = ICE_MAKE_SHARED(ObjectAdapterFactory, this, communicator);
+        _objectAdapterFactory = std::make_shared<ObjectAdapterFactory>(this, communicator);
 
         _retryQueue = new RetryQueue(this);
 
@@ -1379,7 +1379,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
         const string processFacetName = "Process";
         if(_adminFacetFilter.empty() || _adminFacetFilter.find(processFacetName) != _adminFacetFilter.end())
         {
-            _adminFacets.insert(make_pair(processFacetName, ICE_MAKE_SHARED(ProcessI, communicator)));
+            _adminFacets.insert(make_pair(processFacetName, std::make_shared<ProcessI>(communicator)));
         }
 
         //
@@ -1400,7 +1400,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
         PropertiesAdminIPtr propsAdmin;
         if(_adminFacetFilter.empty() || _adminFacetFilter.find(propertiesFacetName) != _adminFacetFilter.end())
         {
-            propsAdmin = ICE_MAKE_SHARED(PropertiesAdminI, this);
+            propsAdmin = std::make_shared<PropertiesAdminI>(this);
             _adminFacets.insert(make_pair(propertiesFacetName, propsAdmin));
         }
 
@@ -1410,7 +1410,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
         const string metricsFacetName = "Metrics";
         if(_adminFacetFilter.empty() || _adminFacetFilter.find(metricsFacetName) != _adminFacetFilter.end())
         {
-            CommunicatorObserverIPtr observer = ICE_MAKE_SHARED(CommunicatorObserverI, _initData);
+            CommunicatorObserverIPtr observer = std::make_shared<CommunicatorObserverI>(_initData);
             _initData.observer = observer;
             _adminFacets.insert(make_pair(metricsFacetName, observer->getFacet()));
 
@@ -1431,7 +1431,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
     //
     if(_initData.observer)
     {
-        _initData.observer->setObserverUpdater(ICE_MAKE_SHARED(ObserverUpdaterI, this));
+        _initData.observer->setObserverUpdater(std::make_shared<ObserverUpdaterI>(this));
     }
 
     //

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1883,7 +1883,7 @@ IceInternal::Instance::findObjectFactory(const string& id) const
     }
     else
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 }
 

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -229,7 +229,7 @@ Timer::updateObserver(const Ice::Instrumentation::CommunicatorObserverPtr& obsv)
     assert(obsv);
     _observer.attach(obsv->getThreadObserver("Communicator",
                                             "Ice.Timer",
-                                            Instrumentation::ICE_ENUM(ThreadState, ThreadStateIdle),
+                                            Instrumentation::ThreadState::ThreadStateIdle,
                                             _observer.get()));
     _hasObserver.exchange(_observer.get() ? 1 : 0);
 }
@@ -246,8 +246,8 @@ Timer::runTimerTask(const IceUtil::TimerTaskPtr& task)
         }
         if(threadObserver)
         {
-            threadObserver->stateChanged(Instrumentation::ICE_ENUM(ThreadState, ThreadStateIdle),
-                                         Instrumentation::ICE_ENUM(ThreadState, ThreadStateInUseForOther));
+            threadObserver->stateChanged(Instrumentation::ThreadState::ThreadStateIdle,
+                                         Instrumentation::ThreadState::ThreadStateInUseForOther);
         }
         try
         {
@@ -257,14 +257,14 @@ Timer::runTimerTask(const IceUtil::TimerTaskPtr& task)
         {
             if(threadObserver)
             {
-                threadObserver->stateChanged(Instrumentation::ICE_ENUM(ThreadState, ThreadStateInUseForOther),
-                                             Instrumentation::ICE_ENUM(ThreadState, ThreadStateIdle));
+                threadObserver->stateChanged(Instrumentation::ThreadState::ThreadStateInUseForOther,
+                                             Instrumentation::ThreadState::ThreadStateIdle);
             }
         }
         if(threadObserver)
         {
-            threadObserver->stateChanged(Instrumentation::ICE_ENUM(ThreadState, ThreadStateInUseForOther),
-                                         Instrumentation::ICE_ENUM(ThreadState, ThreadStateIdle));
+            threadObserver->stateChanged(Instrumentation::ThreadState::ThreadStateInUseForOther,
+                                         Instrumentation::ThreadState::ThreadStateIdle);
         }
     }
     else
@@ -937,7 +937,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
     _batchAutoFlushSize(0),
     _classGraphDepthMax(0),
     _collectObjects(false),
-    _toStringMode(ICE_ENUM(ToStringMode, Unicode)),
+    _toStringMode(ToStringMode::Unicode),
     _implicitContext(0),
     _stringConverter(Ice::getProcessStringConverter()),
     _wstringConverter(Ice::getProcessWstringConverter()),
@@ -1204,11 +1204,11 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
         string toStringModeStr = _initData.properties->getPropertyWithDefault("Ice.ToStringMode", "Unicode");
         if(toStringModeStr == "ASCII")
         {
-            const_cast<ToStringMode&>(_toStringMode) = ICE_ENUM(ToStringMode, ASCII);
+            const_cast<ToStringMode&>(_toStringMode) = ToStringMode::ASCII;
         }
         else if(toStringModeStr == "Compat")
         {
-            const_cast<ToStringMode&>(_toStringMode) = ICE_ENUM(ToStringMode, Compat);
+            const_cast<ToStringMode&>(_toStringMode) = ToStringMode::Compat;
         }
         else if(toStringModeStr != "Unicode")
         {

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -27,13 +27,13 @@ getThreadStateMetric(ThreadState s)
 {
     switch(s)
     {
-        case ICE_ENUM(ThreadState, ThreadStateIdle):
+        case ThreadState::ThreadStateIdle:
             return 0;
-        case ICE_ENUM(ThreadState, ThreadStateInUseForIO):
+        case ThreadState::ThreadStateInUseForIO:
             return &ThreadMetrics::inUseForIO;
-        case ICE_ENUM(ThreadState, ThreadStateInUseForUser):
+        case ThreadState::ThreadStateInUseForUser:
             return &ThreadMetrics::inUseForUser;
-        case ICE_ENUM(ThreadState, ThreadStateInUseForOther):
+        case ThreadState::ThreadStateInUseForOther:
             return &ThreadMetrics::inUseForOther;
         default:
             assert(false);
@@ -49,11 +49,11 @@ struct ThreadStateChanged
 
     void operator()(const ThreadMetricsPtr& v)
     {
-        if(oldState != ICE_ENUM(ThreadState, ThreadStateIdle))
+        if(oldState != ThreadState::ThreadStateIdle)
         {
             --(v.get()->*getThreadStateMetric(oldState));
         }
-        if(newState != ICE_ENUM(ThreadState, ThreadStateIdle))
+        if(newState != ThreadState::ThreadStateIdle)
         {
             ++(v.get()->*getThreadStateMetric(newState));
         }
@@ -136,15 +136,15 @@ public:
     {
         switch(_state)
         {
-            case ICE_ENUM(ConnectionState, ConnectionStateValidating):
+            case ConnectionState::ConnectionStateValidating:
                 return "validating";
-            case ICE_ENUM(ConnectionState, ConnectionStateHolding):
+            case ConnectionState::ConnectionStateHolding:
                 return "holding";
-            case ICE_ENUM(ConnectionState, ConnectionStateActive):
+            case ConnectionState::ConnectionStateActive:
                 return "active";
-            case ICE_ENUM(ConnectionState, ConnectionStateClosing):
+            case ConnectionState::ConnectionStateClosing:
                 return "closing";
-            case ICE_ENUM(ConnectionState, ConnectionStateClosed):
+            case ConnectionState::ConnectionStateClosed:
                 return "closed";
             default:
                 assert(false);
@@ -676,7 +676,7 @@ public:
 
     virtual void initMetrics(const ThreadMetricsPtr& v) const
     {
-        if(_state != ICE_ENUM(ThreadState, ThreadStateIdle))
+        if(_state != ThreadState::ThreadStateIdle)
         {
             ++(v.get()->*getThreadStateMetric(_state));
         }

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -74,7 +74,7 @@ getIPConnectionInfo(const ConnectionInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 class ConnectionHelper : public MetricsHelperT<ConnectionMetrics>
@@ -875,7 +875,7 @@ InvocationObserverI::getRemoteObserver(const ConnectionInfoPtr& connection,
     catch(const exception&)
     {
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 CollocatedObserverPtr
@@ -895,7 +895,7 @@ InvocationObserverI::getCollocatedObserver(const Ice::ObjectAdapterPtr& adapter,
     catch(const exception&)
     {
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 CommunicatorObserverI::CommunicatorObserverI(const InitializationData& initData) :
@@ -943,7 +943,7 @@ CommunicatorObserverI::getConnectionEstablishmentObserver(const EndpointPtr& end
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 ObserverPtr
@@ -966,7 +966,7 @@ CommunicatorObserverI::getEndpointLookupObserver(const EndpointPtr& endpt)
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 ConnectionObserverPtr
@@ -993,7 +993,7 @@ CommunicatorObserverI::getConnectionObserver(const ConnectionInfoPtr& con,
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 ThreadObserverPtr
@@ -1020,7 +1020,7 @@ CommunicatorObserverI::getThreadObserver(const string& parent,
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 InvocationObserverPtr
@@ -1043,7 +1043,7 @@ CommunicatorObserverI::getInvocationObserver(const ObjectPrxPtr& proxy, const st
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 DispatchObserverPtr
@@ -1066,7 +1066,7 @@ CommunicatorObserverI::getDispatchObserver(const Current& current, int size)
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 const IceInternal::MetricsAdminIPtr&

--- a/cpp/src/Ice/InstrumentationI.h
+++ b/cpp/src/Ice/InstrumentationI.h
@@ -16,7 +16,7 @@ template<typename T, typename O> class ObserverWithDelegateT : public IceMX::Obs
 public:
 
     typedef O ObserverType;
-    typedef typename ICE_INTERNAL_HANDLE<O> ObserverPtrType;
+    typedef typename std::shared_ptr<O> ObserverPtrType;
     virtual void
     attach()
     {
@@ -63,7 +63,7 @@ public:
     getObserverWithDelegate(const std::string& mapName, const IceMX::MetricsHelperT<ObserverMetricsType>& helper,
                             const ObserverPtrType& del)
     {
-        ICE_INTERNAL_HANDLE<ObserverImpl> obsv = IceMX::ObserverT<T>::template getObserver<ObserverImpl>(mapName,
+        std::shared_ptr<ObserverImpl> obsv = IceMX::ObserverT<T>::template getObserver<ObserverImpl>(mapName,
                                                                                                          helper);
         if(obsv)
         {
@@ -90,7 +90,7 @@ public:
     template<typename ObserverMetricsType, typename ObserverPtrType> ObserverPtrType
     getObserverWithDelegate(const IceMX::MetricsHelperT<ObserverMetricsType>& helper, const ObserverPtrType& del)
     {
-        ICE_INTERNAL_HANDLE<T> obsv = IceMX::ObserverFactoryT<T>::getObserver(helper);
+        std::shared_ptr<T> obsv = IceMX::ObserverFactoryT<T>::getObserver(helper);
         if(obsv)
         {
             obsv->setDelegate(del);
@@ -103,7 +103,7 @@ public:
     getObserverWithDelegate(const IceMX::MetricsHelperT<ObserverMetricsType>& helper, const ObserverPtrType& del,
                             const ObserverPtrType& old)
     {
-        ICE_INTERNAL_HANDLE<T> obsv = IceMX::ObserverFactoryT<T>::getObserver(helper, old);
+        std::shared_ptr<T> obsv = IceMX::ObserverFactoryT<T>::getObserver(helper, old);
         if(obsv)
         {
             obsv->setDelegate(del);

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -521,7 +521,7 @@ IceInternal::LocatorInfo::getLocatorRegistry()
         // endpoint selection in case the locator returned a proxy
         // with some endpoints which are prefered to be tried first.
         //
-        _locatorRegistry = locatorRegistry->ice_locator(0)->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        _locatorRegistry = locatorRegistry->ice_locator(0)->ice_endpointSelection(Ice::EndpointSelectionType::Ordered);
         return _locatorRegistry;
     }
 }

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -454,7 +454,7 @@ IceInternal::LocatorInfo::Request::exception(const Ice::Exception& ex)
         IceUtil::Monitor<IceUtil::Mutex>::Lock sync(_monitor);
         _locatorInfo->finishRequest(_reference, _wellKnownRefs, 0, dynamic_cast<const Ice::UserException*>(&ex));
 
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
         _monitor.notifyAll();
     }
     for(vector<RequestCallbackPtr>::const_iterator p = _callbacks.begin(); p != _callbacks.end(); ++p)

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -199,7 +199,7 @@ filterLogMessages(LogMessageSeq& logMessages, const set<LogMessageType>& message
             bool keepIt = false;
             if(messageTypes.empty() || messageTypes.count(p->type) != 0)
             {
-                if(p->type != ICE_ENUM(LogMessageType, TraceMessage) || traceCategories.empty() ||
+                if(p->type != LogMessageType::TraceMessage || traceCategories.empty() ||
                    traceCategories.count(p->traceCategory) != 0)
                 {
                     keepIt = true;
@@ -496,12 +496,12 @@ LoggerAdminI::log(const LogMessage& logMessage)
     //
     // Put message in _queue
     //
-    if((logMessage.type != ICE_ENUM(LogMessageType, TraceMessage) && _maxLogCount > 0) ||
-       (logMessage.type == ICE_ENUM(LogMessageType, TraceMessage) && _maxTraceCount > 0))
+    if((logMessage.type != LogMessageType::TraceMessage && _maxLogCount > 0) ||
+       (logMessage.type == LogMessageType::TraceMessage && _maxTraceCount > 0))
     {
         list<LogMessage>::iterator p = _queue.insert(_queue.end(), logMessage);
 
-        if(logMessage.type != ICE_ENUM(LogMessageType, TraceMessage))
+        if(logMessage.type != LogMessageType::TraceMessage)
         {
             assert(_maxLogCount > 0);
             if(_logCount == _maxLogCount)
@@ -511,7 +511,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
                 //
                 assert(_oldestLog != _queue.end());
                 _oldestLog = _queue.erase(_oldestLog);
-                while(_oldestLog != _queue.end() && _oldestLog->type == ICE_ENUM(LogMessageType, TraceMessage))
+                while(_oldestLog != _queue.end() && _oldestLog->type == LogMessageType::TraceMessage)
                 {
                     _oldestLog++;
                 }
@@ -537,7 +537,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
                 //
                 assert(_oldestTrace != _queue.end());
                 _oldestTrace = _queue.erase(_oldestTrace);
-                while(_oldestTrace != _queue.end() && _oldestTrace->type != ICE_ENUM(LogMessageType, TraceMessage))
+                while(_oldestTrace != _queue.end() && _oldestTrace->type != LogMessageType::TraceMessage)
                 {
                     _oldestTrace++;
                 }
@@ -563,7 +563,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
 
             if(filters.messageTypes.empty() || filters.messageTypes.count(logMessage.type) != 0)
             {
-                if(logMessage.type != ICE_ENUM(LogMessageType, TraceMessage) || filters.traceCategories.empty() ||
+                if(logMessage.type != LogMessageType::TraceMessage || filters.traceCategories.empty() ||
                    filters.traceCategories.count(logMessage.traceCategory) != 0)
                 {
                     remoteLoggers.push_back(q->first);
@@ -629,7 +629,7 @@ LoggerAdminLoggerI::LoggerAdminLoggerI(const PropertiesPtr& props,
 void
 LoggerAdminLoggerI::print(const string& message)
 {
-   LogMessage logMessage = { ICE_ENUM(LogMessageType, PrintMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+   LogMessage logMessage = { LogMessageType::PrintMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->print(message);
     log(logMessage);
@@ -638,7 +638,7 @@ LoggerAdminLoggerI::print(const string& message)
 void
 LoggerAdminLoggerI::trace(const string& category, const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, TraceMessage), IceUtil::Time::now().toMicroSeconds(), category, message };
+    LogMessage logMessage = { LogMessageType::TraceMessage, IceUtil::Time::now().toMicroSeconds(), category, message };
 
     _localLogger->trace(category, message);
     log(logMessage);
@@ -647,7 +647,7 @@ LoggerAdminLoggerI::trace(const string& category, const string& message)
 void
 LoggerAdminLoggerI::warning(const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, WarningMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+    LogMessage logMessage = { LogMessageType::WarningMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->warning(message);
     log(logMessage);
@@ -656,7 +656,7 @@ LoggerAdminLoggerI::warning(const string& message)
 void
 LoggerAdminLoggerI::error(const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, ErrorMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+    LogMessage logMessage = { LogMessageType::ErrorMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->error(message);
     log(logMessage);

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -691,7 +691,7 @@ LoggerAdminLoggerI::log(const LogMessage& logMessage)
 
         if(!_sendLogThread)
         {
-            _sendLogThread = new SendLogThread(ICE_SHARED_FROM_THIS);
+            _sendLogThread = new SendLogThread(shared_from_this());
             _sendLogThread->start();
         }
 
@@ -832,7 +832,7 @@ LoggerAdminLoggerPtr
 createLoggerAdminLogger(const PropertiesPtr& props,
                         const LoggerPtr& localLogger)
 {
-    return ICE_MAKE_SHARED(LoggerAdminLoggerI, props, localLogger);
+    return std::make_shared<LoggerAdminLoggerI>(props, localLogger);
 }
 
 }

--- a/cpp/src/Ice/LoggerI.cpp
+++ b/cpp/src/Ice/LoggerI.cpp
@@ -124,7 +124,7 @@ LoggerPtr
 Ice::LoggerI::cloneWithPrefix(const std::string& prefix)
 {
     IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(outputMutex); // for _sizeMax
-    return ICE_MAKE_SHARED(LoggerI, prefix, _file, _convert, _sizeMax);
+    return std::make_shared<LoggerI>(prefix, _file, _convert, _sizeMax);
 }
 
 void

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -341,7 +341,7 @@ MetricsViewI::getMap(const string& mapName) const
     {
         return p->second;
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 MetricsAdminI::MetricsAdminI(const PropertiesPtr& properties, const LoggerPtr& logger) :
@@ -573,7 +573,7 @@ MetricsAdminI::getMetricsView(const std::string& name)
         {
             throw UnknownMetricsView();
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
     return p->second;
 }

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -75,7 +75,7 @@ parseRule(const PropertiesPtr& properties, const string& name)
     {
         try
         {
-            regexps.push_back(ICE_MAKE_SHARED(MetricsMapI::RegExp, p->first.substr(name.length() + 1), p->second));
+            regexps.push_back(std::make_shared<MetricsMapI::RegExp>(p->first.substr(name.length() + 1), p->second));
         }
         catch(const std::exception&)
         {
@@ -402,7 +402,7 @@ MetricsAdminI::updateViews()
             map<string, MetricsViewIPtr>::const_iterator q = _views.find(viewName);
             if(q == _views.end())
             {
-                q = views.insert(map<string, MetricsViewIPtr>::value_type(viewName, ICE_MAKE_SHARED(MetricsViewI, viewName))).first;
+                q = views.insert(map<string, MetricsViewIPtr>::value_type(viewName, std::make_shared<MetricsViewI>(viewName))).first;
             }
             else
             {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -92,7 +92,7 @@ public:
 void
 sortAddresses(vector<Address>& addrs, ProtocolSupport protocol, Ice::EndpointSelectionType selType, bool preferIPv6)
 {
-    if(selType == Ice::ICE_ENUM(EndpointSelectionType, Random))
+    if(selType == Ice::EndpointSelectionType::Random)
     {
         IceUtilInternal::shuffle(addrs.begin(), addrs.end());
     }
@@ -994,7 +994,7 @@ IceInternal::getAddressForServer(const string& host, int port, ProtocolSupport p
         }
         return addr;
     }
-    vector<Address> addrs = getAddresses(host, port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Ordered),
+    vector<Address> addrs = getAddresses(host, port, protocol, Ice::EndpointSelectionType::Ordered,
                                          preferIPv6, canBlock);
     return addrs.empty() ? Address() : addrs[0];
 }
@@ -1696,7 +1696,7 @@ IceInternal::doBind(SOCKET fd, const Address& addr, const string&)
 Address
 IceInternal::getNumericAddress(const std::string& address)
 {
-    vector<Address> addrs = getAddresses(address, 0, EnableBoth, Ice::ICE_ENUM(EndpointSelectionType, Ordered), false,
+    vector<Address> addrs = getAddresses(address, 0, EnableBoth, Ice::EndpointSelectionType::Ordered, false,
                                          false);
     if(addrs.empty())
     {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -148,7 +148,7 @@ setTcpLoopbackFastPath(SOCKET fd)
     DWORD NumberOfBytesReturned = 0;
 
     int status =
-        WSAIoctl(fd, SIO_LOOPBACK_FAST_PATH, &OptionValue, sizeof(OptionValue), ICE_NULLPTR, 0, &NumberOfBytesReturned, 0, 0);
+        WSAIoctl(fd, SIO_LOOPBACK_FAST_PATH, &OptionValue, sizeof(OptionValue), nullptr, 0, &NumberOfBytesReturned, 0, 0);
     if(status == SOCKET_ERROR)
     {
             // On platforms that do not support fast path (< Windows 8), WSAEONOTSUPP is expected.
@@ -222,20 +222,20 @@ getLocalAddresses(ProtocolSupport protocol, bool includeLoopback, bool singleAdd
     }
 
     DWORD size;
-    DWORD rv = GetAdaptersAddresses(family, 0, ICE_NULLPTR, ICE_NULLPTR, &size);
+    DWORD rv = GetAdaptersAddresses(family, 0, nullptr, nullptr, &size);
     if(rv == ERROR_BUFFER_OVERFLOW)
     {
         PIP_ADAPTER_ADDRESSES adapter_addresses = (PIP_ADAPTER_ADDRESSES) malloc(size);
-        rv = GetAdaptersAddresses(family, 0, ICE_NULLPTR, adapter_addresses, &size);
+        rv = GetAdaptersAddresses(family, 0, nullptr, adapter_addresses, &size);
         if(rv == ERROR_SUCCESS)
         {
-            for(PIP_ADAPTER_ADDRESSES aa = adapter_addresses; aa != ICE_NULLPTR; aa = aa->Next)
+            for(PIP_ADAPTER_ADDRESSES aa = adapter_addresses; aa != nullptr; aa = aa->Next)
             {
                 if(aa->OperStatus != IfOperStatusUp)
                 {
                     continue;
                 }
-                for(PIP_ADAPTER_UNICAST_ADDRESS ua = aa->FirstUnicastAddress; ua != ICE_NULLPTR; ua = ua->Next)
+                for(PIP_ADAPTER_UNICAST_ADDRESS ua = aa->FirstUnicastAddress; ua != nullptr; ua = ua->Next)
                 {
                     Address addr;
                     memcpy(&addr.saStorage, ua->Address.lpSockaddr, ua->Address.iSockaddrLength);
@@ -926,7 +926,7 @@ IceInternal::getAddresses(const string& host, int port, ProtocolSupport protocol
         throw DNSException(__FILE__, __LINE__, rs, host);
     }
 
-    for(struct addrinfo* p = info; p != ICE_NULLPTR; p = p->ai_next)
+    for(struct addrinfo* p = info; p != nullptr; p = p->ai_next)
     {
         memcpy(&addr.saStorage, p->ai_addr, p->ai_addrlen);
         if(p->ai_family == PF_INET)
@@ -2171,7 +2171,7 @@ IceInternal::doConnectAsync(SOCKET fd, const Address& addr, const Address& sourc
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }
 
-    LPFN_CONNECTEX ConnectEx = ICE_NULLPTR; // a pointer to the 'ConnectEx()' function
+    LPFN_CONNECTEX ConnectEx = nullptr; // a pointer to the 'ConnectEx()' function
     GUID GuidConnectEx = WSAID_CONNECTEX; // The Guid
     DWORD dwBytes;
     if(WSAIoctl(fd,
@@ -2181,8 +2181,8 @@ IceInternal::doConnectAsync(SOCKET fd, const Address& addr, const Address& sourc
                 &ConnectEx,
                 sizeof(ConnectEx),
                 &dwBytes,
-                ICE_NULLPTR,
-                ICE_NULLPTR) == SOCKET_ERROR)
+                nullptr,
+                nullptr) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }
@@ -2232,7 +2232,7 @@ IceInternal::doFinishConnectAsync(SOCKET fd, AsyncInfo& info)
         }
     }
 
-    if(setsockopt(fd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, ICE_NULLPTR, 0) == SOCKET_ERROR)
+    if(setsockopt(fd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, nullptr, 0) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -160,7 +160,7 @@ NetworkProxyPtr
 SOCKSNetworkProxy::resolveHost(ProtocolSupport protocol) const
 {
     assert(!_host.empty());
-    return new SOCKSNetworkProxy(getAddresses(_host, _port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Random), false, true)[0]);
+    return new SOCKSNetworkProxy(getAddresses(_host, _port, protocol, Ice::EndpointSelectionType::Random, false, true)[0]);
 }
 
 Address
@@ -263,7 +263,7 @@ NetworkProxyPtr
 HTTPNetworkProxy::resolveHost(ProtocolSupport protocol) const
 {
     assert(!_host.empty());
-    return new HTTPNetworkProxy(getAddresses(_host, _port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Random), false, true)[0], protocol);
+    return new HTTPNetworkProxy(getAddresses(_host, _port, protocol, Ice::EndpointSelectionType::Random, false, true)[0], protocol);
 }
 
 Address

--- a/cpp/src/Ice/OSLogLoggerI.cpp
+++ b/cpp/src/Ice/OSLogLoggerI.cpp
@@ -51,7 +51,7 @@ Ice::OSLogLoggerI::getPrefix()
 LoggerPtr
 Ice::OSLogLoggerI::cloneWithPrefix(const std::string& prefix)
 {
-    return ICE_MAKE_SHARED(OSLogLoggerI, prefix);
+    return std::make_shared<OSLogLoggerI>(prefix);
 }
 
 #endif

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -193,13 +193,13 @@ operationModeToString(OperationMode mode)
 {
     switch(mode)
     {
-    case ICE_ENUM(OperationMode, Normal):
+    case OperationMode::Normal:
         return "::Ice::Normal";
 
-    case ICE_ENUM(OperationMode, Nonmutating):
+    case OperationMode::Nonmutating:
         return "::Ice::Nonmutating";
 
-    case ICE_ENUM(OperationMode, Idempotent):
+    case OperationMode::Idempotent:
         return "::Ice::Idempotent";
     }
     //
@@ -216,8 +216,8 @@ Ice::Object::_iceCheckMode(OperationMode expected, OperationMode received)
 {
     if(expected != received)
     {
-        assert(expected != ICE_ENUM(OperationMode, Nonmutating)); // We never expect Nonmutating
-        if(expected == ICE_ENUM(OperationMode, Idempotent) && received == ICE_ENUM(OperationMode, Nonmutating))
+        assert(expected != OperationMode::Nonmutating); // We never expect Nonmutating
+        if(expected == OperationMode::Idempotent && received == OperationMode::Nonmutating)
         {
             //
             // Fine: typically an old client still using the deprecated nonmutating keyword

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -32,8 +32,8 @@ IceInternal::ObjectAdapterFactory::shutdown()
 
         adapters = _adapters;
 
-        _instance = ICE_NULLPTR;
-        _communicator = ICE_NULLPTR;
+        _instance = nullptr;
+        _communicator = nullptr;
 
         notifyAll();
     }
@@ -194,7 +194,7 @@ IceInternal::ObjectAdapterFactory::findObjectAdapter(const ObjectPrxPtr& proxy)
 
         if(!_instance)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         adapters = _adapters;
@@ -215,7 +215,7 @@ IceInternal::ObjectAdapterFactory::findObjectAdapter(const ObjectPrxPtr& proxy)
         }
     }
 
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -134,7 +134,7 @@ IceInternal::ObjectAdapterFactory::createObjectAdapter(const string& name, const
         if(name.empty())
         {
             string uuid = Ice::generateUUID();
-            adapter = ICE_MAKE_SHARED(ObjectAdapterI, _instance, _communicator, ICE_SHARED_FROM_THIS, uuid, true);
+            adapter = std::make_shared<ObjectAdapterI>(_instance, _communicator, shared_from_this(), uuid, true);
         }
         else
         {
@@ -142,7 +142,7 @@ IceInternal::ObjectAdapterFactory::createObjectAdapter(const string& name, const
             {
                 throw AlreadyRegisteredException(__FILE__, __LINE__, "object adapter", name);
             }
-            adapter = ICE_MAKE_SHARED(ObjectAdapterI, _instance, _communicator, ICE_SHARED_FROM_THIS, name, false);
+            adapter = std::make_shared<ObjectAdapterI>(_instance, _communicator, shared_from_this(), name, false);
             _adapterNamesInUse.insert(name);
         }
     }

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -67,7 +67,7 @@ inline EndpointIPtr toEndpointI(const EndpointPtr& endp)
 }
 
 string
-Ice::ObjectAdapterI::getName() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::getName() const noexcept
 {
     //
     // No mutex lock necessary, _name is immutable.
@@ -76,7 +76,7 @@ Ice::ObjectAdapterI::getName() const ICE_NOEXCEPT
 }
 
 CommunicatorPtr
-Ice::ObjectAdapterI::getCommunicator() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::getCommunicator() const noexcept
 {
     return _communicator;
 }
@@ -199,7 +199,7 @@ Ice::ObjectAdapterI::waitForHold()
 }
 
 void
-Ice::ObjectAdapterI::deactivate() ICE_NOEXCEPT
+Ice::ObjectAdapterI::deactivate() noexcept
 {
     {
         IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
@@ -266,7 +266,7 @@ Ice::ObjectAdapterI::deactivate() ICE_NOEXCEPT
 }
 
 void
-Ice::ObjectAdapterI::waitForDeactivate() ICE_NOEXCEPT
+Ice::ObjectAdapterI::waitForDeactivate() noexcept
 {
     vector<IceInternal::IncomingConnectionFactoryPtr> incomingConnectionFactories;
 
@@ -300,7 +300,7 @@ Ice::ObjectAdapterI::waitForDeactivate() ICE_NOEXCEPT
 }
 
 bool
-Ice::ObjectAdapterI::isDeactivated() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::isDeactivated() const noexcept
 {
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
 
@@ -308,7 +308,7 @@ Ice::ObjectAdapterI::isDeactivated() const ICE_NOEXCEPT
 }
 
 void
-Ice::ObjectAdapterI::destroy() ICE_NOEXCEPT
+Ice::ObjectAdapterI::destroy() noexcept
 {
     //
     // Deactivate and wait for completion.
@@ -587,7 +587,7 @@ Ice::ObjectAdapterI::setLocator(const LocatorPrxPtr& locator)
 }
 
 LocatorPrxPtr
-Ice::ObjectAdapterI::getLocator() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::getLocator() const noexcept
 {
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
 
@@ -602,7 +602,7 @@ Ice::ObjectAdapterI::getLocator() const ICE_NOEXCEPT
 }
 
 EndpointSeq
-Ice::ObjectAdapterI::getEndpoints() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::getEndpoints() const noexcept
 {
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
 
@@ -651,7 +651,7 @@ Ice::ObjectAdapterI::refreshPublishedEndpoints()
 }
 
 EndpointSeq
-Ice::ObjectAdapterI::getPublishedEndpoints() const ICE_NOEXCEPT
+Ice::ObjectAdapterI::getPublishedEndpoints() const noexcept
 {
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
     return EndpointSeq(_publishedEndpoints.begin(), _publishedEndpoints.end());

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -255,7 +255,7 @@ Ice::ObjectAdapterI::deactivate() noexcept
             factory->destroy();
         });
 
-    _instance->outgoingConnectionFactory()->removeAdapter(ICE_SHARED_FROM_THIS);
+    _instance->outgoingConnectionFactory()->removeAdapter(shared_from_this());
 
     {
         IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
@@ -353,7 +353,7 @@ Ice::ObjectAdapterI::destroy() noexcept
 
     if(_objectAdapterFactory)
     {
-        _objectAdapterFactory->removeObjectAdapter(ICE_SHARED_FROM_THIS);
+        _objectAdapterFactory->removeObjectAdapter(shared_from_this());
     }
 
     {
@@ -884,7 +884,7 @@ Ice::ObjectAdapterI::setAdapterOnConnection(const Ice::ConnectionIPtr& connectio
 {
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
     checkForDeactivation();
-    connection->setAdapterAndServantManager(ICE_SHARED_FROM_THIS, _servantManager);
+    connection->setAdapterAndServantManager(shared_from_this(), _servantManager);
 }
 
 //
@@ -1015,7 +1015,7 @@ Ice::ObjectAdapterI::initialize(const RouterPrxPtr& router)
             // Associate this object adapter with the router. This way, new outgoing connections
             // to the router's client proxy will use this object adapter for callbacks.
             //
-            _routerInfo->setAdapter(ICE_SHARED_FROM_THIS);
+            _routerInfo->setAdapter(shared_from_this());
 
             //
             // Also modify all existing outgoing connections to the router's client proxy to use
@@ -1037,11 +1037,11 @@ Ice::ObjectAdapterI::initialize(const RouterPrxPtr& router)
                 vector<EndpointIPtr> expanded = (*p)->expandHost(publishedEndpoint);
                 for(vector<EndpointIPtr>::iterator q = expanded.begin(); q != expanded.end(); ++q)
                 {
-                    IncomingConnectionFactoryPtr factory = ICE_MAKE_SHARED(IncomingConnectionFactory,
+                    IncomingConnectionFactoryPtr factory = std::make_shared<IncomingConnectionFactory>(
                                                                            _instance,
                                                                            *q,
                                                                            publishedEndpoint,
-                                                                           ICE_SHARED_FROM_THIS);
+                                                                           shared_from_this());
                     factory->initialize();
                     _incomingConnectionFactories.push_back(factory);
                 }

--- a/cpp/src/Ice/ObjectAdapterI.h
+++ b/cpp/src/Ice/ObjectAdapterI.h
@@ -40,17 +40,17 @@ class ObjectAdapterI : public ObjectAdapter,
 {
 public:
 
-    virtual std::string getName() const ICE_NOEXCEPT;
+    virtual std::string getName() const noexcept;
 
-    virtual CommunicatorPtr getCommunicator() const ICE_NOEXCEPT;
+    virtual CommunicatorPtr getCommunicator() const noexcept;
 
     virtual void activate();
     virtual void hold();
     virtual void waitForHold();
-    virtual void deactivate() ICE_NOEXCEPT;
-    virtual void waitForDeactivate() ICE_NOEXCEPT;
-    virtual bool isDeactivated() const ICE_NOEXCEPT;
-    virtual void destroy() ICE_NOEXCEPT;
+    virtual void deactivate() noexcept;
+    virtual void waitForDeactivate() noexcept;
+    virtual bool isDeactivated() const noexcept;
+    virtual void destroy() noexcept;
 
     virtual ObjectPrxPtr add(const ObjectPtr&, const Identity&);
     virtual ObjectPrxPtr addFacet(const ObjectPtr&, const Identity&, const std::string&);
@@ -76,11 +76,11 @@ public:
     virtual ObjectPrxPtr createIndirectProxy(const Identity&) const;
 
     virtual void setLocator(const LocatorPrxPtr&);
-    virtual Ice::LocatorPrxPtr getLocator() const ICE_NOEXCEPT;
-    virtual EndpointSeq getEndpoints() const ICE_NOEXCEPT;
+    virtual Ice::LocatorPrxPtr getLocator() const noexcept;
+    virtual EndpointSeq getEndpoints() const noexcept;
 
     virtual void refreshPublishedEndpoints();
-    virtual EndpointSeq getPublishedEndpoints() const ICE_NOEXCEPT;
+    virtual EndpointSeq getPublishedEndpoints() const noexcept;
     virtual void setPublishedEndpoints(const EndpointSeq&);
 
 #ifdef ICE_SWIFT

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -91,7 +91,7 @@ OpaqueEndpointInfoI::OpaqueEndpointInfoI(Ice::Short type, const Ice::EncodingVer
 void
 IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 {
-    s->startEncapsulation(_rawEncoding, ICE_ENUM(FormatType, DefaultFormat));
+    s->startEncapsulation(_rawEncoding, FormatType::DefaultFormat);
     s->writeBlob(_rawBytes);
     s->endEncapsulation();
 }

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -55,19 +55,19 @@ public:
     OpaqueEndpointInfoI(Ice::Short type, const Ice::EncodingVersion& rawEncoding, const Ice::ByteSeq& rawBytes);
 
     virtual Ice::Short
-    type() const ICE_NOEXCEPT
+    type() const noexcept
     {
         return _type;
     }
 
     virtual bool
-    datagram() const ICE_NOEXCEPT
+    datagram() const noexcept
     {
         return false;
     }
 
     virtual bool
-    secure() const ICE_NOEXCEPT
+    secure() const noexcept
     {
         return false;
     }
@@ -83,7 +83,7 @@ private:
 //
 OpaqueEndpointInfoI::OpaqueEndpointInfoI(Ice::Short type, const Ice::EncodingVersion& rawEncodingP,
                                          const Ice::ByteSeq& rawBytesP) :
-    Ice::OpaqueEndpointInfo(ICE_NULLPTR, -1, false, rawEncodingP, rawBytesP),
+    Ice::OpaqueEndpointInfo(nullptr, -1, false, rawEncodingP, rawBytesP),
     _type(type)
 {
 }
@@ -97,7 +97,7 @@ IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 }
 
 Ice::EndpointInfoPtr
-IceInternal::OpaqueEndpointI::getInfo() const ICE_NOEXCEPT
+IceInternal::OpaqueEndpointI::getInfo() const noexcept
 {
     return ICE_MAKE_SHARED(OpaqueEndpointInfoI, _type, _rawEncoding, _rawBytes);
 }
@@ -165,7 +165,7 @@ IceInternal::OpaqueEndpointI::secure() const
 TransceiverPtr
 IceInternal::OpaqueEndpointI::transceiver() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void
@@ -177,7 +177,7 @@ IceInternal::OpaqueEndpointI::connectors_async(Ice::EndpointSelectionType, const
 AcceptorPtr
 IceInternal::OpaqueEndpointI::acceptor(const string&) const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 vector<EndpointIPtr>

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -99,7 +99,7 @@ IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 Ice::EndpointInfoPtr
 IceInternal::OpaqueEndpointI::getInfo() const noexcept
 {
-    return ICE_MAKE_SHARED(OpaqueEndpointInfoI, _type, _rawEncoding, _rawBytes);
+    return std::make_shared<OpaqueEndpointInfoI>(_type, _rawEncoding, _rawBytes);
 }
 
 Short

--- a/cpp/src/Ice/OpaqueEndpointI.h
+++ b/cpp/src/Ice/OpaqueEndpointI.h
@@ -20,7 +20,7 @@ public:
     OpaqueEndpointI(Ice::Short, Ice::InputStream*);
 
     virtual void streamWrite(Ice::OutputStream*) const;
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Short type() const;
     virtual const std::string& protocol() const;
 

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -282,7 +282,7 @@ bool
 OutgoingAsyncBase::exceptionImpl(const Exception& ex)
 {
     Lock sync(_m);
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+    _ex = ex.ice_clone();
     if(_childObserver)
     {
         _childObserver.failed(ex.ice_id());
@@ -316,7 +316,7 @@ OutgoingAsyncBase::responseImpl(bool ok, bool invoke)
     }
     catch(const Ice::Exception& ex)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+        _ex = ex.ice_clone();
         invoke = handleException(ex);
     }
     if(!invoke)
@@ -334,7 +334,7 @@ OutgoingAsyncBase::cancel(const Ice::LocalException& ex)
         Lock sync(_m);
         if(!_cancellationHandler)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(_cancellationException, ex.ice_clone());
+            _cancellationException = ex.ice_clone();
             return;
         }
         handler = _cancellationHandler;

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -471,7 +471,7 @@ ProxyOutgoingAsyncBase::abort(const Ice::Exception& ex)
 ProxyOutgoingAsyncBase::ProxyOutgoingAsyncBase(const ObjectPrxPtr& prx) :
     OutgoingAsyncBase(prx->_getReference()->getInstance()),
     _proxy(prx),
-    _mode(ICE_ENUM(OperationMode, Normal)),
+    _mode(OperationMode::Normal),
     _cnt(0),
     _sent(false)
 {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -574,7 +574,7 @@ Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = ICE_NULLPTR;
+        Byte* lastByte = nullptr;
         bool converted = false;
         if(_instance)
         {
@@ -686,7 +686,7 @@ Ice::OutputStream::write(const wstring& v)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = ICE_NULLPTR;
+        Byte* lastByte = nullptr;
 
         // Note: wstringConverter is never null; when set to null, get returns the default unicode wstring converter
         if(_instance)

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -70,7 +70,7 @@ Ice::OutputStream::OutputStream() :
     _instance(0),
     _closure(0),
     _encoding(currentEncoding),
-    _format(ICE_ENUM(FormatType, CompactFormat)),
+    _format(FormatType::CompactFormat),
     _currentEncaps(0)
 {
 }
@@ -210,7 +210,7 @@ Ice::OutputStream::startEncapsulation()
     }
     else
     {
-        startEncapsulation(_encoding, Ice::ICE_ENUM(FormatType, DefaultFormat));
+        startEncapsulation(_encoding, Ice::FormatType::DefaultFormat);
     }
 }
 
@@ -862,7 +862,7 @@ Ice::OutputStream::initEncaps()
         _currentEncaps->encoding = _encoding;
     }
 
-    if(_currentEncaps->format == Ice::ICE_ENUM(FormatType, DefaultFormat))
+    if(_currentEncaps->format == Ice::FormatType::DefaultFormat)
     {
         _currentEncaps->format = _format;
     }
@@ -1084,7 +1084,7 @@ Ice::OutputStream::EncapsEncoder11::write(const ValuePtr& v)
     {
         _stream->writeSize(0); // Nil reference.
     }
-    else if(_current && _encaps->format == ICE_ENUM(FormatType, SlicedFormat))
+    else if(_current && _encaps->format == FormatType::SlicedFormat)
     {
         //
         // If writing an instance within a slice and using the sliced
@@ -1152,7 +1152,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(const string& typeId, int compact
     _current->sliceFlagsPos = _stream->b.size();
 
     _current->sliceFlags = 0;
-    if(_encaps->format == ICE_ENUM(FormatType, SlicedFormat))
+    if(_encaps->format == FormatType::SlicedFormat)
     {
         _current->sliceFlags |= FLAG_HAS_SLICE_SIZE; // Encode the slice size if using the sliced format.
     }
@@ -1174,7 +1174,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(const string& typeId, int compact
         // Encode the type ID (only in the first slice for the compact
         // encoding).
         //
-        if(_encaps->format == ICE_ENUM(FormatType, SlicedFormat) || _current->firstSlice)
+        if(_encaps->format == FormatType::SlicedFormat || _current->firstSlice)
         {
             if(compactId >= 0)
             {
@@ -1239,7 +1239,7 @@ Ice::OutputStream::EncapsEncoder11::endSlice()
     //
     if(!_current->indirectionTable.empty())
     {
-        assert(_encaps->format == ICE_ENUM(FormatType, SlicedFormat));
+        assert(_encaps->format == FormatType::SlicedFormat);
         _current->sliceFlags |= FLAG_HAS_INDIRECTION_TABLE;
 
         //
@@ -1294,7 +1294,7 @@ Ice::OutputStream::EncapsEncoder11::writeSlicedData(const SlicedDataPtr& slicedD
     // essentially "slices" the instance into the most-derived type
     // known by the sender.
     //
-    if(_encaps->format != ICE_ENUM(FormatType, SlicedFormat))
+    if(_encaps->format != FormatType::SlicedFormat)
     {
         return;
     }

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -126,7 +126,7 @@ Ice::PluginManagerI::initializePlugins()
 }
 
 StringSeq
-Ice::PluginManagerI::getPlugins() ICE_NOEXCEPT
+Ice::PluginManagerI::getPlugins() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -179,7 +179,7 @@ Ice::PluginManagerI::addPlugin(const string& name, const PluginPtr& plugin)
 }
 
 void
-Ice::PluginManagerI::destroy() ICE_NOEXCEPT
+Ice::PluginManagerI::destroy() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 

--- a/cpp/src/Ice/PluginManagerI.h
+++ b/cpp/src/Ice/PluginManagerI.h
@@ -25,10 +25,10 @@ public:
     static void registerPluginFactory(const std::string&, PluginFactory, bool);
 
     virtual void initializePlugins();
-    virtual StringSeq getPlugins() ICE_NOEXCEPT;
+    virtual StringSeq getPlugins() noexcept;
     virtual PluginPtr getPlugin(const std::string&);
     virtual void addPlugin(const std::string&, const PluginPtr&);
-    virtual void destroy() ICE_NOEXCEPT;
+    virtual void destroy() noexcept;
     PluginManagerI(const CommunicatorPtr&, const IceInternal::DynamicLibraryListPtr&);
 
 private:

--- a/cpp/src/Ice/PropertiesI.cpp
+++ b/cpp/src/Ice/PropertiesI.cpp
@@ -423,7 +423,7 @@ PropertiesPtr
 Ice::PropertiesI::clone() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
-    return ICE_MAKE_SHARED(PropertiesI, this);
+    return std::make_shared<PropertiesI>(this);
 }
 
 set<string>

--- a/cpp/src/Ice/PropertiesI.cpp
+++ b/cpp/src/Ice/PropertiesI.cpp
@@ -18,7 +18,7 @@ using namespace Ice;
 using namespace IceInternal;
 
 string
-Ice::PropertiesI::getProperty(const string& key) ICE_NOEXCEPT
+Ice::PropertiesI::getProperty(const string& key) noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -35,7 +35,7 @@ Ice::PropertiesI::getProperty(const string& key) ICE_NOEXCEPT
 }
 
 string
-Ice::PropertiesI::getPropertyWithDefault(const string& key, const string& value) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertyWithDefault(const string& key, const string& value) noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -52,13 +52,13 @@ Ice::PropertiesI::getPropertyWithDefault(const string& key, const string& value)
 }
 
 Int
-Ice::PropertiesI::getPropertyAsInt(const string& key) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertyAsInt(const string& key) noexcept
 {
     return getPropertyAsIntWithDefault(key, 0);
 }
 
 Int
-Ice::PropertiesI::getPropertyAsIntWithDefault(const string& key, Int value) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertyAsIntWithDefault(const string& key, Int value) noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -80,13 +80,13 @@ Ice::PropertiesI::getPropertyAsIntWithDefault(const string& key, Int value) ICE_
 }
 
 Ice::StringSeq
-Ice::PropertiesI::getPropertyAsList(const string& key) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertyAsList(const string& key) noexcept
 {
     return getPropertyAsListWithDefault(key, StringSeq());
 }
 
 Ice::StringSeq
-Ice::PropertiesI::getPropertyAsListWithDefault(const string& key, const StringSeq& value) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertyAsListWithDefault(const string& key, const StringSeq& value) noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -114,7 +114,7 @@ Ice::PropertiesI::getPropertyAsListWithDefault(const string& key, const StringSe
 }
 
 PropertyDict
-Ice::PropertiesI::getPropertiesForPrefix(const string& prefix) ICE_NOEXCEPT
+Ice::PropertiesI::getPropertiesForPrefix(const string& prefix) noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -230,7 +230,7 @@ Ice::PropertiesI::setProperty(const string& key, const string& value)
 }
 
 StringSeq
-Ice::PropertiesI::getCommandLineOptions() ICE_NOEXCEPT
+Ice::PropertiesI::getCommandLineOptions() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -309,8 +309,8 @@ Ice::PropertiesI::load(const std::string& file)
         DWORD numValues;
         try
         {
-            err = RegQueryInfoKey(iceKey, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR,
-                                  &numValues, &maxNameSize, &maxDataSize, ICE_NULLPTR, ICE_NULLPTR);
+            err = RegQueryInfoKey(iceKey, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                  &numValues, &maxNameSize, &maxDataSize, nullptr, nullptr);
             if(err != ERROR_SUCCESS)
             {
                 throw InitializationException(__FILE__, __LINE__, "could not open Windows registry key `" + file +
@@ -324,7 +324,7 @@ Ice::PropertiesI::load(const std::string& file)
                 DWORD keyType;
                 DWORD nameBufSize = static_cast<DWORD>(nameBuf.size());
                 DWORD dataBufSize = static_cast<DWORD>(dataBuf.size());
-                err = RegEnumValueW(iceKey, i, &nameBuf[0], &nameBufSize, ICE_NULLPTR, &keyType, &dataBuf[0], &dataBufSize);
+                err = RegEnumValueW(iceKey, i, &nameBuf[0], &nameBufSize, nullptr, &keyType, &dataBuf[0], &dataBufSize);
                 if(err != ERROR_SUCCESS || nameBufSize == 0)
                 {
                     ostringstream os;
@@ -420,7 +420,7 @@ Ice::PropertiesI::load(const std::string& file)
 }
 
 PropertiesPtr
-Ice::PropertiesI::clone() ICE_NOEXCEPT
+Ice::PropertiesI::clone() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
     return ICE_MAKE_SHARED(PropertiesI, this);

--- a/cpp/src/Ice/PropertiesI.h
+++ b/cpp/src/Ice/PropertiesI.h
@@ -18,20 +18,20 @@ class PropertiesI : public Properties, public IceUtil::Mutex
 {
 public:
 
-    virtual std::string getProperty(const std::string&) ICE_NOEXCEPT;
-    virtual std::string getPropertyWithDefault(const std::string&, const std::string&) ICE_NOEXCEPT;
-    virtual Ice::Int getPropertyAsInt(const std::string&) ICE_NOEXCEPT;
-    virtual Ice::Int getPropertyAsIntWithDefault(const std::string&, Ice::Int) ICE_NOEXCEPT;
-    virtual Ice::StringSeq getPropertyAsList(const std::string&) ICE_NOEXCEPT;
-    virtual Ice::StringSeq getPropertyAsListWithDefault(const std::string&, const Ice::StringSeq&) ICE_NOEXCEPT;
+    virtual std::string getProperty(const std::string&) noexcept;
+    virtual std::string getPropertyWithDefault(const std::string&, const std::string&) noexcept;
+    virtual Ice::Int getPropertyAsInt(const std::string&) noexcept;
+    virtual Ice::Int getPropertyAsIntWithDefault(const std::string&, Ice::Int) noexcept;
+    virtual Ice::StringSeq getPropertyAsList(const std::string&) noexcept;
+    virtual Ice::StringSeq getPropertyAsListWithDefault(const std::string&, const Ice::StringSeq&) noexcept;
 
-    virtual PropertyDict getPropertiesForPrefix(const std::string&) ICE_NOEXCEPT;
+    virtual PropertyDict getPropertiesForPrefix(const std::string&) noexcept;
     virtual void setProperty(const std::string&, const std::string&);
-    virtual StringSeq getCommandLineOptions() ICE_NOEXCEPT;
+    virtual StringSeq getCommandLineOptions() noexcept;
     virtual StringSeq parseCommandLineOptions(const std::string&, const StringSeq&);
     virtual StringSeq parseIceCommandLineOptions(const StringSeq&);
     virtual void load(const std::string&);
-    virtual PropertiesPtr clone() ICE_NOEXCEPT;
+    virtual PropertiesPtr clone() noexcept;
 
     std::set<std::string> getUnusedProperties();
 

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -63,7 +63,7 @@ ProxyFlushBatchAsync::invokeRemote(const ConnectionIPtr& connection, bool compre
         }
     }
     _cachedConnection = connection;
-    return connection->sendAsyncRequest(ICE_SHARED_FROM_THIS, compress, false, _batchRequestNum);
+    return connection->sendAsyncRequest(shared_from_this(), compress, false, _batchRequestNum);
 }
 
 AsyncStatus
@@ -878,7 +878,7 @@ ICE_OBJECT_PRX::_getRequestHandler()
             return _requestHandler;
         }
     }
-    return _reference->getRequestHandler(ICE_SHARED_FROM_THIS);
+    return _reference->getRequestHandler(shared_from_this());
 }
 
 IceInternal::BatchRequestQueuePtr

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -154,7 +154,7 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<IceInternal::OutgoingAsyncT<bool>>& o
                           const Context& ctx)
 {
     _checkTwowayOnly(ice_isA_name);
-    outAsync->invoke(ice_isA_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx,
+    outAsync->invoke(ice_isA_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx,
                      [&](Ice::OutputStream* os)
                      {
                          os->write(typeId, false);
@@ -165,14 +165,14 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<IceInternal::OutgoingAsyncT<bool>>& o
 void
 Ice::ObjectPrx::_iceI_ping(const shared_ptr<IceInternal::OutgoingAsyncT<void>>& outAsync, const Context& ctx)
 {
-    outAsync->invoke(ice_ping_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr);
+    outAsync->invoke(ice_ping_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr);
 }
 
 void
 Ice::ObjectPrx::_iceI_ids(const shared_ptr<IceInternal::OutgoingAsyncT<vector<string>>>& outAsync, const Context& ctx)
 {
     _checkTwowayOnly(ice_ids_name);
-    outAsync->invoke(ice_ids_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr,
+    outAsync->invoke(ice_ids_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          vector<string> v;
@@ -185,7 +185,7 @@ void
 Ice::ObjectPrx::_iceI_id(const shared_ptr<IceInternal::OutgoingAsyncT<string>>& outAsync, const Context& ctx)
 {
     _checkTwowayOnly(ice_id_name);
-    outAsync->invoke(ice_id_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr,
+    outAsync->invoke(ice_id_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          string v;
@@ -843,7 +843,7 @@ ICE_OBJECT_PRX::_handleException(const Exception& ex,
     //
     const LocalException* localEx = dynamic_cast<const LocalException*>(&ex);
     if(localEx && (!sent ||
-                   mode == ICE_ENUM(OperationMode, Nonmutating) || mode == ICE_ENUM(OperationMode, Idempotent) ||
+                   mode == OperationMode::Nonmutating || mode == OperationMode::Idempotent ||
                    dynamic_cast<const CloseConnectionException*>(&ex) ||
                    dynamic_cast<const ObjectNotExistException*>(&ex)))
     {

--- a/cpp/src/Ice/ProxyFactory.cpp
+++ b/cpp/src/Ice/ProxyFactory.cpp
@@ -86,7 +86,7 @@ IceInternal::ProxyFactory::referenceToProxy(const ReferencePtr& ref) const
     }
     else
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 }
 

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1575,7 +1575,7 @@ IceInternal::RoutableReference::getConnectionNoRouterInfo(const GetConnectionCal
     {
     public:
 
-        class Callback2 ICE_FINAL : public Reference::GetConnectionCallback
+        class Callback2 final : public Reference::GetConnectionCallback
         {
         public:
 

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -618,7 +618,7 @@ IceInternal::FixedReference::getPreferSecure() const
 Ice::EndpointSelectionType
 IceInternal::FixedReference::getEndpointSelection() const
 {
-    return ICE_ENUM(EndpointSelectionType, Random);
+    return EndpointSelectionType::Random;
 }
 
 int
@@ -1264,7 +1264,7 @@ IceInternal::RoutableReference::toProperty(const string& prefix) const
     properties[prefix + ".CollocationOptimized"] = _collocationOptimized ? "1" : "0";
     properties[prefix + ".ConnectionCached"] = _cacheConnection ? "1" : "0";
     properties[prefix + ".PreferSecure"] = _preferSecure ? "1" : "0";
-    properties[prefix + ".EndpointSelection"] = _endpointSelection == ICE_ENUM(EndpointSelectionType, Random) ? "Random" : "Ordered";
+    properties[prefix + ".EndpointSelection"] = _endpointSelection == EndpointSelectionType::Random ? "Random" : "Ordered";
     {
         ostringstream s;
         s << _locatorCacheTimeout;
@@ -1904,12 +1904,12 @@ IceInternal::RoutableReference::filterEndpoints(const vector<EndpointIPtr>& allE
     //
     switch(getEndpointSelection())
     {
-        case ICE_ENUM(EndpointSelectionType, Random):
+        case EndpointSelectionType::Random:
         {
             IceUtilInternal::shuffle(endpoints.begin(), endpoints.end());
             break;
         }
-        case ICE_ENUM(EndpointSelectionType, Ordered):
+        case EndpointSelectionType::Ordered:
         {
             // Nothing to do.
             break;

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1763,7 +1763,7 @@ IceInternal::RoutableReference::createConnection(const vector<EndpointIPtr>& all
             {
                 if(!_exception)
                 {
-                    ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+                    _exception = ex.ice_clone();
                 }
 
                 if(++_i == _endpoints.size())

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -800,7 +800,7 @@ IceInternal::FixedReference::getRequestHandler(const Ice::ObjectPrxPtr& proxy) c
     }
 
     ReferencePtr ref = const_cast<FixedReference*>(this);
-    return proxy->_setRequestHandler(ICE_MAKE_SHARED(ConnectionRequestHandler, ref, _fixedConnection, compress));
+    return proxy->_setRequestHandler(std::make_shared<ConnectionRequestHandler>(ref, _fixedConnection, compress));
 }
 
 BatchRequestQueuePtr
@@ -1640,7 +1640,7 @@ IceInternal::RoutableReference::getConnectionNoRouterInfo(const GetConnectionCal
 
             vector<EndpointIPtr> endpts = endpoints;
             _reference->applyOverrides(endpts);
-            _reference->createConnection(endpts, ICE_MAKE_SHARED(Callback2, _reference, _callback, cached));
+            _reference->createConnection(endpts, std::make_shared<Callback2>(_reference, _callback, cached));
         }
 
         virtual void

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -448,7 +448,7 @@ IceInternal::ReferenceFactory::create(const string& str, const string& propertyP
 
                 string es = s.substr(beg, end - beg);
                 EndpointIPtr endp = _instance->endpointFactoryManager()->create(es, false);
-                if(endp != ICE_NULLPTR)
+                if(endp != nullptr)
                 {
                     endpoints.push_back(endp);
                 }

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -812,11 +812,11 @@ IceInternal::ReferenceFactory::create(const Identity& ident,
             string type = properties->getProperty(property);
             if(type == "Random")
             {
-                endpointSelection = ICE_ENUM(EndpointSelectionType, Random);
+                endpointSelection = EndpointSelectionType::Random;
             }
             else if(type == "Ordered")
             {
-                endpointSelection = ICE_ENUM(EndpointSelectionType, Ordered);
+                endpointSelection = EndpointSelectionType::Ordered;
             }
             else
             {

--- a/cpp/src/Ice/RequestHandler.cpp
+++ b/cpp/src/Ice/RequestHandler.cpp
@@ -10,12 +10,12 @@ using namespace IceInternal;
 
 RetryException::RetryException(const Ice::LocalException& ex)
 {
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+    _ex = ex.ice_clone();
 }
 
 RetryException::RetryException(const RetryException& ex)
 {
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.get()->ice_clone());
+    _ex = ex.get()->ice_clone();
 }
 
 const Ice::LocalException*

--- a/cpp/src/Ice/RequestHandlerFactory.cpp
+++ b/cpp/src/Ice/RequestHandlerFactory.cpp
@@ -25,7 +25,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
         Ice::ObjectAdapterPtr adapter = _instance->objectAdapterFactory()->findObjectAdapter(proxy);
         if(adapter)
         {
-            return proxy->_setRequestHandler(ICE_MAKE_SHARED(CollocatedRequestHandler, ref, adapter));
+            return proxy->_setRequestHandler(std::make_shared<CollocatedRequestHandler>(ref, adapter));
         }
     }
 
@@ -37,7 +37,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
         map<ReferencePtr, ConnectRequestHandlerPtr>::iterator p = _handlers.find(ref);
         if(p == _handlers.end())
         {
-            handler = ICE_MAKE_SHARED(ConnectRequestHandler, ref, proxy);
+            handler = std::make_shared<ConnectRequestHandler>(ref, proxy);
             _handlers.insert(make_pair(ref, handler));
             connect = true;
         }
@@ -48,7 +48,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
     }
     else
     {
-        handler = ICE_MAKE_SHARED(ConnectRequestHandler, ref, proxy);
+        handler = std::make_shared<ConnectRequestHandler>(ref, proxy);
         connect = true;
     }
     if(connect)

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -35,13 +35,13 @@ IceInternal::RetryTask::runTimerTask()
     // (we still need the client thread pool at this point to call
     // exception callbacks with CommunicatorDestroyedException).
     //
-    _queue->remove(ICE_SHARED_FROM_THIS);
+    _queue->remove(shared_from_this());
 }
 
 void
 IceInternal::RetryTask::asyncRequestCanceled(const OutgoingAsyncBasePtr& /*outAsync*/, const Ice::LocalException& ex)
 {
-    if(_queue->cancel(ICE_SHARED_FROM_THIS))
+    if(_queue->cancel(shared_from_this()))
     {
         if(_instance->traceLevels()->retry >= 1)
         {
@@ -86,7 +86,7 @@ IceInternal::RetryQueue::add(const ProxyOutgoingAsyncBasePtr& out, int interval)
     {
         throw CommunicatorDestroyedException(__FILE__, __LINE__);
     }
-    RetryTaskPtr task = ICE_MAKE_SHARED(RetryTask, _instance, this, out);
+    RetryTaskPtr task = std::make_shared<RetryTask>(_instance, this, out);
     out->cancelable(task); // This will throw if the request is canceled.
     try
     {

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -75,7 +75,7 @@ IceInternal::RouterManager::erase(const RouterPrxPtr& rtr)
     RouterInfoPtr info;
     if(rtr)
     {
-        RouterPrxPtr router = ICE_UNCHECKED_CAST(RouterPrx, rtr->ice_router(ICE_NULLPTR)); // The router cannot be routed.
+        RouterPrxPtr router = ICE_UNCHECKED_CAST(RouterPrx, rtr->ice_router(nullptr)); // The router cannot be routed.
         IceUtil::Mutex::Lock sync(*this);
 
         RouterInfoTable::iterator p = _table.end();

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -38,8 +38,8 @@ Selector::~Selector()
 void
 Selector::setup(int sizeIO)
 {
-    _handle = CreateIoCompletionPort(INVALID_HANDLE_VALUE, ICE_NULLPTR, 0, sizeIO);
-    if(_handle == ICE_NULLPTR)
+    _handle = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, sizeIO);
+    if(_handle == nullptr)
     {
         throw Ice::SocketException(__FILE__, __LINE__, GetLastError());
     }
@@ -69,7 +69,7 @@ Selector::initialize(EventHandler* handler)
         if(CreateIoCompletionPort(reinterpret_cast<HANDLE>(socket),
                                   _handle,
                                   reinterpret_cast<ULONG_PTR>(handler),
-                                  0) == ICE_NULLPTR)
+                                  0) == nullptr)
         {
             throw Ice::SocketException(__FILE__, __LINE__, GetLastError());
         }

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -76,7 +76,7 @@ Selector::initialize(EventHandler* handler)
     }
     handler->getNativeInfo()->initialize(_handle, reinterpret_cast<ULONG_PTR>(handler));
 #else
-    EventHandlerPtr h = ICE_GET_SHARED_FROM_THIS(handler);
+    EventHandlerPtr h = handler->shared_from_this();
     handler->getNativeInfo()->setCompletedHandler(
         ref new SocketOperationCompletedHandler(
             [=](int operation)
@@ -658,7 +658,7 @@ Selector::finishSelect(vector<pair<EventHandler*, SocketOperation> >& handlers)
             continue; // Interrupted
         }
 
-        map<EventHandlerPtr, SocketOperation>::iterator q = _readyHandlers.find(ICE_GET_SHARED_FROM_THIS(p.first));
+        map<EventHandlerPtr, SocketOperation>::iterator q = _readyHandlers.find(p.first->shared_from_this());
 
         if(q != _readyHandlers.end()) // Handler will be added by the loop below
         {
@@ -778,12 +778,12 @@ Selector::checkReady(EventHandler* handler)
 {
     if(handler->_ready & ~handler->_disabled & handler->_registered)
     {
-        _readyHandlers.insert(make_pair(ICE_GET_SHARED_FROM_THIS(handler), SocketOperationNone));
+        _readyHandlers.insert(make_pair(handler->shared_from_this(), SocketOperationNone));
         wakeup();
     }
     else
     {
-        map<EventHandlerPtr, SocketOperation>::iterator p = _readyHandlers.find(ICE_GET_SHARED_FROM_THIS(handler));
+        map<EventHandlerPtr, SocketOperation>::iterator p = _readyHandlers.find(handler->shared_from_this());
         if(p != _readyHandlers.end())
         {
             _readyHandlers.erase(p);
@@ -1082,7 +1082,7 @@ toCFCallbacks(SocketOperation op)
 }
 
 EventHandlerWrapper::EventHandlerWrapper(EventHandler* handler, Selector& selector) :
-    _handler(ICE_GET_SHARED_FROM_THIS(handler)),
+    _handler(handler->shared_from_this()),
     _streamNativeInfo(StreamNativeInfoPtr::dynamicCast(handler->getNativeInfo())),
     _selector(selector),
     _ready(SocketOperationNone),

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -196,7 +196,7 @@ public:
     virtual Ice::LoggerPtr
     cloneWithPrefix(const string& prefix)
     {
-        return ICE_MAKE_SHARED(SMEventLoggerIWrapper, _logger, prefix);
+        return std::make_shared<SMEventLoggerIWrapper>(_logger, prefix);
     }
 
 private:
@@ -584,7 +584,7 @@ Ice::Service::main(int argc, const char* const argv[], const InitializationData&
             if(ICE_DYNAMIC_CAST(LoggerI, _logger))
             {
                 string eventLogSource = initData.properties->getPropertyWithDefault("Ice.EventLog.Source", name);
-                _logger = ICE_MAKE_SHARED(SMEventLoggerIWrapper, new SMEventLoggerI(eventLogSource, stringConverter), "");
+                _logger = std::make_shared<SMEventLoggerIWrapper>(new SMEventLoggerI(eventLogSource, stringConverter), "");
                 setProcessLogger(_logger);
             }
 
@@ -714,7 +714,7 @@ Ice::Service::main(int argc, const char* const argv[], const InitializationData&
                 initData.properties->getPropertyAsIntWithDefault("Ice.LogStdErr.Convert", 1) > 0 &&
                 initData.properties->getProperty("Ice.StdErr").empty();
 
-            _logger = ICE_MAKE_SHARED(LoggerI, initData.properties->getProperty("Ice.ProgramName"), "", convert);
+            _logger = std::make_shared<LoggerI>(initData.properties->getProperty("Ice.ProgramName"), "", convert);
             setProcessLogger(_logger);
         }
     }

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -351,7 +351,7 @@ StreamSocket::startWrite(Buffer& buf)
     _write.buf.len = static_cast<DWORD>(packetSize);
     _write.buf.buf = reinterpret_cast<char*>(&*buf.i);
     _write.error = ERROR_SUCCESS;
-    int err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, ICE_NULLPTR);
+    int err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, nullptr);
     if(err == SOCKET_ERROR)
     {
         if(!wouldBlock())
@@ -407,7 +407,7 @@ StreamSocket::startRead(Buffer& buf)
     _read.buf.len = static_cast<DWORD>(packetSize);
     _read.buf.buf = reinterpret_cast<char*>(&*buf.i);
     _read.error = ERROR_SUCCESS;
-    int err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, ICE_NULLPTR);
+    int err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, nullptr);
     if(err == SOCKET_ERROR)
     {
         if(!wouldBlock())

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -160,7 +160,7 @@ Ice::SysLoggerI::getPrefix()
 Ice::LoggerPtr
 Ice::SysLoggerI::cloneWithPrefix(const string& prefix)
 {
-    return ICE_MAKE_SHARED(SysLoggerI, prefix, _facility);
+    return std::make_shared<SysLoggerI>(prefix, _facility);
 }
 
 #endif

--- a/cpp/src/Ice/SystemdJournalI.cpp
+++ b/cpp/src/Ice/SystemdJournalI.cpp
@@ -51,7 +51,7 @@ Ice::SystemdJournalI::getPrefix()
 Ice::LoggerPtr
 Ice::SystemdJournalI::cloneWithPrefix(const string& prefix)
 {
-    return ICE_MAKE_SHARED(SystemdJournalI, prefix);
+    return std::make_shared<SystemdJournalI>(prefix);
 }
 
 void

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -84,7 +84,7 @@ IceInternal::TcpAcceptor::getAsyncInfo(SocketOperation)
 void
 IceInternal::TcpAcceptor::startAccept()
 {
-    LPFN_ACCEPTEX AcceptEx = ICE_NULLPTR; // a pointer to the 'AcceptEx()' function
+    LPFN_ACCEPTEX AcceptEx = nullptr; // a pointer to the 'AcceptEx()' function
     GUID GuidAcceptEx = WSAID_ACCEPTEX; // The Guid
     DWORD dwBytes;
     if(WSAIoctl(_fd,
@@ -94,8 +94,8 @@ IceInternal::TcpAcceptor::startAccept()
                 &AcceptEx,
                 sizeof(AcceptEx),
                 &dwBytes,
-                ICE_NULLPTR,
-                ICE_NULLPTR) == SOCKET_ERROR)
+                nullptr,
+                nullptr) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -66,7 +66,7 @@ IceInternal::TcpEndpointI::streamWriteImpl(OutputStream* s) const
 }
 
 EndpointInfoPtr
-IceInternal::TcpEndpointI::getInfo() const ICE_NOEXCEPT
+IceInternal::TcpEndpointI::getInfo() const noexcept
 {
     TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(TcpEndpointI));
     fillEndpointInfo(info.get());
@@ -120,7 +120,7 @@ IceInternal::TcpEndpointI::datagram() const
 TransceiverPtr
 IceInternal::TcpEndpointI::transceiver() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 AcceptorPtr

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -68,7 +68,7 @@ IceInternal::TcpEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceInternal::TcpEndpointI::getInfo() const noexcept
 {
-    TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(TcpEndpointI));
+    TCPEndpointInfoPtr info = std::make_shared<InfoI<Ice::TCPEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(TcpEndpointI));
     fillEndpointInfo(info.get());
     return info;
 }
@@ -88,7 +88,7 @@ IceInternal::TcpEndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, _port, _sourceAddr, timeout, _connectionId, _compress);
+        return std::make_shared<TcpEndpointI>(_instance, _host, _port, _sourceAddr, timeout, _connectionId, _compress);
     }
 }
 
@@ -107,7 +107,7 @@ IceInternal::TcpEndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, _port, _sourceAddr, _timeout, _connectionId, compress);
+        return std::make_shared<TcpEndpointI>(_instance, _host, _port, _sourceAddr, _timeout, _connectionId, compress);
     }
 }
 
@@ -139,7 +139,7 @@ IceInternal::TcpEndpointI::endpoint(const TcpAcceptorPtr& acceptor) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, port, _sourceAddr, _timeout, _connectionId, _compress);
+        return std::make_shared<TcpEndpointI>(_instance, _host, port, _sourceAddr, _timeout, _connectionId, _compress);
     }
 }
 
@@ -322,7 +322,7 @@ IceInternal::TcpEndpointI::createConnector(const Address& address, const Network
 IPEndpointIPtr
 IceInternal::TcpEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(TcpEndpointI, _instance, host, port, _sourceAddr, _timeout, connectionId, _compress);
+    return std::make_shared<TcpEndpointI>(_instance, host, port, _sourceAddr, _timeout, connectionId, _compress);
 }
 
 IceInternal::TcpEndpointFactory::TcpEndpointFactory(const ProtocolInstancePtr& instance) : _instance(instance)
@@ -348,7 +348,7 @@ IceInternal::TcpEndpointFactory::protocol() const
 EndpointIPtr
 IceInternal::TcpEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(TcpEndpointI, _instance);
+    IPEndpointIPtr endpt = std::make_shared<TcpEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -356,7 +356,7 @@ IceInternal::TcpEndpointFactory::create(vector<string>& args, bool oaEndpoint) c
 EndpointIPtr
 IceInternal::TcpEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(TcpEndpointI, _instance, s);
+    return std::make_shared<TcpEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/TcpEndpointI.h
+++ b/cpp/src/Ice/TcpEndpointI.h
@@ -24,7 +24,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
 
     virtual Ice::Int timeout() const;
     virtual EndpointIPtr timeout(Ice::Int) const;

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -102,7 +102,7 @@ IceInternal::TcpTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::TcpTransceiver::getInfo() const
 {
-    TCPConnectionInfoPtr info = ICE_MAKE_SHARED(TCPConnectionInfo);
+    TCPConnectionInfoPtr info = std::make_shared<TCPConnectionInfo>();
     fdToAddressAndPort(_stream->fd(), info->localAddress, info->localPort, info->remoteAddress, info->remotePort);
     if(_stream->fd() != INVALID_SOCKET)
     {

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -666,7 +666,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
             {
                 Lock sync(*this);
                 --_inUse;
-                thread->setState(ICE_ENUM(ThreadState, ThreadStateIdle));
+                thread->setState(ThreadState::ThreadStateIdle);
                 return;
             }
             catch(const exception& ex)
@@ -757,7 +757,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
                 current._handler = ICE_GET_SHARED_FROM_THIS(_nextHandler->first);
                 current.operation = _nextHandler->second;
                 ++_nextHandler;
-                thread->setState(ICE_ENUM(ThreadState, ThreadStateInUseForIO));
+                thread->setState(ThreadState::ThreadStateInUseForIO);
             }
             else
             {
@@ -781,7 +781,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
                     _handlers.clear();
                     _selector.startSelect();
                     select = true;
-                    thread->setState(ICE_ENUM(ThreadState, ThreadStateIdle));
+                    thread->setState(ThreadState::ThreadStateIdle);
                 }
             }
             else if(_sizeMax > 1)
@@ -860,7 +860,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
 
         {
             IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
-            thread->setState(ICE_ENUM(ThreadState, ThreadStateInUseForIO));
+            thread->setState(ThreadState::ThreadStateInUseForIO);
         }
 
         try
@@ -890,7 +890,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
                 assert(_inUse > 0);
                 --_inUse;
             }
-            thread->setState(ICE_ENUM(ThreadState, ThreadStateIdle));
+            thread->setState(ThreadState::ThreadStateIdle);
         }
     }
 #endif
@@ -903,7 +903,7 @@ IceInternal::ThreadPool::ioCompleted(ThreadPoolCurrent& current)
 
     current._ioCompleted = true; // Set the IO completed flag to specifiy that ioCompleted() has been called.
 
-    current._thread->setState(ICE_ENUM(ThreadState, ThreadStateInUseForUser));
+    current._thread->setState(ThreadState::ThreadStateInUseForUser);
 
     if(_sizeMax > 1)
     {
@@ -1101,7 +1101,7 @@ IceInternal::ThreadPool::followerWait(ThreadPoolCurrent& current)
 {
     assert(!current._leader);
 
-    current._thread->setState(ICE_ENUM(ThreadState, ThreadStateIdle));
+    current._thread->setState(ThreadState::ThreadStateIdle);
 
     //
     // It's important to clear the handler before waiting to make sure that
@@ -1158,7 +1158,7 @@ IceInternal::ThreadPool::nextThreadId()
 IceInternal::ThreadPool::EventHandlerThread::EventHandlerThread(const ThreadPoolPtr& pool, const string& name) :
     IceUtil::Thread(name),
     _pool(pool),
-    _state(ICE_ENUM(ThreadState, ThreadStateIdle))
+    _state(ThreadState::ThreadStateIdle)
 {
     updateObserver();
 }

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -396,7 +396,7 @@ IceInternal::ThreadPool::ThreadPool(const InstancePtr& instance, const string& p
         const_cast<int&>(_priority) = properties->getPropertyAsInt("Ice.ThreadPriority");
     }
 
-    _workQueue = ICE_MAKE_SHARED(ThreadPoolWorkQueue, *this);
+    _workQueue = std::make_shared<ThreadPoolWorkQueue>(*this);
     _selector.initialize(_workQueue.get());
 
     if(_instance->traceLevels()->threadPool >= 1)
@@ -754,7 +754,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
             if(_nextHandler != _handlers.end())
             {
                 current._ioCompleted = false;
-                current._handler = ICE_GET_SHARED_FROM_THIS(_nextHandler->first);
+                current._handler = _nextHandler->first->shared_from_this();
                 current.operation = _nextHandler->second;
                 ++_nextHandler;
                 thread->setState(ThreadState::ThreadStateInUseForIO);
@@ -805,8 +805,8 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
         try
         {
             current._ioCompleted = false;
-            current._handler = ICE_GET_SHARED_FROM_THIS(_selector.getNextHandler(current.operation, current._count,
-                                                                                 current._error, _threadIdleTime));
+            current._handler = _selector.getNextHandler(current.operation, current._count, current._error,
+                                                        _threadIdleTime)->shared_from_this();
         }
         catch(const SelectorTimeoutException&)
         {
@@ -844,8 +844,8 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
             try
             {
 
-                current._handler = ICE_GET_SHARED_FROM_THIS(_selector.getNextHandler(current.operation, current._count,
-                                                                                     current._error, _serverIdleTime));
+                current._handler = _selector.getNextHandler(current.operation, current._count,
+                                   current._error, _serverIdleTime)->shared_from_this();
             }
             catch(const SelectorTimeoutException&)
             {

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -641,7 +641,7 @@ IceInternal::ThreadPool::prefix() const
 #ifdef ICE_SWIFT
 
 dispatch_queue_t
-IceInternal::ThreadPool::getDispatchQueue() const ICE_NOEXCEPT
+IceInternal::ThreadPool::getDispatchQueue() const noexcept
 {
     return _dispatchQueue;
 }

--- a/cpp/src/Ice/ThreadPool.h
+++ b/cpp/src/Ice/ThreadPool.h
@@ -111,7 +111,7 @@ public:
     std::string prefix() const;
 
 #ifdef ICE_SWIFT
-    dispatch_queue_t getDispatchQueue() const ICE_NOEXCEPT;
+    dispatch_queue_t getDispatchQueue() const noexcept;
 #endif
 
 private:

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -250,7 +250,7 @@ Timer::run()
                 // in the synchronization block above. Clearing the task reference might end up
                 // calling user code which could trigger a deadlock. See also issue #352.
                 //
-                token.task = ICE_NULLPTR;
+                token.task = nullptr;
             }
         }
     }

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -24,7 +24,7 @@ using namespace IceInternal;
 static void
 printIdentityFacetOperation(ostream& s, InputStream& stream)
 {
-    ToStringMode toStringMode = ICE_ENUM(ToStringMode, Unicode);
+    ToStringMode toStringMode = ToStringMode::Unicode;
     if(stream.instance())
     {
         toStringMode = stream.instance()->toStringMode();
@@ -77,19 +77,19 @@ printRequestHeader(ostream& s, InputStream& stream)
     s << "\nmode = " << static_cast<int>(mode) << ' ';
     switch(static_cast<OperationMode>(mode))
     {
-        case ICE_ENUM(OperationMode, Normal):
+        case OperationMode::Normal:
         {
             s << "(normal)";
             break;
         }
 
-        case ICE_ENUM(OperationMode, Nonmutating):
+        case OperationMode::Nonmutating:
         {
             s << "(nonmutating)";
             break;
         }
 
-        case ICE_ENUM(OperationMode, Idempotent):
+        case OperationMode::Idempotent:
         {
             s << "(idempotent)";
             break;

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -104,7 +104,7 @@ IceInternal::UdpEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceInternal::UdpEndpointI::getInfo() const noexcept
 {
-    Ice::UDPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::UDPEndpointInfo>,
+    Ice::UDPEndpointInfoPtr info = std::make_shared<InfoI<Ice::UDPEndpointInfo>>(
                                                    ICE_DYNAMIC_CAST(UdpEndpointI, ICE_SHARED_FROM_CONST_THIS(UdpEndpointI)));
     fillEndpointInfo(info.get());
     return info;
@@ -137,7 +137,7 @@ IceInternal::UdpEndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(UdpEndpointI, _instance, _host, _port, _sourceAddr, _mcastInterface, _mcastTtl,
+        return std::make_shared<UdpEndpointI>(_instance, _host, _port, _sourceAddr, _mcastInterface, _mcastTtl,
                                _connect, _connectionId, compress);
     }
 }
@@ -171,7 +171,7 @@ IceInternal::UdpEndpointI::endpoint(const UdpTransceiverPtr& transceiver) const
     }
     else
     {
-        return ICE_MAKE_SHARED(UdpEndpointI, _instance, _host, port, _sourceAddr, _mcastInterface,_mcastTtl, _connect,
+        return std::make_shared<UdpEndpointI>(_instance, _host, port, _sourceAddr, _mcastInterface,_mcastTtl, _connect,
                                _connectionId, _compress);
     }
 }
@@ -452,7 +452,7 @@ IceInternal::UdpEndpointI::createConnector(const Address& address, const Network
 IPEndpointIPtr
 IceInternal::UdpEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(UdpEndpointI, _instance, host, port, _sourceAddr, _mcastInterface, _mcastTtl, _connect,
+    return std::make_shared<UdpEndpointI>(_instance, host, port, _sourceAddr, _mcastInterface, _mcastTtl, _connect,
                            connectionId, _compress);
 }
 
@@ -479,7 +479,7 @@ IceInternal::UdpEndpointFactory::protocol() const
 EndpointIPtr
 IceInternal::UdpEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(UdpEndpointI, _instance);
+    IPEndpointIPtr endpt = std::make_shared<UdpEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -487,7 +487,7 @@ IceInternal::UdpEndpointFactory::create(vector<string>& args, bool oaEndpoint) c
 EndpointIPtr
 IceInternal::UdpEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(UdpEndpointI, _instance, s);
+    return std::make_shared<UdpEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -102,7 +102,7 @@ IceInternal::UdpEndpointI::streamWriteImpl(OutputStream* s) const
 }
 
 EndpointInfoPtr
-IceInternal::UdpEndpointI::getInfo() const ICE_NOEXCEPT
+IceInternal::UdpEndpointI::getInfo() const noexcept
 {
     Ice::UDPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::UDPEndpointInfo>,
                                                    ICE_DYNAMIC_CAST(UdpEndpointI, ICE_SHARED_FROM_CONST_THIS(UdpEndpointI)));

--- a/cpp/src/Ice/UdpEndpointI.h
+++ b/cpp/src/Ice/UdpEndpointI.h
@@ -24,7 +24,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
 
     virtual Ice::Int timeout() const;
     virtual EndpointIPtr timeout(Ice::Int) const;

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -323,7 +323,7 @@ IceInternal::UdpTransceiver::startWrite(Buffer& buf)
     int err;
     if(_state == StateConnected)
     {
-        err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, ICE_NULLPTR);
+        err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, nullptr);
     }
     else
     {
@@ -341,7 +341,7 @@ IceInternal::UdpTransceiver::startWrite(Buffer& buf)
             // No peer has sent a datagram yet.
             throw SocketException(__FILE__, __LINE__, 0);
         }
-        err = WSASendTo(_fd, &_write.buf, 1, &_write.count, 0, &_peerAddr.sa, len, &_write, ICE_NULLPTR);
+        err = WSASendTo(_fd, &_write.buf, 1, &_write.count, 0, &_peerAddr.sa, len, &_write, nullptr);
     }
 
     if(err == SOCKET_ERROR)
@@ -399,7 +399,7 @@ IceInternal::UdpTransceiver::startRead(Buffer& buf)
     int err;
     if(_state == StateConnected)
     {
-        err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, ICE_NULLPTR);
+        err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, nullptr);
     }
     else
     {
@@ -407,7 +407,7 @@ IceInternal::UdpTransceiver::startRead(Buffer& buf)
         _readAddrLen = static_cast<socklen_t>(sizeof(sockaddr_storage));
 
         err = WSARecvFrom(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_readAddr.sa, &_readAddrLen, &_read,
-                          ICE_NULLPTR);
+                          nullptr);
     }
 
     if(err == SOCKET_ERROR)

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -535,7 +535,7 @@ IceInternal::UdpTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::UdpTransceiver::getInfo() const
 {
-    Ice::UDPConnectionInfoPtr info = ICE_MAKE_SHARED(Ice::UDPConnectionInfo);
+    Ice::UDPConnectionInfoPtr info = std::make_shared<Ice::UDPConnectionInfo>();
     if(_fd == INVALID_SOCKET)
     {
         return info;

--- a/cpp/src/Ice/ValueFactoryManagerI.cpp
+++ b/cpp/src/Ice/ValueFactoryManagerI.cpp
@@ -10,7 +10,7 @@ using namespace Ice;
 using namespace IceInternal;
 
 void
-IceInternal::ValueFactoryManagerI::add(ICE_IN(ValueFactory) factory, const string& id)
+IceInternal::ValueFactoryManagerI::add(ValueFactory factory, const string& id)
 {
     IceUtil::Mutex::Lock sync(*this);
 

--- a/cpp/src/Ice/ValueFactoryManagerI.cpp
+++ b/cpp/src/Ice/ValueFactoryManagerI.cpp
@@ -10,7 +10,7 @@ using namespace Ice;
 using namespace IceInternal;
 
 void
-IceInternal::ValueFactoryManagerI::add(ICE_IN(ICE_DELEGATE(ValueFactory)) factory, const string& id)
+IceInternal::ValueFactoryManagerI::add(ICE_IN(ValueFactory) factory, const string& id)
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -20,10 +20,10 @@ IceInternal::ValueFactoryManagerI::add(ICE_IN(ICE_DELEGATE(ValueFactory)) factor
         throw AlreadyRegisteredException(__FILE__, __LINE__, "value factory", id);
     }
 
-    _factoryMapHint = _factoryMap.insert(_factoryMapHint, pair<const string, ICE_DELEGATE(ValueFactory)>(id, factory));
+    _factoryMapHint = _factoryMap.insert(_factoryMapHint, pair<const string, ValueFactory>(id, factory));
 }
 
-ICE_DELEGATE(ValueFactory)
+ValueFactory
 IceInternal::ValueFactoryManagerI::find(const string& id) const noexcept
 {
     IceUtil::Mutex::Lock sync(*this);

--- a/cpp/src/Ice/ValueFactoryManagerI.cpp
+++ b/cpp/src/Ice/ValueFactoryManagerI.cpp
@@ -24,7 +24,7 @@ IceInternal::ValueFactoryManagerI::add(ICE_IN(ICE_DELEGATE(ValueFactory)) factor
 }
 
 ICE_DELEGATE(ValueFactory)
-IceInternal::ValueFactoryManagerI::find(const string& id) const ICE_NOEXCEPT
+IceInternal::ValueFactoryManagerI::find(const string& id) const noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
 
@@ -51,7 +51,7 @@ IceInternal::ValueFactoryManagerI::find(const string& id) const ICE_NOEXCEPT
     }
     else
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 }
 

--- a/cpp/src/Ice/ValueFactoryManagerI.h
+++ b/cpp/src/Ice/ValueFactoryManagerI.h
@@ -21,12 +21,12 @@ public:
 
     ValueFactoryManagerI();
 
-    virtual void add(ICE_IN(ICE_DELEGATE(::Ice::ValueFactory)), const std::string&);
-    virtual ICE_DELEGATE(::Ice::ValueFactory) find(const std::string&) const noexcept;
+    virtual void add(ICE_IN(::Ice::ValueFactory), const std::string&);
+    virtual ::Ice::ValueFactory find(const std::string&) const noexcept;
 
 private:
 
-    typedef std::map<std::string, ICE_DELEGATE(::Ice::ValueFactory)> FactoryMap;
+    typedef std::map<std::string, ::Ice::ValueFactory> FactoryMap;
 
     FactoryMap _factoryMap;
     mutable FactoryMap::iterator _factoryMapHint;

--- a/cpp/src/Ice/ValueFactoryManagerI.h
+++ b/cpp/src/Ice/ValueFactoryManagerI.h
@@ -22,7 +22,7 @@ public:
     ValueFactoryManagerI();
 
     virtual void add(ICE_IN(ICE_DELEGATE(::Ice::ValueFactory)), const std::string&);
-    virtual ICE_DELEGATE(::Ice::ValueFactory) find(const std::string&) const ICE_NOEXCEPT;
+    virtual ICE_DELEGATE(::Ice::ValueFactory) find(const std::string&) const noexcept;
 
 private:
 

--- a/cpp/src/Ice/ValueFactoryManagerI.h
+++ b/cpp/src/Ice/ValueFactoryManagerI.h
@@ -21,7 +21,7 @@ public:
 
     ValueFactoryManagerI();
 
-    virtual void add(ICE_IN(::Ice::ValueFactory), const std::string&);
+    virtual void add(::Ice::ValueFactory, const std::string&);
     virtual ::Ice::ValueFactory find(const std::string&) const noexcept;
 
 private:

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -120,7 +120,7 @@ IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& instance, const E
 EndpointInfoPtr
 IceInternal::WSEndpoint::getInfo() const noexcept
 {
-    WSEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<WSEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(WSEndpoint));
+    WSEndpointInfoPtr info = std::make_shared<InfoI<WSEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(WSEndpoint));
     info->underlying = _delegate->getInfo();
     info->compress = info->underlying->compress;
     info->timeout = info->underlying->timeout;
@@ -162,7 +162,7 @@ IceInternal::WSEndpoint::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->timeout(timeout), _resource);
+        return std::make_shared<WSEndpoint>(_instance, _delegate->timeout(timeout), _resource);
     }
 }
 
@@ -181,7 +181,7 @@ IceInternal::WSEndpoint::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->connectionId(connectionId), _resource);
+        return std::make_shared<WSEndpoint>(_instance, _delegate->connectionId(connectionId), _resource);
     }
 }
 
@@ -200,7 +200,7 @@ IceInternal::WSEndpoint::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->compress(compress), _resource);
+        return std::make_shared<WSEndpoint>(_instance, _delegate->compress(compress), _resource);
     }
 }
 
@@ -265,7 +265,7 @@ IceInternal::WSEndpoint::connectors_async(EndpointSelectionType selType,
     {
         host << info->host << ":" << info->port;
     }
-    _delegate->connectors_async(selType, ICE_MAKE_SHARED(CallbackI, callback, _instance, host.str(), _resource));
+    _delegate->connectors_async(selType, std::make_shared<CallbackI>(callback, _instance, host.str(), _resource));
 }
 
 AcceptorPtr
@@ -284,7 +284,7 @@ IceInternal::WSEndpoint::endpoint(const EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, delEndp, _resource);
+        return std::make_shared<WSEndpoint>(_instance, delEndp, _resource);
     }
 }
 
@@ -300,7 +300,7 @@ IceInternal::WSEndpoint::expandIfWildcard() const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(WSEndpoint, _instance, *p, _resource);
+            *p = std::make_shared<WSEndpoint>(_instance, *p, _resource);
         }
     }
     return endps;
@@ -316,7 +316,7 @@ IceInternal::WSEndpoint::expandHost(EndpointIPtr& publish) const
     }
     else if(publish.get())
     {
-        publish = ICE_MAKE_SHARED(WSEndpoint, _instance, publish, _resource);
+        publish = std::make_shared<WSEndpoint>(_instance, publish, _resource);
     }
     for(vector<EndpointIPtr>::iterator p = endps.begin(); p != endps.end(); ++p)
     {
@@ -326,7 +326,7 @@ IceInternal::WSEndpoint::expandHost(EndpointIPtr& publish) const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(WSEndpoint, _instance, *p, _resource);
+            *p = std::make_shared<WSEndpoint>(_instance, *p, _resource);
         }
     }
     return endps;
@@ -486,11 +486,11 @@ IceInternal::WSEndpointFactory::cloneWithUnderlying(const ProtocolInstancePtr& i
 EndpointIPtr
 IceInternal::WSEndpointFactory::createWithUnderlying(const EndpointIPtr& underlying, vector<string>& args, bool) const
 {
-    return ICE_MAKE_SHARED(WSEndpoint, _instance, underlying, args);
+    return std::make_shared<WSEndpoint>(_instance, underlying, args);
 }
 
 EndpointIPtr
 IceInternal::WSEndpointFactory::readWithUnderlying(const EndpointIPtr& underlying, InputStream* s) const
 {
-    return ICE_MAKE_SHARED(WSEndpoint, _instance, underlying, s);
+    return std::make_shared<WSEndpoint>(_instance, underlying, s);
 }

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -40,7 +40,7 @@ getIPEndpointInfo(const EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }
@@ -118,7 +118,7 @@ IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& instance, const E
 }
 
 EndpointInfoPtr
-IceInternal::WSEndpoint::getInfo() const ICE_NOEXCEPT
+IceInternal::WSEndpoint::getInfo() const noexcept
 {
     WSEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<WSEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(WSEndpoint));
     info->underlying = _delegate->getInfo();

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -26,7 +26,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Short type() const;
     virtual const std::string& protocol() const;
 

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -781,7 +781,7 @@ IceInternal::WSTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::WSTransceiver::getInfo() const
 {
-    WSConnectionInfoPtr info = ICE_MAKE_SHARED(WSConnectionInfo);
+    WSConnectionInfoPtr info = std::make_shared<WSConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->headers = _parser->getHeaders();
     return info;

--- a/cpp/src/Ice/ios/StreamAcceptor.cpp
+++ b/cpp/src/Ice/ios/StreamAcceptor.cpp
@@ -72,7 +72,7 @@ IceObjC::StreamAcceptor::accept()
     UniqueRef<CFWriteStreamRef> writeStream;
     try
     {
-        CFStreamCreatePairWithSocket(ICE_NULLPTR, fd, &readStream.get(), &writeStream.get());
+        CFStreamCreatePairWithSocket(nullptr, fd, &readStream.get(), &writeStream.get());
         _instance->setupStreams(readStream.get(), writeStream.get(), true, "");
         return new StreamTransceiver(_instance, readStream.release(), writeStream.release(), fd);
     }

--- a/cpp/src/Ice/ios/StreamConnector.cpp
+++ b/cpp/src/Ice/ios/StreamConnector.cpp
@@ -27,9 +27,9 @@ IceObjC::StreamConnector::connect()
 {
     UniqueRef<CFReadStreamRef> readStream;
     UniqueRef<CFWriteStreamRef> writeStream;
-    UniqueRef<CFStringRef> h(CFStringCreateWithCString(ICE_NULLPTR, _host.c_str(), kCFStringEncodingUTF8));
-    UniqueRef<CFHostRef> host(CFHostCreateWithName(ICE_NULLPTR, h.get()));
-    CFStreamCreatePairWithSocketToCFHost(ICE_NULLPTR, host.get(), _port, &readStream.get(), &writeStream.get());
+    UniqueRef<CFStringRef> h(CFStringCreateWithCString(nullptr, _host.c_str(), kCFStringEncodingUTF8));
+    UniqueRef<CFHostRef> host(CFHostCreateWithName(nullptr, h.get()));
+    CFStreamCreatePairWithSocketToCFHost(nullptr, host.get(), _port, &readStream.get(), &writeStream.get());
     _instance->setupStreams(readStream.get(), writeStream.get(), false, _host);
     return new StreamTransceiver(_instance, readStream.release(), writeStream.release(), _host, _port);
 }

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -143,7 +143,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance, Ice::Inpu
 EndpointInfoPtr
 IceObjC::StreamEndpointI::getInfo() const noexcept
 {
-    TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(StreamEndpointI));
+    TCPEndpointInfoPtr info = std::make_shared<InfoI<Ice::TCPEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(StreamEndpointI));
     IPEndpointI::fillEndpointInfo(info.get());
     info->timeout = _timeout;
     info->compress = _compress;
@@ -165,7 +165,7 @@ IceObjC::StreamEndpointI::timeout(Int t) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, _port, _sourceAddr, t, _connectionId, _compress);
+        return std::make_shared<StreamEndpointI>(_streamInstance, _host, _port, _sourceAddr, t, _connectionId, _compress);
     }
 }
 
@@ -184,7 +184,7 @@ IceObjC::StreamEndpointI::compress(bool c) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, _port, _sourceAddr, _timeout, _connectionId, c);
+        return std::make_shared<StreamEndpointI>(_streamInstance, _host, _port, _sourceAddr, _timeout, _connectionId, c);
     }
 }
 
@@ -231,7 +231,7 @@ IceObjC::StreamEndpointI::endpoint(const StreamAcceptorPtr& a) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, port, _sourceAddr, _timeout, _connectionId,
+        return std::make_shared<StreamEndpointI>(_streamInstance, _host, port, _sourceAddr, _timeout, _connectionId,
                                _compress);
     }
 }
@@ -417,7 +417,7 @@ IceObjC::StreamEndpointI::createConnector(const Address& /*address*/, const Netw
 IPEndpointIPtr
 IceObjC::StreamEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, host, port, _sourceAddr, _timeout, connectionId,
+    return std::make_shared<StreamEndpointI>(_streamInstance, host, port, _sourceAddr, _timeout, connectionId,
                            _compress);
 }
 
@@ -444,7 +444,7 @@ IceObjC::StreamEndpointFactory::protocol() const
 EndpointIPtr
 IceObjC::StreamEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(StreamEndpointI, _instance);
+    IPEndpointIPtr endpt = std::make_shared<StreamEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -452,7 +452,7 @@ IceObjC::StreamEndpointFactory::create(vector<string>& args, bool oaEndpoint) co
 EndpointIPtr
 IceObjC::StreamEndpointFactory::read(Ice::InputStream* s) const
 {
-    return ICE_MAKE_SHARED(StreamEndpointI, _instance, s);
+    return std::make_shared<StreamEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -49,7 +49,7 @@ namespace
 inline CFStringRef
 toCFString(const string& s)
 {
-    return CFStringCreateWithCString(ICE_NULLPTR, s.c_str(), kCFStringEncodingUTF8);
+    return CFStringCreateWithCString(nullptr, s.c_str(), kCFStringEncodingUTF8);
 }
 
 }
@@ -141,7 +141,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance, Ice::Inpu
 }
 
 EndpointInfoPtr
-IceObjC::StreamEndpointI::getInfo() const ICE_NOEXCEPT
+IceObjC::StreamEndpointI::getInfo() const noexcept
 {
     TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(StreamEndpointI));
     IPEndpointI::fillEndpointInfo(info.get());

--- a/cpp/src/Ice/ios/StreamEndpointI.h
+++ b/cpp/src/Ice/ios/StreamEndpointI.h
@@ -75,7 +75,7 @@ public:
     StreamEndpointI(const InstancePtr&);
     StreamEndpointI(const InstancePtr&, Ice::InputStream*);
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
 
     virtual Ice::Int timeout() const;
     virtual IceInternal::EndpointIPtr timeout(Ice::Int) const;

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -420,7 +420,7 @@ IceObjC::StreamTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceObjC::StreamTransceiver::getInfo() const
 {
-    Ice::TCPConnectionInfoPtr info = ICE_MAKE_SHARED(Ice::TCPConnectionInfo);
+    Ice::TCPConnectionInfoPtr info = std::make_shared<Ice::TCPConnectionInfo>();
     fdToAddressAndPort(_fd, info->localAddress, info->localPort, info->remoteAddress, info->remotePort);
     info->rcvSize = getRecvBufferSize(_fd);
     info->sndSize = getSendBufferSize(_fd);

--- a/cpp/src/IceBT/AcceptorI.cpp
+++ b/cpp/src/IceBT/AcceptorI.cpp
@@ -79,7 +79,7 @@ IceBT::AcceptorI::listen()
 
     try
     {
-        ProfileCallbackPtr cb = ICE_MAKE_SHARED(ProfileCallbackI, this);
+        ProfileCallbackPtr cb = std::make_shared<ProfileCallbackI>(this);
         _path = _instance->engine()->registerProfile(_uuid, _name, _channel, cb);
     }
     catch(const BluetoothException& ex)

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -101,7 +101,7 @@ IceBT::EndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, timeout, _connectionId, _compress);
+        return std::make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, timeout, _connectionId, _compress);
     }
 }
 
@@ -120,7 +120,7 @@ IceBT::EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, _timeout, connectionId, _compress);
+        return std::make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, _timeout, connectionId, _compress);
     }
 }
 
@@ -139,7 +139,7 @@ IceBT::EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, _timeout, _connectionId, compress);
+        return std::make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, _timeout, _connectionId, compress);
     }
 }
 
@@ -186,7 +186,7 @@ IceBT::EndpointI::expandIfWildcard() const
         // getDefaultAdapterAddress will raise BluetoothException if no adapter is present.
         //
         string addr = _instance->engine()->getDefaultAdapterAddress();
-        endps.push_back(ICE_MAKE_SHARED(EndpointI, _instance, addr, _uuid, _name, _channel, _timeout, _connectionId,
+        endps.push_back(std::make_shared<EndpointI>(_instance, addr, _uuid, _name, _channel, _timeout, _connectionId,
                                         _compress));
     }
     else
@@ -424,7 +424,7 @@ IceBT::EndpointI::options() const
 Ice::EndpointInfoPtr
 IceBT::EndpointI::getInfo() const noexcept
 {
-    EndpointInfoPtr info = ICE_MAKE_SHARED(EndpointInfoI, ICE_SHARED_FROM_CONST_THIS(EndpointI));
+    EndpointInfoPtr info = std::make_shared<EndpointInfoI>(ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->addr = _addr;
     info->uuid = _uuid;
     return info;
@@ -488,7 +488,7 @@ IceBT::EndpointI::initWithOptions(vector<string>& args, bool oaEndpoint)
 IceBT::EndpointIPtr
 IceBT::EndpointI::endpoint(const AcceptorIPtr& acceptor) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, acceptor->effectiveChannel(), _timeout,
+    return std::make_shared<EndpointI>(_instance, _addr, _uuid, _name, acceptor->effectiveChannel(), _timeout,
                            _connectionId, _compress);
 }
 
@@ -642,7 +642,7 @@ IceBT::EndpointFactoryI::protocol() const
 IceInternal::EndpointIPtr
 IceBT::EndpointFactoryI::create(vector<string>& args, bool oaEndpoint) const
 {
-    EndpointIPtr endpt = ICE_MAKE_SHARED(EndpointI, _instance);
+    EndpointIPtr endpt = std::make_shared<EndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -650,7 +650,7 @@ IceBT::EndpointFactoryI::create(vector<string>& args, bool oaEndpoint) const
 IceInternal::EndpointIPtr
 IceBT::EndpointFactoryI::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _instance, s);
+    return std::make_shared<EndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -422,7 +422,7 @@ IceBT::EndpointI::options() const
 }
 
 Ice::EndpointInfoPtr
-IceBT::EndpointI::getInfo() const ICE_NOEXCEPT
+IceBT::EndpointI::getInfo() const noexcept
 {
     EndpointInfoPtr info = ICE_MAKE_SHARED(EndpointInfoI, ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->addr = _addr;
@@ -602,19 +602,19 @@ IceBT::EndpointInfoI::~EndpointInfoI()
 }
 
 Ice::Short
-IceBT::EndpointInfoI::type() const ICE_NOEXCEPT
+IceBT::EndpointInfoI::type() const noexcept
 {
     return _endpoint->type();
 }
 
 bool
-IceBT::EndpointInfoI::datagram() const ICE_NOEXCEPT
+IceBT::EndpointInfoI::datagram() const noexcept
 {
     return _endpoint->datagram();
 }
 
 bool
-IceBT::EndpointInfoI::secure() const ICE_NOEXCEPT
+IceBT::EndpointInfoI::secure() const noexcept
 {
     return _endpoint->secure();
 }

--- a/cpp/src/IceBT/EndpointI.h
+++ b/cpp/src/IceBT/EndpointI.h
@@ -51,7 +51,7 @@ public:
 
     virtual std::string options() const;
 
-    Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    Ice::EndpointInfoPtr getInfo() const noexcept;
 
     void initWithOptions(std::vector<std::string>&, bool);
 
@@ -80,9 +80,9 @@ public:
     EndpointInfoI(const EndpointIPtr&);
     virtual ~EndpointInfoI();
 
-    virtual Ice::Short type() const ICE_NOEXCEPT;
-    virtual bool datagram() const ICE_NOEXCEPT;
-    virtual bool secure() const ICE_NOEXCEPT;
+    virtual Ice::Short type() const noexcept;
+    virtual bool datagram() const noexcept;
+    virtual bool secure() const noexcept;
 
 private:
 

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -315,7 +315,7 @@ public:
             // from the Bluetooth service.
             //
             _dbusConnection = DBus::Connection::getSystemBus();
-            _dbusConnection->addFilter(ICE_SHARED_FROM_THIS);
+            _dbusConnection->addFilter(shared_from_this());
             getManagedObjects();
         }
         catch(const DBus::Exception& ex)
@@ -520,7 +520,7 @@ public:
         // As a subclass of DBus::Service, the ServerProfile object will receive DBus method
         // invocations for a given object path.
         //
-        ProfilePtr profile = ICE_MAKE_SHARED(ServerProfile, cb);
+        ProfilePtr profile = std::make_shared<ServerProfile>(cb);
 
         string path = generatePath();
 
@@ -570,7 +570,7 @@ public:
         //
         // Start a thread to establish the connection.
         //
-        IceUtil::ThreadPtr t = new ConnectThread(ICE_SHARED_FROM_THIS, addr, uuid, cb);
+        IceUtil::ThreadPtr t = new ConnectThread(shared_from_this(), addr, uuid, cb);
         _connectThreads.push_back(t);
         t->start();
     }
@@ -1152,7 +1152,7 @@ public:
             DBus::ConnectionPtr dbusConn = DBus::Connection::getSystemBus();
             conn = new ConnectionI(dbusConn, devicePath, uuid);
 
-            ProfilePtr profile = ICE_MAKE_SHARED(ClientProfile, conn, cb);
+            ProfilePtr profile = std::make_shared<ClientProfile>(conn, cb);
             string path = generatePath();
 
             //
@@ -1285,7 +1285,7 @@ IceBT::Engine::communicator() const
 void
 IceBT::Engine::initialize()
 {
-    _service = ICE_MAKE_SHARED(BluetoothService);
+    _service = std::make_shared<BluetoothService>();
     _service->init();
     _initialized = true;
 }

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -184,7 +184,7 @@ IceBT::TransceiverI::connectFailed(const Ice::LocalException& ex)
     //
     // Save the exception - it will be raised in initialize().
     //
-    ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+    _exception = ex.ice_clone();
     //
     // Triggers a call to write() from a different thread.
     //

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -43,7 +43,7 @@ IceBT::TransceiverI::initialize(IceInternal::Buffer& /*readBuffer*/, IceInternal
         // We need to initiate a connection attempt.
         //
         _needConnect = false;
-        _instance->engine()->connect(_addr, _uuid, ICE_MAKE_SHARED(ConnectCallbackI, this));
+        _instance->engine()->connect(_addr, _uuid, std::make_shared<ConnectCallbackI>(this));
         return IceInternal::SocketOperationConnect;
     }
 
@@ -119,7 +119,7 @@ IceBT::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceBT::TransceiverI::getInfo() const
 {
-    IceBT::ConnectionInfoPtr info = ICE_MAKE_SHARED(IceBT::ConnectionInfo);
+    IceBT::ConnectionInfoPtr info = std::make_shared<IceBT::ConnectionInfo>();
     fdToAddressAndChannel(_stream->fd(), info->localAddress, info->localChannel, info->remoteAddress,
                           info->remoteChannel);
     if(_stream->fd() != INVALID_SOCKET)

--- a/cpp/src/IceBox/ServiceI.cpp
+++ b/cpp/src/IceBox/ServiceI.cpp
@@ -98,7 +98,7 @@ IceBox::IceBoxService::start(int argc, char* argv[], int& status)
         return false;
     }
 
-    _serviceManager = ICE_MAKE_SHARED(ServiceManagerI, communicator(), argc, argv);
+    _serviceManager = std::make_shared<ServiceManagerI>(communicator(), argc, argv);
 
     return _serviceManager->start();
 }

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -105,7 +105,7 @@ IceBox::ServiceManagerI::~ServiceManagerI()
 }
 
 void
-IceBox::ServiceManagerI::startService(ICE_IN(string) name, const Current&)
+IceBox::ServiceManagerI::startService(string name, const Current&)
 {
     ServiceInfo info;
     {
@@ -181,7 +181,7 @@ IceBox::ServiceManagerI::startService(ICE_IN(string) name, const Current&)
 }
 
 void
-IceBox::ServiceManagerI::stopService(ICE_IN(string) name, const Current&)
+IceBox::ServiceManagerI::stopService(string name, const Current&)
 {
     ServiceInfo info;
     {
@@ -257,7 +257,7 @@ IceBox::ServiceManagerI::stopService(ICE_IN(string) name, const Current&)
 }
 
 void
-IceBox::ServiceManagerI::addObserver(ICE_IN(ServiceObserverPrxPtr) observer, const Current&)
+IceBox::ServiceManagerI::addObserver(ServiceObserverPrxPtr observer, const Current&)
 {
     //
     // Null observers and duplicate registrations are ignored

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -300,7 +300,7 @@ IceBox::ServiceManagerI::start()
 {
     try
     {
-        ServiceManagerPtr obj = ICE_SHARED_FROM_THIS;
+        ServiceManagerPtr obj = shared_from_this();
         PropertiesPtr properties = _communicator->getProperties();
 
         //
@@ -439,7 +439,7 @@ IceBox::ServiceManagerI::start()
         //
         // Start Admin (if enabled) and/or deprecated IceBox.ServiceManager OA
         //
-        _communicator->addAdminFacet(ICE_SHARED_FROM_THIS, "IceBox.ServiceManager");
+        _communicator->addAdminFacet(shared_from_this(), "IceBox.ServiceManager");
         _communicator->getAdmin();
         if(adapter)
         {

--- a/cpp/src/IceBox/ServiceManagerI.h
+++ b/cpp/src/IceBox/ServiceManagerI.h
@@ -23,10 +23,10 @@ public:
     ServiceManagerI(Ice::CommunicatorPtr, int&, char*[]);
     virtual ~ServiceManagerI();
 
-    virtual void startService(ICE_IN(std::string), const ::Ice::Current&);
-    virtual void stopService(ICE_IN(std::string), const ::Ice::Current&);
+    virtual void startService(std::string, const ::Ice::Current&);
+    virtual void stopService(std::string, const ::Ice::Current&);
 
-    virtual void addObserver(ICE_IN(ServiceObserverPrxPtr), const Ice::Current&);
+    virtual void addObserver(ServiceObserverPrxPtr, const Ice::Current&);
 
     virtual void shutdown(const ::Ice::Current&);
 

--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -255,7 +255,7 @@ LookupI::setLookupReply(const LookupReplyPrxPtr& lookupReply)
 }
 
 void
-LookupI::findObjectById(ICE_IN(string) domainId, ICE_IN(Ice::Identity) id, ICE_IN(LookupReplyPrxPtr) reply,
+LookupI::findObjectById(string domainId, Ice::Identity id, LookupReplyPrxPtr reply,
                         const Ice::Current&)
 {
     if(domainId != _domainId)
@@ -281,7 +281,7 @@ LookupI::findObjectById(ICE_IN(string) domainId, ICE_IN(Ice::Identity) id, ICE_I
 }
 
 void
-LookupI::findAdapterById(ICE_IN(string) domainId, ICE_IN(string) adapterId, ICE_IN(LookupReplyPrxPtr) reply,
+LookupI::findAdapterById(string domainId, string adapterId, LookupReplyPrxPtr reply,
                          const Ice::Current&)
 {
     if(domainId != _domainId)

--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -329,7 +329,7 @@ LookupI::findObject(const ObjectCB& cb, const Ice::Identity& id)
         }
         catch(const Ice::LocalException&)
         {
-            p->second->finished(ICE_NULLPTR);
+            p->second->finished(nullptr);
             _objectRequests.erase(p);
         }
     }
@@ -357,7 +357,7 @@ LookupI::findAdapter(const AdapterCB& cb, const std::string& adapterId)
         }
         catch(const Ice::LocalException&)
         {
-            p->second->finished(ICE_NULLPTR);
+            p->second->finished(nullptr);
             _adapterRequests.erase(p);
         }
     }

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -140,9 +140,9 @@ public:
 
     void setLookupReply(const LookupReplyPrxPtr&);
 
-    virtual void findObjectById(ICE_IN(std::string), ICE_IN(Ice::Identity), ICE_IN(IceDiscovery::LookupReplyPrxPtr),
+    virtual void findObjectById(std::string, Ice::Identity, IceDiscovery::LookupReplyPrxPtr,
                                 const Ice::Current&);
-    virtual void findAdapterById(ICE_IN(std::string), ICE_IN(std::string), ICE_IN(IceDiscovery::LookupReplyPrxPtr),
+    virtual void findAdapterById(std::string, std::string, IceDiscovery::LookupReplyPrxPtr,
                                  const Ice::Current&);
     void findObject(const ObjectCB&, const Ice::Identity&);
     void findAdapter(const AdapterCB&, const std::string&);

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -129,7 +129,7 @@ PluginI::initialize()
     //
     // Setup locatory registry.
     //
-    LocatorRegistryIPtr locatorRegistry = ICE_MAKE_SHARED(LocatorRegistryI, _communicator);
+    LocatorRegistryIPtr locatorRegistry = std::make_shared<LocatorRegistryI>(_communicator);
     Ice::LocatorRegistryPrxPtr locatorRegistryPrx =
         ICE_UNCHECKED_CAST(Ice::LocatorRegistryPrx, _locatorAdapter->addWithUUID(locatorRegistry));
 
@@ -140,10 +140,10 @@ PluginI::initialize()
     //
     // Add lookup and lookup reply Ice objects
     //
-    _lookup = ICE_MAKE_SHARED(LookupI, locatorRegistry, ICE_UNCHECKED_CAST(LookupPrx, lookupPrx), properties);
+    _lookup = std::make_shared<LookupI>(locatorRegistry, ICE_UNCHECKED_CAST(LookupPrx, lookupPrx), properties);
     _multicastAdapter->add(_lookup, Ice::stringToIdentity("IceDiscovery/Lookup"));
 
-    _replyAdapter->addDefaultServant(ICE_MAKE_SHARED(LookupReplyI, _lookup), "");
+    _replyAdapter->addDefaultServant(std::make_shared<LookupReplyI>(_lookup), "");
     Ice::Identity id;
     id.name = "dummy";
     _lookup->setLookupReply(ICE_UNCHECKED_CAST(LookupReplyPrx, _replyAdapter->createProxy(id)->ice_datagram()));
@@ -151,7 +151,7 @@ PluginI::initialize()
     //
     // Setup locator on the communicator.
     //
-    Ice::ObjectPrxPtr loc = _locatorAdapter->addWithUUID(ICE_MAKE_SHARED(LocatorI, _lookup, locatorRegistryPrx));
+    Ice::ObjectPrxPtr loc = _locatorAdapter->addWithUUID(std::make_shared<LocatorI>(_lookup, locatorRegistryPrx));
     _defaultLocator = _communicator->getDefaultLocator();
     _locator = ICE_UNCHECKED_CAST(Ice::LocatorPrx, loc);
     _communicator->setDefaultLocator(_locator);

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -135,7 +135,7 @@ PluginI::initialize()
 
     Ice::ObjectPrxPtr lookupPrx = _communicator->stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
     // No collocation optimization for the multicast proxy!
-    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(ICE_NULLPTR);
+    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(nullptr);
 
     //
     // Add lookup and lookup reply Ice objects

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -367,7 +367,7 @@ Activator::activate(const string& name,
             // IceGrid doesn't support to use string converters, so don't need to use
             // any string converter in wstringToString conversions.
             //
-            if(SearchPathW(ICE_NULLPTR, stringToWstring(path).c_str(), ext.c_str(), _MAX_PATH, absbuf, &fPart) == 0)
+            if(SearchPathW(nullptr, stringToWstring(path).c_str(), ext.c_str(), _MAX_PATH, absbuf, &fPart) == 0)
             {
                 if(_traceLevels->activator > 0)
                 {
@@ -394,7 +394,7 @@ Activator::activate(const string& name,
     if(!pwd.empty())
     {
         wchar_t absbuf[_MAX_PATH];
-        if(_wfullpath(absbuf, stringToWstring(pwd).c_str(), _MAX_PATH) == ICE_NULLPTR)
+        if(_wfullpath(absbuf, stringToWstring(pwd).c_str(), _MAX_PATH) == nullptr)
         {
             if(_traceLevels->activator > 0)
             {
@@ -483,7 +483,7 @@ Activator::activate(const string& name,
     // any string converter in stringToWstring conversions.
     //
     wstring wpwd = stringToWstring(pwd);
-    const wchar_t* dir = !wpwd.empty() ? wpwd.c_str() : ICE_NULLPTR;
+    const wchar_t* dir = !wpwd.empty() ? wpwd.c_str() : nullptr;
 
     //
     // Make a copy of the command line.
@@ -496,7 +496,7 @@ Activator::activate(const string& name,
     // Since Windows is case insensitive wrt environment variables we convert the keys to
     // uppercase to ensure matches are found.
     //
-    const wchar_t* env = ICE_NULLPTR;
+    const wchar_t* env = nullptr;
     wstring envbuf;
     if(!envs.empty())
     {
@@ -1010,7 +1010,7 @@ Activator::sendSignal(const string& name, int signal)
     else if(signal == SIGKILL)
     {
         HANDLE hnd = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
-        if(hnd == ICE_NULLPTR)
+        if(hnd == nullptr)
         {
             throw SyscallException(__FILE__, __LINE__, getSystemErrno());
         }

--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -630,7 +630,7 @@ run(const Ice::StringSeq& args)
 
         if(acmTimeout > 0)
         {
-            session->ice_getConnection()->setACM(acmTimeout, IceUtil::None, Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+            session->ice_getConnection()->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
         }
 
         {

--- a/cpp/src/IceGrid/PluginFacadeI.cpp
+++ b/cpp/src/IceGrid/PluginFacadeI.cpp
@@ -186,7 +186,7 @@ RegistryPluginFacadeI::getPropertyForAdapter(const std::string& adapterId, const
 }
 
 void
-RegistryPluginFacadeI::addReplicaGroupFilter(const string& id, const shared_ptr<ReplicaGroupFilter>& filter) ICE_NOEXCEPT
+RegistryPluginFacadeI::addReplicaGroupFilter(const string& id, const shared_ptr<ReplicaGroupFilter>& filter) noexcept
 {
     lock_guard lock(_mutex);
     map<string, vector<shared_ptr<ReplicaGroupFilter>> >::iterator p = _replicaGroupFilters.find(id);
@@ -198,7 +198,7 @@ RegistryPluginFacadeI::addReplicaGroupFilter(const string& id, const shared_ptr<
 }
 
 bool
-RegistryPluginFacadeI::removeReplicaGroupFilter(const string& id, const shared_ptr<ReplicaGroupFilter>& filter) ICE_NOEXCEPT
+RegistryPluginFacadeI::removeReplicaGroupFilter(const string& id, const shared_ptr<ReplicaGroupFilter>& filter) noexcept
 {
     lock_guard lock(_mutex);
 
@@ -223,7 +223,7 @@ RegistryPluginFacadeI::removeReplicaGroupFilter(const string& id, const shared_p
 }
 
 void
-RegistryPluginFacadeI::addTypeFilter(const string& id, const shared_ptr<TypeFilter>& filter) ICE_NOEXCEPT
+RegistryPluginFacadeI::addTypeFilter(const string& id, const shared_ptr<TypeFilter>& filter) noexcept
 {
     lock_guard lock(_mutex);
     map<string, vector<shared_ptr<TypeFilter>> >::iterator p = _typeFilters.find(id);
@@ -235,7 +235,7 @@ RegistryPluginFacadeI::addTypeFilter(const string& id, const shared_ptr<TypeFilt
 }
 
 bool
-RegistryPluginFacadeI::removeTypeFilter(const string& id, const shared_ptr<TypeFilter>& filter) ICE_NOEXCEPT
+RegistryPluginFacadeI::removeTypeFilter(const string& id, const shared_ptr<TypeFilter>& filter) noexcept
 {
     lock_guard lock(_mutex);
 

--- a/cpp/src/IceIAP/EndpointI.h
+++ b/cpp/src/IceIAP/EndpointI.h
@@ -27,7 +27,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Short type() const;
     virtual const std::string& protocol() const;
     virtual bool datagram() const;

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -132,7 +132,7 @@ IceObjC::iAPEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceObjC::iAPEndpointI::getInfo() const noexcept
 {
-    IceIAP::EndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<IceIAP::EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(iAPEndpointI));
+    IceIAP::EndpointInfoPtr info = std::make_shared<InfoI<IceIAP::EndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(iAPEndpointI));
     info->timeout = _timeout;
     info->compress = _compress;
     info->manufacturer = _manufacturer;
@@ -181,7 +181,7 @@ IceObjC::iAPEndpointI::timeout(Int t) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, t, _connectionId,
+        return std::make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, t, _connectionId,
                                _compress);
     }
 }
@@ -201,7 +201,7 @@ IceObjC::iAPEndpointI::connectionId(const string& cId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, _timeout, cId,
+        return std::make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, _timeout, cId,
                                _compress);
     }
 }
@@ -221,7 +221,7 @@ IceObjC::iAPEndpointI::compress(bool c) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, _timeout,
+        return std::make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, _timeout,
                                _connectionId, c);
     }
 }
@@ -679,7 +679,7 @@ IceObjC::iAPEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
     {
         return 0;
     }
-    EndpointIPtr endpt = ICE_MAKE_SHARED(iAPEndpointI, _instance);
+    EndpointIPtr endpt = std::make_shared<iAPEndpointI>(_instance);
     endpt->initWithOptions(args);
     return endpt;
 }
@@ -687,7 +687,7 @@ IceObjC::iAPEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 EndpointIPtr
 IceObjC::iAPEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(iAPEndpointI, _instance, s);
+    return std::make_shared<iAPEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -130,7 +130,7 @@ IceObjC::iAPEndpointI::streamWriteImpl(OutputStream* s) const
 }
 
 EndpointInfoPtr
-IceObjC::iAPEndpointI::getInfo() const ICE_NOEXCEPT
+IceObjC::iAPEndpointI::getInfo() const noexcept
 {
     IceIAP::EndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<IceIAP::EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(iAPEndpointI));
     info->timeout = _timeout;

--- a/cpp/src/IceIAP/Transceiver.mm
+++ b/cpp/src/IceIAP/Transceiver.mm
@@ -366,7 +366,7 @@ IceObjC::iAPTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceObjC::iAPTransceiver::getInfo() const
 {
-    IceIAP::ConnectionInfoPtr info = ICE_MAKE_SHARED(IceIAP::ConnectionInfo);
+    IceIAP::ConnectionInfoPtr info = std::make_shared<IceIAP::ConnectionInfo>();
     info->manufacturer = [_session.accessory.manufacturer UTF8String];
     info->name = [_session.accessory.name UTF8String];
     info->modelNumber = [_session.accessory.modelNumber UTF8String];

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -151,7 +151,7 @@ public:
     virtual Ice::LocatorRegistryPrxPtr
     getRegistry(const Ice::Current&) const
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 };
 
@@ -278,7 +278,7 @@ PluginI::initialize()
 
     Ice::ObjectPrxPtr lookupPrx = _communicator->stringToProxy("IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
     // No collocation optimization for the multicast proxy!
-    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(ICE_NULLPTR);
+    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(nullptr);
 
     Ice::LocatorPrxPtr voidLocator = ICE_UNCHECKED_CAST(Ice::LocatorPrx,
                                                         _locatorAdapter->addWithUUID(ICE_MAKE_SHARED(VoidLocatorI)));
@@ -538,7 +538,7 @@ LocatorI::getLocators(const string& instanceName, const IceUtil::Time& waitTime)
     //
     // Find a locator
     //
-    invoke(ICE_NULLPTR, ICE_NULLPTR);
+    invoke(nullptr, nullptr);
 
     //
     // Wait for responses

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -116,7 +116,7 @@ public:
     {
     }
 
-    virtual void foundLocator(ICE_IN(Ice::LocatorPrxPtr), const Ice::Current&);
+    virtual void foundLocator(Ice::LocatorPrxPtr, const Ice::Current&);
 
 private:
 
@@ -887,7 +887,7 @@ LocatorI::runTimerTask()
 }
 
 void
-LookupReplyI::foundLocator(ICE_IN(Ice::LocatorPrxPtr) locator, const Ice::Current&)
+LookupReplyI::foundLocator(Ice::LocatorPrxPtr locator, const Ice::Current&)
 {
     _locator->foundLocator(locator);
 }

--- a/cpp/src/IceSSL/EndpointI.cpp
+++ b/cpp/src/IceSSL/EndpointI.cpp
@@ -51,7 +51,7 @@ IceSSL::EndpointI::streamWriteImpl(Ice::OutputStream* stream) const
 Ice::EndpointInfoPtr
 IceSSL::EndpointI::getInfo() const noexcept
 {
-    EndpointInfoPtr info = ICE_MAKE_SHARED(IceInternal::InfoI<EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(EndpointI));
+    EndpointInfoPtr info = std::make_shared<IceInternal::InfoI<EndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->underlying = _delegate->getInfo();
     info->compress = info->underlying->compress;
     info->timeout = info->underlying->timeout;
@@ -85,7 +85,7 @@ IceSSL::EndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->timeout(timeout));
+        return std::make_shared<EndpointI>(_instance, _delegate->timeout(timeout));
     }
 }
 
@@ -104,7 +104,7 @@ IceSSL::EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->connectionId(connectionId));
+        return std::make_shared<EndpointI>(_instance, _delegate->connectionId(connectionId));
     }
 }
 
@@ -123,7 +123,7 @@ IceSSL::EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->compress(compress));
+        return std::make_shared<EndpointI>(_instance, _delegate->compress(compress));
     }
 }
 
@@ -182,7 +182,7 @@ IceSSL::EndpointI::connectors_async(Ice::EndpointSelectionType selType,
     };
 
     IPEndpointInfoPtr info = getIPEndpointInfo(_delegate->getInfo());
-    _delegate->connectors_async(selType, ICE_MAKE_SHARED(CallbackI, callback, _instance, info ? info->host : string()));
+    _delegate->connectors_async(selType, std::make_shared<CallbackI>(callback, _instance, info ? info->host : string()));
 }
 
 IceInternal::AcceptorPtr
@@ -200,7 +200,7 @@ IceSSL::EndpointI::endpoint(const IceInternal::EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, delEndp);
+        return std::make_shared<EndpointI>(_instance, delEndp);
     }
 }
 
@@ -216,7 +216,7 @@ IceSSL::EndpointI::expandIfWildcard() const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(EndpointI, _instance, *p);
+            *p = std::make_shared<EndpointI>(_instance, *p);
         }
     }
     return endps;
@@ -232,7 +232,7 @@ IceSSL::EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
     }
     else if(publish.get())
     {
-        publish = ICE_MAKE_SHARED(EndpointI, _instance, publish);
+        publish = std::make_shared<EndpointI>(_instance, publish);
     }
     for(vector<IceInternal::EndpointIPtr>::iterator p = endps.begin(); p != endps.end(); ++p)
     {
@@ -242,7 +242,7 @@ IceSSL::EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(EndpointI, _instance, *p);
+            *p = std::make_shared<EndpointI>(_instance, *p);
         }
     }
     return endps;
@@ -350,11 +350,11 @@ IceSSL::EndpointFactoryI::cloneWithUnderlying(const IceInternal::ProtocolInstanc
 IceInternal::EndpointIPtr
 IceSSL::EndpointFactoryI::createWithUnderlying(const IceInternal::EndpointIPtr& underlying, vector<string>&, bool) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _sslInstance, underlying);
+    return std::make_shared<EndpointI>(_sslInstance, underlying);
 }
 
 IceInternal::EndpointIPtr
 IceSSL::EndpointFactoryI::readWithUnderlying(const IceInternal::EndpointIPtr& underlying, Ice::InputStream*) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _sslInstance, underlying);
+    return std::make_shared<EndpointI>(_sslInstance, underlying);
 }

--- a/cpp/src/IceSSL/EndpointI.cpp
+++ b/cpp/src/IceSSL/EndpointI.cpp
@@ -32,7 +32,7 @@ getIPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }
@@ -49,7 +49,7 @@ IceSSL::EndpointI::streamWriteImpl(Ice::OutputStream* stream) const
 }
 
 Ice::EndpointInfoPtr
-IceSSL::EndpointI::getInfo() const ICE_NOEXCEPT
+IceSSL::EndpointI::getInfo() const noexcept
 {
     EndpointInfoPtr info = ICE_MAKE_SHARED(IceInternal::InfoI<EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->underlying = _delegate->getInfo();

--- a/cpp/src/IceSSL/EndpointI.h
+++ b/cpp/src/IceSSL/EndpointI.h
@@ -25,7 +25,7 @@ public:
 
     virtual void streamWriteImpl(Ice::OutputStream*) const;
 
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Short type() const;
     virtual const std::string& protocol() const;
 

--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -497,7 +497,7 @@ OpenSSLCertificateI::loadX509Extensions() const
             len = OBJ_obj2txt(&oid[0], len, obj, 1);
             oid.resize(len);
             _extensions.push_back(ICE_DYNAMIC_CAST(IceSSL::X509Extension,
-                ICE_MAKE_SHARED(OpenSSLX509ExtensionI, ext, oid, _cert)));
+                std::make_shared<OpenSSLX509ExtensionI>(ext, oid, _cert)));
         }
     }
 }
@@ -505,7 +505,7 @@ OpenSSLCertificateI::loadX509Extensions() const
 IceSSL::OpenSSL::CertificatePtr
 IceSSL::OpenSSL::Certificate::create(x509_st* cert)
 {
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, cert);
+    return std::make_shared<OpenSSLCertificateI>(cert);
 }
 
 IceSSL::OpenSSL::CertificatePtr
@@ -525,7 +525,7 @@ IceSSL::OpenSSL::Certificate::load(const std::string& file)
         throw CertificateReadException(__FILE__, __LINE__, "error reading file:\n" + getSslErrors(false));
     }
     BIO_free(cert);
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, x);
+    return std::make_shared<OpenSSLCertificateI>(x);
 }
 
 IceSSL::OpenSSL::CertificatePtr
@@ -539,5 +539,5 @@ IceSSL::OpenSSL::Certificate::decode(const std::string& encoding)
         throw CertificateEncodingException(__FILE__, __LINE__, getSslErrors(false));
     }
     BIO_free(cert);
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, x);
+    return std::make_shared<OpenSSLCertificateI>(x);
 }

--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -518,8 +518,8 @@ IceSSL::OpenSSL::Certificate::load(const std::string& file)
         throw CertificateReadException(__FILE__, __LINE__, "error opening file");
     }
 
-    x509_st* x = PEM_read_bio_X509(cert, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR);
-    if(x == ICE_NULLPTR)
+    x509_st* x = PEM_read_bio_X509(cert, nullptr, nullptr, nullptr);
+    if(x == nullptr)
     {
         BIO_free(cert);
         throw CertificateReadException(__FILE__, __LINE__, "error reading file:\n" + getSslErrors(false));
@@ -532,8 +532,8 @@ IceSSL::OpenSSL::CertificatePtr
 IceSSL::OpenSSL::Certificate::decode(const std::string& encoding)
 {
     BIO *cert = BIO_new_mem_buf(static_cast<void*>(const_cast<char*>(&encoding[0])), static_cast<int>(encoding.size()));
-    x509_st* x = PEM_read_bio_X509(cert, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR);
-    if(x == ICE_NULLPTR)
+    x509_st* x = PEM_read_bio_X509(cert, nullptr, nullptr, nullptr);
+    if(x == nullptr)
     {
         BIO_free(cert);
         throw CertificateEncodingException(__FILE__, __LINE__, getSslErrors(false));

--- a/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
@@ -823,7 +823,7 @@ OpenSSL::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 OpenSSL::TransceiverI::getInfo() const
 {
-    ConnectionInfoPtr info = ICE_MAKE_SHARED(ConnectionInfo);
+    ConnectionInfoPtr info = std::make_shared<ConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/OpenSSLUtil.cpp
+++ b/cpp/src/IceSSL/OpenSSLUtil.cpp
@@ -270,7 +270,7 @@ IceSSL::OpenSSL::getSslErrors(bool verbose)
         else
         {
             const char* reason = ERR_reason_error_string(err);
-            ostr << (reason == ICE_NULLPTR ? "unknown reason" : reason);
+            ostr << (reason == nullptr ? "unknown reason" : reason);
             if(flags & ERR_TXT_STRING)
             {
                 ostr << ": " << data;

--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -526,7 +526,7 @@ SChannelCertificateI::loadX509Extensions() const
         {
             CERT_EXTENSION ext = _certInfo->rgExtension[i];
             _extensions.push_back(ICE_DYNAMIC_CAST(X509Extension,
-                ICE_MAKE_SHARED(SCHannelX509ExtensionI, ext, ext.pszObjId,
+                std::make_shared<SCHannelX509ExtensionI>(ext, ext.pszObjId,
                 _certInfoHolder)));
         }
     }
@@ -535,7 +535,7 @@ SChannelCertificateI::loadX509Extensions() const
 SChannel::CertificatePtr
 SChannel::Certificate::create(CERT_SIGNED_CONTENT_INFO* cert)
 {
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return std::make_shared<SChannelCertificateI>(cert);
 }
 
 SChannel::CertificatePtr
@@ -543,7 +543,7 @@ SChannel::Certificate::load(const std::string& file)
 {
     CERT_SIGNED_CONTENT_INFO* cert;
     loadCertificate(&cert, file);
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return std::make_shared<SChannelCertificateI>(cert);
 }
 
 SChannel::CertificatePtr
@@ -551,5 +551,5 @@ SChannel::Certificate::decode(const std::string& encoding)
 {
     CERT_SIGNED_CONTENT_INFO* cert;
     loadCertificate(&cert, encoding.c_str(), static_cast<DWORD>(encoding.size()));
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return std::make_shared<SChannelCertificateI>(cert);
 }

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -1001,7 +1001,7 @@ SChannel::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 SChannel::TransceiverI::getInfo() const
 {
-    ConnectionInfoPtr info = ICE_MAKE_SHARED(ConnectionInfo);
+    ConnectionInfoPtr info = std::make_shared<ConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/SecureTransportCertificateI.cpp
+++ b/cpp/src/IceSSL/SecureTransportCertificateI.cpp
@@ -225,7 +225,7 @@ private:
 
 #endif
 
-class SecureTransportCertificateI ICE_FINAL : public IceSSL::SecureTransport::Certificate,
+class SecureTransportCertificateI final : public IceSSL::SecureTransport::Certificate,
                                               public IceSSL::CertificateI
 {
 public:

--- a/cpp/src/IceSSL/SecureTransportCertificateI.cpp
+++ b/cpp/src/IceSSL/SecureTransportCertificateI.cpp
@@ -770,7 +770,7 @@ SecureTransportCertificateI::initializeAttributes() const
 IceSSL::SecureTransport::CertificatePtr
 IceSSL::SecureTransport::Certificate::create(SecCertificateRef cert)
 {
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, cert);
+    return std::make_shared<SecureTransportCertificateI>(cert);
 }
 
 IceSSL::SecureTransport::CertificatePtr
@@ -779,7 +779,7 @@ IceSSL::SecureTransport::Certificate::load(const std::string& file)
     string resolved;
     if(checkPath(file, "", false, resolved))
     {
-        return ICE_MAKE_SHARED(SecureTransportCertificateI, loadCertificate(resolved));
+        return std::make_shared<SecureTransportCertificateI>(loadCertificate(resolved));
     }
     else
     {
@@ -814,7 +814,7 @@ IceSSL::SecureTransport::Certificate::decode(const std::string& encoding)
         assert(false);
         throw CertificateEncodingException(__FILE__, __LINE__, "certificate is not a valid PEM-encoded certificate");
     }
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, cert);
+    return std::make_shared<SecureTransportCertificateI>(cert);
 #else // macOS
     UniqueRef<CFDataRef> data(
         CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
@@ -838,6 +838,6 @@ IceSSL::SecureTransport::Certificate::decode(const std::string& encoding)
     UniqueRef<SecKeychainItemRef> item;
     item.retain(static_cast<SecKeychainItemRef>(const_cast<void*>(CFArrayGetValueAtIndex(items.get(), 0))));
     assert(SecCertificateGetTypeID() == CFGetTypeID(item.get()));
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, reinterpret_cast<SecCertificateRef>(item.release()));
+    return std::make_shared<SecureTransportCertificateI>(reinterpret_cast<SecCertificateRef>(item.release()));
 #endif
 }

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
@@ -546,7 +546,7 @@ IceSSL::SecureTransport::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceSSL::SecureTransport::TransceiverI::getInfo() const
 {
-    IceSSL::ConnectionInfoPtr info = ICE_MAKE_SHARED(IceSSL::ConnectionInfo);
+    IceSSL::ConnectionInfoPtr info = std::make_shared<IceSSL::ConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/SecureTransportUtil.cpp
+++ b/cpp/src/IceSSL/SecureTransportUtil.cpp
@@ -85,7 +85,7 @@ CFDictionaryRef
 IceSSL::SecureTransport::getCertificateProperty(SecCertificateRef cert, CFTypeRef key)
 {
     UniqueRef<CFDictionaryRef> property;
-    UniqueRef<CFArrayRef> keys(CFArrayCreate(ICE_NULLPTR, &key , 1, &kCFTypeArrayCallBacks));
+    UniqueRef<CFArrayRef> keys(CFArrayCreate(nullptr, &key , 1, &kCFTypeArrayCallBacks));
     UniqueRef<CFErrorRef> err;
     UniqueRef<CFDictionaryRef> values(SecCertificateCopyValues(cert, keys.get(), &err.get()));
     if(err)

--- a/cpp/src/IceSSL/Util.h
+++ b/cpp/src/IceSSL/Util.h
@@ -32,7 +32,7 @@ std::string fromCFString(CFStringRef);
 inline CFStringRef
 toCFString(const std::string& s)
 {
-    return CFStringCreateWithCString(ICE_NULLPTR, s.c_str(), kCFStringEncodingUTF8);
+    return CFStringCreateWithCString(nullptr, s.c_str(), kCFStringEncodingUTF8);
 }
 #endif
 

--- a/cpp/src/IceUtil/CtrlCHandler.cpp
+++ b/cpp/src/IceUtil/CtrlCHandler.cpp
@@ -20,7 +20,7 @@ using namespace IceUtil;
 namespace
 {
 
-CtrlCHandlerCallback _callback = ICE_NULLPTR;
+CtrlCHandlerCallback _callback = nullptr;
 
 const CtrlCHandler* _handler = 0;
 
@@ -118,7 +118,7 @@ CtrlCHandler::~CtrlCHandler()
     {
         IceUtilInternal::MutexPtrLock<IceUtil::Mutex> lock(globalMutex);
         _handler = 0;
-        _callback = ICE_NULLPTR;
+        _callback = nullptr;
     }
 }
 
@@ -230,7 +230,7 @@ CtrlCHandler::~CtrlCHandler()
     {
         IceUtilInternal::MutexPtrLock<IceUtil::Mutex> lock(globalMutex);
         _handler = 0;
-        _callback = ICE_NULLPTR;
+        _callback = nullptr;
     }
 
     //

--- a/cpp/src/IceUtil/FileUtil.cpp
+++ b/cpp/src/IceUtil/FileUtil.cpp
@@ -244,7 +244,7 @@ IceUtilInternal::getcwd(string& cwd)
     // from Windows API.
     //
     wchar_t cwdbuf[_MAX_PATH];
-    if(_wgetcwd(cwdbuf, _MAX_PATH) == ICE_NULLPTR)
+    if(_wgetcwd(cwdbuf, _MAX_PATH) == nullptr)
     {
         return -1;
     }
@@ -281,7 +281,7 @@ IceUtilInternal::FileLock::FileLock(const std::string& path) :
     // to Windows API.
     //
     _fd = ::CreateFileW(stringToWstring(path, IceUtil::getProcessStringConverter()).c_str(),
-                        GENERIC_WRITE, 0, ICE_NULLPTR, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, ICE_NULLPTR);
+                        GENERIC_WRITE, 0, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     _path = path;
 
     if(_fd == INVALID_HANDLE_VALUE)
@@ -384,7 +384,7 @@ int
 IceUtilInternal::getcwd(string& cwd)
 {
     char cwdbuf[PATH_MAX];
-    if(::getcwd(cwdbuf, PATH_MAX) == ICE_NULLPTR)
+    if(::getcwd(cwdbuf, PATH_MAX) == nullptr)
     {
         return -1;
     }

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -241,7 +241,7 @@ Init init;
 const WstringConverterPtr&
 getUnicodeWstringConverter()
 {
-    static const WstringConverterPtr unicodeWstringConverter = ICE_MAKE_SHARED(UnicodeWstringConverter);
+    static const WstringConverterPtr unicodeWstringConverter = std::make_shared<UnicodeWstringConverter>();
     return unicodeWstringConverter;
 }
 
@@ -656,6 +656,6 @@ WindowsStringConverter::fromUTF8(const Byte* sourceStart, const Byte* sourceEnd,
 StringConverterPtr
 IceUtil::createWindowsStringConverter(unsigned int cp)
 {
-    return ICE_MAKE_SHARED(WindowsStringConverter, cp);
+    return std::make_shared<WindowsStringConverter>(cp);
 }
 #endif

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -150,7 +150,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
             }
             case '\a':
             {
-                if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                if(toStringMode == ToStringMode::Compat)
                 {
                     // Octal escape for compatibility with 3.6 and earlier
                     result.append("\\007");
@@ -188,7 +188,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
             }
             case '\v':
             {
-                if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                if(toStringMode == ToStringMode::Compat)
                 {
                     // Octal escape for compatibility with 3.6 and earlier
                     result.append("\\013");
@@ -212,7 +212,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
 
                     if(i < 32 || i > 126)
                     {
-                        if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                        if(toStringMode == ToStringMode::Compat)
                         {
                             // append octal string
 
@@ -234,7 +234,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
                             result.push_back(toHexDigit(i >> 4));
                             result.push_back(toHexDigit(i & 0x0F));
                         }
-                        else if(toStringMode == ICE_ENUM(ToStringMode, ASCII))
+                        else if(toStringMode == ToStringMode::ASCII)
                         {
                             // append \unnnn or \Unnnnnnnn after reading more UTF-8 bytes
                             appendUniversalName(c, p, u8s.end(), result);
@@ -256,7 +256,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
         }
     }
 
-    if(toStringMode == ICE_ENUM(ToStringMode, Unicode))
+    if(toStringMode == ToStringMode::Unicode)
     {
         //
         // Convert back to Native

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -818,13 +818,13 @@ IceUtilInternal::errorToString(int error, LPCVOID source)
             FORMAT_MESSAGE_ALLOCATE_BUFFER |
             FORMAT_MESSAGE_FROM_SYSTEM |
             FORMAT_MESSAGE_IGNORE_INSERTS |
-            (source != ICE_NULLPTR ? FORMAT_MESSAGE_FROM_HMODULE : 0),
+            (source != nullptr ? FORMAT_MESSAGE_FROM_HMODULE : 0),
             source,
             error,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
             reinterpret_cast<LPWSTR>(&msg),
             0,
-            ICE_NULLPTR);
+            nullptr);
 
         if(stored > 0)
         {

--- a/cpp/src/IceUtil/UtilException.cpp
+++ b/cpp/src/IceUtil/UtilException.cpp
@@ -541,7 +541,7 @@ IceUtil::Exception::ice_print(ostream& out) const
 }
 
 const char*
-IceUtil::Exception::what() const ICE_NOEXCEPT
+IceUtil::Exception::what() const noexcept
 {
     try
     {

--- a/cpp/src/IceXML/Parser.cpp
+++ b/cpp/src/IceXML/Parser.cpp
@@ -376,7 +376,7 @@ IceXML::Parser::parse(const string& file, Handler& handler) // The given filenam
 void
 IceXML::Parser::parse(istream& in, Handler& handler)
 {
-    XML_Parser parser = XML_ParserCreate(ICE_NULLPTR);
+    XML_Parser parser = XML_ParserCreate(nullptr);
     CallbackData cb;
     cb.parser = parser;
     cb.handler = &handler;

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -285,7 +285,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -251,7 +251,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -268,7 +268,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -297,7 +297,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -4408,7 +4408,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -640,7 +640,7 @@ Slice::Python::compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -242,7 +242,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/test/Glacier2/sessionHelper/Server.cpp
+++ b/cpp/test/Glacier2/sessionHelper/Server.cpp
@@ -53,7 +53,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("CallbackAdapter.Endpoints", getTestEndpoint());
     auto adapter = communicator->createObjectAdapter("CallbackAdapter");
-    adapter->add(ICE_MAKE_SHARED(CallbackI), Ice::stringToIdentity("callback"));
+    adapter->add(std::make_shared<CallbackI>(), Ice::stringToIdentity("callback"));
     adapter->activate();
     communicator->waitForShutdown();
 }

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -274,7 +274,7 @@ protected:
 };
 ICE_DEFINE_PTR(TestCasePtr, TestCase);
 
-class InvocationHeartbeatTest ICE_FINAL : public TestCase
+class InvocationHeartbeatTest final : public TestCase
 {
 public:
 
@@ -293,7 +293,7 @@ public:
     }
 };
 
-class InvocationHeartbeatOnHoldTest ICE_FINAL : public TestCase
+class InvocationHeartbeatOnHoldTest final : public TestCase
 {
 public:
 
@@ -323,7 +323,7 @@ public:
     }
 };
 
-class InvocationNoHeartbeatTest ICE_FINAL : public TestCase
+class InvocationNoHeartbeatTest final : public TestCase
 {
 public:
 
@@ -355,7 +355,7 @@ public:
     }
 };
 
-class InvocationHeartbeatCloseOnIdleTest ICE_FINAL : public TestCase
+class InvocationHeartbeatCloseOnIdleTest final : public TestCase
 {
 public:
 
@@ -377,7 +377,7 @@ public:
     }
 };
 
-class CloseOnIdleTest ICE_FINAL : public TestCase
+class CloseOnIdleTest final : public TestCase
 {
 public:
 
@@ -395,7 +395,7 @@ public:
     }
 };
 
-class CloseOnInvocationTest ICE_FINAL : public TestCase
+class CloseOnInvocationTest final : public TestCase
 {
 public:
 
@@ -414,7 +414,7 @@ public:
     }
 };
 
-class CloseOnIdleAndInvocationTest ICE_FINAL : public TestCase
+class CloseOnIdleAndInvocationTest final : public TestCase
 {
 public:
 
@@ -445,7 +445,7 @@ public:
     }
 };
 
-class ForcefulCloseOnIdleAndInvocationTest ICE_FINAL : public TestCase
+class ForcefulCloseOnIdleAndInvocationTest final : public TestCase
 {
 public:
 
@@ -466,7 +466,7 @@ public:
     }
 };
 
-class HeartbeatOnIdleTest ICE_FINAL : public TestCase
+class HeartbeatOnIdleTest final : public TestCase
 {
 public:
 
@@ -484,7 +484,7 @@ public:
     }
 };
 
-class HeartbeatAlwaysTest ICE_FINAL : public TestCase
+class HeartbeatAlwaysTest final : public TestCase
 {
 public:
 
@@ -506,7 +506,7 @@ public:
     }
 };
 
-class HeartbeatManualTest ICE_FINAL : public TestCase
+class HeartbeatManualTest final : public TestCase
 {
 public:
 
@@ -532,7 +532,7 @@ public:
     }
 };
 
-class SetACMTest ICE_FINAL : public TestCase
+class SetACMTest final : public TestCase
 {
 public:
 

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -91,7 +91,7 @@ public:
     virtual Ice::LoggerPtr
     cloneWithPrefix(const std::string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 
 private:
@@ -617,20 +617,20 @@ allTests(Test::TestHelper* helper)
 
     vector<TestCasePtr> tests;
 
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatOnHoldTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationNoHeartbeatTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatCloseOnIdleTest, com));
+    tests.push_back(std::make_shared<InvocationHeartbeatTest>(com));
+    tests.push_back(std::make_shared<InvocationHeartbeatOnHoldTest>(com));
+    tests.push_back(std::make_shared<InvocationNoHeartbeatTest>(com));
+    tests.push_back(std::make_shared<InvocationHeartbeatCloseOnIdleTest>(com));
 
-    tests.push_back(ICE_MAKE_SHARED(CloseOnIdleTest, com));
-    tests.push_back(ICE_MAKE_SHARED(CloseOnInvocationTest, com));
-    tests.push_back(ICE_MAKE_SHARED(CloseOnIdleAndInvocationTest, com));
-    tests.push_back(ICE_MAKE_SHARED(ForcefulCloseOnIdleAndInvocationTest, com));
+    tests.push_back(std::make_shared<CloseOnIdleTest>(com));
+    tests.push_back(std::make_shared<CloseOnInvocationTest>(com));
+    tests.push_back(std::make_shared<CloseOnIdleAndInvocationTest>(com));
+    tests.push_back(std::make_shared<ForcefulCloseOnIdleAndInvocationTest>(com));
 
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatOnIdleTest, com));
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatAlwaysTest, com));
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatManualTest, com));
-    tests.push_back(ICE_MAKE_SHARED(SetACMTest, com));
+    tests.push_back(std::make_shared<HeartbeatOnIdleTest>(com));
+    tests.push_back(std::make_shared<HeartbeatAlwaysTest>(com));
+    tests.push_back(std::make_shared<HeartbeatManualTest>(com));
+    tests.push_back(std::make_shared<SetACMTest>(com));
 
     for(vector<TestCasePtr>::const_iterator p = tests.begin(); p != tests.end(); ++p)
     {

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -557,21 +557,21 @@ public:
         Ice::ACM acm;
         acm = con->getACM();
         test(acm.timeout == 15);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnIdleForceful));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatOff));
+        test(acm.close == Ice::ACMClose::CloseOnIdleForceful);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatOff);
 
         con->setACM(IceUtil::None, IceUtil::None, IceUtil::None);
         acm = con->getACM();
         test(acm.timeout == 15);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnIdleForceful));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatOff));
+        test(acm.close == Ice::ACMClose::CloseOnIdleForceful);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatOff);
 
-        con->setACM(1, Ice::ICE_ENUM(ACMClose, CloseOnInvocationAndIdle),
-                                                 Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+        con->setACM(1, Ice::ACMClose::CloseOnInvocationAndIdle,
+                                                 Ice::ACMHeartbeat::HeartbeatAlways);
         acm = con->getACM();
         test(acm.timeout == 1);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnInvocationAndIdle));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+        test(acm.close == Ice::ACMClose::CloseOnInvocationAndIdle);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatAlways);
 
         // Make sure the client sends a few heartbeats to the server.
         proxy->startHeartbeatCount();

--- a/cpp/test/Ice/acm/Server.cpp
+++ b/cpp/test/Ice/acm/Server.cpp
@@ -26,7 +26,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ACM.Timeout", "0");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("communicator");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorI>(), id);
     adapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/acm/TestI.cpp
+++ b/cpp/test/Ice/acm/TestI.cpp
@@ -52,7 +52,7 @@ RemoteCommunicatorI::createObjectAdapter(int timeout, int close, int heartbeat, 
     ObjectAdapterPtr adapter = com->createObjectAdapterWithEndpoints(name, protocol + opts);
 
     return ICE_UNCHECKED_CAST(RemoteObjectAdapterPrx, current.adapter->addWithUUID(
-                              ICE_MAKE_SHARED(RemoteObjectAdapterI, adapter)));
+                              std::make_shared<RemoteObjectAdapterI>(adapter)));
 }
 
 void
@@ -63,7 +63,7 @@ RemoteCommunicatorI::shutdown(const Ice::Current& current)
 
 RemoteObjectAdapterI::RemoteObjectAdapterI(const Ice::ObjectAdapterPtr& adapter) :
     _adapter(adapter),
-    _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx, _adapter->add(ICE_MAKE_SHARED(TestI),
+    _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx, _adapter->add(std::make_shared<TestI>(),
                                          stringToIdentity("test"))))
 {
     _adapter->activate();
@@ -124,7 +124,7 @@ TestI::interruptSleep(const Ice::Current&)
 void
 TestI::startHeartbeatCount(const Ice::Current& current)
 {
-    _callback = ICE_MAKE_SHARED(HeartbeatCallbackI);
+    _callback = std::make_shared<HeartbeatCallbackI>();
     HeartbeatCallbackIPtr callback = _callback;
     current.con->setHeartbeatCallback([callback](Ice::ConnectionPtr connection)
     {

--- a/cpp/test/Ice/acm/TestI.h
+++ b/cpp/test/Ice/acm/TestI.h
@@ -44,7 +44,7 @@ public:
 
 private:
 
-    class HeartbeatCallbackI ICE_FINAL :
+    class HeartbeatCallbackI final :
                                 public std::enable_shared_from_this<HeartbeatCallbackI>,
                                 private IceUtil::Monitor<IceUtil::Mutex>
     {

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -92,7 +92,7 @@ allTests(Test::TestHelper* helper)
         cout << "testing object adapter with bi-dir connection... " << flush;
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
         obj->ice_getConnection()->setAdapter(adapter);
-        obj->ice_getConnection()->setAdapter(ICE_NULLPTR);
+        obj->ice_getConnection()->setAdapter(nullptr);
         adapter->deactivate();
         try
         {

--- a/cpp/test/Ice/adapterDeactivation/Collocated.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Collocated.cpp
@@ -29,7 +29,7 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ThreadPool.Size", "2");
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    ServantLocatorPtr locator = ICE_MAKE_SHARED(ServantLocatorI);
+    ServantLocatorPtr locator = std::make_shared<ServantLocatorI>();
     adapter->addServantLocator(locator, "");
 
     TestIntfPrxPtr allTests(TestHelper*);

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
@@ -24,7 +24,7 @@ public:
     virtual Ice::ObjectPrxPtr
     getClientProxy(IceUtil::Optional<bool>&, const Ice::Current&) const
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectPrxPtr

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
@@ -48,7 +48,7 @@ private:
 
 }
 
-ServantLocatorI::ServantLocatorI() : _deactivated(false), _router(ICE_MAKE_SHARED(RouterI))
+ServantLocatorI::ServantLocatorI() : _deactivated(false), _router(std::make_shared<RouterI>())
 {
 }
 
@@ -70,9 +70,9 @@ ServantLocatorI::locate(const Ice::Current& current, std::shared_ptr<void>& cook
     test(current.id.category == "");
     test(current.id.name == "test");
 
-    cookie = ICE_MAKE_SHARED(Cookie);
+    cookie = std::make_shared<Cookie>();
 
-    return ICE_MAKE_SHARED(TestI);
+    return std::make_shared<TestI>();
 }
 
 void

--- a/cpp/test/Ice/adapterDeactivation/Server.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Server.cpp
@@ -21,7 +21,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    ServantLocatorPtr locator = ICE_MAKE_SHARED(ServantLocatorI);
+    ServantLocatorPtr locator = std::make_shared<ServantLocatorI>();
     adapter->addServantLocator(locator, "");
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -21,9 +21,9 @@ testFacets(const Ice::CommunicatorPtr& com, bool builtInFacets = true)
         test(com->findAdminFacet("Metrics"));
     }
 
-    TestFacetPtr f1 = ICE_MAKE_SHARED(TestFacetI);
-    TestFacetPtr f2 = ICE_MAKE_SHARED(TestFacetI);
-    TestFacetPtr f3 = ICE_MAKE_SHARED(TestFacetI);
+    TestFacetPtr f1 = std::make_shared<TestFacetI>();
+    TestFacetPtr f2 = std::make_shared<TestFacetI>();
+    TestFacetPtr f3 = std::make_shared<TestFacetI>();
 
     com->addAdminFacet(f1, "Facet1");
     com->addAdminFacet(f2, "Facet2");
@@ -482,7 +482,7 @@ allTests(Test::TestHelper* helper)
         Ice::ObjectAdapterPtr adapter =
             communicator->createObjectAdapterWithEndpoints("RemoteLoggerAdapter", "tcp -h localhost");
 
-        RemoteLoggerIPtr remoteLogger = ICE_MAKE_SHARED(RemoteLoggerI);
+        RemoteLoggerIPtr remoteLogger = std::make_shared<RemoteLoggerI>();
 
         Ice::RemoteLoggerPrxPtr myProxy =
             ICE_UNCHECKED_CAST(Ice::RemoteLoggerPrx, adapter->addWithUUID(remoteLogger));

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -419,8 +419,8 @@ allTests(Test::TestHelper* helper)
         com->warning("warning2");
 
         Ice::LogMessageTypeSeq messageTypes;
-        messageTypes.push_back(ICE_ENUM(LogMessageType, ErrorMessage));
-        messageTypes.push_back(ICE_ENUM(LogMessageType, WarningMessage));
+        messageTypes.push_back(LogMessageType::ErrorMessage);
+        messageTypes.push_back(LogMessageType::WarningMessage);
 
         logMessages =
             logger->getLog(messageTypes, Ice::StringSeq(), -1, prefix);
@@ -430,7 +430,7 @@ allTests(Test::TestHelper* helper)
         p = logMessages.begin();
         while(p != logMessages.end())
         {
-            test(p->type == ICE_ENUM(LogMessageType, ErrorMessage) || p->type == ICE_ENUM(LogMessageType, WarningMessage));
+            test(p->type == LogMessageType::ErrorMessage || p->type == LogMessageType::WarningMessage);
             ++p;
         }
 
@@ -442,8 +442,8 @@ allTests(Test::TestHelper* helper)
         com->trace("testCat2", "B");
 
         messageTypes.clear();
-        messageTypes.push_back(ICE_ENUM(LogMessageType, ErrorMessage));
-        messageTypes.push_back(ICE_ENUM(LogMessageType, TraceMessage));
+        messageTypes.push_back(LogMessageType::ErrorMessage);
+        messageTypes.push_back(LogMessageType::TraceMessage);
 
         Ice::StringSeq categories;
         categories.push_back("testCat");
@@ -456,8 +456,8 @@ allTests(Test::TestHelper* helper)
         p = logMessages.begin();
         while(p != logMessages.end())
         {
-            test(p->type == ICE_ENUM(LogMessageType, ErrorMessage) ||
-                (p->type == ICE_ENUM(LogMessageType, TraceMessage) && p->traceCategory == "testCat"));
+            test(p->type == LogMessageType::ErrorMessage ||
+                (p->type == LogMessageType::TraceMessage && p->traceCategory == "testCat"));
             ++p;
         }
 
@@ -507,10 +507,10 @@ allTests(Test::TestHelper* helper)
         com->print("rprint");
         remoteLogger->wait(4);
 
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, TraceMessage), "rtrace", "testCat");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, WarningMessage), "rwarning");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, ErrorMessage), "rerror");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, PrintMessage), "rprint");
+        remoteLogger->checkNextLog(LogMessageType::TraceMessage, "rtrace", "testCat");
+        remoteLogger->checkNextLog(LogMessageType::WarningMessage, "rwarning");
+        remoteLogger->checkNextLog(LogMessageType::ErrorMessage, "rerror");
+        remoteLogger->checkNextLog(LogMessageType::PrintMessage, "rprint");
 
         test(logger->detachRemoteLogger(myProxy));
         test(!logger->detachRemoteLogger(myProxy));
@@ -535,8 +535,8 @@ allTests(Test::TestHelper* helper)
         com->print("rprint2");
         remoteLogger->wait(2);
 
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, TraceMessage), "rtrace2", "testCat");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, ErrorMessage), "rerror2");
+        remoteLogger->checkNextLog(LogMessageType::TraceMessage, "rtrace2", "testCat");
+        remoteLogger->checkNextLog(LogMessageType::ErrorMessage, "rerror2");
 
         //
         // Attempt reconnection with slightly different proxy

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -93,8 +93,8 @@ public:
 
     RemoteLoggerI();
 
-    virtual void init(ICE_IN(string), ICE_IN(Ice::LogMessageSeq), const Ice::Current&);
-    virtual void log(ICE_IN(Ice::LogMessage), const Ice::Current&);
+    virtual void init(string, Ice::LogMessageSeq, const Ice::Current&);
+    virtual void log(Ice::LogMessage, const Ice::Current&);
 
     void checkNextInit(const string&, Ice::LogMessageType, const string&, const string& = "");
     void checkNextLog(Ice::LogMessageType, const string&, const string& = "");
@@ -117,7 +117,7 @@ RemoteLoggerI::RemoteLoggerI() : _receivedCalls(0)
 }
 
 void
-RemoteLoggerI::init(ICE_IN(string) prefix, ICE_IN(Ice::LogMessageSeq) logMessages, const Ice::Current&)
+RemoteLoggerI::init(string prefix, Ice::LogMessageSeq logMessages, const Ice::Current&)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock lock(_monitor);
     _prefix = prefix;
@@ -127,7 +127,7 @@ RemoteLoggerI::init(ICE_IN(string) prefix, ICE_IN(Ice::LogMessageSeq) logMessage
 }
 
 void
-RemoteLoggerI::log(ICE_IN(Ice::LogMessage) logMessage, const Ice::Current&)
+RemoteLoggerI::log(Ice::LogMessage logMessage, const Ice::Current&)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock lock(_monitor);
     _logMessages.push_back(logMessage);

--- a/cpp/test/Ice/admin/Server.cpp
+++ b/cpp/test/Ice/admin/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 10000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("factory");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorFactoryI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorFactoryI>(), id);
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -110,23 +110,23 @@ RemoteCommunicatorI::removeUpdateCallback(const Ice::Current&)
 }
 
 void
-RemoteCommunicatorI::print(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::print(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->print(message);
 }
 void
-RemoteCommunicatorI::trace(ICE_IN(std::string) category,
-                           ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::trace(std::string category,
+                           std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->trace(category, message);
 }
 void
-RemoteCommunicatorI::warning(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::warning(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->warning(message);
 }
 void
-RemoteCommunicatorI::error(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::error(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->error(message);
 }
@@ -161,7 +161,7 @@ RemoteCommunicatorI::updated(const Ice::PropertyDict& changes)
 }
 
 Test::RemoteCommunicatorPrxPtr
-RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, const Ice::Current& current)
+RemoteCommunicatorFactoryI::createCommunicator(Ice::PropertyDict props, const Ice::Current& current)
 {
     //
     // Prepare the property set using the given properties.

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -42,7 +42,7 @@ public:
 
     virtual Ice::LoggerPtr cloneWithPrefix(const string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 };
 
@@ -175,7 +175,7 @@ RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, 
 
     if(init.properties->getPropertyAsInt("NullLogger") > 0)
     {
-        init.logger = ICE_MAKE_SHARED(NullLogger);
+        init.logger = std::make_shared<NullLogger>();
     }
 
     //
@@ -186,13 +186,13 @@ RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, 
     //
     // Install a custom admin facet.
     //
-    communicator->addAdminFacet(ICE_MAKE_SHARED(TestFacetI), "TestFacet");
+    communicator->addAdminFacet(std::make_shared<TestFacetI>(), "TestFacet");
 
     //
     // The RemoteCommunicator servant also implements PropertiesAdminUpdateCallback.
     // Set the callback on the admin facet.
     //
-    RemoteCommunicatorIPtr servant = ICE_MAKE_SHARED(RemoteCommunicatorI, communicator);
+    RemoteCommunicatorIPtr servant = std::make_shared<RemoteCommunicatorI>(communicator);
     servant->addUpdateCallback(Ice::emptyCurrent);
 
     Ice::ObjectPrxPtr proxy = current.adapter->addWithUUID(servant);

--- a/cpp/test/Ice/admin/TestI.h
+++ b/cpp/test/Ice/admin/TestI.h
@@ -22,10 +22,10 @@ public:
     virtual void addUpdateCallback(const Ice::Current&);
     virtual void removeUpdateCallback(const Ice::Current&);
 
-    virtual void print(ICE_IN(std::string), const Ice::Current&);
-    virtual void trace(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void warning(ICE_IN(std::string), const Ice::Current&);
-    virtual void error(ICE_IN(std::string), const Ice::Current&);
+    virtual void print(std::string, const Ice::Current&);
+    virtual void trace(std::string, std::string, const Ice::Current&);
+    virtual void warning(std::string, const Ice::Current&);
+    virtual void error(std::string, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
     virtual void waitForShutdown(const Ice::Current&);
@@ -46,7 +46,7 @@ class RemoteCommunicatorFactoryI : public Test::RemoteCommunicatorFactory
 {
 public:
 
-    virtual Test::RemoteCommunicatorPrxPtr createCommunicator(ICE_IN(Ice::PropertyDict), const Ice::Current&);
+    virtual Test::RemoteCommunicatorPrxPtr createCommunicator(Ice::PropertyDict, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 };
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1075,7 +1075,7 @@ allTests(Test::TestHelper* helper, bool collocated)
             test(p->opBatchCount() == 0);
             auto b1 = p->ice_batchOneway();
             b1->opBatch();
-            b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
             auto id = this_thread::get_id();
             promise<void> promise;
@@ -1151,7 +1151,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                 auto b1 = Ice::uncheckedCast<Test::TestIntfPrx>(
                     p->ice_getConnection()->createProxy(p->ice_getIdentity())->ice_batchOneway());
                 b1->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 b1->ice_getConnection()->flushBatchRequestsAsync(
@@ -1231,7 +1231,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                 auto b1 = Ice::uncheckedCast<Test::TestIntfPrx>(
                     p->ice_getConnection()->createProxy(p->ice_getIdentity())->ice_batchOneway());
                 b1->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 auto id = this_thread::get_id();
@@ -1303,8 +1303,8 @@ allTests(Test::TestHelper* helper, bool collocated)
                 b2->ice_getConnection(); // Ensure connection is established.
                 b1->opBatch();
                 b2->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
-                b2->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
+                b2->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 auto id = this_thread::get_id();
@@ -1413,7 +1413,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                               [s](exception_ptr ex) { s->set_exception(ex); });
                 auto f = s->get_future();
                 // Blocks until the request completes.
-                con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                con->close(Ice::ConnectionClose::GracefullyWithWait);
                 f.get(); // Should complete successfully.
                 fc.get();
             }

--- a/cpp/test/Ice/ami/Collocated.cpp
+++ b/cpp/test/Ice/ami/Collocated.cpp
@@ -28,10 +28,10 @@ Collocated::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = std::make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfII), Ice::stringToIdentity("test2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     //adapter->activate(); // Collocated test doesn't need to activate the OA
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -39,10 +39,10 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = std::make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfII), Ice::stringToIdentity("test2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     adapter->activate();
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -37,7 +37,7 @@ TestIntfI::opWithResultAndUE(const Ice::Current&)
 }
 
 void
-TestIntfI::opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&)
+TestIntfI::opWithPayload(Ice::ByteSeq, const Ice::Current&)
 {
 }
 
@@ -158,7 +158,7 @@ TestIntfI::supportsFunctionalTests(const Ice::Current&)
 }
 
 void
-TestIntfI::pingBiDir(ICE_IN(Test::PingReplyPrxPtr) reply, const Ice::Current& current)
+TestIntfI::pingBiDir(Test::PingReplyPrxPtr reply, const Ice::Current& current)
 {
     reply->ice_fixed(current.con)->replyAsync().get();
 }

--- a/cpp/test/Ice/ami/TestI.h
+++ b/cpp/test/Ice/ami/TestI.h
@@ -21,7 +21,7 @@ public:
     virtual int opWithResult(const Ice::Current&);
     virtual void opWithUE(const Ice::Current&);
     virtual int opWithResultAndUE(const Ice::Current&);
-    virtual void opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual void opWithPayload(Ice::ByteSeq, const Ice::Current&);
     virtual void opBatch(const Ice::Current&);
     virtual Ice::Int opBatchCount(const Ice::Current&);
     virtual void opWithArgs(Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&,
@@ -37,7 +37,7 @@ public:
     virtual bool supportsAMD(const Ice::Current&);
     virtual bool supportsFunctionalTests(const Ice::Current&);
 
-    virtual void pingBiDir(ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
+    virtual void pingBiDir(Test::PingReplyPrxPtr, const Ice::Current&);
 
 private:
 

--- a/cpp/test/Ice/background/AllTests.cpp
+++ b/cpp/test/Ice/background/AllTests.cpp
@@ -341,7 +341,7 @@ allTests(Test::TestHelper* helper)
         backgroundController->buffered(true);
 
         background->opAsync();
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         background->opAsync();
 
         vector<future<void>> results;
@@ -384,7 +384,7 @@ connectTests(const ConfigurationPtr& configuration, const Test::BackgroundPrxPtr
     {
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     for(int i = 0; i < 4; ++i)
     {
@@ -471,7 +471,7 @@ connectTests(const ConfigurationPtr& configuration, const Test::BackgroundPrxPtr
         }
 
         configuration->connectException(new Ice::SocketException(__FILE__, __LINE__));
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         configuration->connectException(0);
         try
@@ -505,7 +505,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     for(int i = 0; i < 4; i++)
     {
@@ -575,7 +575,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -589,7 +589,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 #endif
 
     //
@@ -624,7 +624,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -662,7 +662,7 @@ initializeTests(const ConfigurationPtr& configuration,
         }
 
         configuration->initializeException(new Ice::SocketException(__FILE__, __LINE__));
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         configuration->initializeException(0);
         try
@@ -684,12 +684,12 @@ initializeTests(const ConfigurationPtr& configuration,
         }
 
         configuration->initializeSocketOperation(IceInternal::SocketOperationWrite);
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         background->ice_ping();
         configuration->initializeSocketOperation(IceInternal::SocketOperationNone);
 
         ctl->initializeException(true);
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         ctl->initializeException(false);
         try
@@ -714,11 +714,11 @@ initializeTests(const ConfigurationPtr& configuration,
         {
 #if !defined(ICE_USE_IOCP) && !defined(ICE_USE_CFSTREAM)
             ctl->initializeSocketOperation(IceInternal::SocketOperationWrite);
-            background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
             background->op();
             ctl->initializeSocketOperation(IceInternal::SocketOperationNone);
 #else
-            background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
             background->op();
 #endif
         }
@@ -750,7 +750,7 @@ validationTests(const ConfigurationPtr& configuration,
     {
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -811,7 +811,7 @@ validationTests(const ConfigurationPtr& configuration,
             cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
-        background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         try
         {
@@ -949,7 +949,7 @@ validationTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -1030,7 +1030,7 @@ validationTests(const ConfigurationPtr& configuration,
     backgroundBatchOneway->op();
     ctl->resumeAdapter();
     backgroundBatchOneway->ice_flushBatchRequestsAsync();
-    backgroundBatchOneway->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    backgroundBatchOneway->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     ctl->holdAdapter();
     backgroundBatchOneway->opWithPayload(seq);
@@ -1039,7 +1039,7 @@ validationTests(const ConfigurationPtr& configuration,
     backgroundBatchOneway->opWithPayload(seq);
     ctl->resumeAdapter();
     backgroundBatchOneway->ice_flushBatchRequestsAsync().get();
-    backgroundBatchOneway->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    backgroundBatchOneway->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 }
 
 void
@@ -1520,10 +1520,10 @@ readWriteTests(const ConfigurationPtr& configuration,
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
 
         background->ice_ping();
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
 
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
     }
 
     thread1->destroy();

--- a/cpp/test/Ice/background/EndpointFactory.cpp
+++ b/cpp/test/Ice/background/EndpointFactory.cpp
@@ -33,7 +33,7 @@ EndpointFactory::protocol() const
 IceInternal::EndpointIPtr
 EndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _factory->create(args, oaEndpoint));
+    return std::make_shared<EndpointI>(_factory->create(args, oaEndpoint));
 }
 
 IceInternal::EndpointIPtr
@@ -44,7 +44,7 @@ EndpointFactory::read(Ice::InputStream* s) const
     assert(type == _factory->type());
 
     s->startEncapsulation();
-    IceInternal::EndpointIPtr endpoint = ICE_MAKE_SHARED(EndpointI, _factory->read(s));
+    IceInternal::EndpointIPtr endpoint = std::make_shared<EndpointI>(_factory->read(s));
     s->endEncapsulation();
     return endpoint;
 }

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -251,13 +251,13 @@ EndpointI::equivalent(const IceInternal::EndpointIPtr& endpoint) const
 }
 
 string
-EndpointI::toString() const ICE_NOEXCEPT
+EndpointI::toString() const noexcept
 {
     return "test-" + _endpoint->toString();
 }
 
 Ice::EndpointInfoPtr
-EndpointI::getInfo() const ICE_NOEXCEPT
+EndpointI::getInfo() const noexcept
 {
     return _endpoint->getInfo();
 }

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -71,7 +71,7 @@ EndpointI::timeout(int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return std::make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -85,7 +85,7 @@ EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return std::make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -105,7 +105,7 @@ EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return std::make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -171,7 +171,7 @@ EndpointI::connectors_async(Ice::EndpointSelectionType selType, const IceInterna
     try
     {
         _configuration->checkConnectorsException();
-        _endpoint->connectors_async(selType, ICE_MAKE_SHARED(Callback, cb));
+        _endpoint->connectors_async(selType, std::make_shared<Callback>(cb));
     }
     catch(const Ice::LocalException& ex)
     {
@@ -209,7 +209,7 @@ EndpointI::endpoint(const IceInternal::EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, delEndp);
+        return std::make_shared<EndpointI>(delEndp);
     }
 }
 
@@ -219,7 +219,7 @@ EndpointI::expandIfWildcard() const
     vector<IceInternal::EndpointIPtr> e = _endpoint->expandIfWildcard();
     for(vector<IceInternal::EndpointIPtr>::iterator p = e.begin(); p != e.end(); ++p)
     {
-        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, *p);
+        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : std::make_shared<EndpointI>(*p);
     }
     return e;
 }
@@ -230,11 +230,11 @@ EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
     vector<IceInternal::EndpointIPtr> e = _endpoint->expandHost(publish);
     if(publish)
     {
-        publish = publish == _endpoint ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, publish);
+        publish = publish == _endpoint ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : std::make_shared<EndpointI>(publish);
     }
     for(vector<IceInternal::EndpointIPtr>::iterator p = e.begin(); p != e.end(); ++p)
     {
-        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, *p);
+        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : std::make_shared<EndpointI>(*p);
     }
     return e;
 }

--- a/cpp/test/Ice/background/EndpointI.h
+++ b/cpp/test/Ice/background/EndpointI.h
@@ -36,8 +36,8 @@ public:
     virtual bool equivalent(const IceInternal::EndpointIPtr&) const;
 
     // From TestEndpoint
-    virtual std::string toString() const ICE_NOEXCEPT;
-    virtual Ice::EndpointInfoPtr getInfo() const ICE_NOEXCEPT;
+    virtual std::string toString() const noexcept;
+    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
     virtual Ice::Int timeout() const;
     virtual const std::string& connectionId() const;
     virtual bool compress() const;

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -146,11 +146,11 @@ Server::run(int argc, char** argv)
     shared_ptr<PluginI> plugin = dynamic_pointer_cast<PluginI>(communicator->getPluginManager()->getPlugin("Test"));
     assert(plugin);
     ConfigurationPtr configuration = plugin->getConfiguration();
-    BackgroundControllerIPtr backgroundController = ICE_MAKE_SHARED(BackgroundControllerI, adapter, configuration);
+    BackgroundControllerIPtr backgroundController = std::make_shared<BackgroundControllerI>(adapter, configuration);
 
-    adapter->add(ICE_MAKE_SHARED(BackgroundI, backgroundController), Ice::stringToIdentity("background"));
-    adapter->add(ICE_MAKE_SHARED(LocatorI, backgroundController), Ice::stringToIdentity("locator"));
-    adapter->add(ICE_MAKE_SHARED(RouterI, backgroundController), Ice::stringToIdentity("router"));
+    adapter->add(std::make_shared<BackgroundI>(backgroundController), Ice::stringToIdentity("background"));
+    adapter->add(std::make_shared<LocatorI>(backgroundController), Ice::stringToIdentity("locator"));
+    adapter->add(std::make_shared<RouterI>(backgroundController), Ice::stringToIdentity("router"));
     adapter->activate();
 
     adapter2->add(backgroundController, Ice::stringToIdentity("backgroundController"));

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -84,7 +84,7 @@ public:
     }
 
     virtual Ice::ObjectProxySeq
-    addProxies(ICE_IN(Ice::ObjectProxySeq), const Ice::Current&)
+    addProxies(Ice::ObjectProxySeq, const Ice::Current&)
     {
         return Ice::ObjectProxySeq();
     }

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -52,7 +52,7 @@ public:
     virtual Ice::LocatorRegistryPrxPtr
     getRegistry(const Ice::Current&) const
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     LocatorI(const BackgroundControllerIPtr& controller) : _controller(controller)
@@ -73,14 +73,14 @@ public:
     {
         hasRoutingTable = true;
         _controller->checkCallPause(current);
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectPrxPtr
     getServerProxy(const Ice::Current& current) const
     {
         _controller->checkCallPause(current);
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectProxySeq

--- a/cpp/test/Ice/background/TestI.cpp
+++ b/cpp/test/Ice/background/TestI.cpp
@@ -15,7 +15,7 @@ BackgroundI::op(const Ice::Current& current)
 }
 
 void
-BackgroundI::opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current& current)
+BackgroundI::opWithPayload(Ice::ByteSeq, const Ice::Current& current)
 {
     _controller->checkCallPause(current);
 }
@@ -32,14 +32,14 @@ BackgroundI::BackgroundI(const BackgroundControllerIPtr& controller) :
 }
 
 void
-BackgroundControllerI::pauseCall(ICE_IN(string) opName, const Ice::Current&)
+BackgroundControllerI::pauseCall(string opName, const Ice::Current&)
 {
     Lock sync(*this);
     _pausedCalls.insert(opName);
 }
 
 void
-BackgroundControllerI::resumeCall(ICE_IN(string) opName, const Ice::Current&)
+BackgroundControllerI::resumeCall(string opName, const Ice::Current&)
 {
     Lock sync(*this);
     _pausedCalls.erase(opName);

--- a/cpp/test/Ice/background/TestI.h
+++ b/cpp/test/Ice/background/TestI.h
@@ -18,7 +18,7 @@ class BackgroundI : public virtual Test::Background
 public:
 
     virtual void op(const Ice::Current&);
-    virtual void opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual void opWithPayload(Ice::ByteSeq, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 
     BackgroundI(const BackgroundControllerIPtr&);
@@ -32,8 +32,8 @@ class BackgroundControllerI : public Test::BackgroundController, IceUtil::Monito
 {
 public:
 
-    virtual void pauseCall(ICE_IN(std::string), const Ice::Current&);
-    virtual void resumeCall(ICE_IN(std::string), const Ice::Current&);
+    virtual void pauseCall(std::string, const Ice::Current&);
+    virtual void resumeCall(std::string, const Ice::Current&);
     virtual void checkCallPause(const Ice::Current&);
 
     virtual void holdAdapter(const Ice::Current&);

--- a/cpp/test/Ice/binding/AllTests.cpp
+++ b/cpp/test/Ice/binding/AllTests.cpp
@@ -109,7 +109,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -132,7 +132,7 @@ allTests(Test::TestHelper* helper)
             for(vector<RemoteObjectAdapterPrxPtr>::const_iterator q = adapters.begin(); q != adapters.end(); ++q)
             {
                 (*q)->getTestIntf()->ice_getConnection()->close(
-                    Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                    Ice::ConnectionClose::GracefullyWithWait);
             }
         }
 
@@ -157,7 +157,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -245,7 +245,7 @@ allTests(Test::TestHelper* helper)
                 try
                 {
                     (*q)->getTestIntf()->ice_getConnection()->close(
-                        Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                        Ice::ConnectionClose::GracefullyWithWait);
                 }
                 catch(const Ice::LocalException&)
                 {
@@ -285,7 +285,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(getAdapterNameWithAMI(test1));
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -308,7 +308,7 @@ allTests(Test::TestHelper* helper)
             for(vector<RemoteObjectAdapterPrxPtr>::const_iterator q = adapters.begin(); q != adapters.end(); ++q)
             {
                 (*q)->getTestIntf()->ice_getConnection()->close(
-                    Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                    Ice::ConnectionClose::GracefullyWithWait);
             }
         }
 
@@ -333,7 +333,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -356,7 +356,7 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter23", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
 
         set<string> names;
         names.insert("Adapter21");
@@ -365,11 +365,11 @@ allTests(Test::TestHelper* helper)
         while(!names.empty())
         {
             names.erase(test->getAdapterName());
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Random));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
 
         names.insert("Adapter21");
         names.insert("Adapter22");
@@ -377,7 +377,7 @@ allTests(Test::TestHelper* helper)
         while(!names.empty())
         {
             names.erase(test->getAdapterName());
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         deactivate(com, adapters);
@@ -392,8 +392,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter33", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         const int nRetry = 5;
         int i;
 
@@ -405,7 +405,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter31"; i++);
         }
 #endif
@@ -415,7 +415,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter32"; i++);
         }
 #endif
@@ -425,7 +425,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter33"; i++);
         }
 #endif
@@ -455,29 +455,29 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter36"; i++);
         }
 #endif
         test(i == nRetry);
-        test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         adapters.push_back(com->createObjectAdapter("Adapter35", endpoints[1]->toString()));
         for(i = 0; i < nRetry && test->getAdapterName() == "Adapter35"; i++);
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter35"; i++);
         }
 #endif
         test(i == nRetry);
-        test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         adapters.push_back(com->createObjectAdapter("Adapter34", endpoints[0]->toString()));
         for(i = 0; i < nRetry && test->getAdapterName() == "Adapter34"; i++);
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter34"; i++);
         }
 #endif
@@ -597,8 +597,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter63", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_connectionCached(false));
         test(!test->ice_isConnectionCached());
         const int nRetry = 5;
@@ -682,8 +682,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("AdapterAMI63", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_connectionCached(false));
         test(!test->ice_isConnectionCached());
         const int nRetry = 5;
@@ -787,7 +787,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter82");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             TestIntfPrxPtr testSecure = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_secure(true));
@@ -803,7 +803,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter81");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             com->createObjectAdapter("Adapter83", (test->ice_getEndpoints()[1])->toString()); // Reactive tcp OA.
@@ -811,7 +811,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter83");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             com->deactivateObjectAdapter(adapters[0]);
@@ -1019,7 +1019,7 @@ allTests(Test::TestHelper* helper)
             // there could be race condition since the connection might not be closed
             // immediately due to threading).
             test->ice_connectionId("0")->ice_getConnection()->close(
-                Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                Ice::ConnectionClose::GracefullyWithWait);
 
             //
             // The server closed the acceptor, wait one second and retry after freeing a FD.

--- a/cpp/test/Ice/binding/Server.cpp
+++ b/cpp/test/Ice/binding/Server.cpp
@@ -43,7 +43,7 @@ public:
 
     virtual Ice::LoggerPtr cloneWithPrefix(const string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 };
 
@@ -62,12 +62,12 @@ Server::run(int argc, char** argv)
     Ice::InitializationData initData;
     initData.properties = createTestProperties(argc, argv);
     initData.properties->setProperty("Ice.Warn.Connections", "0");
-    initData.logger = ICE_MAKE_SHARED(NullLogger);
+    initData.logger = std::make_shared<NullLogger>();
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("communicator");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorI>(), id);
     adapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/binding/TestI.cpp
+++ b/cpp/test/Ice/binding/TestI.cpp
@@ -36,7 +36,7 @@ RemoteCommunicatorI::createObjectAdapter(string name, string endpts, const Ice::
             com->getProperties()->setProperty(name + ".ThreadPool.Size", "1");
             ObjectAdapterPtr adapter = com->createObjectAdapterWithEndpoints(name, endpoints);
             return ICE_UNCHECKED_CAST(RemoteObjectAdapterPrx,
-                                      current.adapter->addWithUUID(ICE_MAKE_SHARED(RemoteObjectAdapterI, adapter)));
+                                      current.adapter->addWithUUID(std::make_shared<RemoteObjectAdapterI>(adapter)));
         }
         catch(const Ice::SocketException&)
         {
@@ -63,7 +63,7 @@ RemoteCommunicatorI::shutdown(const Ice::Current& current)
 RemoteObjectAdapterI::RemoteObjectAdapterI(const Ice::ObjectAdapterPtr& adapter) :
     _adapter(adapter),
     _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx,
-                    _adapter->add(ICE_MAKE_SHARED(TestI),
+                    _adapter->add(std::make_shared<TestI>(),
                                   stringToIdentity("test"))))
 {
     _adapter->activate();

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -355,11 +355,11 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::E> in(5);
-        in[0] = Test:: ICE_ENUM(E, E1);
-        in[1] = Test:: ICE_ENUM(E, E2);
-        in[2] = Test:: ICE_ENUM(E, E3);
-        in[3] = Test:: ICE_ENUM(E, E1);
-        in[4] = Test:: ICE_ENUM(E, E3);
+        in[0] = Test:: E::E1;
+        in[1] = Test:: E::E2;
+        in[2] = Test:: E::E3;
+        in[3] = Test:: E::E1;
+        in[4] = Test:: E::E3;
 
         deque<Test::E> out;
         deque<Test::E> ret = t->opESeq(in, out);
@@ -369,11 +369,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::E> in;
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E2));
-        in.push_back(Test:: ICE_ENUM(E, E3));
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E3));
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E2);
+        in.push_back(Test:: E::E3);
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E3);
 
         list<Test::E> out;
         list<Test::E> ret = t->opEList(in, out);
@@ -844,11 +844,11 @@ allTests(Test::TestHelper* helper)
 
         {
             deque<Test::E> in(5);
-            in[0] = Test:: ICE_ENUM(E, E1);
-            in[1] = Test:: ICE_ENUM(E, E2);
-            in[2] = Test:: ICE_ENUM(E, E3);
-            in[3] = Test:: ICE_ENUM(E, E1);
-            in[4] = Test:: ICE_ENUM(E, E3);
+            in[0] = Test:: E::E1;
+            in[1] = Test:: E::E2;
+            in[2] = Test:: E::E3;
+            in[3] = Test:: E::E1;
+            in[4] = Test:: E::E3;
 
             auto r = t->opESeqAsync(in).get();
             test(r.outSeq == in);
@@ -857,11 +857,11 @@ allTests(Test::TestHelper* helper)
 
         {
             list<Test::E> in;
-            in.push_back(Test:: ICE_ENUM(E, E1));
-            in.push_back(Test:: ICE_ENUM(E, E2));
-            in.push_back(Test:: ICE_ENUM(E, E3));
-            in.push_back(Test:: ICE_ENUM(E, E1));
-            in.push_back(Test:: ICE_ENUM(E, E3));
+            in.push_back(Test:: E::E1);
+            in.push_back(Test:: E::E2);
+            in.push_back(Test:: E::E3);
+            in.push_back(Test:: E::E1);
+            in.push_back(Test:: E::E3);
 
             auto r = t->opEListAsync(in).get();
             test(r.outSeq == in);
@@ -1449,11 +1449,11 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::E> in(5);
-        in[0] = Test:: ICE_ENUM(E, E1);
-        in[1] = Test:: ICE_ENUM(E, E2);
-        in[2] = Test:: ICE_ENUM(E, E3);
-        in[3] = Test:: ICE_ENUM(E, E1);
-        in[4] = Test:: ICE_ENUM(E, E3);
+        in[0] = Test:: E::E1;
+        in[1] = Test:: E::E2;
+        in[2] = Test:: E::E3;
+        in[3] = Test:: E::E1;
+        in[4] = Test:: E::E3;
 
         promise<bool> done;
 
@@ -1474,11 +1474,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::E> in;
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E2));
-        in.push_back(Test:: ICE_ENUM(E, E3));
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E3));
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E2);
+        in.push_back(Test:: E::E3);
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E3);
 
         promise<bool> done;
 

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -424,7 +424,7 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::CPtr> in(5);
-        in[0] = ICE_MAKE_SHARED(Test::C);
+        in[0] = std::make_shared<Test::C>();
         in[1] = in[0];
         in[2] = in[0];
         in[3] = in[0];
@@ -443,11 +443,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::CPtr> in;
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
 
         list<Test::CPtr> out;
         list<Test::CPtr> ret = t->opCList(in, out);
@@ -916,7 +916,7 @@ allTests(Test::TestHelper* helper)
 
         {
             deque<Test::CPtr> in(5);
-            in[0] = ICE_MAKE_SHARED(Test::C);
+            in[0] = std::make_shared<Test::C>();
             in[1] = in[0];
             in[2] = in[0];
             in[3] = in[0];
@@ -936,11 +936,11 @@ allTests(Test::TestHelper* helper)
 
         {
             list<Test::CPtr> in;
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
+            in.push_back(std::make_shared<Test::C>());
+            in.push_back(std::make_shared<Test::C>());
+            in.push_back(std::make_shared<Test::C>());
+            in.push_back(std::make_shared<Test::C>());
+            in.push_back(std::make_shared<Test::C>());
 
             auto r = t->opCListAsync(in).get();
             test(r.outSeq.size() == in.size());
@@ -1561,7 +1561,7 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::CPtr> in(5);
-        in[0] = ICE_MAKE_SHARED(Test::C);
+        in[0] = std::make_shared<Test::C>();
         in[1] = in[0];
         in[2] = in[0];
         in[3] = in[0];
@@ -1586,11 +1586,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::CPtr> in;
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
+        in.push_back(std::make_shared<Test::C>());
 
         promise<bool> done;
 

--- a/cpp/test/Ice/custom/Client.cpp
+++ b/cpp/test/Ice/custom/Client.cpp
@@ -19,8 +19,8 @@ public:
 void
 Client::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(std::make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(std::make_shared<Test::WstringConverterI>());
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     Test::TestIntfPrxPtr test = allTests(this);

--- a/cpp/test/Ice/custom/Collocated.cpp
+++ b/cpp/test/Ice/custom/Collocated.cpp
@@ -20,16 +20,16 @@ public:
 void
 Collocated::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(std::make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(std::make_shared<Test::WstringConverterI>());
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(std::make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(std::make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/custom/Server.cpp
+++ b/cpp/test/Ice/custom/Server.cpp
@@ -20,14 +20,14 @@ public:
 void
 Server::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(std::make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(std::make_shared<Test::WstringConverterI>());
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(std::make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(std::make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/custom/ServerAMD.cpp
+++ b/cpp/test/Ice/custom/ServerAMD.cpp
@@ -20,16 +20,16 @@ public:
 void
 ServerAMD::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(std::make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(std::make_shared<Test::WstringConverterI>());
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(std::make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(std::make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -6,7 +6,7 @@
 #include <TestI.h>
 
 Test::DoubleSeq
-TestIntfI::opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*>) inSeq,
+TestIntfI::opDoubleArray(std::pair<const Ice::Double*, const Ice::Double*> inSeq,
                          Test::DoubleSeq& outSeq,
                          const Ice::Current&)
 {
@@ -15,7 +15,7 @@ TestIntfI::opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*
 }
 
 Test::BoolSeq
-TestIntfI::opBoolArray(ICE_IN(std::pair<const bool*, const bool*>) inSeq,
+TestIntfI::opBoolArray(std::pair<const bool*, const bool*> inSeq,
                        Test::BoolSeq& outSeq,
                        const Ice::Current&)
 {
@@ -24,7 +24,7 @@ TestIntfI::opBoolArray(ICE_IN(std::pair<const bool*, const bool*>) inSeq,
 }
 
 Test::ByteList
-TestIntfI::opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>) inSeq,
+TestIntfI::opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*> inSeq,
                        Test::ByteList& outSeq,
                        const Ice::Current&)
 {
@@ -33,7 +33,7 @@ TestIntfI::opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>) inS
 }
 
 Test::VariableList
-TestIntfI::opVariableArray(ICE_IN(std::pair<const Test::Variable*, const Test::Variable*>) inSeq,
+TestIntfI::opVariableArray(std::pair<const Test::Variable*, const Test::Variable*> inSeq,
                            Test::VariableList& outSeq,
                            const Ice::Current&)
 {
@@ -42,7 +42,7 @@ TestIntfI::opVariableArray(ICE_IN(std::pair<const Test::Variable*, const Test::V
 }
 
 std::deque<bool>
-TestIntfI::opBoolSeq(ICE_IN(std::deque<bool>) inSeq,
+TestIntfI::opBoolSeq(std::deque<bool> inSeq,
                      std::deque<bool>& outSeq,
                      const Ice::Current&)
 {
@@ -51,7 +51,7 @@ TestIntfI::opBoolSeq(ICE_IN(std::deque<bool>) inSeq,
 }
 
 std::list<bool>
-TestIntfI::opBoolList(ICE_IN(std::list<bool>) inSeq,
+TestIntfI::opBoolList(std::list<bool> inSeq,
                       std::list<bool>& outSeq,
                       const Ice::Current&)
 {
@@ -60,14 +60,14 @@ TestIntfI::opBoolList(ICE_IN(std::list<bool>) inSeq,
 }
 
 ::Test::BoolDequeList
-TestIntfI::opBoolDequeList(ICE_IN(::Test::BoolDequeList) inSeq, ::Test::BoolDequeList& outSeq, const Ice::Current&)
+TestIntfI::opBoolDequeList(::Test::BoolDequeList inSeq, ::Test::BoolDequeList& outSeq, const Ice::Current&)
 {
     outSeq = inSeq;
     return inSeq;
 }
 
 ::Test::BoolDequeList
-TestIntfI::opBoolDequeListArray(ICE_IN(::std::pair<const std::deque<bool>*, const std::deque<bool>*>) inSeq,
+TestIntfI::opBoolDequeListArray(::std::pair<const std::deque<bool>*, const std::deque<bool>*> inSeq,
                                 ::Test::BoolDequeList& outSeq,
                                 const ::Ice::Current&)
 {
@@ -79,7 +79,7 @@ TestIntfI::opBoolDequeListArray(ICE_IN(::std::pair<const std::deque<bool>*, cons
 }
 
 std::deque< ::Ice::Byte>
-TestIntfI::opByteSeq(ICE_IN(std::deque< ::Ice::Byte>) inSeq,
+TestIntfI::opByteSeq(std::deque< ::Ice::Byte> inSeq,
                      std::deque< ::Ice::Byte>& outSeq,
                      const Ice::Current&)
 {
@@ -88,7 +88,7 @@ TestIntfI::opByteSeq(ICE_IN(std::deque< ::Ice::Byte>) inSeq,
 }
 
 std::list< ::Ice::Byte>
-TestIntfI::opByteList(ICE_IN(std::list< ::Ice::Byte>) inSeq,
+TestIntfI::opByteList(std::list< ::Ice::Byte> inSeq,
                       std::list< ::Ice::Byte>& outSeq,
                       const Ice::Current&)
 {
@@ -97,7 +97,7 @@ TestIntfI::opByteList(ICE_IN(std::list< ::Ice::Byte>) inSeq,
 }
 
 MyByteSeq
-TestIntfI::opMyByteSeq(ICE_IN(MyByteSeq) inSeq,
+TestIntfI::opMyByteSeq(MyByteSeq inSeq,
                        MyByteSeq& outSeq,
                        const Ice::Current&)
 {
@@ -106,7 +106,7 @@ TestIntfI::opMyByteSeq(ICE_IN(MyByteSeq) inSeq,
 }
 
 std::string
-TestIntfI::opString(ICE_IN(Util::string_view) inString,
+TestIntfI::opString(Util::string_view inString,
                     std::string& outString,
                     const Ice::Current&)
 {
@@ -115,7 +115,7 @@ TestIntfI::opString(ICE_IN(Util::string_view) inString,
 }
 
 std::deque< ::std::string>
-TestIntfI::opStringSeq(ICE_IN(std::deque< ::std::string>) inSeq,
+TestIntfI::opStringSeq(std::deque< ::std::string> inSeq,
                        std::deque< ::std::string>& outSeq,
                        const Ice::Current&)
 {
@@ -124,7 +124,7 @@ TestIntfI::opStringSeq(ICE_IN(std::deque< ::std::string>) inSeq,
 }
 
 std::list< ::std::string>
-TestIntfI::opStringList(ICE_IN(std::list< ::std::string>) inSeq,
+TestIntfI::opStringList(std::list< ::std::string> inSeq,
                         std::list< ::std::string>& outSeq,
                         const Ice::Current&)
 {
@@ -133,7 +133,7 @@ TestIntfI::opStringList(ICE_IN(std::list< ::std::string>) inSeq,
 }
 
 std::deque< ::Test::Fixed>
-TestIntfI::opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>) inSeq,
+TestIntfI::opFixedSeq(std::deque< ::Test::Fixed> inSeq,
                       std::deque< ::Test::Fixed>& outSeq,
                       const Ice::Current&)
 {
@@ -142,7 +142,7 @@ TestIntfI::opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>) inSeq,
 }
 
 std::list< ::Test::Fixed>
-TestIntfI::opFixedList(ICE_IN(std::list< ::Test::Fixed>) inSeq,
+TestIntfI::opFixedList(std::list< ::Test::Fixed> inSeq,
                        std::list< ::Test::Fixed>& outSeq,
                        const Ice::Current&)
 {
@@ -151,7 +151,7 @@ TestIntfI::opFixedList(ICE_IN(std::list< ::Test::Fixed>) inSeq,
 }
 
 std::deque< ::Test::Variable>
-TestIntfI::opVariableSeq(ICE_IN(std::deque< ::Test::Variable>) inSeq,
+TestIntfI::opVariableSeq(std::deque< ::Test::Variable> inSeq,
                          std::deque< ::Test::Variable>& outSeq,
                          const Ice::Current&)
 {
@@ -160,7 +160,7 @@ TestIntfI::opVariableSeq(ICE_IN(std::deque< ::Test::Variable>) inSeq,
 }
 
 std::list< ::Test::Variable>
-TestIntfI::opVariableList(ICE_IN(std::list< ::Test::Variable>) inSeq,
+TestIntfI::opVariableList(std::list< ::Test::Variable> inSeq,
                           std::list< ::Test::Variable>& outSeq,
                           const Ice::Current&)
 {
@@ -169,7 +169,7 @@ TestIntfI::opVariableList(ICE_IN(std::list< ::Test::Variable>) inSeq,
 }
 
 std::deque< ::Test::StringStringDict>
-TestIntfI::opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>) inSeq,
+TestIntfI::opStringStringDictSeq(std::deque< ::Test::StringStringDict> inSeq,
                                        std::deque< ::Test::StringStringDict>& outSeq,
                                        const Ice::Current&)
 {
@@ -178,7 +178,7 @@ TestIntfI::opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>) i
 }
 
 std::list< ::Test::StringStringDict>
-TestIntfI::opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>) inSeq,
+TestIntfI::opStringStringDictList(std::list< ::Test::StringStringDict> inSeq,
                                         std::list< ::Test::StringStringDict>& outSeq,
                                         const Ice::Current&)
 {
@@ -187,7 +187,7 @@ TestIntfI::opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>) i
 }
 
 std::deque< ::Test::E>
-TestIntfI::opESeq(ICE_IN(std::deque< ::Test::E>) inSeq,
+TestIntfI::opESeq(std::deque< ::Test::E> inSeq,
                         std::deque< ::Test::E>& outSeq,
                         const Ice::Current&)
 {
@@ -196,7 +196,7 @@ TestIntfI::opESeq(ICE_IN(std::deque< ::Test::E>) inSeq,
 }
 
 std::list< ::Test::E>
-TestIntfI::opEList(ICE_IN(std::list< ::Test::E>) inSeq,
+TestIntfI::opEList(std::list< ::Test::E> inSeq,
                          std::list< ::Test::E>& outSeq,
                          const Ice::Current&)
 {
@@ -205,7 +205,7 @@ TestIntfI::opEList(ICE_IN(std::list< ::Test::E>) inSeq,
 }
 
 std::deque< ::Test::DPrxPtr>
-TestIntfI::opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>) inSeq,
+TestIntfI::opDPrxSeq(std::deque< ::Test::DPrxPtr> inSeq,
                            std::deque< ::Test::DPrxPtr>& outSeq,
                            const Ice::Current&)
 {
@@ -214,7 +214,7 @@ TestIntfI::opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>) inSeq,
 }
 
 std::list< ::Test::DPrxPtr>
-TestIntfI::opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>) inSeq,
+TestIntfI::opDPrxList(std::list< ::Test::DPrxPtr> inSeq,
                             std::list< ::Test::DPrxPtr>& outSeq,
                             const Ice::Current&)
 {
@@ -223,7 +223,7 @@ TestIntfI::opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>) inSeq,
 }
 
 std::deque< ::Test::CPtr>
-TestIntfI::opCSeq(ICE_IN(std::deque< ::Test::CPtr>) inSeq,
+TestIntfI::opCSeq(std::deque< ::Test::CPtr> inSeq,
                   std::deque< ::Test::CPtr>& outSeq,
                   const Ice::Current&)
 {
@@ -232,7 +232,7 @@ TestIntfI::opCSeq(ICE_IN(std::deque< ::Test::CPtr>) inSeq,
 }
 
 std::list< ::Test::CPtr>
-TestIntfI::opCList(ICE_IN(std::list< ::Test::CPtr>) inSeq,
+TestIntfI::opCList(std::list< ::Test::CPtr> inSeq,
                    std::list< ::Test::CPtr>& outSeq,
                    const Ice::Current&)
 {
@@ -241,20 +241,20 @@ TestIntfI::opCList(ICE_IN(std::list< ::Test::CPtr>) inSeq,
 }
 
 void
-TestIntfI::opOutArrayByteSeq(ICE_IN(Test::ByteSeq) data, Test::ByteSeq& copy, const Ice::Current&)
+TestIntfI::opOutArrayByteSeq(Test::ByteSeq data, Test::ByteSeq& copy, const Ice::Current&)
 {
     copy = data;
 }
 
 Test::IntStringDict
-TestIntfI::opIntStringDict(ICE_IN(Test::IntStringDict) data, Test::IntStringDict& copy, const Ice::Current&)
+TestIntfI::opIntStringDict(Test::IntStringDict data, Test::IntStringDict& copy, const Ice::Current&)
 {
     copy = data;
     return data;
 }
 
 Test::CustomMap<Ice::Long, Ice::Long>
-TestIntfI::opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>) data,
+TestIntfI::opVarDict(Test::CustomMap<std::string, Ice::Int> data,
                      Test::CustomMap<std::string, Ice::Int>& copy, const Ice::Current&)
 {
     copy = data;
@@ -269,7 +269,7 @@ TestIntfI::opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>) data,
 
 Test::CustomMap<Ice::Int, std::string>
 TestIntfI::opCustomIntStringDict(
-    ICE_IN(std::map<Ice::Int, Util::string_view>) data,
+    std::map<Ice::Int, Util::string_view> data,
     Test::CustomMap<Ice::Int, std::string>& copy,
     const Ice::Current&)
 {
@@ -285,21 +285,21 @@ TestIntfI::opCustomIntStringDict(
 }
 
 Test::ShortBuffer
-TestIntfI::opShortBuffer(ICE_IN(Test::ShortBuffer) inS, Test::ShortBuffer& outS, const Ice::Current&)
+TestIntfI::opShortBuffer(Test::ShortBuffer inS, Test::ShortBuffer& outS, const Ice::Current&)
 {
     outS = inS;
     return outS;
 }
 
 Test::CustomBuffer<bool>
-TestIntfI::opBoolBuffer(ICE_IN(Test::CustomBuffer<bool>) inS, Test::CustomBuffer<bool>& outS, const Ice::Current&)
+TestIntfI::opBoolBuffer(Test::CustomBuffer<bool> inS, Test::CustomBuffer<bool>& outS, const Ice::Current&)
 {
     outS = inS;
     return outS;
 }
 
 Test::BufferStruct
-TestIntfI::opBufferStruct(ICE_IN(Test::BufferStruct) bs, const Ice::Current&)
+TestIntfI::opBufferStruct(Test::BufferStruct bs, const Ice::Current&)
 {
     return bs;
 }

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -11,128 +11,128 @@ class TestIntfI : public virtual Test::TestIntf
 {
 public:
 
-    virtual Test::DoubleSeq opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*>),
+    virtual Test::DoubleSeq opDoubleArray(std::pair<const Ice::Double*, const Ice::Double*>,
                                           Test::DoubleSeq&,
                                           const Ice::Current&);
 
-    virtual Test::BoolSeq opBoolArray(ICE_IN(std::pair<const bool*, const bool*>),
+    virtual Test::BoolSeq opBoolArray(std::pair<const bool*, const bool*>,
                                       Test::BoolSeq&,
                                       const Ice::Current&);
 
-    virtual Test::ByteList opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>),
+    virtual Test::ByteList opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*>,
                                        Test::ByteList&,
                                        const Ice::Current&);
 
-    virtual Test::VariableList opVariableArray(ICE_IN(std::pair<const Test::Variable*, const Test::Variable*>),
+    virtual Test::VariableList opVariableArray(std::pair<const Test::Variable*, const Test::Variable*>,
                                                Test::VariableList&,
                                                const Ice::Current&);
 
-    virtual std::deque<bool> opBoolSeq(ICE_IN(std::deque<bool>),
+    virtual std::deque<bool> opBoolSeq(std::deque<bool>,
                                        std::deque<bool>&,
                                        const Ice::Current&);
 
-    virtual std::list<bool> opBoolList(ICE_IN(std::list<bool>),
+    virtual std::list<bool> opBoolList(std::list<bool>,
                                        std::list<bool>&,
                                        const Ice::Current&);
 
-    virtual ::Test::BoolDequeList opBoolDequeList(ICE_IN(::Test::BoolDequeList),
+    virtual ::Test::BoolDequeList opBoolDequeList(::Test::BoolDequeList,
                                                   ::Test::BoolDequeList&,
                                                   const Ice::Current&);
 
-    virtual ::Test::BoolDequeList opBoolDequeListArray(ICE_IN(::std::pair<const std::deque<bool>*, const std::deque<bool>*>),
+    virtual ::Test::BoolDequeList opBoolDequeListArray(::std::pair<const std::deque<bool>*, const std::deque<bool>*>,
                                                        ::Test::BoolDequeList&,
                                                        const ::Ice::Current&);
 
-    virtual std::deque< ::Ice::Byte> opByteSeq(ICE_IN(std::deque< ::Ice::Byte>),
+    virtual std::deque< ::Ice::Byte> opByteSeq(std::deque< ::Ice::Byte>,
                                                std::deque< ::Ice::Byte>&,
                                                const Ice::Current&);
 
-    virtual std::list< ::Ice::Byte> opByteList(ICE_IN(std::list< ::Ice::Byte>),
+    virtual std::list< ::Ice::Byte> opByteList(std::list< ::Ice::Byte>,
                                                std::list< ::Ice::Byte>&,
                                                const Ice::Current&);
 
-    virtual MyByteSeq opMyByteSeq(ICE_IN(MyByteSeq),
+    virtual MyByteSeq opMyByteSeq(MyByteSeq,
                                   MyByteSeq&,
                                   const Ice::Current&);
 
-    virtual std::string opString(ICE_IN(Util::string_view),
+    virtual std::string opString(Util::string_view,
                                  std::string&,
                                  const Ice::Current&);
 
-    virtual std::deque< ::std::string> opStringSeq(ICE_IN(std::deque< ::std::string>),
+    virtual std::deque< ::std::string> opStringSeq(std::deque< ::std::string>,
                                                    std::deque< ::std::string>&,
                                                    const Ice::Current&);
 
-    virtual std::list< ::std::string> opStringList(ICE_IN(std::list< ::std::string>),
+    virtual std::list< ::std::string> opStringList(std::list< ::std::string>,
                                                    std::list< ::std::string>&,
                                                    const Ice::Current&);
 
-    virtual std::deque< ::Test::Fixed> opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>),
+    virtual std::deque< ::Test::Fixed> opFixedSeq(std::deque< ::Test::Fixed>,
                                                   std::deque< ::Test::Fixed>&,
                                                   const Ice::Current&);
 
-    virtual std::list< ::Test::Fixed> opFixedList(ICE_IN(std::list< ::Test::Fixed>),
+    virtual std::list< ::Test::Fixed> opFixedList(std::list< ::Test::Fixed>,
                                                   std::list< ::Test::Fixed>&,
                                                   const Ice::Current&);
 
-    virtual std::deque< ::Test::Variable> opVariableSeq(ICE_IN(std::deque< ::Test::Variable>),
+    virtual std::deque< ::Test::Variable> opVariableSeq(std::deque< ::Test::Variable>,
                                                         std::deque< ::Test::Variable>&,
                                                         const Ice::Current&);
 
-    virtual std::list< ::Test::Variable> opVariableList(ICE_IN(std::list< ::Test::Variable>),
+    virtual std::list< ::Test::Variable> opVariableList(std::list< ::Test::Variable>,
                                                         std::list< ::Test::Variable>&,
                                                         const Ice::Current&);
 
-    virtual std::deque< ::Test::StringStringDict> opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>),
+    virtual std::deque< ::Test::StringStringDict> opStringStringDictSeq(std::deque< ::Test::StringStringDict>,
                                                                         std::deque< ::Test::StringStringDict>&,
                                                                         const Ice::Current&);
 
-    virtual std::list< ::Test::StringStringDict> opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>),
+    virtual std::list< ::Test::StringStringDict> opStringStringDictList(std::list< ::Test::StringStringDict>,
                                                                         std::list< ::Test::StringStringDict>&,
                                                                         const Ice::Current&);
 
-    virtual std::deque< ::Test::E> opESeq(ICE_IN(std::deque< ::Test::E>),
+    virtual std::deque< ::Test::E> opESeq(std::deque< ::Test::E>,
                                           std::deque< ::Test::E>&,
                                           const Ice::Current&);
 
-    virtual std::list< ::Test::E> opEList(ICE_IN(std::list< ::Test::E>),
+    virtual std::list< ::Test::E> opEList(std::list< ::Test::E>,
                                           std::list< ::Test::E>&,
                                           const Ice::Current&);
 
-    virtual std::deque< ::Test::DPrxPtr> opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>),
+    virtual std::deque< ::Test::DPrxPtr> opDPrxSeq(std::deque< ::Test::DPrxPtr>,
                                                 std::deque< ::Test::DPrxPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::list< ::Test::DPrxPtr> opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>),
+    virtual std::list< ::Test::DPrxPtr> opDPrxList(std::list< ::Test::DPrxPtr>,
                                                 std::list< ::Test::DPrxPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::deque< ::Test::CPtr> opCSeq(ICE_IN(std::deque< ::Test::CPtr>),
+    virtual std::deque< ::Test::CPtr> opCSeq(std::deque< ::Test::CPtr>,
                                                 std::deque< ::Test::CPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::list< ::Test::CPtr> opCList(ICE_IN(std::list< ::Test::CPtr>),
+    virtual std::list< ::Test::CPtr> opCList(std::list< ::Test::CPtr>,
                                                 std::list< ::Test::CPtr>&,
                                                 const Ice::Current&);
 
-    virtual void opOutArrayByteSeq(ICE_IN(Test::ByteSeq), Test::ByteSeq&, const Ice::Current&);
+    virtual void opOutArrayByteSeq(Test::ByteSeq, Test::ByteSeq&, const Ice::Current&);
 
-    virtual Test::IntStringDict opIntStringDict(ICE_IN(Test::IntStringDict), Test::IntStringDict&,
+    virtual Test::IntStringDict opIntStringDict(Test::IntStringDict, Test::IntStringDict&,
                                                 const Ice::Current&);
 
-    virtual Test::CustomMap<Ice::Long, Ice::Long> opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>),
+    virtual Test::CustomMap<Ice::Long, Ice::Long> opVarDict(Test::CustomMap<std::string, Ice::Int>,
                                                             Test::CustomMap<std::string, Ice::Int>&,
                                                             const Ice::Current&);
 
     virtual Test::CustomMap<Ice::Int, std::string> opCustomIntStringDict(
-        ICE_IN(std::map<Ice::Int, Util::string_view>), Test::CustomMap<Ice::Int, std::string>&, const Ice::Current&);
+        std::map<Ice::Int, Util::string_view>, Test::CustomMap<Ice::Int, std::string>&, const Ice::Current&);
 
-    Test::ShortBuffer opShortBuffer(ICE_IN(Test::ShortBuffer), Test::ShortBuffer&, const Ice::Current&);
+    Test::ShortBuffer opShortBuffer(Test::ShortBuffer, Test::ShortBuffer&, const Ice::Current&);
 
-    Test::CustomBuffer<bool> opBoolBuffer(ICE_IN(Test::CustomBuffer<bool>), Test::CustomBuffer<bool>&,
+    Test::CustomBuffer<bool> opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&,
                                           const Ice::Current&);
 
-    Test::BufferStruct opBufferStruct(ICE_IN(Test::BufferStruct), const Ice::Current&);
+    Test::BufferStruct opBufferStruct(Test::BufferStruct, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };

--- a/cpp/test/Ice/custom/WstringI.cpp
+++ b/cpp/test/Ice/custom/WstringI.cpp
@@ -5,7 +5,7 @@
 #include <WstringI.h>
 
 ::std::wstring
-Test1::WstringClassI::opString(ICE_IN(::std::wstring) s1,
+Test1::WstringClassI::opString(::std::wstring s1,
                                ::std::wstring& s2,
                                const Ice::Current&)
 {
@@ -14,7 +14,7 @@ Test1::WstringClassI::opString(ICE_IN(::std::wstring) s1,
 }
 
 ::Test1::WstringStruct
-Test1::WstringClassI::opStruct(ICE_IN(::Test1::WstringStruct) s1,
+Test1::WstringClassI::opStruct(::Test1::WstringStruct s1,
                                ::Test1::WstringStruct& s2,
                                const Ice::Current&)
 {
@@ -23,7 +23,7 @@ Test1::WstringClassI::opStruct(ICE_IN(::Test1::WstringStruct) s1,
 }
 
 void
-Test1::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
+Test1::WstringClassI::throwExcept(::std::wstring reason,
                                   const Ice::Current&)
 {
     Test1::WstringException ex;
@@ -32,7 +32,7 @@ Test1::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
 }
 
 ::std::wstring
-Test2::WstringClassI::opString(ICE_IN(::std::wstring) s1,
+Test2::WstringClassI::opString(::std::wstring s1,
                                ::std::wstring& s2,
                                const Ice::Current&)
 {
@@ -41,7 +41,7 @@ Test2::WstringClassI::opString(ICE_IN(::std::wstring) s1,
 }
 
 ::Test2::WstringStruct
-Test2::WstringClassI::opStruct(ICE_IN(::Test2::WstringStruct) s1,
+Test2::WstringClassI::opStruct(::Test2::WstringStruct s1,
                                ::Test2::WstringStruct& s2,
                                const Ice::Current&)
 {
@@ -50,7 +50,7 @@ Test2::WstringClassI::opStruct(ICE_IN(::Test2::WstringStruct) s1,
 }
 
 void
-Test2::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
+Test2::WstringClassI::throwExcept(::std::wstring reason,
                                   const Ice::Current&)
 {
     Test2::WstringException ex;

--- a/cpp/test/Ice/custom/WstringI.h
+++ b/cpp/test/Ice/custom/WstringI.h
@@ -14,15 +14,15 @@ class WstringClassI : public virtual WstringClass
 {
 public:
 
-    virtual ::std::wstring opString(ICE_IN(::std::wstring),
+    virtual ::std::wstring opString(::std::wstring,
                                     ::std::wstring&,
                                     const Ice::Current&);
 
-    virtual ::Test1::WstringStruct opStruct(ICE_IN(::Test1::WstringStruct),
+    virtual ::Test1::WstringStruct opStruct(::Test1::WstringStruct,
                                             ::Test1::WstringStruct&,
                                             const Ice::Current&);
 
-    virtual void throwExcept(ICE_IN(::std::wstring),
+    virtual void throwExcept(::std::wstring,
                              const Ice::Current&);
 };
 
@@ -35,15 +35,15 @@ class WstringClassI : public virtual WstringClass
 {
 public:
 
-    virtual ::std::wstring opString(ICE_IN(::std::wstring),
+    virtual ::std::wstring opString(::std::wstring,
                                     ::std::wstring&,
                                     const Ice::Current&);
 
-    virtual ::Test2::WstringStruct opStruct(ICE_IN(::Test2::WstringStruct),
+    virtual ::Test2::WstringStruct opStruct(::Test2::WstringStruct,
                                             ::Test2::WstringStruct&,
                                             const Ice::Current&);
 
-    virtual void throwExcept(ICE_IN(::std::wstring),
+    virtual void throwExcept(::std::wstring,
                              const Ice::Current&);
 };
 

--- a/cpp/test/Ice/defaultServant/AllTests.cpp
+++ b/cpp/test/Ice/defaultServant/AllTests.cpp
@@ -16,7 +16,7 @@ allTests(Test::TestHelper* helper)
     Ice::ObjectAdapterPtr oa = communicator->createObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");
     oa->activate();
 
-    Ice::ObjectPtr servant = ICE_MAKE_SHARED(MyObjectI);
+    Ice::ObjectPtr servant = std::make_shared<MyObjectI>();
 
     //
     // Register default servant with category "foo"

--- a/cpp/test/Ice/defaultValue/AllTests.cpp
+++ b/cpp/test/Ice/defaultValue/AllTests.cpp
@@ -91,7 +91,7 @@ allTests()
     }
 
     {
-        BasePtr v = ICE_MAKE_SHARED(Base);
+        BasePtr v = std::make_shared<Base>();
         test(!v->boolFalse);
         test(v->boolTrue);
         test(v->b == 1);
@@ -111,7 +111,7 @@ allTests()
     }
 
     {
-        DerivedPtr v = ICE_MAKE_SHARED(Derived);
+        DerivedPtr v = std::make_shared<Derived>();
         test(!v->boolFalse);
         test(v->boolTrue);
         test(v->b == 1);

--- a/cpp/test/Ice/dispatcher/AllTests.cpp
+++ b/cpp/test/Ice/dispatcher/AllTests.cpp
@@ -124,7 +124,7 @@ allTests(Test::TestHelper* helper)
     {
         p->op();
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opAsync(
             [cb]()
             {

--- a/cpp/test/Ice/dispatcher/Collocated.cpp
+++ b/cpp/test/Ice/dispatcher/Collocated.cpp
@@ -35,9 +35,9 @@ Collocated::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = std::make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/dispatcher/Server.cpp
+++ b/cpp/test/Ice/dispatcher/Server.cpp
@@ -43,9 +43,9 @@ Server::run(int argc, char** argv)
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
         Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-        TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+        TestIntfControllerIPtr testController = std::make_shared<TestIntfControllerI>(adapter);
 
-        adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         adapter->activate();
 
         adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -56,9 +56,9 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    BlobjectIPtr blob = ICE_MAKE_SHARED(BlobjectI);
+    BlobjectIPtr blob = std::make_shared<BlobjectI>();
     adapter->addDefaultServant(blob, "");
-    adapter->add(ICE_MAKE_SHARED(EchoI, blob), Ice::stringToIdentity("__echo"));
+    adapter->add(std::make_shared<EchoI>(blob), Ice::stringToIdentity("__echo"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/enums/AllTests.cpp
+++ b/cpp/test/Ice/enums/AllTests.cpp
@@ -21,74 +21,74 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing enum values... " << flush;
 
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum1)) == 0);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum2)) == 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum11)) == ByteConst2);
+    test(static_cast<int>(ByteEnum::benum1) == 0);
+    test(static_cast<int>(ByteEnum::benum2) == 1);
+    test(static_cast<int>(ByteEnum::benum3) == ByteConst1);
+    test(static_cast<int>(ByteEnum::benum4) == ByteConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum5) == ShortConst1);
+    test(static_cast<int>(ByteEnum::benum6) == ShortConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum7) == IntConst1);
+    test(static_cast<int>(ByteEnum::benum8) == IntConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum9) == LongConst1);
+    test(static_cast<int>(ByteEnum::benum10) == LongConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum11) == ByteConst2);
 
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum1)) == 3);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum2)) == 4);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum11)) == ShortConst2);
+    test(static_cast<int>(ShortEnum::senum1) == 3);
+    test(static_cast<int>(ShortEnum::senum2) == 4);
+    test(static_cast<int>(ShortEnum::senum3) == ByteConst1);
+    test(static_cast<int>(ShortEnum::senum4) == ByteConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum5) == ShortConst1);
+    test(static_cast<int>(ShortEnum::senum6) == ShortConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum7) == IntConst1);
+    test(static_cast<int>(ShortEnum::senum8) == IntConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum9) == LongConst1);
+    test(static_cast<int>(ShortEnum::senum10) == LongConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum11) == ShortConst2);
 
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum1)) == 0);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum2)) == 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum11)) == IntConst2);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum12)) == LongConst2);
+    test(static_cast<int>(IntEnum::ienum1) == 0);
+    test(static_cast<int>(IntEnum::ienum2) == 1);
+    test(static_cast<int>(IntEnum::ienum3) == ByteConst1);
+    test(static_cast<int>(IntEnum::ienum4) == ByteConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum5) == ShortConst1);
+    test(static_cast<int>(IntEnum::ienum6) == ShortConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum7) == IntConst1);
+    test(static_cast<int>(IntEnum::ienum8) == IntConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum9) == LongConst1);
+    test(static_cast<int>(IntEnum::ienum10) == LongConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum11) == IntConst2);
+    test(static_cast<int>(IntEnum::ienum12) == LongConst2);
 
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, red)) == 0);
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, green)) == 1);
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, blue)) == 2);
+    test(static_cast<int>(SimpleEnum::red) == 0);
+    test(static_cast<int>(SimpleEnum::green) == 1);
+    test(static_cast<int>(SimpleEnum::blue) == 2);
 
     cout << "ok" << endl;
 
     cout << "testing enum operations... " << flush;
 
     ByteEnum byteEnum;
-    test(proxy->opByte(ICE_ENUM(ByteEnum, benum1), byteEnum) == ICE_ENUM(ByteEnum, benum1));
-    test(byteEnum == ICE_ENUM(ByteEnum, benum1));
-    test(proxy->opByte(ICE_ENUM(ByteEnum, benum11), byteEnum) == ICE_ENUM(ByteEnum, benum11));
-    test(byteEnum == ICE_ENUM(ByteEnum, benum11));
+    test(proxy->opByte(ByteEnum::benum1, byteEnum) == ByteEnum::benum1);
+    test(byteEnum == ByteEnum::benum1);
+    test(proxy->opByte(ByteEnum::benum11, byteEnum) == ByteEnum::benum11);
+    test(byteEnum == ByteEnum::benum11);
 
     ShortEnum shortEnum;
-    test(proxy->opShort(ICE_ENUM(ShortEnum, senum1), shortEnum) == ICE_ENUM(ShortEnum, senum1));
-    test(shortEnum == ICE_ENUM(ShortEnum, senum1));
-    test(proxy->opShort(ICE_ENUM(ShortEnum, senum11), shortEnum) == ICE_ENUM(ShortEnum, senum11));
-    test(shortEnum == ICE_ENUM(ShortEnum, senum11));
+    test(proxy->opShort(ShortEnum::senum1, shortEnum) == ShortEnum::senum1);
+    test(shortEnum == ShortEnum::senum1);
+    test(proxy->opShort(ShortEnum::senum11, shortEnum) == ShortEnum::senum11);
+    test(shortEnum == ShortEnum::senum11);
 
     IntEnum intEnum;
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum1), intEnum) == ICE_ENUM(IntEnum, ienum1));
-    test(intEnum == ICE_ENUM(IntEnum, ienum1));
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum11), intEnum) == ICE_ENUM(IntEnum, ienum11));
-    test(intEnum == ICE_ENUM(IntEnum, ienum11));
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum12), intEnum) == ICE_ENUM(IntEnum, ienum12));
-    test(intEnum == ICE_ENUM(IntEnum, ienum12));
+    test(proxy->opInt(IntEnum::ienum1, intEnum) == IntEnum::ienum1);
+    test(intEnum == IntEnum::ienum1);
+    test(proxy->opInt(IntEnum::ienum11, intEnum) == IntEnum::ienum11);
+    test(intEnum == IntEnum::ienum11);
+    test(proxy->opInt(IntEnum::ienum12, intEnum) == IntEnum::ienum12);
+    test(intEnum == IntEnum::ienum12);
 
     SimpleEnum s;
-    test(proxy->opSimple(ICE_ENUM(SimpleEnum, green), s) == ICE_ENUM(SimpleEnum, green));
-    test(s == ICE_ENUM(SimpleEnum, green));
+    test(proxy->opSimple(SimpleEnum::green, s) == SimpleEnum::green);
+    test(s == SimpleEnum::green);
 
     cout << "ok" << endl;
 
@@ -97,17 +97,17 @@ allTests(Test::TestHelper* helper)
     {
         ByteEnum values[] =
         {
-            ICE_ENUM(ByteEnum, benum1),
-            ICE_ENUM(ByteEnum, benum2),
-            ICE_ENUM(ByteEnum, benum3),
-            ICE_ENUM(ByteEnum, benum4),
-            ICE_ENUM(ByteEnum, benum5),
-            ICE_ENUM(ByteEnum, benum6),
-            ICE_ENUM(ByteEnum, benum7),
-            ICE_ENUM(ByteEnum, benum8),
-            ICE_ENUM(ByteEnum, benum9),
-            ICE_ENUM(ByteEnum, benum10),
-            ICE_ENUM(ByteEnum, benum11)
+            ByteEnum::benum1,
+            ByteEnum::benum2,
+            ByteEnum::benum3,
+            ByteEnum::benum4,
+            ByteEnum::benum5,
+            ByteEnum::benum6,
+            ByteEnum::benum7,
+            ByteEnum::benum8,
+            ByteEnum::benum9,
+            ByteEnum::benum10,
+            ByteEnum::benum11
         };
         ByteEnumSeq b1(&values[0], &values[0] + sizeof(values) / sizeof(ByteEnum));
 
@@ -124,17 +124,17 @@ allTests(Test::TestHelper* helper)
     {
         ShortEnum values[] =
         {
-            ICE_ENUM(ShortEnum, senum1),
-            ICE_ENUM(ShortEnum, senum2),
-            ICE_ENUM(ShortEnum, senum3),
-            ICE_ENUM(ShortEnum, senum4),
-            ICE_ENUM(ShortEnum, senum5),
-            ICE_ENUM(ShortEnum, senum6),
-            ICE_ENUM(ShortEnum, senum7),
-            ICE_ENUM(ShortEnum, senum8),
-            ICE_ENUM(ShortEnum, senum9),
-            ICE_ENUM(ShortEnum, senum10),
-            ICE_ENUM(ShortEnum, senum11)
+            ShortEnum::senum1,
+            ShortEnum::senum2,
+            ShortEnum::senum3,
+            ShortEnum::senum4,
+            ShortEnum::senum5,
+            ShortEnum::senum6,
+            ShortEnum::senum7,
+            ShortEnum::senum8,
+            ShortEnum::senum9,
+            ShortEnum::senum10,
+            ShortEnum::senum11
         };
         ShortEnumSeq s1(&values[0], &values[0] + sizeof(values) / sizeof(ShortEnum));
 
@@ -151,17 +151,17 @@ allTests(Test::TestHelper* helper)
     {
         IntEnum values[] =
         {
-            ICE_ENUM(IntEnum, ienum1),
-            ICE_ENUM(IntEnum, ienum2),
-            ICE_ENUM(IntEnum, ienum3),
-            ICE_ENUM(IntEnum, ienum4),
-            ICE_ENUM(IntEnum, ienum5),
-            ICE_ENUM(IntEnum, ienum6),
-            ICE_ENUM(IntEnum, ienum7),
-            ICE_ENUM(IntEnum, ienum8),
-            ICE_ENUM(IntEnum, ienum9),
-            ICE_ENUM(IntEnum, ienum10),
-            ICE_ENUM(IntEnum, ienum11)
+            IntEnum::ienum1,
+            IntEnum::ienum2,
+            IntEnum::ienum3,
+            IntEnum::ienum4,
+            IntEnum::ienum5,
+            IntEnum::ienum6,
+            IntEnum::ienum7,
+            IntEnum::ienum8,
+            IntEnum::ienum9,
+            IntEnum::ienum10,
+            IntEnum::ienum11
         };
         IntEnumSeq i1(&values[0], &values[0] + sizeof(values) / sizeof(IntEnum));
 
@@ -178,9 +178,9 @@ allTests(Test::TestHelper* helper)
     {
         SimpleEnum values[] =
         {
-            ICE_ENUM(SimpleEnum, red),
-            ICE_ENUM(SimpleEnum, green),
-            ICE_ENUM(SimpleEnum, blue)
+            SimpleEnum::red,
+            SimpleEnum::green,
+            SimpleEnum::blue
         };
         SimpleEnumSeq s1(&values[0], &values[0] + sizeof(values) / sizeof(SimpleEnum));
 

--- a/cpp/test/Ice/enums/Server.cpp
+++ b/cpp/test/Ice/enums/Server.cpp
@@ -21,7 +21,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/enums/TestI.cpp
+++ b/cpp/test/Ice/enums/TestI.cpp
@@ -34,28 +34,28 @@ TestIntfI::opSimple(Test::SimpleEnum s1, Test::SimpleEnum& s2, const Ice::Curren
 }
 
 Test::ByteEnumSeq
-TestIntfI::opByteSeq(ICE_IN(Test::ByteEnumSeq) bs1, Test::ByteEnumSeq& bs2, const Ice::Current&)
+TestIntfI::opByteSeq(Test::ByteEnumSeq bs1, Test::ByteEnumSeq& bs2, const Ice::Current&)
 {
     bs2 = bs1;
     return bs1;
 }
 
 Test::ShortEnumSeq
-TestIntfI::opShortSeq(ICE_IN(Test::ShortEnumSeq) ss1, Test::ShortEnumSeq& ss2, const ::Ice::Current&)
+TestIntfI::opShortSeq(Test::ShortEnumSeq ss1, Test::ShortEnumSeq& ss2, const ::Ice::Current&)
 {
     ss2 = ss1;
     return ss1;
 }
 
 Test::IntEnumSeq
-TestIntfI::opIntSeq(ICE_IN(Test::IntEnumSeq) is1, Test::IntEnumSeq& is2, const ::Ice::Current&)
+TestIntfI::opIntSeq(Test::IntEnumSeq is1, Test::IntEnumSeq& is2, const ::Ice::Current&)
 {
     is2 = is1;
     return is1;
 }
 
 Test::SimpleEnumSeq
-TestIntfI::opSimpleSeq(ICE_IN(Test::SimpleEnumSeq) ss1, Test::SimpleEnumSeq& ss2, const ::Ice::Current&)
+TestIntfI::opSimpleSeq(Test::SimpleEnumSeq ss1, Test::SimpleEnumSeq& ss2, const ::Ice::Current&)
 {
     ss2 = ss1;
     return ss1;

--- a/cpp/test/Ice/enums/TestI.h
+++ b/cpp/test/Ice/enums/TestI.h
@@ -19,13 +19,13 @@ public:
 
     virtual Test::SimpleEnum opSimple(Test::SimpleEnum, Test::SimpleEnum&, const Ice::Current&);
 
-    virtual Test::ByteEnumSeq opByteSeq(ICE_IN(Test::ByteEnumSeq), Test::ByteEnumSeq&, const Ice::Current&);
+    virtual Test::ByteEnumSeq opByteSeq(Test::ByteEnumSeq, Test::ByteEnumSeq&, const Ice::Current&);
 
-    virtual Test::ShortEnumSeq opShortSeq(ICE_IN(Test::ShortEnumSeq), Test::ShortEnumSeq&, const ::Ice::Current&);
+    virtual Test::ShortEnumSeq opShortSeq(Test::ShortEnumSeq, Test::ShortEnumSeq&, const ::Ice::Current&);
 
-    virtual Test::IntEnumSeq opIntSeq(ICE_IN(Test::IntEnumSeq), Test::IntEnumSeq&, const ::Ice::Current&);
+    virtual Test::IntEnumSeq opIntSeq(Test::IntEnumSeq, Test::IntEnumSeq&, const ::Ice::Current&);
 
-    virtual Test::SimpleEnumSeq opSimpleSeq(ICE_IN(Test::SimpleEnumSeq), Test::SimpleEnumSeq&, const ::Ice::Current&);
+    virtual Test::SimpleEnumSeq opSimpleSeq(Test::SimpleEnumSeq, Test::SimpleEnumSeq&, const ::Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };

--- a/cpp/test/Ice/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/exceptions/AllTests.cpp
@@ -528,7 +528,7 @@ allTests(Test::TestHelper* helper)
     {
         communicator->getProperties()->setProperty("TestAdapter1.Endpoints", localOAEndpoint);
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter1");
-        Ice::ObjectPtr obj = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj = std::make_shared<EmptyI>();
         adapter->add(obj, Ice::stringToIdentity("x"));
         try
         {
@@ -594,7 +594,7 @@ allTests(Test::TestHelper* helper)
     {
         communicator->getProperties()->setProperty("TestAdapter2.Endpoints", localOAEndpoint);
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter2");
-        Ice::ServantLocatorPtr loc = ICE_MAKE_SHARED(ServantLocatorI);
+        Ice::ServantLocatorPtr loc = std::make_shared<ServantLocatorI>();
         adapter->addServantLocator(loc, "x");
         try
         {

--- a/cpp/test/Ice/exceptions/Collocated.cpp
+++ b/cpp/test/Ice/exceptions/Collocated.cpp
@@ -28,7 +28,7 @@ Collocated::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
 
     ThrowerPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/exceptions/Server.cpp
+++ b/cpp/test/Ice/exceptions/Server.cpp
@@ -33,7 +33,7 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
     Ice::ObjectAdapterPtr adapter3 = communicator->createObjectAdapter("TestAdapter3");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
     adapter2->add(object, Ice::stringToIdentity("thrower"));
     adapter3->add(object, Ice::stringToIdentity("thrower"));

--- a/cpp/test/Ice/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/exceptions/ServerAMD.cpp
@@ -32,7 +32,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
     Ice::ObjectAdapterPtr adapter3 = communicator->createObjectAdapter("TestAdapter3");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
     adapter2->add(object, Ice::stringToIdentity("thrower"));
     adapter3->add(object, Ice::stringToIdentity("thrower"));

--- a/cpp/test/Ice/exceptions/TestAMDI.cpp
+++ b/cpp/test/Ice/exceptions/TestAMDI.cpp
@@ -292,7 +292,7 @@ ThrowerI::throwAssertExceptionAsync(function<void()>,
 }
 
 void
-ThrowerI::throwMemoryLimitExceptionAsync(ICE_IN(Ice::ByteSeq),
+ThrowerI::throwMemoryLimitExceptionAsync(Ice::ByteSeq,
                                          function<void(const Ice::ByteSeq&)> response,
                                          function<void(exception_ptr)>,
                                          const Ice::Current&)

--- a/cpp/test/Ice/exceptions/TestAMDI.h
+++ b/cpp/test/Ice/exceptions/TestAMDI.h
@@ -95,7 +95,7 @@ public:
                                            std::function<void(std::exception_ptr)>,
                                            const Ice::Current&);
 
-    virtual void throwMemoryLimitExceptionAsync(ICE_IN(Ice::ByteSeq),
+    virtual void throwMemoryLimitExceptionAsync(Ice::ByteSeq,
                                                 std::function<void(const Ice::ByteSeq&)>,
                                                 std::function<void(std::exception_ptr)>,
                                                 const Ice::Current&);

--- a/cpp/test/Ice/exceptions/TestI.cpp
+++ b/cpp/test/Ice/exceptions/TestI.cpp
@@ -148,7 +148,7 @@ ThrowerI::throwAssertException(const Ice::Current&)
 }
 
 Ice::ByteSeq
-ThrowerI::throwMemoryLimitException(ICE_IN(Ice::ByteSeq), const Ice::Current&)
+ThrowerI::throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&)
 {
     return Ice::ByteSeq(1024 * 20); // 20 KB.
 }

--- a/cpp/test/Ice/exceptions/TestI.h
+++ b/cpp/test/Ice/exceptions/TestI.h
@@ -35,7 +35,7 @@ public:
     virtual void throwLocalException(const Ice::Current&);
     virtual void throwNonIceException(const Ice::Current&);
     virtual void throwAssertException(const Ice::Current&);
-    virtual Ice::ByteSeq throwMemoryLimitException(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual Ice::ByteSeq throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&);
 
     virtual void throwLocalExceptionIdempotent(const Ice::Current&);
 

--- a/cpp/test/Ice/facets/AllTests.cpp
+++ b/cpp/test/Ice/facets/AllTests.cpp
@@ -59,7 +59,7 @@ allTests(Test::TestHelper* helper)
        communicator->getProperties()->getProperty("Ice.Default.Protocol") != "wss")
     {
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("FacetExceptionTestAdapter");
-        Ice::ObjectPtr obj = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj = std::make_shared<EmptyI>();
         adapter->add(obj, Ice::stringToIdentity("d"));
         adapter->addFacet(obj, Ice::stringToIdentity("d"), "facetABCD");
         try
@@ -82,11 +82,11 @@ allTests(Test::TestHelper* helper)
         cout << "ok" << endl;
 
         cout << "testing removeAllFacets... " << flush;
-        Ice::ObjectPtr obj1 = ICE_MAKE_SHARED(EmptyI);
-        Ice::ObjectPtr obj2 = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj1 = std::make_shared<EmptyI>();
+        Ice::ObjectPtr obj2 = std::make_shared<EmptyI>();
         adapter->addFacet(obj1, Ice::stringToIdentity("id1"), "f1");
         adapter->addFacet(obj2, Ice::stringToIdentity("id1"), "f2");
-        Ice::ObjectPtr obj3 = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj3 = std::make_shared<EmptyI>();
         adapter->addFacet(obj1, Ice::stringToIdentity("id2"), "f1");
         adapter->addFacet(obj2, Ice::stringToIdentity("id2"), "f2");
         adapter->addFacet(obj3, Ice::stringToIdentity("id2"), "");

--- a/cpp/test/Ice/facets/Collocated.cpp
+++ b/cpp/test/Ice/facets/Collocated.cpp
@@ -22,12 +22,12 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr d = ICE_MAKE_SHARED(DI);
+    Ice::ObjectPtr d = std::make_shared<DI>();
     adapter->add(d, Ice::stringToIdentity("d"));
     adapter->addFacet(d, Ice::stringToIdentity("d"), "facetABCD");
-    Ice::ObjectPtr f = ICE_MAKE_SHARED(FI);
+    Ice::ObjectPtr f = std::make_shared<FI>();
     adapter->addFacet(f, Ice::stringToIdentity("d"), "facetEF");
-    Ice::ObjectPtr h = ICE_MAKE_SHARED(HI);
+    Ice::ObjectPtr h = std::make_shared<HI>();
     adapter->addFacet(h, Ice::stringToIdentity("d"), "facetGH");
 
     GPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/facets/Server.cpp
+++ b/cpp/test/Ice/facets/Server.cpp
@@ -19,12 +19,12 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr d = ICE_MAKE_SHARED(DI);
+    Ice::ObjectPtr d = std::make_shared<DI>();
     adapter->add(d, Ice::stringToIdentity("d"));
     adapter->addFacet(d, Ice::stringToIdentity("d"), "facetABCD");
-    Ice::ObjectPtr f = ICE_MAKE_SHARED(FI);
+    Ice::ObjectPtr f = std::make_shared<FI>();
     adapter->addFacet(f, Ice::stringToIdentity("d"), "facetEF");
-    Ice::ObjectPtr h = ICE_MAKE_SHARED(HI);
+    Ice::ObjectPtr h = std::make_shared<HI>();
     adapter->addFacet(h, Ice::stringToIdentity("d"), "facetGH");
     serverReady();
     adapter->activate();

--- a/cpp/test/Ice/faultTolerance/Server.cpp
+++ b/cpp/test/Ice/faultTolerance/Server.cpp
@@ -55,7 +55,7 @@ Server::run(int argc, char** argv)
     endpts << getTestEndpoint(port);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", endpts.str());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/hold/AllTests.cpp
+++ b/cpp/test/Ice/hold/AllTests.cpp
@@ -232,7 +232,7 @@ allTests(Test::TestHelper* helper)
             {
                 completed->get_future().get();
                 holdSerialized->ice_ping(); // Ensure everything's dispatched
-                holdSerialized->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                holdSerialized->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
         }
         completed->get_future().get();

--- a/cpp/test/Ice/hold/Server.cpp
+++ b/cpp/test/Ice/hold/Server.cpp
@@ -27,7 +27,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter1.ThreadPool.SizeWarn", "0");
     communicator->getProperties()->setProperty("TestAdapter1.ThreadPool.Serialize", "0");
     Ice::ObjectAdapterPtr adapter1 = communicator->createObjectAdapter("TestAdapter1");
-    adapter1->add(ICE_MAKE_SHARED(HoldI, timer, adapter1), Ice::stringToIdentity("hold"));
+    adapter1->add(std::make_shared<HoldI>(timer, adapter1), Ice::stringToIdentity("hold"));
 
     communicator->getProperties()->setProperty("TestAdapter2.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.Size", "5");
@@ -35,7 +35,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.SizeWarn", "0");
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.Serialize", "1");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
-    adapter2->add(ICE_MAKE_SHARED(HoldI, timer, adapter2), Ice::stringToIdentity("hold"));
+    adapter2->add(std::make_shared<HoldI>(timer, adapter2), Ice::stringToIdentity("hold"));
 
     adapter1->activate();
     adapter2->activate();

--- a/cpp/test/Ice/hold/TestI.cpp
+++ b/cpp/test/Ice/hold/TestI.cpp
@@ -28,7 +28,7 @@ HoldI::putOnHold(Ice::Int milliSeconds, const Ice::Current&)
     {
         try
         {
-            _timer->schedule(ICE_SHARED_FROM_THIS, IceUtil::Time::milliSeconds(milliSeconds));
+            _timer->schedule(shared_from_this(), IceUtil::Time::milliSeconds(milliSeconds));
         }
         catch(const IceUtil::IllegalArgumentException&)
         {
@@ -72,7 +72,7 @@ HoldI::waitForHold(const Ice::Current& current)
 
     try
     {
-        _timer->schedule(ICE_MAKE_SHARED(WaitForHold, current.adapter), IceUtil::Time());
+        _timer->schedule(std::make_shared<WaitForHold>(current.adapter), IceUtil::Time());
     }
     catch(const IceUtil::IllegalArgumentException&)
     {

--- a/cpp/test/Ice/impl/Server.cpp
+++ b/cpp/test/Ice/impl/Server.cpp
@@ -29,7 +29,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/impl/ServerAMD.cpp
+++ b/cpp/test/Ice/impl/ServerAMD.cpp
@@ -29,7 +29,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/info/AllTests.cpp
+++ b/cpp/test/Ice/info/AllTests.cpp
@@ -24,7 +24,7 @@ getTCPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return tcpInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::TCPConnectionInfoPtr
@@ -38,7 +38,7 @@ getTCPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return tcpInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/info/Server.cpp
+++ b/cpp/test/Ice/info/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints",
                                                getTestEndpoint() + ":" + getTestEndpoint("udp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/info/TestI.cpp
+++ b/cpp/test/Ice/info/TestI.cpp
@@ -25,7 +25,7 @@ getIPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::IPConnectionInfoPtr
@@ -39,7 +39,7 @@ getIPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/inheritance/AllTests.cpp
+++ b/cpp/test/Ice/inheritance/AllTests.cpp
@@ -274,19 +274,19 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing one shot constructor... " << flush;
     {
-        MC::APtr a = ICE_MAKE_SHARED(MC::A, 1);
+        MC::APtr a = std::make_shared<MC::A>(1);
         test(a->aA == 1);
 
-        MC::BPtr b = ICE_MAKE_SHARED(MC::B, 1, 2);
+        MC::BPtr b = std::make_shared<MC::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MC::CPtr c = ICE_MAKE_SHARED(MC::C, 1, 2, 3);
+        MC::CPtr c = std::make_shared<MC::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MC::DPtr d = ICE_MAKE_SHARED(MC::D, 1, 2, 3, 4);
+        MC::DPtr d = std::make_shared<MC::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -294,19 +294,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MD::APtr a = ICE_MAKE_SHARED(MD::A, 1);
+        MD::APtr a = std::make_shared<MD::A>(1);
         test(a->aA == 1);
 
-        MD::BPtr b = ICE_MAKE_SHARED(MD::B, 1, 2);
+        MD::BPtr b = std::make_shared<MD::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MD::CPtr c = ICE_MAKE_SHARED(MD::C, 1, 2, 3);
+        MD::CPtr c = std::make_shared<MD::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MD::DPtr d = ICE_MAKE_SHARED(MD::D, 1, 2, 3, 4);
+        MD::DPtr d = std::make_shared<MD::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -314,19 +314,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        ME::APtr a = ICE_MAKE_SHARED(ME::A, 1);
+        ME::APtr a = std::make_shared<ME::A>(1);
         test(a->aA == 1);
 
-        ME::BPtr b = ICE_MAKE_SHARED(ME::B, 1, 2);
+        ME::BPtr b = std::make_shared<ME::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        ME::CPtr c = ICE_MAKE_SHARED(ME::C, 1, 2, 3);
+        ME::CPtr c = std::make_shared<ME::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        ME::DPtr d = ICE_MAKE_SHARED(ME::D, 1, 2, 3, 4);
+        ME::DPtr d = std::make_shared<ME::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -334,19 +334,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MF::APtr a = ICE_MAKE_SHARED(MF::A, 1);
+        MF::APtr a = std::make_shared<MF::A>(1);
         test(a->aA == 1);
 
-        MF::BPtr b = ICE_MAKE_SHARED(MF::B, 1, 2);
+        MF::BPtr b = std::make_shared<MF::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MF::CPtr c = ICE_MAKE_SHARED(MF::C, 1, 2, 3);
+        MF::CPtr c = std::make_shared<MF::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MF::DPtr d = ICE_MAKE_SHARED(MF::D, 1, 2, 3, 4);
+        MF::DPtr d = std::make_shared<MF::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -354,19 +354,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MG::APtr a = ICE_MAKE_SHARED(MG::A, 1);
+        MG::APtr a = std::make_shared<MG::A>(1);
         test(a->aA == 1);
 
-        MG::BPtr b = ICE_MAKE_SHARED(MG::B, 1, 2);
+        MG::BPtr b = std::make_shared<MG::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MG::CPtr c = ICE_MAKE_SHARED(MG::C, 1, 2, 3);
+        MG::CPtr c = std::make_shared<MG::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MG::DPtr d = ICE_MAKE_SHARED(MG::D, 1, 2, 3, 4);
+        MG::DPtr d = std::make_shared<MG::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -374,19 +374,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MH::APtr a = ICE_MAKE_SHARED(MH::A, 1);
+        MH::APtr a = std::make_shared<MH::A>(1);
         test(a->aA == 1);
 
-        MH::BPtr b = ICE_MAKE_SHARED(MH::B, 1, 2);
+        MH::BPtr b = std::make_shared<MH::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MH::CPtr c = ICE_MAKE_SHARED(MH::C, 1, 2, 3);
+        MH::CPtr c = std::make_shared<MH::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MH::DPtr d = ICE_MAKE_SHARED(MH::D, 1, 2, 3, 4);
+        MH::DPtr d = std::make_shared<MH::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);

--- a/cpp/test/Ice/inheritance/Collocated.cpp
+++ b/cpp/test/Ice/inheritance/Collocated.cpp
@@ -22,7 +22,7 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(InitialI, adapter);
+    Ice::ObjectPtr object = std::make_shared<InitialI>(adapter);
     adapter->add(object, Ice::stringToIdentity("initial"));
     InitialPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/inheritance/Server.cpp
+++ b/cpp/test/Ice/inheritance/Server.cpp
@@ -21,7 +21,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(InitialI, adapter);
+    Ice::ObjectPtr object = std::make_shared<InitialI>(adapter);
     adapter->add(object, Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/inheritance/TestI.cpp
+++ b/cpp/test/Ice/inheritance/TestI.cpp
@@ -8,49 +8,49 @@
 using namespace Test;
 
 MA::CAPrxPtr
-CAI_::caop(ICE_IN(MA::CAPrxPtr) p, const Ice::Current&)
+CAI_::caop(MA::CAPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MB::CBPrxPtr
-CBI::cbop(ICE_IN(MB::CBPrxPtr) p, const Ice::Current&)
+CBI::cbop(MB::CBPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MA::CCPrxPtr
-CCI::ccop(ICE_IN(MA::CCPrxPtr) p, const Ice::Current&)
+CCI::ccop(MA::CCPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MA::CDPrxPtr
-CDI::cdop(ICE_IN(MA::CDPrxPtr) p, const Ice::Current&)
+CDI::cdop(MA::CDPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MA::IAPrxPtr
-IAI::iaop(ICE_IN(MA::IAPrxPtr) p, const Ice::Current&)
+IAI::iaop(MA::IAPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MB::IB1PrxPtr
-IB1I::ib1op(ICE_IN(MB::IB1PrxPtr) p, const Ice::Current&)
+IB1I::ib1op(MB::IB1PrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MB::IB2PrxPtr
-IB2I::ib2op(ICE_IN(MB::IB2PrxPtr) p, const Ice::Current&)
+IB2I::ib2op(MB::IB2PrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MA::ICPrxPtr
-ICI::icop(ICE_IN(MA::ICPrxPtr) p, const Ice::Current&)
+ICI::icop(MA::ICPrxPtr p, const Ice::Current&)
 {
     return p;
 }

--- a/cpp/test/Ice/inheritance/TestI.cpp
+++ b/cpp/test/Ice/inheritance/TestI.cpp
@@ -57,14 +57,14 @@ ICI::icop(ICE_IN(MA::ICPrxPtr) p, const Ice::Current&)
 
 InitialI::InitialI(const Ice::ObjectAdapterPtr& adapter)
 {
-    _ca = ICE_UNCHECKED_CAST(MA::CAPrx, adapter->addWithUUID(ICE_MAKE_SHARED(CAI_)));
-    _cb = ICE_UNCHECKED_CAST(MB::CBPrx, adapter->addWithUUID(ICE_MAKE_SHARED(CBI)));
-    _cc = ICE_UNCHECKED_CAST(MA::CCPrx, adapter->addWithUUID(ICE_MAKE_SHARED(CCI)));
-    _cd = ICE_UNCHECKED_CAST(MA::CDPrx, adapter->addWithUUID(ICE_MAKE_SHARED(CDI)));
-    _ia = ICE_UNCHECKED_CAST(MA::IAPrx, adapter->addWithUUID(ICE_MAKE_SHARED(IAI)));
-    _ib1 = ICE_UNCHECKED_CAST(MB::IB1Prx, adapter->addWithUUID(ICE_MAKE_SHARED(IB1I)));
-    _ib2 = ICE_UNCHECKED_CAST(MB::IB2Prx, adapter->addWithUUID(ICE_MAKE_SHARED(IB2I)));
-    _ic = ICE_UNCHECKED_CAST(MA::ICPrx, adapter->addWithUUID(ICE_MAKE_SHARED(ICI)));
+    _ca = ICE_UNCHECKED_CAST(MA::CAPrx, adapter->addWithUUID(std::make_shared<CAI_>()));
+    _cb = ICE_UNCHECKED_CAST(MB::CBPrx, adapter->addWithUUID(std::make_shared<CBI>()));
+    _cc = ICE_UNCHECKED_CAST(MA::CCPrx, adapter->addWithUUID(std::make_shared<CCI>()));
+    _cd = ICE_UNCHECKED_CAST(MA::CDPrx, adapter->addWithUUID(std::make_shared<CDI>()));
+    _ia = ICE_UNCHECKED_CAST(MA::IAPrx, adapter->addWithUUID(std::make_shared<IAI>()));
+    _ib1 = ICE_UNCHECKED_CAST(MB::IB1Prx, adapter->addWithUUID(std::make_shared<IB1I>()));
+    _ib2 = ICE_UNCHECKED_CAST(MB::IB2Prx, adapter->addWithUUID(std::make_shared<IB2I>()));
+    _ic = ICE_UNCHECKED_CAST(MA::ICPrx, adapter->addWithUUID(std::make_shared<ICI>()));
 }
 
 void

--- a/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
+++ b/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
@@ -113,7 +113,7 @@ void
 AMDInterceptorI::setException(const IceUtil::Exception& e)
 {
     IceUtil::Mutex::Lock lock(_mutex);
-    ICE_SET_EXCEPTION_FROM_CLONE(_exception, e.ice_clone());
+    _exception = e.ice_clone();
 }
 
 IceUtil::Exception*

--- a/cpp/test/Ice/interceptor/Client.cpp
+++ b/cpp/test/Ice/interceptor/Client.cpp
@@ -59,9 +59,9 @@ Client::run(int argc, char* argv[])
     //
     Ice::ObjectAdapterPtr oa = communicator->createObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");
 
-    Ice::ObjectPtr servant = ICE_MAKE_SHARED(MyObjectI);
-    InterceptorIPtr interceptor = ICE_MAKE_SHARED(InterceptorI, servant);
-    AMDInterceptorIPtr amdInterceptor = ICE_MAKE_SHARED(AMDInterceptorI, servant);
+    Ice::ObjectPtr servant = std::make_shared<MyObjectI>();
+    InterceptorIPtr interceptor = std::make_shared<InterceptorI>(servant);
+    AMDInterceptorIPtr amdInterceptor = std::make_shared<AMDInterceptorI>(servant);
 
     Test::MyObjectPrxPtr prx = ICE_UNCHECKED_CAST(Test::MyObjectPrx, oa->addWithUUID(interceptor));
     Test::MyObjectPrxPtr prxForAMD = ICE_UNCHECKED_CAST(Test::MyObjectPrx, oa->addWithUUID(amdInterceptor));

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -28,15 +28,15 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::ByteSeq inEncaps, outEncaps;
-        if(!oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps))
+        if(!oneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps))
         {
             test(false);
         }
 
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
         batchOneway->ice_flushBatchRequests();
 
         Ice::OutputStream out(communicator);
@@ -46,7 +46,7 @@ allTests(Test::TestHelper* helper)
         out.finished(inEncaps);
 
         // ice_invoke
-        if(cl->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps))
+        if(cl->ice_invoke("opString", Ice::OperationMode::Normal, inEncaps, outEncaps))
         {
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -64,7 +64,7 @@ allTests(Test::TestHelper* helper)
 
         // ice_invoke with array mapping
         pair<const ::Ice::Byte*, const ::Ice::Byte*> inPair(&inEncaps[0], &inEncaps[0] + inEncaps.size());
-        if(cl->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inPair, outEncaps))
+        if(cl->ice_invoke("opString", Ice::OperationMode::Normal, inPair, outEncaps))
         {
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -89,7 +89,7 @@ allTests(Test::TestHelper* helper)
         {
             ctx["raise"] = "";
         }
-        if(cl->ice_invoke("opException", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps, ctx))
+        if(cl->ice_invoke("opException", Ice::OperationMode::Normal, inEncaps, outEncaps, ctx))
         {
             test(false);
         }
@@ -118,7 +118,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::ByteSeq inEncaps;
-        batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps,
+        batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps,
             [](bool, const vector<Ice::Byte>)
             {
                 test(false);
@@ -138,10 +138,10 @@ allTests(Test::TestHelper* helper)
     //
     {
         Ice::ByteSeq inEncaps;
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
         batchOneway->ice_flushBatchRequests();
     }
 

--- a/cpp/test/Ice/invoke/BlobjectI.cpp
+++ b/cpp/test/Ice/invoke/BlobjectI.cpp
@@ -79,14 +79,14 @@ invokeInternal(Ice::InputStream& in, vector<Ice::Byte>& outEncaps, const Ice::Cu
 }
 
 bool
-BlobjectI::ice_invoke(ICE_IN(vector<Ice::Byte>) inEncaps, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
+BlobjectI::ice_invoke(vector<Ice::Byte> inEncaps, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);
     return invokeInternal(in, outEncaps, current);
 }
 
 bool
-BlobjectArrayI::ice_invoke(ICE_IN(pair<const Ice::Byte*, const Ice::Byte*>) inEncaps, vector<Ice::Byte>& outEncaps,
+BlobjectArrayI::ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inEncaps, vector<Ice::Byte>& outEncaps,
                            const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);

--- a/cpp/test/Ice/invoke/BlobjectI.h
+++ b/cpp/test/Ice/invoke/BlobjectI.h
@@ -11,14 +11,14 @@ class BlobjectI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::vector<Ice::Byte>), std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
 };
 
 class BlobjectArrayI : public Ice::BlobjectArray
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>), std::vector<Ice::Byte>&,
+    virtual bool ice_invoke(std::pair<const Ice::Byte*, const Ice::Byte*>, std::vector<Ice::Byte>&,
                             const Ice::Current&);
 };
 

--- a/cpp/test/Ice/invoke/Server.cpp
+++ b/cpp/test/Ice/invoke/Server.cpp
@@ -19,22 +19,22 @@ public:
         {
             if(async)
             {
-                _blobject = ICE_MAKE_SHARED(BlobjectArrayAsyncI);
+                _blobject = std::make_shared<BlobjectArrayAsyncI>();
             }
             else
             {
-                _blobject = ICE_MAKE_SHARED(BlobjectArrayI);
+                _blobject = std::make_shared<BlobjectArrayI>();
             }
         }
         else
         {
             if(async)
             {
-                _blobject = ICE_MAKE_SHARED(BlobjectAsyncI);
+                _blobject = std::make_shared<BlobjectAsyncI>();
             }
             else
             {
-                _blobject = ICE_MAKE_SHARED(BlobjectI);
+                _blobject = std::make_shared<BlobjectI>();
             }
         }
     }
@@ -89,7 +89,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, array, async), "");
+    adapter->addServantLocator(std::make_shared<ServantLocatorI>(array, async), "");
     adapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/library/AllTests.cpp
+++ b/cpp/test/Ice/library/AllTests.cpp
@@ -32,7 +32,7 @@ TestI::op(bool throwIt, const Ice::Current&)
 ICE_DECLSPEC_EXPORT
 void allTests(const Ice::ObjectAdapterPtr& oa)
 {
-    Test::MyInterfacePtr servant = ICE_MAKE_SHARED(TestI);
+    Test::MyInterfacePtr servant = std::make_shared<TestI>();
     Test::MyInterfacePrxPtr proxy = ICE_UNCHECKED_CAST(Test::MyInterfacePrx, oa->addWithUUID(servant));
     consume(servant, proxy);
 }

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -594,7 +594,7 @@ allTests(Test::TestHelper* helper, const string& ref)
     cout << "testing object migration... " << flush;
     hello = ICE_CHECKED_CAST(HelloPrx, communicator->stringToProxy("hello"));
     obj->migrateHello();
-    hello->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    hello->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
     hello->sayHello();
     obj->migrateHello();
     hello->sayHello();

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -79,7 +79,7 @@ allTests(Test::TestHelper* helper, const string& ref)
     Ice::LocatorPrxPtr anotherLocator = ICE_UNCHECKED_CAST(Ice::LocatorPrx, communicator->stringToProxy("anotherLocator"));
     base = base->ice_locator(anotherLocator);
     test(Ice::proxyIdentityEqual(base->ice_getLocator(), anotherLocator));
-    communicator->setDefaultLocator(ICE_NULLPTR);
+    communicator->setDefaultLocator(nullptr);
     base = communicator->stringToProxy("test @ TestAdapter");
     test(!base->ice_getLocator());
     base = base->ice_locator(anotherLocator);

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -654,7 +654,7 @@ allTests(Test::TestHelper* helper, const string& ref)
 
         Ice::Identity id;
         id.name = Ice::generateUUID();
-        adapter->add(ICE_MAKE_SHARED(HelloI), id);
+        adapter->add(std::make_shared<HelloI>(), id);
 
         // Ensure that calls on the well-known proxy is collocated.
         HelloPrxPtr helloPrx = ICE_CHECKED_CAST(HelloPrx, communicator->stringToProxy(communicator->identityToString(id)));

--- a/cpp/test/Ice/location/Server.cpp
+++ b/cpp/test/Ice/location/Server.cpp
@@ -39,16 +39,16 @@ Server::run(int argc, char** argv)
     // locator interface, this locator is used by the clients and the
     // 'servers' created with the server manager interface.
     //
-    ServerLocatorRegistryPtr registry = ICE_MAKE_SHARED(ServerLocatorRegistry);
+    ServerLocatorRegistryPtr registry = std::make_shared<ServerLocatorRegistry>();
     registry->addObject(adapter->createProxy(Ice::stringToIdentity("ServerManager")));
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ServerManagerI, registry, initData);
+    Ice::ObjectPtr object = std::make_shared<ServerManagerI>(registry, initData);
     adapter->add(object, Ice::stringToIdentity("ServerManager"));
 
     Ice::LocatorRegistryPrxPtr registryPrx =
         ICE_UNCHECKED_CAST(Ice::LocatorRegistryPrx,
                            adapter->add(registry, Ice::stringToIdentity("registry")));
 
-    Ice::LocatorPtr locator = ICE_MAKE_SHARED(ServerLocator, registry, registryPrx);
+    Ice::LocatorPtr locator = std::make_shared<ServerLocator>(registry, registryPrx);
     adapter->add(locator, Ice::stringToIdentity("locator"));
 
     adapter->activate();

--- a/cpp/test/Ice/location/TestI.cpp
+++ b/cpp/test/Ice/location/TestI.cpp
@@ -67,7 +67,7 @@ ServerManagerI::startServer(const Ice::Current&)
             adapter->setLocator(ICE_UNCHECKED_CAST(Ice::LocatorPrx, locator));
             adapter2->setLocator(ICE_UNCHECKED_CAST(Ice::LocatorPrx, locator));
 
-            Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI, adapter, adapter2, _registry);
+            Ice::ObjectPtr object = std::make_shared<TestI>(adapter, adapter2, _registry);
             _registry->addObject(adapter->add(object, Ice::stringToIdentity("test")));
             _registry->addObject(adapter->add(object, Ice::stringToIdentity("test2")));
             adapter->add(object, Ice::stringToIdentity("test3"));
@@ -112,7 +112,7 @@ TestI::TestI(const Ice::ObjectAdapterPtr& adapter,
              const ServerLocatorRegistryPtr& registry) :
     _adapter1(adapter), _adapter2(adapter2), _registry(registry)
 {
-    _registry->addObject(_adapter1->add(ICE_MAKE_SHARED(HelloI), Ice::stringToIdentity("hello")));
+    _registry->addObject(_adapter1->add(std::make_shared<HelloI>(), Ice::stringToIdentity("hello")));
 }
 
 void

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -441,7 +441,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     IceMX::MetricsAdminPrxPtr serverMetrics = ICE_CHECKED_CAST(IceMX::MetricsAdminPrx, admin, "Metrics");
     test(serverProps && serverMetrics);
 
-    UpdateCallbackIPtr update = ICE_MAKE_SHARED(UpdateCallbackI, serverProps);
+    UpdateCallbackIPtr update = std::make_shared<UpdateCallbackI>(serverProps);
 
     ICE_DYNAMIC_CAST(Ice::NativePropertiesAdmin, communicator->findAdminFacet("Properties"))->addUpdateCallback(
         [update](const Ice::PropertyDict& changes) { update->updated(changes); }

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -279,7 +279,7 @@ struct Connect
     {
         if(proxy->ice_getCachedConnection())
         {
-            proxy->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            proxy->ice_getCachedConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
         try
         {
@@ -290,7 +290,7 @@ struct Connect
         }
         if(proxy->ice_getCachedConnection())
         {
-            proxy->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            proxy->ice_getCachedConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
     }
 
@@ -520,9 +520,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
 
     if(!collocated)
     {
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         metrics->ice_connectionId("Con1")->ice_getConnection()->close(
-            Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            Ice::ConnectionClose::GracefullyWithWait);
 
         waitForCurrent(clientMetrics, "View", "Connection", 0);
         waitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -632,7 +632,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         map = toMap(serverMetrics->getMetricsView("View", timestamp)["Connection"]);
         test(map["holding"]->current == 1);
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Connection"]);
         test(map["closing"]->current == 1);
@@ -647,7 +647,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         props["IceMX.Metrics.View.Map.Connection.GroupBy"] = "none";
         updateProps(clientProps, serverProps, update.get(), props, "Connection");
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         metrics->ice_timeout(500)->ice_ping();
         controller->hold();
@@ -704,7 +704,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "mcastHost", "");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "mcastPort", "");
 
-        m->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        m->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         waitForCurrent(clientMetrics, "View", "Connection", 0);
         waitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -723,7 +723,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         IceMX::MetricsPtr m1 = clientMetrics->getMetricsView("View", timestamp)["ConnectionEstablishment"][0];
         test(m1->current == 0 && m1->total == 1 && m1->id == hostAndPort);
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         controller->hold();
         try
         {
@@ -771,7 +771,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         try
         {
             prx->ice_ping();
-            prx->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            prx->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
         catch(const Ice::LocalException&)
         {
@@ -1370,9 +1370,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         metricsBatchOneway = metricsBatchOneway->ice_fixed(con);
         metricsBatchOneway->op();
 
-        con->flushBatchRequests(ICE_SCOPED_ENUM(Ice::CompressBatch, No));
-        con->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No)).get();
-        con->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No), [cb](exception_ptr) {});
+        con->flushBatchRequests(Ice::CompressBatch::No);
+        con->flushBatchRequestsAsync(Ice::CompressBatch::No).get();
+        con->flushBatchRequestsAsync(Ice::CompressBatch::No, [cb](exception_ptr) {});
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Invocation"]);
         test(map.size() == 3);
 
@@ -1383,9 +1383,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         clearView(clientProps, serverProps, update.get());
         metricsBatchOneway->op();
 
-        communicator->flushBatchRequests(ICE_SCOPED_ENUM(Ice::CompressBatch, No));
-        communicator->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No)).get();
-        communicator->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No),
+        communicator->flushBatchRequests(Ice::CompressBatch::No);
+        communicator->flushBatchRequestsAsync(Ice::CompressBatch::No).get();
+        communicator->flushBatchRequestsAsync(Ice::CompressBatch::No,
                                               [cb](exception_ptr) {});
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Invocation"]);
         test(map.size() == 2);

--- a/cpp/test/Ice/metrics/Client.cpp
+++ b/cpp/test/Ice/metrics/Client.cpp
@@ -26,7 +26,7 @@ Client::run(int argc, char** argv)
     initData.properties->setProperty("Ice.Admin.InstanceName", "client");
     initData.properties->setProperty("Ice.Admin.DelayCreation", "1");
     initData.properties->setProperty("Ice.Warn.Connections", "0");
-    CommunicatorObserverIPtr observer = ICE_MAKE_SHARED(CommunicatorObserverI);
+    CommunicatorObserverIPtr observer = std::make_shared<CommunicatorObserverI>();
     initData.observer = observer;
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 

--- a/cpp/test/Ice/metrics/Collocated.cpp
+++ b/cpp/test/Ice/metrics/Collocated.cpp
@@ -27,18 +27,18 @@ Collocated::run(int argc, char** argv)
     initData.properties->setProperty("Ice.Admin.DelayCreation", "1");
     initData.properties->setProperty("Ice.Warn.Connections", "0");
     initData.properties->setProperty("Ice.Warn.Dispatch", "0");
-    CommunicatorObserverIPtr observer = ICE_MAKE_SHARED(CommunicatorObserverI);
+    CommunicatorObserverIPtr observer = std::make_shared<CommunicatorObserverI>();
     initData.observer = observer;
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(std::make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(std::make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     //controllerAdapter->activate(); // Don't activate OA to ensure collocation is used.
 
     MetricsPrxPtr allTests(Test::TestHelper*, const CommunicatorObserverIPtr&);

--- a/cpp/test/Ice/metrics/InstrumentationI.h
+++ b/cpp/test/Ice/metrics/InstrumentationI.h
@@ -227,7 +227,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!remoteObserver)
         {
-            remoteObserver = ICE_MAKE_SHARED(RemoteObserverI);
+            remoteObserver = std::make_shared<RemoteObserverI>();
             remoteObserver->reset();
         }
         return remoteObserver;
@@ -239,7 +239,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!collocatedObserver)
         {
-            collocatedObserver = ICE_MAKE_SHARED(CollocatedObserverI);
+            collocatedObserver = std::make_shared<CollocatedObserverI>();
             collocatedObserver->reset();
         }
         return collocatedObserver;
@@ -269,7 +269,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!connectionEstablishmentObserver)
         {
-            connectionEstablishmentObserver = ICE_MAKE_SHARED(ObserverI);
+            connectionEstablishmentObserver = std::make_shared<ObserverI>();
             connectionEstablishmentObserver->reset();
         }
         return connectionEstablishmentObserver;
@@ -281,7 +281,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!endpointLookupObserver)
         {
-            endpointLookupObserver = ICE_MAKE_SHARED(ObserverI);
+            endpointLookupObserver = std::make_shared<ObserverI>();
             endpointLookupObserver->reset();
         }
         return endpointLookupObserver;
@@ -297,7 +297,7 @@ public:
         test(!old || dynamic_cast<ConnectionObserverI*>(old.get()));
         if(!connectionObserver)
         {
-            connectionObserver = ICE_MAKE_SHARED(ConnectionObserverI);
+            connectionObserver = std::make_shared<ConnectionObserverI>();
             connectionObserver->reset();
         }
         return connectionObserver;
@@ -311,7 +311,7 @@ public:
         test(!old || dynamic_cast<ThreadObserverI*>(old.get()));
         if(!threadObserver)
         {
-            threadObserver = ICE_MAKE_SHARED(ThreadObserverI);
+            threadObserver = std::make_shared<ThreadObserverI>();
             threadObserver->reset();
         }
         return threadObserver;
@@ -323,7 +323,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!invocationObserver)
         {
-            invocationObserver = ICE_MAKE_SHARED(InvocationObserverI);
+            invocationObserver = std::make_shared<InvocationObserverI>();
             invocationObserver->reset();
         }
         return invocationObserver;
@@ -335,7 +335,7 @@ public:
         IceUtil::Mutex::Lock sync(*this);
         if(!dispatchObserver)
         {
-            dispatchObserver = ICE_MAKE_SHARED(DispatchObserverI);
+            dispatchObserver = std::make_shared<DispatchObserverI>();
             dispatchObserver->reset();
         }
         return dispatchObserver;

--- a/cpp/test/Ice/metrics/Server.cpp
+++ b/cpp/test/Ice/metrics/Server.cpp
@@ -28,12 +28,12 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(std::make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(std::make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/metrics/ServerAMD.cpp
+++ b/cpp/test/Ice/metrics/ServerAMD.cpp
@@ -28,12 +28,12 @@ ServerAMD::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(std::make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(std::make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/metrics/TestAMDI.cpp
+++ b/cpp/test/Ice/metrics/TestAMDI.cpp
@@ -16,7 +16,7 @@ MetricsI::opAsync(function<void()> response, function<void(exception_ptr)>, cons
 void
 MetricsI::failAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current& current)
 {
-    current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+    current.con->close(Ice::ConnectionClose::Forcefully);
     response();
 }
 

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -13,7 +13,7 @@ MetricsI::op(const Ice::Current&)
 void
 MetricsI::fail(const Ice::Current& current)
 {
-    current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+    current.con->close(Ice::ConnectionClose::Forcefully);
 }
 
 void

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -41,7 +41,7 @@ MetricsI::opWithUnknownException(const Ice::Current&)
 }
 
 void
-MetricsI::opByteS(ICE_IN(Test::ByteSeq), const Ice::Current&)
+MetricsI::opByteS(Test::ByteSeq, const Ice::Current&)
 {
 }
 

--- a/cpp/test/Ice/metrics/TestI.h
+++ b/cpp/test/Ice/metrics/TestI.h
@@ -21,7 +21,7 @@ class MetricsI : public Test::Metrics
 
     virtual void opWithUnknownException(const Ice::Current&);
 
-    virtual void opByteS(ICE_IN(Test::ByteSeq), const Ice::Current&);
+    virtual void opByteS(Test::ByteSeq, const Ice::Current&);
 
     virtual Ice::ObjectPrxPtr getAdmin(const Ice::Current&);
 

--- a/cpp/test/Ice/networkProxy/AllTests.cpp
+++ b/cpp/test/Ice/networkProxy/AllTests.cpp
@@ -23,7 +23,7 @@ getIPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/networkProxy/Server.cpp
+++ b/cpp/test/Ice/networkProxy/Server.cpp
@@ -37,7 +37,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -181,7 +181,7 @@ allTests(Test::TestHelper* helper)
     test(b2 != dynamic_pointer_cast<B>(d));
     test(c != dynamic_pointer_cast<C>(d));
     test(b1->theB == b1);
-    test(b1->theC == ICE_NULLPTR);
+    test(b1->theC == nullptr);
     test(ICE_DYNAMIC_CAST(B, b1->theA));
     test(ICE_DYNAMIC_CAST(B, b1->theA)->theA == b1->theA);
     test(ICE_DYNAMIC_CAST(B, b1->theA)->theB == b1);
@@ -196,7 +196,7 @@ allTests(Test::TestHelper* helper)
     test(dynamic_pointer_cast<B>(b1->theA)->theC->postUnmarshalInvoked);
     // More tests possible for b2 and d, but I think this is already sufficient.
     test(b2->theA == b2);
-    test(d->theC == ICE_NULLPTR);
+    test(d->theC == nullptr);
 
     clear(b1);
     clear(b2);

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -116,13 +116,13 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing constructor, copy constructor, and assignment operator... " << flush;
 
-    BasePtr ba1 = ICE_MAKE_SHARED(Base);
+    BasePtr ba1 = std::make_shared<Base>();
     test(ba1->theS.str == "");
     test(ba1->str == "");
 
     S s;
     s.str = "hello";
-    BasePtr ba2 = ICE_MAKE_SHARED(Base, s, "hi");
+    BasePtr ba2 = std::make_shared<Base>(s, "hi");
     test(ba2->theS.str == "hello");
     test(ba2->str == "hi");
 
@@ -138,7 +138,7 @@ allTests(Test::TestHelper* helper)
     test(*ba1 >= *ba2);
     test(*ba1 <= *ba2);
 
-    BasePtr bp1 = ICE_MAKE_SHARED(Base);
+    BasePtr bp1 = std::make_shared<Base>();
     *bp1 = *ba2;
     test(bp1->theS.str == "hello");
     test(bp1->str == "hi");
@@ -269,7 +269,7 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing Value as parameter..." << flush;
     {
-        LPtr v1 = ICE_MAKE_SHARED(L, "l");
+        LPtr v1 = std::make_shared<L>("l");
         Ice::ValuePtr v2;
         Ice::ValuePtr v3 = initial->opValue(v1, v2);
         test(ICE_DYNAMIC_CAST(L, v2)->data == "l");
@@ -277,7 +277,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        LPtr l = ICE_MAKE_SHARED(L, "l");
+        LPtr l = std::make_shared<L>("l");
         Test::ValueSeq v1;
         v1.push_back(l);
         Test::ValueSeq v2;
@@ -287,7 +287,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        LPtr l = ICE_MAKE_SHARED(L, "l");
+        LPtr l = std::make_shared<L>("l");
         Test::ValueMap v1;
         v1["l"] = l;
         Test::ValueMap v2;
@@ -298,11 +298,11 @@ allTests(Test::TestHelper* helper)
     cout << "ok" << endl;
 
     cout << "getting D1... " << flush;
-    D1Ptr d1 = ICE_MAKE_SHARED(D1,
-                               ICE_MAKE_SHARED(A1, "a1"),
-                               ICE_MAKE_SHARED(A1, "a2"),
-                               ICE_MAKE_SHARED(A1, "a3"),
-                               ICE_MAKE_SHARED(A1, "a4"));
+    D1Ptr d1 = std::make_shared<D1>(
+                               std::make_shared<A1>("a1"),
+                               std::make_shared<A1>("a2"),
+                               std::make_shared<A1>("a3"),
+                               std::make_shared<A1>("a4"));
     d1 = initial->getD1(d1);
     test(d1->a1->name == "a1");
     test(d1->a2->name == "a2");
@@ -326,7 +326,7 @@ allTests(Test::TestHelper* helper)
     cout << "ok" << endl;
 
     cout << "setting G... " << flush;
-    GPtr g = ICE_MAKE_SHARED(G, s, "g");
+    GPtr g = std::make_shared<G>(s, "g");
     try
     {
         initial->setG(g);
@@ -347,13 +347,13 @@ allTests(Test::TestHelper* helper)
     retS = initial->opBaseSeq(inS, outS);
 
     inS.resize(1);
-    inS[0] = ICE_MAKE_SHARED(Base);
+    inS[0] = std::make_shared<Base>();
     retS = initial->opBaseSeq(inS, outS);
     test(retS.size() == 1 && outS.size() == 1);
     cout << "ok" << endl;
 
     cout << "testing recursive type... " << flush;
-    RecursivePtr top = ICE_MAKE_SHARED(Recursive);
+    RecursivePtr top = std::make_shared<Recursive>();
     int depth = 0;
     try
     {
@@ -366,7 +366,7 @@ allTests(Test::TestHelper* helper)
 #endif
         for(; depth <= maxDepth; ++depth)
         {
-            p->v = ICE_MAKE_SHARED(Recursive);
+            p->v = std::make_shared<Recursive>();
             p = p->v;
             if((depth < 10 && (depth % 10) == 0) ||
                (depth < 1000 && (depth % 100) == 0) ||
@@ -387,7 +387,7 @@ allTests(Test::TestHelper* helper)
     {
         // Expected stack overflow from the server (Java only)
     }
-    initial->setRecursive(ICE_MAKE_SHARED(Recursive));
+    initial->setRecursive(std::make_shared<Recursive>());
     cout << "ok" << endl;
 
     cout << "testing compact ID..." << flush;
@@ -454,17 +454,17 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing class containing complex dictionary... " << flush;
     {
-        Test::MPtr m = ICE_MAKE_SHARED(Test::M);
+        Test::MPtr m = std::make_shared<Test::M>();
 
         Test::StructKey k1;
         k1.i = 1;
         k1.s = "1";
-        m->v[k1] = ICE_MAKE_SHARED(L, "one");
+        m->v[k1] = std::make_shared<L>("one");
 
         Test::StructKey k2;
         k2.i = 2;
         k2.s = "2";
-        m->v[k2] = ICE_MAKE_SHARED(L, "two");
+        m->v[k2] = std::make_shared<L>("two");
 
         Test::MPtr m1;
         Test::MPtr m2 = initial->opM(m, m1);
@@ -484,7 +484,7 @@ allTests(Test::TestHelper* helper)
     cout << "testing forward declarations... " << flush;
     {
         F1Ptr f12;
-        F1Ptr f11 = initial->opF1(ICE_MAKE_SHARED(F1, "F11"), f12);
+        F1Ptr f11 = initial->opF1(std::make_shared<F1>("F11"), f12);
         test(f11->name == "F11");
         test(f12->name == "F12");
 
@@ -498,7 +498,7 @@ allTests(Test::TestHelper* helper)
         if(initial->hasF3())
         {
             F3Ptr f32;
-            F3Ptr f31 = initial->opF3(ICE_MAKE_SHARED(F3, f11, f21), f32);
+            F3Ptr f31 = initial->opF3(std::make_shared<F3>(f11, f21), f32);
             test(f31->f1->name == "F11");
             test(f31->f2->ice_getIdentity().name == "F21");
 

--- a/cpp/test/Ice/objects/Client.cpp
+++ b/cpp/test/Ice/objects/Client.cpp
@@ -49,7 +49,7 @@ public:
 
     virtual Ice::ValuePtr create(const string&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual void destroy()

--- a/cpp/test/Ice/objects/Collocated.cpp
+++ b/cpp/test/Ice/objects/Collocated.cpp
@@ -78,10 +78,10 @@ Collocated::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI, adapter), Ice::stringToIdentity("initial"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(F2I), Ice::stringToIdentity("F21"));
-    adapter->add(ICE_MAKE_SHARED(UnexpectedObjectExceptionTestI), Ice::stringToIdentity("uoet"));
+    adapter->add(std::make_shared<InitialI>(adapter), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<F2I>(), Ice::stringToIdentity("F21"));
+    adapter->add(std::make_shared<UnexpectedObjectExceptionTestI>(), Ice::stringToIdentity("uoet"));
     InitialPrxPtr allTests(Test::TestHelper*);
     InitialPrxPtr initial = allTests(this);
     // We must call shutdown even in the collocated case for cyclic dependency cleanup

--- a/cpp/test/Ice/objects/Collocated.cpp
+++ b/cpp/test/Ice/objects/Collocated.cpp
@@ -41,7 +41,7 @@ public:
 
     virtual Ice::ValuePtr create(const string&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual void destroy()

--- a/cpp/test/Ice/objects/Server.cpp
+++ b/cpp/test/Ice/objects/Server.cpp
@@ -39,11 +39,11 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI, adapter), Ice::stringToIdentity("initial"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(F2I), Ice::stringToIdentity("F21"));
+    adapter->add(std::make_shared<InitialI>(adapter), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<F2I>(), Ice::stringToIdentity("F21"));
 
-    adapter->add(ICE_MAKE_SHARED(UnexpectedObjectExceptionTestI), Ice::stringToIdentity("uoet"));
+    adapter->add(std::make_shared<UnexpectedObjectExceptionTestI>(), Ice::stringToIdentity("uoet"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -168,7 +168,7 @@ InitialI::getF(const Ice::Current&)
 }
 
 void
-InitialI::setRecursive(ICE_IN(RecursivePtr), const Ice::Current&)
+InitialI::setRecursive(RecursivePtr, const Ice::Current&)
 {
 }
 
@@ -206,7 +206,7 @@ InitialI::getAll(BPtr& b1, BPtr& b2, CPtr& c, DPtr& d, const Ice::Current&)
 }
 
 void
-InitialI::setG(ICE_IN(Test::GPtr), const Ice::Current&)
+InitialI::setG(Test::GPtr, const Ice::Current&)
 {
 }
 
@@ -217,12 +217,12 @@ InitialI::getI(const Ice::Current&)
 }
 
 void
-InitialI::setI(ICE_IN(shared_ptr<Ice::Value>), const Ice::Current&)
+InitialI::setI(shared_ptr<Ice::Value>, const Ice::Current&)
 {
 }
 
 BaseSeq
-InitialI::opBaseSeq(ICE_IN(BaseSeq) inSeq, BaseSeq& outSeq, const Ice::Current&)
+InitialI::opBaseSeq(BaseSeq inSeq, BaseSeq& outSeq, const Ice::Current&)
 {
     outSeq = inSeq;
     return inSeq;
@@ -281,28 +281,28 @@ InitialI::getK(const Ice::Current&)
 }
 
 Ice::ValuePtr
-InitialI::opValue(ICE_IN(Ice::ValuePtr) v1, Ice::ValuePtr& v2, const Ice::Current&)
+InitialI::opValue(Ice::ValuePtr v1, Ice::ValuePtr& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 Test::ValueSeq
-InitialI::opValueSeq(ICE_IN(Test::ValueSeq) v1, Test::ValueSeq& v2, const Ice::Current&)
+InitialI::opValueSeq(Test::ValueSeq v1, Test::ValueSeq& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 Test::ValueMap
-InitialI::opValueMap(ICE_IN(Test::ValueMap) v1, Test::ValueMap& v2, const Ice::Current&)
+InitialI::opValueMap(Test::ValueMap v1, Test::ValueMap& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 D1Ptr
-InitialI::getD1(ICE_IN(Test::D1Ptr) d1, const Ice::Current&)
+InitialI::getD1(Test::D1Ptr d1, const Ice::Current&)
 {
     return d1;
 }
@@ -317,14 +317,14 @@ InitialI::throwEDerived(const Ice::Current&)
 }
 
 Test::MPtr
-InitialI::opM(ICE_IN(Test::MPtr) v1, Test::MPtr& v2, const Ice::Current&)
+InitialI::opM(Test::MPtr v1, Test::MPtr& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 bool
-UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
+UnexpectedObjectExceptionTestI::ice_invoke(std::vector<Ice::Byte>,
                                            std::vector<Ice::Byte>& outParams,
                                            const Ice::Current& current)
 {
@@ -340,21 +340,21 @@ UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
 }
 
 Test::F1Ptr
-InitialI::opF1(ICE_IN(Test::F1Ptr) f11, Test::F1Ptr& f12, const Ice::Current&)
+InitialI::opF1(Test::F1Ptr f11, Test::F1Ptr& f12, const Ice::Current&)
 {
     f12 = std::make_shared<F1>("F12");
     return f11;
 }
 
 Test::F2PrxPtr
-InitialI::opF2(ICE_IN(Test::F2PrxPtr) f21, Test::F2PrxPtr& f22, const Ice::Current& current)
+InitialI::opF2(Test::F2PrxPtr f21, Test::F2PrxPtr& f22, const Ice::Current& current)
 {
     f22 = ICE_UNCHECKED_CAST(F2Prx, current.adapter->getCommunicator()->stringToProxy("F22"));
     return f21;
 }
 
 Test::F3Ptr
-InitialI::opF3(ICE_IN(Test::F3Ptr) f31, Test::F3Ptr& f32, const Ice::Current& current)
+InitialI::opF3(Test::F3Ptr f31, Test::F3Ptr& f32, const Ice::Current& current)
 {
     f32 = std::make_shared<F3>();
     f32->f1 = std::make_shared<F1>("F12");

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -330,7 +330,7 @@ UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
     Ice::OutputStream out(communicator);
-    out.startEncapsulation(current.encoding, Ice::ICE_ENUM(FormatType, DefaultFormat));
+    out.startEncapsulation(current.encoding, Ice::FormatType::DefaultFormat);
     AlsoEmptyPtr obj = ICE_MAKE_SHARED(AlsoEmpty);
     out.write(obj);
     out.writePendingValues();

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -231,19 +231,19 @@ InitialI::opBaseSeq(ICE_IN(BaseSeq) inSeq, BaseSeq& outSeq, const Ice::Current&)
 CompactPtr
 InitialI::getCompact(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(CompactExt);
+    return std::make_shared<CompactExt>();
 }
 
 Test::Inner::APtr
 InitialI::getInnerA(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(Inner::A, _b1);
+    return std::make_shared<Inner::A>(_b1);
 }
 
 Test::Inner::Sub::APtr
 InitialI::getInnerSubA(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(Inner::Sub::A, ICE_MAKE_SHARED(Inner::A, _b1));
+    return std::make_shared<Inner::Sub::A>(std::make_shared<Inner::A>(_b1));
 }
 
 void
@@ -277,7 +277,7 @@ InitialI::getH(const Ice::Current&)
 KPtr
 InitialI::getK(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(K, ICE_MAKE_SHARED(L, "l"));
+    return std::make_shared<K>(std::make_shared<L>("l"));
 }
 
 Ice::ValuePtr
@@ -310,10 +310,10 @@ InitialI::getD1(ICE_IN(Test::D1Ptr) d1, const Ice::Current&)
 void
 InitialI::throwEDerived(const Ice::Current&)
 {
-    throw EDerived(ICE_MAKE_SHARED(A1, "a1"),
-                   ICE_MAKE_SHARED(A1, "a2"),
-                   ICE_MAKE_SHARED(A1, "a3"),
-                   ICE_MAKE_SHARED(A1, "a4"));
+    throw EDerived(std::make_shared<A1>("a1"),
+                   std::make_shared<A1>("a2"),
+                   std::make_shared<A1>("a3"),
+                   std::make_shared<A1>("a4"));
 }
 
 Test::MPtr
@@ -331,7 +331,7 @@ UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
     Ice::OutputStream out(communicator);
     out.startEncapsulation(current.encoding, Ice::FormatType::DefaultFormat);
-    AlsoEmptyPtr obj = ICE_MAKE_SHARED(AlsoEmpty);
+    AlsoEmptyPtr obj = std::make_shared<AlsoEmpty>();
     out.write(obj);
     out.writePendingValues();
     out.endEncapsulation();
@@ -342,7 +342,7 @@ UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
 Test::F1Ptr
 InitialI::opF1(ICE_IN(Test::F1Ptr) f11, Test::F1Ptr& f12, const Ice::Current&)
 {
-    f12 = ICE_MAKE_SHARED(F1, "F12");
+    f12 = std::make_shared<F1>("F12");
     return f11;
 }
 
@@ -356,8 +356,8 @@ InitialI::opF2(ICE_IN(Test::F2PrxPtr) f21, Test::F2PrxPtr& f22, const Ice::Curre
 Test::F3Ptr
 InitialI::opF3(ICE_IN(Test::F3Ptr) f31, Test::F3Ptr& f32, const Ice::Current& current)
 {
-    f32 = ICE_MAKE_SHARED(F3);
-    f32->f1 = ICE_MAKE_SHARED(F1, "F12");
+    f32 = std::make_shared<F3>();
+    f32->f1 = std::make_shared<F1>("F12");
     f32->f2 = ICE_UNCHECKED_CAST(F2Prx, current.adapter->getCommunicator()->stringToProxy("F22"));
     return f31;
 }

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -102,14 +102,14 @@ InitialI::InitialI(const Ice::ObjectAdapterPtr& adapter) :
 
 InitialI::~InitialI()
 {
-    _b1->theA = ICE_NULLPTR;
-    _b1->theB = ICE_NULLPTR;
+    _b1->theA = nullptr;
+    _b1->theB = nullptr;
 
-    _b2->theA = ICE_NULLPTR;
-    _b2->theB = ICE_NULLPTR;
-    _b2->theC = ICE_NULLPTR;
+    _b2->theA = nullptr;
+    _b2->theB = nullptr;
+    _b2->theC = nullptr;
 
-    _c->theB = ICE_NULLPTR;
+    _c->theB = nullptr;
 }
 
 void

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -80,7 +80,7 @@ public:
     virtual Test::EPtr getE(const Ice::Current&);
     virtual Test::FPtr getF(const Ice::Current&);
 
-    virtual void setRecursive(ICE_IN(Test::RecursivePtr), const Ice::Current&);
+    virtual void setRecursive(Test::RecursivePtr, const Ice::Current&);
     virtual bool supportsClassGraphDepthMax(const Ice::Current&);
 
     virtual GetMBMarshaledResult getMB(const Ice::Current&);
@@ -96,17 +96,17 @@ public:
 
     virtual Test::KPtr getK(const Ice::Current&);
 
-    virtual Ice::ValuePtr opValue(ICE_IN(Ice::ValuePtr), Ice::ValuePtr&, const Ice::Current&);
-    virtual Test::ValueSeq opValueSeq(ICE_IN(Test::ValueSeq), Test::ValueSeq&, const Ice::Current&);
-    virtual Test::ValueMap opValueMap(ICE_IN(Test::ValueMap), Test::ValueMap&, const Ice::Current&);
+    virtual Ice::ValuePtr opValue(Ice::ValuePtr, Ice::ValuePtr&, const Ice::Current&);
+    virtual Test::ValueSeq opValueSeq(Test::ValueSeq, Test::ValueSeq&, const Ice::Current&);
+    virtual Test::ValueMap opValueMap(Test::ValueMap, Test::ValueMap&, const Ice::Current&);
 
-    virtual Test::D1Ptr getD1(ICE_IN(Test::D1Ptr), const Ice::Current&);
+    virtual Test::D1Ptr getD1(Test::D1Ptr, const Ice::Current&);
     virtual void throwEDerived(const Ice::Current&);
 
-    virtual void setG(ICE_IN(Test::GPtr), const Ice::Current&);
+    virtual void setG(Test::GPtr, const Ice::Current&);
 
     virtual void setI(::std::shared_ptr<::Ice::Value>, const Ice::Current&);
-    virtual Test::BaseSeq opBaseSeq(ICE_IN(Test::BaseSeq), Test::BaseSeq&, const Ice::Current&);
+    virtual Test::BaseSeq opBaseSeq(Test::BaseSeq, Test::BaseSeq&, const Ice::Current&);
 
     virtual Test::CompactPtr getCompact(const Ice::Current&);
 
@@ -116,11 +116,11 @@ public:
     virtual void throwInnerEx(const Ice::Current&);
     virtual void throwInnerSubEx(const Ice::Current&);
 
-    virtual Test::MPtr opM(ICE_IN(Test::MPtr), Test::MPtr&, const Ice::Current&);
+    virtual Test::MPtr opM(Test::MPtr, Test::MPtr&, const Ice::Current&);
 
-    virtual Test::F1Ptr opF1(ICE_IN(Test::F1Ptr), Test::F1Ptr&, const Ice::Current&);
-    virtual Test::F2PrxPtr opF2(ICE_IN(Test::F2PrxPtr), Test::F2PrxPtr&, const Ice::Current&);
-    virtual Test::F3Ptr opF3(ICE_IN(Test::F3Ptr), Test::F3Ptr&, const Ice::Current&);
+    virtual Test::F1Ptr opF1(Test::F1Ptr, Test::F1Ptr&, const Ice::Current&);
+    virtual Test::F2PrxPtr opF2(Test::F2PrxPtr, Test::F2PrxPtr&, const Ice::Current&);
+    virtual Test::F3Ptr opF3(Test::F3Ptr, Test::F3Ptr&, const Ice::Current&);
     virtual bool hasF3(const Ice::Current&);
 
 private:
@@ -138,7 +138,7 @@ class UnexpectedObjectExceptionTestI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::vector<Ice::Byte>), std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
 };
 ICE_DEFINE_PTR(UnexpectedObjectExceptionTestIPtr, UnexpectedObjectExceptionTestI);
 

--- a/cpp/test/Ice/objects/TestIntfI.cpp
+++ b/cpp/test/Ice/objects/TestIntfI.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 BasePtr
 TestIntfI::opDerived(const Ice::Current&)
 {
-    DerivedPtr d = ICE_MAKE_SHARED(Derived);
+    DerivedPtr d = std::make_shared<Derived>();
     d->theS.str = "S.str";
     d->str = "str";
     d->b = "b";

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -79,9 +79,9 @@ batchOneways(const Test::MyClassPrxPtr& p)
     batch->ice_flushBatchRequests(); // Empty flush
     if(batch->ice_getConnection())
     {
-        batch->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
     }
-    batch->ice_getCommunicator()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+    batch->ice_getCommunicator()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
     int i;
     p->opByteSOnewayCallCount(); // Reset the call count
@@ -114,7 +114,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch1->ice_ping();
         batch2->ice_ping();
         batch1->ice_flushBatchRequests();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_ping();
         batch2->ice_ping();
 
@@ -122,7 +122,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch2->ice_getConnection();
 
         batch1->ice_ping();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_ping();
         batch2->ice_ping();
     }
@@ -205,26 +205,26 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, Yes));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::Yes);
 
         batch2->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, No));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::No);
 
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
         batch1->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
         batch1->opByteSOneway(bs1);
         batch3->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
     }
 }

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -11,7 +11,7 @@ using namespace std;
 namespace
 {
 
-class BatchRequestInterceptorI ICE_FINAL
+class BatchRequestInterceptorI final
 {
 public:
 

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -145,7 +145,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
     {
         Ice::InitializationData initData;
         initData.properties = p->ice_getCommunicator()->getProperties()->clone();
-        BatchRequestInterceptorIPtr interceptor = ICE_MAKE_SHARED(BatchRequestInterceptorI);
+        BatchRequestInterceptorIPtr interceptor = std::make_shared<BatchRequestInterceptorI>();
 
         initData.batchRequestInterceptor = [=](const Ice::BatchRequest& request, int countP, int size)
         {

--- a/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
@@ -121,7 +121,7 @@ batchOnewaysAMI(const Test::MyClassPrxPtr& p)
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();
         batch1->ice_flushBatchRequestsAsync().get();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();
 
@@ -129,7 +129,7 @@ batchOnewaysAMI(const Test::MyClassPrxPtr& p)
         batch2->ice_getConnection();
 
         batch1->ice_pingAsync().get();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();

--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -24,8 +24,8 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     communicator->getProperties()->setProperty("TestAdapter.AdapterId", "test");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPrxPtr prx = adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(BI), Ice::stringToIdentity("b"));
+    Ice::ObjectPrxPtr prx = adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<BI>(), Ice::stringToIdentity("b"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     test(!prx->ice_getConnection());

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -78,7 +78,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     Test::MyClassPrxPtr p = ICE_UNCHECKED_CAST(Test::MyClassPrx, proxy->ice_oneway());
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_pingAsync(
             nullptr,
             [](exception_ptr)
@@ -137,7 +137,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opVoidAsync(
             nullptr,
             [](exception_ptr)
@@ -152,7 +152,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opIdempotentAsync(
             nullptr,
             [](exception_ptr)
@@ -167,7 +167,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opNonmutatingAsync(
             nullptr,
             [](exception_ptr)
@@ -196,7 +196,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
         }
     }
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_pingAsync(nullptr,
                         [=](exception_ptr e)
                         {

--- a/cpp/test/Ice/operations/Server.cpp
+++ b/cpp/test/Ice/operations/Server.cpp
@@ -29,8 +29,8 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(BI), Ice::stringToIdentity("b"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<BI>(), Ice::stringToIdentity("b"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/operations/ServerAMD.cpp
+++ b/cpp/test/Ice/operations/ServerAMD.cpp
@@ -29,8 +29,8 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(BI), Ice::stringToIdentity("b"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<BI>(), Ice::stringToIdentity("b"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -18,7 +18,7 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 }
 
 bool
-MyDerivedClassI::ice_isA(ICE_IN(string) id, const Ice::Current& current) const
+MyDerivedClassI::ice_isA(string id, const Ice::Current& current) const
 {
     test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(move(id), current);

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -20,14 +20,14 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 bool
 MyDerivedClassI::ice_isA(ICE_IN(string) id, const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(move(id), current);
 }
 
 void
 MyDerivedClassI::ice_ping(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     Test::MyDerivedClass::ice_ping(current);
 
 }
@@ -35,14 +35,14 @@ MyDerivedClassI::ice_ping(const Ice::Current& current) const
 std::vector<std::string>
 MyDerivedClassI::ice_ids(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_ids(current);
 }
 
 std::string
 MyDerivedClassI::ice_id(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_id(current);
 }
 
@@ -979,7 +979,7 @@ MyDerivedClassI::opMStruct1Async(function<void(const OpMStruct1MarshaledResult&)
                                  const Ice::Current& current)
 {
     Test::Structure s;
-    s.e = ICE_ENUM(MyEnum, enum1); // enum must be initialized
+    s.e = MyEnum::enum1; // enum must be initialized
     response(OpMStruct1MarshaledResult(s, current));
 }
 

--- a/cpp/test/Ice/operations/TestAMDI.h
+++ b/cpp/test/Ice/operations/TestAMDI.h
@@ -17,7 +17,7 @@ public:
     //
     // Override the Object "pseudo" operations to verify the operation mode.
     //
-    virtual bool ice_isA(ICE_IN(std::string), const Ice::Current&) const;
+    virtual bool ice_isA(std::string, const Ice::Current&) const;
     virtual void ice_ping(const Ice::Current&) const;
     virtual std::vector<std::string> ice_ids(const Ice::Current&) const;
     virtual std::string ice_id(const Ice::Current&) const;
@@ -375,7 +375,7 @@ public:
                                  ::std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
 
-    virtual void opMStruct2Async(ICE_IN(Test::Structure),
+    virtual void opMStruct2Async(Test::Structure,
                                  ::std::function<void(const OpMStruct2MarshaledResult&)>,
                                  ::std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
@@ -384,7 +384,7 @@ public:
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);
 
-    virtual void opMSeq2Async(ICE_IN(Test::StringS),
+    virtual void opMSeq2Async(Test::StringS,
                               ::std::function<void(const OpMSeq2MarshaledResult&)>,
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);
@@ -393,7 +393,7 @@ public:
                                ::std::function<void(std::exception_ptr)>,
                                const Ice::Current&);
 
-    virtual void opMDict2Async(ICE_IN(Test::StringStringD),
+    virtual void opMDict2Async(Test::StringStringD,
                                ::std::function<void(const OpMDict2MarshaledResult&)>,
                                ::std::function<void(std::exception_ptr)>,
                                const Ice::Current&);

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -18,7 +18,7 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 }
 
 bool
-MyDerivedClassI::ice_isA(ICE_IN(string) id, const Ice::Current& current) const
+MyDerivedClassI::ice_isA(string id, const Ice::Current& current) const
 {
     test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(move(id), current);
@@ -111,8 +111,8 @@ MyDerivedClassI::opFloatDouble(Ice::Float p1,
 }
 
 std::string
-MyDerivedClassI::opString(ICE_IN(string) p1,
-                          ICE_IN(string) p2,
+MyDerivedClassI::opString(string p1,
+                          string p2,
                           string& p3,
                           const Ice::Current&)
 {
@@ -130,7 +130,7 @@ MyDerivedClassI::opMyEnum(Test::MyEnum p1,
 }
 
 Test::MyClassPrxPtr
-MyDerivedClassI::opMyClass(ICE_IN(Test::MyClassPrxPtr) p1,
+MyDerivedClassI::opMyClass(Test::MyClassPrxPtr p1,
                            Test::MyClassPrxPtr& p2,
                            Test::MyClassPrxPtr& p3,
                            const Ice::Current& current)
@@ -143,8 +143,8 @@ MyDerivedClassI::opMyClass(ICE_IN(Test::MyClassPrxPtr) p1,
 }
 
 Test::Structure
-MyDerivedClassI::opStruct(ICE_IN(Test::Structure) p1,
-                          ICE_IN(Test::Structure) p2,
+MyDerivedClassI::opStruct(Test::Structure p1,
+                          Test::Structure p2,
                           ::Test::Structure& p3,
                           const Ice::Current&)
 {
@@ -154,8 +154,8 @@ MyDerivedClassI::opStruct(ICE_IN(Test::Structure) p1,
 }
 
 Test::ByteS
-MyDerivedClassI::opByteS(ICE_IN(Test::ByteS) p1,
-                         ICE_IN(Test::ByteS) p2,
+MyDerivedClassI::opByteS(Test::ByteS p1,
+                         Test::ByteS p2,
                          Test::ByteS& p3,
                          const Ice::Current&)
 {
@@ -167,8 +167,8 @@ MyDerivedClassI::opByteS(ICE_IN(Test::ByteS) p1,
 }
 
 Test::BoolS
-MyDerivedClassI::opBoolS(ICE_IN(Test::BoolS) p1,
-                         ICE_IN(Test::BoolS) p2,
+MyDerivedClassI::opBoolS(Test::BoolS p1,
+                         Test::BoolS p2,
                          Test::BoolS& p3,
                          const Ice::Current&)
 {
@@ -181,9 +181,9 @@ MyDerivedClassI::opBoolS(ICE_IN(Test::BoolS) p1,
 }
 
 Test::LongS
-MyDerivedClassI::opShortIntLongS(ICE_IN(Test::ShortS) p1,
-                                 ICE_IN(Test::IntS) p2,
-                                 ICE_IN(Test::LongS) p3,
+MyDerivedClassI::opShortIntLongS(Test::ShortS p1,
+                                 Test::IntS p2,
+                                 Test::LongS p3,
                                  Test::ShortS& p4,
                                  Test::IntS& p5,
                                  Test::LongS& p6,
@@ -198,8 +198,8 @@ MyDerivedClassI::opShortIntLongS(ICE_IN(Test::ShortS) p1,
 }
 
 Test::DoubleS
-MyDerivedClassI::opFloatDoubleS(ICE_IN(Test::FloatS) p1,
-                                ICE_IN(Test::DoubleS) p2,
+MyDerivedClassI::opFloatDoubleS(Test::FloatS p1,
+                                Test::DoubleS p2,
                                 Test::FloatS& p3,
                                 Test::DoubleS& p4,
                                 const Ice::Current&)
@@ -213,8 +213,8 @@ MyDerivedClassI::opFloatDoubleS(ICE_IN(Test::FloatS) p1,
 }
 
 Test::StringS
-MyDerivedClassI::opStringS(ICE_IN(Test::StringS) p1,
-                           ICE_IN(Test::StringS) p2,
+MyDerivedClassI::opStringS(Test::StringS p1,
+                           Test::StringS p2,
                            Test::StringS& p3,
                            const Ice::Current&)
 {
@@ -227,8 +227,8 @@ MyDerivedClassI::opStringS(ICE_IN(Test::StringS) p1,
 }
 
 Test::ByteSS
-MyDerivedClassI::opByteSS(ICE_IN(Test::ByteSS) p1,
-                          ICE_IN(Test::ByteSS) p2,
+MyDerivedClassI::opByteSS(Test::ByteSS p1,
+                          Test::ByteSS p2,
                           Test::ByteSS& p3,
                           const Ice::Current&)
 {
@@ -240,8 +240,8 @@ MyDerivedClassI::opByteSS(ICE_IN(Test::ByteSS) p1,
 }
 
 Test::BoolSS
-MyDerivedClassI::opBoolSS(ICE_IN(Test::BoolSS) p1,
-                          ICE_IN(Test::BoolSS) p2,
+MyDerivedClassI::opBoolSS(Test::BoolSS p1,
+                          Test::BoolSS p2,
                           Test::BoolSS& p3,
                           const Ice::Current&)
 {
@@ -254,9 +254,9 @@ MyDerivedClassI::opBoolSS(ICE_IN(Test::BoolSS) p1,
 }
 
 Test::LongSS
-MyDerivedClassI::opShortIntLongSS(ICE_IN(Test::ShortSS) p1,
-                                  ICE_IN(Test::IntSS) p2,
-                                  ICE_IN(Test::LongSS) p3,
+MyDerivedClassI::opShortIntLongSS(Test::ShortSS p1,
+                                  Test::IntSS p2,
+                                  Test::LongSS p3,
                                   Test::ShortSS& p4,
                                   Test::IntSS& p5,
                                   Test::LongSS& p6,
@@ -271,8 +271,8 @@ MyDerivedClassI::opShortIntLongSS(ICE_IN(Test::ShortSS) p1,
 }
 
 Test::DoubleSS
-MyDerivedClassI::opFloatDoubleSS(ICE_IN(Test::FloatSS) p1,
-                                 ICE_IN(Test::DoubleSS) p2,
+MyDerivedClassI::opFloatDoubleSS(Test::FloatSS p1,
+                                 Test::DoubleSS p2,
                                  Test::FloatSS& p3,
                                  Test::DoubleSS& p4,
                                  const Ice::Current&)
@@ -286,8 +286,8 @@ MyDerivedClassI::opFloatDoubleSS(ICE_IN(Test::FloatSS) p1,
 }
 
 Test::StringSS
-MyDerivedClassI::opStringSS(ICE_IN(Test::StringSS) p1,
-                            ICE_IN(Test::StringSS) p2,
+MyDerivedClassI::opStringSS(Test::StringSS p1,
+                            Test::StringSS p2,
                             Test::StringSS& p3,
                             const Ice::Current&)
 {
@@ -300,8 +300,8 @@ MyDerivedClassI::opStringSS(ICE_IN(Test::StringSS) p1,
 }
 
 Test::StringSSS
-MyDerivedClassI::opStringSSS(ICE_IN(Test::StringSSS) p1,
-                             ICE_IN(Test::StringSSS) p2,
+MyDerivedClassI::opStringSSS(Test::StringSSS p1,
+                             Test::StringSSS p2,
                              Test::StringSSS& p3,
                              const ::Ice::Current&)
 {
@@ -314,8 +314,8 @@ MyDerivedClassI::opStringSSS(ICE_IN(Test::StringSSS) p1,
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD(ICE_IN(Test::ByteBoolD) p1,
-                             ICE_IN(Test::ByteBoolD) p2,
+MyDerivedClassI::opByteBoolD(Test::ByteBoolD p1,
+                             Test::ByteBoolD p2,
                              Test::ByteBoolD& p3,
                              const Ice::Current&)
 {
@@ -326,8 +326,8 @@ MyDerivedClassI::opByteBoolD(ICE_IN(Test::ByteBoolD) p1,
 }
 
 Test::ShortIntD
-MyDerivedClassI::opShortIntD(ICE_IN(Test::ShortIntD) p1,
-                             ICE_IN(Test::ShortIntD) p2,
+MyDerivedClassI::opShortIntD(Test::ShortIntD p1,
+                             Test::ShortIntD p2,
                              Test::ShortIntD& p3,
                              const Ice::Current&)
 {
@@ -338,8 +338,8 @@ MyDerivedClassI::opShortIntD(ICE_IN(Test::ShortIntD) p1,
 }
 
 Test::LongFloatD
-MyDerivedClassI::opLongFloatD(ICE_IN(Test::LongFloatD) p1,
-                              ICE_IN(Test::LongFloatD) p2,
+MyDerivedClassI::opLongFloatD(Test::LongFloatD p1,
+                              Test::LongFloatD p2,
                               Test::LongFloatD& p3,
                               const Ice::Current&)
 {
@@ -350,8 +350,8 @@ MyDerivedClassI::opLongFloatD(ICE_IN(Test::LongFloatD) p1,
 }
 
 Test::StringStringD
-MyDerivedClassI::opStringStringD(ICE_IN(Test::StringStringD) p1,
-                                 ICE_IN(Test::StringStringD) p2,
+MyDerivedClassI::opStringStringD(Test::StringStringD p1,
+                                 Test::StringStringD p2,
                                  Test::StringStringD& p3,
                                  const Ice::Current&)
 {
@@ -362,8 +362,8 @@ MyDerivedClassI::opStringStringD(ICE_IN(Test::StringStringD) p1,
 }
 
 Test::StringMyEnumD
-MyDerivedClassI::opStringMyEnumD(ICE_IN(Test::StringMyEnumD) p1,
-                                 ICE_IN(Test::StringMyEnumD) p2,
+MyDerivedClassI::opStringMyEnumD(Test::StringMyEnumD p1,
+                                 Test::StringMyEnumD p2,
                                  Test::StringMyEnumD& p3,
                                  const Ice::Current&)
 {
@@ -374,8 +374,8 @@ MyDerivedClassI::opStringMyEnumD(ICE_IN(Test::StringMyEnumD) p1,
 }
 
 Test::MyEnumStringD
-MyDerivedClassI::opMyEnumStringD(ICE_IN(Test::MyEnumStringD) p1,
-                                 ICE_IN(Test::MyEnumStringD) p2,
+MyDerivedClassI::opMyEnumStringD(Test::MyEnumStringD p1,
+                                 Test::MyEnumStringD p2,
                                  Test::MyEnumStringD& p3,
                                  const Ice::Current&)
 {
@@ -386,8 +386,8 @@ MyDerivedClassI::opMyEnumStringD(ICE_IN(Test::MyEnumStringD) p1,
 }
 
 Test::MyStructMyEnumD
-MyDerivedClassI::opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD) p1,
-                                   ICE_IN(Test::MyStructMyEnumD) p2,
+MyDerivedClassI::opMyStructMyEnumD(Test::MyStructMyEnumD p1,
+                                   Test::MyStructMyEnumD p2,
                                    Test::MyStructMyEnumD& p3,
                                    const Ice::Current&)
 {
@@ -398,8 +398,8 @@ MyDerivedClassI::opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD) p1,
 }
 
 Test::ByteBoolDS
-MyDerivedClassI::opByteBoolDS(ICE_IN(Test::ByteBoolDS) p1,
-                              ICE_IN(Test::ByteBoolDS) p2,
+MyDerivedClassI::opByteBoolDS(Test::ByteBoolDS p1,
+                              Test::ByteBoolDS p2,
                               Test::ByteBoolDS& p3,
                               const Ice::Current&)
 {
@@ -412,8 +412,8 @@ MyDerivedClassI::opByteBoolDS(ICE_IN(Test::ByteBoolDS) p1,
 }
 
 Test::ShortIntDS
-MyDerivedClassI::opShortIntDS(ICE_IN(Test::ShortIntDS) p1,
-                              ICE_IN(Test::ShortIntDS) p2,
+MyDerivedClassI::opShortIntDS(Test::ShortIntDS p1,
+                              Test::ShortIntDS p2,
                               Test::ShortIntDS& p3,
                               const Ice::Current&)
 {
@@ -426,8 +426,8 @@ MyDerivedClassI::opShortIntDS(ICE_IN(Test::ShortIntDS) p1,
 }
 
 Test::LongFloatDS
-MyDerivedClassI::opLongFloatDS(ICE_IN(Test::LongFloatDS) p1,
-                               ICE_IN(Test::LongFloatDS) p2,
+MyDerivedClassI::opLongFloatDS(Test::LongFloatDS p1,
+                               Test::LongFloatDS p2,
                                Test::LongFloatDS& p3,
                                const Ice::Current&)
 {
@@ -440,8 +440,8 @@ MyDerivedClassI::opLongFloatDS(ICE_IN(Test::LongFloatDS) p1,
 }
 
 Test::StringStringDS
-MyDerivedClassI::opStringStringDS(ICE_IN(Test::StringStringDS) p1,
-                                  ICE_IN(Test::StringStringDS) p2,
+MyDerivedClassI::opStringStringDS(Test::StringStringDS p1,
+                                  Test::StringStringDS p2,
                                   Test::StringStringDS& p3,
                                   const Ice::Current&)
 {
@@ -454,8 +454,8 @@ MyDerivedClassI::opStringStringDS(ICE_IN(Test::StringStringDS) p1,
 }
 
 Test::StringMyEnumDS
-MyDerivedClassI::opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS) p1,
-                                  ICE_IN(Test::StringMyEnumDS) p2,
+MyDerivedClassI::opStringMyEnumDS(Test::StringMyEnumDS p1,
+                                  Test::StringMyEnumDS p2,
                                   Test::StringMyEnumDS& p3,
                                   const Ice::Current&)
 {
@@ -468,8 +468,8 @@ MyDerivedClassI::opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS) p1,
 }
 
 Test::MyEnumStringDS
-MyDerivedClassI::opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS) p1,
-                                  ICE_IN(Test::MyEnumStringDS) p2,
+MyDerivedClassI::opMyEnumStringDS(Test::MyEnumStringDS p1,
+                                  Test::MyEnumStringDS p2,
                                   Test::MyEnumStringDS& p3,
                                   const Ice::Current&)
 {
@@ -482,8 +482,8 @@ MyDerivedClassI::opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS) p1,
 }
 
 Test::MyStructMyEnumDS
-MyDerivedClassI::opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS) p1,
-                                    ICE_IN(Test::MyStructMyEnumDS) p2,
+MyDerivedClassI::opMyStructMyEnumDS(Test::MyStructMyEnumDS p1,
+                                    Test::MyStructMyEnumDS p2,
                                     Test::MyStructMyEnumDS& p3,
                                     const Ice::Current&)
 {
@@ -496,8 +496,8 @@ MyDerivedClassI::opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS) p1,
 }
 
 Test::ByteByteSD
-MyDerivedClassI::opByteByteSD(ICE_IN(Test::ByteByteSD) p1,
-                              ICE_IN(Test::ByteByteSD) p2,
+MyDerivedClassI::opByteByteSD(Test::ByteByteSD p1,
+                              Test::ByteByteSD p2,
                               Test::ByteByteSD& p3,
                               const Ice::Current&)
 {
@@ -508,8 +508,8 @@ MyDerivedClassI::opByteByteSD(ICE_IN(Test::ByteByteSD) p1,
 }
 
 Test::BoolBoolSD
-MyDerivedClassI::opBoolBoolSD(ICE_IN(Test::BoolBoolSD) p1,
-                              ICE_IN(Test::BoolBoolSD) p2,
+MyDerivedClassI::opBoolBoolSD(Test::BoolBoolSD p1,
+                              Test::BoolBoolSD p2,
                               Test::BoolBoolSD& p3,
                               const Ice::Current&)
 {
@@ -520,8 +520,8 @@ MyDerivedClassI::opBoolBoolSD(ICE_IN(Test::BoolBoolSD) p1,
 }
 
 Test::ShortShortSD
-MyDerivedClassI::opShortShortSD(ICE_IN(Test::ShortShortSD) p1,
-                                ICE_IN(Test::ShortShortSD) p2,
+MyDerivedClassI::opShortShortSD(Test::ShortShortSD p1,
+                                Test::ShortShortSD p2,
                                 Test::ShortShortSD& p3,
                                 const Ice::Current&)
 {
@@ -532,8 +532,8 @@ MyDerivedClassI::opShortShortSD(ICE_IN(Test::ShortShortSD) p1,
 }
 
 Test::IntIntSD
-MyDerivedClassI::opIntIntSD(ICE_IN(Test::IntIntSD) p1,
-                            ICE_IN(Test::IntIntSD) p2,
+MyDerivedClassI::opIntIntSD(Test::IntIntSD p1,
+                            Test::IntIntSD p2,
                             Test::IntIntSD& p3,
                             const Ice::Current&)
 {
@@ -544,8 +544,8 @@ MyDerivedClassI::opIntIntSD(ICE_IN(Test::IntIntSD) p1,
 }
 
 Test::LongLongSD
-MyDerivedClassI::opLongLongSD(ICE_IN(Test::LongLongSD) p1,
-                              ICE_IN(Test::LongLongSD) p2,
+MyDerivedClassI::opLongLongSD(Test::LongLongSD p1,
+                              Test::LongLongSD p2,
                               Test::LongLongSD& p3,
                               const Ice::Current&)
 {
@@ -556,8 +556,8 @@ MyDerivedClassI::opLongLongSD(ICE_IN(Test::LongLongSD) p1,
 }
 
 Test::StringFloatSD
-MyDerivedClassI::opStringFloatSD(ICE_IN(Test::StringFloatSD) p1,
-                                 ICE_IN(Test::StringFloatSD) p2,
+MyDerivedClassI::opStringFloatSD(Test::StringFloatSD p1,
+                                 Test::StringFloatSD p2,
                                  Test::StringFloatSD& p3,
                                  const Ice::Current&)
 {
@@ -568,8 +568,8 @@ MyDerivedClassI::opStringFloatSD(ICE_IN(Test::StringFloatSD) p1,
 }
 
 Test::StringDoubleSD
-MyDerivedClassI::opStringDoubleSD(ICE_IN(Test::StringDoubleSD) p1,
-                                  ICE_IN(Test::StringDoubleSD) p2,
+MyDerivedClassI::opStringDoubleSD(Test::StringDoubleSD p1,
+                                  Test::StringDoubleSD p2,
                                   Test::StringDoubleSD& p3,
                                   const Ice::Current&)
 {
@@ -580,8 +580,8 @@ MyDerivedClassI::opStringDoubleSD(ICE_IN(Test::StringDoubleSD) p1,
 }
 
 Test::StringStringSD
-MyDerivedClassI::opStringStringSD(ICE_IN(Test::StringStringSD) p1,
-                                  ICE_IN(Test::StringStringSD) p2,
+MyDerivedClassI::opStringStringSD(Test::StringStringSD p1,
+                                  Test::StringStringSD p2,
                                   Test::StringStringSD& p3,
                                   const Ice::Current&)
 {
@@ -592,8 +592,8 @@ MyDerivedClassI::opStringStringSD(ICE_IN(Test::StringStringSD) p1,
 }
 
 Test::MyEnumMyEnumSD
-MyDerivedClassI::opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD) p1,
-                                  ICE_IN(Test::MyEnumMyEnumSD) p2,
+MyDerivedClassI::opMyEnumMyEnumSD(Test::MyEnumMyEnumSD p1,
+                                  Test::MyEnumMyEnumSD p2,
                                   Test::MyEnumMyEnumSD& p3,
                                   const Ice::Current&)
 {
@@ -604,7 +604,7 @@ MyDerivedClassI::opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD) p1,
 }
 
 Test::IntS
-MyDerivedClassI::opIntS(ICE_IN(Test::IntS) s, const Ice::Current&)
+MyDerivedClassI::opIntS(Test::IntS s, const Ice::Current&)
 {
     Test::IntS r;
     std::transform(s.begin(), s.end(), std::back_inserter(r), std::negate<int>());
@@ -612,7 +612,7 @@ MyDerivedClassI::opIntS(ICE_IN(Test::IntS) s, const Ice::Current&)
 }
 
 void
-MyDerivedClassI::opByteSOneway(ICE_IN(Test::ByteS), const Ice::Current&)
+MyDerivedClassI::opByteSOneway(Test::ByteS, const Ice::Current&)
 {
     IceUtil::Mutex::Lock sync(_mutex);
     ++_opByteSOnewayCallCount;
@@ -634,7 +634,7 @@ MyDerivedClassI::opContext(const Ice::Current& c)
 }
 
 void
-MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, ICE_IN(Test::DoubleS) p2, const Ice::Current&)
+MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, Test::DoubleS p2, const Ice::Current&)
 {
     Ice::Double d = 1278312346.0 / 13.0;
     test(p1 == d);
@@ -698,43 +698,43 @@ MyDerivedClassI::opDouble1(Ice::Double d, const Ice::Current&)
 }
 
 std::string
-MyDerivedClassI::opString1(ICE_IN(string) s, const Ice::Current&)
+MyDerivedClassI::opString1(string s, const Ice::Current&)
 {
     return s;
 }
 
 Test::StringS
-MyDerivedClassI::opStringS1(ICE_IN(Test::StringS) seq, const Ice::Current&)
+MyDerivedClassI::opStringS1(Test::StringS seq, const Ice::Current&)
 {
     return seq;
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD1(ICE_IN(Test::ByteBoolD) dict, const Ice::Current&)
+MyDerivedClassI::opByteBoolD1(Test::ByteBoolD dict, const Ice::Current&)
 {
     return dict;
 }
 
 Test::StringS
-MyDerivedClassI::opStringS2(ICE_IN(Test::StringS) seq, const Ice::Current&)
+MyDerivedClassI::opStringS2(Test::StringS seq, const Ice::Current&)
 {
     return seq;
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD2(ICE_IN(Test::ByteBoolD) dict, const Ice::Current&)
+MyDerivedClassI::opByteBoolD2(Test::ByteBoolD dict, const Ice::Current&)
 {
     return dict;
 }
 
 Test::MyStruct1
-MyDerivedClassI::opMyStruct1(ICE_IN(Test::MyStruct1) s, const Ice::Current&)
+MyDerivedClassI::opMyStruct1(Test::MyStruct1 s, const Ice::Current&)
 {
     return s;
 }
 
 Test::MyClass1Ptr
-MyDerivedClassI::opMyClass1(ICE_IN(Test::MyClass1Ptr) c, const Ice::Current&)
+MyDerivedClassI::opMyClass1(Test::MyClass1Ptr c, const Ice::Current&)
 {
     return c;
 }
@@ -832,7 +832,7 @@ MyDerivedClassI::opMStruct1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMStruct2MarshaledResult
-MyDerivedClassI::opMStruct2(ICE_IN(Test::Structure) p1, const Ice::Current& current)
+MyDerivedClassI::opMStruct2(Test::Structure p1, const Ice::Current& current)
 {
     return OpMStruct2MarshaledResult(p1, p1, current);
 }
@@ -844,7 +844,7 @@ MyDerivedClassI::opMSeq1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMSeq2MarshaledResult
-MyDerivedClassI::opMSeq2(ICE_IN(Test::StringS) p1, const Ice::Current& current)
+MyDerivedClassI::opMSeq2(Test::StringS p1, const Ice::Current& current)
 {
     return OpMSeq2MarshaledResult(p1, p1, current);
 }
@@ -856,7 +856,7 @@ MyDerivedClassI::opMDict1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMDict2MarshaledResult
-MyDerivedClassI::opMDict2(ICE_IN(Test::StringStringD) p1, const Ice::Current& current)
+MyDerivedClassI::opMDict2(Test::StringStringD p1, const Ice::Current& current)
 {
     return OpMDict2MarshaledResult(p1, p1, current);
 }

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -20,28 +20,28 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 bool
 MyDerivedClassI::ice_isA(ICE_IN(string) id, const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(move(id), current);
 }
 
 void
 MyDerivedClassI::ice_ping(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     Test::MyDerivedClass::ice_ping(current);
 }
 
 std::vector<std::string>
 MyDerivedClassI::ice_ids(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_ids(current);
 }
 
 std::string
 MyDerivedClassI::ice_id(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_id(current);
 }
 
@@ -60,7 +60,7 @@ MyDerivedClassI::supportsCompress(const Ice::Current&)
 void
 MyDerivedClassI::opVoid(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Normal));
+    test(current.mode == OperationMode::Normal);
 }
 
 Ice::Byte
@@ -126,7 +126,7 @@ MyDerivedClassI::opMyEnum(Test::MyEnum p1,
                           const Ice::Current&)
 {
     p2 = p1;
-    return ICE_ENUM(MyEnum, enum3);
+    return MyEnum::enum3;
 }
 
 Test::MyClassPrxPtr
@@ -647,13 +647,13 @@ MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, ICE_IN(Test::DoubleS) p2, co
 void
 MyDerivedClassI::opIdempotent(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Idempotent));
+    test(current.mode == OperationMode::Idempotent);
 }
 
 void
 MyDerivedClassI::opNonmutating(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
 }
 
 void
@@ -827,7 +827,7 @@ MyDerivedClassI::OpMStruct1MarshaledResult
 MyDerivedClassI::opMStruct1(const Ice::Current& current)
 {
     Test::Structure s;
-    s.e = ICE_ENUM(MyEnum, enum1); // enum must be initialized
+    s.e = MyEnum::enum1; // enum must be initialized
     return OpMStruct1MarshaledResult(s, current);
 }
 

--- a/cpp/test/Ice/operations/TestI.h
+++ b/cpp/test/Ice/operations/TestI.h
@@ -16,7 +16,7 @@ public:
     //
     // Override the Object "pseudo" operations to verify the operation mode.
     //
-    virtual bool ice_isA(ICE_IN(std::string), const Ice::Current&) const;
+    virtual bool ice_isA(std::string, const Ice::Current&) const;
     virtual void ice_ping(const Ice::Current&) const;
     virtual std::vector<std::string> ice_ids(const Ice::Current&) const;
     virtual std::string ice_id(const Ice::Current&) const;
@@ -51,8 +51,8 @@ public:
                                       Ice::Double&,
                                       const Ice::Current&);
 
-    virtual std::string opString(ICE_IN(std::string),
-                                 ICE_IN(std::string),
+    virtual std::string opString(std::string,
+                                 std::string,
                                  std::string&,
                                  const Ice::Current&);
 
@@ -60,201 +60,201 @@ public:
                                   Test::MyEnum&,
                                   const Ice::Current&);
 
-    virtual Test::MyClassPrxPtr opMyClass(ICE_IN(Test::MyClassPrxPtr),
+    virtual Test::MyClassPrxPtr opMyClass(Test::MyClassPrxPtr,
                                           Test::MyClassPrxPtr&, Test::MyClassPrxPtr&,
                                           const Ice::Current&);
 
-    virtual Test::Structure opStruct(ICE_IN(Test::Structure),
-                                     ICE_IN(Test::Structure),
+    virtual Test::Structure opStruct(Test::Structure,
+                                     Test::Structure,
                                      Test::Structure&,
                                      const Ice::Current&);
 
-    virtual Test::ByteS opByteS(ICE_IN(Test::ByteS),
-                                ICE_IN(Test::ByteS),
+    virtual Test::ByteS opByteS(Test::ByteS,
+                                Test::ByteS,
                                 Test::ByteS&,
                                 const Ice::Current&);
 
-    virtual Test::BoolS opBoolS(ICE_IN(Test::BoolS),
-                                ICE_IN(Test::BoolS),
+    virtual Test::BoolS opBoolS(Test::BoolS,
+                                Test::BoolS,
                                 Test::BoolS&,
                                 const Ice::Current&);
 
-    virtual Test::LongS opShortIntLongS(ICE_IN(Test::ShortS),
-                                        ICE_IN(Test::IntS),
-                                        ICE_IN(Test::LongS),
+    virtual Test::LongS opShortIntLongS(Test::ShortS,
+                                        Test::IntS,
+                                        Test::LongS,
                                         Test::ShortS&,
                                         Test::IntS&,
                                         Test::LongS&,
                                         const Ice::Current&);
 
-    virtual Test::DoubleS opFloatDoubleS(ICE_IN(Test::FloatS),
-                                         ICE_IN(Test::DoubleS),
+    virtual Test::DoubleS opFloatDoubleS(Test::FloatS,
+                                         Test::DoubleS,
                                          Test::FloatS&,
                                          Test::DoubleS&,
                                          const Ice::Current&);
 
-    virtual Test::StringS opStringS(ICE_IN(Test::StringS),
-                                    ICE_IN(Test::StringS),
+    virtual Test::StringS opStringS(Test::StringS,
+                                    Test::StringS,
                                     Test::StringS&,
                                     const Ice::Current&);
 
-    virtual Test::ByteSS opByteSS(ICE_IN(Test::ByteSS),
-                                  ICE_IN(Test::ByteSS),
+    virtual Test::ByteSS opByteSS(Test::ByteSS,
+                                  Test::ByteSS,
                                   Test::ByteSS&,
                                   const Ice::Current&);
 
-    virtual Test::BoolSS opBoolSS(ICE_IN(Test::BoolSS),
-                                  ICE_IN(Test::BoolSS),
+    virtual Test::BoolSS opBoolSS(Test::BoolSS,
+                                  Test::BoolSS,
                                   Test::BoolSS&,
                                   const Ice::Current&);
 
-    virtual Test::LongSS opShortIntLongSS(ICE_IN(Test::ShortSS),
-                                          ICE_IN(Test::IntSS),
-                                          ICE_IN(Test::LongSS),
+    virtual Test::LongSS opShortIntLongSS(Test::ShortSS,
+                                          Test::IntSS,
+                                          Test::LongSS,
                                           Test::ShortSS&,
                                           Test::IntSS&,
                                           Test::LongSS&,
                                           const Ice::Current&);
 
-    virtual Test::DoubleSS opFloatDoubleSS(ICE_IN(Test::FloatSS),
-                                           ICE_IN(Test::DoubleSS),
+    virtual Test::DoubleSS opFloatDoubleSS(Test::FloatSS,
+                                           Test::DoubleSS,
                                            Test::FloatSS&,
                                            Test::DoubleSS&,
                                            const Ice::Current&);
 
-    virtual Test::StringSS opStringSS(ICE_IN(Test::StringSS),
-                                      ICE_IN(Test::StringSS),
+    virtual Test::StringSS opStringSS(Test::StringSS,
+                                      Test::StringSS,
                                       Test::StringSS&,
                                       const Ice::Current&);
 
-    virtual Test::StringSSS opStringSSS(ICE_IN(Test::StringSSS),
-                                        ICE_IN(Test::StringSSS),
+    virtual Test::StringSSS opStringSSS(Test::StringSSS,
+                                        Test::StringSSS,
                                         Test::StringSSS&,
                                         const ::Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD(ICE_IN(Test::ByteBoolD),
-                                        ICE_IN(Test::ByteBoolD),
+    virtual Test::ByteBoolD opByteBoolD(Test::ByteBoolD,
+                                        Test::ByteBoolD,
                                         Test::ByteBoolD&,
                                         const Ice::Current&);
 
-    virtual Test::ShortIntD opShortIntD(ICE_IN(Test::ShortIntD),
-                                        ICE_IN(Test::ShortIntD),
+    virtual Test::ShortIntD opShortIntD(Test::ShortIntD,
+                                        Test::ShortIntD,
                                         Test::ShortIntD&,
                                         const Ice::Current&);
 
-    virtual Test::LongFloatD opLongFloatD(ICE_IN(Test::LongFloatD),
-                                          ICE_IN(Test::LongFloatD),
+    virtual Test::LongFloatD opLongFloatD(Test::LongFloatD,
+                                          Test::LongFloatD,
                                           Test::LongFloatD&,
                                           const Ice::Current&);
 
-    virtual Test::StringStringD opStringStringD(ICE_IN(Test::StringStringD),
-                                                ICE_IN(Test::StringStringD),
+    virtual Test::StringStringD opStringStringD(Test::StringStringD,
+                                                Test::StringStringD,
                                                 Test::StringStringD&,
                                                 const Ice::Current&);
 
-    virtual Test::StringMyEnumD opStringMyEnumD(ICE_IN(Test::StringMyEnumD),
-                                                ICE_IN(Test::StringMyEnumD),
+    virtual Test::StringMyEnumD opStringMyEnumD(Test::StringMyEnumD,
+                                                Test::StringMyEnumD,
                                                 Test::StringMyEnumD&,
                                                 const Ice::Current&);
 
-    virtual Test::MyEnumStringD opMyEnumStringD(ICE_IN(Test::MyEnumStringD),
-                                                ICE_IN(Test::MyEnumStringD),
+    virtual Test::MyEnumStringD opMyEnumStringD(Test::MyEnumStringD,
+                                                Test::MyEnumStringD,
                                                 Test::MyEnumStringD&,
                                                 const Ice::Current&);
 
-    virtual Test::MyStructMyEnumD opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD),
-                                                    ICE_IN(Test::MyStructMyEnumD),
+    virtual Test::MyStructMyEnumD opMyStructMyEnumD(Test::MyStructMyEnumD,
+                                                    Test::MyStructMyEnumD,
                                                     Test::MyStructMyEnumD&,
                                                     const Ice::Current&);
 
-    virtual Test::ByteBoolDS opByteBoolDS(ICE_IN(Test::ByteBoolDS),
-                                          ICE_IN(Test::ByteBoolDS),
+    virtual Test::ByteBoolDS opByteBoolDS(Test::ByteBoolDS,
+                                          Test::ByteBoolDS,
                                           Test::ByteBoolDS&,
                                           const Ice::Current&);
 
-    virtual Test::ShortIntDS opShortIntDS(ICE_IN(Test::ShortIntDS),
-                                          ICE_IN(Test::ShortIntDS),
+    virtual Test::ShortIntDS opShortIntDS(Test::ShortIntDS,
+                                          Test::ShortIntDS,
                                           Test::ShortIntDS&,
                                           const Ice::Current&);
 
-    virtual Test::LongFloatDS opLongFloatDS(ICE_IN(Test::LongFloatDS),
-                                            ICE_IN(Test::LongFloatDS),
+    virtual Test::LongFloatDS opLongFloatDS(Test::LongFloatDS,
+                                            Test::LongFloatDS,
                                             Test::LongFloatDS&,
                                             const Ice::Current&);
 
-    virtual Test::StringStringDS opStringStringDS(ICE_IN(Test::StringStringDS),
-                                                  ICE_IN(Test::StringStringDS),
+    virtual Test::StringStringDS opStringStringDS(Test::StringStringDS,
+                                                  Test::StringStringDS,
                                                   Test::StringStringDS&,
                                                   const Ice::Current&);
 
-    virtual Test::StringMyEnumDS opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS),
-                                                  ICE_IN(Test::StringMyEnumDS),
+    virtual Test::StringMyEnumDS opStringMyEnumDS(Test::StringMyEnumDS,
+                                                  Test::StringMyEnumDS,
                                                   Test::StringMyEnumDS&,
                                                   const Ice::Current&);
 
-    virtual Test::MyStructMyEnumDS opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS),
-                                                      ICE_IN(Test::MyStructMyEnumDS),
+    virtual Test::MyStructMyEnumDS opMyStructMyEnumDS(Test::MyStructMyEnumDS,
+                                                      Test::MyStructMyEnumDS,
                                                       Test::MyStructMyEnumDS&,
                                                       const Ice::Current&);
 
-    virtual Test::MyEnumStringDS opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS),
-                                                  ICE_IN(Test::MyEnumStringDS),
+    virtual Test::MyEnumStringDS opMyEnumStringDS(Test::MyEnumStringDS,
+                                                  Test::MyEnumStringDS,
                                                   Test::MyEnumStringDS&,
                                                   const Ice::Current&);
 
-    virtual Test::ByteByteSD opByteByteSD(ICE_IN(Test::ByteByteSD),
-                                          ICE_IN(Test::ByteByteSD),
+    virtual Test::ByteByteSD opByteByteSD(Test::ByteByteSD,
+                                          Test::ByteByteSD,
                                           Test::ByteByteSD&,
                                           const Ice::Current&);
 
-    virtual Test::BoolBoolSD opBoolBoolSD(ICE_IN(Test::BoolBoolSD),
-                                          ICE_IN(Test::BoolBoolSD),
+    virtual Test::BoolBoolSD opBoolBoolSD(Test::BoolBoolSD,
+                                          Test::BoolBoolSD,
                                           Test::BoolBoolSD&,
                                           const Ice::Current&);
 
-    virtual Test::ShortShortSD opShortShortSD(ICE_IN(Test::ShortShortSD),
-                                              ICE_IN(Test::ShortShortSD),
+    virtual Test::ShortShortSD opShortShortSD(Test::ShortShortSD,
+                                              Test::ShortShortSD,
                                               Test::ShortShortSD&,
                                               const Ice::Current&);
 
-    virtual Test::IntIntSD opIntIntSD(ICE_IN(Test::IntIntSD),
-                                      ICE_IN(Test::IntIntSD),
+    virtual Test::IntIntSD opIntIntSD(Test::IntIntSD,
+                                      Test::IntIntSD,
                                       Test::IntIntSD&,
                                       const Ice::Current&);
 
-    virtual Test::LongLongSD opLongLongSD(ICE_IN(Test::LongLongSD),
-                                          ICE_IN(Test::LongLongSD),
+    virtual Test::LongLongSD opLongLongSD(Test::LongLongSD,
+                                          Test::LongLongSD,
                                           Test::LongLongSD&,
                                           const Ice::Current&);
 
-    virtual Test::StringFloatSD opStringFloatSD(ICE_IN(Test::StringFloatSD),
-                                                ICE_IN(Test::StringFloatSD),
+    virtual Test::StringFloatSD opStringFloatSD(Test::StringFloatSD,
+                                                Test::StringFloatSD,
                                                 Test::StringFloatSD&,
                                                 const Ice::Current&);
 
-    virtual Test::StringDoubleSD opStringDoubleSD(ICE_IN(Test::StringDoubleSD),
-                                                  ICE_IN(Test::StringDoubleSD),
+    virtual Test::StringDoubleSD opStringDoubleSD(Test::StringDoubleSD,
+                                                  Test::StringDoubleSD,
                                                   Test::StringDoubleSD&,
                                                   const Ice::Current&);
 
-    virtual Test::StringStringSD opStringStringSD(ICE_IN(Test::StringStringSD),
-                                                  ICE_IN(Test::StringStringSD),
+    virtual Test::StringStringSD opStringStringSD(Test::StringStringSD,
+                                                  Test::StringStringSD,
                                                   Test::StringStringSD&,
                                                   const Ice::Current&);
 
-    virtual Test::MyEnumMyEnumSD opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD),
-                                                  ICE_IN(Test::MyEnumMyEnumSD),
+    virtual Test::MyEnumMyEnumSD opMyEnumMyEnumSD(Test::MyEnumMyEnumSD,
+                                                  Test::MyEnumMyEnumSD,
                                                   Test::MyEnumMyEnumSD&,
                                                   const Ice::Current&);
 
-    virtual Test::IntS opIntS(ICE_IN(Test::IntS), const Ice::Current&);
+    virtual Test::IntS opIntS(Test::IntS, const Ice::Current&);
 
-    virtual void opByteSOneway(ICE_IN(Test::ByteS), const Ice::Current&);
+    virtual void opByteSOneway(Test::ByteS, const Ice::Current&);
     virtual int opByteSOnewayCallCount(const Ice::Current&);
 
     virtual Ice::Context opContext(const Ice::Current&);
 
-    virtual void opDoubleMarshaling(Ice::Double, ICE_IN(Test::DoubleS), const Ice::Current&);
+    virtual void opDoubleMarshaling(Ice::Double, Test::DoubleS, const Ice::Current&);
 
     virtual void opIdempotent(const Ice::Current&);
 
@@ -274,19 +274,19 @@ public:
 
     virtual Ice::Double opDouble1(Ice::Double, const Ice::Current&);
 
-    virtual std::string opString1(ICE_IN(std::string), const Ice::Current&);
+    virtual std::string opString1(std::string, const Ice::Current&);
 
-    virtual Test::StringS opStringS1(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual Test::StringS opStringS1(Test::StringS, const Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD1(ICE_IN(Test::ByteBoolD), const Ice::Current&);
+    virtual Test::ByteBoolD opByteBoolD1(Test::ByteBoolD, const Ice::Current&);
 
-    virtual Test::StringS opStringS2(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual Test::StringS opStringS2(Test::StringS, const Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD2(ICE_IN(Test::ByteBoolD), const Ice::Current&);
+    virtual Test::ByteBoolD opByteBoolD2(Test::ByteBoolD, const Ice::Current&);
 
-    virtual Test::MyStruct1 opMyStruct1(ICE_IN(Test::MyStruct1), const Ice::Current&);
+    virtual Test::MyStruct1 opMyStruct1(Test::MyStruct1, const Ice::Current&);
 
-    virtual Test::MyClass1Ptr opMyClass1(ICE_IN(Test::MyClass1Ptr), const Ice::Current&);
+    virtual Test::MyClass1Ptr opMyClass1(Test::MyClass1Ptr, const Ice::Current&);
 
     virtual Test::StringS opStringLiterals(const Ice::Current&);
 
@@ -294,15 +294,15 @@ public:
 
     virtual OpMStruct1MarshaledResult opMStruct1(const Ice::Current&);
 
-    virtual OpMStruct2MarshaledResult opMStruct2(ICE_IN(Test::Structure), const Ice::Current&);
+    virtual OpMStruct2MarshaledResult opMStruct2(Test::Structure, const Ice::Current&);
 
     virtual OpMSeq1MarshaledResult opMSeq1(const Ice::Current&);
 
-    virtual OpMSeq2MarshaledResult opMSeq2(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual OpMSeq2MarshaledResult opMSeq2(Test::StringS, const Ice::Current&);
 
     virtual OpMDict1MarshaledResult opMDict1(const Ice::Current&);
 
-    virtual OpMDict2MarshaledResult opMDict2(ICE_IN(Test::StringStringD), const Ice::Current&);
+    virtual OpMDict2MarshaledResult opMDict2(Test::StringStringD, const Ice::Current&);
 
 private:
 

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -331,9 +331,9 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
         Test::MyEnum e;
         Test::MyEnum r;
 
-        r = p->opMyEnum(ICE_ENUM(MyEnum, enum2), e);
-        test(e == ICE_ENUM(MyEnum, enum2));
-        test(r == ICE_ENUM(MyEnum, enum3));
+        r = p->opMyEnum(MyEnum::enum2, e);
+        test(e == MyEnum::enum2);
+        test(r == MyEnum::enum3);
     }
 
     {
@@ -369,20 +369,20 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = ICE_ENUM(MyEnum, enum3);
+        si1.e = MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = ICE_ENUM(MyEnum, enum2);
+        si2.e = MyEnum::enum2;
         si2.s.s = "def";
 
         Test::Structure so;
         Test::Structure rso = p->opStruct(si1, si2, so);
         test(rso.p == 0);
-        test(rso.e == ICE_ENUM(MyEnum, enum2));
+        test(rso.e == MyEnum::enum2);
         test(rso.s.s == "def");
         test(Ice::targetEqualTo(so.p, p));
-        test(so.e == ICE_ENUM(MyEnum, enum3));
+        test(so.e == MyEnum::enum3);
         test(so.s.s == "a new string");
         so.p->opVoid();
     }
@@ -891,64 +891,64 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(MyEnum, enum1);
-        di1[""] = ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = MyEnum::enum1;
+        di1[""] = MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = MyEnum::enum1;
+        di2["qwerty"] = MyEnum::enum3;
+        di2["Hello!!"] = MyEnum::enum2;
 
         Test::StringMyEnumD _do;
         Test::StringMyEnumD ro = p->opStringMyEnumD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 4);
-        test(ro["abc"] == ICE_ENUM(MyEnum, enum1));
-        test(ro["qwerty"] == ICE_ENUM(MyEnum, enum3));
-        test(ro[""] == ICE_ENUM(MyEnum, enum2));
-        test(ro["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+        test(ro["abc"] == MyEnum::enum1);
+        test(ro["qwerty"] == MyEnum::enum3);
+        test(ro[""] == MyEnum::enum2);
+        test(ro["Hello!!"] == MyEnum::enum2);
     }
 
     {
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[MyEnum::enum2] = "Hello!!";
+        di2[MyEnum::enum3] = "qwerty";
 
         Test::MyEnumStringD _do;
         Test::MyEnumStringD ro = p->opMyEnumStringD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 3);
-        test(ro[ICE_ENUM(MyEnum, enum1)] == "abc");
-        test(ro[ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-        test(ro[ICE_ENUM(MyEnum, enum3)] == "qwerty");
+        test(ro[MyEnum::enum1] == "abc");
+        test(ro[MyEnum::enum2] == "Hello!!");
+        test(ro[MyEnum::enum3] == "qwerty");
     }
 
     {
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = MyEnum::enum1;
+        di1[ms12] = MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = MyEnum::enum1;
+        di2[ms22] = MyEnum::enum3;
+        di2[ms23] = MyEnum::enum2;
 
         Test::MyStructMyEnumD _do;
         Test::MyStructMyEnumD ro = p->opMyStructMyEnumD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 4);
-        test(ro[ms11] == ICE_ENUM(MyEnum, enum1));
-        test(ro[ms12] == ICE_ENUM(MyEnum, enum2));
-        test(ro[ms22] == ICE_ENUM(MyEnum, enum3));
-        test(ro[ms23] == ICE_ENUM(MyEnum, enum2));
+        test(ro[ms11] == MyEnum::enum1);
+        test(ro[ms12] == MyEnum::enum2);
+        test(ro[ms22] == MyEnum::enum3);
+        test(ro[ms23] == MyEnum::enum2);
     }
 
     {
@@ -1159,14 +1159,14 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(MyEnum, enum1);
-        di1[""] = ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = MyEnum::enum1;
+        di1[""] = MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = MyEnum::enum1;
+        di2["qwerty"] = MyEnum::enum3;
+        di2["Hello!!"] = MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1179,23 +1179,23 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
             test(ro.size() == 2);
             test(ro[0].size() == 3);
-            test(ro[0]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(ro[0]["qwerty"] == ICE_ENUM(MyEnum, enum3));
-            test(ro[0]["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+            test(ro[0]["abc"] == MyEnum::enum1);
+            test(ro[0]["qwerty"] == MyEnum::enum3);
+            test(ro[0]["Hello!!"] == MyEnum::enum2);
             test(ro[1].size() == 2);
-            test(ro[1]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(ro[1][""] == ICE_ENUM(MyEnum, enum2));
+            test(ro[1]["abc"] == MyEnum::enum1);
+            test(ro[1][""] == MyEnum::enum2);
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0]["Goodbye"] == ICE_ENUM(MyEnum, enum1));
+            test(_do[0]["Goodbye"] == MyEnum::enum1);
             test(_do[1].size() == 2);
-            test(_do[1]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(_do[1][""] == ICE_ENUM(MyEnum, enum2));
+            test(_do[1]["abc"] == MyEnum::enum1);
+            test(_do[1][""] == MyEnum::enum2);
             test(_do[2].size() == 3);
-            test(_do[2]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(_do[2]["qwerty"] == ICE_ENUM(MyEnum, enum3));
-            test(_do[2]["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+            test(_do[2]["abc"] == MyEnum::enum1);
+            test(_do[2]["qwerty"] == MyEnum::enum3);
+            test(_do[2]["Hello!!"] == MyEnum::enum2);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1209,12 +1209,12 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[MyEnum::enum2] = "Hello!!";
+        di2[MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1227,19 +1227,19 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
             test(ro.size() == 2);
             test(ro[0].size() == 2);
-            test(ro[0][ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-            test(ro[0][ICE_ENUM(MyEnum, enum3)] == "qwerty");
+            test(ro[0][MyEnum::enum2] == "Hello!!");
+            test(ro[0][MyEnum::enum3] == "qwerty");
             test(ro[1].size() == 1);
-            test(ro[1][ICE_ENUM(MyEnum, enum1)] == "abc");
+            test(ro[1][MyEnum::enum1] == "abc");
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0][ICE_ENUM(MyEnum, enum1)] == "Goodbye");
+            test(_do[0][MyEnum::enum1] == "Goodbye");
             test(_do[1].size() == 1);
-            test(_do[1][ICE_ENUM(MyEnum, enum1)] == "abc");
+            test(_do[1][MyEnum::enum1] == "abc");
             test(_do[2].size() == 2);
-            test(_do[2][ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-            test(_do[2][ICE_ENUM(MyEnum, enum3)] == "qwerty");
+            test(_do[2][MyEnum::enum2] == "Hello!!");
+            test(_do[2][MyEnum::enum3] == "qwerty");
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1255,18 +1255,18 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = MyEnum::enum1;
+        di1[ms12] = MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = MyEnum::enum1;
+        di2[ms22] = MyEnum::enum3;
+        di2[ms23] = MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1279,23 +1279,23 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
             test(ro.size() == 2);
             test(ro[0].size() == 3);
-            test(ro[0][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(ro[0][ms22] == ICE_ENUM(MyEnum, enum3));
-            test(ro[0][ms23] == ICE_ENUM(MyEnum, enum2));
+            test(ro[0][ms11] == MyEnum::enum1);
+            test(ro[0][ms22] == MyEnum::enum3);
+            test(ro[0][ms23] == MyEnum::enum2);
             test(ro[1].size() == 2);
-            test(ro[1][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(ro[1][ms12] == ICE_ENUM(MyEnum, enum2));
+            test(ro[1][ms11] == MyEnum::enum1);
+            test(ro[1][ms12] == MyEnum::enum2);
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0][ms23] == ICE_ENUM(MyEnum, enum3));
+            test(_do[0][ms23] == MyEnum::enum3);
             test(_do[1].size() == 2);
-            test(_do[1][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(_do[1][ms12] == ICE_ENUM(MyEnum, enum2));
+            test(_do[1][ms11] == MyEnum::enum1);
+            test(_do[1][ms12] == MyEnum::enum2);
             test(_do[2].size() == 3);
-            test(_do[2][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(_do[2][ms22] == ICE_ENUM(MyEnum, enum3));
-            test(_do[2][ms23] == ICE_ENUM(MyEnum, enum2));
+            test(_do[2][ms11] == MyEnum::enum1);
+            test(_do[2][ms22] == MyEnum::enum3);
+            test(_do[2][ms23] == MyEnum::enum2);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1646,17 +1646,17 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(ICE_ENUM(MyEnum, enum1));
-        si1.push_back(ICE_ENUM(MyEnum, enum1));
-        si1.push_back(ICE_ENUM(MyEnum, enum2));
-        si2.push_back(ICE_ENUM(MyEnum, enum1));
-        si2.push_back(ICE_ENUM(MyEnum, enum2));
-        si3.push_back(ICE_ENUM(MyEnum, enum3));
-        si3.push_back(ICE_ENUM(MyEnum, enum3));
+        si1.push_back(MyEnum::enum1);
+        si1.push_back(MyEnum::enum1);
+        si1.push_back(MyEnum::enum2);
+        si2.push_back(MyEnum::enum1);
+        si2.push_back(MyEnum::enum2);
+        si3.push_back(MyEnum::enum3);
+        si3.push_back(MyEnum::enum3);
 
-        sdi1[ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[MyEnum::enum3] = si1;
+        sdi1[MyEnum::enum2] = si2;
+        sdi2[MyEnum::enum1] = si3;
 
         try
         {
@@ -1665,16 +1665,16 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
             test(_do == sdi2);
             test(ro.size() == 3);
-            test(ro[ICE_ENUM(MyEnum, enum3)].size() == 3);
-            test(ro[ICE_ENUM(MyEnum, enum3)][0] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum3)][1] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum3)][2] == ICE_ENUM(MyEnum, enum2));
-            test(ro[ICE_ENUM(MyEnum, enum2)].size() == 2);
-            test(ro[ICE_ENUM(MyEnum, enum2)][0] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum2)][1] == ICE_ENUM(MyEnum, enum2));
-            test(ro[ICE_ENUM(MyEnum, enum1)].size() == 2);
-            test(ro[ICE_ENUM(MyEnum, enum1)][0] == ICE_ENUM(MyEnum, enum3));
-            test(ro[ICE_ENUM(MyEnum, enum1)][1] == ICE_ENUM(MyEnum, enum3));
+            test(ro[MyEnum::enum3].size() == 3);
+            test(ro[MyEnum::enum3][0] == MyEnum::enum1);
+            test(ro[MyEnum::enum3][1] == MyEnum::enum1);
+            test(ro[MyEnum::enum3][2] == MyEnum::enum2);
+            test(ro[MyEnum::enum2].size() == 2);
+            test(ro[MyEnum::enum2][0] == MyEnum::enum1);
+            test(ro[MyEnum::enum2][1] == MyEnum::enum2);
+            test(ro[MyEnum::enum1].size() == 2);
+            test(ro[MyEnum::enum1][0] == MyEnum::enum3);
+            test(ro[MyEnum::enum1][1] == MyEnum::enum3);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1840,7 +1840,7 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
 
     {
         Test::Structure p1 = p->opMStruct1();
-        p1.e = ICE_ENUM(MyEnum, enum3);
+        p1.e = MyEnum::enum3;
         Test::Structure p2, p3;
         p3 = p->opMStruct2(p1, p2);
         test(p2.e == p1.e && p3.e == p1.e);

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -1823,7 +1823,7 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper* helper, cons
     test(s.myClass == 0);
     test(s.myStruct1 == "Test::MyStruct1::myStruct1");
 
-    Test::MyClass1Ptr c = ICE_MAKE_SHARED(Test::MyClass1);
+    Test::MyClass1Ptr c = std::make_shared<Test::MyClass1>();
     c->tesT = "Test::MyClass1::testT";
     c->myClass = 0;
     c->myClass1 = "Test::MyClass1::myClass1";

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -154,8 +154,8 @@ public:
 
     void opMyEnum(Test::MyEnum r, Test::MyEnum e)
     {
-        test(e == Test::ICE_ENUM(MyEnum, enum2));
-        test(r == Test::ICE_ENUM(MyEnum, enum3));
+        test(e == Test::MyEnum::enum2);
+        test(r == Test::MyEnum::enum3);
         called();
     }
 
@@ -187,9 +187,9 @@ public:
     void opStruct(const Test::Structure& rso, const Test::Structure& so)
     {
         test(rso.p == 0);
-        test(rso.e == Test::ICE_ENUM(MyEnum, enum2));
+        test(rso.e == Test::MyEnum::enum2);
         test(rso.s.s == "def");
-        test(so.e == Test::ICE_ENUM(MyEnum, enum3));
+        test(so.e == Test::MyEnum::enum3);
         test(so.s.s == "a new string");
 
         //
@@ -494,18 +494,18 @@ public:
     void opStringMyEnumD(const Test::StringMyEnumD& ro, const Test::StringMyEnumD& _do)
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         test(_do == di1);
         test(ro.size() == 4);
         test(ro.find("abc") != ro.end());
-        test(ro.find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find("abc")->second == Test::MyEnum::enum1);
         test(ro.find("qwerty") != ro.end());
-        test(ro.find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find("qwerty")->second == Test::MyEnum::enum3);
         test(ro.find("") != ro.end());
-        test(ro.find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find("")->second == Test::MyEnum::enum2);
         test(ro.find("Hello!!") != ro.end());
-        test(ro.find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find("Hello!!")->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -514,20 +514,20 @@ public:
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
         test(_do == di1);
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         test(ro.size() == 4);
         test(ro.find(ms11) != ro.end());
-        test(ro.find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find(ms11)->second == Test::MyEnum::enum1);
         test(ro.find(ms12) != ro.end());
-        test(ro.find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(ms12)->second == Test::MyEnum::enum2);
         test(ro.find(ms22) != ro.end());
-        test(ro.find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find(ms22)->second == Test::MyEnum::enum3);
         test(ro.find(ms23) != ro.end());
-        test(ro.find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(ms23)->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -672,32 +672,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find("abc") != ro[0].end());
-        test(ro[0].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[0].find("abc")->second == Test::MyEnum::enum1);
         test(ro[0].find("qwerty") != ro[0].end());
-        test(ro[0].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro[0].find("qwerty")->second == Test::MyEnum::enum3);
         test(ro[0].find("Hello!!") != ro[0].end());
-        test(ro[0].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[0].find("Hello!!")->second == Test::MyEnum::enum2);
         test(ro[1].size() == 2);
         test(ro[1].find("abc") != ro[1].end());
-        test(ro[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[1].find("abc")->second == Test::MyEnum::enum1);
         test(ro[1].find("") != ro[1].end());
-        test(ro[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[1].find("")->second == Test::MyEnum::enum2);
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find("Goodbye") != _do[0].end());
-        test(_do[0].find("Goodbye")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[0].find("Goodbye")->second == Test::MyEnum::enum1);
         test(_do[1].size() == 2);
         test(_do[1].find("abc") != _do[1].end());
-        test(_do[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[1].find("abc")->second == Test::MyEnum::enum1);
         test(_do[1].find("") != _do[1].end());
-        test(_do[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[1].find("")->second == Test::MyEnum::enum2);
         test(_do[2].size() == 3);
         test(_do[2].find("abc") != _do[2].end());
-        test(_do[2].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[2].find("abc")->second == Test::MyEnum::enum1);
         test(_do[2].find("qwerty") != _do[2].end());
-        test(_do[2].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[2].find("qwerty")->second == Test::MyEnum::enum3);
         test(_do[2].find("Hello!!") != _do[2].end());
-        test(_do[2].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[2].find("Hello!!")->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -705,25 +705,25 @@ public:
     {
         test(ro.size() == 2);
         test(ro[0].size() == 2);
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2)) != ro[0].end());
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3)) != ro[0].end());
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
+        test(ro[0].find(Test::MyEnum::enum2) != ro[0].end());
+        test(ro[0].find(Test::MyEnum::enum2)->second == "Hello!!");
+        test(ro[0].find(Test::MyEnum::enum3) != ro[0].end());
+        test(ro[0].find(Test::MyEnum::enum3)->second == "qwerty");
         test(ro[1].size() == 1);
-        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1)) != ro[1].end());
-        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
+        test(ro[1].find(Test::MyEnum::enum1) != ro[1].end());
+        test(ro[1].find(Test::MyEnum::enum1)->second == "abc");
         test(_do.size() == 3);
         test(_do[0].size() == 1);
-        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[0].end());
-        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1))->second == "Goodbye");
+        test(_do[0].find(Test::MyEnum::enum1) != _do[0].end());
+        test(_do[0].find(Test::MyEnum::enum1)->second == "Goodbye");
         test(_do[1].size() == 1);
-        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[1].end());
-        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
+        test(_do[1].find(Test::MyEnum::enum1) != _do[1].end());
+        test(_do[1].find(Test::MyEnum::enum1)->second == "abc");
         test(_do[2].size() == 2);
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2)) != _do[2].end());
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3)) != _do[2].end());
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
+        test(_do[2].find(Test::MyEnum::enum2) != _do[2].end());
+        test(_do[2].find(Test::MyEnum::enum2)->second == "Hello!!");
+        test(_do[2].find(Test::MyEnum::enum3) != _do[2].end());
+        test(_do[2].find(Test::MyEnum::enum3)->second == "qwerty");
         called();
     }
 
@@ -737,32 +737,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find(ms11) != ro[0].end());
-        test(ro[0].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[0].find(ms11)->second == Test::MyEnum::enum1);
         test(ro[0].find(ms22) != ro[0].end());
-        test(ro[0].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro[0].find(ms22)->second == Test::MyEnum::enum3);
         test(ro[0].find(ms23) != ro[0].end());
-        test(ro[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[0].find(ms23)->second == Test::MyEnum::enum2);
         test(ro[1].size() == 2);
         test(ro[1].find(ms11) != ro[1].end());
-        test(ro[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[1].find(ms11)->second == Test::MyEnum::enum1);
         test(ro[1].find(ms12) != ro[1].end());
-        test(ro[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[1].find(ms12)->second == Test::MyEnum::enum2);
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find(ms23) != _do[0].end());
-        test(_do[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[0].find(ms23)->second == Test::MyEnum::enum3);
         test(_do[1].size() == 2);
         test(_do[1].find(ms11) != _do[1].end());
-        test(_do[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[1].find(ms11)->second == Test::MyEnum::enum1);
         test(_do[1].find(ms12) != _do[1].end());
-        test(_do[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[1].find(ms12)->second == Test::MyEnum::enum2);
         test(_do[2].size() == 3);
         test(_do[2].find(ms11) != _do[2].end());
-        test(_do[2].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[2].find(ms11)->second == Test::MyEnum::enum1);
         test(_do[2].find(ms22) != _do[2].end());
-        test(_do[2].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[2].find(ms22)->second == Test::MyEnum::enum3);
         test(_do[2].find(ms23) != _do[2].end());
-        test(_do[2].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[2].find(ms23)->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -955,24 +955,24 @@ public:
     void opMyEnumMyEnumSD(const Test::MyEnumMyEnumSD& ro, const Test::MyEnumMyEnumSD& _do)
     {
         test(_do.size() == 1);
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1)) != _do.end());
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do.find(Test::MyEnum::enum1) != _do.end());
+        test(_do.find(Test::MyEnum::enum1)->second.size() == 2);
+        test(_do.find(Test::MyEnum::enum1)->second[0] == Test::MyEnum::enum3);
+        test(_do.find(Test::MyEnum::enum1)->second[1] == Test::MyEnum::enum3);
         test(ro.size() == 3);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second.size() == 3);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[1] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[2] == Test::ICE_ENUM(MyEnum, enum2));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second.size() == 2);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[1] == Test::ICE_ENUM(MyEnum, enum2));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find(Test::MyEnum::enum3) != ro.end());
+        test(ro.find(Test::MyEnum::enum3)->second.size() == 3);
+        test(ro.find(Test::MyEnum::enum3)->second[0] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum3)->second[1] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum3)->second[2] == Test::MyEnum::enum2);
+        test(ro.find(Test::MyEnum::enum2) != ro.end());
+        test(ro.find(Test::MyEnum::enum2)->second.size() == 2);
+        test(ro.find(Test::MyEnum::enum2)->second[0] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum2)->second[1] == Test::MyEnum::enum2);
+        test(ro.find(Test::MyEnum::enum1) != ro.end());
+        test(ro.find(Test::MyEnum::enum1)->second.size() == 2);
+        test(ro.find(Test::MyEnum::enum1)->second[0] == Test::MyEnum::enum3);
+        test(ro.find(Test::MyEnum::enum1)->second[1] == Test::MyEnum::enum3);
         called();
     }
 
@@ -1186,11 +1186,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = Test::ICE_ENUM(MyEnum, enum3);
+        si1.e = Test::MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = Test::ICE_ENUM(MyEnum, enum2);
+        si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
@@ -1516,12 +1516,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         p->opStringMyEnumDAsync(di1, di2,
@@ -1537,15 +1537,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         p->opMyStructMyEnumDAsync(di1, di2,
@@ -1686,14 +1686,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = Test::MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1716,12 +1716,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[Test::MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[Test::MyEnum::enum2] = "Hello!!";
+        di2[Test::MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[Test::MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1746,18 +1746,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = Test::MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -2018,17 +2018,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum2);
+        si2.push_back(Test::MyEnum::enum1);
+        si2.push_back(Test::MyEnum::enum2);
+        si3.push_back(Test::MyEnum::enum3);
+        si3.push_back(Test::MyEnum::enum3);
 
-        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[Test::MyEnum::enum3] = si1;
+        sdi1[Test::MyEnum::enum2] = si2;
+        sdi2[Test::MyEnum::enum1] = si3;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         p->opMyEnumMyEnumSDAsync(sdi1, sdi2,
@@ -2522,11 +2522,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = Test::ICE_ENUM(MyEnum, enum3);
+        si1.e = Test::MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = Test::ICE_ENUM(MyEnum, enum2);
+        si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
@@ -2904,12 +2904,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opStringMyEnumDAsync(di1, di2);
@@ -2933,15 +2933,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opMyStructMyEnumDAsync(di1, di2);
@@ -3121,14 +3121,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = Test::MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3159,12 +3159,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[Test::MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[Test::MyEnum::enum2] = "Hello!!";
+        di2[Test::MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[Test::MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3197,18 +3197,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = Test::MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3542,17 +3542,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum2);
+        si2.push_back(Test::MyEnum::enum1);
+        si2.push_back(Test::MyEnum::enum2);
+        si3.push_back(Test::MyEnum::enum3);
+        si3.push_back(Test::MyEnum::enum3);
 
-        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[Test::MyEnum::enum3] = si1;
+        sdi1[Test::MyEnum::enum2] = si2;
+        sdi2[Test::MyEnum::enum1] = si3;
 
         CallbackPtr cb = ICE_MAKE_SHARED(Callback);
         auto f = p->opMyEnumMyEnumSDAsync(sdi1, sdi2);

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -1049,7 +1049,7 @@ void
 twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& p)
 {
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_pingAsync(
             [&]()
             {
@@ -1060,7 +1060,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_isAAsync(
             Test::MyClass::ice_staticId(),
             [&](bool v)
@@ -1072,7 +1072,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_idAsync(
             [&](string id)
             {
@@ -1083,7 +1083,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_idsAsync(
             [&](vector<string> ids)
             {
@@ -1095,7 +1095,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opVoidAsync(
             [&]()
             {
@@ -1107,7 +1107,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
             [&](Ice::Byte b1, Ice::Byte b2)
             {
@@ -1118,7 +1118,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opBoolAsync(true, false,
             [&](bool b1, bool b2)
             {
@@ -1129,7 +1129,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortIntLongAsync(10, 11, 12,
             [&](long long int l1, short s1P, int i1, long long int l2)
             {
@@ -1140,7 +1140,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opFloatDoubleAsync(3.14f, 1.1E10,
             [&](double d1, float f1, double d2)
             {
@@ -1151,7 +1151,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringAsync("hello", "world",
             [&](string s1P, string s2P)
             {
@@ -1162,7 +1162,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opMyEnumAsync(Test::MyEnum::enum2,
                          [&](Test::MyEnum e1, Test::MyEnum e2)
             {
@@ -1173,7 +1173,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = std::make_shared<Callback>(communicator);
         p->opMyClassAsync(p,
                           [&](shared_ptr<Test::MyClassPrx> c1, shared_ptr<Test::MyClassPrx> c2, shared_ptr<Test::MyClassPrx> c3)
             {
@@ -1193,7 +1193,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = std::make_shared<Callback>(communicator);
         p->opStructAsync(si1, si2,
             [&](Test::Structure si3, Test::Structure si4)
             {
@@ -1217,7 +1217,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2.push_back(Ice::Byte(0xf3));
         bsi2.push_back(Ice::Byte(0xf4));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteSAsync(bsi1, bsi2,
             [&](Test::ByteS bsi3, Test::ByteS bsi4)
             {
@@ -1237,7 +1237,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         bsi2.push_back(false);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opBoolSAsync(bsi1, bsi2,
             [&](Test::BoolS bsi3, Test::BoolS bsi4)
             {
@@ -1265,7 +1265,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi.push_back(30);
         lsi.push_back(20);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortIntLongSAsync(ssi, isi, lsi,
             [&](Test::LongS lsi1, Test::ShortS ssi1, Test::IntS isi1, Test::LongS lsi2)
             {
@@ -1286,7 +1286,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi.push_back(Ice::Double(1.2E10));
         dsi.push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opFloatDoubleSAsync(fsi, dsi,
             [&](Test::DoubleS dsi1, Test::FloatS fsi1, Test::DoubleS dsi2)
             {
@@ -1306,7 +1306,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2.push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringSAsync(ssi1, ssi2,
             [&](Test::StringS ssi3, Test::StringS ssi4)
             {
@@ -1331,7 +1331,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[1].push_back(Ice::Byte(0xf2));
         bsi2[1].push_back(Ice::Byte(0xf1));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteSSAsync(bsi1, bsi2,
             [&](Test::ByteSS bsi3, Test::ByteSS bsi4)
             {
@@ -1356,7 +1356,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[0].push_back(false);
         bsi2[0].push_back(true);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opBoolSSAsync(bsi1, bsi2,
             [&](Test::BoolSS bsi3, Test::BoolSS bsi4)
             {
@@ -1383,7 +1383,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi[0].push_back(496);
         lsi[0].push_back(1729);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortIntLongSSAsync(ssi, isi, lsi,
             [&](Test::LongSS lsi1, Test::ShortSS ssi1, Test::IntSS isi1, Test::LongSS lsi2)
             {
@@ -1406,7 +1406,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi[0].push_back(Ice::Double(1.2E10));
         dsi[0].push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opFloatDoubleSSAsync(fsi, dsi,
             [&](Test::DoubleSS dsi1, Test::FloatSS fsi1, Test::DoubleSS dsi2)
             {
@@ -1428,7 +1428,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2[2].push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringSSAsync(ssi1, ssi2,
             [&](Test::StringSS ssi3, Test::StringSS ssi4)
             {
@@ -1447,7 +1447,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[11] = false;
         di2[101] = true;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteBoolDAsync(di1, di2,
             [&](Test::ByteBoolD di3, Test::ByteBoolD di4)
             {
@@ -1466,7 +1466,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[111] = -100;
         di2[1101] = 0;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortIntDAsync(di1, di2,
             [&](Test::ShortIntD di3, Test::ShortIntD di4)
             {
@@ -1485,7 +1485,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[999999120] = Ice::Float(-100.4);
         di2[999999130] = Ice::Float(0.5);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opLongFloatDAsync(di1, di2,
             [&](Test::LongFloatD di3, Test::LongFloatD di4)
             {
@@ -1504,7 +1504,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["FOO"] = "abc -100.4";
         di2["BAR"] = "abc 0.5";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringStringDAsync(di1, di2,
             [&](Test::StringStringD di3, Test::StringStringD di4)
             {
@@ -1523,7 +1523,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["qwerty"] = Test::MyEnum::enum3;
         di2["Hello!!"] = Test::MyEnum::enum2;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringMyEnumDAsync(di1, di2,
             [&](Test::StringMyEnumD di3, Test::StringMyEnumD di4)
             {
@@ -1547,7 +1547,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[ms22] = Test::MyEnum::enum3;
         di2[ms23] = Test::MyEnum::enum2;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opMyStructMyEnumDAsync(di1, di2,
             [&](Test::MyStructMyEnumD di3, Test::MyStructMyEnumD di4)
             {
@@ -1578,7 +1578,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteBoolDSAsync(dsi1, dsi2,
             [&](Test::ByteBoolDS dsi3, Test::ByteBoolDS dsi4)
             {
@@ -1608,7 +1608,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortIntDSAsync(dsi1, dsi2,
             [&](Test::ShortIntDS dsi3, Test::ShortIntDS dsi4)
             {
@@ -1638,7 +1638,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opLongFloatDSAsync(dsi1, dsi2,
             [&](Test::LongFloatDS dsi3, Test::LongFloatDS dsi4)
             {
@@ -1668,7 +1668,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringStringDSAsync(dsi1, dsi2,
             [&](Test::StringStringDS dsi3, Test::StringStringDS dsi4)
             {
@@ -1699,7 +1699,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringMyEnumDSAsync(dsi1, dsi2,
             [&](Test::StringMyEnumDS dsi3, Test::StringMyEnumDS dsi4)
             {
@@ -1727,7 +1727,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opMyEnumStringDSAsync(dsi1, dsi2,
             [&](Test::MyEnumStringDS dsi3, Test::MyEnumStringDS dsi4)
             {
@@ -1763,7 +1763,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opMyStructMyEnumDSAsync(dsi1, dsi2,
                                    [&](Test::MyStructMyEnumDS dsi3, Test::MyStructMyEnumDS dsi4)
             {
@@ -1791,7 +1791,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Ice::Byte(0x22)] = si2;
         sdi2[Ice::Byte(0xf1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opByteByteSDAsync(sdi1, sdi2,
             [&](Test::ByteByteSD sdi3, Test::ByteByteSD sdi4)
             {
@@ -1818,7 +1818,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[true] = si2;
         sdi2[false] = si1;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opBoolBoolSDAsync(sdi1, sdi2,
             [&](Test::BoolBoolSD sdi3, Test::BoolBoolSD sdi4)
             {
@@ -1848,7 +1848,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[2] = si2;
         sdi2[4] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opShortShortSDAsync(sdi1, sdi2,
             [&](Test::ShortShortSD sdi3, Test::ShortShortSD sdi4)
             {
@@ -1878,7 +1878,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[200] = si2;
         sdi2[400] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opIntIntSDAsync(sdi1, sdi2,
             [&](Test::IntIntSD sdi3, Test::IntIntSD sdi4)
             {
@@ -1908,7 +1908,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[999999991] = si2;
         sdi2[999999992] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opLongLongSDAsync(sdi1, sdi2,
             [&](Test::LongLongSD sdi3, Test::LongLongSD sdi4)
             {
@@ -1938,7 +1938,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["ABC"] = si2;
         sdi2["aBc"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringFloatSDAsync(sdi1, sdi2,
             [&](Test::StringFloatSD sdi3, Test::StringFloatSD sdi4)
             {
@@ -1968,7 +1968,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["Goodbye"] = si2;
         sdi2[""] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringDoubleSDAsync(sdi1, sdi2,
             [&](Test::StringDoubleSD sdi3, Test::StringDoubleSD sdi4)
             {
@@ -2000,7 +2000,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["def"] = si2;
         sdi2["ghi"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opStringStringSDAsync(sdi1, sdi2,
             [&](Test::StringStringSD sdi3, Test::StringStringSD sdi4)
             {
@@ -2030,7 +2030,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Test::MyEnum::enum2] = si2;
         sdi2[Test::MyEnum::enum1] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opMyEnumMyEnumSDAsync(sdi1, sdi2,
             [&](Test::MyEnumMyEnumSD sdi3, Test::MyEnumMyEnumSD sdi4)
             {
@@ -2050,7 +2050,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
             {
                 s.push_back(i);
             }
-            CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+            CallbackPtr cb = std::make_shared<Callback>();
             p->opIntSAsync(s,
                 [&](Test::IntS s1P)
                 {
@@ -2248,7 +2248,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Ice::Double d = 1278312346.0 / 13.0;
         Test::DoubleS ds(5, d);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opDoubleMarshalingAsync(d, ds,
             [&]()
             {
@@ -2259,7 +2259,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opIdempotentAsync(
             [&]()
             {
@@ -2270,7 +2270,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opNonmutatingAsync(
             [&]()
             {
@@ -2283,7 +2283,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::MyDerivedClassPrxPtr derived = ICE_CHECKED_CAST(Test::MyDerivedClassPrx, p);
         test(derived);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         derived->opDerivedAsync(
             [&]()
             {
@@ -2294,7 +2294,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->ice_pingAsync();
         try
         {
@@ -2314,7 +2314,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->ice_isAAsync(Test::MyClass::ice_staticId());
         try
         {
@@ -2332,7 +2332,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->ice_idAsync();
         try
         {
@@ -2350,7 +2350,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->ice_idsAsync();
         try
         {
@@ -2368,7 +2368,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opVoidAsync();
         try
         {
@@ -2387,7 +2387,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f));
         try
         {
@@ -2406,7 +2406,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opBoolAsync(true, false);
         try
         {
@@ -2425,7 +2425,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opShortIntLongAsync(10, 11, 12);
         try
         {
@@ -2444,7 +2444,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opFloatDoubleAsync(3.14f, 1.1E10);
         try
         {
@@ -2463,7 +2463,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringAsync("hello", "world");
         try
         {
@@ -2482,7 +2482,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opMyEnumAsync(Test::MyEnum::enum2);
         try
         {
@@ -2501,7 +2501,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = std::make_shared<Callback>(communicator);
         auto f = p->opMyClassAsync(p);
         try
         {
@@ -2529,7 +2529,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = std::make_shared<Callback>(communicator);
         auto f = p->opStructAsync(si1, si2);
         try
         {
@@ -2561,7 +2561,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2.push_back(Ice::Byte(0xf3));
         bsi2.push_back(Ice::Byte(0xf4));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteSAsync(bsi1, bsi2);
         try
         {
@@ -2589,7 +2589,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         bsi2.push_back(false);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opBoolSAsync(bsi1, bsi2);
         try
         {
@@ -2625,7 +2625,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi.push_back(30);
         lsi.push_back(20);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opShortIntLongSAsync(ssi, isi, lsi);
         try
         {
@@ -2654,7 +2654,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi.push_back(Ice::Double(1.2E10));
         dsi.push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opFloatDoubleSAsync(fsi, dsi);
         try
         {
@@ -2682,7 +2682,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2.push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringSAsync(ssi1, ssi2);
         try
         {
@@ -2715,7 +2715,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[1].push_back(Ice::Byte(0xf2));
         bsi2[1].push_back(Ice::Byte(0xf1));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteSSAsync(bsi1, bsi2);
         try
         {
@@ -2746,7 +2746,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi[0].push_back(Ice::Double(1.2E10));
         dsi[0].push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opFloatDoubleSSAsync(fsi, dsi);
         try
         {
@@ -2776,7 +2776,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2[2].push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringSSAsync(ssi1, ssi2);
         try
         {
@@ -2803,7 +2803,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[11] = false;
         di2[101] = true;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteBoolDAsync(di1, di2);
         try
         {
@@ -2830,7 +2830,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[111] = -100;
         di2[1101] = 0;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opShortIntDAsync(di1, di2);
         try
         {
@@ -2857,7 +2857,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[999999120] = Ice::Float(-100.4);
         di2[999999130] = Ice::Float(0.5);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opLongFloatDAsync(di1, di2);
         try
         {
@@ -2884,7 +2884,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["FOO"] = "abc -100.4";
         di2["BAR"] = "abc 0.5";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringStringDAsync(di1, di2);
         try
         {
@@ -2911,7 +2911,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["qwerty"] = Test::MyEnum::enum3;
         di2["Hello!!"] = Test::MyEnum::enum2;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringMyEnumDAsync(di1, di2);
         try
         {
@@ -2943,7 +2943,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[ms22] = Test::MyEnum::enum3;
         di2[ms23] = Test::MyEnum::enum2;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opMyStructMyEnumDAsync(di1, di2);
         try
         {
@@ -2982,7 +2982,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteBoolDSAsync(dsi1, dsi2);
         try
         {
@@ -3020,7 +3020,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opShortIntDSAsync(dsi1, dsi2);
         try
         {
@@ -3058,7 +3058,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opLongFloatDSAsync(dsi1, dsi2);
         try
         {
@@ -3096,7 +3096,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringStringDSAsync(dsi1, dsi2);
         try
         {
@@ -3134,7 +3134,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringMyEnumDSAsync(dsi1, dsi2);
         try
         {
@@ -3170,7 +3170,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opMyEnumStringDSAsync(dsi1, dsi2);
         try
         {
@@ -3214,7 +3214,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opMyStructMyEnumDSAsync(dsi1, dsi2);
         try
         {
@@ -3250,7 +3250,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Ice::Byte(0x22)] = si2;
         sdi2[Ice::Byte(0xf1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opByteByteSDAsync(sdi1, sdi2);
         try
         {
@@ -3285,7 +3285,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[true] = si2;
         sdi2[false] = si1;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opBoolBoolSDAsync(sdi1, sdi2);
         try
         {
@@ -3323,7 +3323,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[2] = si2;
         sdi2[4] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opShortShortSDAsync(sdi1, sdi2);
         try
         {
@@ -3361,7 +3361,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[200] = si2;
         sdi2[400] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opIntIntSDAsync(sdi1, sdi2);
         try
         {
@@ -3399,7 +3399,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[999999991] = si2;
         sdi2[999999992] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opLongLongSDAsync(sdi1, sdi2);
         try
         {
@@ -3437,7 +3437,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["ABC"] = si2;
         sdi2["aBc"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringFloatSDAsync(sdi1, sdi2);
         try
         {
@@ -3475,7 +3475,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["Goodbye"] = si2;
         sdi2[""] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringDoubleSDAsync(sdi1, sdi2);
         try
         {
@@ -3515,7 +3515,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["def"] = si2;
         sdi2["ghi"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opStringStringSDAsync(sdi1, sdi2);
         try
         {
@@ -3554,7 +3554,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Test::MyEnum::enum2] = si2;
         sdi2[Test::MyEnum::enum1] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opMyEnumMyEnumSDAsync(sdi1, sdi2);
         try
         {
@@ -3582,7 +3582,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
             {
                 s.push_back(i);
             }
-            CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+            CallbackPtr cb = std::make_shared<Callback>();
             auto f = p->opIntSAsync(s);
             try
             {
@@ -3603,7 +3603,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Ice::Double d = 1278312346.0 / 13.0;
         Test::DoubleS ds(5, d);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opDoubleMarshalingAsync(d, ds);
         try
         {
@@ -3622,7 +3622,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opIdempotentAsync();
         try
         {
@@ -3641,7 +3641,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = p->opNonmutatingAsync();
         try
         {
@@ -3662,7 +3662,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::MyDerivedClassPrxPtr derived = ICE_CHECKED_CAST(Test::MyDerivedClassPrx, p);
         test(derived);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         auto f = derived->opDerivedAsync();
         try
         {

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -1355,7 +1355,7 @@ allTests(Test::TestHelper* helper, bool)
         if(initial->supportsNullOptional())
         {
             p2 = initial->opOneOptional(OneOptionalPtr(), p3);
-            test(*p2 == ICE_NULLPTR && *p3 == ICE_NULLPTR);
+            test(*p2 == nullptr && *p3 == nullptr);
         }
 
         p1 = ICE_MAKE_SHARED(OneOptional, 58);

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -144,7 +144,7 @@ public:
         o->push_back("test3");
         o->push_back("test4");
         out->write(1, o);
-        APtr a = ICE_MAKE_SHARED(A);
+        APtr a = std::make_shared<A>();
         a->mc = 18;
         out->write(1000, IceUtil::Optional<APtr>(a));
         out->endSlice();
@@ -228,7 +228,7 @@ public:
 
     virtual void _iceRead(Ice::InputStream* in)
     {
-        _f = ICE_MAKE_SHARED(F);
+        _f = std::make_shared<F>();
         in->startValue();
         in->startSlice();
         // Don't read af on purpose
@@ -280,27 +280,27 @@ public:
 
         if(typeId == "::Test::OneOptional")
         {
-           return ICE_MAKE_SHARED(TestObjectReader);
+           return std::make_shared<TestObjectReader>();
         }
         else if(typeId == "::Test::MultiOptional")
         {
-           return ICE_MAKE_SHARED(TestObjectReader);
+           return std::make_shared<TestObjectReader>();
         }
         else if(typeId == "::Test::B")
         {
-           return ICE_MAKE_SHARED(BObjectReader);
+           return std::make_shared<BObjectReader>();
         }
         else if(typeId == "::Test::C")
         {
-           return ICE_MAKE_SHARED(CObjectReader);
+           return std::make_shared<CObjectReader>();
         }
         else if(typeId == "::Test::D")
         {
-           return ICE_MAKE_SHARED(DObjectReader);
+           return std::make_shared<DObjectReader>();
         }
         else if(typeId == "::Test::F")
         {
-           return ICE_MAKE_SHARED(FObjectReader);
+           return std::make_shared<FObjectReader>();
         }
 
         return 0;
@@ -319,7 +319,7 @@ InitialPrxPtr
 allTests(Test::TestHelper* helper, bool)
 {
     Ice::CommunicatorPtr communicator = helper->communicator();
-    FactoryIPtr factory = ICE_MAKE_SHARED(FactoryI);
+    FactoryIPtr factory = std::make_shared<FactoryI>();
 
     communicator->getValueFactoryManager()->add([factory](const string& typeId)
                                                 {
@@ -344,24 +344,24 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing constructor, copy constructor, and assignment operator... " << flush;
 
-    OneOptionalPtr oo1 = ICE_MAKE_SHARED(OneOptional);
+    OneOptionalPtr oo1 = std::make_shared<OneOptional>();
     test(!oo1->a);
     oo1->a = 15;
     test(oo1->a && *oo1->a == 15);
 
-    OneOptionalPtr oo2 = ICE_MAKE_SHARED(OneOptional, 16);
+    OneOptionalPtr oo2 = std::make_shared<OneOptional>(16);
     test(oo2->a && *oo2->a == 16);
 
-    OneOptionalPtr oo3 = ICE_MAKE_SHARED(OneOptional, *oo2);
+    OneOptionalPtr oo3 = std::make_shared<OneOptional>(*oo2);
     test(oo3->a && *oo3->a == 16);
 
     *oo3 = *oo1;
     test(oo3->a && *oo3->a == 15);
 
-    OneOptionalPtr oon = ICE_MAKE_SHARED(OneOptional, IceUtil::None);
+    OneOptionalPtr oon = std::make_shared<OneOptional>(IceUtil::None);
     test(!oon->a);
 
-    MultiOptionalPtr mo1 = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mo1 = std::make_shared<MultiOptional>();
     mo1->a = static_cast<Ice::Byte>(15);
     mo1->b = true;
     mo1->c = static_cast<Ice::Short>(19);
@@ -410,7 +410,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->ivsd = IntVarStructDict();
     mo1->ivsd.value()[5] = vs;
     mo1->iood = IntOneOptionalDict();
-    mo1->iood.value()[5] = ICE_MAKE_SHARED(OneOptional);
+    mo1->iood.value()[5] = std::make_shared<OneOptional>();
     mo1->iood.value()[5]->a = 15;
     mo1->ioopd = IntOneOptionalPrxDict();
     mo1->ioopd.value()[5] = ICE_UNCHECKED_CAST(OneOptionalPrx, communicator->stringToProxy("test"));
@@ -420,9 +420,9 @@ allTests(Test::TestHelper* helper, bool)
     mo1->bos->push_back(true);
     mo1->bos->push_back(false);
 
-    MultiOptionalPtr mo2 = ICE_MAKE_SHARED(MultiOptional, *mo1);
+    MultiOptionalPtr mo2 = std::make_shared<MultiOptional>(*mo1);
 
-    MultiOptionalPtr mo3 = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mo3 = std::make_shared<MultiOptional>();
     *mo3 = *mo2;
 
     test(mo3->a == static_cast<Ice::Byte>(15));
@@ -479,13 +479,13 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing marshalling... " << flush;
-    OneOptionalPtr oo4 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(ICE_MAKE_SHARED(OneOptional)));
+    OneOptionalPtr oo4 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(std::make_shared<OneOptional>()));
     test(!oo4->a);
 
     OneOptionalPtr oo5 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(oo1));
     test(oo1->a == oo5->a);
 
-    MultiOptionalPtr mo4 = ICE_DYNAMIC_CAST(MultiOptional, initial->pingPong(ICE_MAKE_SHARED(MultiOptional)));
+    MultiOptionalPtr mo4 = ICE_DYNAMIC_CAST(MultiOptional, initial->pingPong(std::make_shared<MultiOptional>()));
     test(!mo4->a);
     test(!mo4->b);
     test(!mo4->c);
@@ -565,7 +565,7 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->bos == mo1->bos);
 
     // Clear the first half of the optional parameters
-    MultiOptionalPtr mo6 = ICE_MAKE_SHARED(MultiOptional, *mo5);
+    MultiOptionalPtr mo6 = std::make_shared<MultiOptional>(*mo5);
     mo6->a = IceUtil::None;
     mo6->c = IceUtil::None;
     mo6->e = IceUtil::None;
@@ -617,7 +617,7 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->ioopd);
 
     // Clear the second half of the optional parameters
-    MultiOptionalPtr mo8 = ICE_MAKE_SHARED(MultiOptional, *mo5);
+    MultiOptionalPtr mo8 = std::make_shared<MultiOptional>(*mo5);
     mo8->b = IceUtil::None;
     mo8->d = IceUtil::None;
     mo8->f = IceUtil::None;
@@ -724,7 +724,7 @@ allTests(Test::TestHelper* helper, bool)
     //
     // Use the 1.0 encoding with operations whose only class parameters are optional.
     //
-    IceUtil::Optional<OneOptionalPtr> oo(ICE_MAKE_SHARED(OneOptional, 53));
+    IceUtil::Optional<OneOptionalPtr> oo(std::make_shared<OneOptional>(53));
     initial->sendOptionalClass(true, oo);
     initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalClass(true, oo);
 
@@ -734,19 +734,19 @@ allTests(Test::TestHelper* helper, bool)
     test(!oo);
 
     RecursiveSeq recursive1;
-    recursive1.push_back(ICE_MAKE_SHARED(Recursive));
+    recursive1.push_back(std::make_shared<Recursive>());
     RecursiveSeq recursive2;
-    recursive2.push_back(ICE_MAKE_SHARED(Recursive));
+    recursive2.push_back(std::make_shared<Recursive>());
     recursive1[0]->value = recursive2;
-    RecursivePtr outer = ICE_MAKE_SHARED(Recursive);
+    RecursivePtr outer = std::make_shared<Recursive>();
     outer->value = recursive1;
     initial->pingPong(outer);
 
-    GPtr g = ICE_MAKE_SHARED(G);
-    g->gg1Opt = ICE_MAKE_SHARED(G1, "gg1Opt");
-    g->gg2 = ICE_MAKE_SHARED(G2, 10);
-    g->gg2Opt = ICE_MAKE_SHARED(G2, 20);
-    g->gg1 = ICE_MAKE_SHARED(G1, "gg1");
+    GPtr g = std::make_shared<G>();
+    g->gg1Opt = std::make_shared<G1>("gg1Opt");
+    g->gg2 = std::make_shared<G2>(10);
+    g->gg2Opt = std::make_shared<G2>(20);
+    g->gg1 = std::make_shared<G1>("gg1");
     GPtr r = initial->opG(g);
     test("gg1Opt" == r->gg1Opt.value()->a);
     test(10 == r->gg2->a);
@@ -768,7 +768,7 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing marshalling of large containers with fixed size elements..." << flush;
-    MultiOptionalPtr mc = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mc = std::make_shared<MultiOptional>();
 
     ByteSeq byteSeq;
     byteSeq.resize(1000);
@@ -816,7 +816,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing tag marshalling... " << flush;
     {
-        BPtr b = ICE_MAKE_SHARED(B);
+        BPtr b = std::make_shared<B>();
         BPtr b2 = ICE_DYNAMIC_CAST(B, initial->pingPong(b));
         test(!b2->ma);
         test(!b2->mb);
@@ -853,9 +853,9 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing marshalling of objects with optional objects..." << flush;
     {
-        FPtr f = ICE_MAKE_SHARED(F);
+        FPtr f = std::make_shared<F>();
 
-        f->af = ICE_MAKE_SHARED(A);
+        f->af = std::make_shared<A>();
         f->ae = *f->af;
 
         FPtr rf = ICE_DYNAMIC_CAST(F, initial->pingPong(f));
@@ -880,7 +880,7 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing optional with default values... " << flush;
-    WDPtr wd = ICE_DYNAMIC_CAST(WD, initial->pingPong(ICE_MAKE_SHARED(WD)));
+    WDPtr wd = ICE_DYNAMIC_CAST(WD, initial->pingPong(std::make_shared<WD>()));
     test(*wd->a == 5);
     test(*wd->s == "test");
     wd->a = IceUtil::None;
@@ -894,7 +894,7 @@ allTests(Test::TestHelper* helper, bool)
     {
         cout << "testing marshalling with unknown class slices... " << flush;
         {
-            CPtr c = ICE_MAKE_SHARED(C);
+            CPtr c = std::make_shared<C>();
             c->ss = "test";
             c->ms = string("testms");
 
@@ -919,7 +919,7 @@ allTests(Test::TestHelper* helper, bool)
                 factory->setEnabled(true);
                 Ice::OutputStream out(communicator);
                 out.startEncapsulation();
-                Ice::ValuePtr d = ICE_MAKE_SHARED(DObjectWriter);
+                Ice::ValuePtr d = std::make_shared<DObjectWriter>();
                 out.write(d);
                 out.endEncapsulation();
                 out.finished(inEncaps);
@@ -938,7 +938,7 @@ allTests(Test::TestHelper* helper, bool)
 
         cout << "testing optionals with unknown classes..." << flush;
         {
-            APtr a = ICE_MAKE_SHARED(A);
+            APtr a = std::make_shared<A>();
 
             Ice::OutputStream out(communicator);
             out.startEncapsulation();
@@ -1358,7 +1358,7 @@ allTests(Test::TestHelper* helper, bool)
             test(*p2 == nullptr && *p3 == nullptr);
         }
 
-        p1 = ICE_MAKE_SHARED(OneOptional, 58);
+        p1 = std::make_shared<OneOptional>(58);
         p2 = initial->opOneOptional(p1, p3);
         test((*p2)->a == 58 && (*p3)->a == 58);
 
@@ -1411,8 +1411,8 @@ allTests(Test::TestHelper* helper, bool)
     }
 
     {
-        FPtr f = ICE_MAKE_SHARED(F);
-        f->af = ICE_MAKE_SHARED(A);
+        FPtr f = std::make_shared<F>();
+        f->af = std::make_shared<A>();
         (*f->af)->requiredA = 56;
         f->ae = *f->af;
 
@@ -1769,7 +1769,7 @@ allTests(Test::TestHelper* helper, bool)
         test(!p2 && !p3);
 
         IntOneOptionalDict ss;
-        ss.insert(make_pair<int, OneOptionalPtr>(1, ICE_MAKE_SHARED(OneOptional, 58)));
+        ss.insert(make_pair<int, OneOptionalPtr>(1, std::make_shared<OneOptional>(58)));
         p1 = ss;
         p2 = initial->opIntOneOptionalDict(p1, p3);
         test(p2 && p3);
@@ -1850,7 +1850,7 @@ allTests(Test::TestHelper* helper, bool)
 
         try
         {
-            initial->opOptionalException(30, string("test"), ICE_MAKE_SHARED(OneOptional, 53));
+            initial->opOptionalException(30, string("test"), std::make_shared<OneOptional>(53));
             test(false);
         }
         catch(const OptionalException& ex)
@@ -1866,7 +1866,7 @@ allTests(Test::TestHelper* helper, bool)
             // Use the 1.0 encoding with an exception whose only class members are optional.
             //
             initial->ice_encodingVersion(Ice::Encoding_1_0)->
-                opOptionalException(30, string("test"), ICE_MAKE_SHARED(OneOptional, 53));
+                opOptionalException(30, string("test"), std::make_shared<OneOptional>(53));
             test(false);
         }
         catch(const OptionalException& ex)
@@ -1901,7 +1901,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             IceUtil::Optional<Ice::Int> a = 30;
             IceUtil::Optional<string> b = string("test2");
-            IceUtil::Optional<OneOptionalPtr> o = ICE_MAKE_SHARED(OneOptional, 53);
+            IceUtil::Optional<OneOptionalPtr> o = std::make_shared<OneOptional>(53);
             initial->opDerivedException(a, b, o);
             test(false);
         }
@@ -1943,7 +1943,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             IceUtil::Optional<Ice::Int> a = 30;
             IceUtil::Optional<string> b = string("test2");
-            IceUtil::Optional<OneOptionalPtr> o = ICE_MAKE_SHARED(OneOptional, 53);
+            IceUtil::Optional<OneOptionalPtr> o = std::make_shared<OneOptional>(53);
             initial->opRequiredException(a, b, o);
             test(false);
         }
@@ -2005,7 +2005,7 @@ allTests(Test::TestHelper* helper, bool)
             p3 = initial->opMG2(IceUtil::None, p2);
             test(!p2 && !p3);
 
-            p1 = ICE_MAKE_SHARED(Test::G);
+            p1 = std::make_shared<Test::G>();
             p3 = initial->opMG2(p1, p2);
             test(p2 && p3 && *p3 == *p2);
         }

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -370,7 +370,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->f = 5.5f;
     mo1->g = 1.0;
     mo1->h = string("test");
-    mo1->i = ICE_ENUM(MyEnum, MyEnumMember);
+    mo1->i = MyEnum::MyEnumMember;
     mo1->j = ICE_UNCHECKED_CAST(MultiOptionalPrx, communicator->stringToProxy("test"));
     mo1->k = mo1;
     mo1->bs = ByteSeq();
@@ -392,8 +392,8 @@ allTests(Test::TestHelper* helper, bool)
     mo1->shs = ShortSeq();
     mo1->shs->push_back(1);
     mo1->es = MyEnumSeq();
-    mo1->es->push_back(ICE_ENUM(MyEnum, MyEnumMember));
-    mo1->es->push_back(ICE_ENUM(MyEnum, MyEnumMember));
+    mo1->es->push_back(MyEnum::MyEnumMember);
+    mo1->es->push_back(MyEnum::MyEnumMember);
     mo1->fss = FixedStructSeq();
     mo1->fss->push_back(fs);
     mo1->vss = VarStructSeq();
@@ -404,7 +404,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->oops->push_back(ICE_UNCHECKED_CAST(OneOptionalPrx, communicator->stringToProxy("test")));
 
     mo1->ied = IntEnumDict();
-    mo1->ied.value()[4] = ICE_ENUM(MyEnum, MyEnumMember);
+    mo1->ied.value()[4] = MyEnum::MyEnumMember;
     mo1->ifsd = IntFixedStructDict();
     mo1->ifsd.value()[4] = fs;
     mo1->ivsd = IntVarStructDict();
@@ -433,7 +433,7 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->f == 5.5f);
     test(mo3->g == 1.0);
     test(mo3->h == string("test"));
-    test(mo3->i = ICE_ENUM(MyEnum, MyEnumMember));
+    test(mo3->i = MyEnum::MyEnumMember);
     test(mo3->j = ICE_UNCHECKED_CAST(MultiOptionalPrx, communicator->stringToProxy("test")));
     test(mo3->k == mo1);
     test(mo3->bs == mo1->bs);
@@ -686,7 +686,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(oo1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -701,7 +701,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(mo1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -762,7 +762,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, IceUtil::Optional<string>("test"));
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("opVoid", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("opVoid", Ice::OperationMode::Normal, inEncaps, outEncaps));
     }
 
     cout << "ok" << endl;
@@ -802,7 +802,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(mc);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -839,7 +839,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(b);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -905,7 +905,7 @@ allTests(Test::TestHelper* helper, bool)
                 out.endEncapsulation();
                 out.finished(inEncaps);
                 factory->setEnabled(true);
-                test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+                test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
                 Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
                 in.startEncapsulation();
                 Ice::ValuePtr obj;
@@ -923,7 +923,7 @@ allTests(Test::TestHelper* helper, bool)
                 out.write(d);
                 out.endEncapsulation();
                 out.finished(inEncaps);
-                test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+                test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
                 Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
                 in.startEncapsulation();
                 Ice::ValuePtr obj;
@@ -946,7 +946,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(1, Ice::make_optional(make_shared<DObjectWriter>()));
             out.endEncapsulation();
             out.finished(inEncaps);
-            test(initial->ice_invoke("opClassAndUnknownOptional", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+            test(initial->ice_invoke("opClassAndUnknownOptional", Ice::OperationMode::Normal, inEncaps, outEncaps));
 
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -973,7 +973,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opByte", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opByte", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1005,7 +1005,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opBool", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opBool", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1035,7 +1035,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opShort", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opShort", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1065,7 +1065,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opInt", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opInt", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1095,7 +1095,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(1, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opLong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opLong", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(2, p3);
@@ -1125,7 +1125,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFloat", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFloat", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1155,7 +1155,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opDouble", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opDouble", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1185,7 +1185,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opString", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1217,7 +1217,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(2, p1);
             out.endEncapsulation();
             out.finished(inEncaps);
-            initial->ice_invoke("opCustomString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+            initial->ice_invoke("opCustomString", Ice::OperationMode::Normal, inEncaps, outEncaps);
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
             in.read(1, p2);
@@ -1237,22 +1237,22 @@ allTests(Test::TestHelper* helper, bool)
         IceUtil::Optional<Test::MyEnum> p2 = initial->opMyEnum(p1, p3);
         test(!p2 && !p3);
 
-        p1 = ICE_ENUM(MyEnum, MyEnumMember);
+        p1 = MyEnum::MyEnumMember;
         p2 = initial->opMyEnum(p1, p3);
-        test(p2 == ICE_ENUM(MyEnum, MyEnumMember) && p3 == ICE_ENUM(MyEnum, MyEnumMember));
+        test(p2 == MyEnum::MyEnumMember && p3 == MyEnum::MyEnumMember);
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opMyEnum", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opMyEnum", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
         in.read(3, p3);
         in.endEncapsulation();
-        test(p2 == ICE_ENUM(MyEnum, MyEnumMember) && p3 == ICE_ENUM(MyEnum, MyEnumMember));
+        test(p2 == MyEnum::MyEnumMember && p3 == MyEnum::MyEnumMember);
 
         Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
         in2.startEncapsulation();
@@ -1275,7 +1275,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opSmallStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opSmallStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1304,7 +1304,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFixedStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFixedStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1333,7 +1333,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opVarStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opVarStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1367,7 +1367,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opOneOptional", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opOneOptional", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1396,7 +1396,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opOneOptionalProxy", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opOneOptionalProxy", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1451,7 +1451,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opByteSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opByteSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1483,7 +1483,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opBoolSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opBoolSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1514,7 +1514,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opShortSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opShortSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1545,7 +1545,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1576,7 +1576,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opLongSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opLongSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1607,7 +1607,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFloatSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFloatSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1638,7 +1638,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opDoubleSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opDoubleSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1684,7 +1684,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFixedStructSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFixedStructSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1718,7 +1718,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntIntDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntIntDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1749,7 +1749,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opStringIntDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opStringIntDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1780,7 +1780,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntOneOptionalDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntOneOptionalDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1815,7 +1815,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(2, p1);
             out.endEncapsulation();
             out.finished(inEncaps);
-            initial->ice_invoke("opCustomIntStringDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+            initial->ice_invoke("opCustomIntStringDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
             in.read(1, p2);

--- a/cpp/test/Ice/optional/Server.cpp
+++ b/cpp/test/Ice/optional/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<InitialI>(), Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/optional/ServerAMD.cpp
+++ b/cpp/test/Ice/optional/ServerAMD.cpp
@@ -22,7 +22,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<InitialI>(), Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -431,7 +431,7 @@ InitialI::opMG1Async(function<void(const OpMG1MarshaledResult&)> response,
                      function<void(exception_ptr)>,
                      const Ice::Current& current)
 {
-    response(OpMG1MarshaledResult(ICE_MAKE_SHARED(G), current));
+    response(OpMG1MarshaledResult(std::make_shared<G>(), current));
 }
 
 void

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -386,7 +386,7 @@ InitialI::sendOptionalClass(bool, ICE_IN(Optional<OneOptionalPtr>), const Ice::C
 void
 InitialI::returnOptionalClass(bool, Optional<OneOptionalPtr>& o, const Ice::Current&)
 {
-    o = ICE_MAKE_SHARED(OneOptional, 53);
+    o = std::make_shared<OneOptional>(53);
 }
 
 GPtr
@@ -439,7 +439,7 @@ InitialI::opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>) p1, const Ice:
 InitialI::OpMG1MarshaledResult
 InitialI::opMG1(const Ice::Current& current)
 {
-    return OpMG1MarshaledResult(ICE_MAKE_SHARED(G), current);
+    return OpMG1MarshaledResult(std::make_shared<G>(), current);
 }
 
 InitialI::OpMG2MarshaledResult

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -33,9 +33,9 @@ InitialI::pingPong(shared_ptr<Value> obj, const Current& current)
 }
 
 void
-InitialI::opOptionalException(ICE_IN(Optional<Int>) a,
-                              ICE_IN(Optional<string>) b,
-                              ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opOptionalException(Optional<Int> a,
+                              Optional<string> b,
+                              Optional<OneOptionalPtr> o,
                               const Ice::Current&)
 {
     OptionalException ex;
@@ -46,9 +46,9 @@ InitialI::opOptionalException(ICE_IN(Optional<Int>) a,
 }
 
 void
-InitialI::opDerivedException(ICE_IN(Optional<Int>) a,
-                             ICE_IN(Optional<string>) b,
-                             ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opDerivedException(Optional<Int> a,
+                             Optional<string> b,
+                             Optional<OneOptionalPtr> o,
                              const Ice::Current&)
 {
     DerivedException ex;
@@ -61,9 +61,9 @@ InitialI::opDerivedException(ICE_IN(Optional<Int>) a,
 }
 
 void
-InitialI::opRequiredException(ICE_IN(Optional<Int>) a,
-                              ICE_IN(Optional<string>) b,
-                              ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opRequiredException(Optional<Int> a,
+                              Optional<string> b,
+                              Optional<OneOptionalPtr> o,
                               const Ice::Current&)
 {
     RequiredException ex;
@@ -82,63 +82,63 @@ InitialI::opRequiredException(ICE_IN(Optional<Int>) a,
 }
 
 Optional<Ice::Byte>
-InitialI::opByte(ICE_IN(Optional<Ice::Byte>) p1, Optional<Ice::Byte>& p3, const Current&)
+InitialI::opByte(Optional<Ice::Byte> p1, Optional<Ice::Byte>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<bool>
-InitialI::opBool(ICE_IN(Optional<bool>) p1, Optional<bool>& p3, const Current&)
+InitialI::opBool(Optional<bool> p1, Optional<bool>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Short>
-InitialI::opShort(ICE_IN(Optional<Short>) p1, Optional<Short>& p3, const Current&)
+InitialI::opShort(Optional<Short> p1, Optional<Short>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Int>
-InitialI::opInt(ICE_IN(Optional<Int>) p1, Optional<Int>& p3, const Current&)
+InitialI::opInt(Optional<Int> p1, Optional<Int>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Long>
-InitialI::opLong(ICE_IN(Optional<Long>) p1, Optional<Long>& p3, const Current&)
+InitialI::opLong(Optional<Long> p1, Optional<Long>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Float>
-InitialI::opFloat(ICE_IN(Optional<Float>) p1, Optional<Float>& p3, const Current&)
+InitialI::opFloat(Optional<Float> p1, Optional<Float>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Double>
-InitialI::opDouble(ICE_IN(Optional<Double>) p1, Optional<Double>& p3, const Current&)
+InitialI::opDouble(Optional<Double> p1, Optional<Double>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<string>
-InitialI::opString(ICE_IN(Optional<string>) p1, Optional<string>& p3, const Current&)
+InitialI::opString(Optional<string> p1, Optional<string>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<string>
-InitialI::opCustomString(ICE_IN(Optional<Util::string_view>) p1, Optional<string>& p3, const Current&)
+InitialI::opCustomString(Optional<Util::string_view> p1, Optional<string>& p3, const Current&)
 {
     if(p1)
     {
@@ -148,49 +148,49 @@ InitialI::opCustomString(ICE_IN(Optional<Util::string_view>) p1, Optional<string
 }
 
 Optional<MyEnum>
-InitialI::opMyEnum(ICE_IN(Optional<MyEnum>) p1, Optional<MyEnum>& p3, const Current&)
+InitialI::opMyEnum(Optional<MyEnum> p1, Optional<MyEnum>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<SmallStruct>
-InitialI::opSmallStruct(ICE_IN(Optional<SmallStruct>) p1, Optional<SmallStruct>& p3, const Current&)
+InitialI::opSmallStruct(Optional<SmallStruct> p1, Optional<SmallStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<FixedStruct>
-InitialI::opFixedStruct(ICE_IN(Optional<FixedStruct>) p1, Optional<FixedStruct>& p3, const Current&)
+InitialI::opFixedStruct(Optional<FixedStruct> p1, Optional<FixedStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<VarStruct>
-InitialI::opVarStruct(ICE_IN(Optional<VarStruct>) p1, Optional<VarStruct>& p3, const Current&)
+InitialI::opVarStruct(Optional<VarStruct> p1, Optional<VarStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<OneOptionalPtr>
-InitialI::opOneOptional(ICE_IN(Optional<OneOptionalPtr>) p1, Optional<OneOptionalPtr>& p3, const Current&)
+InitialI::opOneOptional(Optional<OneOptionalPtr> p1, Optional<OneOptionalPtr>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<OneOptionalPrxPtr>
-InitialI::opOneOptionalProxy(ICE_IN(Optional<OneOptionalPrxPtr>) p1, Optional<OneOptionalPrxPtr>& p3, const Current&)
+InitialI::opOneOptionalProxy(Optional<OneOptionalPrxPtr> p1, Optional<OneOptionalPrxPtr>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Test::ByteSeq>
-InitialI::opByteSeq(ICE_IN(Optional<pair<const Ice::Byte*, const Ice::Byte*> >) p1, Optional<Test::ByteSeq>& p3,
+InitialI::opByteSeq(Optional<pair<const Ice::Byte*, const Ice::Byte*> > p1, Optional<Test::ByteSeq>& p3,
                     const Current&)
 {
     if(p1)
@@ -201,7 +201,7 @@ InitialI::opByteSeq(ICE_IN(Optional<pair<const Ice::Byte*, const Ice::Byte*> >) 
 }
 
 Optional<Test::BoolSeq>
-InitialI::opBoolSeq(ICE_IN(Optional<pair<const bool*, const bool*> >) p1, Optional<Test::BoolSeq>& p3, const Current&)
+InitialI::opBoolSeq(Optional<pair<const bool*, const bool*> > p1, Optional<Test::BoolSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -211,7 +211,7 @@ InitialI::opBoolSeq(ICE_IN(Optional<pair<const bool*, const bool*> >) p1, Option
 }
 
 Optional<Test::ShortSeq>
-InitialI::opShortSeq(ICE_IN(Optional<pair<const Short*, const Short*> >) p1, Optional<Test::ShortSeq>& p3,
+InitialI::opShortSeq(Optional<pair<const Short*, const Short*> > p1, Optional<Test::ShortSeq>& p3,
                      const Current&)
 {
     if(p1)
@@ -222,7 +222,7 @@ InitialI::opShortSeq(ICE_IN(Optional<pair<const Short*, const Short*> >) p1, Opt
 }
 
 Optional<Test::IntSeq>
-InitialI::opIntSeq(ICE_IN(Optional<pair<const Int*, const Int*> >) p1, Optional<Test::IntSeq>& p3, const Current&)
+InitialI::opIntSeq(Optional<pair<const Int*, const Int*> > p1, Optional<Test::IntSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -232,7 +232,7 @@ InitialI::opIntSeq(ICE_IN(Optional<pair<const Int*, const Int*> >) p1, Optional<
 }
 
 Optional<Test::LongSeq>
-InitialI::opLongSeq(ICE_IN(Optional<pair<const Long*, const Long*> >) p1, Optional<Test::LongSeq>& p3, const Current&)
+InitialI::opLongSeq(Optional<pair<const Long*, const Long*> > p1, Optional<Test::LongSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -242,7 +242,7 @@ InitialI::opLongSeq(ICE_IN(Optional<pair<const Long*, const Long*> >) p1, Option
 }
 
 Optional<Test::FloatSeq>
-InitialI::opFloatSeq(ICE_IN(Optional<pair<const Float*, const Float*> >) p1, Optional<Test::FloatSeq>& p3,
+InitialI::opFloatSeq(Optional<pair<const Float*, const Float*> > p1, Optional<Test::FloatSeq>& p3,
                      const Current&)
 {
     if(p1)
@@ -253,7 +253,7 @@ InitialI::opFloatSeq(ICE_IN(Optional<pair<const Float*, const Float*> >) p1, Opt
 }
 
 Optional<Test::DoubleSeq>
-InitialI::opDoubleSeq(ICE_IN(Optional<pair<const Double*, const Double*> >) p1, Optional<Test::DoubleSeq>& p3,
+InitialI::opDoubleSeq(Optional<pair<const Double*, const Double*> > p1, Optional<Test::DoubleSeq>& p3,
                       const Current&)
 {
     if(p1)
@@ -275,7 +275,7 @@ InitialI::opStringSeq(Ice::optional<Ice::StringSeq> p1,
 }
 
 Optional<SmallStructSeq>
-InitialI::opSmallStructSeq(ICE_IN(Optional<pair<const SmallStruct*, const SmallStruct*> >) p1,
+InitialI::opSmallStructSeq(Optional<pair<const SmallStruct*, const SmallStruct*> > p1,
                            Optional<SmallStructSeq>& p3, const Current&)
 {
     if(p1)
@@ -286,7 +286,7 @@ InitialI::opSmallStructSeq(ICE_IN(Optional<pair<const SmallStruct*, const SmallS
 }
 
 Optional<SmallStructList>
-InitialI::opSmallStructList(ICE_IN(Optional<pair<const SmallStruct*, const SmallStruct*> >) p1,
+InitialI::opSmallStructList(Optional<pair<const SmallStruct*, const SmallStruct*> > p1,
                             Optional<SmallStructList>& p3, const Current&)
 {
     if(p1)
@@ -297,7 +297,7 @@ InitialI::opSmallStructList(ICE_IN(Optional<pair<const SmallStruct*, const Small
 }
 
 Optional<FixedStructSeq>
-InitialI::opFixedStructSeq(ICE_IN(Optional<pair<const FixedStruct*, const FixedStruct*> >) p1,
+InitialI::opFixedStructSeq(Optional<pair<const FixedStruct*, const FixedStruct*> > p1,
                            Optional<FixedStructSeq>& p3, const Current&)
 {
     if(p1)
@@ -308,7 +308,7 @@ InitialI::opFixedStructSeq(ICE_IN(Optional<pair<const FixedStruct*, const FixedS
 }
 
 Optional<FixedStructList>
-InitialI::opFixedStructList(ICE_IN(Optional<pair<const FixedStruct*, const FixedStruct*> >) p1,
+InitialI::opFixedStructList(Optional<pair<const FixedStruct*, const FixedStruct*> > p1,
                             Optional<FixedStructList>& p3, const Current&)
 {
     if(p1)
@@ -330,35 +330,35 @@ InitialI::opVarStructSeq(Ice::optional<VarStructSeq> p1,
 }
 
 Optional<Serializable>
-InitialI::opSerializable(ICE_IN(Optional<Serializable>) p1, Optional<Serializable>& p3, const Current&)
+InitialI::opSerializable(Optional<Serializable> p1, Optional<Serializable>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntIntDict>
-InitialI::opIntIntDict(ICE_IN(Optional<IntIntDict>) p1, Optional<IntIntDict>& p3, const Current&)
+InitialI::opIntIntDict(Optional<IntIntDict> p1, Optional<IntIntDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<StringIntDict>
-InitialI::opStringIntDict(ICE_IN(Optional<StringIntDict>) p1, Optional<StringIntDict>& p3, const Current&)
+InitialI::opStringIntDict(Optional<StringIntDict> p1, Optional<StringIntDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntOneOptionalDict>
-InitialI::opIntOneOptionalDict(ICE_IN(Optional<IntOneOptionalDict>) p1, Optional<IntOneOptionalDict>& p3, const Current&)
+InitialI::opIntOneOptionalDict(Optional<IntOneOptionalDict> p1, Optional<IntOneOptionalDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntStringDict>
-InitialI::opCustomIntStringDict(ICE_IN(Optional<std::map<int, Util::string_view> >) p1,
+InitialI::opCustomIntStringDict(Optional<std::map<int, Util::string_view> > p1,
                                 Optional<IntStringDict>& p3, const Current&)
 {
     if(p1)
@@ -374,12 +374,12 @@ InitialI::opCustomIntStringDict(ICE_IN(Optional<std::map<int, Util::string_view>
 }
 
 void
-InitialI::opClassAndUnknownOptional(ICE_IN(APtr), const Ice::Current&)
+InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 {
 }
 
 void
-InitialI::sendOptionalClass(bool, ICE_IN(Optional<OneOptionalPtr>), const Ice::Current&)
+InitialI::sendOptionalClass(bool, Optional<OneOptionalPtr>, const Ice::Current&)
 {
 }
 
@@ -390,7 +390,7 @@ InitialI::returnOptionalClass(bool, Optional<OneOptionalPtr>& o, const Ice::Curr
 }
 
 GPtr
-InitialI::opG(ICE_IN(GPtr) g, const Ice::Current&)
+InitialI::opG(GPtr g, const Ice::Current&)
 {
     return g;
 }
@@ -407,7 +407,7 @@ InitialI::opMStruct1(const Ice::Current& current)
 }
 
 InitialI::OpMStruct2MarshaledResult
-InitialI::opMStruct2(ICE_IN(IceUtil::Optional<Test::SmallStruct>) p1, const Ice::Current& current)
+InitialI::opMStruct2(IceUtil::Optional<Test::SmallStruct> p1, const Ice::Current& current)
 {
     return OpMStruct2MarshaledResult(p1, p1, current);
 }
@@ -419,7 +419,7 @@ InitialI::opMSeq1(const Ice::Current& current)
 }
 
 InitialI::OpMSeq2MarshaledResult
-InitialI::opMSeq2(ICE_IN(IceUtil::Optional<Test::StringSeq>) p1, const Ice::Current& current)
+InitialI::opMSeq2(IceUtil::Optional<Test::StringSeq> p1, const Ice::Current& current)
 {
     return OpMSeq2MarshaledResult(p1, p1, current);
 }
@@ -431,7 +431,7 @@ InitialI::opMDict1(const Ice::Current& current)
 }
 
 InitialI::OpMDict2MarshaledResult
-InitialI::opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>) p1, const Ice::Current& current)
+InitialI::opMDict2(IceUtil::Optional<Test::StringIntDict> p1, const Ice::Current& current)
 {
     return OpMDict2MarshaledResult(p1, p1, current);
 }
@@ -443,7 +443,7 @@ InitialI::opMG1(const Ice::Current& current)
 }
 
 InitialI::OpMG2MarshaledResult
-InitialI::opMG2(ICE_IN(IceUtil::Optional<Test::GPtr>) p1, const Ice::Current& current)
+InitialI::opMG2(IceUtil::Optional<Test::GPtr> p1, const Ice::Current& current)
 {
     return OpMG2MarshaledResult(p1, p1, current);
 }

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -19,114 +19,114 @@ public:
    InitialI();
 
     virtual void shutdown(const Ice::Current&);
-    virtual PingPongMarshaledResult pingPong(ICE_IN(Ice::ValuePtr), const Ice::Current&);
+    virtual PingPongMarshaledResult pingPong(Ice::ValuePtr, const Ice::Current&);
 
-    virtual void opOptionalException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                     ICE_IN(IceUtil::Optional< ::std::string>),
-                                     ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opOptionalException(IceUtil::Optional< ::Ice::Int>,
+                                     IceUtil::Optional< ::std::string>,
+                                     IceUtil::Optional<Test::OneOptionalPtr>,
                                      const Ice::Current&);
 
-    virtual void opDerivedException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                    ICE_IN(IceUtil::Optional< ::std::string>),
-                                    ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opDerivedException(IceUtil::Optional< ::Ice::Int>,
+                                    IceUtil::Optional< ::std::string>,
+                                    IceUtil::Optional<Test::OneOptionalPtr>,
                                     const Ice::Current&);
 
-    virtual void opRequiredException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                     ICE_IN(IceUtil::Optional< ::std::string>),
-                                     ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opRequiredException(IceUtil::Optional< ::Ice::Int>,
+                                     IceUtil::Optional< ::std::string>,
+                                     IceUtil::Optional<Test::OneOptionalPtr>,
                                      const Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Byte> opByte(ICE_IN(IceUtil::Optional< ::Ice::Byte>),
+    virtual IceUtil::Optional< ::Ice::Byte> opByte(IceUtil::Optional< ::Ice::Byte>,
                                                    IceUtil::Optional< ::Ice::Byte>&,
                                                    const ::Ice::Current&);
 
-    virtual IceUtil::Optional<bool> opBool(ICE_IN(IceUtil::Optional<bool>), IceUtil::Optional<bool>&,
+    virtual IceUtil::Optional<bool> opBool(IceUtil::Optional<bool>, IceUtil::Optional<bool>&,
                                            const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Short> opShort(ICE_IN(IceUtil::Optional< ::Ice::Short>),
+    virtual IceUtil::Optional< ::Ice::Short> opShort(IceUtil::Optional< ::Ice::Short>,
                                                      IceUtil::Optional< ::Ice::Short>&,
                                                      const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Int> opInt(ICE_IN(IceUtil::Optional< ::Ice::Int>),
+    virtual IceUtil::Optional< ::Ice::Int> opInt(IceUtil::Optional< ::Ice::Int>,
                                                  IceUtil::Optional< ::Ice::Int>&,
                                                  const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Long> opLong(ICE_IN(IceUtil::Optional< ::Ice::Long>),
+    virtual IceUtil::Optional< ::Ice::Long> opLong(IceUtil::Optional< ::Ice::Long>,
                                                    IceUtil::Optional< ::Ice::Long>&,
                                                    const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Float> opFloat(ICE_IN(IceUtil::Optional< ::Ice::Float>),
+    virtual IceUtil::Optional< ::Ice::Float> opFloat(IceUtil::Optional< ::Ice::Float>,
                                                      IceUtil::Optional< ::Ice::Float>&,
                                                      const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Double> opDouble(ICE_IN(IceUtil::Optional< ::Ice::Double>),
+    virtual IceUtil::Optional< ::Ice::Double> opDouble(IceUtil::Optional< ::Ice::Double>,
                                                        IceUtil::Optional< ::Ice::Double>&,
                                                        const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::std::string> opString(ICE_IN(IceUtil::Optional< ::std::string>),
+    virtual IceUtil::Optional< ::std::string> opString(IceUtil::Optional< ::std::string>,
                                                        IceUtil::Optional< ::std::string>&,
                                                        const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::std::string> opCustomString(ICE_IN(IceUtil::Optional< Util::string_view>),
+    virtual IceUtil::Optional< ::std::string> opCustomString(IceUtil::Optional< Util::string_view>,
                                                                IceUtil::Optional< ::std::string>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional< Test::MyEnum> opMyEnum(ICE_IN(IceUtil::Optional<Test::MyEnum>),
+    virtual IceUtil::Optional< Test::MyEnum> opMyEnum(IceUtil::Optional<Test::MyEnum>,
                                                       IceUtil::Optional<Test::MyEnum>&,
                                                       const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::SmallStruct> opSmallStruct(ICE_IN(IceUtil::Optional<Test::SmallStruct>),
+    virtual IceUtil::Optional<Test::SmallStruct> opSmallStruct(IceUtil::Optional<Test::SmallStruct>,
                                                                IceUtil::Optional<Test::SmallStruct>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::FixedStruct> opFixedStruct(ICE_IN(IceUtil::Optional<Test::FixedStruct>),
+    virtual IceUtil::Optional<Test::FixedStruct> opFixedStruct(IceUtil::Optional<Test::FixedStruct>,
                                                                IceUtil::Optional<Test::FixedStruct>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::VarStruct> opVarStruct(ICE_IN(IceUtil::Optional<Test::VarStruct>),
+    virtual IceUtil::Optional<Test::VarStruct> opVarStruct(IceUtil::Optional<Test::VarStruct>,
                                                            IceUtil::Optional<Test::VarStruct>&,
                                                            const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::OneOptionalPtr> opOneOptional(ICE_IN(IceUtil::Optional< Test::OneOptionalPtr>),
+    virtual IceUtil::Optional<Test::OneOptionalPtr> opOneOptional(IceUtil::Optional< Test::OneOptionalPtr>,
                                                                   IceUtil::Optional< Test::OneOptionalPtr>&,
                                                                   const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::OneOptionalPrxPtr> opOneOptionalProxy(ICE_IN(IceUtil::Optional< Test::OneOptionalPrxPtr>),
+    virtual IceUtil::Optional<Test::OneOptionalPrxPtr> opOneOptionalProxy(IceUtil::Optional< Test::OneOptionalPrxPtr>,
                                                                           IceUtil::Optional< Test::OneOptionalPrxPtr>&,
                                                                           const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::ByteSeq> opByteSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Byte*, const ::Ice::Byte*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Byte*, const ::Ice::Byte*> >,
         IceUtil::Optional< ::Test::ByteSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::BoolSeq> opBoolSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const bool*, const bool*> >),
+        IceUtil::Optional< ::std::pair<const bool*, const bool*> >,
         IceUtil::Optional< ::Test::BoolSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::ShortSeq> opShortSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Short*, const ::Ice::Short*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Short*, const ::Ice::Short*> >,
         IceUtil::Optional< ::Test::ShortSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntSeq> opIntSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Int*, const ::Ice::Int*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Int*, const ::Ice::Int*> >,
         IceUtil::Optional< ::Test::IntSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::LongSeq> opLongSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Long*, const ::Ice::Long*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Long*, const ::Ice::Long*> >,
         IceUtil::Optional< ::Test::LongSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FloatSeq> opFloatSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Float*, const ::Ice::Float*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Float*, const ::Ice::Float*> >,
         IceUtil::Optional< ::Test::FloatSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::DoubleSeq> opDoubleSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Double*, const ::Ice::Double*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Double*, const ::Ice::Double*> >,
         IceUtil::Optional< ::Test::DoubleSeq>&,
         const ::Ice::Current&);
 
@@ -135,19 +135,19 @@ public:
          Ice::optional<::Test::StringSeq>&, const ::Ice::Current&) ;
 
     virtual IceUtil::Optional< ::Test::SmallStructSeq> opSmallStructSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >,
         IceUtil::Optional< ::Test::SmallStructSeq>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::SmallStructList> opSmallStructList(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >,
         IceUtil::Optional< ::Test::SmallStructList>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FixedStructSeq> opFixedStructSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >,
         IceUtil::Optional< ::Test::FixedStructSeq>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FixedStructList> opFixedStructList(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >,
         IceUtil::Optional< ::Test::FixedStructList>&, const ::Ice::Current&);
 
     virtual Ice::optional<::Test::VarStructSeq> opVarStructSeq(
@@ -155,55 +155,55 @@ public:
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::Serializable> opSerializable(
-        ICE_IN(IceUtil::Optional< ::Test::Serializable>),
+        IceUtil::Optional< ::Test::Serializable>,
         IceUtil::Optional< ::Test::Serializable>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntIntDict> opIntIntDict(
-        ICE_IN(IceUtil::Optional< ::Test::IntIntDict>),
+        IceUtil::Optional< ::Test::IntIntDict>,
         IceUtil::Optional< ::Test::IntIntDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::StringIntDict> opStringIntDict(
-        ICE_IN(IceUtil::Optional< ::Test::StringIntDict>),
+        IceUtil::Optional< ::Test::StringIntDict>,
         IceUtil::Optional< ::Test::StringIntDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntOneOptionalDict> opIntOneOptionalDict(
-        ICE_IN(IceUtil::Optional< ::Test::IntOneOptionalDict>),
+        IceUtil::Optional< ::Test::IntOneOptionalDict>,
         IceUtil::Optional< ::Test::IntOneOptionalDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntStringDict> opCustomIntStringDict(
-        ICE_IN(IceUtil::Optional<std::map<int, Util::string_view> >),
+        IceUtil::Optional<std::map<int, Util::string_view> >,
         IceUtil::Optional< ::Test::IntStringDict>&,
         const ::Ice::Current&);
 
-    virtual void opClassAndUnknownOptional(ICE_IN(Test::APtr), const Ice::Current&);
+    virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
-    virtual void sendOptionalClass(bool, ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>), const Ice::Current&);
+    virtual void sendOptionalClass(bool, IceUtil::Optional<Test::OneOptionalPtr>, const Ice::Current&);
 
     virtual void returnOptionalClass(bool, IceUtil::Optional<Test::OneOptionalPtr>&, const Ice::Current&);
 
-    virtual ::Test::GPtr opG(ICE_IN(::Test::GPtr) g, const Ice::Current&);
+    virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
 
     virtual void opVoid(const Ice::Current&);
 
     virtual OpMStruct1MarshaledResult opMStruct1(const Ice::Current&);
 
-    virtual OpMStruct2MarshaledResult opMStruct2(ICE_IN(IceUtil::Optional<Test::SmallStruct>), const Ice::Current&);
+    virtual OpMStruct2MarshaledResult opMStruct2(IceUtil::Optional<Test::SmallStruct>, const Ice::Current&);
 
     virtual OpMSeq1MarshaledResult opMSeq1(const Ice::Current&);
 
-    virtual OpMSeq2MarshaledResult opMSeq2(ICE_IN(IceUtil::Optional<Test::StringSeq>), const Ice::Current&);
+    virtual OpMSeq2MarshaledResult opMSeq2(IceUtil::Optional<Test::StringSeq>, const Ice::Current&);
 
     virtual OpMDict1MarshaledResult opMDict1(const Ice::Current&);
 
-    virtual OpMDict2MarshaledResult opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>), const Ice::Current&);
+    virtual OpMDict2MarshaledResult opMDict2(IceUtil::Optional<Test::StringIntDict>, const Ice::Current&);
 
     virtual OpMG1MarshaledResult opMG1(const Ice::Current&);
 
-    virtual OpMG2MarshaledResult opMG2(ICE_IN(IceUtil::Optional<Test::GPtr>), const Ice::Current&);
+    virtual OpMG2MarshaledResult opMG2(IceUtil::Optional<Test::GPtr>, const Ice::Current&);
 
     virtual bool supportsRequiredParams(const Ice::Current&);
 

--- a/cpp/test/Ice/plugin/Client.cpp
+++ b/cpp/test/Ice/plugin/Client.cpp
@@ -244,7 +244,7 @@ Client::run(int argc, char** argv)
         test(pm->getPlugin("PluginTwo"));
         test(pm->getPlugin("PluginThree"));
 
-        MyPluginPtr p4 = ICE_MAKE_SHARED(MyPlugin);
+        MyPluginPtr p4 = std::make_shared<MyPlugin>();
         pm->addPlugin("PluginFour", p4);
         test(pm->getPlugin("PluginFour"));
 

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -53,8 +53,8 @@ class PluginInitializeFailExeption : public std::exception
 
 public:
 
-    PluginInitializeFailExeption() ICE_NOEXCEPT {}
-    virtual const char* what() const ICE_NOEXCEPT { return "PluginInitializeFailExeption"; }
+    PluginInitializeFailExeption() noexcept {}
+    virtual const char* what() const noexcept { return "PluginInitializeFailExeption"; }
 };
 
 class PluginInitializeFail : public Ice::Plugin

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -346,18 +346,18 @@ allTests(Test::TestHelper* helper)
     id.name = "test";
     id.category = "\x7F\xE2\x82\xAC";
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Unicode));
+    idStr = identityToString(id, Ice::ToStringMode::Unicode);
     test(idStr == "\\u007f\xE2\x82\xAC/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
     test(Ice::identityToString(id) == idStr);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, ASCII));
+    idStr = identityToString(id, Ice::ToStringMode::ASCII);
     test(idStr == "\\u007f\\u20ac/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Compat));
+    idStr = identityToString(id, Ice::ToStringMode::Compat);
     test(idStr == "\\177\\342\\202\\254/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
@@ -369,17 +369,17 @@ allTests(Test::TestHelper* helper)
     id.name = u8"banana \016-\U0001F34C\U000020AC\u00a2\u0024";
     id.category = u8"greek \U0001016A";
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Unicode));
+    idStr = identityToString(id, Ice::ToStringMode::Unicode);
     test(idStr == u8"greek \U0001016A/banana \\u000e-\U0001F34C\U000020AC\u00a2$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, ASCII));
+    idStr = identityToString(id, Ice::ToStringMode::ASCII);
     test(idStr == "greek \\U0001016a/banana \\u000e-\\U0001f34c\\u20ac\\u00a2$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Compat));
+    idStr = identityToString(id, Ice::ToStringMode::Compat);
     test(idStr == "greek \\360\\220\\205\\252/banana \\016-\\360\\237\\215\\214\\342\\202\\254\\302\\242$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
@@ -483,13 +483,13 @@ allTests(Test::TestHelper* helper)
     prop->setProperty(property, "");
 
     property = propertyPrefix + ".EndpointSelection";
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
     prop->setProperty(property, "Random");
     b1 = communicator->propertyToProxy(propertyPrefix);
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
     prop->setProperty(property, "Ordered");
     b1 = communicator->propertyToProxy(propertyPrefix);
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
     prop->setProperty(property, "");
 
     property = propertyPrefix + ".CollocationOptimized";
@@ -522,7 +522,7 @@ allTests(Test::TestHelper* helper)
     b1 = b1->ice_collocationOptimized(true);
     b1 = b1->ice_connectionCached(true);
     b1 = b1->ice_preferSecure(false);
-    b1 = b1->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+    b1 = b1->ice_endpointSelection(Ice::EndpointSelectionType::Ordered);
     b1 = b1->ice_locatorCacheTimeout(100);
     b1 = b1->ice_invocationTimeout(1234);
     Ice::EncodingVersion v = { 1, 0 };
@@ -531,7 +531,7 @@ allTests(Test::TestHelper* helper)
     router = router->ice_collocationOptimized(false);
     router = router->ice_connectionCached(true);
     router = router->ice_preferSecure(true);
-    router = router->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random));
+    router = router->ice_endpointSelection(Ice::EndpointSelectionType::Random);
     router = router->ice_locatorCacheTimeout(200);
     router = router->ice_invocationTimeout(1500);
 
@@ -539,7 +539,7 @@ allTests(Test::TestHelper* helper)
     locator = locator->ice_collocationOptimized(true);
     locator = locator->ice_connectionCached(false);
     locator = locator->ice_preferSecure(true);
-    locator = locator->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random));
+    locator = locator->ice_endpointSelection(Ice::EndpointSelectionType::Random);
     locator = locator->ice_locatorCacheTimeout(300);
     locator = locator->ice_invocationTimeout(1500);
 
@@ -719,10 +719,10 @@ allTests(Test::TestHelper* helper)
     test(Ice::targetLess(compObj->ice_connectionCached(false), compObj->ice_connectionCached(true)));
     test(Ice::targetGreaterEqual(compObj->ice_connectionCached(true), compObj->ice_connectionCached(false)));
 
-    test(Ice::targetEqualTo(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random))));
-    test(Ice::targetNotEqualTo(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered))));
-    test(Ice::targetLess(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered))));
-    test(Ice::targetGreaterEqual(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random))));
+    test(Ice::targetEqualTo(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random)));
+    test(Ice::targetNotEqualTo(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered)));
+    test(Ice::targetLess(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered)));
+    test(Ice::targetGreaterEqual(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random)));
 
     test(Ice::targetEqualTo(compObj->ice_connectionId("id2"), compObj->ice_connectionId("id2")));
     test(Ice::targetNotEqualTo(compObj->ice_connectionId("id1"), compObj->ice_connectionId("id2")));
@@ -991,7 +991,7 @@ allTests(Test::TestHelper* helper)
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
         vector<Ice::Byte> outEncaps;
-        cl->ice_invoke("ice_ping", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }
     catch(const Ice::UnknownLocalException& ex)
@@ -1012,7 +1012,7 @@ allTests(Test::TestHelper* helper)
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
         vector<Ice::Byte> outEncaps;
-        cl->ice_invoke("ice_ping", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }
     catch(const Ice::UnknownLocalException& ex)

--- a/cpp/test/Ice/proxy/Collocated.cpp
+++ b/cpp/test/Ice/proxy/Collocated.cpp
@@ -23,7 +23,7 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     Test::MyClassPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/proxy/Server.cpp
+++ b/cpp/test/Ice/proxy/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/proxy/ServerAMD.cpp
+++ b/cpp/test/Ice/proxy/ServerAMD.cpp
@@ -25,7 +25,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/retry/Collocated.cpp
+++ b/cpp/test/Ice/retry/Collocated.cpp
@@ -15,7 +15,7 @@ void
 setupObjectAdapter(const Ice::CommunicatorPtr& communicator)
 {
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
-    adapter->add(ICE_MAKE_SHARED(RetryI), Ice::stringToIdentity("retry"));
+    adapter->add(std::make_shared<RetryI>(), Ice::stringToIdentity("retry"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 }
 

--- a/cpp/test/Ice/retry/InstrumentationI.cpp
+++ b/cpp/test/Ice/retry/InstrumentationI.cpp
@@ -68,13 +68,13 @@ public:
     virtual ::Ice::Instrumentation::RemoteObserverPtr
     getRemoteObserver(const ::Ice::ConnectionInfoPtr&, const ::Ice::EndpointPtr&, ::Ice::Int, ::Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual ::Ice::Instrumentation::CollocatedObserverPtr
     getCollocatedObserver(const Ice::ObjectAdapterPtr&, ::Ice::Int, ::Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
 };
@@ -88,13 +88,13 @@ public:
     virtual Ice::Instrumentation::ObserverPtr
     getConnectionEstablishmentObserver(const Ice::EndpointPtr&, const ::std::string&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ObserverPtr
     getEndpointLookupObserver(const Ice::EndpointPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ConnectionObserverPtr
@@ -103,7 +103,7 @@ public:
                           Ice::Instrumentation::ConnectionState,
                           const Ice::Instrumentation::ConnectionObserverPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ThreadObserverPtr
@@ -112,7 +112,7 @@ public:
                       Ice::Instrumentation::ThreadState,
                       const Ice::Instrumentation::ThreadObserverPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::InvocationObserverPtr
@@ -124,7 +124,7 @@ public:
     virtual Ice::Instrumentation::DispatchObserverPtr
     getDispatchObserver(const Ice::Current&, Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual void

--- a/cpp/test/Ice/retry/InstrumentationI.cpp
+++ b/cpp/test/Ice/retry/InstrumentationI.cpp
@@ -79,7 +79,7 @@ public:
 
 };
 
-Ice::Instrumentation::InvocationObserverPtr invocationObserver = ICE_MAKE_SHARED(InvocationObserverI);
+Ice::Instrumentation::InvocationObserverPtr invocationObserver = std::make_shared<InvocationObserverI>();
 
 class CommunicatorObserverI : public Ice::Instrumentation::CommunicatorObserver
 {
@@ -133,7 +133,7 @@ public:
     }
 };
 
-Ice::Instrumentation::CommunicatorObserverPtr communicatorObserver = ICE_MAKE_SHARED(CommunicatorObserverI);
+Ice::Instrumentation::CommunicatorObserverPtr communicatorObserver = std::make_shared<CommunicatorObserverI>();
 
 void
 testEqual(int& value, int expected)

--- a/cpp/test/Ice/retry/Server.cpp
+++ b/cpp/test/Ice/retry/Server.cpp
@@ -26,7 +26,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(RetryI), Ice::stringToIdentity("retry"));
+    adapter->add(std::make_shared<RetryI>(), Ice::stringToIdentity("retry"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/retry/TestI.cpp
+++ b/cpp/test/Ice/retry/TestI.cpp
@@ -17,7 +17,7 @@ RetryI::op(bool kill, const Ice::Current& current)
     {
         if(current.con)
         {
-            current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            current.con->close(Ice::ConnectionClose::Forcefully);
         }
         else
         {

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -60,8 +60,8 @@ allTests(Test::TestHelper* helper)
         test(cmap2["a"]->s == c1->s);
         test(cmap3["a"]->s == c1->s);
 
-        Test::E1 e = i->opE1(Test::ICE_ENUM(E1, v1));
-        test(e == Test::ICE_ENUM(E1, v1));
+        Test::E1 e = i->opE1(Test::E1::v1);
+        test(e == Test::E1::v1);
 
         Test::S1 s;
         s.s = "S1";

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -40,7 +40,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::CPtr c1 = ICE_MAKE_SHARED(Test::C, s1);
+        Test::CPtr c1 = std::make_shared<Test::C>(s1);
         Test::CPtr c2;
         Test::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -68,7 +68,7 @@ allTests(Test::TestHelper* helper)
         s = i->opS1(s);
         test(s.s == "S1");
 
-        Test::C1Ptr c = i->opC1(ICE_MAKE_SHARED(Test::C1, "C1"));
+        Test::C1Ptr c = i->opC1(std::make_shared<Test::C1>("C1"));
         test(c->s == "C1");
     }
 
@@ -139,7 +139,7 @@ allTests(Test::TestHelper* helper)
         }
 
         {
-            auto result = i->opC1Async(ICE_MAKE_SHARED(Test::C1, "C1")).get();
+            auto result = i->opC1Async(std::make_shared<Test::C1>("C1")).get();
             test(result->s == "C1");
         }
     }
@@ -373,7 +373,7 @@ allTests(Test::TestHelper* helper)
         {
             promise<void> p;
             auto f = p.get_future();
-            auto result = i->opC1Async(ICE_MAKE_SHARED(Test::C1, "C1"),
+            auto result = i->opC1Async(std::make_shared<Test::C1>("C1"),
                                        [&p](Test::C1Ptr v)
                                        {
                                            test(v->s == "C1");
@@ -422,7 +422,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::Inner::Inner2::CPtr c1 = ICE_MAKE_SHARED(Test::Inner::Inner2::C, s1);
+        Test::Inner::Inner2::CPtr c1 = std::make_shared<Test::Inner::Inner2::C>(s1);
         Test::Inner::Inner2::CPtr c2;
         Test::Inner::Inner2::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -700,7 +700,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::Inner::Inner2::CPtr c1 = ICE_MAKE_SHARED(Test::Inner::Inner2::C, s1);
+        Test::Inner::Inner2::CPtr c1 = std::make_shared<Test::Inner::Inner2::C>(s1);
         Test::Inner::Inner2::CPtr c2;
         Test::Inner::Inner2::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -977,7 +977,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::CPtr c1 = ICE_MAKE_SHARED(Test::C, s1);
+        Test::CPtr c1 = std::make_shared<Test::C>(s1);
         Test::CPtr c2;
         Test::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);

--- a/cpp/test/Ice/scope/Server.cpp
+++ b/cpp/test/Ice/scope/Server.cpp
@@ -19,17 +19,17 @@ class I1 : public Test::I
 {
 public:
 
-    virtual Test::S opS(ICE_IN(Test::S), Test::S&, const Ice::Current&);
-    virtual Test::SSeq opSSeq(ICE_IN(Test::SSeq), Test::SSeq&, const Ice::Current&);
-    virtual Test::SMap opSMap(ICE_IN(Test::SMap), Test::SMap&, const Ice::Current&);
+    virtual Test::S opS(Test::S, Test::S&, const Ice::Current&);
+    virtual Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
+    virtual Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
 
-    virtual Test::CPtr opC(ICE_IN(Test::CPtr), Test::CPtr&, const Ice::Current&);
-    virtual Test::CSeq opCSeq(ICE_IN(Test::CSeq), Test::CSeq&, const Ice::Current&);
-    virtual Test::CMap opCMap(ICE_IN(Test::CMap), Test::CMap&, const Ice::Current&);
+    virtual Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
+    virtual Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
+    virtual Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
 
     virtual Test::E1 opE1(Test::E1, const Ice::Current&);
-    virtual Test::S1 opS1(ICE_IN(Test::S1), const Ice::Current&);
-    virtual Test::C1Ptr opC1(ICE_IN(Test::C1Ptr), const Ice::Current&);
+    virtual Test::S1 opS1(Test::S1, const Ice::Current&);
+    virtual Test::C1Ptr opC1(Test::C1Ptr, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -39,22 +39,22 @@ class I2 : public Test::Inner::Inner2::I
 public:
 
     virtual Test::Inner::Inner2::S
-    opS(ICE_IN(Test::Inner::Inner2::S), Test::Inner::Inner2::S&, const Ice::Current&);
+    opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SSeq
-    opSSeq(ICE_IN(Test::Inner::Inner2::SSeq), Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SMap
-    opSMap(ICE_IN(Test::Inner::Inner2::SMap), Test::Inner::Inner2::SMap&, const Ice::Current&);
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CPtr
-    opC(ICE_IN(Test::Inner::Inner2::CPtr), Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CSeq
-    opCSeq(ICE_IN(Test::Inner::Inner2::CSeq), Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CMap
-    opCMap(ICE_IN(Test::Inner::Inner2::CMap), Test::Inner::Inner2::CMap&, const Ice::Current&);
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -64,22 +64,22 @@ class I3 : public Test::Inner::I
 public:
 
     virtual Test::Inner::Inner2::S
-    opS(ICE_IN(Test::Inner::Inner2::S), Test::Inner::Inner2::S&, const Ice::Current&);
+    opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SSeq
-    opSSeq(ICE_IN(Test::Inner::Inner2::SSeq), Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SMap
-    opSMap(ICE_IN(Test::Inner::Inner2::SMap), Test::Inner::Inner2::SMap&, const Ice::Current&);
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CPtr
-    opC(ICE_IN(Test::Inner::Inner2::CPtr), Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CSeq
-    opCSeq(ICE_IN(Test::Inner::Inner2::CSeq), Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CMap
-    opCMap(ICE_IN(Test::Inner::Inner2::CMap), Test::Inner::Inner2::CMap&, const Ice::Current&);
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -89,22 +89,22 @@ class I4 : public Inner::Test::Inner2::I
 public:
 
     virtual Test::S
-    opS(ICE_IN(Test::S), Test::S&, const Ice::Current&);
+    opS(Test::S, Test::S&, const Ice::Current&);
 
     virtual Test::SSeq
-    opSSeq(ICE_IN(Test::SSeq), Test::SSeq&, const Ice::Current&);
+    opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
 
     virtual Test::SMap
-    opSMap(ICE_IN(Test::SMap), Test::SMap&, const Ice::Current&);
+    opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
 
     virtual Test::CPtr
-    opC(ICE_IN(Test::CPtr), Test::CPtr&, const Ice::Current&);
+    opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
 
     virtual Test::CSeq
-    opCSeq(ICE_IN(Test::CSeq), Test::CSeq&, const Ice::Current&);
+    opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
 
     virtual Test::CMap
-    opCMap(ICE_IN(Test::CMap), Test::CMap&, const Ice::Current&);
+    opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -113,41 +113,41 @@ public:
 // I1 implementation
 //
 Test::S
-I1::opS(ICE_IN(Test::S) s1, Test::S& s2, const Ice::Current&)
+I1::opS(Test::S s1, Test::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SSeq
-I1::opSSeq(ICE_IN(Test::SSeq) s1, Test::SSeq& s2, const Ice::Current&)
+I1::opSSeq(Test::SSeq s1, Test::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SMap
-I1::opSMap(ICE_IN(Test::SMap) s1, Test::SMap& s2, const Ice::Current&)
+I1::opSMap(Test::SMap s1, Test::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::CPtr
-I1::opC(ICE_IN(Test::CPtr) c1, Test::CPtr& c2, const Ice::Current&)
+I1::opC(Test::CPtr c1, Test::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CSeq
-I1::opCSeq(ICE_IN(Test::CSeq) c1, Test::CSeq& c2, const Ice::Current&)
+I1::opCSeq(Test::CSeq c1, Test::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::CMap
-I1::opCMap(ICE_IN(Test::CMap) c1, Test::CMap& c2, const Ice::Current&)
+I1::opCMap(Test::CMap c1, Test::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -160,13 +160,13 @@ I1::opE1(Test::E1 e1, const Ice::Current&)
 }
 
 Test::S1
-I1::opS1(ICE_IN(Test::S1) s1, const Ice::Current&)
+I1::opS1(Test::S1 s1, const Ice::Current&)
 {
     return s1;
 }
 
 Test::C1Ptr
-I1::opC1(ICE_IN(Test::C1Ptr) c1, const Ice::Current&)
+I1::opC1(Test::C1Ptr c1, const Ice::Current&)
 {
     return c1;
 }
@@ -181,41 +181,41 @@ I1::shutdown(const Ice::Current& current)
 // I2 implementation
 //
 Test::Inner::Inner2::S
-I2::opS(ICE_IN(Test::Inner::Inner2::S) s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
+I2::opS(Test::Inner::Inner2::S s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SSeq
-I2::opSSeq(ICE_IN(Test::Inner::Inner2::SSeq) s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
+I2::opSSeq(Test::Inner::Inner2::SSeq s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SMap
-I2::opSMap(ICE_IN(Test::Inner::Inner2::SMap) s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
+I2::opSMap(Test::Inner::Inner2::SMap s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::CPtr
-I2::opC(ICE_IN(Test::Inner::Inner2::CPtr) c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
+I2::opC(Test::Inner::Inner2::CPtr c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::Inner::Inner2::CSeq
-I2::opCSeq(ICE_IN(Test::Inner::Inner2::CSeq) c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
+I2::opCSeq(Test::Inner::Inner2::CSeq c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::Inner::Inner2::CMap
-I2::opCMap(ICE_IN(Test::Inner::Inner2::CMap) c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
+I2::opCMap(Test::Inner::Inner2::CMap c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -231,41 +231,41 @@ I2::shutdown(const Ice::Current& current)
 // I3 implementation
 //
 Test::Inner::Inner2::S
-I3::opS(ICE_IN(Test::Inner::Inner2::S) s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
+I3::opS(Test::Inner::Inner2::S s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SSeq
-I3::opSSeq(ICE_IN(Test::Inner::Inner2::SSeq) s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
+I3::opSSeq(Test::Inner::Inner2::SSeq s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SMap
-I3::opSMap(ICE_IN(Test::Inner::Inner2::SMap) s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
+I3::opSMap(Test::Inner::Inner2::SMap s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::CPtr
-I3::opC(ICE_IN(Test::Inner::Inner2::CPtr) c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
+I3::opC(Test::Inner::Inner2::CPtr c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::Inner::Inner2::CSeq
-I3::opCSeq(ICE_IN(Test::Inner::Inner2::CSeq) c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
+I3::opCSeq(Test::Inner::Inner2::CSeq c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::Inner::Inner2::CMap
-I3::opCMap(ICE_IN(Test::Inner::Inner2::CMap) c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
+I3::opCMap(Test::Inner::Inner2::CMap c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -281,42 +281,42 @@ I3::shutdown(const Ice::Current& current)
 // I4 implementation
 //
 Test::S
-I4::opS(ICE_IN(Test::S) s1, Test::S& s2, const Ice::Current&)
+I4::opS(Test::S s1, Test::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SSeq
-I4::opSSeq(ICE_IN(Test::SSeq) s1, Test::SSeq& s2, const Ice::Current&)
+I4::opSSeq(Test::SSeq s1, Test::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SMap
-I4::opSMap(ICE_IN(Test::SMap) s1, Test::SMap& s2, const Ice::Current&)
+I4::opSMap(Test::SMap s1, Test::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::CPtr
-I4::opC(ICE_IN(Test::CPtr) c1, Test::CPtr& c2, const Ice::Current&)
+I4::opC(Test::CPtr c1, Test::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CSeq
-I4::opCSeq(ICE_IN(Test::CSeq) c1, Test::CSeq& c2, const Ice::Current&)
+I4::opCSeq(Test::CSeq c1, Test::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CMap
-I4::opCMap(ICE_IN(Test::CMap) c1, Test::CMap& c2, const Ice::Current&)
+I4::opCMap(Test::CMap c1, Test::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;

--- a/cpp/test/Ice/scope/Server.cpp
+++ b/cpp/test/Ice/scope/Server.cpp
@@ -334,10 +334,10 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(I1), Ice::stringToIdentity("i1"));
-    adapter->add(ICE_MAKE_SHARED(I2), Ice::stringToIdentity("i2"));
-    adapter->add(ICE_MAKE_SHARED(I3), Ice::stringToIdentity("i3"));
-    adapter->add(ICE_MAKE_SHARED(I4), Ice::stringToIdentity("i4"));
+    adapter->add(std::make_shared<I1>(), Ice::stringToIdentity("i1"));
+    adapter->add(std::make_shared<I2>(), Ice::stringToIdentity("i2"));
+    adapter->add(std::make_shared<I3>(), Ice::stringToIdentity("i3"));
+    adapter->add(std::make_shared<I4>(), Ice::stringToIdentity("i4"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/servantLocator/Collocated.cpp
+++ b/cpp/test/Ice/servantLocator/Collocated.cpp
@@ -49,8 +49,8 @@ public:
     {
         if(activate)
         {
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorI>(""), "");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorI>("category"), "category");
         }
         else
         {
@@ -77,10 +77,10 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->addServantLocator(std::make_shared<ServantLocatorI>(""), "");
+    adapter->addServantLocator(std::make_shared<ServantLocatorI>("category"), "category");
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("asm"));
+    adapter->add(std::make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
 
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/servantLocator/Server.cpp
+++ b/cpp/test/Ice/servantLocator/Server.cpp
@@ -49,8 +49,8 @@ public:
     {
         if(activate)
         {
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorI>(""), "");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorI>("category"), "category");
         }
         else
         {
@@ -78,10 +78,10 @@ Server::run(int argc, char** argv)
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
 
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->addServantLocator(std::make_shared<ServantLocatorI>(""), "");
+    adapter->addServantLocator(std::make_shared<ServantLocatorI>("category"), "category");
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("asm"));
+    adapter->add(std::make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
     adapter->activate();
     serverReady();
     adapter->waitForDeactivate();

--- a/cpp/test/Ice/servantLocator/ServerAMD.cpp
+++ b/cpp/test/Ice/servantLocator/ServerAMD.cpp
@@ -48,8 +48,8 @@ public:
     {
         if(activate)
         {
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorAMDI, ""), "");
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorAMDI, "category"), "category");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorAMDI>(""), "");
+            current.adapter->addServantLocator(std::make_shared<ServantLocatorAMDI>("category"), "category");
         }
         else
         {
@@ -77,10 +77,10 @@ ServerAMD::run(int argc, char** argv)
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
 
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorAMDI, ""), "");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorAMDI, "category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestAMDI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->addServantLocator(std::make_shared<ServantLocatorAMDI>(""), "");
+    adapter->addServantLocator(std::make_shared<ServantLocatorAMDI>("category"), "category");
+    adapter->add(std::make_shared<TestAMDI>(), Ice::stringToIdentity("asm"));
+    adapter->add(std::make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
     adapter->activate();
     serverReady();
     adapter->waitForDeactivate();

--- a/cpp/test/Ice/services/AllTests.cpp
+++ b/cpp/test/Ice/services/AllTests.cpp
@@ -58,7 +58,7 @@ public:
 
     int run(int, char*[])
     {
-        _factory = ICE_MAKE_SHARED(Glacier2::SessionFactoryHelper, ICE_MAKE_SHARED(SessionCallbackI));
+        _factory = std::make_shared<Glacier2::SessionFactoryHelper>(std::make_shared<SessionCallbackI>());
         return EXIT_SUCCESS;
     }
 
@@ -107,7 +107,7 @@ allTests(Test::TestHelper* helper)
         }
 
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("subscriber" ,"tcp");
-        Ice::ObjectPrxPtr subscriber = adapter->addWithUUID(ICE_MAKE_SHARED(ClockI));
+        Ice::ObjectPrxPtr subscriber = adapter->addWithUUID(std::make_shared<ClockI>());
         adapter->activate();
         assert(!topic);
         cout << "ok" << endl;

--- a/cpp/test/Ice/slicing/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/slicing/exceptions/AllTests.cpp
@@ -35,7 +35,7 @@ class RelayI : public Relay
         ex.b = "base";
         ex.kp = "preserved";
         ex.kpd = "derived";
-        ex.p1 = ICE_MAKE_SHARED(PreservedClass, "bc", "pc");
+        ex.p1 = std::make_shared<PreservedClass>("bc", "pc");
         ex.p2 = ex.p1;
         throw ex;
     }
@@ -46,7 +46,7 @@ class RelayI : public Relay
         ex.b = "base";
         ex.kp = "preserved";
         ex.kpd = "derived";
-        ex.p1 = ICE_MAKE_SHARED(PreservedClass, "bc", "pc");
+        ex.p1 = std::make_shared<PreservedClass>("bc", "pc");
         ex.p2 = ex.p1;
         throw ex;
     }
@@ -685,7 +685,7 @@ allTests(Test::TestHelper* helper)
     }
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
-    RelayPrxPtr relay = ICE_UNCHECKED_CAST(RelayPrx, adapter->addWithUUID(ICE_MAKE_SHARED(RelayI)));
+    RelayPrxPtr relay = ICE_UNCHECKED_CAST(RelayPrx, adapter->addWithUUID(std::make_shared<RelayI>()));
     adapter->activate();
     test->ice_getConnection()->setAdapter(adapter);
     try

--- a/cpp/test/Ice/slicing/exceptions/Server.cpp
+++ b/cpp/test/Ice/slicing/exceptions/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     properties->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("Test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
@@ -23,7 +23,7 @@ ServerAMD::run(int argc, char** argv)
     properties->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("Test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/slicing/exceptions/TestI.cpp
+++ b/cpp/test/Ice/slicing/exceptions/TestI.cpp
@@ -166,7 +166,7 @@ TestI::knownPreservedAsKnownPreserved(const ::Ice::Current&)
 }
 
 void
-TestI::relayKnownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayKnownPreservedAsBase(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->knownPreservedAsBase();
@@ -174,7 +174,7 @@ TestI::relayKnownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
 }
 
 void
-TestI::relayKnownPreservedAsKnownPreserved(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayKnownPreservedAsKnownPreserved(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->knownPreservedAsKnownPreserved();
@@ -206,7 +206,7 @@ TestI::unknownPreservedAsKnownPreserved(const ::Ice::Current&)
 }
 
 void
-TestI::relayUnknownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayUnknownPreservedAsBase(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->unknownPreservedAsBase();
@@ -214,7 +214,7 @@ TestI::relayUnknownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& 
 }
 
 void
-TestI::relayUnknownPreservedAsKnownPreserved(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayUnknownPreservedAsKnownPreserved(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->unknownPreservedAsKnownPreserved();

--- a/cpp/test/Ice/slicing/exceptions/TestI.cpp
+++ b/cpp/test/Ice/slicing/exceptions/TestI.cpp
@@ -188,7 +188,7 @@ TestI::unknownPreservedAsBase(const ::Ice::Current&)
     ex.b = "base";
     ex.kp = "preserved";
     ex.kpd = "derived";
-    ex.p1 = ICE_MAKE_SHARED(SPreservedClass, "bc", "spc");
+    ex.p1 = std::make_shared<SPreservedClass>("bc", "spc");
     ex.p2 = ex.p1;
     throw ex;
 }
@@ -200,7 +200,7 @@ TestI::unknownPreservedAsKnownPreserved(const ::Ice::Current&)
     ex.b = "base";
     ex.kp = "preserved";
     ex.kpd = "derived";
-    ex.p1 = ICE_MAKE_SHARED(SPreservedClass, "bc", "spc");
+    ex.p1 = std::make_shared<SPreservedClass>("bc", "spc");
     ex.p2 = ex.p1;
     throw ex;
 }

--- a/cpp/test/Ice/slicing/exceptions/TestI.h
+++ b/cpp/test/Ice/slicing/exceptions/TestI.h
@@ -33,14 +33,14 @@ public:
     virtual void knownPreservedAsBase(const ::Ice::Current&);
     virtual void knownPreservedAsKnownPreserved(const ::Ice::Current&);
 
-    virtual void relayKnownPreservedAsBase(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
-    virtual void relayKnownPreservedAsKnownPreserved(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
+    virtual void relayKnownPreservedAsBase(::Test::RelayPrxPtr, const ::Ice::Current&);
+    virtual void relayKnownPreservedAsKnownPreserved(::Test::RelayPrxPtr, const ::Ice::Current&);
 
     virtual void unknownPreservedAsBase(const ::Ice::Current&);
     virtual void unknownPreservedAsKnownPreserved(const ::Ice::Current&);
 
-    virtual void relayUnknownPreservedAsBase(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
-    virtual void relayUnknownPreservedAsKnownPreserved(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
+    virtual void relayUnknownPreservedAsBase(::Test::RelayPrxPtr, const ::Ice::Current&);
+    virtual void relayUnknownPreservedAsKnownPreserved(::Test::RelayPrxPtr, const ::Ice::Current&);
 
     virtual void shutdown(const ::Ice::Current&);
 };

--- a/cpp/test/Ice/slicing/objects/AllTests.cpp
+++ b/cpp/test/Ice/slicing/objects/AllTests.cpp
@@ -1445,10 +1445,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1494,10 +1494,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1544,10 +1544,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1594,10 +1594,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1770,17 +1770,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            BPtr b1 = ICE_MAKE_SHARED(B);
+            BPtr b1 = std::make_shared<B>();
             b1->sb = "B.sb(1)";
             b1->pb = b1;
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = b1;
 
-            BPtr b2 = ICE_MAKE_SHARED(B);
+            BPtr b2 = std::make_shared<B>();
             b2->sb = "B.sb(2)";
             b2->pb = b1;
 
@@ -1806,17 +1806,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            BPtr b1 = ICE_MAKE_SHARED(B);
+            BPtr b1 = std::make_shared<B>();
             b1->sb = "B.sb(1)";
             b1->pb = b1;
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = b1;
 
-            BPtr b2 = ICE_MAKE_SHARED(B);
+            BPtr b2 = std::make_shared<B>();
             b2->sb = "B.sb(2)";
             b2->pb = b1;
 
@@ -1842,17 +1842,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d11 = ICE_MAKE_SHARED(D1);
+            D1Ptr d11 = std::make_shared<D1>();
             d11->sb = "D1.sb(1)";
             d11->pb = d11;
             d11->sd1 = "D1.sd1(1)";
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = d11;
-            D1Ptr d12 = ICE_MAKE_SHARED(D1);
+            D1Ptr d12 = std::make_shared<D1>();
             d12->sb = "D1.sb(2)";
             d12->pb = d12;
             d12->sd1 = "D1.sd1(2)";
@@ -1880,17 +1880,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d11 = ICE_MAKE_SHARED(D1);
+            D1Ptr d11 = std::make_shared<D1>();
             d11->sb = "D1.sb(1)";
             d11->pb = d11;
             d11->sd1 = "D1.sd1(1)";
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = d11;
-            D1Ptr d12 = ICE_MAKE_SHARED(D1);
+            D1Ptr d12 = std::make_shared<D1>();
             d12->sb = "D1.sb(2)";
             d12->pb = d12;
             d12->sd1 = "D1.sd1(2)";
@@ -1920,29 +1920,29 @@ allTests(Test::TestHelper* helper)
         {
             SS3 ss;
             {
-                BPtr ss1b = ICE_MAKE_SHARED(B);
+                BPtr ss1b = std::make_shared<B>();
                 ss1b->sb = "B.sb";
                 ss1b->pb = ss1b;
 
-                D1Ptr ss1d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss1d1 = std::make_shared<D1>();
                 ss1d1->sb = "D1.sb";
                 ss1d1->sd1 = "D1.sd1";
                 ss1d1->pb = ss1b;
 
-                D3Ptr ss1d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss1d3 = std::make_shared<D3>();
                 ss1d3->sb = "D3.sb";
                 ss1d3->sd3 = "D3.sd3";
                 ss1d3->pb = ss1b;
-                BPtr ss2b = ICE_MAKE_SHARED(B);
+                BPtr ss2b = std::make_shared<B>();
                 ss2b->sb = "B.sb";
                 ss2b->pb = ss1b;
 
-                D1Ptr ss2d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss2d1 = std::make_shared<D1>();
                 ss2d1->sb = "D1.sb";
                 ss2d1->sd1 = "D1.sd1";
                 ss2d1->pb = ss2b;
 
-                D3Ptr ss2d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss2d3 = std::make_shared<D3>();
                 ss2d3->sb = "D3.sb";
                 ss2d3->sd3 = "D3.sd3";
                 ss2d3->pb = ss2b;
@@ -1953,12 +1953,12 @@ allTests(Test::TestHelper* helper)
                 ss2d1->pd1 = ss1d3;
                 ss2d3->pd3 = ss1d1;
 
-                SS1Ptr ss1 = ICE_MAKE_SHARED(SS1);
+                SS1Ptr ss1 = std::make_shared<SS1>();
                 ss1->s.push_back(ss1b);
                 ss1->s.push_back(ss1d1);
                 ss1->s.push_back(ss1d3);
 
-                SS2Ptr ss2 = ICE_MAKE_SHARED(SS2);
+                SS2Ptr ss2 = std::make_shared<SS2>();
                 ss2->s.push_back(ss2b);
                 ss2->s.push_back(ss2d1);
                 ss2->s.push_back(ss2d3);
@@ -2012,30 +2012,30 @@ allTests(Test::TestHelper* helper)
         {
             SS3 ss;
             {
-                BPtr ss1b = ICE_MAKE_SHARED(B);
+                BPtr ss1b = std::make_shared<B>();
                 ss1b->sb = "B.sb";
                 ss1b->pb = ss1b;
 
-                D1Ptr ss1d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss1d1 = std::make_shared<D1>();
                 ss1d1->sb = "D1.sb";
                 ss1d1->sd1 = "D1.sd1";
                 ss1d1->pb = ss1b;
 
-                D3Ptr ss1d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss1d3 = std::make_shared<D3>();
                 ss1d3->sb = "D3.sb";
                 ss1d3->sd3 = "D3.sd3";
                 ss1d3->pb = ss1b;
 
-                BPtr ss2b = ICE_MAKE_SHARED(B);
+                BPtr ss2b = std::make_shared<B>();
                 ss2b->sb = "B.sb";
                 ss2b->pb = ss1b;
 
-                D1Ptr ss2d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss2d1 = std::make_shared<D1>();
                 ss2d1->sb = "D1.sb";
                 ss2d1->sd1 = "D1.sd1";
                 ss2d1->pb = ss2b;
 
-                D3Ptr ss2d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss2d3 = std::make_shared<D3>();
                 ss2d3->sb = "D3.sb";
                 ss2d3->sd3 = "D3.sd3";
                 ss2d3->pb = ss2b;
@@ -2046,12 +2046,12 @@ allTests(Test::TestHelper* helper)
                 ss2d1->pd1 = ss1d3;
                 ss2d3->pd3 = ss1d1;
 
-                SS1Ptr ss1 = ICE_MAKE_SHARED(SS1);
+                SS1Ptr ss1 = std::make_shared<SS1>();
                 ss1->s.push_back(ss1b);
                 ss1->s.push_back(ss1d1);
                 ss1->s.push_back(ss1d3);
 
-                SS2Ptr ss2 = ICE_MAKE_SHARED(SS2);
+                SS2Ptr ss2 = std::make_shared<SS2>();
                 ss2->s.push_back(ss2b);
                 ss2->s.push_back(ss2d1);
                 ss2->s.push_back(ss2d3);
@@ -2111,7 +2111,7 @@ allTests(Test::TestHelper* helper)
             {
                 ostringstream s;
                 s << "D1." << i;
-                D1Ptr d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr d1 = std::make_shared<D1>();
                 d1->sb = s.str();
                 d1->pb = d1;
                 d1->sd1 = s.str();
@@ -2172,7 +2172,7 @@ allTests(Test::TestHelper* helper)
             {
                 ostringstream s;
                 s << "D1." << i;
-                D1Ptr d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr d1 = std::make_shared<D1>();
                 d1->sb = s.str();
                 d1->pb = d1;
                 d1->sd1 = s.str();
@@ -2441,7 +2441,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server knows the most-derived class PDerived.
         //
-        PDerivedPtr pd = ICE_MAKE_SHARED(PDerived);
+        PDerivedPtr pd = std::make_shared<PDerived>();
         pd->pi = 3;
         pd->ps = "preserved";
         pd->pb = pd;
@@ -2464,7 +2464,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server only knows the base (non-preserved) type, so the object is sliced.
         //
-        PCUnknownPtr pu = ICE_MAKE_SHARED(PCUnknown);
+        PCUnknownPtr pu = std::make_shared<PCUnknown>();
         pu->pi = 3;
         pu->pu = "preserved";
         PBasePtr r = test->exchangePBase(pu);
@@ -2484,7 +2484,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type Preserved. The object will be sliced to
         // Preserved for the 1.0 encoding; otherwise it should be returned intact.
         //
-        PCDerivedPtr pcd = ICE_MAKE_SHARED(PCDerived);
+        PCDerivedPtr pcd = std::make_shared<PCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
 
@@ -2515,7 +2515,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type CompactPDerived. The object will be sliced to
         // CompactPDerived for the 1.0 encoding; otherwise it should be returned intact.
         //
-        CompactPCDerivedPtr pcd = ICE_MAKE_SHARED(CompactPCDerived);
+        CompactPCDerivedPtr pcd = std::make_shared<CompactPCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
 
@@ -2546,7 +2546,7 @@ allTests(Test::TestHelper* helper)
         // Send an object that will have multiple preserved slices in the server.
         // The object will be sliced to Preserved for the 1.0 encoding.
         //
-        PCDerived3Ptr pcd = ICE_MAKE_SHARED(PCDerived3);
+        PCDerived3Ptr pcd = std::make_shared<PCDerived3>();
         pcd->pi = 3;
         //
         // Sending more than 254 objects exercises the encoding for object ids.
@@ -2554,7 +2554,7 @@ allTests(Test::TestHelper* helper)
         int i;
         for(i = 0; i < 300; ++i)
         {
-            PCDerived2Ptr p2 = ICE_MAKE_SHARED(PCDerived2);
+            PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
             p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;
@@ -2629,7 +2629,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server knows the most-derived class PDerived.
         //
-        PDerivedPtr pd = ICE_MAKE_SHARED(PDerived);
+        PDerivedPtr pd = std::make_shared<PDerived>();
         pd->pi = 3;
         pd->ps = "preserved";
         pd->ps = "preserved";
@@ -2656,7 +2656,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server only knows the base (non-preserved) type, so the object is sliced.
         //
-        PCUnknownPtr pu = ICE_MAKE_SHARED(PCUnknown);
+        PCUnknownPtr pu = std::make_shared<PCUnknown>();
         pu->pi = 3;
         pu->pu = "preserved";
         try
@@ -2679,7 +2679,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type Preserved. The object will be sliced to
         // Preserved for the 1.0 encoding; otherwise it should be returned intact.
         //
-        PCDerivedPtr pcd = ICE_MAKE_SHARED(PCDerived);
+        PCDerivedPtr pcd = std::make_shared<PCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
         if(test->ice_getEncodingVersion() == Ice::Encoding_1_0)
@@ -2709,7 +2709,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type CompactPDerived. The object will be sliced to
         // CompactPDerived for the 1.0 encoding; otherwise it should be returned intact.
         //
-        CompactPCDerivedPtr pcd = ICE_MAKE_SHARED(CompactPCDerived);
+        CompactPCDerivedPtr pcd = std::make_shared<CompactPCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
 
@@ -2740,14 +2740,14 @@ allTests(Test::TestHelper* helper)
         // Send an object that will have multiple preserved slices in the server.
         // The object will be sliced to Preserved for the 1.0 encoding.
         //
-        PCDerived3Ptr pcd = ICE_MAKE_SHARED(PCDerived3);
+        PCDerived3Ptr pcd = std::make_shared<PCDerived3>();
         pcd->pi = 3;
         //
         // Sending more than 254 objects exercises the encoding for object ids.
         //
         for(int i = 0; i < 300; ++i)
         {
-            PCDerived2Ptr p2 = ICE_MAKE_SHARED(PCDerived2);
+            PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
             p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;

--- a/cpp/test/Ice/slicing/objects/Server.cpp
+++ b/cpp/test/Ice/slicing/objects/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/slicing/objects/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/objects/ServerAMD.cpp
@@ -23,7 +23,7 @@ ServerAMD::run(int argc, char** argv)
     communicator->getProperties()->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/slicing/objects/TestI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestI.cpp
@@ -208,7 +208,7 @@ TestI::SUnknownAsObject(const ::Ice::Current&)
 }
 
 void
-TestI::checkSUnknown(ICE_IN(Ice::ValuePtr) obj, const ::Ice::Current& current)
+TestI::checkSUnknown(Ice::ValuePtr obj, const ::Ice::Current& current)
 {
     SUnknownPtr su = ICE_DYNAMIC_CAST(SUnknown, obj);
     if(current.encoding == Ice::Encoding_1_0)
@@ -390,7 +390,7 @@ TestI::returnTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 }
 
 BPtr
-TestI::returnTest3(ICE_IN(BPtr) p1, ICE_IN(BPtr) p2, const ::Ice::Current&)
+TestI::returnTest3(BPtr p1, BPtr p2, const ::Ice::Current&)
 {
     _values.push_back(p1);
     _values.push_back(p2);
@@ -398,7 +398,7 @@ TestI::returnTest3(ICE_IN(BPtr) p1, ICE_IN(BPtr) p2, const ::Ice::Current&)
 }
 
 SS3
-TestI::sequenceTest(ICE_IN(SS1Ptr) p1, ICE_IN(SS2Ptr) p2, const ::Ice::Current&)
+TestI::sequenceTest(SS1Ptr p1, SS2Ptr p2, const ::Ice::Current&)
 {
     SS3 ss;
     ss.c1 = p1;
@@ -409,7 +409,7 @@ TestI::sequenceTest(ICE_IN(SS1Ptr) p1, ICE_IN(SS2Ptr) p2, const ::Ice::Current&)
 }
 
 Test::BDict
-TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
+TestI::dictionaryTest(BDict bin, BDict& bout, const ::Ice::Current&)
 {
     int i;
     for(i = 0; i < 10; ++i)
@@ -440,7 +440,7 @@ TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
 }
 
 Test::PBasePtr
-TestI::exchangePBase(ICE_IN(Test::PBasePtr) pb, const Ice::Current&)
+TestI::exchangePBase(Test::PBasePtr pb, const Ice::Current&)
 {
     _values.push_back(pb);
     return pb;
@@ -466,7 +466,7 @@ TestI::PBSUnknownAsPreserved(const Ice::Current& current)
 }
 
 void
-TestI::checkPBSUnknown(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknown(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknownPtr pu =  ICE_DYNAMIC_CAST(PSUnknown, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -504,7 +504,7 @@ TestI::PBSUnknownAsPreservedWithGraphAsync(function<void(const shared_ptr<Test::
 }
 
 void
-TestI::checkPBSUnknownWithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknownWithGraph(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknownPtr pu = ICE_DYNAMIC_CAST(PSUnknown, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -540,7 +540,7 @@ TestI::PBSUnknown2AsPreservedWithGraphAsync(function<void(const shared_ptr<Test:
 }
 
 void
-TestI::checkPBSUnknown2WithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknown2WithGraph(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknown2Ptr pu = ICE_DYNAMIC_CAST(PSUnknown2, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -560,7 +560,7 @@ TestI::checkPBSUnknown2WithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Curren
 }
 
 Test::PNodePtr
-TestI::exchangePNode(ICE_IN(Test::PNodePtr) pn, const Ice::Current&)
+TestI::exchangePNode(Test::PNodePtr pn, const Ice::Current&)
 {
     _values.push_back(pn);
     return pn;

--- a/cpp/test/Ice/slicing/objects/TestI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestI.cpp
@@ -148,7 +148,7 @@ TestI::~TestI()
 Ice::ValuePtr
 TestI::SBaseAsObject(const ::Ice::Current&)
 {
-    SBasePtr sb = ICE_MAKE_SHARED(SBase);
+    SBasePtr sb = std::make_shared<SBase>();
     sb->sb = "SBase.sb";
     return sb;
 }
@@ -156,7 +156,7 @@ TestI::SBaseAsObject(const ::Ice::Current&)
 SBasePtr
 TestI::SBaseAsSBase(const ::Ice::Current&)
 {
-    SBasePtr sb = ICE_MAKE_SHARED(SBase);
+    SBasePtr sb = std::make_shared<SBase>();
     sb->sb = "SBase.sb";
     return sb;
 }
@@ -164,7 +164,7 @@ TestI::SBaseAsSBase(const ::Ice::Current&)
 SBasePtr
 TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
 {
-    SBSKnownDerivedPtr sbskd = ICE_MAKE_SHARED(SBSKnownDerived);
+    SBSKnownDerivedPtr sbskd = std::make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
     sbskd->sbskd = "SBSKnownDerived.sbskd";
     return sbskd;
@@ -173,7 +173,7 @@ TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
 SBSKnownDerivedPtr
 TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
 {
-    SBSKnownDerivedPtr sbskd = ICE_MAKE_SHARED(SBSKnownDerived);
+    SBSKnownDerivedPtr sbskd = std::make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
     sbskd->sbskd = "SBSKnownDerived.sbskd";
     return sbskd;
@@ -182,7 +182,7 @@ TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
 SBasePtr
 TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
 {
-    SBSUnknownDerivedPtr sbsud = ICE_MAKE_SHARED(SBSUnknownDerived);
+    SBSUnknownDerivedPtr sbsud = std::make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
     sbsud->sbsud = "SBSUnknownDerived.sbsud";
     return sbsud;
@@ -191,7 +191,7 @@ TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
 SBasePtr
 TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
 {
-    SBSUnknownDerivedPtr sbsud = ICE_MAKE_SHARED(SBSUnknownDerived);
+    SBSUnknownDerivedPtr sbsud = std::make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
     sbsud->sbsud = "SBSUnknownDerived.sbsud";
     return sbsud;
@@ -200,7 +200,7 @@ TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
 Ice::ValuePtr
 TestI::SUnknownAsObject(const ::Ice::Current&)
 {
-    SUnknownPtr su = ICE_MAKE_SHARED(SUnknown);
+    SUnknownPtr su = std::make_shared<SUnknown>();
     su->su = "SUnknown.su";
     su->cycle = su;
     _values.push_back(su);
@@ -226,7 +226,7 @@ TestI::checkSUnknown(ICE_IN(Ice::ValuePtr) obj, const ::Ice::Current& current)
 BPtr
 TestI::oneElementCycle(const ::Ice::Current&)
 {
-    BPtr b = ICE_MAKE_SHARED(B);
+    BPtr b = std::make_shared<B>();
     b->sb = "B1.sb";
     b->pb = b;
     _values.push_back(b);
@@ -236,9 +236,9 @@ TestI::oneElementCycle(const ::Ice::Current&)
 BPtr
 TestI::twoElementCycle(const ::Ice::Current&)
 {
-    BPtr b1 = ICE_MAKE_SHARED(B);
+    BPtr b1 = std::make_shared<B>();
     b1->sb = "B1.sb";
-    BPtr b2 = ICE_MAKE_SHARED(B);
+    BPtr b2 = std::make_shared<B>();
     b2->sb = "B2.sb";
     b2->pb = b1;
     b1->pb = b2;
@@ -249,10 +249,10 @@ TestI::twoElementCycle(const ::Ice::Current&)
 BPtr
 TestI::D1AsB(const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = std::make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -266,10 +266,10 @@ TestI::D1AsB(const ::Ice::Current&)
 D1Ptr
 TestI::D1AsD1(const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = std::make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -283,10 +283,10 @@ TestI::D1AsD1(const ::Ice::Current&)
 BPtr
 TestI::D2AsB(const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = std::make_shared<D1>();
     d1->pb = d2;
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
@@ -300,10 +300,10 @@ TestI::D2AsB(const ::Ice::Current&)
 void
 TestI::paramTest1(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = std::make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -325,26 +325,26 @@ TestI::paramTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 BPtr
 TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->sb = "D2.sb (p1 1)";
     d2->pb = 0;
     d2->sd2 = "D2.sd2 (p1 1)";
     p1 = d2;
 
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = std::make_shared<D1>();
     d1->sb = "D1.sb (p1 2)";
     d1->pb = 0;
     d1->sd1 = "D1.sd2 (p1 2)";
     d1->pd1 = 0;
     d2->pd2 = d1;
 
-    D2Ptr d4 = ICE_MAKE_SHARED(D2);
+    D2Ptr d4 = std::make_shared<D2>();
     d4->sb = "D2.sb (p2 1)";
     d4->pb = 0;
     d4->sd2 = "D2.sd2 (p2 1)";
     p2 = d4;
 
-    D1Ptr d3 = ICE_MAKE_SHARED(D1);
+    D1Ptr d3 = std::make_shared<D1>();
     d3->sb = "D1.sb (p2 2)";
     d3->pb = 0;
     d3->sd1 = "D1.sd2 (p2 2)";
@@ -361,12 +361,12 @@ TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 BPtr
 TestI::paramTest4(BPtr& p1, const ::Ice::Current&)
 {
-    D4Ptr d4 = ICE_MAKE_SHARED(D4);
+    D4Ptr d4 = std::make_shared<D4>();
     d4->sb = "D4.sb (1)";
     d4->pb = 0;
-    d4->p1 = ICE_MAKE_SHARED(B);
+    d4->p1 = std::make_shared<B>();
     d4->p1->sb = "B.sb (1)";
-    d4->p2 = ICE_MAKE_SHARED(B);
+    d4->p2 = std::make_shared<B>();
     d4->p2->sb = "B.sb (2)";
     p1 = d4;
     _values.push_back(d4);
@@ -415,7 +415,7 @@ TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
     for(i = 0; i < 10; ++i)
     {
         BPtr b = bin.find(i)->second;
-        D2Ptr d2 = ICE_MAKE_SHARED(D2);
+        D2Ptr d2 = std::make_shared<D2>();
         d2->sb = b->sb;
         d2->pb = b->pb;
         d2->sd2 = "D2";
@@ -428,7 +428,7 @@ TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
     {
         std::ostringstream s;
         s << "D1." << i * 20;
-        D1Ptr d1 = ICE_MAKE_SHARED(D1);
+        D1Ptr d1 = std::make_shared<D1>();
         d1->sb = s.str();
         d1->pb = (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second);
         d1->sd1 = s.str();
@@ -449,7 +449,7 @@ TestI::exchangePBase(ICE_IN(Test::PBasePtr) pb, const Ice::Current&)
 Test::PreservedPtr
 TestI::PBSUnknownAsPreserved(const Ice::Current& current)
 {
-    PSUnknownPtr r = ICE_MAKE_SHARED(PSUnknown);
+    PSUnknownPtr r = std::make_shared<PSUnknown>();
     r->pi = 5;
     r->ps = "preserved";
     r->psu = "unknown";
@@ -460,7 +460,7 @@ TestI::PBSUnknownAsPreserved(const Ice::Current& current)
         // 1.0 encoding doesn't support unmarshaling unknown classes even if referenced
         // from unread slice.
         //
-        r->cl = ICE_MAKE_SHARED(MyClass, 15);
+        r->cl = std::make_shared<MyClass>(15);
     }
     return r;
 }
@@ -491,13 +491,13 @@ TestI::PBSUnknownAsPreservedWithGraphAsync(function<void(const shared_ptr<Test::
                                             function<void(exception_ptr)>,
                                             const Ice::Current&)
 {
-    PSUnknownPtr r = ICE_MAKE_SHARED(PSUnknown);
+    PSUnknownPtr r = std::make_shared<PSUnknown>();
     r->pi = 5;
     r->ps = "preserved";
     r->psu = "unknown";
-    r->graph = ICE_MAKE_SHARED(PNode);
-    r->graph->next = ICE_MAKE_SHARED(PNode);
-    r->graph->next->next = ICE_MAKE_SHARED(PNode);
+    r->graph = std::make_shared<PNode>();
+    r->graph->next = std::make_shared<PNode>();
+    r->graph->next->next = std::make_shared<PNode>();
     r->graph->next->next->next = r->graph;
     response(r);
     r->graph->next->next->next = 0; // Break the cycle.
@@ -531,7 +531,7 @@ TestI::PBSUnknown2AsPreservedWithGraphAsync(function<void(const shared_ptr<Test:
                                              function<void(exception_ptr)>,
                                              const Ice::Current&)
 {
-    PSUnknown2Ptr r = ICE_MAKE_SHARED(PSUnknown2);
+    PSUnknown2Ptr r = std::make_shared<PSUnknown2>();
     r->pi = 5;
     r->ps = "preserved";
     r->pb = r;
@@ -571,7 +571,7 @@ TestI::throwBaseAsBase(const ::Ice::Current&)
 {
     BaseException be;
     be.sbe = "sbe";
-    be.pb = ICE_MAKE_SHARED(B);
+    be.pb = std::make_shared<B>();
     be.pb->sb = "sb";
     be.pb->pb = be.pb;
     _values.push_back(be.pb);
@@ -583,11 +583,11 @@ TestI::throwDerivedAsBase(const ::Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
-    de.pb = ICE_MAKE_SHARED(B);
+    de.pb = std::make_shared<B>();
     de.pb->sb = "sb1";
     de.pb->pb = de.pb;
     de.sde = "sde1";
-    de.pd1 = ICE_MAKE_SHARED(D1);
+    de.pd1 = std::make_shared<D1>();
     de.pd1->sb = "sb2";
     de.pd1->pb = de.pd1;
     de.pd1->sd1 = "sd2";
@@ -602,11 +602,11 @@ TestI::throwDerivedAsDerived(const ::Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
-    de.pb = ICE_MAKE_SHARED(B);
+    de.pb = std::make_shared<B>();
     de.pb->sb = "sb1";
     de.pb->pb = de.pb;
     de.sde = "sde1";
-    de.pd1 = ICE_MAKE_SHARED(D1);
+    de.pd1 = std::make_shared<D1>();
     de.pd1->sb = "sb2";
     de.pd1->pb = de.pd1;
     de.pd1->sd1 = "sd2";
@@ -619,7 +619,7 @@ TestI::throwDerivedAsDerived(const ::Ice::Current&)
 void
 TestI::throwUnknownDerivedAsBase(const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = std::make_shared<D2>();
     d2->sb = "sb d2";
     d2->pb = d2;
     d2->sd2 = "sd2 d2";
@@ -639,7 +639,7 @@ TestI::throwPreservedExceptionAsync(function<void()>,
                                      const ::Ice::Current&)
 {
     PSUnknownException ue;
-    ue.p = ICE_MAKE_SHARED(PSUnknown2);
+    ue.p = std::make_shared<PSUnknown2>();
     ue.p->pi = 5;
     ue.p->ps = "preserved";
     ue.p->pb = ue.p;
@@ -657,8 +657,8 @@ TestI::throwPreservedExceptionAsync(function<void()>,
 void
 TestI::useForward(ForwardPtr& f, const ::Ice::Current&)
 {
-    f = ICE_MAKE_SHARED(Forward);
-    f->h = ICE_MAKE_SHARED(Hidden);
+    f = std::make_shared<Forward>();
+    f->h = std::make_shared<Hidden>();
     f->h->f = f;
     _values.push_back(f);
 }

--- a/cpp/test/Ice/slicing/objects/TestI.h
+++ b/cpp/test/Ice/slicing/objects/TestI.h
@@ -24,7 +24,7 @@ public:
     virtual ::Test::SBasePtr SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&);
 
     virtual ::Ice::ValuePtr SUnknownAsObject(const ::Ice::Current&);
-    virtual void checkSUnknown(ICE_IN(Ice::ValuePtr) object, const ::Ice::Current&);
+    virtual void checkSUnknown(Ice::ValuePtr object, const ::Ice::Current&);
 
     virtual ::Test::BPtr oneElementCycle(const ::Ice::Current&);
     virtual ::Test::BPtr twoElementCycle(const ::Ice::Current&);
@@ -40,28 +40,28 @@ public:
 
     virtual ::Test::BPtr returnTest1(::Test::BPtr&, ::Test::BPtr&, const ::Ice::Current&);
     virtual ::Test::BPtr returnTest2(::Test::BPtr&, ::Test::BPtr&, const ::Ice::Current&);
-    virtual ::Test::BPtr returnTest3(ICE_IN(::Test::BPtr), ICE_IN(::Test::BPtr), const ::Ice::Current&);
+    virtual ::Test::BPtr returnTest3(::Test::BPtr, ::Test::BPtr, const ::Ice::Current&);
 
-    virtual ::Test::SS3 sequenceTest(ICE_IN(::Test::SS1Ptr), ICE_IN(::Test::SS2Ptr), const ::Ice::Current&);
+    virtual ::Test::SS3 sequenceTest(::Test::SS1Ptr, ::Test::SS2Ptr, const ::Ice::Current&);
 
-    virtual ::Test::BDict dictionaryTest(ICE_IN(::Test::BDict), ::Test::BDict&, const ::Ice::Current&);
+    virtual ::Test::BDict dictionaryTest(::Test::BDict, ::Test::BDict&, const ::Ice::Current&);
 
-    virtual ::Test::PBasePtr exchangePBase(ICE_IN(::Test::PBasePtr), const ::Ice::Current&);
+    virtual ::Test::PBasePtr exchangePBase(::Test::PBasePtr, const ::Ice::Current&);
 
     virtual ::Test::PreservedPtr PBSUnknownAsPreserved(const ::Ice::Current&);
-    virtual void checkPBSUnknown(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknown(::Test::PreservedPtr, const ::Ice::Current&);
 
     virtual void PBSUnknownAsPreservedWithGraphAsync(std::function<void(const std::shared_ptr<Test::Preserved>&)>,
                                                       std::function<void(std::exception_ptr)>,
                                                       const ::Ice::Current&);
-    virtual void checkPBSUnknownWithGraph(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknownWithGraph(::Test::PreservedPtr, const ::Ice::Current&);
 
     virtual void PBSUnknown2AsPreservedWithGraphAsync(std::function<void(const std::shared_ptr<Test::Preserved>&)>,
                                                        std::function<void(std::exception_ptr)>,
                                                        const ::Ice::Current&);
-    virtual void checkPBSUnknown2WithGraph(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknown2WithGraph(::Test::PreservedPtr, const ::Ice::Current&);
 
-    virtual ::Test::PNodePtr exchangePNode(ICE_IN(::Test::PNodePtr), const ::Ice::Current&);
+    virtual ::Test::PNodePtr exchangePNode(::Test::PNodePtr, const ::Ice::Current&);
 
     virtual void throwBaseAsBase(const ::Ice::Current&);
     virtual void throwDerivedAsBase(const ::Ice::Current&);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -57,7 +57,7 @@ public:
 
     virtual void _iceRead(Ice::InputStream* in)
     {
-        obj = ICE_MAKE_SHARED(MyClass);
+        obj = std::make_shared<MyClass>();
         obj->_iceRead(in);
         called = true;
     }
@@ -121,7 +121,7 @@ public:
 
     void clear()
     {
-        _factory = [](const string&) { return ICE_MAKE_SHARED(MyClass); };
+        _factory = [](const string&) { return std::make_shared<MyClass>(); };
     }
 
     function<Ice::ValuePtr(const string&)> _factory;
@@ -301,7 +301,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        OptionalClassPtr o = ICE_MAKE_SHARED(OptionalClass);
+        OptionalClassPtr o = std::make_shared<OptionalClass>();
         o->bo = false;
         o->by = 5;
         o->sh = static_cast<Ice::Short>(4);
@@ -329,7 +329,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator, Ice::Encoding_1_0);
-        OptionalClassPtr o = ICE_MAKE_SHARED(OptionalClass);
+        OptionalClassPtr o = std::make_shared<OptionalClass>();
         o->bo = false;
         o->by = 5;
         o->sh = static_cast<Ice::Short>(4);
@@ -664,7 +664,7 @@ allTests(Test::TestHelper* helper)
         MyClassS arr;
         for(int i = 0; i < 4; ++i)
         {
-            MyClassPtr c = ICE_MAKE_SHARED(MyClass);
+            MyClassPtr c = std::make_shared<MyClass>();
             c->c = c;
             c->o = c;
             c->s.e = MyEnum::enum2;
@@ -807,9 +807,9 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr obj = std::make_shared<MyClass>();
         obj->s.e = MyEnum::enum2;
-        TestObjectWriterPtr writer = ICE_MAKE_SHARED(TestObjectWriter, obj);
+        TestObjectWriterPtr writer = std::make_shared<TestObjectWriter>(obj);
         Ice::ValuePtr w = ICE_DYNAMIC_CAST(Ice::Value, writer);
         out.write(w);
         out.writePendingValues();
@@ -819,15 +819,15 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr obj = std::make_shared<MyClass>();
         obj->s.e = MyEnum::enum2;
-        TestObjectWriterPtr writer = ICE_MAKE_SHARED(TestObjectWriter, obj);
+        TestObjectWriterPtr writer = std::make_shared<TestObjectWriter>(obj);
         Ice::ValuePtr w = ICE_DYNAMIC_CAST(Ice::Value, writer);
         out.write(w);
         out.writePendingValues();
         out.finished(data);
         test(writer->called);
-        factoryWrapper.setFactory([](const string&) { return ICE_MAKE_SHARED(TestObjectReader); });
+        factoryWrapper.setFactory([](const string&) { return std::make_shared<TestObjectReader>(); });
         Ice::InputStream in(communicator, data);
         Ice::ValuePtr p;
         in.read(&patchObject, &p);
@@ -844,7 +844,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyException ex;
-        MyClassPtr c = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr c = std::make_shared<MyClass>();
         c->c = c;
         c->o = c;
         c->s.e = MyEnum::enum2;
@@ -978,9 +978,9 @@ allTests(Test::TestHelper* helper)
 
     {
         StringMyClassD dict;
-        dict["key1"] = ICE_MAKE_SHARED(MyClass);
+        dict["key1"] = std::make_shared<MyClass>();
         dict["key1"]->s.e = MyEnum::enum2;
-        dict["key2"] = ICE_MAKE_SHARED(MyClass);
+        dict["key2"] = std::make_shared<MyClass>();
         dict["key2"]->s.e = MyEnum::enum3;
         Ice::OutputStream out(communicator);
         out.write(dict);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -266,12 +266,12 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(MyEnum, enum3));
+        out.write(MyEnum::enum3);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         MyEnum e;
         in.read(e);
-        test(e == ICE_ENUM(MyEnum, enum3));
+        test(e == MyEnum::enum3);
     }
 
     {
@@ -285,7 +285,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(MyEnum, enum2);
+        s.e = MyEnum::enum2;
         s.p = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test:default"));
         out.write(s);
         out.finished(data);
@@ -584,10 +584,10 @@ allTests(Test::TestHelper* helper)
 
     {
         MyEnumS arr;
-        arr.push_back(ICE_ENUM(MyEnum, enum3));
-        arr.push_back(ICE_ENUM(MyEnum, enum2));
-        arr.push_back(ICE_ENUM(MyEnum, enum1));
-        arr.push_back(ICE_ENUM(MyEnum, enum2));
+        arr.push_back(MyEnum::enum3);
+        arr.push_back(MyEnum::enum2);
+        arr.push_back(MyEnum::enum1);
+        arr.push_back(MyEnum::enum2);
 
         Ice::OutputStream out(communicator);
         out.write(arr);
@@ -625,7 +625,7 @@ allTests(Test::TestHelper* helper)
             s.f = 5.0;
             s.d = 6.0;
             s.str = "7";
-            s.e = ICE_ENUM(MyEnum, enum2);
+            s.e = MyEnum::enum2;
             s.p = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test:default"));
             arr.push_back(s);
         }
@@ -667,7 +667,7 @@ allTests(Test::TestHelper* helper)
             MyClassPtr c = ICE_MAKE_SHARED(MyClass);
             c->c = c;
             c->o = c;
-            c->s.e = ICE_ENUM(MyEnum, enum2);
+            c->s.e = MyEnum::enum2;
 
             c->seq1.push_back(true);
             c->seq1.push_back(false);
@@ -709,9 +709,9 @@ allTests(Test::TestHelper* helper)
             c->seq8.push_back("string3");
             c->seq8.push_back("string4");
 
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum3));
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum2));
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum1));
+            c->seq9.push_back(MyEnum::enum3);
+            c->seq9.push_back(MyEnum::enum2);
+            c->seq9.push_back(MyEnum::enum1);
 
             c->d["hi"] = c;
             arr.push_back(c);
@@ -731,7 +731,7 @@ allTests(Test::TestHelper* helper)
             test(arr2[j]);
             test(arr2[j]->c == arr2[j]);
             test(arr2[j]->o == arr2[j]);
-            test(arr2[j]->s.e == ICE_ENUM(MyEnum, enum2));
+            test(arr2[j]->s.e == MyEnum::enum2);
             test(arr2[j]->seq1 == arr[j]->seq1);
             test(arr2[j]->seq2 == arr[j]->seq2);
             test(arr2[j]->seq3 == arr[j]->seq3);
@@ -768,7 +768,7 @@ allTests(Test::TestHelper* helper)
             {
                 test(arr2S[j][k]->c == arr2S[j][k]);
                 test(arr2S[j][k]->o == arr2S[j][k]);
-                test(arr2S[j][k]->s.e == ICE_ENUM(MyEnum, enum2));
+                test(arr2S[j][k]->s.e == MyEnum::enum2);
                 test(arr2S[j][k]->seq1 == arr[k]->seq1);
                 test(arr2S[j][k]->seq2 == arr[k]->seq2);
                 test(arr2S[j][k]->seq3 == arr[k]->seq3);
@@ -808,7 +808,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
-        obj->s.e = ICE_ENUM(MyEnum, enum2);
+        obj->s.e = MyEnum::enum2;
         TestObjectWriterPtr writer = ICE_MAKE_SHARED(TestObjectWriter, obj);
         Ice::ValuePtr w = ICE_DYNAMIC_CAST(Ice::Value, writer);
         out.write(w);
@@ -820,7 +820,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
-        obj->s.e = ICE_ENUM(MyEnum, enum2);
+        obj->s.e = MyEnum::enum2;
         TestObjectWriterPtr writer = ICE_MAKE_SHARED(TestObjectWriter, obj);
         Ice::ValuePtr w = ICE_DYNAMIC_CAST(Ice::Value, writer);
         out.write(w);
@@ -837,7 +837,7 @@ allTests(Test::TestHelper* helper)
         test(reader);
         test(reader->called);
         test(reader->obj);
-        test(reader->obj->s.e == ICE_ENUM(MyEnum, enum2));
+        test(reader->obj->s.e == MyEnum::enum2);
         factoryWrapper.clear();
     }
 
@@ -847,7 +847,7 @@ allTests(Test::TestHelper* helper)
         MyClassPtr c = ICE_MAKE_SHARED(MyClass);
         c->c = c;
         c->o = c;
-        c->s.e = ICE_ENUM(MyEnum, enum2);
+        c->s.e = MyEnum::enum2;
 
         c->seq1.push_back(true);
         c->seq1.push_back(false);
@@ -889,9 +889,9 @@ allTests(Test::TestHelper* helper)
         c->seq8.push_back("string3");
         c->seq8.push_back("string4");
 
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum3));
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum2));
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum1));
+        c->seq9.push_back(MyEnum::enum3);
+        c->seq9.push_back(MyEnum::enum2);
+        c->seq9.push_back(MyEnum::enum1);
 
         ex.c = c;
 
@@ -979,9 +979,9 @@ allTests(Test::TestHelper* helper)
     {
         StringMyClassD dict;
         dict["key1"] = ICE_MAKE_SHARED(MyClass);
-        dict["key1"]->s.e = ICE_ENUM(MyEnum, enum2);
+        dict["key1"]->s.e = MyEnum::enum2;
         dict["key2"] = ICE_MAKE_SHARED(MyClass);
-        dict["key2"]->s.e = ICE_ENUM(MyEnum, enum3);
+        dict["key2"]->s.e = MyEnum::enum3;
         Ice::OutputStream out(communicator);
         out.write(dict);
         out.writePendingValues();
@@ -991,18 +991,18 @@ allTests(Test::TestHelper* helper)
         in.read(dict2);
         in.readPendingValues();
         test(dict2.size() == dict.size());
-        test(dict2["key1"] && (dict2["key1"]->s.e == ICE_ENUM(MyEnum, enum2)));
-        test(dict2["key2"] && (dict2["key2"]->s.e == ICE_ENUM(MyEnum, enum3)));
+        test(dict2["key1"] && (dict2["key1"]->s.e == MyEnum::enum2));
+        test(dict2["key2"] && (dict2["key2"]->s.e == MyEnum::enum3));
     }
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(Sub::NestedEnum, nestedEnum3));
+        out.write(Sub::NestedEnum::nestedEnum3);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         NestedEnum e;
         in.read(e);
-        test(e == ICE_ENUM(Sub::NestedEnum, nestedEnum3));
+        test(e == Sub::NestedEnum::nestedEnum3);
     }
 
     {
@@ -1016,7 +1016,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(Sub::NestedEnum, nestedEnum2);
+        s.e = Sub::NestedEnum::nestedEnum2;
         out.write(s);
         out.finished(data);
         Ice::InputStream in(communicator, data);
@@ -1047,12 +1047,12 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(NestedEnum2, nestedEnum4));
+        out.write(NestedEnum2::nestedEnum4);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         NestedEnum2 e;
         in.read(e);
-        test(e == ICE_ENUM(NestedEnum2, nestedEnum4));
+        test(e == NestedEnum2::nestedEnum4);
     }
 
     {
@@ -1066,7 +1066,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(NestedEnum2, nestedEnum5);
+        s.e = NestedEnum2::nestedEnum5;
         out.write(s);
         out.finished(data);
         Ice::InputStream in(communicator, data);

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -137,12 +137,12 @@ Client::run(int argc, char** argv)
         Ice::Identity ident = Ice::stringToIdentity(identStr);
         test(ident.name == msg);
         test(ident.category == "cat");
-        test(identityToString(ident, Ice::ICE_ENUM(ToStringMode, Unicode)) == identStr);
+        test(identityToString(ident, Ice::ToStringMode::Unicode) == identStr);
 
-        identStr = identityToString(ident, Ice::ICE_ENUM(ToStringMode, ASCII));
+        identStr = identityToString(ident, Ice::ToStringMode::ASCII);
         test(identStr == "cat/tu me fends le c\\u0153ur!");
         test(Ice::stringToIdentity(identStr) == ident);
-        identStr = identityToString(ident, Ice::ICE_ENUM(ToStringMode, Compat));
+        identStr = identityToString(ident, Ice::ToStringMode::Compat);
         test(identStr == "cat/tu me fends le c\\305\\223ur!");
         test(Ice::stringToIdentity(identStr) == ident);
 

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -149,7 +149,7 @@ Client::run(int argc, char** argv)
         cout << "ok" << endl;
     }
 
-    Ice::setProcessStringConverter(ICE_NULLPTR);
+    Ice::setProcessStringConverter(nullptr);
     Ice::setProcessWstringConverter(Ice::createUnicodeWstringConverter());
 
     string propValue = "Ice:createStringConverter";

--- a/cpp/test/Ice/stringConverter/Server.cpp
+++ b/cpp/test/Ice/stringConverter/Server.cpp
@@ -46,7 +46,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyObjectI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyObjectI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/stringConverter/Server.cpp
+++ b/cpp/test/Ice/stringConverter/Server.cpp
@@ -15,13 +15,13 @@ class MyObjectI : public Test::MyObject
 {
 public:
 
-    virtual wstring widen(ICE_IN(string) msg, const Ice::Current&)
+    virtual wstring widen(string msg, const Ice::Current&)
     {
         return stringToWstring(msg, Ice::getProcessStringConverter(),
                                Ice::getProcessWstringConverter());
     }
 
-    virtual string narrow(ICE_IN(wstring) wmsg, const Ice::Current&)
+    virtual string narrow(wstring wmsg, const Ice::Current&)
     {
         return wstringToString(wmsg, Ice::getProcessStringConverter(),
                                Ice::getProcessWstringConverter());

--- a/cpp/test/Ice/threadPoolPriority/Server.cpp
+++ b/cpp/test/Ice/threadPoolPriority/Server.cpp
@@ -50,7 +50,7 @@ Server::run(int argc, char** argv)
 #endif
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(PriorityI, adapter);
+    Ice::ObjectPtr object = std::make_shared<PriorityI>(adapter);
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/threadPoolPriority/ServerCustomThreadPool.cpp
+++ b/cpp/test/Ice/threadPoolPriority/ServerCustomThreadPool.cpp
@@ -54,7 +54,7 @@ ServerCustomThreadPool::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ThreadPool.ThreadPriority", "50");
 #endif
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(PriorityI, adapter);
+    Ice::ObjectPtr object = std::make_shared<PriorityI>(adapter);
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -307,7 +307,7 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrxPtr& control
         TimeoutPrxPtr to = ICE_UNCHECKED_CAST(TimeoutPrx, obj->ice_timeout(250));
         Ice::ConnectionPtr connection = connect(to);
         controller->holdAdapter(-1);
-        connection->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        connection->close(Ice::ConnectionClose::GracefullyWithWait);
         try
         {
             connection->getInfo(); // getInfo() doesn't throw in the closing state.

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -461,7 +461,7 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrxPtr& control
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TimeoutCollocated");
         adapter->activate();
 
-        timeout = ICE_UNCHECKED_CAST(TimeoutPrx, adapter->addWithUUID(ICE_MAKE_SHARED(TimeoutI)));
+        timeout = ICE_UNCHECKED_CAST(TimeoutPrx, adapter->addWithUUID(std::make_shared<TimeoutI>()));
         timeout = timeout->ice_invocationTimeout(100);
         try
         {

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -52,11 +52,11 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TimeoutI), Ice::stringToIdentity("timeout"));
+    adapter->add(std::make_shared<TimeoutI>(), Ice::stringToIdentity("timeout"));
     adapter->activate();
 
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(std::make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/timeout/TestI.cpp
+++ b/cpp/test/Ice/timeout/TestI.cpp
@@ -37,7 +37,7 @@ TimeoutI::op(const Ice::Current&)
 }
 
 void
-TimeoutI::sendData(ICE_IN(Test::ByteSeq), const Ice::Current&)
+TimeoutI::sendData(Test::ByteSeq, const Ice::Current&)
 {
 }
 

--- a/cpp/test/Ice/timeout/TestI.h
+++ b/cpp/test/Ice/timeout/TestI.h
@@ -12,7 +12,7 @@ class TimeoutI : public virtual Test::Timeout
 public:
 
     virtual void op(const Ice::Current&);
-    virtual void sendData(ICE_IN(Test::ByteSeq), const Ice::Current&);
+    virtual void sendData(Test::ByteSeq, const Ice::Current&);
     virtual void sleep(Ice::Int, const Ice::Current&);
 };
 

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -112,7 +112,7 @@ allTests(Test::TestHelper* helper)
         {
             test(seq.size() > 16384);
         }
-        obj->ice_getConnection()->close(ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        obj->ice_getConnection()->close(ConnectionClose::GracefullyWithWait);
         communicator->getProperties()->setProperty("Ice.UDP.SndSize", "64000");
         seq.resize(50000);
         try

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -60,7 +60,7 @@ allTests(Test::TestHelper* helper)
     Ice::CommunicatorPtr communicator = helper->communicator();
     communicator->getProperties()->setProperty("ReplyAdapter.Endpoints", "udp");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("ReplyAdapter");
-    PingReplyIPtr replyI = ICE_MAKE_SHARED(PingReplyI);
+    PingReplyIPtr replyI = std::make_shared<PingReplyI>();
     PingReplyPrxPtr reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     adapter->activate();
 
@@ -84,7 +84,7 @@ allTests(Test::TestHelper* helper)
 
         // If the 3 datagrams were not received within the 2 seconds, we try again to
         // receive 3 new datagrams using a new object. We give up after 5 retries.
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     test(ret);
@@ -175,7 +175,7 @@ allTests(Test::TestHelper* helper)
         {
             break; // Success
         }
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     if(!ret)
@@ -205,7 +205,7 @@ allTests(Test::TestHelper* helper)
 
         // If the 3 datagrams were not received within the 2 seconds, we try again to
         // receive 3 new datagrams using a new object. We give up after 5 retries.
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     test(ret);

--- a/cpp/test/Ice/udp/Server.cpp
+++ b/cpp/test/Ice/udp/Server.cpp
@@ -29,14 +29,14 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("ControlAdapter.Endpoints", getTestEndpoint(num, "tcp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("ControlAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("control"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("control"));
     adapter->activate();
 
     if(num == 0)
     {
         communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(num, "udp"));
         Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter");
-        adapter2->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        adapter2->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         adapter2->activate();
     }
 
@@ -60,7 +60,7 @@ Server::run(int argc, char** argv)
     try
     {
         Ice::ObjectAdapterPtr mcastAdapter = communicator->createObjectAdapter("McastTestAdapter");
-        mcastAdapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        mcastAdapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         mcastAdapter->activate();
     }
     catch(const Ice::SocketException&)

--- a/cpp/test/Ice/udp/TestI.cpp
+++ b/cpp/test/Ice/udp/TestI.cpp
@@ -10,7 +10,7 @@ using namespace std;
 using namespace Ice;
 
 void
-TestIntfI::ping(ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
+TestIntfI::ping(Test::PingReplyPrxPtr reply, const Current&)
 {
     try
     {
@@ -23,7 +23,7 @@ TestIntfI::ping(ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
 }
 
 void
-TestIntfI::sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
+TestIntfI::sendByteSeq(Test::ByteSeq, Test::PingReplyPrxPtr reply, const Current&)
 {
     try
     {
@@ -36,7 +36,7 @@ TestIntfI::sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr) repl
 }
 
 void
-TestIntfI::pingBiDir(ICE_IN(Ice::Identity) id, const Ice::Current& current)
+TestIntfI::pingBiDir(Ice::Identity id, const Ice::Current& current)
 {
     try
     {

--- a/cpp/test/Ice/udp/TestI.h
+++ b/cpp/test/Ice/udp/TestI.h
@@ -11,9 +11,9 @@ class TestIntfI : public Test::TestIntf
 {
 public:
 
-    virtual void ping(ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
-    virtual void sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
-    virtual void pingBiDir(ICE_IN(Ice::Identity), const Ice::Current&);
+    virtual void ping(Test::PingReplyPrxPtr, const Ice::Current&);
+    virtual void sendByteSeq(Test::ByteSeq, Test::PingReplyPrxPtr, const Ice::Current&);
+    virtual void pingBiDir(Ice::Identity, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 };
 

--- a/cpp/test/IceBox/admin/Service.cpp
+++ b/cpp/test/IceBox/admin/Service.cpp
@@ -39,7 +39,7 @@ create(const shared_ptr<Communicator>& communicator)
 
 ServiceI::ServiceI(const CommunicatorPtr& serviceManagerCommunicator)
 {
-    TestFacetIPtr facet = ICE_MAKE_SHARED(TestFacetI);
+    TestFacetIPtr facet = std::make_shared<TestFacetI>();
 
     //
     // Install a custom admin facet.

--- a/cpp/test/IceBox/configuration/Service.cpp
+++ b/cpp/test/IceBox/configuration/Service.cpp
@@ -49,7 +49,7 @@ void
 ServiceI::start(const string& name, const CommunicatorPtr& communicator, const StringSeq& args)
 {
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter(name + "OA");
-    adapter->add(ICE_MAKE_SHARED(TestI, args), stringToIdentity("test"));
+    adapter->add(std::make_shared<TestI>(args), stringToIdentity("test"));
     adapter->activate();
 }
 

--- a/cpp/test/IceBox/configuration/TestI.cpp
+++ b/cpp/test/IceBox/configuration/TestI.cpp
@@ -12,7 +12,7 @@ TestI::TestI(const Ice::StringSeq& args) : _args(args)
 }
 
 std::string
-TestI::getProperty(ICE_IN(std::string) name, const Ice::Current& current)
+TestI::getProperty(std::string name, const Ice::Current& current)
 {
     return current.adapter->getCommunicator()->getProperties()->getProperty(name);
 }

--- a/cpp/test/IceBox/configuration/TestI.h
+++ b/cpp/test/IceBox/configuration/TestI.h
@@ -13,7 +13,7 @@ public:
 
     TestI(const Ice::StringSeq&);
 
-    virtual std::string getProperty(ICE_IN(std::string), const Ice::Current&);
+    virtual std::string getProperty(std::string, const Ice::Current&);
     virtual Ice::StringSeq getArgs(const Ice::Current&);
 
 private:

--- a/cpp/test/IceDiscovery/simple/Server.cpp
+++ b/cpp/test/IceDiscovery/simple/Server.cpp
@@ -39,7 +39,7 @@ Server::run(int argc, char** argv)
     {
         ostringstream os;
         os << "controller" << num;
-        adapter->add(ICE_MAKE_SHARED(ControllerI), Ice::stringToIdentity(os.str()));
+        adapter->add(std::make_shared<ControllerI>(), Ice::stringToIdentity(os.str()));
     }
     adapter->activate();
 

--- a/cpp/test/IceDiscovery/simple/TestI.cpp
+++ b/cpp/test/IceDiscovery/simple/TestI.cpp
@@ -43,7 +43,7 @@ ControllerI::addObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Curr
     assert(_adapters[oaName]);
     Ice::Identity identity;
     identity.name = id;
-    _adapters[oaName]->add(ICE_MAKE_SHARED(TestIntfI), identity);
+    _adapters[oaName]->add(std::make_shared<TestIntfI>(), identity);
 }
 
 void

--- a/cpp/test/IceDiscovery/simple/TestI.cpp
+++ b/cpp/test/IceDiscovery/simple/TestI.cpp
@@ -16,9 +16,9 @@ TestIntfI::getAdapterId(const Ice::Current& current)
 }
 
 void
-ControllerI::activateObjectAdapter(ICE_IN(string) name,
-                                   ICE_IN(string) adapterId,
-                                   ICE_IN(string) replicaGroupId,
+ControllerI::activateObjectAdapter(string name,
+                                   string adapterId,
+                                   string replicaGroupId,
                                    const Ice::Current& current)
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
@@ -31,14 +31,14 @@ ControllerI::activateObjectAdapter(ICE_IN(string) name,
 }
 
 void
-ControllerI::deactivateObjectAdapter(ICE_IN(string) name, const Ice::Current&)
+ControllerI::deactivateObjectAdapter(string name, const Ice::Current&)
 {
     _adapters[name]->destroy();
     _adapters.erase(name);
 }
 
 void
-ControllerI::addObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Current&)
+ControllerI::addObject(string oaName, string id, const Ice::Current&)
 {
     assert(_adapters[oaName]);
     Ice::Identity identity;
@@ -47,7 +47,7 @@ ControllerI::addObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Curr
 }
 
 void
-ControllerI::removeObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Current&)
+ControllerI::removeObject(string oaName, string id, const Ice::Current&)
 {
     assert(_adapters[oaName]);
     Ice::Identity identity;

--- a/cpp/test/IceDiscovery/simple/TestI.h
+++ b/cpp/test/IceDiscovery/simple/TestI.h
@@ -18,11 +18,11 @@ class ControllerI : public Test::Controller
 {
 public:
 
-    virtual void activateObjectAdapter(ICE_IN(std::string), ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void deactivateObjectAdapter(ICE_IN(std::string), const Ice::Current&);
+    virtual void activateObjectAdapter(std::string, std::string, std::string, const Ice::Current&);
+    virtual void deactivateObjectAdapter(std::string, const Ice::Current&);
 
-    virtual void addObject(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void removeObject(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
+    virtual void addObject(std::string, std::string, const Ice::Current&);
+    virtual void removeObject(std::string, std::string, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -261,7 +261,7 @@ public:
 };
 #endif
 
-class PasswordPromptI ICE_FINAL
+class PasswordPromptI final
 {
 public:
 
@@ -287,7 +287,7 @@ private:
 };
 ICE_DEFINE_PTR(PasswordPromptIPtr, PasswordPromptI);
 
-class CertificateVerifierI ICE_FINAL
+class CertificateVerifierI final
 {
 public:
 
@@ -529,7 +529,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 #ifdef __APPLE__
     vector<char> s(256);
     size_t size = s.size();
-    int ret = sysctlbyname("kern.osrelease", &s[0], &size, ICE_NULLPTR, 0);
+    int ret = sysctlbyname("kern.osrelease", &s[0], &size, nullptr, 0);
     if(ret == 0)
     {
         // version format is x.y.z

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -1717,7 +1717,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         CommunicatorPtr comm = initialize(initData);
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, comm->getPluginManager()->getPlugin("IceSSL"));
         test(plugin);
-        CertificateVerifierIPtr verifier = ICE_MAKE_SHARED(CertificateVerifierI);
+        CertificateVerifierIPtr verifier = std::make_shared<CertificateVerifierI>();
 
         plugin->setCertificateVerifier([verifier](const shared_ptr<IceSSL::ConnectionInfo>& infoP)
                                        { return verifier->verify(infoP); });
@@ -1789,7 +1789,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         CommunicatorPtr comm = initialize(initData);
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, comm->getPluginManager()->getPlugin("IceSSL"));
         test(plugin);
-        CertificateVerifierIPtr verifier = ICE_MAKE_SHARED(CertificateVerifierI);
+        CertificateVerifierIPtr verifier = std::make_shared<CertificateVerifierI>();
 
         plugin->setCertificateVerifier([verifier](const shared_ptr<IceSSL::ConnectionInfo>& infoP)
                                        { return verifier->verify(infoP); });
@@ -2280,7 +2280,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         PluginManagerPtr pm = comm->getPluginManager();
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, pm->getPlugin("IceSSL"));
         test(plugin);
-        PasswordPromptIPtr prompt = ICE_MAKE_SHARED(PasswordPromptI, "client");
+        PasswordPromptIPtr prompt = std::make_shared<PasswordPromptI>("client");
 
         plugin->setPasswordPrompt([prompt]{ return prompt->getPassword(); });
         pm->initializePlugins();
@@ -2312,7 +2312,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         pm = comm->getPluginManager();
         plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, pm->getPlugin("IceSSL"));
         test(plugin);
-        prompt = ICE_MAKE_SHARED(PasswordPromptI, "invalid");
+        prompt = std::make_shared<PasswordPromptI>("invalid");
 
         plugin->setPasswordPrompt([prompt]{ return prompt->getPassword(); });
         try

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -1757,7 +1757,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         //
         verifier->reset();
         verifier->returnValue(false);
-        server->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        server->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         try
         {
             server->ice_ping();

--- a/cpp/test/IceSSL/configuration/Server.cpp
+++ b/cpp/test/IceSSL/configuration/Server.cpp
@@ -39,7 +39,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint("tcp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("factory");
-    adapter->add(ICE_MAKE_SHARED(ServerFactoryI, testdir), id);
+    adapter->add(std::make_shared<ServerFactoryI>(testdir), id);
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/IceSSL/configuration/TestI.cpp
+++ b/cpp/test/IceSSL/configuration/TestI.cpp
@@ -33,7 +33,7 @@ ServerI::noCert(const Ice::Current& c)
 }
 
 void
-ServerI::checkCert(ICE_IN(string) subjectDN, ICE_IN(string) issuerDN, const Ice::Current& c)
+ServerI::checkCert(string subjectDN, string issuerDN, const Ice::Current& c)
 {
     try
     {
@@ -50,7 +50,7 @@ ServerI::checkCert(ICE_IN(string) subjectDN, ICE_IN(string) issuerDN, const Ice:
 }
 
 void
-ServerI::checkCipher(ICE_IN(string) cipher, const Ice::Current& c)
+ServerI::checkCipher(string cipher, const Ice::Current& c)
 {
     try
     {
@@ -74,7 +74,7 @@ ServerFactoryI::ServerFactoryI(const string& defaultDir) : _defaultDir(defaultDi
 }
 
 Test::ServerPrxPtr
-ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
+ServerFactoryI::createServer(Test::Properties props, const Current&)
 {
     InitializationData initData;
     initData.properties = createProperties();
@@ -95,7 +95,7 @@ ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
 }
 
 void
-ServerFactoryI::destroyServer(ICE_IN(Test::ServerPrxPtr) srv, const Ice::Current&)
+ServerFactoryI::destroyServer(Test::ServerPrxPtr srv, const Ice::Current&)
 {
     map<Identity, ServerIPtr>::iterator p = _servers.find(srv->ice_getIdentity());
     if(p != _servers.end())

--- a/cpp/test/IceSSL/configuration/TestI.cpp
+++ b/cpp/test/IceSSL/configuration/TestI.cpp
@@ -86,7 +86,7 @@ ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
 
     CommunicatorPtr communicator = initialize(initData);
     ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("ServerAdapter", "ssl");
-    ServerIPtr server = ICE_MAKE_SHARED(ServerI, communicator);
+    ServerIPtr server = std::make_shared<ServerI>(communicator);
     ObjectPrxPtr obj = adapter->addWithUUID(server);
     _servers[obj->ice_getIdentity()] = server;
     adapter->activate();

--- a/cpp/test/IceSSL/configuration/TestI.h
+++ b/cpp/test/IceSSL/configuration/TestI.h
@@ -14,8 +14,8 @@ public:
     ServerI(const Ice::CommunicatorPtr&);
 
     virtual void noCert(const Ice::Current&);
-    virtual void checkCert(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void checkCipher(ICE_IN(std::string), const Ice::Current&);
+    virtual void checkCert(std::string, std::string, const Ice::Current&);
+    virtual void checkCipher(std::string, const Ice::Current&);
 
     void destroy();
 
@@ -31,8 +31,8 @@ public:
 
     ServerFactoryI(const std::string&);
 
-    virtual Test::ServerPrxPtr createServer(ICE_IN(Test::Properties), const Ice::Current&);
-    virtual void destroyServer(ICE_IN(Test::ServerPrxPtr), const Ice::Current&);
+    virtual Test::ServerPrxPtr createServer(Test::Properties, const Ice::Current&);
+    virtual void destroyServer(Test::ServerPrxPtr, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 
 private:

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -163,7 +163,7 @@ Client::run(int, char*[])
         IceUtil::TimerPtr timer = new IceUtil::Timer();
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = std::make_shared<TestTask>();
             timer->schedule(task, IceUtil::Time());
             task->waitForRun();
             task->clear();
@@ -185,7 +185,7 @@ Client::run(int, char*[])
         }
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = std::make_shared<TestTask>();
             test(!timer->cancel(task));
             timer->schedule(task, IceUtil::Time::seconds(1));
             test(!task->hasRun() && timer->cancel(task) && !task->hasRun());
@@ -199,7 +199,7 @@ Client::run(int, char*[])
             IceUtil::Time start = IceUtil::Time::now(IceUtil::Time::Monotonic) + IceUtil::Time::milliSeconds(500);
             for(int i = 0; i < 20; ++i)
             {
-                tasks.push_back(ICE_MAKE_SHARED(TestTask, IceUtil::Time::milliSeconds(500 + i * 50)));
+                tasks.push_back(std::make_shared<TestTask>(IceUtil::Time::milliSeconds(500 + i * 50)));
             }
 
             IceUtilInternal::shuffle(tasks.begin(), tasks.end());
@@ -227,7 +227,7 @@ Client::run(int, char*[])
         }
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = std::make_shared<TestTask>();
             timer->scheduleRepeated(task, IceUtil::Time::milliSeconds(20));
             IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(500));
             test(task->hasRun());
@@ -247,7 +247,7 @@ Client::run(int, char*[])
     {
         {
             IceUtil::TimerPtr timer = new IceUtil::Timer();
-            DestroyTaskPtr destroyTask = ICE_MAKE_SHARED(DestroyTask, timer);
+            DestroyTaskPtr destroyTask = std::make_shared<DestroyTask>(timer);
             timer->schedule(destroyTask, IceUtil::Time());
             destroyTask->waitForRun();
             try
@@ -261,7 +261,7 @@ Client::run(int, char*[])
         }
         {
             IceUtil::TimerPtr timer = new IceUtil::Timer();
-            TestTaskPtr testTask = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr testTask = std::make_shared<TestTask>();
             timer->schedule(testTask, IceUtil::Time());
             timer->destroy();
             try

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -82,18 +82,18 @@ testtypes()
     _cpp_and::breakPrxPtr d;
     int d2;
     d->_cpp_case(0, d2);
-    _cpp_and::breakPtr d1 = ICE_MAKE_SHARED(breakI);
+    _cpp_and::breakPtr d1 = std::make_shared<breakI>();
 
     _cpp_and::charPrxPtr e;
     e->_cpp_explicit();
-    _cpp_and::charPtr e1 = ICE_MAKE_SHARED(charI);
+    _cpp_and::charPtr e1 = std::make_shared<charI>();
 
-    _cpp_and::switchPtr f1 = ICE_MAKE_SHARED(switchI);
+    _cpp_and::switchPtr f1 = std::make_shared<switchI>();
 
     _cpp_and::doPrxPtr g;
     g->_cpp_case(0, d2);
     g->_cpp_explicit();
-    _cpp_and::doPtr g1 = ICE_MAKE_SHARED(doI);
+    _cpp_and::doPtr g1 = std::make_shared<doI>();
 
     _cpp_and::_cpp_extern h;
     _cpp_and::_cpp_for i;
@@ -123,7 +123,7 @@ Client::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", "default");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(charI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<charI>(), Ice::stringToIdentity("test"));
     adapter->activate();
 
     cout << "Testing operation name... " << flush;

--- a/cpp/test/Slice/macros/Client.cpp
+++ b/cpp/test/Slice/macros/Client.cpp
@@ -20,11 +20,11 @@ void
 Client::run(int, char**)
 {
     cout << "testing Slice predefined macros... " << flush;
-    DefaultPtr d = ICE_MAKE_SHARED(Default);
+    DefaultPtr d = std::make_shared<Default>();
     test(d->x == 10);
     test(d->y == 10);
 
-    CppOnlyPtr c = ICE_MAKE_SHARED(CppOnly);
+    CppOnlyPtr c = std::make_shared<CppOnly>();
     test(c->lang == "cpp");
     test(c->version == ICE_INT_VERSION);
     cout << "ok" << endl;

--- a/cpp/test/Slice/structure/Client.cpp
+++ b/cpp/test/Slice/structure/Client.cpp
@@ -33,7 +33,7 @@ allTests(const Ice::CommunicatorPtr& communicator)
     def_s2.il.push_back(2);
     def_s2.il.push_back(3);
     def_s2.sd["abc"] = "def";
-    def_s2.cls = ICE_MAKE_SHARED(C, 5);
+    def_s2.cls = std::make_shared<C>(5);
     def_s2.prx = communicator->stringToProxy("test");
 
     cout << "ok" << endl;

--- a/cpp/test/include/TestHelper.h
+++ b/cpp/test/include/TestHelper.h
@@ -107,7 +107,7 @@ public:
     createTestProperties(int&, char*[]);
 
     Ice::CommunicatorPtr
-    initialize(int& argc, char* argv[], const Ice::PropertiesPtr& properties = ICE_NULLPTR);
+    initialize(int& argc, char* argv[], const Ice::PropertiesPtr& properties = nullptr);
 
     Ice::CommunicatorPtr initialize(int&, char*[], const Ice::InitializationData&);
 

--- a/cpp/test/ios/controller/Bundle/ControllerI.mm
+++ b/cpp/test/ios/controller/Bundle/ControllerI.mm
@@ -340,7 +340,7 @@ ProcessControllerI::start(string testSuite, string exe, StringSeq args, const Ic
     // test on arm64 devices with a debug Ice libraries which require lots of stack space.
     //
     helper->start(768 * 1024);
-    return ICE_UNCHECKED_CAST(ProcessPrx, c.adapter->addWithUUID(ICE_MAKE_SHARED(ProcessI, _controller, helper.get())));
+    return ICE_UNCHECKED_CAST(ProcessPrx, c.adapter->addWithUUID(std::make_shared<ProcessI>(_controller, helper.get())));
 }
 
 string
@@ -372,7 +372,7 @@ ControllerI::ControllerI(id<ControllerView> controller, NSString* ipv4, NSString
     ident.category = "iPhoneOS";
 #endif
     ident.name = [[[NSBundle mainBundle] bundleIdentifier] UTF8String];
-    adapter->add(ICE_MAKE_SHARED(ProcessControllerI, controller, ipv4, ipv6), ident);
+    adapter->add(std::make_shared<ProcessControllerI>(controller, ipv4, ipv6), ident);
     adapter->activate();
 }
 


### PR DESCRIPTION
This PR removes the following macros from the code and replaces them with the corresponding macro definitions:

ICE_NOEXCEPT, ICE_NOEXCEPT_FALSE, ICE_FINAL, ICE_HANDLE, ICE_INTERNAL_HANDLE, ICE_PROXY_HANDLE, ICE_MAKE_SHARED, ICE_ENUM, ICE_SCOPED_ENUM, ICE_NULLPTR, ICE_SHARED_FROM_THIS, ICE_GET_SHARED_FROM_THIS, ICE_DELEGATE, ICE_IN, ICE_SET_EXCEPTION_FROM_CLONE

These macros were only necessary to allow bridging between the cpp11 and cpp98 mappings. Now that the latter is gone, these macros are no longer necessary.