### PR TITLE
Update C# mapping for outgoing sequences and dictionaries

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -548,6 +548,12 @@ Slice::Builtin::isNumericType() const
 }
 
 bool
+Slice::Builtin::isNumericTypeOrBool() const
+{
+    return isNumericType() || (_kind == KindBool);
+}
+
+bool
 Slice::Builtin::isIntegralType() const
 {
     switch(_kind)

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -375,6 +375,7 @@ public:
     virtual bool isVariableLength() const;
 
     bool isNumericType() const;
+    bool isNumericTypeOrBool() const;
     bool isIntegralType() const;
     bool isUnsignedType() const;
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -820,7 +820,7 @@ Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope,
     ostringstream out;
     if(builtin && !builtin->usesClasses() && builtin->kind() != Builtin::KindObjectProxy)
     {
-        out << "Ice.OutputStream.IceWriterFrom" << builtinSuffixTable[builtin->kind()];
+        out << "global::Ice.OutputStream.IceWriterFrom" << builtinSuffixTable[builtin->kind()];
     }
     else if(DictionaryPtr::dynamicCast(type) || EnumPtr::dynamicCast(type))
     {
@@ -831,7 +831,7 @@ Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope,
         if (forNestedType && isMappedToReadOnlyMemory(seq))
         {
             builtin = BuiltinPtr::dynamicCast(seq->type());
-            out << "Ice.OutputStream.IceWriterFrom" << builtinSuffixTable[builtin->kind()] << "Array";
+            out << "global::Ice.OutputStream.IceWriterFrom" << builtinSuffixTable[builtin->kind()] << "Array";
         }
         else
         {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -826,11 +826,12 @@ Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope,
     {
         out << helperName(type, scope) << ".IceWriter";
     }
-    else if (SequencePtr::dynamicCast(type))
+    else if (SequencePtr seq = SequencePtr::dynamicCast(type))
     {
-        if (forNestedType && isMappedToReadOnlyMemory(SequencePtr::dynamicCast(type)))
+        if (forNestedType && isMappedToReadOnlyMemory(seq))
         {
-            out << helperName(type, scope) << ".IceNestedWriter";
+            builtin = BuiltinPtr::dynamicCast(seq->type());
+            out << "Ice.OutputStream.IceWriterFrom" << builtinSuffixTable[builtin->kind()] << "Array";
         }
         else
         {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -811,7 +811,7 @@ Slice::getNames(const list<ParamInfo>& params, function<string (const ParamInfo&
 }
 
 string
-Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope, ForNestedType forNestedType)
+Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope, bool forNestedType)
 {
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
     ostringstream out;
@@ -825,7 +825,7 @@ Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope,
     }
     else if (SequencePtr::dynamicCast(type))
     {
-        if (forNestedType == ForNestedType::Yes)
+        if (forNestedType)
         {
             out << helperName(type, scope) << ".IceNestedWriter";
         }
@@ -970,7 +970,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
         else if (elementType->isVariableLength())
         {
             out << nl << stream << ".WriteTaggedSeq(" << tag << ", " << param << ", " <<
-                outputStreamWriter(elementType, scope, ForNestedType::Yes) << ");";
+                outputStreamWriter(elementType, scope, true) << ");";
         }
         else if (builtin && isArray && builtin->isNumericTypeOrBool())
         {
@@ -985,7 +985,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
         {
             // Fixed size = min-size
             out << nl << stream << ".WriteTaggedSeq(" << tag << ", " << param << ", "
-                << elementType->minWireSize() << ", " << outputStreamWriter(elementType, scope, ForNestedType::Yes)
+                << elementType->minWireSize() << ", " << outputStreamWriter(elementType, scope, true)
                 << ");";
         }
     }
@@ -1004,8 +1004,8 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output &out,
             out << (keyType->minWireSize() + valueType->minWireSize()) << ", ";
         }
 
-        out << outputStreamWriter(keyType, scope, ForNestedType::Yes) << ", "
-            << outputStreamWriter(valueType, scope, ForNestedType::Yes) << ");";
+        out << outputStreamWriter(keyType, scope, true) << ", "
+            << outputStreamWriter(valueType, scope, true) << ");";
     }
 }
 
@@ -1120,7 +1120,7 @@ Slice::CsGenerator::sequenceMarshalCode(const SequencePtr& seq, const string& sc
     }
     else
     {
-        out << stream << ".WriteSeq(" << param << ", " << outputStreamWriter(type, scope, ForNestedType::Yes) << ")";
+        out << stream << ".WriteSeq(" << param << ", " << outputStreamWriter(type, scope, true) << ")";
     }
     return out.str();
 }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -15,6 +15,9 @@ namespace Slice
 
 enum CSharpBaseType { ObjectType=1, ExceptionType=2 };
 
+enum class Direction { Outgoing, Incoming };
+enum class ForNestedType { Yes, No };
+
 std::string fixId(const std::string&, unsigned int = 0);
 //
 // Returns the namespace of a Contained entity.
@@ -42,9 +45,9 @@ struct ParamInfo
     ParamDeclPtr param; // 0 == return value
     OperationPtr operation;
 
-    ParamInfo(const OperationPtr& operation, const std::string& name, const TypePtr& type, bool tagged, int tag,
-              const std::string& prefix = "");
-    ParamInfo(const ParamDeclPtr& param, const std::string& prefix = "");
+    ParamInfo(const OperationPtr& operation, const std::string& name, const TypePtr& type, bool readOnly,
+        bool tagged, int tag, const std::string& prefix = "");
+    ParamInfo(const ParamDeclPtr& param, bool readOnly, const std::string& prefix = "");
 };
 
 bool normalizeCase(const ContainedPtr&);
@@ -68,12 +71,14 @@ bool isClassType(const TypePtr&);
 bool isValueType(const TypePtr&);
 bool isReferenceType(const TypePtr&);
 
-std::list<ParamInfo> getAllInParams(const OperationPtr&, const std::string& prefix = "");
-void getInParams(const OperationPtr&, std::list<ParamInfo>&, std::list<ParamInfo>&, const std::string& prefix = "");
+std::list<ParamInfo> getAllInParams(const OperationPtr&, Direction, const std::string& prefix = "");
+void getInParams(const OperationPtr&, Direction, std::list<ParamInfo>&, std::list<ParamInfo>&,
+    const std::string& prefix = "");
 
-std::list<ParamInfo> getAllOutParams(const OperationPtr&, const std::string& prefix = "",
+std::list<ParamInfo> getAllOutParams(const OperationPtr&, Direction direction, const std::string& prefix = "",
                                      bool returnTypeIsFirst = false);
-void getOutParams(const OperationPtr&, std::list<ParamInfo>&, std::list<ParamInfo>&, const std::string& prefix = "");
+void getOutParams(const OperationPtr&, Direction direction, std::list<ParamInfo>&, std::list<ParamInfo>&,
+    const std::string& prefix = "");
 
 std::vector<std::string> getNames(const std::list<ParamInfo>& params, std::string prefix = "");
 std::vector<std::string> getNames(const std::list<ParamInfo>& params, std::function<std::string (const ParamInfo&)>);
@@ -115,7 +120,7 @@ protected:
     //
     // Generate code to marshal or unmarshal a type
     //
-    std::string outputStreamWriter(const TypePtr&, const std::string&);
+    std::string outputStreamWriter(const TypePtr&, const std::string&, ForNestedType);
     void writeMarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
                           const std::string& = "ostr");
 
@@ -123,8 +128,8 @@ protected:
     void writeUnmarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
                             const std::string& = "istr");
 
-    void writeTaggedMarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
-                                  int, const std::string& = "ostr");
+    void writeTaggedMarshalCode(::IceUtilInternal::Output&, const TypePtr&, bool, const std::string&,
+                                const std::string&, int, const std::string& = "ostr");
     void writeTaggedUnmarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
                                     int, const std::string& = "istr");
 

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -15,8 +15,6 @@ namespace Slice
 
 enum CSharpBaseType { ObjectType=1, ExceptionType=2 };
 
-enum class Direction { Outgoing, Incoming };
-
 std::string fixId(const std::string&, unsigned int = 0);
 //
 // Returns the namespace of a Contained entity.
@@ -69,14 +67,15 @@ bool isProxyType(const TypePtr&);
 bool isClassType(const TypePtr&);
 bool isValueType(const TypePtr&);
 bool isReferenceType(const TypePtr&);
+bool isMappedToReadOnlyMemory(const SequencePtr& seq);
 
-std::list<ParamInfo> getAllInParams(const OperationPtr&, Direction, const std::string& prefix = "");
-void getInParams(const OperationPtr&, Direction, std::list<ParamInfo>&, std::list<ParamInfo>&,
+std::list<ParamInfo> getAllInParams(const OperationPtr&, bool readOnly, const std::string& prefix = "");
+void getInParams(const OperationPtr&, bool, std::list<ParamInfo>&, std::list<ParamInfo>&,
     const std::string& prefix = "");
 
-std::list<ParamInfo> getAllOutParams(const OperationPtr&, Direction direction, const std::string& prefix = "",
+std::list<ParamInfo> getAllOutParams(const OperationPtr&, bool readOnly, const std::string& prefix = "",
                                      bool returnTypeIsFirst = false);
-void getOutParams(const OperationPtr&, Direction direction, std::list<ParamInfo>&, std::list<ParamInfo>&,
+void getOutParams(const OperationPtr&, bool readOnly, std::list<ParamInfo>&, std::list<ParamInfo>&,
     const std::string& prefix = "");
 
 std::vector<std::string> getNames(const std::list<ParamInfo>& params, std::string prefix = "");

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -16,7 +16,6 @@ namespace Slice
 enum CSharpBaseType { ObjectType=1, ExceptionType=2 };
 
 enum class Direction { Outgoing, Incoming };
-enum class ForNestedType { Yes, No };
 
 std::string fixId(const std::string&, unsigned int = 0);
 //
@@ -120,7 +119,7 @@ protected:
     //
     // Generate code to marshal or unmarshal a type
     //
-    std::string outputStreamWriter(const TypePtr&, const std::string&, ForNestedType);
+    std::string outputStreamWriter(const TypePtr&, const std::string&, bool);
     void writeMarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
                           const std::string& = "ostr");
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2499,7 +2499,7 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestWriter(const OperationPtr& operati
     bool defaultWriter = params.size() == 1 && !params.front().tagged;
     if(defaultWriter)
     {
-        _out << outputStreamWriter(params.front().type, ns, ForNestedType::No);
+        _out << outputStreamWriter(params.front().type, ns, false);
     }
     else if(params.size() > 1)
     {
@@ -2641,8 +2641,8 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     _out << nl << "public static void Write(this Ice.OutputStream ostr, "<< readOnlyDictS << " dictionary) => ";
     _out.inc();
     _out << nl << "ostr.WriteDict(dictionary, "
-         << outputStreamWriter(key, ns, ForNestedType::Yes) << ", "
-         << outputStreamWriter(value, ns, ForNestedType::Yes) << ");";
+         << outputStreamWriter(key, ns, true) << ", "
+         << outputStreamWriter(value, ns, true) << ");";
     _out.dec();
 
     _out << sp;
@@ -2903,7 +2903,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     getOutParams(operation, Direction::Outgoing, requiredOutParams, taggedOutParams);
 
     bool defaultWriter = outParams.size() == 1 && !outParams.front().tagged;
-    string writer = defaultWriter ? outputStreamWriter(outParams.front().type, ns, ForNestedType::No) :
+    string writer = defaultWriter ? outputStreamWriter(outParams.front().type, ns, false) :
         "_iceD_" + opName + "Writer";
 
     bool defaultReader = inParams.size() == 1 && !inParams.front().tagged;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -154,7 +154,7 @@ Slice::CsVisitor::writeMarshalParams(const OperationPtr& op,
 
     for(const auto& param : taggedParams)
     {
-        writeTaggedMarshalCode(_out, param.type, ns, obj + param.name, param.tag, stream);
+        writeTaggedMarshalCode(_out, param.type, false, ns, obj + param.name, param.tag, stream);
     }
 }
 
@@ -192,7 +192,7 @@ Slice::CsVisitor::writeMarshalDataMember(const DataMemberPtr& member, const stri
     const string stream = customStream.empty() ? "ostr" : customStream;
     if(member->tagged())
     {
-        writeTaggedMarshalCode(_out, member->type(), ns, "this." + name, member->tag(), stream);
+        writeTaggedMarshalCode(_out, member->type(), true, ns, "this." + name, member->tag(), stream);
     }
     else
     {
@@ -371,7 +371,7 @@ getInvocationParams(const OperationPtr& op, const string& ns)
         {
             param << "in ";
         }
-        param << CsGenerator::typeToString(p->type(), ns, p->tagged() || isNullable(p->type()))
+        param << CsGenerator::typeToString(p->type(), ns, p->tagged() || isNullable(p->type()), true)
               << " "
               << fixId(p->name());
         params.push_back(param.str());
@@ -398,7 +398,7 @@ getInvocationParamsAMI(const OperationPtr& op, const string& ns, bool defaultVal
         {
             param << "in ";
         }
-        param << CsGenerator::typeToString(p->type(), ns, p->tagged() || isNullable(p->type()))
+        param << CsGenerator::typeToString(p->type(), ns, p->tagged() || isNullable(p->type()), true)
               << " "
               << fixId(prefix + p->name());
         params.push_back(param.str());
@@ -431,7 +431,7 @@ getInvocationArgsAMI(const OperationPtr& op,
                      const string cancelationToken = "global::System.Threading.CancellationToken.None",
                      const string& async = "true")
 {
-    vector<string> args = getNames(getAllInParams(op));
+    vector<string> args = getNames(getAllInParams(op, Direction::Outgoing));
 
     if(context.empty())
     {
@@ -616,6 +616,8 @@ Slice::CsVisitor::writeConstantValue(const TypePtr& type, const SyntaxTreeBasePt
 void
 Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& members, const string& ns, unsigned int baseTypes)
 {
+    // This helper function is called only for class/exception data members.
+
     for(const auto& p : members)
     {
         TypePtr type = p->type();
@@ -641,11 +643,18 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& members, con
             {
                 _out << nl << fixId(dataMemberName(p), baseTypes) << " = new " << typeToString(st, ns) << "();";
             }
-            else if(seq && !seq->hasMetaDataWithPrefix("cs:serializable:"))
+            else if(seq)
             {
                 if(seq->hasMetaDataWithPrefix("cs:generic:"))
                 {
                     _out << nl << fixId(dataMemberName(p), baseTypes) << " = new " << typeToString(type, ns) << "();";
+                }
+                else if (seq->hasMetaDataWithPrefix("cs:serializable:"))
+                {
+                    // Disable warning
+                    // TODO: do the same for all non-nullable data members once we make the parameterless constructor
+                    // private.
+                    _out << nl << fixId(dataMemberName(p), baseTypes) << " = null!;";
                 }
                 else
                 {
@@ -964,7 +973,7 @@ Slice::CsVisitor::writeOperationDocComment(const OperationPtr& p, const string& 
     writeDocCommentLines(_out, comment.summaryLines, "summary");
     writeParamDocComment(p, comment, InParam);
 
-    list<ParamInfo> outParams = getAllOutParams(p,"", true);
+    list<ParamInfo> outParams = getAllOutParams(p, dispatch ? Direction::Outgoing : Direction::Incoming, "", true);
 
     if(dispatch)
     {
@@ -1042,7 +1051,7 @@ Slice::CsVisitor::writeParamDocComment(const OperationPtr& p, const CommentInfo&
             auto i = comment.params.find(param->name());
             if(i != comment.params.end())
             {
-                writeDocCommentLines(_out, i->second, "param", "name", paramName(param));
+                writeDocCommentLines(_out, i->second, "param", "name", fixId(param->name()));
             }
         }
     }
@@ -2333,7 +2342,7 @@ namespace
 {
 
 string
-requestType(const list<ParamInfo> inParams, const list<ParamInfo>& outParams)
+requestType(const list<ParamInfo>& inParams, const list<ParamInfo>& outParams)
 {
     ostringstream os;
     if(inParams.size() == 0)
@@ -2370,15 +2379,15 @@ requestType(const list<ParamInfo> inParams, const list<ParamInfo>& outParams)
 void
 Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
 {
-    list<ParamInfo> outParams = getAllOutParams(operation);
+    list<ParamInfo> outParams = getAllOutParams(operation, Direction::Incoming);
     list<ParamInfo> requiredOutParams;
     list<ParamInfo> taggedOutParams;
-    getOutParams(operation, requiredOutParams, taggedOutParams, "iceP_");
+    getOutParams(operation, Direction::Incoming, requiredOutParams, taggedOutParams, "iceP_");
 
-    list<ParamInfo> inParams = getAllInParams(operation);
+    list<ParamInfo> inParams = getAllInParams(operation, Direction::Outgoing);
     list<ParamInfo> requiredInParams;
     list<ParamInfo> taggedInParams;
-    getInParams(operation, requiredInParams, taggedInParams);
+    getInParams(operation, Direction::Outgoing, requiredInParams, taggedInParams);
 
     ClassDefPtr cl = ClassDefPtr::dynamicCast(operation->container());
     string deprecateReason = getDeprecateReason(operation, cl, "operation");
@@ -2445,7 +2454,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
         _out.dec();
     }
 
-    outParams = getAllOutParams(operation, "iceP_", true);
+    outParams = getAllOutParams(operation, Direction::Incoming, "iceP_", true);
     string requestT = requestType(inParams, outParams);
     // Write the static outgoing request instance
     _out << sp;
@@ -2482,15 +2491,15 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestWriter(const OperationPtr& operati
     ClassDefPtr cl = ClassDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(cl);
 
-    list<ParamInfo> params = getAllInParams(operation);
+    list<ParamInfo> params = getAllInParams(operation, Direction::Outgoing);
     list<ParamInfo> requiredParams;
     list<ParamInfo> taggedParams;
-    getInParams(operation, requiredParams, taggedParams, "iceP_");
+    getInParams(operation, Direction::Outgoing, requiredParams, taggedParams, "iceP_");
 
     bool defaultWriter = params.size() == 1 && !params.front().tagged;
     if(defaultWriter)
     {
-        _out << outputStreamWriter(params.front().type, ns);
+        _out << outputStreamWriter(params.front().type, ns, ForNestedType::No);
     }
     else if(params.size() > 1)
     {
@@ -2518,10 +2527,10 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestReader(const OperationPtr& operati
     ClassDefPtr cl = ClassDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(cl);
 
-    list<ParamInfo> params = getAllOutParams(operation);
+    list<ParamInfo> params = getAllOutParams(operation, Direction::Incoming);
     list<ParamInfo> requiredParams;
     list<ParamInfo> taggedParams;
-    getOutParams(operation, requiredParams, taggedParams, "iceP_");
+    getOutParams(operation, Direction::Incoming, requiredParams, taggedParams, "iceP_");
 
     bool defaultReader = params.size() == 1 && !params.front().tagged;
 
@@ -2542,7 +2551,7 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestReader(const OperationPtr& operati
         }
         else
         {
-            params = getAllOutParams(operation, "iceP_", true);
+            params = getAllOutParams(operation, Direction::Incoming, "iceP_", true);
             _out << nl << "return " << spar << getNames(params) << epar << ";";
         }
         _out << eb;
@@ -2580,8 +2589,8 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
 {
     string name = p->name();
     string scope = getNamespace(p);
-    string seqS = typeToString(p, scope, p->hasMetaDataWithPrefix("cs:serializable:"));
-    TypePtr type = p->type();
+    string seqS = typeToString(p, scope);
+    string seqReadOnly = typeToString(p, scope, false, true);
 
     _out << sp;
     emitGeneratedCodeAttribute();
@@ -2589,13 +2598,18 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     _out << sb;
 
     _out << sp;
-    _out << nl << "public static void Write(this Ice.OutputStream ostr, " << seqS << " sequence) => ";
+    _out << nl << "public static void Write(this Ice.OutputStream ostr, " << seqReadOnly << " sequence) => ";
     _out.inc();
     _out << nl << sequenceMarshalCode(p, scope, "sequence", "ostr") << ";";
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqS << "> IceWriter = Write;";
+     _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqReadOnly << "> IceWriter = Write;";
+    // IceNestedWriter is used only when marshaling nested sequences, and we need them in the correct type because
+    // a T[] (where T : fixed size numeric type) is only implicitly converted to a ReadOnlyMemory<T>, there is no is-a
+    // relationship.
+    _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqS
+        << "> IceNestedWriter = (ostr, sequence) => Write(ostr, sequence);";
 
     _out << sp;
     _out << nl << "public static " << seqS << " Read" << name << "(this Ice.InputStream istr) => ";
@@ -2627,8 +2641,8 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     _out << nl << "public static void Write(this Ice.OutputStream ostr, "<< readOnlyDictS << " dictionary) => ";
     _out.inc();
     _out << nl << "ostr.WriteDict(dictionary, "
-         << outputStreamWriter(key, ns) << ", "
-         << outputStreamWriter(value, ns) << ");";
+         << outputStreamWriter(key, ns, ForNestedType::Yes) << ", "
+         << outputStreamWriter(value, ns, ForNestedType::Yes) << ");";
     _out.dec();
 
     _out << sp;
@@ -2791,10 +2805,10 @@ Slice::Gen::DispatcherVisitor::writeReturnValueStruct(const OperationPtr& operat
     string ns = getNamespace(cl);
     const string opName = pascalCase(operation->name());
 
-    list<ParamInfo> outParams = getAllOutParams(operation, "", true);
+    list<ParamInfo> outParams = getAllOutParams(operation, Direction::Outgoing, "", true);
     list<ParamInfo> requiredOutParams;
     list<ParamInfo> taggedOutParams;
-    getOutParams(operation, requiredOutParams, taggedOutParams, "iceP_");
+    getOutParams(operation, Direction::Incoming, requiredOutParams, taggedOutParams, "iceP_");
 
     if(operation->hasMarshaledResult())
     {
@@ -2844,7 +2858,7 @@ Slice::Gen::DispatcherVisitor::writeMethodDeclaration(const OperationPtr& operat
     string deprecateReason = getDeprecateReason(operation, cl, "operation");
     bool amd = cl->hasMetaData("amd") || operation->hasMetaData("amd");
     const string name = fixId(operationName(operation) + (amd ? "Async" : ""));
-    list<ParamInfo> inParams = getAllInParams(operation);
+    list<ParamInfo> inParams = getAllInParams(operation, Direction::Incoming);
 
     _out << sp;
     writeOperationDocComment(operation, deprecateReason, true, amd);
@@ -2878,18 +2892,19 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     string name = fixId(opName + (amd ? "Async" : ""));
     string internalName = "IceD_" + operation->name() + "Async";
 
-    list<ParamInfo> inParams = getAllInParams(operation, "iceP_");
+    list<ParamInfo> inParams = getAllInParams(operation, Direction::Incoming, "iceP_");
     list<ParamInfo> requiredInParams;
     list<ParamInfo> taggedInParams;
-    getInParams(operation, requiredInParams, taggedInParams, "iceP_");
+    getInParams(operation, Direction::Incoming, requiredInParams, taggedInParams, "iceP_");
 
-    list<ParamInfo> outParams = getAllOutParams(operation, "", true);
+    list<ParamInfo> outParams = getAllOutParams(operation, Direction::Outgoing, "", true);
     list<ParamInfo> requiredOutParams;
     list<ParamInfo> taggedOutParams;
-    getOutParams(operation, requiredOutParams, taggedOutParams);
+    getOutParams(operation, Direction::Outgoing, requiredOutParams, taggedOutParams);
 
     bool defaultWriter = outParams.size() == 1 && !outParams.front().tagged;
-    string writer = defaultWriter ? outputStreamWriter(outParams.front().type, ns) : "_iceD_" + opName + "Writer";
+    string writer = defaultWriter ? outputStreamWriter(outParams.front().type, ns, ForNestedType::No) :
+        "_iceD_" + opName + "Writer";
 
     bool defaultReader = inParams.size() == 1 && !inParams.front().tagged;
     string reader = defaultReader ? inputStreamReader(inParams.front().type, ns) : "_iceD_" + opName + "Reader";
@@ -3089,14 +3104,14 @@ Slice::Gen::ImplVisitor::visitOperation(const OperationPtr& op)
     string ns = getNamespace(cl);
     string opName = operationName(op);
 
-    list<ParamInfo> outParams = getAllOutParams(op);
+    list<ParamInfo> outParams = getAllOutParams(op, Direction::Outgoing);
 
     _out << sp << nl;
 
     if(cl->hasMetaData("amd") || op->hasMetaData("amd"))
     {
         _out << "public override " << resultTask(op, ns, true) << " " << opName << "Async" << spar
-             << getNames(getAllInParams(op))
+             << getNames(getAllInParams(op, Direction::Incoming))
              << (getUnqualified("Ice.Current", ns) + " " + getEscapedParamName(op, "current"))
              << epar;
         _out << sb;
@@ -3114,7 +3129,7 @@ Slice::Gen::ImplVisitor::visitOperation(const OperationPtr& op)
         {
             _out << nl << "return new " << opName << (op->hasMarshaledResult() ? "MarshaledResult" : "Result")
                  << spar
-                 << getNames(getAllOutParams(op, "", true));
+                 << getNames(getAllOutParams(op, Direction::Outgoing, "", true));
             if(op->hasMarshaledResult())
             {
                 _out << (getUnqualified("Ice.Current", ns) + " " + getEscapedParamName(op, "current"));
@@ -3130,7 +3145,7 @@ Slice::Gen::ImplVisitor::visitOperation(const OperationPtr& op)
     else
     {
         _out << "public override " << resultType(op, ns, true) << " " << opName << spar
-             << getNames(getAllInParams(op))
+             << getNames(getAllInParams(op, Direction::Incoming))
              << (getUnqualified("Ice.Current", ns) + " " + getEscapedParamName(op, "current"))
              << epar;
         _out << sb;
@@ -3139,7 +3154,7 @@ Slice::Gen::ImplVisitor::visitOperation(const OperationPtr& op)
         {
             _out << nl << "return new " << opName << "MarshaledResult"
                  << spar
-                 << getNames(getAllOutParams(op, "", true))
+                 << getNames(getAllOutParams(op, Direction::Outgoing, "", true))
                  << (getUnqualified("Ice.Current", ns) + " " + getEscapedParamName(op, "current"))
                  << epar << ";";
         }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2606,15 +2606,6 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     _out << sp;
     _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqReadOnly << "> IceWriter = Write;";
 
-    if (isMappedToReadOnlyMemory(p))
-    {
-        // IceNestedWriter is used only when marshaling nested sequences, and we need them in the correct type because
-        // a T[] (where T : fixed size numeric type) is only implicitly converted to a ReadOnlyMemory<T>, there is no
-        // is-a relationship.
-        _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqS
-            << "> IceNestedWriter = (ostr, sequence) => Write(ostr, sequence);";
-    }
-
     _out << sp;
     _out << nl << "public static " << seqS << " Read" << name << "(this Ice.InputStream istr) => ";
     _out.inc();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -448,12 +448,12 @@ namespace Ice
 
         /// <summary>Extracts a serializable object from the stream.</summary>
         /// <returns>The serializable object.</returns>
-        public object? ReadSerializable()
+        public object ReadSerializable()
         {
             int sz = ReadAndCheckSeqSize(1);
             if (sz == 0)
             {
-                return null;
+                throw new InvalidDataException("read an empty byte sequence for non-null serializable object");
             }
             var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, Communicator));
             return f.Deserialize(new InputStreamWrapper(this));

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -131,8 +131,8 @@ namespace IceInternal
             return found;
         }
 
-        public (LogMessage[], string)
-        GetLog(LogMessageType[] messageTypes, string[] categories, int messageMax, Current current)
+        public (IEnumerable<LogMessage>, string) GetLog(LogMessageType[] messageTypes, string[] categories,
+            int messageMax, Current current)
         {
             LinkedList<Ice.LogMessage> logMessages;
             lock (this)

--- a/csharp/src/Ice/MetricsAdminI.cs
+++ b/csharp/src/Ice/MetricsAdminI.cs
@@ -768,8 +768,7 @@ namespace IceInternal
             }
         }
 
-        public (string[], string[])
-        GetMetricsViewNames(Ice.Current current)
+        public (IEnumerable<string>, IEnumerable<string>) GetMetricsViewNames(Ice.Current current)
         {
             lock (this)
             {
@@ -797,8 +796,8 @@ namespace IceInternal
             UpdateViews();
         }
 
-        public (Dictionary<string, IceMX.Metrics?[]>, long)
-        GetMetricsView(string viewName, Ice.Current current)
+        public (IReadOnlyDictionary<string, IceMX.Metrics?[]>, long) GetMetricsView(string viewName,
+            Ice.Current current)
         {
             lock (this)
             {
@@ -808,7 +807,7 @@ namespace IceInternal
             }
         }
 
-        public IceMX.MetricsFailures[] GetMapMetricsFailures(string viewName, string mapName, Ice.Current c)
+        public IEnumerable<IceMX.MetricsFailures> GetMapMetricsFailures(string viewName, string mapName, Ice.Current c)
         {
             lock (this)
             {

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -93,7 +93,7 @@ namespace Ice
         public override void IceWrite(Ice.OutputStream s)
         {
             s.StartEndpointEncapsulation(Encoding);
-            s.WriteSpan(Bytes.Span);
+            s.WriteByteSpan(Bytes.Span);
             s.EndEndpointEncapsulation();
         }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -52,8 +52,32 @@ namespace Ice
         public static readonly OutputStreamWriter<int> IceWriterFromInt = (ostr, value) => ostr.WriteInt(value);
         public static readonly OutputStreamWriter<long> IceWriterFromLong = (ostr, value) => ostr.WriteLong(value);
         public static readonly OutputStreamWriter<float> IceWriterFromFloat = (ostr, value) => ostr.WriteFloat(value);
-        public static readonly OutputStreamWriter<double> IceWriterFromDouble = (ostr, value) => ostr.WriteDouble(value);
-        public static readonly OutputStreamWriter<string> IceWriterFromString = (ostr, value) => ostr.WriteString(value);
+        public static readonly OutputStreamWriter<double> IceWriterFromDouble =
+            (ostr, value) => ostr.WriteDouble(value);
+
+        public static readonly OutputStreamWriter<string> IceWriterFromString =
+            (ostr, value) => ostr.WriteString(value);
+
+        public static readonly OutputStreamWriter<bool[]> IceWriterFromBoolArray =
+            (ostr, value) => ostr.WriteBoolSeq(value);
+
+        public static readonly OutputStreamWriter<byte[]> IceWriterFromByteArray =
+            (ostr, value) => ostr.WriteByteSeq(value);
+
+        public static readonly OutputStreamWriter<short[]> IceWriterFromShortArray =
+            (ostr, value) => ostr.WriteShortSeq(value);
+
+        public static readonly OutputStreamWriter<int[]> IceWriterFromIntArray =
+            (ostr, value) => ostr.WriteIntSeq(value);
+
+        public static readonly OutputStreamWriter<long[]> IceWriterFromLongArray =
+            (ostr, value) => ostr.WriteLongSeq(value);
+
+        public static readonly OutputStreamWriter<float[]> IceWriterFromFloatArray =
+            (ostr, value) => ostr.WriteFloatSeq(value);
+
+        public static readonly OutputStreamWriter<double[]> IceWriterFromDoubleArray =
+            (ostr, value) => ostr.WriteDoubleSeq(value);
 
         /// <summary>The encoding used when writing to this stream.</summary>
         /// <value>The encoding.</value>

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -307,9 +307,7 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Write the header information for a tagged  value.
-        /// </summary>
+        /// <summary>Write the header information for a tagged value.</summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
         /// <param name="format">The optional format of the value.</param>
         public bool WriteOptional(int tag, OptionalFormat format)
@@ -727,7 +725,7 @@ namespace Ice
             Debug.Assert(elementSize > 0);
             if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.VSize))
             {
-                int count = v.Count(); // potentially slow Linq Count()
+                int count = value.Count(); // potentially slow Linq Count()
 
                 if (elementSize > 1)
                 {
@@ -755,7 +753,7 @@ namespace Ice
             Debug.Assert(elementSize > 0);
             if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.VSize))
             {
-                int count = v.Count(); // potentially slow Linq Count()
+                int count = value.Count(); // potentially slow Linq Count()
 
                 if (elementSize > 1)
                 {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -13,7 +13,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Ice
 {
-    public interface IStreamableStruct // value with the value-type semantics
+    public interface IStreamableStruct
     {
         public void IceWrite(OutputStream ostr);
     }
@@ -24,10 +24,10 @@ namespace Ice
     /// <summary>
     /// Interface for output streams used to write Slice types to a sequence of bytes.
     /// </summary>
-    public class OutputStream
+    public sealed class OutputStream
     {
         /// <summary>Represents a position in a list of array segments, the position
-        /// is compose of the index  of the segment in the list and the offset into
+        /// consists of the index of the segment in the list and the offset into
         /// the array.</summary>
         public struct Position
         {
@@ -55,14 +55,12 @@ namespace Ice
         public static readonly OutputStreamWriter<double> IceWriterFromDouble = (ostr, value) => ostr.WriteDouble(value);
         public static readonly OutputStreamWriter<string> IceWriterFromString = (ostr, value) => ostr.WriteString(value);
 
-        /// <summary>
-        /// The encoding used when writing from this stream.
-        /// </summary>
+        /// <summary>The encoding used when writing to this stream.</summary>
         /// <value>The encoding.</value>
         public Encoding Encoding { get; private set; }
 
-        /// <summary>Determines the current size of the stream, this correspond
-        /// to the number of bytes already written to the stream.</summary>
+        /// <summary>Determines the current size of the stream. This corresponds to the number of bytes already written
+        /// to the stream.</summary>
         /// <value>The current size.</value>
         internal int Size { get; private set; }
 
@@ -72,32 +70,41 @@ namespace Ice
 
         // The number of bytes that the stream can hold.
         private int _capacity;
+
         // Data for the class or exception instance that is currently getting marshaled.
         private InstanceData? _current;
+
         // The segment currently used by write operations, this is usually the last segment of
         // the segment list but it can occasionally be one before last after expanding the list.
         // The tail Position always points to this segment, and the tail offset indicates how much
         // of the segment has been used.
         private ArraySegment<byte> _currentSegment;
+
         // When set, we are writing an endpoint encapsulation. An endpoint encapsulation is a lightweight
         // encapsulation that cannot contain classes, exceptions, tagged members/parameters, or another
         // endpoint. It is often but not always set when _mainEncaps is set (so nested inside _mainEncaps).
         private Encaps? _endpointEncaps;
+
         // The current class/exception format, can be either Compact or Sliced.
         private readonly FormatType _format;
+
         // Map of class instance to instance ID, where the instance IDs start at 2.
         // When writing a top-level encapsulation:
         //  - Instance ID = 0 means null.
         //  - Instance ID = 1 means the instance is encoded inline afterwards.
         //  - Instance ID > 1 means a reference to a previously encoded instance, found in this map.
         private Dictionary<AnyClass, int>? _instanceMap;
+
         // When set, we are writing to a top-level encapsulation.
         private readonly Encaps? _mainEncaps;
+
         // all segments before the tail segment are fully used
         private readonly List<ArraySegment<byte>> _segmentList;
+
         // This is the position for the next write operation, it holds the index of the current
         // segment and the offset into it.
         private Position _tail;
+
         // Map of type ID string to type ID index.
         // When writing into a top-level encapsulation, we assign a type ID index (starting with 1) to each type ID we
         // write, in order.
@@ -285,9 +292,7 @@ namespace Ice
             RewriteByte((byte)_current.SliceFlags, _current.SliceFlagsPos);
         }
 
-        /// <summary>
-        /// Writes a size to the stream.
-        /// </summary>
+        /// <summary>Writes a size to the stream.</summary>
         /// <param name="v">The size to write.</param>
         public void WriteSize(int v)
         {
@@ -302,27 +307,8 @@ namespace Ice
             }
         }
 
-        /// <summary>Returns the current position and write an int (four bytes) placeholder
-        /// for a fixed-length (32-bit) size value, the position can be used to calculate and
-        /// re-write the size later.</summary>
-        public Position StartSize()
-        {
-            Position pos = _tail;
-            WriteInt(0); // Placeholder for 32-bit size
-            return pos;
-        }
-
-        /// <summary>Computes the amount of data written from the start position to the current position
-        /// and writes that value to the start position.</summary>
-        /// <param name="start">The start position.</param>
-        public void EndSize(Position start)
-        {
-            Debug.Assert(start.Offset >= 0);
-            RewriteInt(Distance(start) - 4, start);
-        }
-
         /// <summary>
-        /// Write the header information for an optional value.
+        /// Write the header information for a tagged  value.
         /// </summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
         /// <param name="format">The optional format of the value.</param>
@@ -350,10 +336,52 @@ namespace Ice
             return true;
         }
 
-        /// <summary>
-        /// Writes an optional byte to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a serializable object to the stream.</summary>
+        /// <param name="o">The serializable object to write.</param>
+        public void WriteSerializable(object o)
+        {
+            var w = new OutputStreamWrapper(this);
+            IFormatter f = new BinaryFormatter();
+            f.Serialize(w, o);
+            w.Close();
+        }
+
+        /// <summary>Writes a tagged serializable object to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="o">The serializable object to write.</param>
+        public void WriteSerializable(int tag, object? o)
+        {
+            if (o !=null && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                var w = new OutputStreamWrapper(this);
+                IFormatter f = new BinaryFormatter();
+                f.Serialize(w, o);
+                w.Close();
+            }
+        }
+
+        /// <summary>Writes a byte to the stream.</summary>
+        /// <param name="v">The byte to write.</param>
+        public void WriteByte(byte v)
+        {
+            Expand(1);
+            int offset = _tail.Offset;
+            if (offset < _currentSegment.Count)
+            {
+                _currentSegment[offset] = v;
+                _tail.Offset++;
+            }
+            else
+            {
+                _currentSegment = _segmentList[++_tail.Segment];
+                _currentSegment[0] = v;
+                _tail.Offset = 1;
+            }
+            Size++;
+        }
+
+        /// <summary>Writes a tagged byte to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The byte to write to the stream.</param>
         public void WriteByte(int tag, byte? v)
         {
@@ -363,79 +391,21 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a byte sequence to the stream.
-        /// </summary>
-        /// <param name="v">The byte sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteByteSeq(byte[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of bytes to the stream.</summary>
+        /// <param name="v">The sequence of bytes to write to the stream.</param>
+        public void WriteByteSeq(ReadOnlySpan<byte> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a byte sequence to the stream.
-        /// </summary>
-        /// <param name="v">The byte sequence to write to the stream.</param>
-        public void WriteByteSeq(IReadOnlyCollection<byte> v) => WriteSeq(v, (ostr, value) => ostr.WriteByte(value));
+        /// <summary>Writes a tagged sequence of byte to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of byte to write to the stream.</param>
+        public void WriteByteSeq(int tag, ReadOnlySpan<byte> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(byte));
 
-        /// <summary>
-        /// Writes an optional byte sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The byte sequence to write to the stream.</param>
-        public void WriteByteSeq(int tag, byte[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteByteSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional byte sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the byte sequence.</param>
-        public void WriteByteSeq(int tag, IReadOnlyCollection<byte>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteByteSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes a serializable object to the stream.
-        /// </summary>
-        /// <param name="o">The serializable object to write.</param>
-        public void WriteSerializable(object? o)
-        {
-            if (o == null)
-            {
-                WriteSize(0);
-                return;
-            }
-            else
-            {
-                var w = new OutputStreamWrapper(this);
-                IFormatter f = new BinaryFormatter();
-                f.Serialize(w, o);
-                w.Close();
-            }
-        }
-
-        /// <summary>
-        /// Writes a boolean to the stream.
-        /// </summary>
+        /// <summary>Writes a boolean to the stream.</summary>
         /// <param name="v">The boolean to write to the stream.</param>
         public void WriteBool(bool v) => WriteByte(v ? (byte)1 : (byte)0);
 
-        /// <summary>
-        /// Writes an optional boolean to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged boolean to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The boolean to write to the stream.</param>
         public void WriteBool(int tag, bool? v)
         {
@@ -445,59 +415,22 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a boolean sequence to the stream.
-        /// </summary>
-        /// <param name="v">The boolean sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteBoolSeq(bool[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of boolean to the stream.</summary>
+        /// <param name="v">The sequence of boolean.</param>
+        // Note: bool is treated as is if it was a fixed-size numeric type.
+        public void WriteBoolSeq(ReadOnlySpan<bool> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a boolean sequence to the stream.
-        /// </summary>
-        /// <param name="v">The boolean sequence to write to the stream.</param>
-        public void WriteBoolSeq(IReadOnlyCollection<bool> v) => WriteSeq(v, IceWriterFromBool);
+        /// <summary>Writes a tagged sequence of boolean to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of boolean to write to the stream.</param>
+        public void WriteBoolSeq(int tag, ReadOnlySpan<bool> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(bool));
 
-        /// <summary>
-        /// Writes an optional boolean sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The optional boolean sequence to write to the stream.</param>
-        public void WriteBoolSeq(int tag, bool[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteBoolSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional boolean sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the optional boolean sequence.</param>
-        public void WriteBoolSeq(int tag, IReadOnlyCollection<bool>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteBoolSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes a short to the stream.
-        /// </summary>
+        /// <summary>Writes a short to the stream.</summary>
         /// <param name="v">The short to write to the stream.</param>
-        public void WriteShort(short v) => WriteNumeric(v, 2);
+        public void WriteShort(short v) => WriteFixedSizeNumeric(v, sizeof(short));
 
-        /// <summary>
-        /// Writes an optional short to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged short to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The short to write to the stream.</param>
         public void WriteShort(int tag, short? v)
         {
@@ -507,64 +440,21 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a short sequence to the stream.
-        /// </summary>
-        /// <param name="v">The short sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteShortSeq(short[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of short to the stream.</summary>
+        /// <param name="v">The sequence of short to write to the stream.</param>
+        public void WriteShortSeq(ReadOnlySpan<short> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a short sequence to the stream.
-        /// </summary>
-        /// <param name="v">The short sequence to write to the stream.</param>
-        public void WriteShortSeq(IReadOnlyCollection<short> v) => WriteSeq(v, IceWriterFromShort);
+        /// <summary>Writes a tagged sequence of short to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of short to  write to the stream.</param>
+        public void WriteShortSeq(int tag, ReadOnlySpan<short> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(short));
 
-        /// <summary>
-        /// Writes an optional short sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The short sequence to write to the stream.</param>
-        public void WriteShortSeq(int tag, short[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteSize(v.Length == 0 ? 1 : (v.Length * 2) + (v.Length > 254 ? 5 : 1));
-                WriteShortSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional short sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the short sequence.</param>
-        public void WriteShortSeq(int tag, IReadOnlyCollection<short>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                int count = v.Count;
-                WriteSize(count == 0 ? 1 : (count * 2) + (count > 254 ? 5 : 1));
-                WriteShortSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an int to the stream.
-        /// </summary>
+        /// <summary>Writes an int to the stream.</summary>
         /// <param name="v">The int to write to the stream.</param>
-        public void WriteInt(int v) => WriteNumeric(v, 4);
+        public void WriteInt(int v) => WriteFixedSizeNumeric(v, sizeof(int));
 
-        internal static void WriteInt(int v, Span<byte> data) => MemoryMarshal.Write(data, ref v);
-
-        /// <summary>
-        /// Writes an optional int to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged int to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The int to write to the stream.</param>
         public void WriteInt(int tag, int? v)
         {
@@ -574,62 +464,21 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes an int sequence to the stream.
-        /// </summary>
-        /// <param name="v">The int sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteIntSeq(int[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of int to the stream.</summary>
+        /// <param name="v">The sequence of int to write to the stream.</param>
+        public void WriteIntSeq(ReadOnlySpan<int> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes an int sequence to the stream.
-        /// </summary>
-        /// <param name="v">The int sequence to write to the stream.</param>
-        public void WriteIntSeq(IReadOnlyCollection<int> v) => WriteSeq(v, IceWriterFromInt);
+        /// <summary>Writes a tagged sequence of int to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of int to write to the stream.</param>
+        public void WriteIntSeq(int tag, ReadOnlySpan<int> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(int));
 
-        /// <summary>
-        /// Writes an optional int sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The int sequence to write to the stream.</param>
-        public void WriteIntSeq(int tag, int[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteSize(v.Length == 0 ? 1 : (v.Length * 4) + (v.Length > 254 ? 5 : 1));
-                WriteIntSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional int sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the int sequence.</param>
-        public void WriteIntSeq(int tag, IReadOnlyCollection<int>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                int count = v.Count;
-                WriteSize(count == 0 ? 1 : (count * 4) + (count > 254 ? 5 : 1));
-                WriteIntSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes a long to the stream.
-        /// </summary>
+        /// <summary>Writes a long to the stream.</summary>
         /// <param name="v">The long to write to the stream.</param>
-        public void WriteLong(long v) => WriteNumeric(v, 8);
+        public void WriteLong(long v) => WriteFixedSizeNumeric(v, sizeof(long));
 
-        /// <summary>
-        /// Writes an optional long to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged long to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The long to write to the stream.</param>
         public void WriteLong(int tag, long? v)
         {
@@ -639,62 +488,21 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a long sequence to the stream.
-        /// </summary>
-        /// <param name="v">The long sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteLongSeq(long[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of long to the stream.</summary>
+        /// <param name="v">The sequence of long to write to the stream.</param>
+        public void WriteLongSeq(ReadOnlySpan<long> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a long sequence to the stream.
-        /// </summary>
-        /// <param name="v">The long sequence to write to the stream.</param>
-        public void WriteLongSeq(IReadOnlyCollection<long> v) => WriteSeq(v, IceWriterFromLong);
+        /// <summary>Writes a tagged sequence of long to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of long to write to the stream.</param>
+        public void WriteLongSeq(int tag, ReadOnlySpan<long> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(long));
 
-        /// <summary>
-        /// Writes an optional long sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The long sequence to write to the stream.</param>
-        public void WriteLongSeq(int tag, long[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteSize(v.Length == 0 ? 1 : (v.Length * 8) + (v.Length > 254 ? 5 : 1));
-                WriteLongSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional long sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the long sequence.</param>
-        public void WriteLongSeq(int tag, IReadOnlyCollection<long>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                int count = v.Count;
-                WriteSize(count == 0 ? 1 : (count * 8) + (count > 254 ? 5 : 1));
-                WriteLongSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes a float to the stream.
-        /// </summary>
+        /// <summary>Writes a float to the stream.</summary>
         /// <param name="v">The float to write to the stream.</param>
-        public void WriteFloat(float v) => WriteNumeric(v, 4);
+        public void WriteFloat(float v) => WriteFixedSizeNumeric(v, sizeof(float));
 
-        /// <summary>
-        /// Writes an optional float to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged float to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The float to write to the stream.</param>
         public void WriteFloat(int tag, float? v)
         {
@@ -704,62 +512,21 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a float sequence to the stream.
-        /// </summary>
-        /// <param name="v">The float sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteFloatSeq(float[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of float to the stream.</summary>
+        /// <param name="v">The sequence of float to write to the stream.</param>
+        public void WriteFloatSeq(ReadOnlySpan<float> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a float sequence to the stream.
-        /// </summary>
-        /// <param name="v">The float sequence to write to the stream.</param>
-        public void WriteFloatSeq(IReadOnlyCollection<float> v) => WriteSeq(v, IceWriterFromFloat);
+        /// <summary>Writes a tagged sequence of float to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of float to write to the stream.</param>
+        public void WriteFloatSeq(int tag, ReadOnlySpan<float> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(float));
 
-        /// <summary>
-        /// Writes an optional float sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The float sequence to write to the stream.</param>
-        public void WriteFloatSeq(int tag, float[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteSize(v.Length == 0 ? 1 : (v.Length * 4) + (v.Length > 254 ? 5 : 1));
-                WriteFloatSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional float sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the float sequence.</param>
-        public void WriteFloatSeq(int tag, IReadOnlyCollection<float>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                int count = v.Count;
-                WriteSize(count == 0 ? 1 : (count * 4) + (count > 254 ? 5 : 1));
-                WriteFloatSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes a double to the stream.
-        /// </summary>
+        /// <summary>Writes a double to the stream.</summary>
         /// <param name="v">The double to write to the stream.</param>
-        public void WriteDouble(double v) => WriteNumeric(v, 8);
+        public void WriteDouble(double v) => WriteFixedSizeNumeric(v, sizeof(double));
 
-        /// <summary>
-        /// Writes an optional double to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged double to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The double to write to the stream.</param>
         public void WriteDouble(int tag, double? v)
         {
@@ -769,57 +536,18 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a double sequence to the stream.
-        /// </summary>
-        /// <param name="v">The double sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteDoubleSeq(double[] v)
-        {
-            WriteSize(v.Length);
-            WriteNumericSeq(v);
-        }
+        /// <summary>Writes a sequence of double to the stream.</summary>
+        /// <param name="v">The sequence of double to  write to the stream.</param>
+        public void WriteDoubleSeq(ReadOnlySpan<double> v) => WriteFixedSizeNumericSeq(v);
 
-        /// <summary>
-        /// Writes a double sequence to the stream.
-        /// </summary>
-        /// <param name="v">The double sequence to write to the stream.</param>
-        public void WriteDoubleSeq(IReadOnlyCollection<double> v) => WriteSeq(v, IceWriterFromDouble);
-
-        /// <summary>
-        /// Writes an optional double sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The double sequence to write to the stream.</param>
-        public void WriteDoubleSeq(int tag, double[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                WriteSize(v.Length == 0 ? 1 : (v.Length * 8) + (v.Length > 254 ? 5 : 1));
-                WriteDoubleSeq(v);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional double sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the double sequence.</param>
-        public void WriteDoubleSeq(int tag, IReadOnlyCollection<double>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
-            {
-                int count = v.Count;
-                WriteSize(count == 0 ? 1 : (count * 8) + (count > 254 ? 5 : 1));
-                WriteDoubleSeq(v);
-            }
-        }
+        /// <summary>Writes a tagged sequence of double to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence of double to write to the stream.</param>
+        public void WriteDoubleSeq(int tag, ReadOnlySpan<double> v) => WriteFixedSizeNumericSeq(tag, v, sizeof(double));
 
         private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
 
-        /// <summary>
-        /// Writes a string to the stream.
-        /// </summary>
+        /// <summary>Writes a string to the stream.</summary>
         /// <param name="v">The string to write to the stream.</param>
         public void WriteString(string v)
         {
@@ -831,69 +559,26 @@ namespace Ice
             {
                 byte[] data = _utf8.GetBytes(v);
                 WriteSize(data.Length);
-                WriteSpan(data.AsSpan());
+                WriteByteSpan(data.AsSpan());
             }
         }
 
-        /// <summary>
-        /// Writes an optional string to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged string to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The string to write to the stream.</param>
         public void WriteString(int tag, string? v)
         {
-            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
+            if (v is string value && WriteOptional(tag, OptionalFormat.VSize))
             {
-                WriteString(v);
+                WriteString(value);
             }
         }
 
-        /// <summary>
-        /// Writes a string sequence to the stream.
-        /// </summary>
-        /// <param name="v">The string sequence to write to the stream.
-        /// Passing null causes an empty sequence to be written to the stream.</param>
-        public void WriteStringSeq(string[] v) => WriteSeq(v, IceWriterFromString);
-
-        /// <summary>
-        /// Writes a string sequence to the stream.
-        /// </summary>
+        /// <summary>Writes a sequence of strings to the stream.</summary>
         /// <param name="v">The string sequence to write to the stream.</param>
-        public void WriteStringSeq(IReadOnlyCollection<string> v) => WriteSeq(v, IceWriterFromString);
+        public void WriteStringSeq(IEnumerable<string> v) => WriteSeq(v, IceWriterFromString);
 
-        /// <summary>
-        /// Writes an optional string sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The string sequence to write to the stream.</param>
-        public void WriteStringSeq(int tag, string[]? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.FSize))
-            {
-                Position pos = StartSize();
-                WriteStringSeq(v);
-                EndSize(pos);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional string sequence to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">An enumerator for the string sequence.</param>
-        public void WriteStringSeq(int tag, IReadOnlyCollection<string>? v)
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.FSize))
-            {
-                Position pos = StartSize();
-                WriteStringSeq(v);
-                EndSize(pos);
-            }
-        }
-
-        /// <summary>
-        /// Writes a proxy to the stream.
-        /// </summary>
+        /// <summary>Writes a proxy to the stream.</summary>
         /// <param name="v">The proxy to write.</param>
         public void WriteProxy<T>(T? v) where T : class, IObjectPrx
         {
@@ -907,10 +592,8 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes an optional proxy to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged  proxy to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The proxy to write.</param>
         public void WriteProxy(int tag, IObjectPrx? v)
         {
@@ -922,34 +605,8 @@ namespace Ice
             }
         }
 
-        public void WriteProxySeq<T>(T[] v) where T : class, IObjectPrx => WriteSeq(v, IObjectPrx.IceWriter);
-
-        public void WriteProxySeq<T>(IReadOnlyCollection<T> v) where T : class, IObjectPrx => WriteSeq(v, IObjectPrx.IceWriter);
-
-        public void WriteProxySeq<T>(int tag, T[]? v) where T : class, IObjectPrx
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.FSize))
-            {
-                Position pos = StartSize();
-                WriteProxySeq(v);
-                EndSize(pos);
-            }
-        }
-
-        public void WriteProxySeq<T>(int tag, IReadOnlyCollection<T>? v) where T : class, IObjectPrx
-        {
-            if (v != null && WriteOptional(tag, OptionalFormat.FSize))
-            {
-                Position pos = StartSize();
-                WriteProxySeq(v);
-                EndSize(pos);
-            }
-        }
-
-        /// <summary>
-        /// Writes an optional enumerator to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
+        /// <summary>Writes a tagged enumerator to the stream.</summary>
+        /// <param name="tag">The tag.</param>
         /// <param name="v">The enumerator.</param>
         public void WriteEnum(int tag, int? v)
         {
@@ -959,10 +616,8 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes a class instance to the stream.
-        /// </summary>
-        /// <param name="v">The value to write.</param>
+        /// <summary>Writes a class instance to the stream.</summary>
+        /// <param name="v">The class instance to write.</param>
         public void WriteClass(AnyClass? v)
         {
             Debug.Assert(_mainEncaps != null && _endpointEncaps == null);
@@ -996,11 +651,9 @@ namespace Ice
             }
         }
 
-        /// <summary>
-        /// Writes an optional class instance to the stream.
-        /// </summary>
-        /// <param name="tag">The optional tag.</param>
-        /// <param name="v">The value to write.</param>
+        /// <summary>Writes a tagged class instance to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The class instance to write.</param>
         public void WriteClass(int tag, AnyClass? v)
         {
             if (v != null && WriteOptional(tag, OptionalFormat.Class))
@@ -1009,95 +662,390 @@ namespace Ice
             }
         }
 
-        public void WriteStruct<T>(in T value) where T : struct, IStreamableStruct => value.IceWrite(this);
+        /// <summary>Writes a mapped Slice struct to the stream.</summary>
+        /// <param name="v">The struct instance to write.</param>
+        public void WriteStruct<T>(in T v) where T : struct, IStreamableStruct => v.IceWrite(this);
 
-        public void WriteSeq<T>(T[] v, OutputStreamWriter<T> writer)
+        /// <summary>Writes a tagged fixed-size struct to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The struct to write.</param>
+        /// <param name="fixedSize">The size of the struct, in bytes.</param>
+        public void WriteTaggedStruct<T>(int tag, T? v, int fixedSize) where T : struct, IStreamableStruct
         {
-            WriteSize(v.Length);
+            if (v is T value && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                WriteSize(fixedSize);
+                value.IceWrite(this);
+            }
+        }
+
+        /// <summary>Writes a tagged variable-size struct to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The struct to write.</param>
+        public void WriteTaggedStruct<T>(int tag, T? v) where T : struct, IStreamableStruct
+        {
+            if (v is T value && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                var pos = StartSize();
+                value.IceWrite(this);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a sequence to the stream.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteSeq<T>(IEnumerable<T> v, OutputStreamWriter<T> writer)
+        {
+            WriteSize(v.Count()); // potentially slow Linq Count()
             foreach (T item in v)
             {
                 writer(this, item);
             }
         }
 
-        public void WriteSeq<T>(T[] v, OutputStreamStructWriter<T> writer) where T : struct
+        /// <summary>Writes a sequence to the stream. Elements of the sequence are mapped Slice structs.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteSeq<T>(IEnumerable<T> v, OutputStreamStructWriter<T> writer)
+            where T : struct, IStreamableStruct
         {
-            WriteSize(v.Length);
+            WriteSize(v.Count()); // potentially slow Linq Count()
             foreach (T item in v)
             {
                 writer(this, item);
             }
         }
 
-        public void WriteSeq<T>(IReadOnlyCollection<T> v, OutputStreamWriter<T> writer)
+        /// <summary>Writes a tagged sequence of fixed-size elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="elementSize">The fixed size of each element of the sequence, in bytes.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteTaggedSeq<T>(int tag, IEnumerable<T>? v, int elementSize, OutputStreamWriter<T> writer)
         {
-            WriteSize(v.Count);
-            foreach (T item in v)
+            Debug.Assert(elementSize > 0);
+            if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.VSize))
             {
-                writer(this, item);
+                int count = v.Count(); // potentially slow Linq Count()
+
+                if (elementSize > 1)
+                {
+                    // First write the size in bytes, so that the reader can skip it. We optimize-out this byte size
+                    // when size is 1.
+                    WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                }
+                WriteSize(count);
+                foreach (T item in value)
+                {
+                    writer(this, item);
+                }
             }
         }
 
-        public void WriteSeq<T>(IReadOnlyCollection<T> v, OutputStreamStructWriter<T> writer) where T : struct
+        /// <summary>Writes a tagged sequence of fixed-size elements to the stream. Elements of the sequence are
+        /// mapped Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="elementSize">The fixed size of each element of the sequence, in bytes.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteTaggedSeq<T>(int tag, IEnumerable<T>? v, int elementSize,
+            OutputStreamStructWriter<T> writer) where T : struct, IStreamableStruct
         {
-            WriteSize(v.Count);
-            foreach (T item in v)
+            Debug.Assert(elementSize > 0);
+            if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.VSize))
             {
-                writer(this, item);
+                int count = v.Count(); // potentially slow Linq Count()
+
+                if (elementSize > 1)
+                {
+                    // First write the size in bytes, so that the reader can skip it. We optimize-out this byte size
+                    // when size is 1.
+                    WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                }
+                WriteSize(count);
+                foreach (T item in value)
+                {
+                    writer(this, item);
+                }
             }
         }
 
-        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> dict, OutputStreamWriter<TKey> keyWriter,
+        /// <summary>Writes a tagged sequence of variable-size elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteTaggedSeq<T>(int tag, IEnumerable<T>? v, OutputStreamWriter<T> writer)
+        {
+            if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteSeq(value, writer);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of variable-size elements to the stream. Elements of the sequence are
+        /// mapped Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteTaggedSeq<T>(int tag, IEnumerable<T>? v, OutputStreamStructWriter<T> writer)
+            where T : struct, IStreamableStruct
+        {
+            if (v is IEnumerable<T> value && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteSeq(value, writer);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
+                                            OutputStreamWriter<TKey> keyWriter,
                                             OutputStreamWriter<TValue> valueWriter) where TKey : notnull
         {
-            WriteSize(dict.Count);
-            foreach ((TKey key, TValue value) in dict)
+            WriteSize(v.Count);
+            foreach ((TKey key, TValue value) in v)
             {
                 keyWriter(this, key);
                 valueWriter(this, value);
             }
         }
 
-        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> dict,
+        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
                                             OutputStreamStructWriter<TKey> keyWriter,
-                                            OutputStreamWriter<TValue> valueWriter) where TKey : struct
+                                            OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
         {
-            WriteSize(dict.Count);
-            foreach ((TKey key, TValue value) in dict)
+            WriteSize(v.Count);
+            foreach ((TKey key, TValue value) in v)
             {
                 keyWriter(this, key);
                 valueWriter(this, value);
             }
         }
 
-        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> dict, OutputStreamWriter<TKey> keyWriter,
-                                            OutputStreamStructWriter<TValue> valueWriter) where TKey : notnull
-                                                                                          where TValue : struct
+        /// <summary>Writes a dictionary to the stream. The dictionary's value is a mapped Slice struct.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
+                                            OutputStreamWriter<TKey> keyWriter,
+                                            OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : struct, IStreamableStruct
         {
-            WriteSize(dict.Count);
-            foreach ((TKey key, TValue value) in dict)
+            WriteSize(v.Count);
+            foreach ((TKey key, TValue value) in v)
             {
                 keyWriter(this, key);
                 valueWriter(this, value);
             }
         }
 
-        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> dict,
-                                            OutputStreamStructWriter<TKey> keyWriter,
-                                            OutputStreamStructWriter<TValue> valueWriter) where TKey : struct
-                                                                                          where TValue : struct
-        {
-            WriteSize(dict.Count);
-            foreach ((TKey key, TValue value) in dict)
-            {
-                keyWriter(this, key);
-                valueWriter(this, value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a user exception to the stream.
+        /// <summary>Writes a dictionary to the stream. Both the dictionary's key and value are mapped Slice structs.
         /// </summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteDict<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
+                                            OutputStreamStructWriter<TKey> keyWriter,
+                                            OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct, IStreamableStruct
+        {
+            WriteSize(v.Count);
+            foreach ((TKey key, TValue value) in v)
+            {
+                keyWriter(this, key);
+                valueWriter(this, value);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with fixed-size elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="elementSize">The size of each element (key + value), in bytes.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  int elementSize,
+                                                  OutputStreamWriter<TKey> keyWriter,
+                                                  OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+        {
+            Debug.Assert(elementSize > 1);
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                int count = dict.Count;
+                WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                WriteDict(dict, keyWriter, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with fixed-size elements to the stream. The dictionary's key is a mapped
+        /// Slice struct.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="elementSize">The size of each element (key + value), in bytes.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  int elementSize,
+                                                  OutputStreamStructWriter<TKey> keyWriter,
+                                                  OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+        {
+            Debug.Assert(elementSize > 1);
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                int count = dict.Count;
+                WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                WriteDict(dict, keyWriter, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with fixed-size elements to the stream. The dictionary's value is a
+        /// mapped Slice struct.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="elementSize">The size of each element (key + value), in bytes.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  int elementSize,
+                                                  OutputStreamWriter<TKey> keyWriter,
+                                                  OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : struct, IStreamableStruct
+        {
+            Debug.Assert(elementSize > 1);
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                int count = dict.Count;
+                WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                WriteDict(dict, keyWriter, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with fixed-size elements to the stream. Both the dictionary's key and
+        /// value are mapped Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="elementSize">The size of each element (key + value), in bytes.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  int elementSize,
+                                                  OutputStreamStructWriter<TKey> keyWriter,
+                                                  OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct, IStreamableStruct
+        {
+            Debug.Assert(elementSize > 1);
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                int count = dict.Count;
+                WriteSize(count == 0 ? 1 : (count * elementSize) + (count > 254 ? 5 : 1));
+                WriteDict(dict, keyWriter, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with variable-size elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  OutputStreamWriter<TKey> keyWriter,
+                                                  OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteDict(dict, keyWriter, valueWriter);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. The dictionary's key is
+        /// a mapped Slice struct.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  OutputStreamStructWriter<TKey> keyWriter,
+                                                  OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteDict(dict, keyWriter, valueWriter);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. The dictionary's value is
+        /// a mapped Slice struct.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  OutputStreamWriter<TKey> keyWriter,
+                                                  OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : struct, IStreamableStruct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteDict(dict, keyWriter, valueWriter);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. Both the dictionary's key and
+        /// value are mapped Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDict<TKey, TValue>(int tag,
+                                                  IReadOnlyDictionary<TKey, TValue>? v,
+                                                  OutputStreamStructWriter<TKey> keyWriter,
+                                                  OutputStreamStructWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct, IStreamableStruct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue> dict && WriteOptional(tag, OptionalFormat.FSize))
+            {
+                Position pos = StartSize();
+                WriteDict(dict, keyWriter, valueWriter);
+                EndSize(pos);
+            }
+        }
+
+        /// <summary>Writes a user exception to the stream.</summary>
         /// <param name="v">The user exception to write.</param>
         public void WriteException(RemoteException v)
         {
@@ -1141,6 +1089,8 @@ namespace Ice
             MemoryMarshal.Write(data, ref v);
             RewriteSpan(data, pos);
         }
+
+        internal static void WriteInt(int v, Span<byte> data) => MemoryMarshal.Write(data, ref v);
 
         internal void RewriteSize(int size, Position pos)
         {
@@ -1189,27 +1139,6 @@ namespace Ice
             return data;
         }
 
-        /// <summary>Write a byte to the current buffer position, the buffer is
-        /// expanded if required, the position and Size are increase.</summary>
-        /// <param name="v">The byte to write.</param>
-        public void WriteByte(byte v)
-        {
-            Expand(1);
-            int offset = _tail.Offset;
-            if (offset < _currentSegment.Count)
-            {
-                _currentSegment[offset] = v;
-                _tail.Offset++;
-            }
-            else
-            {
-                _currentSegment = _segmentList[++_tail.Segment];
-                _currentSegment[0] = v;
-                _tail.Offset = 1;
-            }
-            Size++;
-        }
-
         /// <summary>Returns the distance in bytes from start position to the current position.</summary>
         /// <param name="start">The start position from where to calculate distance to current position.</param>
         /// <returns>The distance in bytes from the current position to the start position.</returns>
@@ -1242,11 +1171,10 @@ namespace Ice
             return size + end.Offset;
         }
 
-        /// <summary>Write a span of bytes to the stream. The stream capacity is expanded
-        /// if required, the size and tail position are increased according to the span
-        /// length.</summary>
+        /// <summary>Writes a span of bytes. The stream capacity is expanded if required, the size and tail position are
+        /// increased according to the span length.</summary>
         /// <param name="span">The data to write as a span of bytes.</param>
-        public void WriteSpan(ReadOnlySpan<byte> span)
+        internal void WriteByteSpan(ReadOnlySpan<byte> span)
         {
             int length = span.Length;
             Expand(length);
@@ -1283,6 +1211,25 @@ namespace Ice
             }
         }
 
+        /// <summary>Returns the current position and write an int (four bytes) placeholder
+        /// for a fixed-length (32-bit) size value, the position can be used to calculate and
+        /// re-write the size later.</summary>
+        private Position StartSize()
+        {
+            Position pos = _tail;
+            WriteInt(0); // Placeholder for 32-bit size
+            return pos;
+        }
+
+        /// <summary>Computes the amount of data written from the start position to the current position
+        /// and writes that value to the start position.</summary>
+        /// <param name="start">The start position.</param>
+        private void EndSize(Position start)
+        {
+            Debug.Assert(start.Offset >= 0);
+            RewriteInt(Distance(start) - 4, start);
+        }
+
         /// <summary>Expand the stream to make room for more data, if the stream
         /// remaining bytes are not enough to hold the given number of bytes allocate
         /// a new byte array, after this method return the stream has enough free space
@@ -1305,42 +1252,47 @@ namespace Ice
             }
         }
 
-        /// <summary>Helper method used to write an array of numeric types to the stream.
-        /// The stream capacity is expanded if required, the size and tail position are increased
-        /// according to the length in bytes of the numeric sequence.</summary>
-        /// <param name="array">The numeric array to write to the stream.</param>
-        private void WriteNumericSeq(Array array)
-        {
-            int length = Buffer.ByteLength(array);
-            Expand(length);
-            Size += length;
-            int offset = _tail.Offset;
-            int remaining = Math.Min(_currentSegment.Count - offset, length);
-            if (remaining > 0)
-            {
-                Debug.Assert(_currentSegment.Array != null);
-                Buffer.BlockCopy(array, 0, _currentSegment.Array, _currentSegment.Offset + offset, remaining);
-                _tail.Offset += remaining;
-                length -= remaining;
-            }
-
-            if (length > 0)
-            {
-                _currentSegment = _segmentList[++_tail.Segment];
-                Debug.Assert(_currentSegment.Array != null);
-                Buffer.BlockCopy(array, remaining, _currentSegment.Array, _currentSegment.Offset, length);
-                _tail.Offset = length;
-            }
-        }
-
-        /// <summary>Helper method used to write numeric types to the stream.</summary>
+        /// <summary>Writes a fixed-size numeric to the stream.</summary>
         /// <param name="v">The numeric value to write to the stream.</param>
         /// <param name="elementSize">The size in bytes of the numeric type.</param>
-        private void WriteNumeric<T>(T v, int elementSize) where T : struct
+        private void WriteFixedSizeNumeric<T>(T v, int elementSize) where T : struct
         {
+            Debug.Assert(elementSize > 1); // for size 1, we write the byte directly
             Span<byte> data = stackalloc byte[elementSize];
             MemoryMarshal.Write(data, ref v);
-            WriteSpan(data);
+            WriteByteSpan(data);
+        }
+
+        /// <summary>Writes a sequence of fixed-size numeric type, such as int and long, to the stream.</summary>
+        /// <param name="v">The sequence of numeric types.</param>
+        // This method works because (as long as) there is no padding in the memory representation of the
+        // ReadOnlySpan.
+        private void WriteFixedSizeNumericSeq<T>(ReadOnlySpan<T> v) where T : struct
+        {
+            WriteSize(v.Length);
+            WriteByteSpan(MemoryMarshal.AsBytes(v));
+        }
+
+        /// <summary>Writes a tagged sequence of fixed-size numeric type to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="elementSize">The fixed size of each element of the sequence.</param>
+        private void WriteFixedSizeNumericSeq<T>(int tag, ReadOnlySpan<T> v, int elementSize) where T : struct
+        {
+            Debug.Assert(elementSize > 0);
+
+            // A null T[]? or List<T>? is implicitly converted into a default aka null ReadOnlyMemory<T> or
+            // ReadOnlySpan<T>. Furthermore, the span of a default ReadOnlyMemory<T> is a default ReadOnlySpan<T>, which
+            // is distinct from the span of an empty sequence. This is why the "v != null" below works correctly.
+            if (v != null && WriteOptional(tag, OptionalFormat.VSize))
+            {
+                if (elementSize > 1)
+                {
+                    // This size is redundant and optimized out by the encoding when elementSize is 1.
+                    WriteSize(v.Length == 0 ? 1 : (v.Length * elementSize) + (v.Length > 254 ? 5 : 1));
+                }
+                WriteFixedSizeNumericSeq(v);
+            }
         }
 
         internal void StartEndpointEncapsulation() => StartEndpointEncapsulation(Encoding);
@@ -1369,9 +1321,7 @@ namespace Ice
             _endpointEncaps = null;
         }
 
-        /// <summary>
-        /// Writes an empty encapsulation.
-        /// </summary>
+        /// <summary>Writes an empty encapsulation.</summary>
         internal Position WriteEmptyEncapsulation(Encoding encoding)
         {
             WriteEncapsulationHeader(6, encoding);
@@ -1402,7 +1352,7 @@ namespace Ice
                 firstSlice = false;
 
                 // Write the bytes associated with this slice.
-                WriteSpan(info.Bytes.Span);
+                WriteByteSpan(info.Bytes.Span);
 
                 if (info.HasOptionalMembers)
                 {

--- a/csharp/src/Ice/PropertiesAdmin.cs
+++ b/csharp/src/Ice/PropertiesAdmin.cs
@@ -27,7 +27,7 @@ namespace Ice
 
         public string GetProperty(string key, Current current) => _communicator.GetProperty(key) ?? "";
 
-        public Dictionary<string, string> GetPropertiesForPrefix(string prefix, Current current) =>
+        public IReadOnlyDictionary<string, string> GetPropertiesForPrefix(string prefix, Current current) =>
             _communicator.GetProperties(forPrefix: prefix);
 
         public void SetProperties(Dictionary<string, string> newProperties, Current current)

--- a/csharp/src/Ice/StreamWrapper.cs
+++ b/csharp/src/Ice/StreamWrapper.cs
@@ -52,7 +52,7 @@ namespace Ice
                 {
                     Debug.Assert(_pos <= _data.Length);
                     _stream.WriteSize(_pos);
-                    _stream.WriteSpan(_data.AsSpan(0, _pos));
+                    _stream.WriteByteSpan(_data.AsSpan(0, _pos));
                 }
                 else
                 {
@@ -94,14 +94,14 @@ namespace Ice
                     if (_pos > 0)
                     {
                         // Write the current contents of _data.
-                        _stream.WriteSpan(_data.AsSpan(0, _pos));
+                        _stream.WriteByteSpan(_data.AsSpan(0, _pos));
                     }
 
                     _data = null;
                 }
 
                 // Write data passed by caller.
-                _stream.WriteSpan(buffer);
+                _stream.WriteByteSpan(buffer);
                 _pos += buffer.Length;
             }
             catch (Exception ex)
@@ -128,7 +128,7 @@ namespace Ice
                     if (_pos > 0)
                     {
                         // Write the current contents of _data.
-                        _stream.WriteSpan(_data.AsSpan(0, _pos));
+                        _stream.WriteByteSpan(_data.AsSpan(0, _pos));
                     }
 
                     _data = null;

--- a/csharp/test/Ice/adapterDeactivation/Servant.cs
+++ b/csharp/test/Ice/adapterDeactivation/Servant.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Test;
 
@@ -15,7 +16,7 @@ namespace Ice.adapterDeactivation
         public IObjectPrx GetServerProxy(Current current) =>
             IObjectPrx.Parse($"dummy:tcp -h localhost -p {_nextPort++} -t 30000", current.Adapter.Communicator);
 
-        public IObjectPrx?[] AddProxies(IObjectPrx?[] proxies, Current current) => Array.Empty<IObjectPrx?>();
+        public IEnumerable<IObjectPrx?> AddProxies(IObjectPrx?[] proxies, Current current) => Array.Empty<IObjectPrx?>();
 
         private int _nextPort = 23456;
     }

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -24,7 +24,8 @@ namespace Ice.admin
 
         public IObjectPrx? getAdmin(Current current) => _communicator.GetAdmin();
 
-        public Dictionary<string, string> getChanges(Current current) => new Dictionary<string, string>(_changes!);
+        public IReadOnlyDictionary<string, string> getChanges(Current current) =>
+            new Dictionary<string, string>(_changes!);
 
         public void print(string message, Current current) => _communicator.Logger.Print(message);
 

--- a/csharp/test/Ice/background/Server.cs
+++ b/csharp/test/Ice/background/Server.cs
@@ -49,7 +49,7 @@ public class Server : TestHelper
             return null;
         }
 
-        public IObjectPrx[] AddProxies(IObjectPrx?[] proxies, Current current) => new IObjectPrx[0];
+        public IEnumerable<IObjectPrx> AddProxies(IObjectPrx?[] proxies, Current current) => new IObjectPrx[0];
 
         internal RouterI(BackgroundController controller) => _controller = controller;
 

--- a/csharp/test/Ice/dictMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/dictMapping/MyClassAMDI.cs
@@ -15,30 +15,32 @@ namespace Ice.dictMapping.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<(Dictionary<int, int>, Dictionary<int, int>)>
-        opNVAsync(Dictionary<int, int> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<int, int>, IReadOnlyDictionary<int, int>)> opNVAsync(
+            Dictionary<int, int> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, string>, Dictionary<string, string>)>
-        opNRAsync(Dictionary<string, string> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>)> opNRAsync(
+            Dictionary<string, string> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, Dictionary<int, int>>, Dictionary<string, Dictionary<int, int>>)>
-        opNDVAsync(Dictionary<string, Dictionary<int, int>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, Dictionary<int, int>>, IReadOnlyDictionary<string, Dictionary<int, int>>)>
+        opNDVAsync(Dictionary<string, Dictionary<int, int>> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, Dictionary<string, string>>, Dictionary<string, Dictionary<string, string>>)>
-        opNDRAsync(Dictionary<string, Dictionary<string, string>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, Dictionary<string, string>>, IReadOnlyDictionary<string, Dictionary<string, string>>)>
+        opNDRAsync(Dictionary<string, Dictionary<string, string>> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, int[]>, Dictionary<string, int[]>)>
-        opNDAISAsync(Dictionary<string, int[]> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, int[]>, IReadOnlyDictionary<string, int[]>)>
+        opNDAISAsync(Dictionary<string, int[]> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, List<int>>, Dictionary<string, List<int>>)>
-        opNDGISAsync(Dictionary<string, List<int>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, List<int>>, IReadOnlyDictionary<string, List<int>>)>
+        opNDGISAsync(Dictionary<string, List<int>> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, string[]>, Dictionary<string, string[]>)>
-        opNDASSAsync(Dictionary<string, string[]> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, string[]>, IReadOnlyDictionary<string, string[]>)>
+        opNDASSAsync(Dictionary<string, string[]> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Dictionary<string, List<string>>, Dictionary<string, List<string>>)>
-        opNDGSSAsync(Dictionary<string, List<string>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IReadOnlyDictionary<string, List<string>>, IReadOnlyDictionary<string, List<string>>)>
+        opNDGSSAsync(Dictionary<string, List<string>> i, Current current) => ToReturnValue(i);
 
-        internal static ValueTask<T> FromResult<T>(T result) => new ValueTask<T>(result);
+        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>
+        ToReturnValue<TKey, TValue>(Dictionary<TKey, TValue> input) where TKey : notnull =>
+            new ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>((input, input));
     }
 }

--- a/csharp/test/Ice/dictMapping/MyClassI.cs
+++ b/csharp/test/Ice/dictMapping/MyClassI.cs
@@ -10,28 +10,28 @@ namespace Ice.dictMapping
     {
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
 
-        public (Dictionary<int, int>, Dictionary<int, int>)
+        public (IReadOnlyDictionary<int, int>, IReadOnlyDictionary<int, int>)
         opNV(Dictionary<int, int> i, Current current) => (i, i);
 
-        public (Dictionary<string, string>, Dictionary<string, string>)
+        public (IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>)
         opNR(Dictionary<string, string> i, Current current) => (i, i);
 
-        public (Dictionary<string, Dictionary<int, int>>, Dictionary<string, Dictionary<int, int>>)
+        public (IReadOnlyDictionary<string, Dictionary<int, int>>, IReadOnlyDictionary<string, Dictionary<int, int>>)
         opNDV(Dictionary<string, Dictionary<int, int>> i, Current current) => (i, i);
 
-        public (Dictionary<string, Dictionary<string, string>>, Dictionary<string, Dictionary<string, string>>)
+        public (IReadOnlyDictionary<string, Dictionary<string, string>>, IReadOnlyDictionary<string, Dictionary<string, string>>)
         opNDR(Dictionary<string, Dictionary<string, string>> i, Current current) => (i, i);
 
-        public (Dictionary<string, int[]>, Dictionary<string, int[]>)
+        public (IReadOnlyDictionary<string, int[]>, IReadOnlyDictionary<string, int[]>)
         opNDAIS(Dictionary<string, int[]> i, Current current) => (i, i);
 
-        public (Dictionary<string, List<int>>, Dictionary<string, List<int>>)
+        public (IReadOnlyDictionary<string, List<int>>, IReadOnlyDictionary<string, List<int>>)
         opNDGIS(Dictionary<string, List<int>> i, Current current) => (i, i);
 
-        public (Dictionary<string, string[]>, Dictionary<string, string[]>)
+        public (IReadOnlyDictionary<string, string[]>, IReadOnlyDictionary<string, string[]>)
         opNDASS(Dictionary<string, string[]> i, Current current) => (i, i);
 
-        public (Dictionary<string, List<string>>, Dictionary<string, List<string>>)
+        public (IReadOnlyDictionary<string, List<string>>, IReadOnlyDictionary<string, List<string>>)
         opNDGSS(Dictionary<string, List<string>> i, Current current) => (i, i);
     }
 }

--- a/csharp/test/Ice/enums/TestI.cs
+++ b/csharp/test/Ice/enums/TestI.cs
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Collections.Generic;
+
 namespace Ice.enums
 {
     public class TestIntf : Test.ITestIntf
@@ -18,16 +20,16 @@ namespace Ice.enums
         public (Test.SimpleEnum, Test.SimpleEnum)
         opSimple(Test.SimpleEnum s1, Current current) => (s1, s1);
 
-        public (Test.ByteEnum[], Test.ByteEnum[])
+        public (IEnumerable<Test.ByteEnum>, IEnumerable<Test.ByteEnum>)
         opByteSeq(Test.ByteEnum[] b1, Current current) => (b1, b1);
 
-        public (Test.ShortEnum[], Test.ShortEnum[])
+        public (IEnumerable<Test.ShortEnum>, IEnumerable<Test.ShortEnum>)
         opShortSeq(Test.ShortEnum[] s1, Current current) => (s1, s1);
 
-        public (Test.IntEnum[], Test.IntEnum[])
+        public (IEnumerable<Test.IntEnum>, IEnumerable<Test.IntEnum>)
         opIntSeq(Test.IntEnum[] i1, Current current) => (i1, i1);
 
-        public (Test.SimpleEnum[], Test.SimpleEnum[])
+        public (IEnumerable<Test.SimpleEnum>, IEnumerable<Test.SimpleEnum>)
         opSimpleSeq(Test.SimpleEnum[] s1, Current current) => (s1, s1);
 
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();

--- a/csharp/test/Ice/exceptions/ThrowerAMDI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerAMDI.cs
@@ -87,9 +87,9 @@ namespace Ice
                     return new ValueTask(Task.CompletedTask);
                 }
 
-                public ValueTask<byte[]>
+                public ValueTask<ReadOnlyMemory<byte>>
                 throwMemoryLimitExceptionAsync(byte[] seq, Current current) =>
-                    new ValueTask<byte[]>(new byte[1024 * 20]); // 20KB is over the configured 10KB message size max.
+                    new ValueTask<ReadOnlyMemory<byte>>(new byte[1024 * 20]); // 20KB is over the configured 10KB message size max.
 
                 public ValueTask
                 throwLocalExceptionIdempotentAsync(Current current) =>

--- a/csharp/test/Ice/exceptions/ThrowerI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using Test;
 
 namespace Ice.exceptions
@@ -43,7 +44,7 @@ namespace Ice.exceptions
         public void throwAssertException(Current current) => TestHelper.Assert(false);
 
         // 20KB is over the configured 10KB message size max.
-        public byte[] throwMemoryLimitException(byte[] seq, Current current) => new byte[1024 * 20];
+        public ReadOnlyMemory<byte> throwMemoryLimitException(byte[] seq, Current current) => new byte[1024 * 20];
 
         public void throwLocalExceptionIdempotent(Current current) => throw new ConnectionTimeoutException();
 

--- a/csharp/test/Ice/info/TestI.cs
+++ b/csharp/test/Ice/info/TestI.cs
@@ -36,7 +36,7 @@ namespace Ice.info
 
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
 
-        public Dictionary<string, string> getEndpointInfoAsContext(Current current)
+        public IReadOnlyDictionary<string, string> getEndpointInfoAsContext(Current current)
         {
             TestHelper.Assert(current.Connection != null);
             var ctx = new Dictionary<string, string>();
@@ -61,7 +61,7 @@ namespace Ice.info
             return ctx;
         }
 
-        public Dictionary<string, string> getConnectionInfoAsContext(Current current)
+        public IReadOnlyDictionary<string, string> getConnectionInfoAsContext(Current current)
         {
             TestHelper.Assert(current.Connection != null);
             var ctx = new Dictionary<string, string>();

--- a/csharp/test/Ice/objects/InitialI.cs
+++ b/csharp/test/Ice/objects/InitialI.cs
@@ -47,10 +47,10 @@ namespace Ice.objects
 
         public (AnyClass?, AnyClass?) opClass(AnyClass? v1, Current current) => (v1, v1);
 
-        public (AnyClass?[], AnyClass?[]) opClassSeq(AnyClass?[] v1, Current current) => (v1, v1);
+        public (IEnumerable<AnyClass?>, IEnumerable<AnyClass?>) opClassSeq(AnyClass?[] v1, Current current) => (v1, v1);
 
-        public (Dictionary<string, AnyClass?>, Dictionary<string, AnyClass?>)
-        opClassMap(Dictionary<string, AnyClass?> v1, Current current) => (v1, v1);
+        public (IReadOnlyDictionary<string, AnyClass?>, IReadOnlyDictionary<string, AnyClass?>) opClassMap(
+            Dictionary<string, AnyClass?> v1, Current current) => (v1, v1);
 
         public void setRecursive(Test.Recursive? r, Current current)
         {
@@ -66,8 +66,8 @@ namespace Ice.objects
         public void setG(Test.G? theG, Current current)
         {
         }
-        public (Test.Base?[], Test.Base?[])
-        opBaseSeq(Test.Base?[] inS, Current current) => (inS, inS);
+        public (IEnumerable<Test.Base?>, IEnumerable<Test.Base?>) opBaseSeq(Test.Base?[] inS, Current current) =>
+            (inS, inS);
 
         public Test.Compact getCompact(Current current) => new Test.CompactExt();
 

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -49,7 +49,7 @@ namespace Ice.operations.AMD
 
         public void IcePing(Current current) => TestHelper.Assert(current.IsIdempotent);
 
-        public string[] IceIds(Current current)
+        public IEnumerable<string> IceIds(Current current)
         {
             TestHelper.Assert(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds();
@@ -73,7 +73,7 @@ namespace Ice.operations.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<bool> supportsCompressAsync(Current current) => FromResult(true);
+        public ValueTask<bool> supportsCompressAsync(Current current) => MakeValueTask(true);
 
         public ValueTask opVoidAsync(Current current)
         {
@@ -90,9 +90,10 @@ namespace Ice.operations.AMD
             return new ValueTask(_opVoidThread.Task);
         }
 
-        public ValueTask<(bool, bool)> opBoolAsync(bool p1, bool p2, Current current) => FromResult((p2, p1));
+        public ValueTask<(bool, bool)> opBoolAsync(bool p1, bool p2, Current current) => MakeValueTask((p2, p1));
 
-        public ValueTask<(bool[], bool[])> opBoolSAsync(bool[] p1, bool[] p2, Current current)
+        public ValueTask<(ReadOnlyMemory<bool>, ReadOnlyMemory<bool>)> opBoolSAsync(bool[] p1, bool[] p2,
+            Current current)
         {
             bool[] p3 = new bool[p1.Length + p2.Length];
             Array.Copy(p1, p3, p1.Length);
@@ -104,10 +105,10 @@ namespace Ice.operations.AMD
                 r[i] = p1[p1.Length - (i + 1)];
             }
 
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(bool[][], bool[][])>
+        public ValueTask<(IEnumerable<bool[]>, IEnumerable<bool[]>)>
         opBoolSSAsync(bool[][] p1, bool[][] p2, Current current)
         {
             bool[][] p3 = new bool[p1.Length + p2.Length][];
@@ -120,12 +121,12 @@ namespace Ice.operations.AMD
                 r[i] = p1[p1.Length - (i + 1)];
             }
 
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(byte, byte)> opByteAsync(byte p1, byte p2, Current current) => FromResult((p1, (byte)(p1 ^ p2)));
+        public ValueTask<(byte, byte)> opByteAsync(byte p1, byte p2, Current current) => MakeValueTask((p1, (byte)(p1 ^ p2)));
 
-        public ValueTask<(Dictionary<byte, bool>, Dictionary<byte, bool>)>
+        public ValueTask<(IReadOnlyDictionary<byte, bool>, IReadOnlyDictionary<byte, bool>)>
         opByteBoolDAsync(Dictionary<byte, bool> p1, Dictionary<byte, bool> p2, Current current)
         {
             Dictionary<byte, bool> p3 = p1;
@@ -138,11 +139,11 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(byte[], byte[])>
-        opByteSAsync(byte[] p1, byte[] p2, Current current)
+        public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> opByteSAsync(byte[] p1, byte[] p2,
+            Current current)
         {
             byte[] p3 = new byte[p1.Length];
             for (int i = 0; i < p1.Length; i++)
@@ -154,10 +155,10 @@ namespace Ice.operations.AMD
             Array.Copy(p1, r, p1.Length);
             Array.Copy(p2, 0, r, p1.Length, p2.Length);
 
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(byte[][], byte[][])>
+        public ValueTask<(IEnumerable<byte[]>, IEnumerable<byte[]>)>
         opByteSSAsync(byte[][] p1, byte[][] p2, Current current)
         {
             byte[][] p3 = new byte[p1.Length][];
@@ -170,14 +171,14 @@ namespace Ice.operations.AMD
             Array.Copy(p1, r, p1.Length);
             Array.Copy(p2, 0, r, p1.Length, p2.Length);
 
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
         public ValueTask<(double, float, double)>
-        opFloatDoubleAsync(float p1, double p2, Current current) => FromResult((p2, p1, p2));
+        opFloatDoubleAsync(float p1, double p2, Current current) => MakeValueTask((p2, p1, p2));
 
-        public ValueTask<(double[], float[], double[])>
-        opFloatDoubleSAsync(float[] p1, double[] p2, Current current)
+        public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<float>, ReadOnlyMemory<double>)> opFloatDoubleSAsync(
+            float[] p1, double[] p2, Current current)
         {
             float[] p3 = p1;
 
@@ -194,10 +195,10 @@ namespace Ice.operations.AMD
                 r[p2.Length + i] = p1[i];
             }
 
-            return FromResult((r, p3, p4));
+            return MakeValueTask(((ReadOnlyMemory<double>)r, (ReadOnlyMemory<float>)p3, (ReadOnlyMemory<double>)p4));
         }
 
-        public ValueTask<(double[][], float[][], double[][])>
+        public ValueTask<(IEnumerable<double[]>, IEnumerable<float[]>, IEnumerable<double[]>)>
         opFloatDoubleSSAsync(float[][] p1, double[][] p2, Current current)
         {
             var p3 = p1;
@@ -219,10 +220,10 @@ namespace Ice.operations.AMD
                 }
             }
 
-            return FromResult((r, p3, p4));
+            return MakeValueTask((r as IEnumerable<double[]>, p3 as IEnumerable<float[]>, p4 as IEnumerable<double[]>));
         }
 
-        public ValueTask<(Dictionary<long, float>, Dictionary<long, float>)>
+        public ValueTask<(IReadOnlyDictionary<long, float>, IReadOnlyDictionary<long, float>)>
         opLongFloatDAsync(Dictionary<long, float> p1, Dictionary<long, float> p2, Current current)
         {
             var p3 = p1;
@@ -236,7 +237,7 @@ namespace Ice.operations.AMD
                 r[e.Key] = e.Value;
             }
 
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
         public ValueTask<(Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?)>
@@ -244,14 +245,14 @@ namespace Ice.operations.AMD
         {
             var p2 = p1;
             var p3 = current.Adapter.CreateProxy("noSuchIdentity", Test.IMyClassPrx.Factory);
-            return FromResult<(Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?)>((
+            return new ValueTask<(Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?)>((
                 current.Adapter.CreateProxy(current.Identity, Test.IMyClassPrx.Factory), p2, p3));
         }
 
         public ValueTask<(Test.MyEnum, Test.MyEnum)>
-        opMyEnumAsync(Test.MyEnum p1, Current current) => FromResult((Test.MyEnum.enum3, p1));
+        opMyEnumAsync(Test.MyEnum p1, Current current) => MakeValueTask((Test.MyEnum.enum3, p1));
 
-        public ValueTask<(Dictionary<short, int>, Dictionary<short, int>)>
+        public ValueTask<(IReadOnlyDictionary<short, int>, IReadOnlyDictionary<short, int>)>
         opShortIntDAsync(Dictionary<short, int> p1, Dictionary<short, int> p2, Current current)
         {
             var p3 = p1;
@@ -264,13 +265,13 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
         public ValueTask<(long, short, int, long)>
-        opShortIntLongAsync(short p1, int p2, long p3, Current current) => FromResult((p3, p1, p2, p3));
+        opShortIntLongAsync(short p1, int p2, long p3, Current current) => MakeValueTask((p3, p1, p2, p3));
 
-        public ValueTask<(long[], short[], int[], long[])>
+        public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<short>, ReadOnlyMemory<int>, ReadOnlyMemory<long>)>
         opShortIntLongSAsync(short[] p1, int[] p2, long[] p3, Current current)
         {
             var p4 = p1;
@@ -282,10 +283,11 @@ namespace Ice.operations.AMD
             var p6 = new long[p3.Length + p3.Length];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return FromResult((p3, p4, p5, p6));
+            return MakeValueTask(((ReadOnlyMemory<long>)p3, (ReadOnlyMemory<short>)p4, (ReadOnlyMemory<int>)p5,
+                (ReadOnlyMemory<long>)p6));
         }
 
-        public ValueTask<(long[][], short[][], int[][], long[][])>
+        public ValueTask<(IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>)>
         opShortIntLongSSAsync(short[][] p1, int[][] p2, long[][] p3, Current current)
         {
             var p4 = p1;
@@ -299,13 +301,14 @@ namespace Ice.operations.AMD
             var p6 = new long[p3.Length + p3.Length][];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return FromResult((p3, p4, p5, p6));
+            return MakeValueTask((p3 as IEnumerable<long[]>, p4 as IEnumerable<short[]>, p5 as IEnumerable<int[]>,
+                p6 as IEnumerable<long[]>));
         }
 
         public ValueTask<(string, string)>
-        opStringAsync(string p1, string p2, Current current) => FromResult(($"{p1} {p2}", $"{p2} {p1}"));
+        opStringAsync(string p1, string p2, Current current) => MakeValueTask(($"{p1} {p2}", $"{p2} {p1}"));
 
-        public ValueTask<(Dictionary<string, Test.MyEnum>, Dictionary<string, Test.MyEnum>)>
+        public ValueTask<(IReadOnlyDictionary<string, Test.MyEnum>, IReadOnlyDictionary<string, Test.MyEnum>)>
         opStringMyEnumDAsync(Dictionary<string, Test.MyEnum> p1, Dictionary<string, Test.MyEnum> p2, Current current)
         {
             var p3 = p1;
@@ -318,10 +321,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<Test.MyEnum, string>, Dictionary<Test.MyEnum, string>)>
+        public ValueTask<(IReadOnlyDictionary<Test.MyEnum, string>, IReadOnlyDictionary<Test.MyEnum, string>)>
         opMyEnumStringDAsync(Dictionary<Test.MyEnum, string> p1, Dictionary<Test.MyEnum, string> p2, Current current)
         {
             var p3 = p1;
@@ -334,10 +337,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<Test.MyStruct, Test.MyEnum>, Dictionary<Test.MyStruct, Test.MyEnum>)>
+        public ValueTask<(IReadOnlyDictionary<Test.MyStruct, Test.MyEnum>, IReadOnlyDictionary<Test.MyStruct, Test.MyEnum>)>
         opMyStructMyEnumDAsync(Dictionary<Test.MyStruct, Test.MyEnum> p1,
                                Dictionary<Test.MyStruct, Test.MyEnum> p2, Current current)
         {
@@ -351,10 +354,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<byte, bool>[], Dictionary<byte, bool>[])>
+        public ValueTask<(IEnumerable<Dictionary<byte, bool>>, IEnumerable<Dictionary<byte, bool>>)>
         opByteBoolDSAsync(Dictionary<byte, bool>[] p1, Dictionary<byte, bool>[] p2, Current current)
         {
             var p3 = new Dictionary<byte, bool>[p1.Length + p2.Length];
@@ -366,10 +369,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<short, int>[], Dictionary<short, int>[])>
+        public ValueTask<(IEnumerable<Dictionary<short, int>>, IEnumerable<Dictionary<short, int>>)>
         opShortIntDSAsync(Dictionary<short, int>[] p1, Dictionary<short, int>[] p2, Current current)
         {
             var p3 = new Dictionary<short, int>[p1.Length + p2.Length];
@@ -381,10 +384,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<long, float>[], Dictionary<long, float>[])>
+        public ValueTask<(IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>)>
         opLongFloatDSAsync(Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
         {
             var p3 = new Dictionary<long, float>[p1.Length + p2.Length];
@@ -396,10 +399,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, string>[], Dictionary<string, string>[])>
+        public ValueTask<(IEnumerable<Dictionary<string, string>>, IEnumerable<Dictionary<string, string>>)>
         opStringStringDSAsync(Dictionary<string, string>[] p1, Dictionary<string, string>[] p2, Current current)
         {
             var p3 = new Dictionary<string, string>[p1.Length + p2.Length];
@@ -411,10 +414,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, Test.MyEnum>[], Dictionary<string, Test.MyEnum>[])>
+        public ValueTask<(IEnumerable<Dictionary<string, Test.MyEnum>>, IEnumerable<Dictionary<string, Test.MyEnum>>)>
         opStringMyEnumDSAsync(Dictionary<string, Test.MyEnum>[] p1, Dictionary<string, Test.MyEnum>[] p2, Current current)
         {
             var p3 = new Dictionary<string, Test.MyEnum>[p1.Length + p2.Length];
@@ -426,10 +429,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<Test.MyEnum, string>[], Dictionary<Test.MyEnum, string>[])>
+        public ValueTask<(IEnumerable<Dictionary<Test.MyEnum, string>>, IEnumerable<Dictionary<Test.MyEnum, string>>)>
         opMyEnumStringDSAsync(Dictionary<Test.MyEnum, string>[] p1, Dictionary<Test.MyEnum, string>[] p2, Current current)
         {
             var p3 = new Dictionary<Test.MyEnum, string>[p1.Length + p2.Length];
@@ -441,10 +444,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<Test.MyStruct, Test.MyEnum>[], Dictionary<Test.MyStruct, Test.MyEnum>[])>
+        public ValueTask<(IEnumerable<Dictionary<Test.MyStruct, Test.MyEnum>>, IEnumerable<Dictionary<Test.MyStruct, Test.MyEnum>>)>
         opMyStructMyEnumDSAsync(Dictionary<Test.MyStruct, Test.MyEnum>[] p1,
                                 Dictionary<Test.MyStruct, Test.MyEnum>[] p2,
                                 Current current)
@@ -458,10 +461,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<byte, byte[]>, Dictionary<byte, byte[]>)>
+        public ValueTask<(IReadOnlyDictionary<byte, byte[]>, IReadOnlyDictionary<byte, byte[]>)>
         opByteByteSDAsync(Dictionary<byte, byte[]> p1, Dictionary<byte, byte[]> p2, Current current)
         {
             var p3 = p2;
@@ -474,10 +477,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<bool, bool[]>, Dictionary<bool, bool[]>)>
+        public ValueTask<(IReadOnlyDictionary<bool, bool[]>, IReadOnlyDictionary<bool, bool[]>)>
         opBoolBoolSDAsync(Dictionary<bool, bool[]> p1, Dictionary<bool, bool[]> p2, Current current)
         {
             var p3 = p2;
@@ -490,10 +493,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<short, short[]>, Dictionary<short, short[]>)>
+        public ValueTask<(IReadOnlyDictionary<short, short[]>, IReadOnlyDictionary<short, short[]>)>
         opShortShortSDAsync(Dictionary<short, short[]> p1, Dictionary<short, short[]> p2, Current current)
         {
             var p3 = p2;
@@ -506,10 +509,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<int, int[]>, Dictionary<int, int[]>)>
+        public ValueTask<(IReadOnlyDictionary<int, int[]>, IReadOnlyDictionary<int, int[]>)>
         opIntIntSDAsync(Dictionary<int, int[]> p1, Dictionary<int, int[]> p2, Current current)
         {
             var p3 = p2;
@@ -522,10 +525,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<long, long[]>, Dictionary<long, long[]>)>
+        public ValueTask<(IReadOnlyDictionary<long, long[]>, IReadOnlyDictionary<long, long[]>)>
         opLongLongSDAsync(Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current)
         {
             var p3 = p2;
@@ -538,10 +541,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, float[]>, Dictionary<string, float[]>)>
+        public ValueTask<(IReadOnlyDictionary<string, float[]>, IReadOnlyDictionary<string, float[]>)>
         opStringFloatSDAsync(Dictionary<string, float[]> p1, Dictionary<string, float[]> p2, Current current)
         {
             var p3 = p2;
@@ -554,10 +557,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, double[]>, Dictionary<string, double[]>)>
+        public ValueTask<(IReadOnlyDictionary<string, double[]>, IReadOnlyDictionary<string, double[]>)>
         opStringDoubleSDAsync(Dictionary<string, double[]> p1, Dictionary<string, double[]> p2, Current current)
         {
             var p3 = p2;
@@ -570,10 +573,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, string[]>, Dictionary<string, string[]>)>
+        public ValueTask<(IReadOnlyDictionary<string, string[]>, IReadOnlyDictionary<string, string[]>)>
         opStringStringSDAsync(Dictionary<string, string[]> p1, Dictionary<string, string[]> p2, Current current)
         {
             var p3 = p2;
@@ -586,10 +589,10 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<Test.MyEnum, Test.MyEnum[]>, Dictionary<Test.MyEnum, Test.MyEnum[]>)>
+        public ValueTask<(IReadOnlyDictionary<Test.MyEnum, Test.MyEnum[]>, IReadOnlyDictionary<Test.MyEnum, Test.MyEnum[]>)>
         opMyEnumMyEnumSDAsync(Dictionary<Test.MyEnum, Test.MyEnum[]> p1, Dictionary<Test.MyEnum, Test.MyEnum[]> p2,
             Current current)
         {
@@ -603,22 +606,21 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<int[]>
-        opIntSAsync(int[] s, Current current)
+        public ValueTask<ReadOnlyMemory<int>> opIntSAsync(int[] s, Current current)
         {
             var r = new int[s.Length];
             for (int i = 0; i < s.Length; ++i)
             {
                 r[i] = -s[i];
             }
-            return FromResult(r);
+            return MakeValueTask((ReadOnlyMemory<int>)r);
         }
 
-        public ValueTask<Dictionary<string, string>>
-        opContextAsync(Current current) => FromResult(current.Context);
+        public ValueTask<IReadOnlyDictionary<string, string>> opContextAsync(Current current) =>
+            MakeValueTask(current.Context as IReadOnlyDictionary<string, string>);
 
         public ValueTask
         opByteSOnewayAsync(byte[] s, Current current)
@@ -637,7 +639,7 @@ namespace Ice.operations.AMD
             {
                 var count = _opByteSOnewayCallCount;
                 _opByteSOnewayCallCount = 0;
-                return FromResult(count);
+                return MakeValueTask(count);
             }
         }
 
@@ -653,7 +655,7 @@ namespace Ice.operations.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<(string[], string[])>
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)>
         opStringSAsync(string[] p1, string[] p2, Current current)
         {
             var p3 = new string[p1.Length + p2.Length];
@@ -665,10 +667,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p1[p1.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(string[][], string[][])>
+        public ValueTask<(IEnumerable<string[]>, IEnumerable<string[]>)>
         opStringSSAsync(string[][] p1, string[][] p2, Current current)
         {
             var p3 = new string[p1.Length + p2.Length][];
@@ -679,10 +681,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p2[p2.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(string[][][], string[][][])>
+        public ValueTask<(IEnumerable<string[][]>, IEnumerable<string[][]>)>
         opStringSSSAsync(string[][][] p1, string[][][] p2, Current current)
         {
             var p3 = new string[p1.Length + p2.Length][][];
@@ -694,10 +696,10 @@ namespace Ice.operations.AMD
             {
                 r[i] = p2[p2.Length - (i + 1)];
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(Dictionary<string, string>, Dictionary<string, string>)>
+        public ValueTask<(IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>)>
         opStringStringDAsync(Dictionary<string, string> p1, Dictionary<string, string> p2, Current current)
         {
             var p3 = p1;
@@ -710,7 +712,7 @@ namespace Ice.operations.AMD
             {
                 r[e.Key] = e.Value;
             }
-            return FromResult((r, p3));
+            return ToReturnValue(r, p3);
         }
 
         public ValueTask<(Test.Structure, Test.Structure)>
@@ -718,7 +720,7 @@ namespace Ice.operations.AMD
         {
             var p3 = p1;
             p3.s.s = "a new string";
-            return FromResult((p2, p3));
+            return MakeValueTask((p2, p3));
         }
 
         public ValueTask
@@ -738,48 +740,50 @@ namespace Ice.operations.AMD
         opDerivedAsync(Current current) => new ValueTask(Task.CompletedTask);
 
         public ValueTask<byte>
-        opByte1Async(byte value, Current current) => FromResult(value);
+        opByte1Async(byte value, Current current) => MakeValueTask(value);
 
         public ValueTask<short>
-        opShort1Async(short value, Current current) => FromResult(value);
+        opShort1Async(short value, Current current) => MakeValueTask(value);
 
         public ValueTask<int>
-        opInt1Async(int value, Current current) => FromResult(value);
+        opInt1Async(int value, Current current) => MakeValueTask(value);
 
         public ValueTask<long>
-        opLong1Async(long value, Current current) => FromResult(value);
+        opLong1Async(long value, Current current) => MakeValueTask(value);
 
         public ValueTask<float>
-        opFloat1Async(float value, Current current) => FromResult(value);
+        opFloat1Async(float value, Current current) => MakeValueTask(value);
 
         public ValueTask<double>
-        opDouble1Async(double value, Current current) => FromResult(value);
+        opDouble1Async(double value, Current current) => MakeValueTask(value);
 
         public ValueTask<string>
-        opString1Async(string value, Current current) => FromResult(value);
+        opString1Async(string value, Current current) => MakeValueTask(value);
 
-        public ValueTask<string[]>
-        opStringS1Async(string[] value, Current current) => FromResult(value);
+        public ValueTask<IEnumerable<string>>
+        opStringS1Async(string[] value, Current current) => MakeValueTask(value as IEnumerable<string>);
 
-        public ValueTask<Dictionary<byte, bool>>
-        opByteBoolD1Async(Dictionary<byte, bool> value, Current current) => FromResult(value);
+        public ValueTask<IReadOnlyDictionary<byte, bool>>
+        opByteBoolD1Async(Dictionary<byte, bool> value, Current current) =>
+            MakeValueTask(value as IReadOnlyDictionary<byte, bool>);
 
-        public ValueTask<string[]>
-        opStringS2Async(string[] value, Current current) => FromResult(value);
+        public ValueTask<IEnumerable<string>>
+        opStringS2Async(string[] value, Current current) => MakeValueTask(value as IEnumerable<string>);
 
-        public ValueTask<Dictionary<byte, bool>>
-        opByteBoolD2Async(Dictionary<byte, bool> value, Current current) => FromResult(value);
+        public ValueTask<IReadOnlyDictionary<byte, bool>>
+        opByteBoolD2Async(Dictionary<byte, bool> value, Current current) =>
+            MakeValueTask(value as IReadOnlyDictionary<byte, bool>);
 
         public ValueTask<Test.MyClass1?>
-        opMyClass1Async(Test.MyClass1? value, Current current) => FromResult(value);
+        opMyClass1Async(Test.MyClass1? value, Current current) => MakeValueTask(value);
 
         public ValueTask<Test.MyStruct1>
-        opMyStruct1Async(Test.MyStruct1 value, Current current) => FromResult(value);
+        opMyStruct1Async(Test.MyStruct1 value, Current current) => MakeValueTask(value);
 
-        public ValueTask<string[]>
+        public ValueTask<IEnumerable<string>>
         opStringLiteralsAsync(Current current)
         {
-            return FromResult(new string[]
+            return MakeValueTask(new string[]
                 {
                         Test.s0.value,
                         Test.s1.value,
@@ -814,13 +818,13 @@ namespace Ice.operations.AMD
                         Test.su0.value,
                         Test.su1.value,
                         Test.su2.value
-                });
+                } as IEnumerable<string>);
         }
 
-        public ValueTask<string[]>
+        public ValueTask<IEnumerable<string>>
         opWStringLiteralsAsync(Current current)
         {
-            return FromResult(new string[]
+            return MakeValueTask(new string[]
                 {
                         Test.s0.value,
                         Test.s1.value,
@@ -856,7 +860,7 @@ namespace Ice.operations.AMD
                         Test.su0.value,
                         Test.su1.value,
                         Test.su2.value
-                });
+                } as IEnumerable<string>);
         }
 
         public async ValueTask<Test.IMyClass.OpMStruct1MarshaledReturnValue>
@@ -902,7 +906,20 @@ namespace Ice.operations.AMD
             return new Test.IMyClass.OpMDict2MarshaledReturnValue(p1, p1, current);
         }
 
-        internal static ValueTask<T> FromResult<T>(T result) => new ValueTask<T>(result);
+        // Type-inference helper method
+        private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
+
+        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(T[] input1,
+            T[] input2) where T : struct =>
+                new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input1, input2));
+
+        private static ValueTask<(IEnumerable<T>, IEnumerable<T>)> ToReturnValue<T>(IEnumerable<T> input1,
+            IEnumerable<T> input2) => new ValueTask<(IEnumerable<T>, IEnumerable<T>)>((input1, input2));
+
+        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>
+        ToReturnValue<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> input1,
+            IReadOnlyDictionary<TKey, TValue> input2) where TKey : notnull =>
+            new ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>((input1, input2));
 
         private Thread_opVoid? _opVoidThread;
         private int _opByteSOnewayCallCount = 0;

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -21,7 +21,7 @@ namespace Ice.operations
 
         public void IcePing(Current current) => TestHelper.Assert(current.IsIdempotent);
 
-        public string[] IceIds(Current current)
+        public IEnumerable<string> IceIds(Current current)
         {
             TestHelper.Assert(current.IsIdempotent);
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds();
@@ -42,7 +42,7 @@ namespace Ice.operations
 
         public (bool, bool) opBool(bool p1, bool p2, Current current) => (p2, p1);
 
-        public (bool[], bool[]) opBoolS(bool[] p1, bool[] p2, Current current)
+        public (ReadOnlyMemory<bool>, ReadOnlyMemory<bool>) opBoolS(bool[] p1, bool[] p2, Current current)
         {
             var p3 = new bool[p1.Length + p2.Length];
             Array.Copy(p1, p3, p1.Length);
@@ -56,7 +56,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (bool[][], bool[][]) opBoolSS(bool[][] p1, bool[][] p2, Current current)
+        public (IEnumerable<bool[]>, IEnumerable<bool[]>) opBoolSS(bool[][] p1, bool[][] p2, Current current)
         {
             var p3 = new bool[p1.Length + p2.Length][];
             Array.Copy(p1, p3, p1.Length);
@@ -72,8 +72,8 @@ namespace Ice.operations
 
         public (byte, byte) opByte(byte p1, byte p2, Current current) => (p1, (byte)(p1 ^ p2));
 
-        public (Dictionary<byte, bool>, Dictionary<byte, bool>)
-        opByteBoolD(Dictionary<byte, bool> p1, Dictionary<byte, bool> p2, Current current)
+        public (IReadOnlyDictionary<byte, bool>, IReadOnlyDictionary<byte, bool>) opByteBoolD(
+            Dictionary<byte, bool> p1, Dictionary<byte, bool> p2, Current current)
         {
             var r = new Dictionary<byte, bool>();
             foreach (KeyValuePair<byte, bool> e in p1)
@@ -87,7 +87,7 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (byte[], byte[]) opByteS(byte[] p1, byte[] p2, Current current)
+        public (ReadOnlyMemory<byte>, ReadOnlyMemory<byte>) opByteS(byte[] p1, byte[] p2, Current current)
         {
             var p3 = new byte[p1.Length];
             for (int i = 0; i < p1.Length; i++)
@@ -101,7 +101,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (byte[][], byte[][]) opByteSS(byte[][] p1, byte[][] p2, Current current)
+        public (IEnumerable<byte[]>, IEnumerable<byte[]>) opByteSS(byte[][] p1, byte[][] p2, Current current)
         {
             var p3 = new byte[p1.Length][];
             for (int i = 0; i < p1.Length; i++)
@@ -117,7 +117,8 @@ namespace Ice.operations
 
         public (double, float, double) opFloatDouble(float p1, double p2, Current current) => (p2, p1, p2);
 
-        public (double[], float[], double[]) opFloatDoubleS(float[] p1, double[] p2, Current current)
+        public (ReadOnlyMemory<double>, ReadOnlyMemory<float>, ReadOnlyMemory<double>) opFloatDoubleS(float[] p1,
+            double[] p2, Current current)
         {
             var p4 = new double[p2.Length];
             for (int i = 0; i < p2.Length; i++)
@@ -134,8 +135,8 @@ namespace Ice.operations
             return (r, p1, p4);
         }
 
-        public (double[][], float[][], double[][])
-        opFloatDoubleSS(float[][] p1, double[][] p2, Current current)
+        public (IEnumerable<double[]>, IEnumerable<float[]>, IEnumerable<double[]>) opFloatDoubleSS(float[][] p1,
+            double[][] p2, Current current)
         {
             var p4 = new double[p2.Length][];
             for (int i = 0; i < p2.Length; i++)
@@ -156,8 +157,8 @@ namespace Ice.operations
             return (r, p1, p4);
         }
 
-        public (Dictionary<long, float>, Dictionary<long, float>)
-        opLongFloatD(Dictionary<long, float> p1, Dictionary<long, float> p2, Current current)
+        public (IReadOnlyDictionary<long, float>, IReadOnlyDictionary<long, float>) opLongFloatD(
+            Dictionary<long, float> p1, Dictionary<long, float> p2, Current current)
         {
             var r = new Dictionary<long, float>();
             foreach (KeyValuePair<long, float> e in p1)
@@ -171,16 +172,16 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?)
-        opMyClass(Test.IMyClassPrx? p1, Current current) =>
+        public (Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?) opMyClass(Test.IMyClassPrx? p1,
+            Current current) =>
             (current.Adapter.CreateProxy(current.Identity, Test.IMyClassPrx.Factory),
             p1,
             current.Adapter.CreateProxy("noSuchIdentity", Test.IMyClassPrx.Factory));
 
         public (Test.MyEnum, Test.MyEnum) opMyEnum(Test.MyEnum p1, Current current) => (Test.MyEnum.enum3, p1);
 
-        public (Dictionary<short, int>, Dictionary<short, int>)
-        opShortIntD(Dictionary<short, int> p1, Dictionary<short, int> p2, Current current)
+        public (IReadOnlyDictionary<short, int>, IReadOnlyDictionary<short, int>) opShortIntD(Dictionary<short, int> p1,
+            Dictionary<short, int> p2, Current current)
         {
             var r = new Dictionary<short, int>();
             foreach (KeyValuePair<short, int> e in p1)
@@ -194,10 +195,10 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (long, short, int, long)
-        opShortIntLong(short p1, int p2, long p3, Current current) => (p3, p1, p2, p3);
+        public (long, short, int, long) opShortIntLong(short p1, int p2, long p3, Current current) => (p3, p1, p2, p3);
 
-        public (long[], short[], int[], long[]) opShortIntLongS(short[] p1, int[] p2, long[] p3, Current current)
+        public (ReadOnlyMemory<long>, ReadOnlyMemory<short>, ReadOnlyMemory<int>, ReadOnlyMemory<long>) opShortIntLongS(
+            short[] p1, int[] p2, long[] p3, Current current)
         {
             var p5 = new int[p2.Length];
             for (int i = 0; i < p2.Length; i++)
@@ -212,8 +213,8 @@ namespace Ice.operations
             return (p3, p1, p5, p6);
         }
 
-        public (long[][], short[][], int[][], long[][])
-        opShortIntLongSS(short[][] p1, int[][] p2, long[][] p3, Current current)
+        public (IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>) opShortIntLongSS(
+            short[][] p1, int[][] p2, long[][] p3, Current current)
         {
             var p5 = new int[p2.Length][];
             for (int i = 0; i < p2.Length; i++)
@@ -230,8 +231,8 @@ namespace Ice.operations
 
         public (string, string) opString(string p1, string p2, Current current) => (p1 + " " + p2, p2 + " " + p1);
 
-        public (Dictionary<string, Test.MyEnum>, Dictionary<string, Test.MyEnum>)
-        opStringMyEnumD(Dictionary<string, Test.MyEnum> p1, Dictionary<string, Test.MyEnum> p2, Current current)
+        public (IReadOnlyDictionary<string, Test.MyEnum>, IReadOnlyDictionary<string, Test.MyEnum>) opStringMyEnumD(
+            Dictionary<string, Test.MyEnum> p1, Dictionary<string, Test.MyEnum> p2, Current current)
         {
             var r = new Dictionary<string, Test.MyEnum>();
             foreach (KeyValuePair<string, Test.MyEnum> e in p1)
@@ -245,8 +246,8 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (Dictionary<Test.MyEnum, string>, Dictionary<Test.MyEnum, string>)
-        opMyEnumStringD(Dictionary<Test.MyEnum, string> p1, Dictionary<Test.MyEnum, string> p2, Current current)
+        public (IReadOnlyDictionary<Test.MyEnum, string>, IReadOnlyDictionary<Test.MyEnum, string>) opMyEnumStringD(
+            Dictionary<Test.MyEnum, string> p1, Dictionary<Test.MyEnum, string> p2, Current current)
         {
             var r = new Dictionary<Test.MyEnum, string>();
             foreach (var e in p1)
@@ -260,7 +261,7 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (Dictionary<Test.MyStruct, Test.MyEnum>, Dictionary<Test.MyStruct, Test.MyEnum>)
+        public (IReadOnlyDictionary<Test.MyStruct, Test.MyEnum>, IReadOnlyDictionary<Test.MyStruct, Test.MyEnum>)
         opMyStructMyEnumD(Dictionary<Test.MyStruct, Test.MyEnum> p1, Dictionary<Test.MyStruct, Test.MyEnum> p2,
             Current current)
         {
@@ -276,7 +277,7 @@ namespace Ice.operations
             return (r, p1);
         }
 
-        public (Dictionary<byte, bool>[], Dictionary<byte, bool>[]) opByteBoolDS(
+        public (IEnumerable<Dictionary<byte, bool>>, IEnumerable<Dictionary<byte, bool>>) opByteBoolDS(
             Dictionary<byte, bool>[] p1, Dictionary<byte, bool>[] p2, Current current)
         {
             var p3 = new Dictionary<byte, bool>[p1.Length + p2.Length];
@@ -291,8 +292,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<short, int>[], Dictionary<short, int>[])
-        opShortIntDS(Dictionary<short, int>[] p1, Dictionary<short, int>[] p2, Current current)
+        public (IEnumerable<Dictionary<short, int>>, IEnumerable<Dictionary<short, int>>) opShortIntDS(
+            Dictionary<short, int>[] p1, Dictionary<short, int>[] p2, Current current)
         {
             var p3 = new Dictionary<short, int>[p1.Length + p2.Length];
             Array.Copy(p2, p3, p2.Length);
@@ -306,8 +307,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<long, float>[], Dictionary<long, float>[])
-        opLongFloatDS(Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
+        public (IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>) opLongFloatDS(
+            Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
         {
             var p3 = new Dictionary<long, float>[p1.Length + p2.Length];
             Array.Copy(p2, p3, p2.Length);
@@ -321,8 +322,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<string, string>[], Dictionary<string, string>[])
-        opStringStringDS(Dictionary<string, string>[] p1, Dictionary<string, string>[] p2, Current current)
+        public (IEnumerable<Dictionary<string, string>>, IEnumerable<Dictionary<string, string>>) opStringStringDS(
+            Dictionary<string, string>[] p1, Dictionary<string, string>[] p2, Current current)
         {
             var p3 = new Dictionary<string, string>[p1.Length + p2.Length];
             Array.Copy(p2, p3, p2.Length);
@@ -336,7 +337,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<string, Test.MyEnum>[], Dictionary<string, Test.MyEnum>[])
+        public (IEnumerable<Dictionary<string, Test.MyEnum>>, IEnumerable<Dictionary<string, Test.MyEnum>>)
         opStringMyEnumDS(Dictionary<string, Test.MyEnum>[] p1, Dictionary<string, Test.MyEnum>[] p2, Current current)
         {
             var p3 = new Dictionary<string, Test.MyEnum>[p1.Length + p2.Length];
@@ -351,7 +352,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<Test.MyEnum, string>[], Dictionary<Test.MyEnum, string>[])
+        public (IEnumerable<Dictionary<Test.MyEnum, string>>, IEnumerable<Dictionary<Test.MyEnum, string>>)
         opMyEnumStringDS(Dictionary<Test.MyEnum, string>[] p1,
                          Dictionary<Test.MyEnum, string>[] p2,
                             Current current)
@@ -368,7 +369,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<Test.MyStruct, Test.MyEnum>[], Dictionary<Test.MyStruct, Test.MyEnum>[])
+        public (IEnumerable<Dictionary<Test.MyStruct, Test.MyEnum>>,
+                IEnumerable<Dictionary<Test.MyStruct, Test.MyEnum>>)
         opMyStructMyEnumDS(Dictionary<Test.MyStruct, Test.MyEnum>[] p1,
             Dictionary<Test.MyStruct, Test.MyEnum>[] p2,
             Current current)
@@ -385,8 +387,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<byte, byte[]>, Dictionary<byte, byte[]>)
-        opByteByteSD(Dictionary<byte, byte[]> p1,
+        public (IReadOnlyDictionary<byte, byte[]>, IReadOnlyDictionary<byte, byte[]>) opByteByteSD(
+            Dictionary<byte, byte[]> p1,
             Dictionary<byte, byte[]> p2,
             Current current)
         {
@@ -402,8 +404,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<bool, bool[]>, Dictionary<bool, bool[]>)
-        opBoolBoolSD(Dictionary<bool, bool[]> p1, Dictionary<bool, bool[]> p2, Current current)
+        public (IReadOnlyDictionary<bool, bool[]>, IReadOnlyDictionary<bool, bool[]>) opBoolBoolSD(
+            Dictionary<bool, bool[]> p1, Dictionary<bool, bool[]> p2, Current current)
         {
             var r = new Dictionary<bool, bool[]>();
             foreach (KeyValuePair<bool, bool[]> e in p1)
@@ -417,8 +419,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<short, short[]>, Dictionary<short, short[]>)
-        opShortShortSD(Dictionary<short, short[]> p1, Dictionary<short, short[]> p2, Current current)
+        public (IReadOnlyDictionary<short, short[]>, IReadOnlyDictionary<short, short[]>) opShortShortSD(
+            Dictionary<short, short[]> p1, Dictionary<short, short[]> p2, Current current)
         {
             var r = new Dictionary<short, short[]>();
             foreach (KeyValuePair<short, short[]> e in p1)
@@ -432,8 +434,7 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<int, int[]>, Dictionary<int, int[]>)
-        opIntIntSD(Dictionary<int, int[]> p1,
+        public (IReadOnlyDictionary<int, int[]>, IReadOnlyDictionary<int, int[]>) opIntIntSD(Dictionary<int, int[]> p1,
             Dictionary<int, int[]> p2,
             Current current)
         {
@@ -449,8 +450,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<long, long[]>, Dictionary<long, long[]>)
-        opLongLongSD(Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current)
+        public (IReadOnlyDictionary<long, long[]>, IReadOnlyDictionary<long, long[]>) opLongLongSD(
+            Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current)
         {
             var r = new Dictionary<long, long[]>();
             foreach (KeyValuePair<long, long[]> e in p1)
@@ -464,8 +465,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<string, float[]>, Dictionary<string, float[]>)
-        opStringFloatSD(Dictionary<string, float[]> p1, Dictionary<string, float[]> p2, Current current)
+        public (IReadOnlyDictionary<string, float[]>, IReadOnlyDictionary<string, float[]>) opStringFloatSD(
+            Dictionary<string, float[]> p1, Dictionary<string, float[]> p2, Current current)
         {
             var r = new Dictionary<string, float[]>();
             foreach (KeyValuePair<string, float[]> e in p1)
@@ -479,8 +480,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<string, double[]>, Dictionary<string, double[]>)
-        opStringDoubleSD(Dictionary<string, double[]> p1, Dictionary<string, double[]> p2, Current current)
+        public (IReadOnlyDictionary<string, double[]>, IReadOnlyDictionary<string, double[]>) opStringDoubleSD(
+            Dictionary<string, double[]> p1, Dictionary<string, double[]> p2, Current current)
         {
             var r = new Dictionary<string, double[]>();
             foreach (KeyValuePair<string, double[]> e in p1)
@@ -494,8 +495,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<string, string[]>, Dictionary<string, string[]>)
-        opStringStringSD(Dictionary<string, string[]> p1, Dictionary<string, string[]> p2, Current current)
+        public (IReadOnlyDictionary<string, string[]>, IReadOnlyDictionary<string, string[]>) opStringStringSD(
+            Dictionary<string, string[]> p1, Dictionary<string, string[]> p2, Current current)
         {
             var r = new Dictionary<string, string[]>();
             foreach (KeyValuePair<string, string[]> e in p1)
@@ -509,7 +510,8 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public (Dictionary<Test.MyEnum, Test.MyEnum[]>, Dictionary<Test.MyEnum, Test.MyEnum[]>) opMyEnumMyEnumSD(
+        public (IReadOnlyDictionary<Test.MyEnum, Test.MyEnum[]>, IReadOnlyDictionary<Test.MyEnum, Test.MyEnum[]>)
+        opMyEnumMyEnumSD(
             Dictionary<Test.MyEnum, Test.MyEnum[]> p1,
             Dictionary<Test.MyEnum, Test.MyEnum[]> p2,
             Current ice)
@@ -526,7 +528,7 @@ namespace Ice.operations
             return (r, p2);
         }
 
-        public int[] opIntS(int[] s, Current current)
+        public ReadOnlyMemory<int> opIntS(int[] s, Current current)
         {
             int[] r = new int[s.Length];
             for (int i = 0; i < s.Length; ++i)
@@ -554,7 +556,7 @@ namespace Ice.operations
             }
         }
 
-        public Dictionary<string, string> opContext(Current current) =>
+        public IReadOnlyDictionary<string, string> opContext(Current current) =>
             current.Context == null ? new Dictionary<string, string>() : new Dictionary<string, string>(current.Context);
 
         public void opDoubleMarshaling(double p1, double[] p2, Current current)
@@ -567,8 +569,7 @@ namespace Ice.operations
             }
         }
 
-        public (string[], string[])
-        opStringS(string[] p1, string[] p2, Current current)
+        public (IEnumerable<string>, IEnumerable<string>) opStringS(string[] p1, string[] p2, Current current)
         {
             var p3 = new string[p1.Length + p2.Length];
             Array.Copy(p1, p3, p1.Length);
@@ -582,8 +583,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (string[][], string[][])
-        opStringSS(string[][] p1, string[][] p2, Current current)
+        public (IEnumerable<string[]>, IEnumerable<string[]>) opStringSS(string[][] p1, string[][] p2, Current current)
         {
             var p3 = new string[p1.Length + p2.Length][];
             Array.Copy(p1, p3, p1.Length);
@@ -597,8 +597,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (string[][][], string[][][])
-        opStringSSS(string[][][] p1, string[][][] p2, Current current)
+        public (IEnumerable<string[][]>, IEnumerable<string[][]>) opStringSSS(string[][][] p1, string[][][] p2,
+            Current current)
         {
             var p3 = new string[p1.Length + p2.Length][][];
             Array.Copy(p1, p3, p1.Length);
@@ -612,8 +612,8 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Dictionary<string, string>, Dictionary<string, string>)
-        opStringStringD(Dictionary<string, string> p1,
+        public (IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>) opStringStringD(
+            Dictionary<string, string> p1,
             Dictionary<string, string> p2,
             Current current)
         {
@@ -630,8 +630,7 @@ namespace Ice.operations
             return (r, p3);
         }
 
-        public (Test.Structure, Test.Structure)
-        opStruct(Test.Structure p1, Test.Structure p2, Current current)
+        public (Test.Structure, Test.Structure) opStruct(Test.Structure p1, Test.Structure p2, Current current)
         {
             var p3 = p1;
             p3.s.s = "a new string";
@@ -661,20 +660,21 @@ namespace Ice.operations
 
         public string opString1(string opString1, Current current) => opString1;
 
-        public string[] opStringS1(string[] opStringS1, Current current) => opStringS1;
+        public IEnumerable<string> opStringS1(string[] opStringS1, Current current) => opStringS1;
 
-        public Dictionary<byte, bool> opByteBoolD1(Dictionary<byte, bool> opByteBoolD1, Current current) => opByteBoolD1;
+        public IReadOnlyDictionary<byte, bool> opByteBoolD1(Dictionary<byte, bool> opByteBoolD1, Current current) =>
+            opByteBoolD1;
 
-        public string[] opStringS2(string[] opStringS2, Current current) => opStringS2;
+        public IEnumerable<string> opStringS2(string[] opStringS2, Current current) => opStringS2;
 
-        public Dictionary<byte, bool>
-        opByteBoolD2(Dictionary<byte, bool> opByteBoolD2, Current current) => opByteBoolD2;
+        public IReadOnlyDictionary<byte, bool> opByteBoolD2(Dictionary<byte, bool> opByteBoolD2, Current current) =>
+            opByteBoolD2;
 
         public Test.MyClass1? opMyClass1(Test.MyClass1? c, Current current) => c;
 
         public Test.MyStruct1 opMyStruct1(Test.MyStruct1 s, Current current) => s;
 
-        public string[] opStringLiterals(Current current)
+        public IEnumerable<string> opStringLiterals(Current current)
         {
             return new string[]
                 {
@@ -715,7 +715,7 @@ namespace Ice.operations
                 };
         }
 
-        public string[] opWStringLiterals(Current current) => opStringLiterals(current);
+        public IEnumerable<string> opWStringLiterals(Current current) => opStringLiterals(current);
 
         public Test.IMyClass.OpMStruct1MarshaledReturnValue opMStruct1(Current current) =>
             new Test.IMyClass.OpMStruct1MarshaledReturnValue(

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -965,10 +965,7 @@ namespace Ice.optional
                     (OutputStream ostr, VarStruct? p1) =>
                     {
                         TestHelper.Assert(p1 != null);
-                        ostr.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = ostr.StartSize();
-                        p1.Value.IceWrite(ostr);
-                        ostr.EndSize(pos);
+                        ostr.WriteTaggedStruct(2, p1);
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1070,13 +1067,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opOneOptionalProxy", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, IObjectPrx? p1) =>
-                    {
-                        ostr.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = ostr.StartSize();
-                        ostr.WriteProxy(p1);
-                        ostr.EndSize(pos);
-                    });
+                    (OutputStream ostr, IObjectPrx? p1) => ostr.WriteProxy(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
 
@@ -1426,14 +1417,7 @@ namespace Ice.optional
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opStringSeq", idempotent: false,
                     format: null, context: null, p1,
                     (OutputStream ostr, string[]? p1) =>
-                    {
-                        if (p1 != null && ostr.WriteOptional(2, OptionalFormat.FSize))
-                        {
-                            OutputStream.Position pos = ostr.StartSize();
-                            ostr.WriteStringSeq(p1);
-                            ostr.EndSize(pos);
-                        }
-                    });
+                        ostr.WriteTaggedSeq(2, p1, (ost, s) => ostr.WriteString(s)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1478,7 +1462,7 @@ namespace Ice.optional
                         if (p1 != null && ostr.WriteOptional(2, OptionalFormat.VSize))
                         {
                             ostr.WriteSize(p1.Length + (p1.Length > 254 ? 5 : 1));
-                            ostr.Write(p1);
+                            SmallStructSeqHelper.Write(ostr, p1);
                         }
                     });
 
@@ -1529,7 +1513,7 @@ namespace Ice.optional
                         TestHelper.Assert(p1 != null);
                         ostr.WriteOptional(2, OptionalFormat.VSize);
                         ostr.WriteSize(p1.Count + (p1.Count > 254 ? 5 : 1));
-                        ostr.Write(p1);
+                        SmallStructListHelper.Write(ostr, p1);
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1575,7 +1559,7 @@ namespace Ice.optional
                         TestHelper.Assert(p1 != null);
                         ostr.WriteOptional(2, OptionalFormat.VSize);
                         ostr.WriteSize((p1.Length * 4) + (p1.Length > 254 ? 5 : 1));
-                        ostr.Write(p1);
+                        FixedStructSeqHelper.Write(ostr, p1);
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1625,7 +1609,7 @@ namespace Ice.optional
                         TestHelper.Assert(p1 != null);
                         ostr.WriteOptional(2, OptionalFormat.VSize);
                         ostr.WriteSize((p1.Count * 4) + (p1.Count > 254 ? 5 : 1));
-                        ostr.Write(p1);
+                        FixedStructListHelper.Write(ostr, p1);
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1668,10 +1652,7 @@ namespace Ice.optional
                     (OutputStream ostr, VarStruct[]? p1) =>
                     {
                         TestHelper.Assert(p1 != null);
-                        ostr.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = ostr.StartSize();
-                        ostr.Write(p1);
-                        ostr.EndSize(pos);
+                        ostr.WriteTaggedSeq(2, p1, (ostr, vs) => ostr.WriteStruct(vs));
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1807,10 +1788,8 @@ namespace Ice.optional
                     (OutputStream ostr, Dictionary<string, int>? p1) =>
                     {
                         TestHelper.Assert(p1 != null);
-                        ostr.WriteOptional(2, OptionalFormat.FSize);
-                        OutputStream.Position pos = ostr.StartSize();
-                        ostr.Write(p1);
-                        ostr.EndSize(pos);
+                        ostr.WriteTaggedDict(2, p1,
+                            (ostr, k) => ostr.WriteString(k), (ostr, v) => ostr.WriteInt(v));
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
@@ -1853,14 +1832,7 @@ namespace Ice.optional
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opIntOneOptionalDict", idempotent: false,
                     format: null, context: null, p1,
                     (OutputStream ostr, Dictionary<int, OneOptional?>? p1) =>
-                    {
-                        if (p1 != null && ostr.WriteOptional(2, OptionalFormat.FSize))
-                        {
-                            OutputStream.Position pos = ostr.StartSize();
-                            ostr.Write(p1);
-                            ostr.EndSize(pos);
-                        }
-                    });
+                        ostr.WriteTaggedDict(2, p1, (ostr, k) => ostr.WriteInt(k), (ostr, v) => ostr.WriteClass(v)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>

--- a/csharp/test/Ice/optional/TestAMDI.cs
+++ b/csharp/test/Ice/optional/TestAMDI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace Ice.optional.AMD
         }
 
         public ValueTask<AnyClass?>
-        pingPongAsync(AnyClass? obj, Current current) => FromResult(obj);
+        pingPongAsync(AnyClass? obj, Current current) => MakeValueTask(obj);
 
         public ValueTask
         opOptionalExceptionAsync(int? a, string? b, Test.OneOptional? o, Current c) =>
@@ -48,104 +49,108 @@ namespace Ice.optional.AMD
             throw e;
         }
 
-        public ValueTask<(byte?, byte?)> opByteAsync(byte? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(byte?, byte?)> opByteAsync(byte? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(bool?, bool?)> opBoolAsync(bool? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(bool?, bool?)> opBoolAsync(bool? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(short?, short?)> opShortAsync(short? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(short?, short?)> opShortAsync(short? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(int?, int?)> opIntAsync(int? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(int?, int?)> opIntAsync(int? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(long?, long?)> opLongAsync(long? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(long?, long?)> opLongAsync(long? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(float?, float?)> opFloatAsync(float? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(float?, float?)> opFloatAsync(float? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(double?, double?)> opDoubleAsync(double? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(double?, double?)> opDoubleAsync(double? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(string?, string?)> opStringAsync(string? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(string?, string?)> opStringAsync(string? p1, Current current) => MakeValueTask((p1, p1));
 
         public ValueTask<(Test.MyEnum?, Test.MyEnum?)> opMyEnumAsync(Test.MyEnum? p1, Current current) =>
-            FromResult((p1, p1));
+            MakeValueTask((p1, p1));
 
         public ValueTask<(Test.SmallStruct?, Test.SmallStruct?)> opSmallStructAsync(Test.SmallStruct? p1, Current current) =>
-            FromResult((p1, p1));
+            MakeValueTask((p1, p1));
 
         public ValueTask<(Test.FixedStruct?, Test.FixedStruct?)> opFixedStructAsync(Test.FixedStruct? p1, Current current) =>
-            FromResult((p1, p1));
+            MakeValueTask((p1, p1));
 
         public ValueTask<(Test.VarStruct?, Test.VarStruct?)>
-        opVarStructAsync(Test.VarStruct? p1, Current current) => FromResult((p1, p1));
+        opVarStructAsync(Test.VarStruct? p1, Current current) => MakeValueTask((p1, p1));
 
         public ValueTask<(Test.OneOptional?, Test.OneOptional?)> opOneOptionalAsync(Test.OneOptional? p1, Current current) =>
-            FromResult((p1, p1));
+            MakeValueTask((p1, p1));
 
         public ValueTask<(IObjectPrx?, IObjectPrx?)> opOneOptionalProxyAsync(IObjectPrx? p1, Current current) =>
-            FromResult((p1, p1));
+            MakeValueTask((p1, p1));
 
-        public ValueTask<(byte[]?, byte[]?)> opByteSeqAsync(byte[]? p1, Current current) => FromResult((p1, p1));
-        public ValueTask<(List<byte>?, List<byte>?)> opByteListAsync(List<byte>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> opByteSeqAsync(byte[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<byte>?, IEnumerable<byte>?)> opByteListAsync(List<byte>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(bool[]?, bool[]?)> opBoolSeqAsync(bool[]? p1, Current current) => FromResult((p1, p1));
-        public ValueTask<(List<bool>?, List<bool>?)> opBoolListAsync(List<bool>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<bool>, ReadOnlyMemory<bool>)> opBoolSeqAsync(bool[]? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(short[]?, short[]?)> opShortSeqAsync(short[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<short>?, List<short>?)> opShortListAsync(List<short>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(IEnumerable<bool>?, IEnumerable<bool>?)> opBoolListAsync(List<bool>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(int[]?, int[]?)> opIntSeqAsync(int[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<int>?, List<int>?)> opIntListAsync(List<int>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<short>, ReadOnlyMemory<short>)> opShortSeqAsync(short[]? p1,
+            Current current) => ToReturnValue(p1);
 
-        public ValueTask<(long[]?, long[]?)> opLongSeqAsync(long[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<long>?, List<long>?)> opLongListAsync(List<long>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(IEnumerable<short>?, IEnumerable<short>?)> opShortListAsync(List<short>? p1,
+            Current current) =>  ToReturnValue(p1);
 
-        public ValueTask<(float[]?, float[]?)> opFloatSeqAsync(float[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<float>?, List<float>?)> opFloatListAsync(List<float>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<int>, ReadOnlyMemory<int>)> opIntSeqAsync(int[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<int>?, IEnumerable<int>?)> opIntListAsync(List<int>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(double[]?, double[]?)> opDoubleSeqAsync(double[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<double>?, List<double>?)> opDoubleListAsync(List<double>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<long>)> opLongSeqAsync(long[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<long>?, IEnumerable<long>?)> opLongListAsync(List<long>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(string[]?, string[]?)> opStringSeqAsync(string[]? p1, Current current) =>
-            FromResult((p1, p1));
-        public ValueTask<(List<string>?, List<string>?)> opStringListAsync(List<string>? p1, Current current) =>
-            FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<float>, ReadOnlyMemory<float>)> opFloatSeqAsync(float[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<float>?, IEnumerable<float>?)> opFloatListAsync(List<float>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(Test.SmallStruct[]?, Test.SmallStruct[]?)>
-        opSmallStructSeqAsync(Test.SmallStruct[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<double>)> opDoubleSeqAsync(double[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<double>?, IEnumerable<double>?)> opDoubleListAsync(List<double>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(List<Test.SmallStruct>?, List<Test.SmallStruct>?)>
-        opSmallStructListAsync(List<Test.SmallStruct>? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> opStringSeqAsync(string[]? p1, Current current) =>
+            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> opStringListAsync(List<string>? p1, Current current) =>
+            ToReturnValue(p1);
 
-        public ValueTask<(Test.FixedStruct[]?, Test.FixedStruct[]?)>
-        opFixedStructSeqAsync(Test.FixedStruct[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IEnumerable<Test.SmallStruct>?, IEnumerable<Test.SmallStruct>?)> opSmallStructSeqAsync(
+            Test.SmallStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<Test.SmallStruct>);
 
-        public ValueTask<(LinkedList<Test.FixedStruct>?, LinkedList<Test.FixedStruct>?)>
-        opFixedStructListAsync(LinkedList<Test.FixedStruct>? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IEnumerable<Test.SmallStruct>?, IEnumerable<Test.SmallStruct>?)>
+        opSmallStructListAsync(List<Test.SmallStruct>? p1, Current current) => ToReturnValue(p1);
 
-        public ValueTask<(Test.VarStruct[]?, Test.VarStruct[]?)>
-        opVarStructSeqAsync(Test.VarStruct[]? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IEnumerable<Test.FixedStruct>?, IEnumerable<Test.FixedStruct>?)> opFixedStructSeqAsync(
+            Test.FixedStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<Test.FixedStruct>);
+
+        public ValueTask<(IEnumerable<Test.FixedStruct>?, IEnumerable<Test.FixedStruct>?)>
+        opFixedStructListAsync(LinkedList<Test.FixedStruct>? p1, Current current) => ToReturnValue(p1);
+
+        public ValueTask<(IEnumerable<Test.VarStruct>?, IEnumerable<Test.VarStruct>?)> opVarStructSeqAsync(
+            Test.VarStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<Test.VarStruct>);
 
         public ValueTask<(optional.Test.SerializableClass?, optional.Test.SerializableClass?)>
-        opSerializableAsync(optional.Test.SerializableClass? p1, Current current) => FromResult((p1, p1));
+        opSerializableAsync(optional.Test.SerializableClass? p1, Current current) => MakeValueTask((p1, p1));
 
-        public ValueTask<(Dictionary<int, int>?, Dictionary<int, int>?)>
-        opIntIntDictAsync(Dictionary<int, int>? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IReadOnlyDictionary<int, int>?, IReadOnlyDictionary<int, int>?)>
+        opIntIntDictAsync(Dictionary<int, int>? p1, Current current) => ToReturnValue(p1);
 
-        public ValueTask<(Dictionary<string, int>?, Dictionary<string, int>?)>
-        opStringIntDictAsync(Dictionary<string, int>? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IReadOnlyDictionary<string, int>?, IReadOnlyDictionary<string, int>?)>
+        opStringIntDictAsync(Dictionary<string, int>? p1, Current current) => ToReturnValue(p1);
 
-        public ValueTask<(Dictionary<int, Test.OneOptional?>?, Dictionary<int, Test.OneOptional?>?)>
-        opIntOneOptionalDictAsync(Dictionary<int, Test.OneOptional?>? p1, Current current) => FromResult((p1, p1));
+        public ValueTask<(IReadOnlyDictionary<int, Test.OneOptional?>?, IReadOnlyDictionary<int, Test.OneOptional?>?)>
+        opIntOneOptionalDictAsync(Dictionary<int, Test.OneOptional?>? p1, Current current) => ToReturnValue(p1);
 
         public ValueTask
         opClassAndUnknownOptionalAsync(Test.A? p, Current current) => new ValueTask(Task.CompletedTask);
@@ -155,9 +160,9 @@ namespace Ice.optional.AMD
 
         public ValueTask<Test.OneOptional?>
         returnOptionalClassAsync(bool req, Current current) =>
-            FromResult<Test.OneOptional?>(new Test.OneOptional(53));
+            new ValueTask<Test.OneOptional?>(new Test.OneOptional(53));
 
-        public ValueTask<Test.G?> opGAsync(Test.G? g, Current current) => FromResult(g);
+        public ValueTask<Test.G?> opGAsync(Test.G? g, Current current) => MakeValueTask(g);
 
         public ValueTask opVoidAsync(Current current) => new ValueTask(Task.CompletedTask);
 
@@ -218,20 +223,30 @@ namespace Ice.optional.AMD
         }
 
         public ValueTask<bool>
-        supportsRequiredParamsAsync(Current current) => FromResult(false);
+        supportsRequiredParamsAsync(Current current) => MakeValueTask(false);
 
         public ValueTask<bool>
-        supportsJavaSerializableAsync(Current current) => FromResult(false);
+        supportsJavaSerializableAsync(Current current) => MakeValueTask(false);
 
         public ValueTask<bool>
-        supportsCsharpSerializableAsync(Current current) => FromResult(true);
+        supportsCsharpSerializableAsync(Current current) => MakeValueTask(true);
 
         public ValueTask<bool>
-        supportsCppStringViewAsync(Current current) => FromResult(false);
+        supportsCppStringViewAsync(Current current) => MakeValueTask(false);
 
         public ValueTask<bool>
-        supportsNullOptionalAsync(Current current) => FromResult(true);
+        supportsNullOptionalAsync(Current current) => MakeValueTask(true);
 
-        internal static ValueTask<T> FromResult<T>(T result) => new ValueTask<T>(result);
+        private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
+
+        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(T[]? input)
+            where T : struct => new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input, input));
+
+        private static ValueTask<(IEnumerable<T>?, IEnumerable<T>?)> ToReturnValue<T>(IEnumerable<T>? input) =>
+            new ValueTask<(IEnumerable<T>?, IEnumerable<T>?)>((input, input));
+
+        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>?, IReadOnlyDictionary<TKey, TValue>?)>
+        ToReturnValue<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? input) where TKey : notnull =>
+            new ValueTask<(IReadOnlyDictionary<TKey, TValue>?, IReadOnlyDictionary<TKey, TValue>?)>((input, input));
     }
 }

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Collections.Generic;
 
 namespace Ice.optional
@@ -67,54 +68,54 @@ namespace Ice.optional
 
         public (IObjectPrx?, IObjectPrx?) opOneOptionalProxy(IObjectPrx? p1, Current current) => (p1, p1);
 
-        public (byte[]?, byte[]?) opByteSeq(byte[]? p1, Current current) => (p1, p1);
-        public (List<byte>?, List<byte>?) opByteList(List<byte>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<byte>, ReadOnlyMemory<byte>) opByteSeq(byte[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<byte>?, IEnumerable<byte>?) opByteList(List<byte>? p1, Current current) => (p1, p1);
 
-        public (bool[]?, bool[]?) opBoolSeq(bool[]? p1, Current current) => (p1, p1);
-        public (List<bool>?, List<bool>?) opBoolList(List<bool>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<bool>, ReadOnlyMemory<bool>) opBoolSeq(bool[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<bool>?, IEnumerable<bool>?) opBoolList(List<bool>? p1, Current current) => (p1, p1);
 
-        public (short[]?, short[]?) opShortSeq(short[]? p1, Current current) => (p1, p1);
-        public (List<short>?, List<short>?) opShortList(List<short>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<short>, ReadOnlyMemory<short>) opShortSeq(short[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<short>?, IEnumerable<short>?) opShortList(List<short>? p1, Current current) => (p1, p1);
 
-        public (int[]?, int[]?) opIntSeq(int[]? p1, Current current) => (p1, p1);
-        public (List<int>?, List<int>?) opIntList(List<int>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<int>, ReadOnlyMemory<int>) opIntSeq(int[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<int>?, IEnumerable<int>?) opIntList(List<int>? p1, Current current) => (p1, p1);
 
-        public (long[]?, long[]?) opLongSeq(long[]? p1, Current current) => (p1, p1);
-        public (List<long>?, List<long>?) opLongList(List<long>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<long>, ReadOnlyMemory<long>) opLongSeq(long[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<long>?, IEnumerable<long>?) opLongList(List<long>? p1, Current current) => (p1, p1);
 
-        public (float[]?, float[]?) opFloatSeq(float[]? p1, Current current) => (p1, p1);
-        public (List<float>?, List<float>?) opFloatList(List<float>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<float>, ReadOnlyMemory<float>) opFloatSeq(float[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<float>?, IEnumerable<float>?) opFloatList(List<float>? p1, Current current) => (p1, p1);
 
-        public (double[]?, double[]?) opDoubleSeq(double[]? p1, Current current) => (p1, p1);
-        public (List<double>?, List<double>?) opDoubleList(List<double>? p1, Current current) => (p1, p1);
+        public (ReadOnlyMemory<double>, ReadOnlyMemory<double>) opDoubleSeq(double[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<double>?, IEnumerable<double>?) opDoubleList(List<double>? p1, Current current) => (p1, p1);
 
-        public (string[]?, string[]?) opStringSeq(string[]? p1, Current current) => (p1, p1);
-        public (List<string>?, List<string>?) opStringList(List<string>? p1, Current current) => (p1, p1);
+        public (IEnumerable<string>?, IEnumerable<string>?) opStringSeq(string[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<string>?, IEnumerable<string>?) opStringList(List<string>? p1, Current current) => (p1, p1);
 
-        public (Test.SmallStruct[]?, Test.SmallStruct[]?) opSmallStructSeq(Test.SmallStruct[]? p1, Current current) =>
+        public (IEnumerable<Test.SmallStruct>?, IEnumerable<Test.SmallStruct>?) opSmallStructSeq(Test.SmallStruct[]? p1, Current current) =>
             (p1, p1);
 
-        public (List<Test.SmallStruct>?, List<Test.SmallStruct>?)
+        public (IEnumerable<Test.SmallStruct>?, IEnumerable<Test.SmallStruct>?)
         opSmallStructList(List<Test.SmallStruct>? p1, Current current) => (p1, p1);
 
-        public (Test.FixedStruct[]?, Test.FixedStruct[]?)
+        public (IEnumerable<Test.FixedStruct>?, IEnumerable<Test.FixedStruct>?)
         opFixedStructSeq(Test.FixedStruct[]? p1, Current current) => (p1, p1);
 
-        public (LinkedList<Test.FixedStruct>?, LinkedList<Test.FixedStruct>?)
+        public (IEnumerable<Test.FixedStruct>?, IEnumerable<Test.FixedStruct>?)
         opFixedStructList(LinkedList<Test.FixedStruct>? p1, Current current) => (p1, p1);
 
-        public (Test.VarStruct[]?, Test.VarStruct[]?) opVarStructSeq(Test.VarStruct[]? p1, Current current) => (p1, p1);
+        public (IEnumerable<Test.VarStruct>?, IEnumerable<Test.VarStruct>?) opVarStructSeq(Test.VarStruct[]? p1, Current current) => (p1, p1);
 
         public (Test.SerializableClass?, Test.SerializableClass?)
         opSerializable(Test.SerializableClass? p1, Current current) => (p1, p1);
 
-        public (Dictionary<int, int>?, Dictionary<int, int>?)
+        public (IReadOnlyDictionary<int, int>?, IReadOnlyDictionary<int, int>?)
         opIntIntDict(Dictionary<int, int>? p1, Current current) => (p1, p1);
 
-        public (Dictionary<string, int>?, Dictionary<string, int>?)
+        public (IReadOnlyDictionary<string, int>?, IReadOnlyDictionary<string, int>?)
         opStringIntDict(Dictionary<string, int>? p1, Current current) => (p1, p1);
 
-        public (Dictionary<int, Test.OneOptional?>?, Dictionary<int, Test.OneOptional?>?)
+        public (IReadOnlyDictionary<int, Test.OneOptional?>?, IReadOnlyDictionary<int, Test.OneOptional?>?)
         opIntOneOptionalDict(Dictionary<int, Test.OneOptional?>? p1, Current current) => (p1, p1);
 
         public void opClassAndUnknownOptional(Test.A? p, Current current)

--- a/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
@@ -20,8 +20,8 @@ namespace Ice.proxy.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<Dictionary<string, string>> getContextAsync(Current current)
-            => new ValueTask<Dictionary<string, string>>(_ctx!);
+        public ValueTask<IReadOnlyDictionary<string, string>> getContextAsync(Current current)
+            => new ValueTask<IReadOnlyDictionary<string, string>>(_ctx!);
 
         public bool IceIsA(string typeId, Current current)
         {
@@ -29,6 +29,6 @@ namespace Ice.proxy.AMD
             return typeof(Test.IMyDerivedClass).GetAllIceTypeIds().Contains(typeId);
         }
 
-        private Dictionary<string, string>? _ctx;
+        private IReadOnlyDictionary<string, string>? _ctx;
     }
 }

--- a/csharp/test/Ice/proxy/MyDerivedClassI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassI.cs
@@ -15,7 +15,7 @@ namespace Ice.proxy
 
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
 
-        public Dictionary<string, string> getContext(Current current) => _ctx!;
+        public IReadOnlyDictionary<string, string> getContext(Current current) => _ctx!;
 
         public bool IceIsA(string typeId, Current current)
         {

--- a/csharp/test/Ice/scope/Server.cs
+++ b/csharp/test/Ice/scope/Server.cs
@@ -14,16 +14,16 @@ namespace Ice.scope
         {
             public (S, S) opS(S s1, Current current) => (s1, s1);
 
-            public (S[], S[]) opSSeq(S[] s1, Current current) => (s1, s1);
+            public (IEnumerable<S>, IEnumerable<S>) opSSeq(S[] s1, Current current) => (s1, s1);
 
-            public (Dictionary<string, S>, Dictionary<string, S>)
+            public (IReadOnlyDictionary<string, S>, IReadOnlyDictionary<string, S>)
             opSMap(Dictionary<string, S> s1, Current current) => (s1, s1);
 
             public (C?, C?) opC(C? c1, Current current) => (c1, c1);
 
-            public (C?[], C?[]) opCSeq(C?[] c1, Current current) => (c1, c1);
+            public (IEnumerable<C?>, IEnumerable<C?>) opCSeq(C?[] c1, Current current) => (c1, c1);
 
-            public (Dictionary<string, C?>, Dictionary<string, C?>)
+            public (IReadOnlyDictionary<string, C?>, IReadOnlyDictionary<string, C?>)
             opCMap(Dictionary<string, C?> c1, Current current) => (c1, c1);
 
             public E1 opE1(E1 e1, Current current) => e1;
@@ -40,19 +40,19 @@ namespace Ice.scope
             public (Test.Inner.Inner2.S, Test.Inner.Inner2.S)
             opS(Test.Inner.Inner2.S s1, Current current) => (s1, s1);
 
-            public (Test.Inner.Inner2.S[], Test.Inner.Inner2.S[])
+            public (IEnumerable<Test.Inner.Inner2.S>, IEnumerable<Test.Inner.Inner2.S>)
             opSSeq(Test.Inner.Inner2.S[] s1, Current current) => (s1, s1);
 
-            public (Dictionary<string, Test.Inner.Inner2.S>, Dictionary<string, Test.Inner.Inner2.S>)
+            public (IReadOnlyDictionary<string, Test.Inner.Inner2.S>, IReadOnlyDictionary<string, Test.Inner.Inner2.S>)
             opSMap(Dictionary<string, Test.Inner.Inner2.S> s1, Current current) => (s1, s1);
 
             public (Test.Inner.Inner2.C?, Test.Inner.Inner2.C?)
             opC(Test.Inner.Inner2.C? c1, Current current) => (c1, c1);
 
-            public (Test.Inner.Inner2.C?[], Test.Inner.Inner2.C?[])
+            public (IEnumerable<Test.Inner.Inner2.C?>, IEnumerable<Test.Inner.Inner2.C?>)
             opCSeq(Test.Inner.Inner2.C?[] c1, Current current) => (c1, c1);
 
-            public (Dictionary<string, Test.Inner.Inner2.C?>, Dictionary<string, Test.Inner.Inner2.C?>)
+            public (IReadOnlyDictionary<string, Test.Inner.Inner2.C?>, IReadOnlyDictionary<string, Test.Inner.Inner2.C?>)
             opCMap(Dictionary<string, Test.Inner.Inner2.C?> c1, Current current) => (c1, c1);
 
             public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
@@ -63,19 +63,19 @@ namespace Ice.scope
             public (Test.Inner.Inner2.S, Test.Inner.Inner2.S)
             opS(Test.Inner.Inner2.S s1, Current current) => (s1, s1);
 
-            public (Test.Inner.Inner2.S[], Test.Inner.Inner2.S[])
+            public (IEnumerable<Test.Inner.Inner2.S>, IEnumerable<Test.Inner.Inner2.S>)
             opSSeq(Test.Inner.Inner2.S[] s1, Current current) => (s1, s1);
 
-            public (Dictionary<string, Test.Inner.Inner2.S>, Dictionary<string, Test.Inner.Inner2.S>)
+            public (IReadOnlyDictionary<string, Test.Inner.Inner2.S>, IReadOnlyDictionary<string, Test.Inner.Inner2.S>)
             opSMap(Dictionary<string, Test.Inner.Inner2.S> s1, Current current) => (s1, s1);
 
             public (Test.Inner.Inner2.C?, Test.Inner.Inner2.C?)
             opC(Test.Inner.Inner2.C? c1, Current current) => (c1, c1);
 
-            public (Test.Inner.Inner2.C?[], Test.Inner.Inner2.C?[])
+            public (IEnumerable<Test.Inner.Inner2.C?>, IEnumerable<Test.Inner.Inner2.C?>)
             opCSeq(Test.Inner.Inner2.C?[] c1, Current current) => (c1, c1);
 
-            public (Dictionary<string, Test.Inner.Inner2.C?>, Dictionary<string, Test.Inner.Inner2.C?>)
+            public (IReadOnlyDictionary<string, Test.Inner.Inner2.C?>, IReadOnlyDictionary<string, Test.Inner.Inner2.C?>)
             opCMap(Dictionary<string, Test.Inner.Inner2.C?> c1, Current current) => (c1, c1);
 
             public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
@@ -85,16 +85,16 @@ namespace Ice.scope
         {
             public (S, S) opS(S s1, Current current) => (s1, s1);
 
-            public (S[], S[]) opSSeq(S[] s1, Current current) => (s1, s1);
+            public (IEnumerable<S>, IEnumerable<S>) opSSeq(S[] s1, Current current) => (s1, s1);
 
-            public (Dictionary<string, S>, Dictionary<string, S>)
+            public (IReadOnlyDictionary<string, S>, IReadOnlyDictionary<string, S>)
             opSMap(Dictionary<string, S> s1, Current current) => (s1, s1);
 
             public (C?, C?) opC(C? c1, Current current) => (c1, c1);
 
-            public (C?[], C?[]) opCSeq(C?[] c1, Current current) => (c1, c1);
+            public (IEnumerable<C?>, IEnumerable<C?>) opCSeq(C?[] c1, Current current) => (c1, c1);
 
-            public (Dictionary<string, C?>, Dictionary<string, C?>)
+            public (IReadOnlyDictionary<string, C?>, IReadOnlyDictionary<string, C?>)
             opCMap(Dictionary<string, C?> c1, Current current) => (c1, c1);
 
             public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();

--- a/csharp/test/Ice/seqMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/seqMapping/MyClassAMDI.cs
@@ -2,8 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using System.Threading.Tasks;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Ice.seqMapping.AMD
 {
@@ -15,228 +16,244 @@ namespace Ice.seqMapping.AMD
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<(byte[], byte[])> opAByteSAsync(byte[] i, Current current) => FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> opAByteSAsync(byte[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<byte>, List<byte>)> opLByteSAsync(List<byte> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> opLByteSAsync(List<byte> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<byte>, LinkedList<byte>)>
-        opKByteSAsync(LinkedList<byte> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> opKByteSAsync(LinkedList<byte> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Queue<byte>, Queue<byte>)> opQByteSAsync(Queue<byte> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> opQByteSAsync(Queue<byte> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<byte>, Stack<byte>)> opSByteSAsync(Stack<byte> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> opSByteSAsync(Stack<byte> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(bool[], bool[])> opABoolSAsync(bool[] i, Current current) => FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<bool>, ReadOnlyMemory<bool>)> opABoolSAsync(bool[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<bool>, List<bool>)> opLBoolSAsync(List<bool> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> opLBoolSAsync(List<bool> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<bool>, LinkedList<bool>)> opKBoolSAsync(LinkedList<bool> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> opKBoolSAsync(LinkedList<bool> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Queue<bool>, Queue<bool>)> opQBoolSAsync(Queue<bool> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> opQBoolSAsync(Queue<bool> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<bool>, Stack<bool>)> opSBoolSAsync(Stack<bool> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> opSBoolSAsync(Stack<bool> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(short[], short[])> opAShortSAsync(short[] i, Current current) => FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<short>, ReadOnlyMemory<short>)> opAShortSAsync(short[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<short>, List<short>)> opLShortSAsync(List<short> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<short>, IEnumerable<short>)> opLShortSAsync(List<short> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<short>, LinkedList<short>)>
-        opKShortSAsync(LinkedList<short> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<short>, IEnumerable<short>)> opKShortSAsync(LinkedList<short> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<short>, Queue<short>)> opQShortSAsync(Queue<short> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<short>, IEnumerable<short>)> opQShortSAsync(Queue<short> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<short>, Stack<short>)> opSShortSAsync(Stack<short> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<short>, IEnumerable<short>)> opSShortSAsync(Stack<short> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(int[], int[])> opAIntSAsync(int[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<int>, ReadOnlyMemory<int>)> opAIntSAsync(int[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<int>, List<int>)> opLIntSAsync(List<int> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<int>, IEnumerable<int>)> opLIntSAsync(List<int> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<int>, LinkedList<int>)> opKIntSAsync(LinkedList<int> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<int>, IEnumerable<int>)> opKIntSAsync(LinkedList<int> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Queue<int>, Queue<int>)> opQIntSAsync(Queue<int> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<int>, IEnumerable<int>)> opQIntSAsync(Queue<int> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<int>, Stack<int>)> opSIntSAsync(Stack<int> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<int>, IEnumerable<int>)> opSIntSAsync(Stack<int> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(long[], long[])> opALongSAsync(long[] i, Current current) => FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<long>)> opALongSAsync(long[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<long>, List<long>)> opLLongSAsync(List<long> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<long>, IEnumerable<long>)> opLLongSAsync(List<long> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<long>, LinkedList<long>)> opKLongSAsync(LinkedList<long> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<long>, IEnumerable<long>)> opKLongSAsync(LinkedList<long> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Queue<long>, Queue<long>)> opQLongSAsync(Queue<long> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<long>, IEnumerable<long>)> opQLongSAsync(Queue<long> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<long>, Stack<long>)> opSLongSAsync(Stack<long> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<long>, IEnumerable<long>)> opSLongSAsync(Stack<long> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(float[], float[])> opAFloatSAsync(float[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<float>, ReadOnlyMemory<float>)> opAFloatSAsync(float[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<float>, List<float>)> opLFloatSAsync(List<float> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<float>, IEnumerable<float>)> opLFloatSAsync(List<float> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<float>, LinkedList<float>)> opKFloatSAsync(LinkedList<float> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<float>, IEnumerable<float>)> opKFloatSAsync(LinkedList<float> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<float>, Queue<float>)> opQFloatSAsync(Queue<float> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<float>, IEnumerable<float>)> opQFloatSAsync(Queue<float> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<float>, Stack<float>)> opSFloatSAsync(Stack<float> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<float>, IEnumerable<float>)> opSFloatSAsync(Stack<float> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(double[], double[])> opADoubleSAsync(double[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<double>)> opADoubleSAsync(double[] i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(List<double>, List<double>)> opLDoubleSAsync(List<double> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<double>, IEnumerable<double>)> opLDoubleSAsync(List<double> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<double>, LinkedList<double>)> opKDoubleSAsync(LinkedList<double> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<double>, IEnumerable<double>)> opKDoubleSAsync(LinkedList<double> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<double>, Queue<double>)> opQDoubleSAsync(Queue<double> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<double>, IEnumerable<double>)> opQDoubleSAsync(Queue<double> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<double>, Stack<double>)> opSDoubleSAsync(Stack<double> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<double>, IEnumerable<double>)> opSDoubleSAsync(Stack<double> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(string[], string[])> opAStringSAsync(string[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)> opAStringSAsync(string[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<string>, List<string>)> opLStringSAsync(List<string> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)> opLStringSAsync(List<string> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<string>, LinkedList<string>)> opKStringSAsync(LinkedList<string> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)> opKStringSAsync(LinkedList<string> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<string>, Queue<string>)> opQStringSAsync(Queue<string> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)> opQStringSAsync(Queue<string> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<string>, Stack<string>)> opSStringSAsync(Stack<string> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<string>, IEnumerable<string>)> opSStringSAsync(Stack<string> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(AnyClass?[], AnyClass?[])> opAObjectSAsync(AnyClass?[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<AnyClass?>, IEnumerable<AnyClass?>)> opAObjectSAsync(AnyClass?[] i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(List<AnyClass?>, List<AnyClass?>)> opLObjectSAsync(List<AnyClass?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<AnyClass?>, IEnumerable<AnyClass?>)> opLObjectSAsync(List<AnyClass?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(IObjectPrx?[], IObjectPrx?[])> opAObjectPrxSAsync(IObjectPrx?[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> opAObjectPrxSAsync(IObjectPrx?[] i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(List<IObjectPrx?>, List<IObjectPrx?>)> opLObjectPrxSAsync(List<IObjectPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> opLObjectPrxSAsync(List<IObjectPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(LinkedList<IObjectPrx?>, LinkedList<IObjectPrx?>)>
-        opKObjectPrxSAsync(LinkedList<IObjectPrx?> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> opKObjectPrxSAsync(
+            LinkedList<IObjectPrx?> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<IObjectPrx?>, Queue<IObjectPrx?>)> opQObjectPrxSAsync(Queue<IObjectPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> opQObjectPrxSAsync(Queue<IObjectPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<IObjectPrx?>, Stack<IObjectPrx?>)> opSObjectPrxSAsync(Stack<IObjectPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> opSObjectPrxSAsync(Stack<IObjectPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.S[], Test.S[])> opAStructSAsync(Test.S[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.S>, IEnumerable<Test.S>)> opAStructSAsync(Test.S[] i, Current current) =>
+            ToReturnValue(i as IEnumerable<Test.S>);
 
-        public ValueTask<(List<Test.S>, List<Test.S>)> opLStructSAsync(List<Test.S> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.S>, IEnumerable<Test.S>)> opLStructSAsync(List<Test.S> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<Test.S>, LinkedList<Test.S>)> opKStructSAsync(LinkedList<Test.S> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.S>, IEnumerable<Test.S>)> opKStructSAsync(LinkedList<Test.S> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<Test.S>, Queue<Test.S>)> opQStructSAsync(Queue<Test.S> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.S>, IEnumerable<Test.S>)> opQStructSAsync(Queue<Test.S> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<Test.S>, Stack<Test.S>)> opSStructSAsync(Stack<Test.S> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.S>, IEnumerable<Test.S>)> opSStructSAsync(Stack<Test.S> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.SD[], Test.SD[])> opAStructSDAsync(Test.SD[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.SD>, IEnumerable<Test.SD>)> opAStructSDAsync(Test.SD[] i, Current current) =>
+            ToReturnValue(i as IEnumerable<Test.SD>);
 
-        public ValueTask<(List<Test.SD>, List<Test.SD>)> opLStructSDAsync(List<Test.SD> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.SD>, IEnumerable<Test.SD>)> opLStructSDAsync(List<Test.SD> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(LinkedList<Test.SD>, LinkedList<Test.SD>)> opKStructSDAsync(LinkedList<Test.SD> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.SD>, IEnumerable<Test.SD>)> opKStructSDAsync(LinkedList<Test.SD> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<Test.SD>, Queue<Test.SD>)> opQStructSDAsync(Queue<Test.SD> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.SD>, IEnumerable<Test.SD>)> opQStructSDAsync(Queue<Test.SD> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<Test.SD>, Stack<Test.SD>)> opSStructSDAsync(Stack<Test.SD> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.SD>, IEnumerable<Test.SD>)> opSStructSDAsync(Stack<Test.SD> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.CV?[], Test.CV?[])> opACVSAsync(Test.CV?[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.CV?>, IEnumerable<Test.CV?>)> opACVSAsync(Test.CV?[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<Test.CV?>, List<Test.CV?>)> opLCVSAsync(List<Test.CV?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.CV?>, IEnumerable<Test.CV?>)> opLCVSAsync(List<Test.CV?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.IIPrx?[], Test.IIPrx?[])> opAIPrxSAsync(Test.IIPrx?[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>)> opAIPrxSAsync(Test.IIPrx?[] i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(List<Test.IIPrx?>, List<Test.IIPrx?>)> opLIPrxSAsync(List<Test.IIPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>)> opLIPrxSAsync(List<Test.IIPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(LinkedList<Test.IIPrx?>, LinkedList<Test.IIPrx?>)>
-        opKIPrxSAsync(LinkedList<Test.IIPrx?> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>)> opKIPrxSAsync(LinkedList<Test.IIPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<Test.IIPrx?>, Queue<Test.IIPrx?>)> opQIPrxSAsync(Queue<Test.IIPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>)> opQIPrxSAsync(Queue<Test.IIPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Stack<Test.IIPrx?>, Stack<Test.IIPrx?>)> opSIPrxSAsync(Stack<Test.IIPrx?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>)> opSIPrxSAsync(Stack<Test.IIPrx?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.CR?[], Test.CR?[])> opACRSAsync(Test.CR?[] i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.CR?>, IEnumerable<Test.CR?>)> opACRSAsync(Test.CR?[] i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(List<Test.CR?>, List<Test.CR?>)> opLCRSAsync(List<Test.CR?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.CR?>, IEnumerable<Test.CR?>)> opLCRSAsync(List<Test.CR?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Test.En[], Test.En[])> opAEnSAsync(Test.En[] i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.En>, IEnumerable<Test.En>)> opAEnSAsync(Test.En[] i, Current current) =>
+            ToReturnValue(i as IEnumerable<Test.En>);
 
-        public ValueTask<(List<Test.En>, List<Test.En>)> opLEnSAsync(List<Test.En> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.En>, IEnumerable<Test.En>)> opLEnSAsync(List<Test.En> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(LinkedList<Test.En>, LinkedList<Test.En>)> opKEnSAsync(LinkedList<Test.En> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.En>, IEnumerable<Test.En>)> opKEnSAsync(LinkedList<Test.En> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Queue<Test.En>, Queue<Test.En>)> opQEnSAsync(Queue<Test.En> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.En>, IEnumerable<Test.En>)> opQEnSAsync(Queue<Test.En> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Stack<Test.En>, Stack<Test.En>)> opSEnSAsync(Stack<Test.En> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.En>, IEnumerable<Test.En>)> opSEnSAsync(Stack<Test.En> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Custom<int>, Custom<int>)> opCustomIntSAsync(Custom<int> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<int>, IEnumerable<int>)> opCustomIntSAsync(Custom<int> i, Current current) =>
+            ToReturnValue(i);
 
-        public ValueTask<(Custom<Test.CV?>, Custom<Test.CV?>)> opCustomCVSAsync(Custom<Test.CV?> i, Current current) =>
-            FromResult((i, i));
+        public ValueTask<(IEnumerable<Test.CV?>, IEnumerable<Test.CV?>)> opCustomCVSAsync(Custom<Test.CV?> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Custom<Custom<int>>, Custom<Custom<int>>)>
-        opCustomIntSSAsync(Custom<Custom<int>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<Custom<int>>, IEnumerable<Custom<int>>)> opCustomIntSSAsync(Custom<Custom<int>> i,
+            Current current) => ToReturnValue(i);
 
-        public ValueTask<(Custom<Custom<Test.CV?>>, Custom<Custom<Test.CV?>>)>
-        opCustomCVSSAsync(Custom<Custom<Test.CV?>> i, Current current) => FromResult((i, i));
+        public ValueTask<(IEnumerable<Custom<Test.CV?>>, IEnumerable<Custom<Test.CV?>>)> opCustomCVSSAsync(
+            Custom<Custom<Test.CV?>> i, Current current) => ToReturnValue(i);
 
-        public ValueTask<(Serialize.Small?, Serialize.Small?)> opSerialSmallCSharpAsync(
-            Serialize.Small? i, Current current) => FromResult((i, i));
+        public ValueTask<(Serialize.Small, Serialize.Small)> opSerialSmallCSharpAsync(Serialize.Small i,
+            Current current) => new ValueTask<(Serialize.Small, Serialize.Small)>((i, i));
 
-        public ValueTask<(Serialize.Large?, Serialize.Large?)> opSerialLargeCSharpAsync(
-            Serialize.Large? i, Current current) => FromResult((i, i));
+        public ValueTask<(Serialize.Large, Serialize.Large)> opSerialLargeCSharpAsync(Serialize.Large i,
+            Current current) => new ValueTask<(Serialize.Large, Serialize.Large)>((i, i));
 
-        public ValueTask<(Serialize.Struct?, Serialize.Struct?)> opSerialStructCSharpAsync(
-            Serialize.Struct? i, Current current) => FromResult((i, i));
+        public ValueTask<(Serialize.Struct, Serialize.Struct)> opSerialStructCSharpAsync(Serialize.Struct i,
+            Current current) => new ValueTask<(Serialize.Struct, Serialize.Struct)>((i, i));
 
-        internal static ValueTask<T> FromResult<T>(T result) => new ValueTask<T>(result);
+        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(T[] input) where T : struct =>
+            new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input, input));
+
+        private static ValueTask<(IEnumerable<T>, IEnumerable<T>)> ToReturnValue<T>(IEnumerable<T> input) =>
+            new ValueTask<(IEnumerable<T>, IEnumerable<T>)>((input, input));
     }
 }

--- a/csharp/test/Ice/seqMapping/MyClassI.cs
+++ b/csharp/test/Ice/seqMapping/MyClassI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Collections.Generic;
 
 namespace Ice.seqMapping
@@ -10,163 +11,160 @@ namespace Ice.seqMapping
     {
         public void shutdown(Current current) => current.Adapter.Communicator.Shutdown();
 
-        public (byte[], byte[]) opAByteS(byte[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<byte>, ReadOnlyMemory<byte>) opAByteS(byte[] i, Current current) => (i, i);
 
-        public (List<byte>, List<byte>) opLByteS(List<byte> i, Current current) => (i, i);
+        public (IEnumerable<byte>, IEnumerable<byte>) opLByteS(List<byte> i, Current current) => (i, i);
 
-        public (LinkedList<byte>, LinkedList<byte>) opKByteS(LinkedList<byte> i, Current current) => (i, i);
+        public (IEnumerable<byte>, IEnumerable<byte>) opKByteS(LinkedList<byte> i, Current current) => (i, i);
 
-        public (Queue<byte>, Queue<byte>) opQByteS(Queue<byte> i, Current current) => (i, i);
+        public (IEnumerable<byte>, IEnumerable<byte>) opQByteS(Queue<byte> i, Current current) => (i, i);
 
-        public (Stack<byte>, Stack<byte>) opSByteS(Stack<byte> i, Current current) => (i, i);
+        public (IEnumerable<byte>, IEnumerable<byte>) opSByteS(Stack<byte> i, Current current) => (i, i);
 
-        public (bool[], bool[]) opABoolS(bool[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<bool>, ReadOnlyMemory<bool>) opABoolS(bool[] i, Current current) => (i, i);
 
-        public (List<bool>, List<bool>) opLBoolS(List<bool> i, Current current) => (i, i);
+        public (IEnumerable<bool>, IEnumerable<bool>) opLBoolS(List<bool> i, Current current) => (i, i);
 
-        public (LinkedList<bool>, LinkedList<bool>) opKBoolS(LinkedList<bool> i, Current current) => (i, i);
+        public (IEnumerable<bool>, IEnumerable<bool>) opKBoolS(LinkedList<bool> i, Current current) => (i, i);
 
-        public (Queue<bool>, Queue<bool>) opQBoolS(Queue<bool> i, Current current) => (i, i);
+        public (IEnumerable<bool>, IEnumerable<bool>) opQBoolS(Queue<bool> i, Current current) => (i, i);
 
-        public (Stack<bool>, Stack<bool>) opSBoolS(Stack<bool> i, Current current) => (i, i);
+        public (IEnumerable<bool>, IEnumerable<bool>) opSBoolS(Stack<bool> i, Current current) => (i, i);
 
-        public (short[], short[]) opAShortS(short[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<short>, ReadOnlyMemory<short>) opAShortS(short[] i, Current current) => (i, i);
 
-        public (List<short>, List<short>) opLShortS(List<short> i, Current current) => (i, i);
+        public (IEnumerable<short>, IEnumerable<short>) opLShortS(List<short> i, Current current) => (i, i);
 
-        public (LinkedList<short>, LinkedList<short>) opKShortS(LinkedList<short> i, Current current) => (i, i);
+        public (IEnumerable<short>, IEnumerable<short>) opKShortS(LinkedList<short> i, Current current) => (i, i);
 
-        public (Queue<short>, Queue<short>) opQShortS(Queue<short> i, Current current) => (i, i);
+        public (IEnumerable<short>, IEnumerable<short>) opQShortS(Queue<short> i, Current current) => (i, i);
 
-        public (Stack<short>, Stack<short>) opSShortS(Stack<short> i, Current current) => (i, i);
+        public (IEnumerable<short>, IEnumerable<short>) opSShortS(Stack<short> i, Current current) => (i, i);
 
-        public (int[], int[]) opAIntS(int[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<int>, ReadOnlyMemory<int>) opAIntS(int[] i, Current current) => (i, i);
 
-        public (List<int>, List<int>) opLIntS(List<int> i, Current current) => (i, i);
+        public (IEnumerable<int>, IEnumerable<int>) opLIntS(List<int> i, Current current) => (i, i);
 
-        public (LinkedList<int>, LinkedList<int>) opKIntS(LinkedList<int> i, Current current) => (i, i);
+        public (IEnumerable<int>, IEnumerable<int>) opKIntS(LinkedList<int> i, Current current) => (i, i);
 
-        public (Queue<int>, Queue<int>) opQIntS(Queue<int> i, Current current) => (i, i);
+        public (IEnumerable<int>, IEnumerable<int>) opQIntS(Queue<int> i, Current current) => (i, i);
 
-        public (Stack<int>, Stack<int>) opSIntS(Stack<int> i, Current current) => (i, i);
+        public (IEnumerable<int>, IEnumerable<int>) opSIntS(Stack<int> i, Current current) => (i, i);
 
-        public (long[], long[]) opALongS(long[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<long>, ReadOnlyMemory<long>) opALongS(long[] i, Current current) => (i, i);
 
-        public (List<long>, List<long>) opLLongS(List<long> i, Current current) => (i, i);
+        public (IEnumerable<long>, IEnumerable<long>) opLLongS(List<long> i, Current current) => (i, i);
 
-        public (LinkedList<long>, LinkedList<long>) opKLongS(LinkedList<long> i, Current current) => (i, i);
+        public (IEnumerable<long>, IEnumerable<long>) opKLongS(LinkedList<long> i, Current current) => (i, i);
 
-        public (Queue<long>, Queue<long>) opQLongS(Queue<long> i, Current current) => (i, i);
+        public (IEnumerable<long>, IEnumerable<long>) opQLongS(Queue<long> i, Current current) => (i, i);
 
-        public (Stack<long>, Stack<long>) opSLongS(Stack<long> i, Current current) => (i, i);
+        public (IEnumerable<long>, IEnumerable<long>) opSLongS(Stack<long> i, Current current) => (i, i);
 
-        public (float[], float[]) opAFloatS(float[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<float>, ReadOnlyMemory<float>) opAFloatS(float[] i, Current current) => (i, i);
 
-        public (List<float>, List<float>) opLFloatS(List<float> i, Current current) => (i, i);
+        public (IEnumerable<float>, IEnumerable<float>) opLFloatS(List<float> i, Current current) => (i, i);
 
-        public (LinkedList<float>, LinkedList<float>) opKFloatS(LinkedList<float> i, Current current) => (i, i);
+        public (IEnumerable<float>, IEnumerable<float>) opKFloatS(LinkedList<float> i, Current current) => (i, i);
 
-        public (Queue<float>, Queue<float>) opQFloatS(Queue<float> i, Current current) => (i, i);
+        public (IEnumerable<float>, IEnumerable<float>) opQFloatS(Queue<float> i, Current current) => (i, i);
 
-        public (Stack<float>, Stack<float>) opSFloatS(Stack<float> i, Current current) => (i, i);
+        public (IEnumerable<float>, IEnumerable<float>) opSFloatS(Stack<float> i, Current current) => (i, i);
 
-        public (double[], double[]) opADoubleS(double[] i, Current current) => (i, i);
+        public (ReadOnlyMemory<double>, ReadOnlyMemory<double>) opADoubleS(double[] i, Current current) => (i, i);
 
-        public (List<double>, List<double>) opLDoubleS(List<double> i, Current current) => (i, i);
+        public (IEnumerable<double>, IEnumerable<double>) opLDoubleS(List<double> i, Current current) => (i, i);
 
-        public (LinkedList<double>, LinkedList<double>) opKDoubleS(LinkedList<double> i, Current current) => (i, i);
+        public (IEnumerable<double>, IEnumerable<double>) opKDoubleS(LinkedList<double> i, Current current) => (i, i);
 
-        public (Queue<double>, Queue<double>) opQDoubleS(Queue<double> i, Current current) => (i, i);
+        public (IEnumerable<double>, IEnumerable<double>) opQDoubleS(Queue<double> i, Current current) => (i, i);
 
-        public (Stack<double>, Stack<double>) opSDoubleS(Stack<double> i, Current current) => (i, i);
+        public (IEnumerable<double>, IEnumerable<double>) opSDoubleS(Stack<double> i, Current current) => (i, i);
 
-        public (string[], string[]) opAStringS(string[] i, Current current) => (i, i);
+        public (IEnumerable<string>, IEnumerable<string>) opAStringS(string[] i, Current current) => (i, i);
 
-        public (List<string>, List<string>) opLStringS(List<string> i, Current current) => (i, i);
+        public (IEnumerable<string>, IEnumerable<string>) opLStringS(List<string> i, Current current) => (i, i);
 
-        public (LinkedList<string>, LinkedList<string>) opKStringS(LinkedList<string> i, Current current) => (i, i);
+        public (IEnumerable<string>, IEnumerable<string>) opKStringS(LinkedList<string> i, Current current) => (i, i);
 
-        public (Queue<string>, Queue<string>) opQStringS(Queue<string> i, Current current) => (i, i);
+        public (IEnumerable<string>, IEnumerable<string>) opQStringS(Queue<string> i, Current current) => (i, i);
 
-        public (Stack<string>, Stack<string>) opSStringS(Stack<string> i, Current current) => (i, i);
+        public (IEnumerable<string>, IEnumerable<string>) opSStringS(Stack<string> i, Current current) => (i, i);
 
-        public (AnyClass?[], AnyClass?[]) opAObjectS(AnyClass?[] i, Current current) => (i, i);
+        public (IEnumerable<AnyClass?>, IEnumerable<AnyClass?>) opAObjectS(AnyClass?[] i, Current current) => (i, i);
 
-        public (List<AnyClass?>, List<AnyClass?>) opLObjectS(List<AnyClass?> i, Current current) => (i, i);
+        public (IEnumerable<AnyClass?>, IEnumerable<AnyClass?>) opLObjectS(List<AnyClass?> i, Current current) => (i, i);
 
-        public (IObjectPrx?[], IObjectPrx?[]) opAObjectPrxS(IObjectPrx?[] i, Current current) => (i, i);
+        public (IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>) opAObjectPrxS(IObjectPrx?[] i, Current current) => (i, i);
 
-        public (List<IObjectPrx?>, List<IObjectPrx?>) opLObjectPrxS(List<IObjectPrx?> i, Current current) => (i, i);
+        public (IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>) opLObjectPrxS(List<IObjectPrx?> i, Current current) => (i, i);
 
-        public (LinkedList<IObjectPrx?>, LinkedList<IObjectPrx?>)
-        opKObjectPrxS(LinkedList<IObjectPrx?> i, Current current) => (i, i);
+        public (IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>) opKObjectPrxS(LinkedList<IObjectPrx?> i, Current current) => (i, i);
 
-        public (Queue<IObjectPrx?>, Queue<IObjectPrx?>) opQObjectPrxS(Queue<IObjectPrx?> i, Current current) => (i, i);
+        public (IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>) opQObjectPrxS(Queue<IObjectPrx?> i, Current current) => (i, i);
 
-        public (Stack<IObjectPrx?>, Stack<IObjectPrx?>) opSObjectPrxS(Stack<IObjectPrx?> i, Current current) => (i, i);
+        public (IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>) opSObjectPrxS(Stack<IObjectPrx?> i, Current current) => (i, i);
 
-        public (Test.S[], Test.S[]) opAStructS(Test.S[] i, Current current) => (i, i);
+        public (IEnumerable<Test.S>, IEnumerable<Test.S>) opAStructS(Test.S[] i, Current current) => (i, i);
 
-        public (List<Test.S>, List<Test.S>) opLStructS(List<Test.S> i, Current current) => (i, i);
+        public (IEnumerable<Test.S>, IEnumerable<Test.S>) opLStructS(List<Test.S> i, Current current) => (i, i);
 
-        public (LinkedList<Test.S>, LinkedList<Test.S>) opKStructS(LinkedList<Test.S> i, Current current) => (i, i);
+        public (IEnumerable<Test.S>, IEnumerable<Test.S>) opKStructS(LinkedList<Test.S> i, Current current) => (i, i);
 
-        public (Queue<Test.S>, Queue<Test.S>) opQStructS(Queue<Test.S> i, Current current) => (i, i);
+        public (IEnumerable<Test.S>, IEnumerable<Test.S>) opQStructS(Queue<Test.S> i, Current current) => (i, i);
 
-        public (Stack<Test.S>, Stack<Test.S>) opSStructS(Stack<Test.S> i, Current current) => (i, i);
+        public (IEnumerable<Test.S>, IEnumerable<Test.S>) opSStructS(Stack<Test.S> i, Current current) => (i, i);
 
-        public (Test.SD[], Test.SD[]) opAStructSD(Test.SD[] i, Current current) => (i, i);
+        public (IEnumerable<Test.SD>, IEnumerable<Test.SD>) opAStructSD(Test.SD[] i, Current current) => (i, i);
 
-        public (List<Test.SD>, List<Test.SD>) opLStructSD(List<Test.SD> i, Current current) => (i, i);
+        public (IEnumerable<Test.SD>, IEnumerable<Test.SD>) opLStructSD(List<Test.SD> i, Current current) => (i, i);
 
-        public (LinkedList<Test.SD>, LinkedList<Test.SD>) opKStructSD(LinkedList<Test.SD> i, Current current) => (i, i);
+        public (IEnumerable<Test.SD>, IEnumerable<Test.SD>) opKStructSD(LinkedList<Test.SD> i, Current current) => (i, i);
 
-        public (Queue<Test.SD>, Queue<Test.SD>) opQStructSD(Queue<Test.SD> i, Current current) => (i, i);
+        public (IEnumerable<Test.SD>, IEnumerable<Test.SD>) opQStructSD(Queue<Test.SD> i, Current current) => (i, i);
 
-        public (Stack<Test.SD>, Stack<Test.SD>) opSStructSD(Stack<Test.SD> i, Current current) => (i, i);
+        public (IEnumerable<Test.SD>, IEnumerable<Test.SD>) opSStructSD(Stack<Test.SD> i, Current current) => (i, i);
 
-        public (Test.CV?[], Test.CV?[]) opACVS(Test.CV?[] i, Current current) => (i, i);
+        public (IEnumerable<Test.CV?>, IEnumerable<Test.CV?>) opACVS(Test.CV?[] i, Current current) => (i, i);
 
-        public (List<Test.CV?>, List<Test.CV?>) opLCVS(List<Test.CV?> i, Current current) => (i, i);
+        public (IEnumerable<Test.CV?>, IEnumerable<Test.CV?>) opLCVS(List<Test.CV?> i, Current current) => (i, i);
 
-        public (Test.CR?[], Test.CR?[]) opACRS(Test.CR?[] i, Current current) => (i, i);
+        public (IEnumerable<Test.CR?>, IEnumerable<Test.CR?>) opACRS(Test.CR?[] i, Current current) => (i, i);
 
-        public (List<Test.CR?>, List<Test.CR?>) opLCRS(List<Test.CR?> i, Current current) => (i, i);
+        public (IEnumerable<Test.CR?>, IEnumerable<Test.CR?>) opLCRS(List<Test.CR?> i, Current current) => (i, i);
 
-        public (Test.En[], Test.En[]) opAEnS(Test.En[] i, Current current) => (i, i);
+        public (IEnumerable<Test.En>, IEnumerable<Test.En>) opAEnS(Test.En[] i, Current current) => (i, i);
 
-        public (List<Test.En>, List<Test.En>) opLEnS(List<Test.En> i, Current current) => (i, i);
+        public (IEnumerable<Test.En>, IEnumerable<Test.En>) opLEnS(List<Test.En> i, Current current) => (i, i);
 
-        public (LinkedList<Test.En>, LinkedList<Test.En>) opKEnS(LinkedList<Test.En> i, Current current) => (i, i);
+        public (IEnumerable<Test.En>, IEnumerable<Test.En>) opKEnS(LinkedList<Test.En> i, Current current) => (i, i);
 
-        public (Queue<Test.En>, Queue<Test.En>) opQEnS(Queue<Test.En> i, Current current) => (i, i);
+        public (IEnumerable<Test.En>, IEnumerable<Test.En>) opQEnS(Queue<Test.En> i, Current current) => (i, i);
 
-        public (Stack<Test.En>, Stack<Test.En>) opSEnS(Stack<Test.En> i, Current current) => (i, i);
+        public (IEnumerable<Test.En>, IEnumerable<Test.En>) opSEnS(Stack<Test.En> i, Current current) => (i, i);
 
-        public (Test.IIPrx?[], Test.IIPrx?[]) opAIPrxS(Test.IIPrx?[] i, Current current) => (i, i);
+        public (IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>) opAIPrxS(Test.IIPrx?[] i, Current current) => (i, i);
 
-        public (List<Test.IIPrx?>, List<Test.IIPrx?>) opLIPrxS(List<Test.IIPrx?> i, Current current) => (i, i);
+        public (IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>) opLIPrxS(List<Test.IIPrx?> i, Current current) => (i, i);
 
-        public (LinkedList<Test.IIPrx?>, LinkedList<Test.IIPrx?>)
-        opKIPrxS(LinkedList<Test.IIPrx?> i, Current current) => (i, i);
+        public (IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>) opKIPrxS(LinkedList<Test.IIPrx?> i, Current current) => (i, i);
 
-        public (Queue<Test.IIPrx?>, Queue<Test.IIPrx?>) opQIPrxS(Queue<Test.IIPrx?> i, Current current) => (i, i);
+        public (IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>) opQIPrxS(Queue<Test.IIPrx?> i, Current current) => (i, i);
 
-        public (Stack<Test.IIPrx?>, Stack<Test.IIPrx?>) opSIPrxS(Stack<Test.IIPrx?> i, Current current) => (i, i);
+        public (IEnumerable<Test.IIPrx?>, IEnumerable<Test.IIPrx?>) opSIPrxS(Stack<Test.IIPrx?> i, Current current) => (i, i);
 
-        public (Custom<int>, Custom<int>) opCustomIntS(Custom<int> i, Current current) => (i, i);
+        public (IEnumerable<int>, IEnumerable<int>) opCustomIntS(Custom<int> i, Current current) => (i, i);
 
-        public (Custom<Test.CV?>, Custom<Test.CV?>) opCustomCVS(Custom<Test.CV?> i, Current current) => (i, i);
+        public (IEnumerable<Test.CV?>, IEnumerable<Test.CV?>) opCustomCVS(Custom<Test.CV?> i, Current current) => (i, i);
 
-        public (Custom<Custom<int>>, Custom<Custom<int>>) opCustomIntSS(Custom<Custom<int>> i, Current current) => (i, i);
+        public (IEnumerable<Custom<int>>, IEnumerable<Custom<int>>) opCustomIntSS(Custom<Custom<int>> i, Current current) => (i, i);
 
-        public (Custom<Custom<Test.CV?>>, Custom<Custom<Test.CV?>>)
-        opCustomCVSS(Custom<Custom<Test.CV?>> i, Current current) => (i, i);
+        public (IEnumerable<Custom<Test.CV?>>, IEnumerable<Custom<Test.CV?>>) opCustomCVSS(Custom<Custom<Test.CV?>> i, Current current) => (i, i);
 
-        public (Serialize.Small?, Serialize.Small?) opSerialSmallCSharp(Serialize.Small? i, Current current) => (i, i);
+        public (Serialize.Small, Serialize.Small) opSerialSmallCSharp(Serialize.Small i, Current current) => (i, i);
 
-        public (Serialize.Large?, Serialize.Large?) opSerialLargeCSharp(Serialize.Large? i, Current current) => (i, i);
+        public (Serialize.Large, Serialize.Large) opSerialLargeCSharp(Serialize.Large i, Current current) => (i, i);
 
-        public (Serialize.Struct?, Serialize.Struct?) opSerialStructCSharp(Serialize.Struct? i, Current current) => (i, i);
+        public (Serialize.Struct, Serialize.Struct) opSerialStructCSharp(Serialize.Struct i, Current current) => (i, i);
     }
 }

--- a/csharp/test/Ice/seqMapping/Twoways.cs
+++ b/csharp/test/Ice/seqMapping/Twoways.cs
@@ -564,28 +564,17 @@ namespace Ice.seqMapping
             }
 
             {
-                Serialize.Small?i = null;
-                Serialize.Small? o;
-                Serialize.Small? r;
-
-                (r, o) = p.opSerialSmallCSharp(i);
-
-                TestHelper.Assert(o == null);
-                TestHelper.Assert(r == null);
-            }
-
-            {
                 Serialize.Small i = new Serialize.Small();
                 i.i = 99;
-                Serialize.Small? o;
-                Serialize.Small? r;
+                Serialize.Small o;
+                Serialize.Small r;
 
                 try
                 {
                     (r, o) = p.opSerialSmallCSharp(i);
 
-                    TestHelper.Assert(o!.i == 99);
-                    TestHelper.Assert(r!.i == 99);
+                    TestHelper.Assert(o.i == 99);
+                    TestHelper.Assert(r.i == 99);
                 }
                 catch (OperationNotExistException)
                 {
@@ -594,7 +583,7 @@ namespace Ice.seqMapping
             }
 
             {
-                Serialize.Large? i = new Serialize.Large();
+                Serialize.Large i = new Serialize.Large();
                 i.d1 = 1.0;
                 i.d2 = 2.0;
                 i.d3 = 3.0;
@@ -607,13 +596,12 @@ namespace Ice.seqMapping
                 i.d10 = 10.0;
                 i.d11 = 11.0;
                 i.s1 = Serialize.Large.LargeString;
-                Serialize.Large? o;
-                Serialize.Large? r;
+                Serialize.Large o;
+                Serialize.Large r;
 
                 try
                 {
                     (r, o) = p.opSerialLargeCSharp(i);
-                    TestHelper.Assert(r != null && o != null);
                     TestHelper.Assert(o.d1 == 1.0);
                     TestHelper.Assert(o.d2 == 2.0);
                     TestHelper.Assert(o.d3 == 3.0);
@@ -651,13 +639,12 @@ namespace Ice.seqMapping
                 i.o2 = i;
                 i.s = null;
                 i.s2 = "Hello";
-                Serialize.Struct? o;
-                Serialize.Struct? r;
+                Serialize.Struct o;
+                Serialize.Struct r;
 
                 try
                 {
                     (r, o) = p.opSerialStructCSharp(i);
-                    TestHelper.Assert(o != null && r != null);
                     TestHelper.Assert(o.o == null);
                     TestHelper.Assert(o.o2 != null);
                     TestHelper.Assert(((Serialize.Struct)(o.o2)).o == null);

--- a/csharp/test/Ice/seqMapping/TwowaysAMI.cs
+++ b/csharp/test/Ice/seqMapping/TwowaysAMI.cs
@@ -521,18 +521,12 @@ namespace Ice.seqMapping
             }
 
             {
-                var r = p.opSerialSmallCSharpAsync(null).Result;
-                TestHelper.Assert(r.o == null);
-                TestHelper.Assert(r.ReturnValue == null);
-            }
-
-            {
                 var i = new Serialize.Small();
                 i.i = 99;
 
-                (Serialize.Small? ReturnValue, Serialize.Small? o) = p.opSerialSmallCSharpAsync(i).Result;
-                TestHelper.Assert(o!.i == 99);
-                TestHelper.Assert(ReturnValue!.i == 99);
+                (Serialize.Small ReturnValue, Serialize.Small o) = p.opSerialSmallCSharpAsync(i).Result;
+                TestHelper.Assert(o.i == 99);
+                TestHelper.Assert(ReturnValue.i == 99);
             }
 
             {
@@ -550,8 +544,7 @@ namespace Ice.seqMapping
                 i.d11 = 11.0;
                 i.s1 = Serialize.Large.LargeString;
 
-                (Serialize.Large? ReturnValue, Serialize.Large? o) = p.opSerialLargeCSharpAsync(i).Result;
-                TestHelper.Assert(o != null && ReturnValue != null);
+                (Serialize.Large ReturnValue, Serialize.Large o) = p.opSerialLargeCSharpAsync(i).Result;
                 TestHelper.Assert(o.d1 == 1.0);
                 TestHelper.Assert(o.d2 == 2.0);
                 TestHelper.Assert(o.d3 == 3.0);
@@ -586,8 +579,7 @@ namespace Ice.seqMapping
                 i.s = null;
                 i.s2 = "Hello";
 
-                (Serialize.Struct? ReturnValue, Serialize.Struct? o) = p.opSerialStructCSharpAsync(i).Result;
-                TestHelper.Assert(o != null && ReturnValue != null);
+                (Serialize.Struct ReturnValue, Serialize.Struct o) = p.opSerialStructCSharpAsync(i).Result;
                 TestHelper.Assert(o.o == null);
                 TestHelper.Assert(o.o2 == o);
                 TestHelper.Assert(o.s == null);

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -16,31 +16,31 @@ public sealed class TestIntf : ITestIntf
     }
 
     public ValueTask<Ice.AnyClass?>
-    SBaseAsObjectAsync(Ice.Current current) => FromResult<Ice.AnyClass?>(new SBase("SBase.sb"));
+    SBaseAsObjectAsync(Ice.Current current) => new ValueTask<Ice.AnyClass?>(new SBase("SBase.sb"));
 
-    public ValueTask<SBase?> SBaseAsSBaseAsync(Ice.Current current) => FromResult<SBase?>(new SBase("SBase.sb"));
+    public ValueTask<SBase?> SBaseAsSBaseAsync(Ice.Current current) => new ValueTask<SBase?>(new SBase("SBase.sb"));
 
     public ValueTask<SBase?>
     SBSKnownDerivedAsSBaseAsync(Ice.Current current) =>
-        FromResult<SBase?>(new SBSKnownDerived("SBSKnownDerived.sb", "SBSKnownDerived.sbskd"));
+        new ValueTask<SBase?>(new SBSKnownDerived("SBSKnownDerived.sb", "SBSKnownDerived.sbskd"));
 
     public ValueTask<SBSKnownDerived?>
     SBSKnownDerivedAsSBSKnownDerivedAsync(Ice.Current current) =>
-        FromResult<SBSKnownDerived?>(new SBSKnownDerived("SBSKnownDerived.sb", "SBSKnownDerived.sbskd"));
+        new ValueTask<SBSKnownDerived?>(new SBSKnownDerived("SBSKnownDerived.sb", "SBSKnownDerived.sbskd"));
 
     public ValueTask<SBase?>
     SBSUnknownDerivedAsSBaseAsync(Ice.Current current) =>
-        FromResult<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
+        new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
 
     public ValueTask<SBase?>
     SBSUnknownDerivedAsSBaseCompactAsync(Ice.Current current) =>
-        FromResult<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
+        new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
 
     public ValueTask<Ice.AnyClass?> SUnknownAsObjectAsync(Ice.Current current)
     {
         var su = new SUnknown("SUnknown.su", null);
         su.cycle = su;
-        return FromResult<Ice.AnyClass?>(su);
+        return new ValueTask<Ice.AnyClass?>(su);
     }
 
     public ValueTask checkSUnknownAsync(Ice.AnyClass? obj, Ice.Current current)
@@ -56,7 +56,7 @@ public sealed class TestIntf : ITestIntf
         var b = new B();
         b.sb = "B1.sb";
         b.pb = b;
-        return FromResult<B?>(b);
+        return new ValueTask<B?>(b);
     }
 
     public ValueTask<B?> twoElementCycleAsync(Ice.Current current)
@@ -67,7 +67,7 @@ public sealed class TestIntf : ITestIntf
         b2.sb = "B2.sb";
         b2.pb = b1;
         b1.pb = b2;
-        return FromResult<B?>(b1);
+        return new ValueTask<B?>(b1);
     }
 
     public ValueTask<B?> D1AsBAsync(Ice.Current current)
@@ -82,7 +82,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult<B?>(d1);
+        return new ValueTask<B?>(d1);
     }
 
     public ValueTask<D1?> D1AsD1Async(Ice.Current current)
@@ -97,7 +97,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult<D1?>(d1);
+        return new ValueTask<D1?>(d1);
     }
 
     public ValueTask<B?> D2AsBAsync(Ice.Current current)
@@ -112,7 +112,7 @@ public sealed class TestIntf : ITestIntf
         d1.pd1 = d2;
         d2.pb = d1;
         d2.pd2 = d1;
-        return FromResult<B?>(d2);
+        return new ValueTask<B?>(d2);
     }
 
     public ValueTask<(B?, B?)>
@@ -128,7 +128,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult(((B?)d1, (B?)d2));
+        return MakeValueTask(((B?)d1, (B?)d2));
     }
 
     public ValueTask<(B?, B?)>
@@ -144,7 +144,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult(((B?)d2, (B?)d1));
+        return MakeValueTask(((B?)d2, (B?)d1));
     }
 
     public ValueTask<(B?, B?, B?)>
@@ -174,7 +174,7 @@ public sealed class TestIntf : ITestIntf
         d3.pd1 = null;
         d4.pd2 = d3;
 
-        return FromResult(((B?)d3, (B?)d2, (B?)d4));
+        return MakeValueTask(((B?)d3, (B?)d2, (B?)d4));
     }
 
     public ValueTask<(B?, B?)>
@@ -187,7 +187,7 @@ public sealed class TestIntf : ITestIntf
         d4.p1.sb = "B.sb (1)";
         d4.p2 = new B();
         d4.p2.sb = "B.sb (2)";
-        return FromResult(((B?)d4.p2, (B?)d4));
+        return MakeValueTask(((B?)d4.p2, (B?)d4));
     }
 
     public ValueTask<(B?, B?, B?)>
@@ -203,7 +203,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult(((B?)d2, (B?)d2, (B?)d1));
+        return MakeValueTask(((B?)d2, (B?)d2, (B?)d1));
     }
 
     public ValueTask<(B?, B?, B?)>
@@ -219,17 +219,17 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return FromResult< (B ?, B ?, B ?)>((d1, d1, d2));
+        return new ValueTask< (B ?, B ?, B ?)>((d1, d1, d2));
     }
 
     public ValueTask<B?>
-    returnTest3Async(B? p1, B? p2, Ice.Current current) => FromResult(p1);
+    returnTest3Async(B? p1, B? p2, Ice.Current current) => MakeValueTask(p1);
 
     public ValueTask<SS3>
-    sequenceTestAsync(SS1? p1, SS2? p2, Ice.Current current) => FromResult(new SS3(p1, p2));
+    sequenceTestAsync(SS1? p1, SS2? p2, Ice.Current current) => MakeValueTask(new SS3(p1, p2));
 
-    public ValueTask<(Dictionary<int, B?>, Dictionary<int, B?>)>
-    dictionaryTestAsync(Dictionary<int, B?> bin, Ice.Current current)
+    public ValueTask<(IReadOnlyDictionary<int, B?>, IReadOnlyDictionary<int, B?>)> dictionaryTestAsync(
+        Dictionary<int, B?> bin, Ice.Current current)
     {
         var bout = new Dictionary<int, B?>();
         int i;
@@ -255,11 +255,11 @@ public sealed class TestIntf : ITestIntf
             d1.pd1 = d1;
             r[i * 20] = d1;
         }
-        return FromResult((r, bout));
+        return new ValueTask<(IReadOnlyDictionary<int, B?>, IReadOnlyDictionary<int, B?>)>((r, bout));
     }
 
     public ValueTask<PBase?>
-    exchangePBaseAsync(PBase? pb, Ice.Current current) => FromResult(pb);
+    exchangePBaseAsync(PBase? pb, Ice.Current current) => MakeValueTask(pb);
 
     public ValueTask<Preserved?>
     PBSUnknownAsPreservedAsync(Ice.Current current)
@@ -270,7 +270,7 @@ public sealed class TestIntf : ITestIntf
         r.psu = "unknown";
         r.graph = null;
         r.cl = new MyClass(15);
-        return FromResult<Preserved?>(r);
+        return new ValueTask<Preserved?>(r);
     }
 
     public ValueTask
@@ -297,7 +297,7 @@ public sealed class TestIntf : ITestIntf
         r.graph.next = new PNode();
         r.graph.next.next = new PNode();
         r.graph.next.next.next = r.graph;
-        return FromResult<Preserved?>(r);
+        return new ValueTask<Preserved?>(r);
     }
 
     public ValueTask
@@ -321,7 +321,7 @@ public sealed class TestIntf : ITestIntf
         r.pi = 5;
         r.ps = "preserved";
         r.pb = r;
-        return FromResult<Preserved?>(r);
+        return new ValueTask<Preserved?>(r);
     }
 
     public ValueTask
@@ -336,7 +336,7 @@ public sealed class TestIntf : ITestIntf
     }
 
     public ValueTask<PNode?>
-    exchangePNodeAsync(PNode? pn, Ice.Current current) => FromResult(pn);
+    exchangePNodeAsync(PNode? pn, Ice.Current current) => MakeValueTask(pn);
 
     public ValueTask throwBaseAsBaseAsync(Ice.Current current)
     {
@@ -415,10 +415,11 @@ public sealed class TestIntf : ITestIntf
         var f = new Forward();
         f.h = new Hidden();
         f.h.f = f;
-        return FromResult<Forward?>(f);
+        return new ValueTask<Forward?>(f);
     }
 
-    private static ValueTask<T> FromResult<T>(T result) => new ValueTask<T>(result);
+    // Type-inference helper method
+    private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
 }
 
 public sealed class TestIntf2 : ITestIntf2

--- a/csharp/test/Ice/slicing/objects/TestI.cs
+++ b/csharp/test/Ice/slicing/objects/TestI.cs
@@ -215,8 +215,8 @@ public sealed class TestIntf : ITestIntf
         return ss;
     }
 
-    public (Dictionary<int, B?>, Dictionary<int, B?>)
-    dictionaryTest(Dictionary<int, B?> bin, Ice.Current current)
+    public (IReadOnlyDictionary<int, B?>, IReadOnlyDictionary<int, B?>) dictionaryTest(Dictionary<int, B?> bin,
+        Ice.Current current)
     {
         var bout = new Dictionary<int, B?>();
         int i;

--- a/csharp/test/IceBox/admin/TestI.cs
+++ b/csharp/test/IceBox/admin/TestI.cs
@@ -10,7 +10,8 @@ public class TestFacet : ITestFacet
 {
     private volatile IReadOnlyDictionary<string, string>? _changes;
 
-    public Dictionary<string, string> getChanges(Ice.Current current) => new Dictionary<string, string>(_changes!);
+    public IReadOnlyDictionary<string, string> getChanges(Ice.Current current) =>
+        new Dictionary<string, string>(_changes!);
 
     internal void Updated(IReadOnlyDictionary<string, string> changes) => _changes = changes;
 }

--- a/csharp/test/IceBox/configuration/TestI.cs
+++ b/csharp/test/IceBox/configuration/TestI.cs
@@ -2,17 +2,17 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Collections.Generic;
+
 using Test;
 
 public class TestIntf : ITestIntf
 {
+    private string[] _args;
+
     public TestIntf(string[] args) => _args = args;
 
-    public string
-    getProperty(string name, Ice.Current current) => current.Adapter.Communicator.GetProperty(name) ?? "";
+    public string getProperty(string name, Ice.Current current) => current.Adapter.Communicator.GetProperty(name) ?? "";
 
-    public string[]
-    getArgs(Ice.Current current) => _args;
-
-    private string[] _args;
+    public IEnumerable<string> getArgs(Ice.Current current) => _args;
 }


### PR DESCRIPTION
This PR updates the C# mapping for outgoing arrays and dictionaries as follows:
 - an outgoing `sequence<T>` is mapped to `ReadOnlyMemory<T>` when T is a fixed-size numeric type or bool, and the sequence does not carry metadata such as `cs:generic` or `cs:serializable`
- an outgoing `sequence<byte>` with `cs:serializable` metadata is mapped to the serializable class
- otherwise, an outgoing `sequence<T>` is mapped to `IEnumerable<T>`. The implementation uses Linq's Enumerable.Count(), which is fast when `IEnumerable` is an `ICollection`. The 2.0 encoding will use a different implementation which will be fast even for non-ICollection enumerables.
- an outgoing `dictionary<T>` is mapped to an `IReadOnlyDictionary<T>`

Also replaced all "WriteOptional" in the generated code by helper methods on OutputStream (for tagged structs, sequences, dictionaries).