### PR TITLE
Fix Intellisense warnings for C++ build

### DIFF
--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -682,7 +682,7 @@ public:
      * it will be destroyed.
      * @param holder The holder from which to adopt a communicator.
      */
-    CommunicatorHolder& operator=(CommunicatorHolder&& holder);
+    CommunicatorHolder& operator=(CommunicatorHolder&& holder) noexcept;
 
     /**
      * Determines whether the holder contains an instance.

--- a/cpp/src/Ice/ImplicitContextI.cpp
+++ b/cpp/src/Ice/ImplicitContextI.cpp
@@ -471,7 +471,7 @@ PerThreadImplicitContext::clearThreadContext() const
 #   ifdef _WIN32
             if(TlsSetValue(_key, 0) == 0)
             {
-                IceUtil::ThreadSyscallException(__FILE__, __LINE__, GetLastError());
+                throw IceUtil::ThreadSyscallException(__FILE__, __LINE__, GetLastError());
             }
 #   else
             if(int err = pthread_setspecific(_key, 0))

--- a/cpp/src/Ice/Initialize.cpp
+++ b/cpp/src/Ice/Initialize.cpp
@@ -413,7 +413,7 @@ Ice::CommunicatorHolder::operator=(shared_ptr<Communicator> communicator)
 }
 
 Ice::CommunicatorHolder&
-Ice::CommunicatorHolder::operator=(CommunicatorHolder&& other)
+Ice::CommunicatorHolder::operator=(CommunicatorHolder&& other) noexcept
 {
     if(_communicator)
     {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -298,7 +298,7 @@ getLocalAddresses(ProtocolSupport protocol, bool includeLoopback, bool singleAdd
             break;
     }
 
-    DWORD size;
+    DWORD size = 0;
     DWORD rv = GetAdaptersAddresses(family, 0, ICE_NULLPTR, ICE_NULLPTR, &size);
     if(rv == ERROR_BUFFER_OVERFLOW)
     {

--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -228,7 +228,7 @@ ASMUtcTimeToTime(const ASN1_UTCTIME* s)
 #   pragma warning(default:4996) // localtime is depercated
 #endif
 
-    IceUtil::Time time = IceUtil::Time::seconds(mktime(&tm) - offset * 60 + tzone);
+    IceUtil::Time time = IceUtil::Time::seconds(mktime(&tm) - IceUtil::Int64(offset) * 60 + tzone);
 
 #ifdef ICE_CPP11_MAPPING
     return chrono::system_clock::time_point(chrono::microseconds(time.toMicroSeconds()));

--- a/cpp/src/IceUtil/Time.cpp
+++ b/cpp/src/IceUtil/Time.cpp
@@ -97,7 +97,7 @@ IceUtil::Time::now(Clock clock)
         struct timeb tb;
         ftime(&tb);
 #  endif
-        return Time(static_cast<Int64>(tb.time) * ICE_INT64(1000000) + tb.millitm * 1000);
+        return Time(static_cast<Int64>(tb.time) * ICE_INT64(1000000) + Int64(tb.millitm) * 1000);
 #else
         struct timeval tv;
         if(gettimeofday(&tv, 0) < 0)
@@ -130,7 +130,7 @@ IceUtil::Time::now(Clock clock)
             struct timeb tb;
             ftime(&tb);
 #  endif
-            return Time(static_cast<Int64>(tb.time) * ICE_INT64(1000000) + tb.millitm * 1000);
+            return Time(static_cast<Int64>(tb.time) * ICE_INT64(1000000) + Int64(tb.millitm) * 1000);
         }
 #elif defined(__hppa)
         //

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -6392,14 +6392,7 @@ Slice::Gen::Cpp11TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
                 {
                     H << ", ";
                 }
-                if(isMovable((*q)->type()))
-                {
-                    H << "::std::move(" << fixKwd((*q)->name()) << ")";
-                }
-                else
-                {
-                    H << fixKwd((*q)->name());
-                }
+                H << fixKwd((*q)->name());
             }
 
             H << ")";
@@ -6425,14 +6418,7 @@ Slice::Gen::Cpp11TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
             {
                 H << ",";
             }
-            if(isMovable((*q)->type()))
-            {
-                H << nl << memberName << "(::std::move(" << memberName << "))";
-            }
-            else
-            {
-                H << nl << memberName << "(" << memberName << ")";
-            }
+            H << nl << memberName << "(" << memberName << ")";
         }
 
         H.dec();
@@ -8721,14 +8707,7 @@ Slice::Gen::Cpp11ObjectVisitor::emitVirtualBaseInitializers(const ClassDefPtr& d
         {
             upcall += ", ";
         }
-        if(isMovable((*q)->type()))
-        {
-            upcall += "::std::move(" + fixKwd((*q)->name()) + ")";
-        }
-        else
-        {
-            upcall += "" + fixKwd((*q)->name());
-        }
+        upcall += "" + fixKwd((*q)->name());
     }
     upcall += ")";
 
@@ -8824,14 +8803,7 @@ Slice::Gen::Cpp11ObjectVisitor::emitOneShotConstructor(const ClassDefPtr& p)
                 H << ',' << nl;
             }
             string memberName = fixKwd((*q)->name());
-            if(isMovable((*q)->type()))
-            {
-                H << memberName << "(::std::move(" << memberName << "))";
-            }
-            else
-            {
-                H << memberName << "(" << memberName << ')';
-            }
+            H << memberName << "(" << memberName << ')';
         }
 
         H.dec();


### PR DESCRIPTION
This PR fixes a number of Intellisense warnings for C++ builds - primarily the attempt to move const parameters in generated C++11 code.