### PR TITLE
Simplify slice2cs marshaling & unmarshalling of tagged sequences

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -861,7 +861,6 @@ Slice::CsGenerator::writeUnmarshalCode(Output &out,
 {
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
     StructPtr st = StructPtr::dynamicCast(type);
-    SequencePtr seq = SequencePtr::dynamicCast(type);
 
     out << param << " = ";
     if(isClassType(type))

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -976,16 +976,8 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
         else
         {
             assert(builtin);
-            if(isArray)
-            {
-                out << nl << stream << ".Write" << builtinSuffixTable[builtin->kind()] << "Seq(" << tag << ", "
-                    << param << ");";
-            }
-            else
-            {
-                out << nl << stream << ".Write" << builtinSuffixTable[builtin->kind()] << "Seq(" << tag << ", " << param
-                    << param << ".Count, " << param << ");";
-            }
+            out << nl << stream << ".Write" << builtinSuffixTable[builtin->kind()] << "Seq(" << tag << ", " << param
+                << ");";
         }
     }
     else

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -888,31 +888,6 @@ Slice::CsGenerator::writeUnmarshalCode(Output &out,
     }
 }
 
-namespace
-{
-bool isVariableLength(TypePtr type)
-{
-    BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
-    ProxyPtr proxy = ProxyPtr::dynamicCast(type);
-
-    if(builtin &&
-       builtin->kind() != Builtin::KindValue &&
-       builtin->kind() != Builtin::KindObjectProxy &&
-       builtin->kind() != Builtin::KindString)
-    {
-        return false;
-    }
-    StructPtr st = StructPtr::dynamicCast(type);
-    if(st && !st->isVariableLength())
-    {
-        return false;
-    }
-
-    return true;
-}
-
-}
-
 void
 Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
                                            const TypePtr& type,
@@ -966,7 +941,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
         builtin = BuiltinPtr::dynamicCast(elementType);
         st = StructPtr::dynamicCast(elementType);
 
-        if(isVariableLength(elementType))
+        if(elementType->isVariableLength())
         {
             out << nl << "if (" << param << " != null && " << stream << ".WriteOptional(" << tag << ", "
                 << getTagFormat(seq, scope) << "))";
@@ -1095,7 +1070,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
 
         out << nl << "if (" << stream << ".ReadOptional(" << tag << ", " << getTagFormat(seq, scope) << "))";
         out << sb;
-        if(isVariableLength(elementType))
+        if(elementType->isVariableLength())
         {
             out << nl << stream << ".Skip(4);";
         }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -131,8 +131,10 @@ protected:
     std::string sequenceMarshalCode(const SequencePtr&, const std::string&, const std::string&, const std::string&);
     std::string sequenceUnmarshalCode(const SequencePtr&, const std::string&, const std::string&);
 
-    void writeTaggedSequenceMarshalUnmarshalCode(::IceUtilInternal::Output&, const SequencePtr&, const std::string&,
-                                                 const std::string&, int, bool, const std::string& = "");
+    void writeTaggedSequenceMarshalCode(::IceUtilInternal::Output&, const SequencePtr&, const std::string&,
+                                        const std::string&, int, const std::string&);
+    void writeTaggedSequenceUnmarshalCode(::IceUtilInternal::Output&, const SequencePtr&, const std::string&,
+                                          const std::string&, int, const std::string&);
 private:
 
     class MetaDataVisitor : public ParserVisitor

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -131,10 +131,6 @@ protected:
     std::string sequenceMarshalCode(const SequencePtr&, const std::string&, const std::string&, const std::string&);
     std::string sequenceUnmarshalCode(const SequencePtr&, const std::string&, const std::string&);
 
-    void writeTaggedSequenceMarshalCode(::IceUtilInternal::Output&, const SequencePtr&, const std::string&,
-                                        const std::string&, int, const std::string&);
-    void writeTaggedSequenceUnmarshalCode(::IceUtilInternal::Output&, const SequencePtr&, const std::string&,
-                                          const std::string&, int, const std::string&);
 private:
 
     class MetaDataVisitor : public ParserVisitor

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -173,12 +173,7 @@ Slice::CsVisitor::writeUnmarshalParams(const OperationPtr& op,
         {
             _out << "?";
         }
-        _out << " " << param.name;
-        if(isClassType(param.type) || StructPtr::dynamicCast(param.type))
-        {
-            _out << " = default";
-        }
-        _out << ";";
+        _out << " ";
         writeUnmarshalCode(_out, param.type, ns, param.name, stream);
     }
 
@@ -1915,6 +1910,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << sb;
     for(auto m : dataMembers)
     {
+        _out << nl << fixId(dataMemberName(m)) << " = ";
         writeUnmarshalDataMember(m, fixId(dataMemberName(m)) , ns, "iceP_istr");
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1910,7 +1910,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << sb;
     for(auto m : dataMembers)
     {
-        _out << nl << fixId(dataMemberName(m)) << " = ";
+        _out << nl;
         writeUnmarshalDataMember(m, fixId(dataMemberName(m)) , ns, "iceP_istr");
     }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -398,9 +398,9 @@ namespace Ice
         /// </summary>
         /// <param name="tag">The optional tag.</param>
         /// <param name="v">An enumerator for the byte sequence.</param>
-        public void WriteByteSeq(int tag, IReadOnlyCollection<byte> v)
+        public void WriteByteSeq(int tag, IReadOnlyCollection<byte>? v)
         {
-            if (WriteOptional(tag, OptionalFormat.VSize))
+            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
             {
                 WriteByteSeq(v);
             }
@@ -614,7 +614,7 @@ namespace Ice
             {
                 int count = v.Count;
                 WriteSize(count == 0 ? 1 : (count * 4) + (count > 254 ? 5 : 1));
-                WriteIntSeq(count, v);
+                WriteIntSeq(v);
             }
         }
 
@@ -679,7 +679,7 @@ namespace Ice
             {
                 int count = v.Count;
                 WriteSize(count == 0 ? 1 : (count * 8) + (count > 254 ? 5 : 1));
-                WriteLongSeq(count, v);
+                WriteLongSeq(v);
             }
         }
 
@@ -744,7 +744,7 @@ namespace Ice
             {
                 int count = v.Count;
                 WriteSize(count == 0 ? 1 : (count * 4) + (count > 254 ? 5 : 1));
-                WriteFloatSeq(count, v);
+                WriteFloatSeq(v);
             }
         }
 
@@ -809,7 +809,7 @@ namespace Ice
             {
                 int count = v.Count;
                 WriteSize(count == 0 ? 1 : (count * 8) + (count > 254 ? 5 : 1));
-                WriteDoubleSeq(count, v);
+                WriteDoubleSeq(v);
             }
         }
 

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -1121,6 +1121,10 @@ namespace Ice.optional
                     });
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(x => (byte)56).ToList();
+                (List<byte> l2, List<byte> l3) = initial.opByteList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1164,6 +1168,10 @@ namespace Ice.optional
 
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => true).ToList();
+                (List<bool>? l2, List<bool>? l3) = initial.opBoolList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1210,6 +1218,10 @@ namespace Ice.optional
                     });
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => (short)56).ToList();
+                (List<short>? l2, List<short> ? l3) = initial.opShortList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1256,6 +1268,10 @@ namespace Ice.optional
 
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => 56).ToList();
+                (List<int>? l2, List<int>? l3) = initial.opIntList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1301,6 +1317,10 @@ namespace Ice.optional
                     });
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => 56L).ToList();
+                (List<long>? l2, List<long>? l3) = initial.opLongList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1346,6 +1366,10 @@ namespace Ice.optional
                     });
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => 1.0f).ToList();
+                (List<float>? l2, List<float>? l3) = initial.opFloatList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1392,6 +1416,10 @@ namespace Ice.optional
 
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 100).Select(_ => 1.0).ToList();
+                (List<double>? l2, List<double>? l3) = initial.opDoubleList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {
@@ -1438,6 +1466,10 @@ namespace Ice.optional
 
                 test(global::Test.Collections.Equals(p1, p2));
                 test(global::Test.Collections.Equals(p1, p3));
+
+                var l1 = Enumerable.Range(0, 10).Select(_ => "test1").ToList();
+                (List<string>? l2, List<string>? l3) = initial.opStringList(l1);
+                test(global::Test.Collections.Equals(l2, l1) && global::Test.Collections.Equals(l3, l1));
             }
 
             {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -363,9 +363,9 @@ namespace Ice.optional
             outer.value = recursive1;
             initial.pingPong(outer);
 
-            G g = new Test.G();
-            g.gg1Opt = new Test.G1("gg1Opt");
-            g.gg2 = new Test.G2(10);
+            G g = new G();
+            g.gg1Opt = new G1("gg1Opt");
+            g.gg2 = new G2(10);
             g.gg2Opt = new G2(20);
             g.gg1 = new G1("gg1");
             g = initial.opG(g);

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -34,7 +34,6 @@ struct VarStruct
     string m;
 }
 
-["clr:class"]
 struct ClassVarStruct
 {
     int a;
@@ -48,6 +47,16 @@ sequence<long> LongSeq;
 sequence<float> FloatSeq;
 sequence<double> DoubleSeq;
 sequence<string> StringSeq;
+
+["clr:generic:List"] sequence<byte> ByteList;
+["clr:generic:List"] sequence<bool> BoolList;
+["clr:generic:List"] sequence<short> ShortList;
+["clr:generic:List"] sequence<int> IntList;
+["clr:generic:List"] sequence<long> LongList;
+["clr:generic:List"] sequence<float> FloatList;
+["clr:generic:List"] sequence<double> DoubleList;
+["clr:generic:List"] sequence<string> StringList;
+
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
 ["clr:generic:List"] sequence<SmallStruct> SmallStructList;
@@ -236,20 +245,28 @@ interface Initial
     tag(1) OneOptional* opOneOptionalProxy(tag(2) OneOptional* p1, out tag(3) OneOptional* p3);
 
     tag(1) ByteSeq opByteSeq(tag(2) ByteSeq p1, out tag(3) ByteSeq p3);
+    tag(1) ByteList opByteList(tag(2) ByteList p1, out tag(3) ByteList p3);
 
     tag(1) BoolSeq opBoolSeq(tag(2) BoolSeq p1, out tag(3) BoolSeq p3);
+    tag(1) BoolList opBoolList(tag(2) BoolList p1, out tag(3) BoolList p3);
 
     tag(1) ShortSeq opShortSeq(tag(2) ShortSeq p1, out tag(3) ShortSeq p3);
+    tag(1) ShortList opShortList(tag(2) ShortList p1, out tag(3) ShortList p3);
 
     tag(1) IntSeq opIntSeq(tag(2) IntSeq p1, out tag(3) IntSeq p3);
+    tag(1) IntList opIntList(tag(2) IntList p1, out tag(3) IntList p3);
 
     tag(1) LongSeq opLongSeq(tag(2) LongSeq p1, out tag(3) LongSeq p3);
+    tag(1) LongList opLongList(tag(2) LongList p1, out tag(3) LongList p3);
 
     tag(1) FloatSeq opFloatSeq(tag(2) FloatSeq p1, out tag(3) FloatSeq p3);
+    tag(1) FloatList opFloatList(tag(2) FloatList p1, out tag(3) FloatList p3);
 
     tag(1) DoubleSeq opDoubleSeq(tag(2) DoubleSeq p1, out tag(3) DoubleSeq p3);
+    tag(1) DoubleList opDoubleList(tag(2) DoubleList p1, out tag(3) DoubleList p3);
 
     tag(1) StringSeq opStringSeq(tag(2) StringSeq p1, out tag(3) StringSeq p3);
+    tag(1) StringList opStringList(tag(2) StringList p1, out tag(3) StringList p3);
 
     tag(1) SmallStructSeq opSmallStructSeq(tag(2) SmallStructSeq p1, out tag(3) SmallStructSeq p3);
 

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -48,6 +48,16 @@ sequence<long> LongSeq;
 sequence<float> FloatSeq;
 sequence<double> DoubleSeq;
 sequence<string> StringSeq;
+
+["clr:generic:List"] sequence<byte> ByteList;
+["clr:generic:List"] sequence<bool> BoolList;
+["clr:generic:List"] sequence<short> ShortList;
+["clr:generic:List"] sequence<int> IntList;
+["clr:generic:List"] sequence<long> LongList;
+["clr:generic:List"] sequence<float> FloatList;
+["clr:generic:List"] sequence<double> DoubleList;
+["clr:generic:List"] sequence<string> StringList;
+
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
 ["clr:generic:List"] sequence<SmallStruct> SmallStructList;
@@ -236,20 +246,28 @@ interface Initial
     tag(1) OneOptional* opOneOptionalProxy(tag(2) OneOptional* p1, out tag(3) OneOptional* p3);
 
     tag(1) ByteSeq opByteSeq(tag(2) ByteSeq p1, out tag(3) ByteSeq p3);
+    tag(1) ByteList opByteList(tag(2) ByteList p1, out tag(3) ByteList p3);
 
     tag(1) BoolSeq opBoolSeq(tag(2) BoolSeq p1, out tag(3) BoolSeq p3);
+    tag(1) BoolList opBoolList(tag(2) BoolList p1, out tag(3) BoolList p3);
 
     tag(1) ShortSeq opShortSeq(tag(2) ShortSeq p1, out tag(3) ShortSeq p3);
+    tag(1) ShortList opShortList(tag(2) ShortList p1, out tag(3) ShortList p3);
 
     tag(1) IntSeq opIntSeq(tag(2) IntSeq p1, out tag(3) IntSeq p3);
+    tag(1) IntList opIntList(tag(2) IntList p1, out tag(3) IntList p3);
 
     tag(1) LongSeq opLongSeq(tag(2) LongSeq p1, out tag(3) LongSeq p3);
+    tag(1) LongList opLongList(tag(2) LongList p1, out tag(3) LongList p3);
 
     tag(1) FloatSeq opFloatSeq(tag(2) FloatSeq p1, out tag(3) FloatSeq p3);
+    tag(1) FloatList opFloatList(tag(2) FloatList p1, out tag(3) FloatList p3);
 
     tag(1) DoubleSeq opDoubleSeq(tag(2) DoubleSeq p1, out tag(3) DoubleSeq p3);
+    tag(1) DoubleList opDoubleList(tag(2) DoubleList p1, out tag(3) DoubleList p3);
 
     tag(1) StringSeq opStringSeq(tag(2) StringSeq p1, out tag(3) StringSeq p3);
+    tag(1) StringList opStringList(tag(2) StringList p1, out tag(3) StringList p3);
 
     tag(1) SmallStructSeq opSmallStructSeq(tag(2) SmallStructSeq p1, out tag(3) SmallStructSeq p3);
 

--- a/csharp/test/Ice/optional/TestAMDI.cs
+++ b/csharp/test/Ice/optional/TestAMDI.cs
@@ -82,27 +82,42 @@ namespace Ice.optional.AMD
         public ValueTask<(IObjectPrx?, IObjectPrx?)> opOneOptionalProxyAsync(IObjectPrx? p1, Current current) =>
             FromResult((p1, p1));
 
-        public ValueTask<(byte[]?, byte[]?)>
-        opByteSeqAsync(byte[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(byte[]?, byte[]?)> opByteSeqAsync(byte[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(List<byte>?, List<byte>?)> opByteListAsync(List<byte>? p1, Current current) =>
+            FromResult((p1, p1));
 
         public ValueTask<(bool[]?, bool[]?)> opBoolSeqAsync(bool[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(List<bool>?, List<bool>?)> opBoolListAsync(List<bool>? p1, Current current) =>
+            FromResult((p1, p1));
 
         public ValueTask<(short[]?, short[]?)> opShortSeqAsync(short[]? p1, Current current) =>
+            FromResult((p1, p1));
+        public ValueTask<(List<short>?, List<short>?)> opShortListAsync(List<short>? p1, Current current) =>
             FromResult((p1, p1));
 
         public ValueTask<(int[]?, int[]?)> opIntSeqAsync(int[]? p1, Current current) =>
             FromResult((p1, p1));
+        public ValueTask<(List<int>?, List<int>?)> opIntListAsync(List<int>? p1, Current current) =>
+            FromResult((p1, p1));
 
         public ValueTask<(long[]?, long[]?)> opLongSeqAsync(long[]? p1, Current current) =>
+            FromResult((p1, p1));
+        public ValueTask<(List<long>?, List<long>?)> opLongListAsync(List<long>? p1, Current current) =>
             FromResult((p1, p1));
 
         public ValueTask<(float[]?, float[]?)> opFloatSeqAsync(float[]? p1, Current current) =>
             FromResult((p1, p1));
+        public ValueTask<(List<float>?, List<float>?)> opFloatListAsync(List<float>? p1, Current current) =>
+            FromResult((p1, p1));
 
         public ValueTask<(double[]?, double[]?)> opDoubleSeqAsync(double[]? p1, Current current) =>
             FromResult((p1, p1));
+        public ValueTask<(List<double>?, List<double>?)> opDoubleListAsync(List<double>? p1, Current current) =>
+            FromResult((p1, p1));
 
         public ValueTask<(string[]?, string[]?)> opStringSeqAsync(string[]? p1, Current current) =>
+            FromResult((p1, p1));
+        public ValueTask<(List<string>?, List<string>?)> opStringListAsync(List<string>? p1, Current current) =>
             FromResult((p1, p1));
 
         public ValueTask<(Test.SmallStruct[]?, Test.SmallStruct[]?)>

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -68,20 +68,28 @@ namespace Ice.optional
         public (IObjectPrx?, IObjectPrx?) opOneOptionalProxy(IObjectPrx? p1, Current current) => (p1, p1);
 
         public (byte[]?, byte[]?) opByteSeq(byte[]? p1, Current current) => (p1, p1);
+        public (List<byte>?, List<byte>?) opByteList(List<byte>? p1, Current current) => (p1, p1);
 
         public (bool[]?, bool[]?) opBoolSeq(bool[]? p1, Current current) => (p1, p1);
+        public (List<bool>?, List<bool>?) opBoolList(List<bool>? p1, Current current) => (p1, p1);
 
         public (short[]?, short[]?) opShortSeq(short[]? p1, Current current) => (p1, p1);
+        public (List<short>?, List<short>?) opShortList(List<short>? p1, Current current) => (p1, p1);
 
         public (int[]?, int[]?) opIntSeq(int[]? p1, Current current) => (p1, p1);
+        public (List<int>?, List<int>?) opIntList(List<int>? p1, Current current) => (p1, p1);
 
         public (long[]?, long[]?) opLongSeq(long[]? p1, Current current) => (p1, p1);
+        public (List<long>?, List<long>?) opLongList(List<long>? p1, Current current) => (p1, p1);
 
         public (float[]?, float[]?) opFloatSeq(float[]? p1, Current current) => (p1, p1);
+        public (List<float>?, List<float>?) opFloatList(List<float>? p1, Current current) => (p1, p1);
 
         public (double[]?, double[]?) opDoubleSeq(double[]? p1, Current current) => (p1, p1);
+        public (List<double>?, List<double>?) opDoubleList(List<double>? p1, Current current) => (p1, p1);
 
         public (string[]?, string[]?) opStringSeq(string[]? p1, Current current) => (p1, p1);
+        public (List<string>?, List<string>?) opStringList(List<string>? p1, Current current) => (p1, p1);
 
         public (Test.SmallStruct[]?, Test.SmallStruct[]?) opSmallStructSeq(Test.SmallStruct[]? p1, Current current) =>
             (p1, p1);

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -54,7 +54,7 @@ module Ice
         idempotent ObjectProxySeq addProxies(ObjectProxySeq proxies);
     }
 
-    /// This inferface should be implemented by services implementing the
+    /// This interface should be implemented by services implementing the
     /// Ice::Router interface. It should be advertised through an Ice
     /// object with the identity `Ice/RouterFinder'. This allows clients to
     /// retrieve the router proxy with just the endpoint information of the


### PR DESCRIPTION
This PR simplify the slice2cs code related to marhsall and unmarshall of tagged sequeces.

It also updates generate code to avoid creation of tmp variables during unmarshal

```
string[] tmpVal;
tmpVal = StringSeqHelper.ReadStringSeq(iceP_istr);
ss = tmpVal;
```

We now just do

```
ss = StringSeqHelper.ReadStringSeq(iceP_istr);
```

It also avoid generating code like:

```
reader: istr =>
{
    Structure iceP_p3 = default;
    iceP_p3 = new Structure(istr);
    Structure iceP_ReturnValue = default;
    iceP_ReturnValue = new Structure(istr);
    return (iceP_ReturnValue, iceP_p3);
}
```

We now generate:

```
reader: istr =>
{
    Structure iceP_p3 = new Structure(istr);
    Structure iceP_ReturnValue = new Structure(istr);
    return (iceP_ReturnValue, iceP_p3);
});
```