### PR TITLE
Rework implementation of the Properties admin facet in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2191,7 +2191,7 @@ Slice::Gen::ProxyVisitor::visitClassDefStart(const ClassDefPtr& p)
     writeTypeDocComment(p, getDeprecateReason(p, 0, "interface"));
     emitGeneratedCodeAttribute();
     emitTypeIdAttribute(p->scoped());
-    _out << nl << "public interface " << interfaceName(p) << "Prx : ";
+    _out << nl << "public partial interface " << interfaceName(p) << "Prx : ";
 
     vector<string> baseInterfaces =
         mapfn<ClassDefPtr>(p->bases(), [&ns](const auto& c)
@@ -2710,7 +2710,7 @@ Slice::Gen::DispatcherVisitor::visitClassDefStart(const ClassDefPtr& p)
     emitComVisibleAttribute();
     emitGeneratedCodeAttribute();
     emitTypeIdAttribute(p->scoped());
-    _out << nl << "public interface " << fixId(name) << " : ";
+    _out << nl << "public partial interface " << fixId(name) << " : ";
     if (bases.empty())
     {
         _out << getUnqualified("Ice.IObject", ns);

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -537,13 +537,11 @@ namespace Ice
                         Observer = communicatorObserver;
                         _adminFacets.Add(metricsFacetName, communicatorObserver.GetFacet());
 
-                        //
                         // Make sure the admin plugin receives property updates.
-                        //
                         if (propsAdmin != null)
                         {
-                            propsAdmin.AddUpdateCallback((Dictionary<string, string> updates) =>
-                                communicatorObserver.GetFacet().Updated(updates));
+                            propsAdmin.Updated += (_, updates) =>
+                                communicatorObserver.GetFacet().Updated(updates);
                         }
                     }
                 }

--- a/csharp/src/Ice/MetricsAdminI.cs
+++ b/csharp/src/Ice/MetricsAdminI.cs
@@ -907,13 +907,13 @@ namespace IceInternal
 
         public Ice.ILogger GetLogger() => _logger;
 
-        public void Updated(Dictionary<string, string> props)
+        public void Updated(IReadOnlyDictionary<string, string> props)
         {
             foreach (KeyValuePair<string, string> e in props)
             {
                 if (e.Key.IndexOf("IceMX.") == 0)
                 {
-                    // Udpate the metrics views using the new configuration.
+                    // Update the metrics views using the new configuration.
                     try
                     {
                         UpdateViews();

--- a/csharp/src/Ice/PropertiesAdmin.cs
+++ b/csharp/src/Ice/PropertiesAdmin.cs
@@ -7,8 +7,7 @@ using System.Collections.Generic;
 
 namespace Ice
 {
-    /// <summary>This partial interface extends the IPropertieAdmin interface generated from the Slice interface
-    /// PropertiesAdmin. All Properties admin facet implement this interface.</summary>
+    // This partial interface extends the IPropertieAdmin interface generated from the Slice interface PropertiesAdmin.
     public partial interface IPropertiesAdmin
     {
         /// <summary>The Updated event is triggered when the communicator's properties are updated through a remote call

--- a/csharp/src/Ice/PropertiesAdmin.cs
+++ b/csharp/src/Ice/PropertiesAdmin.cs
@@ -22,7 +22,7 @@ namespace Ice
     {
         public event EventHandler<IReadOnlyDictionary<string, string>>? Updated;
 
-        private const string TraceCategory = "Admin.Properties";
+        private const string TraceCategory = "Ice.Admin.Properties";
         private readonly Communicator _communicator;
         private readonly ILogger _logger;
 
@@ -33,7 +33,7 @@ namespace Ice
 
         public void SetProperties(Dictionary<string, string> props, Current current)
         {
-            int? traceLevel = _communicator.GetPropertyAsInt("Trace.Admin.Properties");
+            int? traceLevel = _communicator.GetPropertyAsInt("Ice.Trace.Admin.Properties");
 
             // Update the communicator's properties and remove the properties that did not change from props.
             _communicator.SetProperties(props);

--- a/csharp/src/Ice/PropertiesAdmin.cs
+++ b/csharp/src/Ice/PropertiesAdmin.cs
@@ -7,35 +7,33 @@ using System.Collections.Generic;
 
 namespace Ice
 {
+    /// <summary>Implementations of the Properties admin facet implement both IPropertiesAdmin (which corresponds
+    /// to the Slice interface PropertiesAdmin) and the local INativePropertiesAdmin interface.</summary>
     public interface INativePropertiesAdmin
     {
-        void AddUpdateCallback(Action<Dictionary<string, string>> callback);
-
-        void RemoveUpdateCallback(Action<Dictionary<string, string>> callback);
+        /// <summary>The Updated event is triggered when the communicator's properties are updated through a remote call
+        /// to the setProperties operation implemented by this Properties admin facet. The event's args include only the
+        /// communicator properties that were updated by this remote call.</summary>
+        public abstract event EventHandler<IReadOnlyDictionary<string, string>>? Updated;
     }
 
-}
-
-namespace IceInternal
-{
-    internal sealed class PropertiesAdmin : Ice.IPropertiesAdmin, Ice.INativePropertiesAdmin
+    // Default implementation of the Properties Admin facet.
+    internal sealed class PropertiesAdmin : IPropertiesAdmin, INativePropertiesAdmin
     {
-        internal PropertiesAdmin(Ice.Communicator communicator)
+        public event EventHandler<IReadOnlyDictionary<string, string>>? Updated;
+
+        private const string TraceCategory = "Admin.Properties";
+        private readonly Communicator _communicator;
+        private readonly ILogger _logger;
+
+        public string GetProperty(string name, Current current) => _communicator.GetProperty(name) ?? "";
+
+        public Dictionary<string, string> GetPropertiesForPrefix(string name, Current current) =>
+            _communicator.GetProperties(forPrefix: name);
+
+        public void SetProperties(Dictionary<string, string> props, Current current)
         {
-            _communicator = communicator;
-            _logger = communicator.Logger;
-        }
-
-        public string
-        GetProperty(string name, Ice.Current current) => _communicator.GetProperty(name) ?? "";
-
-        public Dictionary<string, string>
-        GetPropertiesForPrefix(string name, Ice.Current current) => _communicator.GetProperties(forPrefix: name);
-
-        public void
-        SetProperties(Dictionary<string, string> props, Ice.Current current)
-        {
-            int? traceLevel = _communicator.GetPropertyAsInt("Ice.Trace.Admin.Properties");
+            int? traceLevel = _communicator.GetPropertyAsInt("Trace.Admin.Properties");
 
             // Update the communicator's properties and remove the properties that did not change from props.
             _communicator.SetProperties(props);
@@ -72,50 +70,13 @@ namespace IceInternal
                 _logger.Trace(TraceCategory, message.ToString());
             }
 
-            lock (this)
-            {
-                if (_updateCallbacks.Count > 0)
-                {
-                    // Copy callbacks to allow callbacks to update callbacks
-                    foreach (Action<Dictionary<string, string>> callback in new List<Action<Dictionary<string, string>>>(_updateCallbacks))
-                    {
-                        try
-                        {
-                            callback(props);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (_communicator.GetPropertyAsInt("Ice.Warn.Dispatch") > 1)
-                            {
-                                _logger.Warning("properties admin update callback raised unexpected exception:\n" + ex);
-                            }
-                        }
-                    }
-                }
-            }
+            Updated?.Invoke(_communicator, props);
         }
 
-        public void AddUpdateCallback(Action<Dictionary<string, string>> cb)
+        internal PropertiesAdmin(Communicator communicator)
         {
-            lock (this)
-            {
-                _updateCallbacks.Add(cb);
-            }
+            _communicator = communicator;
+            _logger = communicator.Logger;
         }
-
-        public void RemoveUpdateCallback(Action<Dictionary<string, string>> cb)
-        {
-            lock (this)
-            {
-                _updateCallbacks.Remove(cb);
-            }
-        }
-
-        private readonly Ice.Communicator _communicator;
-        private readonly Ice.ILogger _logger;
-        private readonly List<Action<Dictionary<string, string>>> _updateCallbacks =
-            new List<Action<Dictionary<string, string>>>();
-
-        private const string TraceCategory = "Admin.Properties";
     }
 }

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -77,14 +77,11 @@ namespace Ice.admin
             {
             }
 
-            //
             // The RemoteCommunicator servant also implements PropertiesAdminUpdateCallback.
-            // Set the callback on the admin facet.
-            //
             var servant = new RemoteCommunicator(communicator);
             var propFacet = communicator.FindAdminFacet("Properties");
 
-            if (propFacet is INativePropertiesAdmin admin)
+            if (propFacet is IPropertiesAdmin admin)
             {
                 admin.Updated += (_, updates) => servant.Updated(updates);
             }

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -156,8 +156,7 @@ public class AllTests : Test.AllTests
             }
         }
 
-        public void
-        updated(Dictionary<string, string> dict)
+        public void Updated()
         {
             lock (this)
             {
@@ -418,7 +417,7 @@ public class AllTests : Test.AllTests
         test(serverProps != null && serverMetrics != null);
 
         UpdateCallbackI update = new UpdateCallbackI(serverProps);
-        ((INativePropertiesAdmin)communicator.FindAdminFacet("Properties")).AddUpdateCallback(update.updated);
+        ((INativePropertiesAdmin)communicator.FindAdminFacet("Properties")).Updated += (_, u) => update.Updated();
 
         output.WriteLine("ok");
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -417,7 +417,7 @@ public class AllTests : Test.AllTests
         test(serverProps != null && serverMetrics != null);
 
         UpdateCallbackI update = new UpdateCallbackI(serverProps);
-        ((INativePropertiesAdmin)communicator.FindAdminFacet("Properties")).Updated += (_, u) => update.Updated();
+        ((IPropertiesAdmin)communicator.FindAdminFacet("Properties")).Updated += (_, u) => update.Updated();
 
         output.WriteLine("ok");
 

--- a/csharp/test/IceBox/admin/TestI.cs
+++ b/csharp/test/IceBox/admin/TestI.cs
@@ -8,15 +8,9 @@ using Test;
 
 public class TestFacet : ITestFacet
 {
-    public Dictionary<string, string> getChanges(Ice.Current current) => _changes;
+    private volatile IReadOnlyDictionary<string, string> _changes;
 
-    public void updated(Dictionary<string, string> changes)
-    {
-        lock (this)
-        {
-            _changes = changes;
-        }
-    }
+    public Dictionary<string, string> getChanges(Ice.Current current) => new Dictionary<string, string>(_changes!);
 
-    private Dictionary<string, string> _changes;
+    internal void Updated(IReadOnlyDictionary<string, string> changes) => _changes = changes;
 }

--- a/csharp/test/IceBox/admin/TestServiceI.cs
+++ b/csharp/test/IceBox/admin/TestServiceI.cs
@@ -21,7 +21,7 @@ public class TestService : IService
         // Set the callback on the admin facet.
         //
         Ice.IObject? propFacet = serviceManagerCommunicator.FindAdminFacet("IceBox.Service.TestService.Properties");
-        if (propFacet is Ice.INativePropertiesAdmin admin)
+        if (propFacet is Ice.IPropertiesAdmin admin)
         {
             admin.Updated += (_, updates) => facet.Updated(updates);
         }

--- a/csharp/test/IceBox/admin/TestServiceI.cs
+++ b/csharp/test/IceBox/admin/TestServiceI.cs
@@ -21,10 +21,9 @@ public class TestService : IService
         // Set the callback on the admin facet.
         //
         Ice.IObject? propFacet = serviceManagerCommunicator.FindAdminFacet("IceBox.Service.TestService.Properties");
-        if (propFacet != null)
+        if (propFacet is Ice.INativePropertiesAdmin admin)
         {
-            var admin = (Ice.INativePropertiesAdmin)propFacet;
-            admin.AddUpdateCallback(facet.updated);
+            admin.Updated += (_, updates) => facet.Updated(updates);
         }
     }
 

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -20,39 +20,30 @@
 
 module Ice
 {
-    /// A simple collection of properties, represented as a dictionary of
-    /// key/value pairs. Both key and value are strings.
-    ///
+    /// A simple collection of properties, represented as a dictionary of key/value pairs. Both key and value are
+    /// strings.
     /// @see Properties#getPropertiesForPrefix
     dictionary<string, string> PropertyDict;
 
-    /// The PropertiesAdmin interface provides remote access to the properties
-    /// of a communicator.
+    /// The PropertiesAdmin interface provides remote access to the properties of a communicator.
     interface PropertiesAdmin
     {
-        /// Get a property by key. If the property is not set, an empty
-        /// string is returned.
-        ///
+        /// Get a property by key. If the property is not set, an empty string is returned.
         /// @param key The property key.
-        ///
         /// @return The property value.
         string getProperty(string key);
 
-        /// Get all properties whose keys begin with <em>prefix</em>. If
-        /// <em>prefix</em> is an empty string then all properties are returned.
-        ///
+        /// Get all properties whose keys begin with <em>prefix</em>. If <em>prefix</em> is an empty string then all
+        /// properties are returned.
         /// @param prefix The prefix to search for (empty string if none).
         /// @return The matching property set.
         ["java:type:java.util.TreeMap<String, String>"] PropertyDict getPropertiesForPrefix(string prefix);
 
         /// Update the communicator's properties with the given property set.
-        ///
-        /// @param newProperties Properties to be added, changed, or removed.
-        /// If an entry in <em>newProperties</em> matches the name of an existing property,
-        /// that property's value is replaced with the new value. If the new value
-        /// is an empty string, the property is removed. Any existing properties
-        /// that are not modified or removed by the entries in newProperties are
-        /// retained with their original values.
+        /// @param newProperties Properties to be added, changed, or removed. If an entry in <em>newProperties</em>
+        /// matches the name of an existing property, that property's value is replaced with the new value. If the new
+        /// value is an empty string, the property is removed. Any existing properties that are not modified or removed
+        /// by the entries in newProperties are retained with their original values.
         void setProperties(PropertyDict newProperties);
     }
 }


### PR DESCRIPTION
This tiny PR mostly changes `INativePropertyAdmin`, which is now using an event.