### PR TITLE
Add EndpointType enum in C#

### DIFF
--- a/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
+++ b/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
@@ -109,7 +109,7 @@ namespace Ice
                     // the actual endpoint.
                     //
                     var ostr = new OutputStream(Ice1Definitions.Encoding, new List<ArraySegment<byte>>());
-                    ostr.WriteShort(ue.Type());
+                    ostr.WriteShort((short)ue.Type());
                     ue.StreamWrite(ostr);
                     // TODO avoid copy OutputStream buffers
                     var iss = new InputStream(this, ostr.ToArray());
@@ -126,7 +126,7 @@ namespace Ice
             return null;
         }
 
-        public IEndpointFactory? GetEndpointFactory(short type)
+        public IEndpointFactory? GetEndpointFactory(EndpointType type)
         {
             lock (this)
             {
@@ -145,7 +145,7 @@ namespace Ice
         {
             lock (this)
             {
-                short type = istr.ReadShort();
+                EndpointType type = (EndpointType)istr.ReadShort();
 
                 IEndpointFactory? factory = GetEndpointFactory(type);
                 Endpoint? e = null;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -181,7 +181,8 @@ namespace Ice
         private static bool _printProcessIdDone = false;
         private readonly int[] _retryIntervals;
         private IceInternal.ThreadPool? _serverThreadPool;
-        private readonly Dictionary<short, BufSizeWarnInfo> _setBufSizeWarn = new Dictionary<short, BufSizeWarnInfo>();
+        private readonly Dictionary<EndpointType, BufSizeWarnInfo> _setBufSizeWarn =
+            new Dictionary<EndpointType, BufSizeWarnInfo>();
         private int _state;
         private readonly IceInternal.Timer _timer;
         private readonly ConcurrentDictionary<string, Type?> _typeIdCache = new ConcurrentDictionary<string, Type?>();
@@ -438,10 +439,10 @@ namespace Ice
                 NetworkProxy = CreateNetworkProxy(IPVersion);
 
                 _endpointFactories = new List<IEndpointFactory>();
-                AddEndpointFactory(new TcpEndpointFactory(new TransportInstance(this, TCPEndpointType.Value, "tcp", false)));
-                AddEndpointFactory(new UdpEndpointFactory(new TransportInstance(this, UDPEndpointType.Value, "udp", false)));
-                AddEndpointFactory(new WSEndpointFactory(new TransportInstance(this, WSEndpointType.Value, "ws", false), TCPEndpointType.Value));
-                AddEndpointFactory(new WSEndpointFactory(new TransportInstance(this, WSSEndpointType.Value, "wss", true), SSLEndpointType.Value));
+                AddEndpointFactory(new TcpEndpointFactory(new TransportInstance(this, EndpointType.TCP, "tcp", false)));
+                AddEndpointFactory(new UdpEndpointFactory(new TransportInstance(this, EndpointType.UDP, "udp", false)));
+                AddEndpointFactory(new WSEndpointFactory(new TransportInstance(this, EndpointType.WS, "ws", false), EndpointType.TCP));
+                AddEndpointFactory(new WSEndpointFactory(new TransportInstance(this, EndpointType.WSS, "wss", true), EndpointType.SSL));
 
                 _outgoingConnectionFactory = new OutgoingConnectionFactory(this);
 
@@ -1808,7 +1809,7 @@ namespace Ice
                 null);
         }
 
-        internal BufSizeWarnInfo GetBufSizeWarn(short type)
+        internal BufSizeWarnInfo GetBufSizeWarn(EndpointType type)
         {
             lock (_setBufSizeWarn)
             {
@@ -1934,7 +1935,7 @@ namespace Ice
             }
         }
 
-        internal void SetRcvBufSizeWarn(short type, int size)
+        internal void SetRcvBufSizeWarn(EndpointType type, int size)
         {
             lock (_setBufSizeWarn)
             {
@@ -1979,7 +1980,7 @@ namespace Ice
             }
         }
 
-        internal void SetSndBufSizeWarn(short type, int size)
+        internal void SetSndBufSizeWarn(EndpointType type, int size)
         {
             lock (_setBufSizeWarn)
             {

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System;
 using System.Collections.Generic;
 
@@ -48,7 +50,7 @@ namespace IceInternal
         //
         // Return the endpoint type.
         //
-        public abstract short Type();
+        public abstract EndpointType Type();
 
         //
         // Return the transport name.

--- a/csharp/src/Ice/IConnector.cs
+++ b/csharp/src/Ice/IConnector.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 namespace IceInternal
 {
     public interface IConnector
@@ -12,7 +14,7 @@ namespace IceInternal
         //
         ITransceiver Connect();
 
-        short Type();
+        EndpointType Type();
     }
 
 }

--- a/csharp/src/Ice/IEndpoint.cs
+++ b/csharp/src/Ice/IEndpoint.cs
@@ -5,49 +5,17 @@
 
 namespace Ice
 {
-    public abstract class TCPEndpointType
+    public enum EndpointType : short
     {
-        public const short Value = 1;
-    }
-
-    public abstract class SSLEndpointType
-    {
-        public const short Value = 2;
-    }
-
-    public abstract class UDPEndpointType
-    {
-        public const short Value = 3;
-    }
-
-    public abstract class WSEndpointType
-    {
-        public const short Value = 4;
-    }
-
-    public abstract class WSSEndpointType
-    {
-        public const short Value = 5;
-    }
-
-    public abstract class BTEndpointType
-    {
-        public const short Value = 6;
-    }
-
-    public abstract class BTSEndpointType
-    {
-        public const short Value = 7;
-    }
-
-    public abstract class iAPEndpointType
-    {
-        public const short Value = 8;
-    }
-
-    public abstract class iAPSEndpointType
-    {
-        public const short Value = 9;
+        TCP = 1,
+        SSL = 2,
+        UDP = 3,
+        WS = 4,
+        WSS = 5,
+        BT = 6,
+        BTS = 7,
+        iAP = 8,
+        iAPS = 9
     }
 
     [System.Serializable]
@@ -61,7 +29,7 @@ namespace Ice
         /// Returns the type of the endpoint.
         /// </summary>
         /// <returns>The endpoint type.</returns>
-        public abstract short Type();
+        public abstract EndpointType Type();
 
         /// <summary>
         /// Returns true if this endpoint is a datagram endpoint.

--- a/csharp/src/Ice/IEndpointFactory.cs
+++ b/csharp/src/Ice/IEndpointFactory.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
 using System.Collections.Generic;
 
 namespace IceInternal
@@ -9,7 +10,7 @@ namespace IceInternal
     public interface IEndpointFactory
     {
         void Initialize();
-        short Type();
+        EndpointType Type();
         string Transport();
         Endpoint? Create(List<string> args, bool oaEndpoint);
         Endpoint? Read(Ice.InputStream s);
@@ -20,7 +21,7 @@ namespace IceInternal
 
     public abstract class EndpointFactoryWithUnderlying : IEndpointFactory
     {
-        public EndpointFactoryWithUnderlying(TransportInstance instance, short type)
+        public EndpointFactoryWithUnderlying(TransportInstance instance, EndpointType type)
         {
             Instance = instance;
             _type = type;
@@ -40,7 +41,7 @@ namespace IceInternal
             }
         }
 
-        public short Type() => Instance!.Type;
+        public EndpointType Type() => Instance!.Type;
 
         public string Transport() => Instance!.Transport;
 
@@ -73,14 +74,14 @@ namespace IceInternal
 
         public IEndpointFactory Clone(TransportInstance instance) => CloneWithUnderlying(instance, _type);
 
-        public abstract IEndpointFactory CloneWithUnderlying(TransportInstance instance, short type);
+        public abstract IEndpointFactory CloneWithUnderlying(TransportInstance instance, EndpointType type);
 
         protected abstract Endpoint CreateWithUnderlying(Endpoint? underlying, List<string> args, bool oaEndpoint);
         protected abstract Endpoint ReadWithUnderlying(Endpoint? underlying, Ice.InputStream s);
 
         protected TransportInstance? Instance;
 
-        private readonly short _type;
+        private readonly EndpointType _type;
         private IEndpointFactory? _underlying;
     }
 }

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -42,7 +44,7 @@ namespace IceInternal
         {
             public Info(IPEndpoint e) => _endpoint = e;
 
-            public override short Type() => _endpoint.Type();
+            public override EndpointType Type() => _endpoint.Type();
 
             public override bool Datagram() => _endpoint.Datagram();
 
@@ -58,7 +60,7 @@ namespace IceInternal
             return info;
         }
 
-        public override short Type() => Instance.Type;
+        public override EndpointType Type() => Instance.Type;
 
         public override string Transport() => Instance.Transport;
 

--- a/csharp/src/Ice/ITransportPluginFacade.cs
+++ b/csharp/src/Ice/ITransportPluginFacade.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 namespace IceInternal
 {
     public interface ITransportPluginFacade
@@ -20,7 +22,7 @@ namespace IceInternal
         //
         // Get an EndpointFactory.
         //
-        IEndpointFactory? GetEndpointFactory(short type);
+        IEndpointFactory? GetEndpointFactory(EndpointType type);
 
         //
         // Obtain the type for a name.
@@ -46,7 +48,7 @@ namespace IceInternal
         //
         // Get an EndpointFactory.
         //
-        public IEndpointFactory? GetEndpointFactory(short type) => Communicator.GetEndpointFactory(type);
+        public IEndpointFactory? GetEndpointFactory(EndpointType type) => Communicator.GetEndpointFactory(type);
 
         //
         // Obtain the type for a name.

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -921,12 +921,12 @@ namespace IceInternal
                 {
                     // Warn if the size that was set is less than the requested size and
                     // we have not already warned.
-                    Ice.BufSizeWarnInfo winfo = instance.GetBufSizeWarn(Ice.TCPEndpointType.Value);
+                    Ice.BufSizeWarnInfo winfo = instance.GetBufSizeWarn(Ice.EndpointType.TCP);
                     if (!winfo.RcvWarn || rcvSize != winfo.RcvSize)
                     {
                         instance.Logger.Warning(
                             $"TCP receive buffer size: requested size of {rcvSize} adjusted to {size}");
-                        instance.SetRcvBufSizeWarn(Ice.TCPEndpointType.Value, rcvSize);
+                        instance.SetRcvBufSizeWarn(Ice.EndpointType.TCP, rcvSize);
                     }
                 }
             }
@@ -944,12 +944,12 @@ namespace IceInternal
                 {
                     // Warn if the size that was set is less than the requested size and
                     // we have not already warned.
-                    Ice.BufSizeWarnInfo winfo = instance.GetBufSizeWarn(Ice.TCPEndpointType.Value);
+                    Ice.BufSizeWarnInfo winfo = instance.GetBufSizeWarn(Ice.EndpointType.TCP);
                     if (!winfo.SndWarn || sndSize != winfo.SndSize)
                     {
                         instance.Logger.Warning(
                             $"TCP send buffer size: requested size of {sndSize} adjusted to {size}");
-                        instance.SetSndBufSizeWarn(Ice.TCPEndpointType.Value, sndSize);
+                        instance.SetSndBufSizeWarn(Ice.EndpointType.TCP, sndSize);
                     }
                 }
             }

--- a/csharp/src/Ice/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/OpaqueEndpointI.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -11,15 +13,20 @@ namespace IceInternal
 {
     internal sealed class OpaqueEndpointI : Endpoint
     {
+        private EndpointType _type;
+        private Ice.Encoding _rawEncoding;
+        private byte[] _rawBytes;
+        private int _hashCode = 0; // 0 is a special value that means not initialized.
+
         public OpaqueEndpointI(List<string> args)
         {
-            _type = -1;
+            _type = (EndpointType)(short)-1;
             _rawEncoding = Ice.Encoding.V1_1;
             _rawBytes = System.Array.Empty<byte>();
 
             InitWithOptions(args);
 
-            if (_type < 0)
+            if ((short)_type < 0)
             {
                 throw new FormatException($"no -t option in endpoint {this}");
             }
@@ -29,7 +36,7 @@ namespace IceInternal
             }
         }
 
-        public OpaqueEndpointI(short type, Ice.Encoding encoding, byte[] rawBytes)
+        public OpaqueEndpointI(EndpointType type, Ice.Encoding encoding, byte[] rawBytes)
         {
             _type = type;
             _rawEncoding = encoding;
@@ -59,16 +66,16 @@ namespace IceInternal
 
         private sealed class InfoI : Ice.OpaqueEndpointInfo
         {
-            public InfoI(short type, Ice.Encoding rawEncoding, byte[] rawBytes) :
+            public InfoI(EndpointType type, Ice.Encoding rawEncoding, byte[] rawBytes) :
                 base(null, -1, false, rawEncoding, rawBytes) => _type = type;
 
-            public override short Type() => _type;
+            public override EndpointType Type() => _type;
 
             public override bool Datagram() => false;
 
             public override bool Secure() => false;
 
-            private readonly short _type;
+            private readonly EndpointType _type;
         }
 
         //
@@ -79,7 +86,7 @@ namespace IceInternal
         //
         // Return the endpoint type
         //
-        public override short Type() => _type;
+        public override EndpointType Type() => _type;
 
         //
         // Return the transport name;
@@ -192,7 +199,7 @@ namespace IceInternal
         public override string Options()
         {
             string s = "";
-            if (_type > -1)
+            if ((short)_type > -1)
             {
                 s += " -t " + _type;
             }
@@ -276,7 +283,7 @@ namespace IceInternal
             {
                 case 't':
                     {
-                        if (_type > -1)
+                        if ((short)_type > -1)
                         {
                             throw new FormatException($"multiple -t options in endpoint {endpoint}");
                         }
@@ -286,10 +293,10 @@ namespace IceInternal
                             throw new FormatException($"no argument provided for -t option in endpoint {endpoint}");
                         }
 
-                        int t;
+                        short t;
                         try
                         {
-                            t = int.Parse(argument, CultureInfo.InvariantCulture);
+                            t = short.Parse(argument, CultureInfo.InvariantCulture);
                         }
                         catch (FormatException ex)
                         {
@@ -301,7 +308,7 @@ namespace IceInternal
                             throw new FormatException($"type value `{argument}' out of range in endpoint {endpoint}");
                         }
 
-                        _type = (short)t;
+                        _type = (EndpointType)t;
                         return true;
                     }
 
@@ -352,11 +359,5 @@ namespace IceInternal
                     }
             }
         }
-
-        private short _type;
-        private Ice.Encoding _rawEncoding;
-        private byte[] _rawBytes;
-        private int _hashCode = 0; // 0 is a special value that means not initialized.
     }
-
 }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1040,7 +1040,7 @@ namespace IceInternal
                 Debug.Assert(_adapterId!.Length == 0);
                 foreach (Endpoint endpoint in _endpoints)
                 {
-                    s.WriteShort(endpoint.Type());
+                    s.WriteShort((short)endpoint.Type());
                     endpoint.StreamWrite(s);
                 }
             }

--- a/csharp/src/Ice/TcpConnector.cs
+++ b/csharp/src/Ice/TcpConnector.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System.Net;
 
 namespace IceInternal
@@ -11,7 +13,7 @@ namespace IceInternal
         public ITransceiver Connect() =>
             new TcpTransceiver(_instance, new StreamSocket(_instance, _proxy, _addr, _sourceAddr));
 
-        public short Type() => _instance.Type;
+        public EndpointType Type() => _instance.Type;
 
         //
         // Only for use by TcpEndpoint

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -37,7 +39,7 @@ namespace IceInternal
         {
             public Info(IPEndpoint e) => _endpoint = e;
 
-            public override short Type() => _endpoint.Type();
+            public override EndpointType Type() => _endpoint.Type();
 
             public override bool Datagram() => _endpoint.Datagram();
 
@@ -260,7 +262,7 @@ namespace IceInternal
         {
         }
 
-        public short Type() => _instance!.Type;
+        public EndpointType Type() => _instance!.Type;
 
         public string Transport() => _instance!.Transport;
 

--- a/csharp/src/Ice/TransportInstance.cs
+++ b/csharp/src/Ice/TransportInstance.cs
@@ -2,13 +2,14 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
 using System.Net;
 
 namespace IceInternal
 {
     public class TransportInstance
     {
-        public TransportInstance(Ice.Communicator communicator, short type, string transport, bool secure)
+        public TransportInstance(Ice.Communicator communicator, EndpointType type, string transport, bool secure)
         {
             Communicator = communicator;
             TraceLevel = Communicator.TraceLevels.Network;
@@ -23,7 +24,7 @@ namespace IceInternal
         public string TraceCategory { get; protected set; }
         public Ice.ILogger Logger { get; protected set; }
         public string Transport { get; protected set; }
-        public short Type { get; protected set; }
+        public EndpointType Type { get; protected set; }
         public bool Secure { get; protected set; }
         public Ice.Communicator Communicator { get; protected set; }
         public bool PreferIPv6 => Communicator.PreferIPv6;
@@ -35,13 +36,13 @@ namespace IceInternal
         public int MessageSizeMax => Communicator.MessageSizeMax;
         public INetworkProxy? NetworkProxy => Communicator.NetworkProxy;
 
-        public IEndpointFactory? GetEndpointFactory(short type) => Communicator.GetEndpointFactory(type);
+        public IEndpointFactory? GetEndpointFactory(EndpointType type) => Communicator.GetEndpointFactory(type);
         public void Resolve(string host, int port, Ice.EndpointSelectionType type, IPEndpoint endpt,
                             IEndpointConnectors callback) =>
             Communicator.Resolve(host, port, type, endpt, callback);
-        public void SetSndBufSizeWarn(short type, int size) => Communicator.SetSndBufSizeWarn(type, size);
-        public void SetRcvBufSizeWarn(short type, int size) => Communicator.SetRcvBufSizeWarn(type, size);
+        public void SetSndBufSizeWarn(EndpointType type, int size) => Communicator.SetSndBufSizeWarn(type, size);
+        public void SetRcvBufSizeWarn(EndpointType type, int size) => Communicator.SetRcvBufSizeWarn(type, size);
 
-        internal Ice.BufSizeWarnInfo GetBufSizeWarn(short type) => Communicator.GetBufSizeWarn(type);
+        internal Ice.BufSizeWarnInfo GetBufSizeWarn(EndpointType type) => Communicator.GetBufSizeWarn(type);
     }
 }

--- a/csharp/src/Ice/UdpConnector.cs
+++ b/csharp/src/Ice/UdpConnector.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System.Net;
 
 namespace IceInternal
@@ -11,7 +13,7 @@ namespace IceInternal
         public ITransceiver Connect() =>
             new UdpTransceiver(_instance, _addr, _sourceAddr, _mcastInterface, _mcastTtl);
 
-        public short Type() => _instance.Type;
+        public EndpointType Type() => _instance.Type;
 
         //
         // Only for use by UdpEndpointI

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -42,7 +42,7 @@ namespace IceInternal
         {
             public InfoI(UdpEndpoint e) => _endpoint = e;
 
-            public override short Type() => _endpoint.Type();
+            public override EndpointType Type() => _endpoint.Type();
 
             public override bool Datagram() => _endpoint.Datagram();
 
@@ -375,7 +375,7 @@ namespace IceInternal
         {
         }
 
-        public short Type() => _instance!.Type;
+        public EndpointType Type() => _instance!.Type;
 
         public string Transport() => _instance!.Transport;
 

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -817,7 +817,7 @@ namespace IceInternal
                     //
                     if (sizeSet < sizeRequested)
                     {
-                        Ice.BufSizeWarnInfo winfo = _instance.GetBufSizeWarn(Ice.UDPEndpointType.Value);
+                        Ice.BufSizeWarnInfo winfo = _instance.GetBufSizeWarn(Ice.EndpointType.UDP);
                         if ((isSnd && (!winfo.SndWarn || winfo.SndSize != sizeRequested)) ||
                            (!isSnd && (!winfo.RcvWarn || winfo.RcvSize != sizeRequested)))
                         {
@@ -826,11 +826,11 @@ namespace IceInternal
 
                             if (isSnd)
                             {
-                                _instance.SetSndBufSizeWarn(Ice.UDPEndpointType.Value, sizeRequested);
+                                _instance.SetSndBufSizeWarn(Ice.EndpointType.UDP, sizeRequested);
                             }
                             else
                             {
-                                _instance.SetRcvBufSizeWarn(Ice.UDPEndpointType.Value, sizeRequested);
+                                _instance.SetRcvBufSizeWarn(Ice.EndpointType.UDP, sizeRequested);
                             }
                         }
                     }

--- a/csharp/src/Ice/WSConnector.cs
+++ b/csharp/src/Ice/WSConnector.cs
@@ -2,13 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 namespace IceInternal
 {
     internal sealed class WSConnector : IConnector
     {
         public ITransceiver Connect() => new WSTransceiver(_instance, _delegate.Connect(), _host, _resource);
 
-        public short Type() => _delegate.Type();
+        public EndpointType Type() => _delegate.Type();
 
         internal WSConnector(TransportInstance instance, IConnector del, string host, string resource)
         {

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -44,7 +46,7 @@ namespace IceInternal
         {
             public InfoI(Endpoint e) => _endpoint = e;
 
-            public override short Type() => _endpoint.Type();
+            public override EndpointType Type() => _endpoint.Type();
 
             public override bool Datagram() => _endpoint.Datagram();
 
@@ -63,7 +65,7 @@ namespace IceInternal
             return info;
         }
 
-        public override short Type() => _delegate.Type();
+        public override EndpointType Type() => _delegate.Type();
 
         public override string Transport() => _delegate.Transport();
 
@@ -293,11 +295,11 @@ namespace IceInternal
 
     public class WSEndpointFactory : EndpointFactoryWithUnderlying
     {
-        public WSEndpointFactory(TransportInstance instance, short type) : base(instance, type)
+        public WSEndpointFactory(TransportInstance instance, EndpointType type) : base(instance, type)
         {
         }
 
-        public override IEndpointFactory CloneWithUnderlying(TransportInstance instance, short underlying) =>
+        public override IEndpointFactory CloneWithUnderlying(TransportInstance instance, EndpointType underlying) =>
             new WSEndpointFactory(instance, underlying);
 
         protected override Endpoint CreateWithUnderlying(Endpoint? underlying, List<string> args, bool oaEndpoint) =>

--- a/csharp/src/IceSSL/ConnectorI.cs
+++ b/csharp/src/IceSSL/ConnectorI.cs
@@ -19,7 +19,7 @@ namespace IceSSL
             return new Transceiver(_instance, _delegate.Connect(), _host, false);
         }
 
-        public short Type() => _delegate.Type();
+        public Ice.EndpointType Type() => _delegate.Type();
 
         //
         // Only for use by EndpointI.

--- a/csharp/src/IceSSL/Endpoint.cs
+++ b/csharp/src/IceSSL/Endpoint.cs
@@ -19,7 +19,7 @@ namespace IceSSL
         private sealed class InfoI : EndpointInfo
         {
             public InfoI(Endpoint e) => _endpoint = e;
-            public override short Type() => _endpoint.Type();
+            public override Ice.EndpointType Type() => _endpoint.Type();
             public override bool Datagram() => _endpoint.Datagram();
             public override bool Secure() => _endpoint.Secure();
 
@@ -35,7 +35,7 @@ namespace IceSSL
             return info;
         }
 
-        public override short Type() => _delegate.Type();
+        public override Ice.EndpointType Type() => _delegate.Type();
 
         public override string Transport() => _delegate.Transport();
 
@@ -206,10 +206,10 @@ namespace IceSSL
 
     internal sealed class EndpointFactoryI : IceInternal.EndpointFactoryWithUnderlying
     {
-        public EndpointFactoryI(Instance instance, short type) : base(instance, type) => _instance = instance;
+        public EndpointFactoryI(Instance instance, Ice.EndpointType type) : base(instance, type) => _instance = instance;
 
         public override IceInternal.IEndpointFactory
-        CloneWithUnderlying(IceInternal.TransportInstance inst, short underlying) =>
+        CloneWithUnderlying(IceInternal.TransportInstance inst, Ice.EndpointType underlying) =>
             new EndpointFactoryI(new Instance(_instance.Engine(), inst.Type, inst.Transport), underlying);
 
         protected override IceInternal.Endpoint

--- a/csharp/src/IceSSL/Instance.cs
+++ b/csharp/src/IceSSL/Instance.cs
@@ -9,7 +9,7 @@ namespace IceSSL
 {
     internal class Instance : IceInternal.TransportInstance
     {
-        internal Instance(SSLEngine engine, short type, string transport) :
+        internal Instance(SSLEngine engine, Ice.EndpointType type, string transport) :
             base(engine.Communicator(), type, transport, true) => _engine = engine;
 
         internal SSLEngine Engine() => _engine;

--- a/csharp/src/IceSSL/Plugin.cs
+++ b/csharp/src/IceSSL/Plugin.cs
@@ -73,8 +73,8 @@ namespace IceSSL
             //
             // SSL based on TCP
             //
-            var instance = new Instance(_engine, SSLEndpointType.Value, "ssl");
-            facade.AddEndpointFactory(new EndpointFactoryI(instance, TCPEndpointType.Value));
+            var instance = new Instance(_engine, EndpointType.SSL, "ssl");
+            facade.AddEndpointFactory(new EndpointFactoryI(instance, EndpointType.TCP));
         }
 
         public void Initialize() => _engine.Initialize();

--- a/csharp/test/Ice/background/Connector.cs
+++ b/csharp/test/Ice/background/Connector.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 internal class Connector : IceInternal.IConnector
 {
     public IceInternal.ITransceiver Connect()
@@ -10,9 +12,9 @@ internal class Connector : IceInternal.IConnector
         return new Transceiver(_connector.Connect());
     }
 
-    public short Type()
+    public EndpointType Type()
     {
-        return (short)(Endpoint.TYPE_BASE + _connector.Type());
+        return (EndpointType)(Endpoint.TYPE_BASE + (short)_connector.Type());
     }
 
     //

--- a/csharp/test/Ice/background/EndpointFactory.cs
+++ b/csharp/test/Ice/background/EndpointFactory.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -16,9 +18,9 @@ internal class EndpointFactory : IceInternal.IEndpointFactory
     {
     }
 
-    public short Type()
+    public EndpointType Type()
     {
-        return (short)(Endpoint.TYPE_BASE + _factory.Type());
+        return (EndpointType)(Endpoint.TYPE_BASE + (short)_factory.Type());
     }
 
     public string Transport()
@@ -33,7 +35,7 @@ internal class EndpointFactory : IceInternal.IEndpointFactory
 
     public IceInternal.Endpoint Read(Ice.InputStream s)
     {
-        short type = s.ReadShort();
+        Ice.EndpointType type = (Ice.EndpointType)s.ReadShort();
         Debug.Assert(type == _factory.Type());
         IceInternal.Endpoint endpoint = new Endpoint(_factory.Read(s));
         return endpoint;

--- a/csharp/test/Ice/background/EndpointI.cs
+++ b/csharp/test/Ice/background/EndpointI.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -27,13 +29,13 @@ internal class Endpoint : IceInternal.Endpoint
 
     public override void StreamWriteImpl(Ice.OutputStream s)
     {
-        s.WriteShort(_endpoint.Type());
+        s.WriteShort((short)_endpoint.Type());
         _endpoint.StreamWriteImpl(s);
     }
 
-    public override short Type()
+    public override EndpointType Type()
     {
-        return (short)(TYPE_BASE + _endpoint.Type());
+        return (EndpointType)(TYPE_BASE + (short)_endpoint.Type());
     }
 
     public override string Transport()

--- a/csharp/test/Ice/background/PluginI.cs
+++ b/csharp/test/Ice/background/PluginI.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using Ice;
+
 internal class Plugin : Ice.IPlugin
 {
     internal Plugin(Ice.Communicator communicator) => _communicator = communicator;
@@ -11,7 +13,7 @@ internal class Plugin : Ice.IPlugin
         IceInternal.ITransportPluginFacade facade = IceInternal.Util.GetTransportPluginFacade(_communicator);
         for (short s = 0; s < 100; ++s)
         {
-            IceInternal.IEndpointFactory? factory = facade.GetEndpointFactory(s);
+            IceInternal.IEndpointFactory? factory = facade.GetEndpointFactory((EndpointType)s);
             if (factory != null)
             {
                 facade.AddEndpointFactory(new EndpointFactory(factory));

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -55,14 +55,14 @@ namespace Ice.info
                 test(tcpEndpoint.Compress);
                 test(!tcpEndpoint.Datagram());
 
-                test(tcpEndpoint.Type() == TCPEndpointType.Value && !tcpEndpoint.Secure() ||
-                        tcpEndpoint.Type() == SSLEndpointType.Value && tcpEndpoint.Secure() ||
-                        tcpEndpoint.Type() == WSEndpointType.Value && !tcpEndpoint.Secure() ||
-                        tcpEndpoint.Type() == WSSEndpointType.Value && tcpEndpoint.Secure());
-                test(tcpEndpoint.Type() == TCPEndpointType.Value && info is TCPEndpointInfo ||
-                        tcpEndpoint.Type() == SSLEndpointType.Value && info is IceSSL.EndpointInfo ||
-                        tcpEndpoint.Type() == WSEndpointType.Value && info is WSEndpointInfo ||
-                        tcpEndpoint.Type() == WSSEndpointType.Value && info is WSEndpointInfo);
+                test(tcpEndpoint.Type() == EndpointType.TCP && !tcpEndpoint.Secure() ||
+                        tcpEndpoint.Type() == EndpointType.SSL && tcpEndpoint.Secure() ||
+                        tcpEndpoint.Type() == EndpointType.WS && !tcpEndpoint.Secure() ||
+                        tcpEndpoint.Type() == EndpointType.WSS && tcpEndpoint.Secure());
+                test(tcpEndpoint.Type() == EndpointType.TCP && info is TCPEndpointInfo ||
+                        tcpEndpoint.Type() == EndpointType.SSL && info is IceSSL.EndpointInfo ||
+                        tcpEndpoint.Type() == EndpointType.WS && info is WSEndpointInfo ||
+                        tcpEndpoint.Type() == EndpointType.WSS && info is WSEndpointInfo);
 
                 UDPEndpointInfo udpEndpoint = (UDPEndpointInfo)endps[1].GetInfo();
                 test(udpEndpoint.Host.Equals("udphost"));
@@ -74,7 +74,7 @@ namespace Ice.info
                 test(!udpEndpoint.Compress);
                 test(!udpEndpoint.Secure());
                 test(udpEndpoint.Datagram());
-                test(udpEndpoint.Type() == 3);
+                test(udpEndpoint.Type() == EndpointType.UDP);
 
                 OpaqueEndpointInfo opaqueEndpoint = (OpaqueEndpointInfo)endps[2].GetInfo();
                 test(opaqueEndpoint.RawBytes.Length > 0);
@@ -97,10 +97,10 @@ namespace Ice.info
                 test(global::Test.Collections.Equals(endpoints, publishedEndpoints));
 
                 TCPEndpointInfo tcpEndpoint = getTCPEndpointInfo(endpoints[0].GetInfo());
-                test(tcpEndpoint.Type() == TCPEndpointType.Value ||
-                        tcpEndpoint.Type() == SSLEndpointType.Value ||
-                        tcpEndpoint.Type() == WSEndpointType.Value ||
-                        tcpEndpoint.Type() == WSSEndpointType.Value);
+                test(tcpEndpoint.Type() == EndpointType.TCP ||
+                        tcpEndpoint.Type() == EndpointType.SSL ||
+                        tcpEndpoint.Type() == EndpointType.WS ||
+                        tcpEndpoint.Type() == EndpointType.WSS);
 
                 test(tcpEndpoint.Host.Equals(host));
                 test(tcpEndpoint.Port > 0);


### PR DESCRIPTION
This smallish PR adds a new EndpointType enum to hold endpoint types. Currently they are just plain shorts and we provide a number of constants for "well-known" endpoint types.

Keep in mind that in C# (and C++) an enum can hold values not represented by its enumerators.