### PR TITLE
Remove redundant writer parameters in OutputStream

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2634,8 +2634,16 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     _out << sb;
     _out << nl << "public static void Write(this Ice.OutputStream ostr, "<< readOnlyDictS << " dictionary) => ";
     _out.inc();
-    _out << nl << "ostr.WriteDictionary(dictionary, " << outputStreamWriter(key, ns, true) << ", "
-         << outputStreamWriter(value, ns, true) << ");";
+    _out << nl << "ostr.WriteDictionary(dictionary";
+    if (!StructPtr::dynamicCast(key))
+    {
+        _out << ", " << outputStreamWriter(key, ns, true);
+    }
+    if (!StructPtr::dynamicCast(value))
+    {
+        _out << ", " << outputStreamWriter(value, ns, true);
+    }
+    _out << ");";
     _out.dec();
 
     _out << sp;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1436,7 +1436,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out << sp;
     _out << nl << "public static readonly new Ice.InputStreamReader<" << name << "?> IceReader =";
     _out.inc();
-    _out << nl << "(istr) => istr.ReadClass<" << name << ">();";
+    _out << nl << "istr => istr.ReadClass<" << name << ">();";
     _out.dec();
 
     _out << sp;
@@ -1853,7 +1853,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     emitGeneratedCodeAttribute();
     _out << nl << "public static Ice.InputStreamReader<" << name << "> IceReader => ";
     _out.inc();
-    _out << nl << "(istr) => new " << name << "(istr);";
+    _out << nl << "istr => new " << name << "(istr);";
     _out.dec();
 
     _out << sp;
@@ -1999,20 +1999,6 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         writeMarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_ostr");
     }
     _out << eb;
-
-    _out << eb;
-
-    _out << sp;
-    _out << nl << "public static class " << p->name() << "Helper";
-    _out << sb;
-
-    _out << sp;
-    _out << nl << "public static Ice.OutputStreamWriter<" << name
-         << "> IceWriter = (ostr, value) => value.IceWrite(ostr);";
-
-    _out << sp;
-    _out << nl << "public static Ice.InputStreamReader<" << name << "> IceReader = (istr) => new " << name << "(istr);";
-
     _out << eb;
 }
 
@@ -2234,7 +2220,7 @@ Slice::Gen::ProxyVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out << sp;
     _out << nl << "public static readonly new Ice.InputStreamReader<" << name << "?> IceReader =";
     _out.inc();
-    _out << nl << "(istr) => istr.ReadProxy(Factory);";
+    _out << nl << "istr => istr.ReadProxy(Factory);";
     _out.dec();
 
     _out << sp;

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -223,23 +223,23 @@ namespace Ice
 
         /// <summary>Writes a double to the stream.</summary>
         /// <param name="v">The double to write to the stream.</param>
-        public void WriteDouble(double v) => WriteFixedSizeNumeric(v, sizeof(double));
+        public void WriteDouble(double v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a float to the stream.</summary>
         /// <param name="v">The float to write to the stream.</param>
-        public void WriteFloat(float v) => WriteFixedSizeNumeric(v, sizeof(float));
+        public void WriteFloat(float v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes an int to the stream.</summary>
         /// <param name="v">The int to write to the stream.</param>
-        public void WriteInt(int v) => WriteFixedSizeNumeric(v, sizeof(int));
+        public void WriteInt(int v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a long to the stream.</summary>
         /// <param name="v">The long to write to the stream.</param>
-        public void WriteLong(long v) => WriteFixedSizeNumeric(v, sizeof(long));
+        public void WriteLong(long v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a short to the stream.</summary>
         /// <param name="v">The short to write to the stream.</param>
-        public void WriteShort(short v) => WriteFixedSizeNumeric(v, sizeof(short));
+        public void WriteShort(short v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a string to the stream.</summary>
         /// <param name="v">The string to write to the stream.</param>
@@ -1147,9 +1147,9 @@ namespace Ice
 
         /// <summary>Writes a fixed-size numeric to the stream.</summary>
         /// <param name="v">The numeric value to write to the stream.</param>
-        /// <param name="elementSize">The sizeof the type.</param>
-        private void WriteFixedSizeNumeric<T>(T v, int elementSize) where T : struct
+        private void WriteFixedSizeNumeric<T>(T v) where T : struct
         {
+            int elementSize = Unsafe.SizeOf<T>();
             Debug.Assert(elementSize > 1); // for size 1, we write the byte directly
             Span<byte> data = stackalloc byte[elementSize];
             MemoryMarshal.Write(data, ref v);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -1054,7 +1054,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opByteSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(byte)));
+                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1086,7 +1086,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opBoolSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(byte)));
+                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1118,7 +1118,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opShortSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(short)));
+                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1149,7 +1149,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opIntSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(int)));
+                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1180,7 +1180,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opLongSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(long)));
+                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1211,7 +1211,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opFloatSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(float)));
+                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1242,7 +1242,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opDoubleSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1, sizeof(double)));
+                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>


### PR DESCRIPTION
This small PR:
- removes redundant "struct" writer parameters in OutputStream. Since all structs given to sequence/dictionaries are IStreamableStruct, we already know how to write them.
- replaces an elementSize always equal to sizeof(T) by Unsafe.Sizeof<T>()