### PR TITLE
Refactor InputStream encapsulation

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -3,7 +3,6 @@
 //
 
 using Ice;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -3,6 +3,7 @@
 //
 
 using Ice;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -230,9 +231,8 @@ namespace IceInternal
                         Ice1Definitions.GetResponseData(responseFrame, requestId));
                 if (_traceLevels.Protocol >= 1)
                 {
-                    var iss = new InputStream(_adapter.Communicator, responseBuffer,
-                        Ice1Definitions.HeaderSize + 4);
-                    TraceUtil.TraceRecv(iss, _logger, _traceLevels);
+                    var istr = new InputStream(_adapter.Communicator, responseBuffer, Ice1Definitions.HeaderSize + 4);
+                    TraceUtil.TraceRecv(istr, _logger, _traceLevels);
                 }
 
                 if (_asyncRequests.TryGetValue(requestId, out outAsync))

--- a/csharp/src/Ice/DispatchException.cs
+++ b/csharp/src/Ice/DispatchException.cs
@@ -42,9 +42,13 @@ namespace Ice
             {
                 message += $" with facet `{facet}'";
             }
+#if DEBUG
+            message += $":\n{innerException}\n---";
+#else
             // Since this custom message will be sent "over the wire", we don't include the stack trace of the inner
             // exception since it can include sensitive information. The stack trace is of course available locally.
             message += $":\n{innerException.Message}";
+#endif
             return message;
         }
     }

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -73,7 +73,7 @@ namespace Ice
 
         /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload
         /// correspond to the empty parameter list.</summary>
-        public void ReadEmptyParamList() => InputStream.ReadEmptyEncapsulation(_communicator, Payload, 0);
+        public void ReadEmptyParamList() => InputStream.ReadEmptyEncapsulation(_communicator, Payload);
 
         /// <summary>Reads the request frame parameter list.</summary>
         /// <param name="reader">An InputStreamReader delegate used to read the request frame

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -73,25 +73,14 @@ namespace Ice
 
         /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload
         /// correspond to the empty parameter list.</summary>
-        public void ReadEmptyParamList()
-        {
-            var istr = new InputStream(_communicator, Payload);
-            istr.StartEncapsulation();
-            istr.EndEncapsulation();
-        }
+        public void ReadEmptyParamList() => InputStream.ReadEmptyEncapsulation(_communicator, Payload, 0);
 
         /// <summary>Reads the request frame parameter list.</summary>
         /// <param name="reader">An InputStreamReader delegate used to read the request frame
         /// parameters.</param>
         /// <returns>The request parameters, when the frame parameter list contains multiple parameters
         /// they must be return as a tuple.</returns>
-        public T ReadParamList<T>(InputStreamReader<T> reader)
-        {
-            var istr = new InputStream(_communicator, Payload);
-            istr.StartEncapsulation();
-            T paramList = reader(istr);
-            istr.EndEncapsulation();
-            return paramList;
-        }
+        public T ReadParamList<T>(InputStreamReader<T> reader) =>
+            InputStream.ReadEncapsulation(_communicator, Payload, 0, reader);
     }
 }

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -81,6 +81,6 @@ namespace Ice
         /// <returns>The request parameters, when the frame parameter list contains multiple parameters
         /// they must be return as a tuple.</returns>
         public T ReadParamList<T>(InputStreamReader<T> reader) =>
-            InputStream.ReadEncapsulation(_communicator, Payload, 0, reader);
+            InputStream.ReadEncapsulation(_communicator, Payload, reader);
     }
 }

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -38,11 +38,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                var istr = new InputStream(_communicator, Payload, 1);
-                istr.StartEncapsulation();
-                T ret = reader(istr);
-                istr.EndEncapsulation();
-                return ret;
+                return InputStream.ReadEncapsulation(_communicator, Payload, 1, reader);
             }
             else
             {
@@ -56,9 +52,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                var istr = new InputStream(_communicator, Payload, 1);
-                istr.StartEncapsulation();
-                istr.EndEncapsulation();
+                InputStream.ReadEmptyEncapsulation(_communicator, Payload, 1);
             }
             else
             {
@@ -108,11 +102,7 @@ namespace Ice
             {
                 case ReplyStatus.UserException:
                 {
-                    var istr = new InputStream(_communicator, Payload, 1);
-                    istr.StartEncapsulation();
-                    RemoteException ex = istr.ReadException();
-                    istr.EndEncapsulation();
-                    return ex;
+                    return InputStream.ReadEncapsulation(_communicator, Payload, 1, istr => istr.ReadException());
                 }
                 case ReplyStatus.ObjectNotExistException:
                 case ReplyStatus.FacetNotExistException:

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -38,7 +38,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                return InputStream.ReadEncapsulation(_communicator, Payload, 1, reader);
+                return InputStream.ReadEncapsulation(_communicator, Payload.Slice(1), reader);
             }
             else
             {
@@ -52,7 +52,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                InputStream.ReadEmptyEncapsulation(_communicator, Payload, 1);
+                InputStream.ReadEmptyEncapsulation(_communicator, Payload.Slice(1));
             }
             else
             {
@@ -102,7 +102,7 @@ namespace Ice
             {
                 case ReplyStatus.UserException:
                 {
-                    return InputStream.ReadEncapsulation(_communicator, Payload, 1, istr => istr.ReadException());
+                    return InputStream.ReadEncapsulation(_communicator, Payload.Slice(1), istr => istr.ReadException());
                 }
                 case ReplyStatus.ObjectNotExistException:
                 case ReplyStatus.FacetNotExistException:

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -84,7 +84,7 @@ namespace Ice
         private int _minTotalSeqSize = 0;
 
         private readonly ArraySegment<byte> _buffer;
-        private int _pos = 0;
+        private int _pos;
 
         // Map of type ID index to type ID string.
         // When reading a top-level encapsulation, we assign a type ID index (starting with 1) to each type ID we
@@ -112,8 +112,13 @@ namespace Ice
         /// <summary>Constructs a new InputStream over a byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
         /// <param name="buffer">The byte buffer.</param>
+        /// <param name="pos">The initial position in the buffer.</param>
         internal InputStream(Communicator communicator, ArraySegment<byte> buffer, int pos = 0)
         {
+            // TODO: pos/_should always be 0 and buffer should be a slice.
+            // Currently this does not work because of the tracing code that resets Pos to 0 to read the protocol frame
+            // headers etc.
+
             Communicator = communicator;
             _buffer = buffer;
             _pos = pos;
@@ -122,6 +127,7 @@ namespace Ice
         /// <summary>Reads the contents of an encapsulation from the provided byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
         /// <param name="buffer">The byte buffer.</param>
+        /// <param name="pos">The initial position in the buffer.</param>
         /// <param name="payloadReader">The reader used to read the payload of this encapsulation.</param>
         internal static T ReadEncapsulation<T>(Communicator communicator,
                                                ArraySegment<byte> buffer,
@@ -138,7 +144,8 @@ namespace Ice
         /// <summary>Reads an empty encapsulation from the provided byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
         /// <param name="buffer">The byte buffer.</param>
-        internal static void ReadEmptyEncapsulation(Communicator communicator, ArraySegment<byte> buffer, int pos)
+        /// <param name="pos">The initial position in the buffer.</param>
+        internal static void ReadEmptyEncapsulation(Communicator communicator, ArraySegment<byte> buffer, int pos = 0)
         {
             var istr = new InputStream(communicator, buffer, pos);
             istr.StartEncapsulation();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -113,9 +113,9 @@ namespace Ice
         internal InputStream(Communicator communicator, ArraySegment<byte> buffer, int pos = 0)
             : this(communicator, buffer, false, pos)
         {
-            // TODO: pos/_should always be 0 and buffer should be a slice as needed.
+            // TODO: pos should always be 0 and buffer should be a slice as needed.
             // Currently this does not work because of the tracing code that resets Pos to 0 to read the protocol frame
-            // headers etc.
+            // headers.
         }
 
         /// <summary>Reads the contents of an encapsulation from the provided byte buffer.</summary>


### PR DESCRIPTION
This PR replaces InputStream's StartEncapsulation/EndEncapsulation by two static methods:
- `ReadEncapsulation<T>`
- `ReadEmptyEncapsulation`
These static methods then create an InputStream just for that encapsulation, which corresponds to the current usage.

This PR also restores the InputStream.Encoding property.