### PR TITLE
Fixes for marshaling of serializable types

### DIFF
--- a/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
+++ b/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
@@ -177,7 +177,12 @@ namespace Ice
                 if (e == null)
                 {
                     byte[] data = new byte[size];
-                    istr.ReadSpan(data);
+                    size = istr.ReadSpan(data);
+                    if (size < data.Length)
+                    {
+                        throw new InvalidDataException(@$"not enough bytes available reading opaque endpoint, requested {
+                            data.Length} bytes, but there was only {size} bytes remaining");
+                    }
                     e = new OpaqueEndpoint(type, encoding, data);
                 }
                 istr.EndEndpointEncapsulation();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -455,7 +455,7 @@ namespace Ice
                 return null;
             }
             var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, Communicator));
-            return f.Deserialize(new IceInternal.InputStreamWrapper(sz, this));
+            return f.Deserialize(new InputStreamWrapper(sz, this));
         }
 
         /// <summary>

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -423,11 +423,12 @@ namespace Ice
             return value;
         }
 
-        public void ReadSpan(Span<byte> span)
+        public int ReadSpan(Span<byte> span)
         {
-            int length = span.Length;
+            int length = Math.Min(span.Length, _buffer.Count - _pos);
             _buffer.AsSpan(_pos, length).CopyTo(span);
             _pos += length;
+            return length;
         }
 
         /// <summary>Extracts an optional byte sequence from the stream.</summary>
@@ -455,7 +456,7 @@ namespace Ice
                 return null;
             }
             var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, Communicator));
-            return f.Deserialize(new InputStreamWrapper(sz, this));
+            return f.Deserialize(new InputStreamWrapper(this));
         }
 
         /// <summary>

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1113,7 +1113,7 @@ namespace Ice
         /// <summary>Write a byte at a given position of the stream.</summary>
         /// <param name="v">The byte value to write.</param>
         /// <param name="pos">The position to write to.</param>
-        internal void RewriteByte(byte v, Position pos)
+        private void RewriteByte(byte v, Position pos)
         {
             ArraySegment<byte> segment = _segmentList[pos.Segment];
             if (pos.Offset < segment.Count)
@@ -1127,10 +1127,10 @@ namespace Ice
             }
         }
 
-        // <summary>Write an integer number (4 bytes) at a given position of the stream.</summary>
+        /// <summary>Write an integer number (4 bytes) at a given position of the stream.</summary>
         /// <param name="v">The integer value to write.</param>
         /// <param name="pos">The position to write to.</param>
-        internal void RewriteInt(int v, Position pos)
+        private void RewriteInt(int v, Position pos)
         {
             Debug.Assert(pos.Segment < _segmentList.Count);
             Debug.Assert(pos.Offset <= Size - _segmentList.Take(pos.Segment).Sum(data => data.Count),
@@ -1156,7 +1156,7 @@ namespace Ice
             }
         }
 
-        internal void RewriteSpan(Span<byte> data, Position pos)
+        private void RewriteSpan(Span<byte> data, Position pos)
         {
             ArraySegment<byte> segment = _segmentList[pos.Segment];
             int remaining = Math.Min(data.Length, segment.Count - pos.Offset);

--- a/csharp/src/Ice/StreamWrapper.cs
+++ b/csharp/src/Ice/StreamWrapper.cs
@@ -43,20 +43,17 @@ namespace Ice
 
         public override int ReadByte() => throw new NotSupportedException();
 
-        public override int Read(Span<byte> buffer) => throw new NotSupportedException();
-
-        public override void Write(byte[] array, int offset, int count)
+        public override void Write(ReadOnlySpan<byte> buffer)
         {
-            Debug.Assert(array != null && offset >= 0 && count >= 0 && offset + count <= array.Length);
             try
             {
                 if (_data != null)
                 {
                     // If we can fit the data into the first 254 bytes, write it to _bytes.
-                    if (count <= _data.Length - _pos)
+                    if (buffer.Length <= _data.Length - _pos)
                     {
-                        Buffer.BlockCopy(array, offset, _data, _pos, count);
-                        _pos += count;
+                        buffer.CopyTo(_data.AsSpan(_pos, buffer.Length));
+                        _pos += buffer.Length;
                         return;
                     }
 
@@ -72,8 +69,8 @@ namespace Ice
                 }
 
                 // Write data passed by caller.
-                _stream.WriteSpan(array.AsSpan(offset, count));
-                _pos += count;
+                _stream.WriteSpan(buffer);
+                _pos += buffer.Length;
             }
             catch (Exception ex)
             {
@@ -115,7 +112,7 @@ namespace Ice
             }
         }
 
-        public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException();
+        public override void Write(byte[] array, int offset, int count) => throw new NotSupportedException();
 
         public override bool CanRead => false;
 

--- a/csharp/test/Ice/seqMapping/Serializable.cs
+++ b/csharp/test/Ice/seqMapping/Serializable.cs
@@ -6,7 +6,6 @@ using System;
 
 namespace Serialize
 {
-
     [Serializable]
     public class Small // Fewer than 254 bytes with a BinaryFormatter.
     {
@@ -26,6 +25,15 @@ namespace Serialize
         public double d8;
         public double d9;
         public double d10;
+        public double d11;
+
+        public string s1;
+
+        // Use as data member of Large to ensure that the class serialization will take more than 254 bytes
+        public static readonly string LargeString =
+            @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sit amet purus consectetur,
+ blandit est eget, eleifend odio. Phasellus augue quam, bibendum id velit eget, tempus aliquet felis.
+ Mauris malesuada elementum feugiat. Aenean risus diam, pretium id.";
     }
 
     [Serializable]

--- a/csharp/test/Ice/seqMapping/Twoways.cs
+++ b/csharp/test/Ice/seqMapping/Twoways.cs
@@ -611,6 +611,8 @@ namespace Ice.seqMapping
                 i.d8 = 8.0;
                 i.d9 = 9.0;
                 i.d10 = 10.0;
+                i.d11 = 11.0;
+                i.s1 = Serialize.Large.LargeString;
                 Serialize.Large o;
                 Serialize.Large r;
 
@@ -628,6 +630,8 @@ namespace Ice.seqMapping
                     test(o.d8 == 8.0);
                     test(o.d9 == 9.0);
                     test(o.d10 == 10.0);
+                    test(o.d11 == 11.0);
+                    test(o.s1 == Serialize.Large.LargeString);
                     test(r.d1 == 1.0);
                     test(r.d2 == 2.0);
                     test(r.d3 == 3.0);
@@ -638,6 +642,8 @@ namespace Ice.seqMapping
                     test(r.d8 == 8.0);
                     test(r.d9 == 9.0);
                     test(r.d10 == 10.0);
+                    test(r.d11 == 11.0);
+                    test(r.s1 == Serialize.Large.LargeString);
                 }
                 catch (Ice.OperationNotExistException)
                 {

--- a/csharp/test/Ice/seqMapping/TwowaysAMI.cs
+++ b/csharp/test/Ice/seqMapping/TwowaysAMI.cs
@@ -552,6 +552,8 @@ namespace Ice.seqMapping
                 i.d8 = 8.0;
                 i.d9 = 9.0;
                 i.d10 = 10.0;
+                i.d11 = 11.0;
+                i.s1 = Serialize.Large.LargeString;
 
                 var r = p.opSerialLargeCSharpAsync(i).Result;
 
@@ -565,6 +567,8 @@ namespace Ice.seqMapping
                 test(r.o.d8 == 8.0);
                 test(r.o.d9 == 9.0);
                 test(r.o.d10 == 10.0);
+                test(r.o.d11 == 11.0);
+                test(r.o.s1 == Serialize.Large.LargeString);
 
                 test(r.ReturnValue.d1 == 1.0);
                 test(r.ReturnValue.d2 == 2.0);
@@ -576,6 +580,8 @@ namespace Ice.seqMapping
                 test(r.ReturnValue.d8 == 8.0);
                 test(r.ReturnValue.d9 == 9.0);
                 test(r.ReturnValue.d10 == 10.0);
+                test(r.ReturnValue.d11 == 11.0);
+                test(r.ReturnValue.s1 == Serialize.Large.LargeString);
             }
 
             {


### PR DESCRIPTION
This PR fix a bug with the marshaling of large serializable types introduced with the refactoring of output-stream.

There is also a fix for serializable testing to ensure that both code paths on StreamWrapper are tested, `Serialize.Large` was supposed to test the code path in StreamWrapper for serializable types that take more than 254 bytes, but it was actually serialized to 252 bytes and the code path for large serialized objects was not tested.