### PR TITLE
Do not always generate a parameterless constructor for class/exception in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -49,7 +49,7 @@ protected:
     // Generate assignment statements for those data members that have default values.
     //
     bool requiresDataMemberInitializers(const DataMemberList&);
-    void writeDataMemberInitializers(const DataMemberList&, const std::string&, unsigned int = 0);
+    void writeDataMemberInitializers(const DataMemberList&, const std::string&, unsigned int, bool);
 
     void writeProxyDocComment(const ClassDefPtr&, const std::string&);
     void writeServantDocComment(const ClassDefPtr&, const std::string&);

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -36,8 +36,6 @@ protected:
     void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&,
                                   const std::string& stream = "istr");
 
-    virtual void writeMarshaling(const ClassDefPtr&);
-
     void emitCommonAttributes(); // GeneratedCode and more if needed
     void emitCustomAttributes(const ContainedPtr&); // attributes specified through metadata
     void emitSerializableAttribute();
@@ -99,30 +97,6 @@ private:
         virtual bool visitUnitStart(const UnitPtr&);
     };
 
-    class CompactIdVisitor : public CsVisitor
-    {
-    public:
-
-        CompactIdVisitor(IceUtilInternal::Output&);
-        virtual bool visitUnitStart(const UnitPtr&);
-        virtual void visitUnitEnd(const UnitPtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&);
-    };
-
-    class TypeIdVisitor : public CsVisitor
-    {
-    public:
-
-        TypeIdVisitor(IceUtilInternal::Output&);
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&);
-        virtual bool visitExceptionStart(const ExceptionPtr&);
-
-    private:
-        void generateHelperClass(const ContainedPtr&);
-    };
-
     class TypesVisitor : public CsVisitor
     {
     public:
@@ -141,6 +115,10 @@ private:
         virtual void visitDataMember(const DataMemberPtr&);
         virtual void visitSequence(const SequencePtr&);
         virtual void visitDictionary(const DictionaryPtr&);
+
+    private:
+
+        void writeMarshaling(const ClassDefPtr&);
     };
 
     class ProxyVisitor : public CsVisitor
@@ -188,6 +166,36 @@ private:
         virtual bool visitClassDefStart(const ClassDefPtr&);
         virtual void visitOperation(const OperationPtr&);
         virtual void visitClassDefEnd(const ClassDefPtr&);
+    };
+
+    class ClassFactoryVisitor : public CsVisitor
+    {
+    public:
+
+        ClassFactoryVisitor(IceUtilInternal::Output&);
+        virtual bool visitModuleStart(const ModulePtr&);
+        virtual void visitModuleEnd(const ModulePtr&);
+        virtual bool visitClassDefStart(const ClassDefPtr&);
+    };
+
+    class CompactIdVisitor : public CsVisitor
+    {
+    public:
+
+        CompactIdVisitor(IceUtilInternal::Output&);
+        virtual bool visitUnitStart(const UnitPtr&);
+        virtual void visitUnitEnd(const UnitPtr&);
+        virtual bool visitClassDefStart(const ClassDefPtr&);
+    };
+
+    class RemoteExceptionFactoryVisitor : public CsVisitor
+    {
+    public:
+
+        RemoteExceptionFactoryVisitor(IceUtilInternal::Output&);
+        virtual bool visitModuleStart(const ModulePtr&);
+        virtual void visitModuleEnd(const ModulePtr&);
+        virtual bool visitExceptionStart(const ExceptionPtr&);
     };
 };
 

--- a/csharp/src/Ice/AnyClass.cs
+++ b/csharp/src/Ice/AnyClass.cs
@@ -18,11 +18,12 @@ namespace Ice
             get => null;
             set => Debug.Assert(false);
         }
-        internal SlicedData? SlicedData => IceSlicedData;
 
-        // See InputStream.
-        protected abstract void IceRead(InputStream istr, bool firstSlice);
-        internal void Read(InputStream istr) => IceRead(istr, true);
+        internal SlicedData? SlicedData
+        {
+            get => IceSlicedData;
+            set => IceSlicedData = value;
+        }
 
         // See OutputStream.
         protected abstract void IceWrite(OutputStream ostr, bool firstSlice);
@@ -31,11 +32,9 @@ namespace Ice
 
     public static class AnyClassExtensions
     {
-        /// <summary>
-        /// During unmarshaling, Ice can slice off derived slices that it does not know how to read, and it can
-        /// optionally preserve those "unknown" slices. See the Slice preserve metadata directive and the
-        /// class UnknownSlicedClass.
-        /// </summary>
+        /// <summary>During unmarshaling, Ice can slice off derived slices that it does not know how to read, and it can
+        /// optionally preserve those "unknown" slices. See the Slice preserve metadata directive and class
+        /// <see cref="UnknownSlicedClass"/>.</summary>
         /// <returns>A SlicedData value that provides the list of sliced-off slices.</returns>
         public static SlicedData? GetSlicedData(this AnyClass obj) => obj.SlicedData;
     }

--- a/csharp/src/Ice/DispatchException.cs
+++ b/csharp/src/Ice/DispatchException.cs
@@ -9,13 +9,31 @@ namespace Ice
 
     public partial class DispatchException
     {
+        public DispatchException(Current current)
+            : this(current.Identity, current.Facet, current.Operation)
+        {
+        }
+
         protected override string DefaultMessage
             => Facet.Length == 0 ? $"failed to dispatch request for operation `{Operation}' on Ice object `{Id}'"
                 : $"failed to dispatch request for operation `{Operation}' on Ice object `{Id}' with facet `{Facet}'";
     }
 
+    public partial class PreExecutionException
+    {
+        public PreExecutionException(Current current)
+            : base(current)
+        {
+        }
+    }
+
     public partial class ObjectNotExistException
     {
+        public ObjectNotExistException(Current current)
+            : base(current)
+        {
+        }
+
         protected override string DefaultMessage
             => $"could not find servant for Ice object `{Id}'" + (Facet.Length > 0 ? $" with facet `{Facet}'" : "") +
                 $" while attempting to dispatch operation `{Operation}'";
@@ -23,6 +41,11 @@ namespace Ice
 
     public partial class OperationNotExistException
     {
+        public OperationNotExistException(Current current)
+            : base(current)
+        {
+        }
+
         protected override string DefaultMessage
             => $"could not find operation `{Operation}' for Ice object `{Id}'" +
                 (Facet.Length > 0 ? $" with facet `{Facet}'" : "");

--- a/csharp/src/Ice/IClassFactory.cs
+++ b/csharp/src/Ice/IClassFactory.cs
@@ -1,0 +1,16 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+namespace Ice
+{
+    /// <summary>IClassFactory is a publicly visible Ice internal interface used by InputStream and implemented by
+    /// the generated code.</summary>
+    public interface IClassFactory
+    {
+        /// <summary>Creates a new instance of the associated class and reads its fields from the stream.</summary>
+        /// <param name="istr">The input stream.</param>
+        /// <returns>The new class instance.</returns>
+        AnyClass Read(InputStream istr);
+    }
+}

--- a/csharp/src/Ice/IRemoteExceptionFactory.cs
+++ b/csharp/src/Ice/IRemoteExceptionFactory.cs
@@ -1,0 +1,17 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+namespace Ice
+{
+    /// <summary>IRemoteExceptionFactory is a publicly visible Ice internal interface used by InputStream and
+    /// implemented by the generated code.</summary>
+    public interface IRemoteExceptionFactory
+    {
+        /// <summary>Creates a new instance of the associated remote exception and reads its fields from the stream.
+        /// </summary>
+        /// <param name="istr">The input stream.</param>
+        /// <returns>The new remote exception.</returns>
+        RemoteException Read(InputStream istr);
+    }
+}

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -103,23 +103,6 @@ namespace Ice
             }
         }
 
-        /// <summary>Returns the sliced data held by the current instance.</summary>
-        internal SlicedData? SlicedData
-        {
-            get
-            {
-                Debug.Assert(_current != null);
-                if (_current.Slices == null)
-                {
-                    return null;
-                }
-                else
-                {
-                    return new SlicedData(Encoding, _current.Slices);
-                }
-            }
-        }
-
         private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
 
         // True when reading a top-level encapsulation; otherwise, false.

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -9,6 +9,21 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
+namespace IceMX
+{
+    // Extends generated class that requires a public parameterless constructor in the code below.
+    public partial class InvocationMetrics
+    {
+        public InvocationMetrics()
+        {
+            Retry = 0;
+            UserException = 0;
+            Remotes = Array.Empty<Metrics>();
+            Collocated = Array.Empty<Metrics>();
+        }
+    }
+}
+
 namespace IceInternal
 {
     public class ObserverWithDelegate<T, O> : Observer<T>

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -15,11 +15,8 @@ namespace IceMX
     public partial class InvocationMetrics
     {
         public InvocationMetrics()
+            : this(remotes: Array.Empty<Metrics>(), collocated: Array.Empty<Metrics>())
         {
-            Retry = 0;
-            UserException = 0;
-            Remotes = Array.Empty<Metrics>();
-            Collocated = Array.Empty<Metrics>();
         }
     }
 }

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -32,7 +32,7 @@ namespace IceInternal
                 {
                     if (_destroyed)
                     {
-                        throw new ObjectNotExistException();
+                        throw new ObjectNotExistException(current);
                     }
 
                     _sendLogCommunicator =

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -135,37 +135,12 @@ namespace Ice
                 ostr = new OutputStream(Encoding, Data, new OutputStream.Position(0, 0));
                 if (dispatchException is PreExecutionException preExecutionException)
                 {
-                    // TODO: the null checks are necessary due to the way we unmarshal the exception through reflection.
-
-                    if (string.IsNullOrEmpty(preExecutionException.Id.Name))
+                    ReplyStatus replyStatus = preExecutionException switch
                     {
-                        preExecutionException.Id = current.Identity;
-                    }
-
-                    if (string.IsNullOrEmpty(preExecutionException.Facet))
-                    {
-                        preExecutionException.Facet = current.Facet;
-                    }
-
-                    if (string.IsNullOrEmpty(preExecutionException.Operation))
-                    {
-                        preExecutionException.Operation = current.Operation;
-                    }
-
-                    ReplyStatus replyStatus = default;
-
-                    if (preExecutionException is ObjectNotExistException)
-                    {
-                        replyStatus = ReplyStatus.ObjectNotExistException;
-                    }
-                    else if (preExecutionException is OperationNotExistException)
-                    {
-                        replyStatus = ReplyStatus.OperationNotExistException;
-                    }
-                    else
-                    {
-                        Debug.Assert(false);
-                    }
+                        ObjectNotExistException _ => ReplyStatus.ObjectNotExistException,
+                        OperationNotExistException _ => ReplyStatus.OperationNotExistException,
+                        _ => throw new ArgumentException("unknown PreExecutionException", nameof(exception))
+                    };
 
                     ostr.WriteByte((byte)replyStatus);
                     preExecutionException.Id.IceWrite(ostr);

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -31,7 +31,11 @@ namespace Ice
 
         private readonly bool _hasCustomMessage = false;
 
-        internal RemoteException(SlicedData slicedData) => IceSlicedData = slicedData;
+        internal RemoteException(SlicedData slicedData)
+        {
+            IceSlicedData = slicedData;
+            ConvertToUnhandled = true;
+        }
 
         /// <summary>Constructs a remote exception with the default system message.</summary>
         protected RemoteException()
@@ -56,15 +60,6 @@ namespace Ice
             : base(info, context)
         {
         }
-
-        // See InputStream.
-        protected virtual void IceRead(InputStream istr, bool firstSlice)
-        {
-            // If this exception is a plain RemoteException, IceSlicedData is set using the internal RemoteException
-            // constructor. As a result, this base method implementation is never called.
-            Debug.Assert(false);
-        }
-        internal void Read(InputStream istr) => IceRead(istr, true);
 
         // See OutputStream
         protected virtual void IceWrite(OutputStream ostr, bool firstSlice)

--- a/csharp/src/Ice/UnknownSlicedClass.cs
+++ b/csharp/src/Ice/UnknownSlicedClass.cs
@@ -6,42 +6,25 @@ using System.Diagnostics;
 
 namespace Ice
 {
-    /// <summary>
-    /// UnknownSlicedClass represents a fully sliced class instance. The local Ice runtime does not known any class
-    /// described by this instance.
-    /// </summary>
+    /// <summary>UnknownSlicedClass represents a fully sliced class instance. The local Ice runtime does not known this
+    /// type or any of its base classes (other than AnyClass).</summary>
     public sealed class UnknownSlicedClass : AnyClass
     {
-        /// <summary>
-        /// Returns the Slice type ID associated with this sliced class instance.
-        /// </summary>
+        /// <summary>Returns the Slice type ID associated with this sliced class instance.</summary>
         /// <value>The type ID.</value>
         public string? TypeId
         {
             get
             {
-                // Can only be called after IceRead filled this instance. TypeId can be null for a slice with an
-                // unresolved compact ID.
-                Debug.Assert(_slicedData.HasValue && _slicedData.Value.Slices.Count > 0);
-                return _slicedData.Value.Slices[0].TypeId;
+                // TypeId can be null for a slice with an unresolved compact ID.
+                Debug.Assert(IceSlicedData is SlicedData slicedData && slicedData.Slices.Count > 0);
+                return IceSlicedData.Value.Slices[0].TypeId;
             }
         }
-        protected override SlicedData? IceSlicedData => _slicedData;
-        private SlicedData? _slicedData;
-        protected override void IceRead(InputStream istr, bool firstSlice)
-        {
-            Debug.Assert(firstSlice);
-            _slicedData = istr.SlicedData;
-            Debug.Assert(_slicedData.HasValue && _slicedData.Value.Slices.Count > 0);
-        }
-        protected override void IceWrite(OutputStream ostr, bool firstSlice)
-        {
-            Debug.Assert(firstSlice);
-            Debug.Assert(_slicedData.HasValue); // Can only be called on an instance previously filled by IceRead.
-            ostr.WriteSlicedData(_slicedData.Value);
-        }
-        internal UnknownSlicedClass()
-        {
-        }
+
+        protected override SlicedData? IceSlicedData { get; set; }
+
+        protected override void IceWrite(OutputStream ostr, bool _) => ostr.WriteSlicedData(IceSlicedData!.Value);
+        internal UnknownSlicedClass(InputStream istr) => istr.FirstSliceInit(this, setSlicedData: true);
     }
 }

--- a/csharp/test/Glacier2/router/CallbackI.cs
+++ b/csharp/test/Glacier2/router/CallbackI.cs
@@ -45,10 +45,7 @@ public sealed class CallbackReceiver : ICallbackReceiver
     callbackEx(Ice.Current current)
     {
         callback(current);
-        var ex = new CallbackException();
-        ex.someValue = 3.14;
-        ex.someString = "3.14";
-        throw ex;
+        throw new CallbackException(3.14, "3.14");
     }
 
     public void

--- a/csharp/test/Ice/defaultServant/MyObjectI.cs
+++ b/csharp/test/Ice/defaultServant/MyObjectI.cs
@@ -12,7 +12,7 @@ namespace Ice.DefaultServant
 
             if (name == "ObjectNotExist")
             {
-                throw new ObjectNotExistException();
+                throw new ObjectNotExistException(current);
             }
         }
 
@@ -22,7 +22,7 @@ namespace Ice.DefaultServant
 
             if (name == "ObjectNotExist")
             {
-                throw new ObjectNotExistException();
+                throw new ObjectNotExistException(current);
             }
             return name;
         }

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -26,7 +26,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.f == 5.1F);
                 TestHelper.Assert(v.d == 6.2);
                 TestHelper.Assert(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.zeroI == 0);
                 TestHelper.Assert(v.zeroL == 0);
                 TestHelper.Assert(v.zeroF == 0);
@@ -52,7 +52,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.nc1 == Test.Nested.Color.red);
                 TestHelper.Assert(v.nc2 == Test.Nested.Color.green);
                 TestHelper.Assert(v.nc3 == Test.Nested.Color.blue);
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.zeroI == 0);
                 TestHelper.Assert(v.zeroL == 0);
                 TestHelper.Assert(v.zeroF == 0);
@@ -72,7 +72,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.f == 5.1F);
                 TestHelper.Assert(v.d == 6.2);
                 TestHelper.Assert(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.zeroI == 0);
                 TestHelper.Assert(v.zeroL == 0);
                 TestHelper.Assert(v.zeroF == 0);
@@ -92,7 +92,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.f == 5.1F);
                 TestHelper.Assert(v.d == 6.2);
                 TestHelper.Assert(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.c1 == Test.Color.red);
                 TestHelper.Assert(v.c2 == Test.Color.green);
                 TestHelper.Assert(v.c3 == Test.Color.blue);
@@ -118,7 +118,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.f == 5.1F);
                 TestHelper.Assert(v.d == 6.2);
                 TestHelper.Assert(v.str.Equals("foo bar"));
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.zeroI == 0);
                 TestHelper.Assert(v.zeroL == 0);
                 TestHelper.Assert(v.zeroF == 0);
@@ -138,7 +138,7 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.f == 5.1F);
                 TestHelper.Assert(v.d == 6.2);
                 TestHelper.Assert(v.str.Equals("foo bar"));
-                TestHelper.Assert(v.noDefault.Equals(""));
+                TestHelper.Assert(v.noDefault == null);
                 TestHelper.Assert(v.zeroI == 0);
                 TestHelper.Assert(v.zeroL == 0);
                 TestHelper.Assert(v.zeroF == 0);
@@ -147,27 +147,6 @@ namespace Ice.defaultValue
                 TestHelper.Assert(v.zeroDotD == 0);
             }
 
-            output.WriteLine("ok");
-
-            output.Write("testing default constructor... ");
-            output.Flush();
-            {
-                var e = new Test.ExceptionNoDefaults();
-                TestHelper.Assert(e.str.Equals(""));
-                TestHelper.Assert(e.c1 == Test.Color.red);
-                TestHelper.Assert(e.bs.Length == 0);
-                TestHelper.Assert(e.st.a == 0);
-                TestHelper.Assert(e.st2 != null);
-                TestHelper.Assert(e.dict.Count == 0);
-
-                var cl = new Test.ClassNoDefaults();
-                TestHelper.Assert(cl.str.Equals(""));
-                TestHelper.Assert(cl.c1 == Test.Color.red);
-                TestHelper.Assert(cl.bs.Length == 0);
-                TestHelper.Assert(cl.st.a == 0);
-                TestHelper.Assert(cl.st2 != null);
-                TestHelper.Assert(cl.dict.Count == 0);
-            }
             output.WriteLine("ok");
         }
     }

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -54,7 +54,7 @@ class Base
     float f = 5.1;
     double d = 6.2;
     string str = "foo \\ \"bar\n \r\n\t\v\f\a\b\? \007 \x07";
-    string noDefault;
+    tag(1) string noDefault;
     int zeroI = 0;
     long zeroL = 0;
     float zeroF = 0;
@@ -85,7 +85,7 @@ exception BaseEx
     float f = 5.1;
     double d = 6.2;
     string str = "foo \\ \"bar\n \r\n\t\v\f\a\b\? \007 \x07";
-    string noDefault;
+    tag(1) string noDefault;
     int zeroI = 0;
     long zeroL = 0;
     float zeroF = 0;
@@ -117,7 +117,7 @@ class ClassProperty
     float f = 5.1;
     double d = 6.2;
     string str = "foo bar";
-    string noDefault;
+    tag(1) string noDefault;
     int zeroI = 0;
     long zeroL = 0;
     float zeroF = 0;
@@ -142,7 +142,7 @@ exception ExceptionProperty
     float f = 5.1;
     double d = 6.2;
     string str = "foo bar";
-    string noDefault;
+    tag(1) string noDefault;
     int zeroI = 0;
     long zeroL = 0;
     float zeroF = 0;

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -17,11 +17,11 @@ namespace Ice.interceptor
             {
                 if (context.Equals("invalidInput"))
                 {
-                    throw new Test.InvalidInputException();
+                    throw new Test.InvalidInputException("intercept");
                 }
                 else if (context.Equals("notExist"))
                 {
-                    throw new ObjectNotExistException();
+                    throw new ObjectNotExistException(current);
                 }
             }
 
@@ -61,11 +61,11 @@ namespace Ice.interceptor
             {
                 if (context.Equals("invalidInput"))
                 {
-                    throw new Test.InvalidInputException();
+                    throw new Test.InvalidInputException("raiseAfterDispatch");
                 }
                 else if (context.Equals("notExist"))
                 {
-                    throw new ObjectNotExistException();
+                    throw new ObjectNotExistException(current);
                 }
             }
 

--- a/csharp/test/Ice/interceptor/MyObjectI.cs
+++ b/csharp/test/Ice/interceptor/MyObjectI.cs
@@ -22,10 +22,10 @@ namespace Ice.interceptor
         }
 
         public int
-        badAdd(int x, int y, Current current) => throw new Test.InvalidInputException();
+        badAdd(int x, int y, Current current) => throw new Test.InvalidInputException("badAdd");
 
         public int
-        notExistAdd(int x, int y, Current current) => throw new ObjectNotExistException();
+        notExistAdd(int x, int y, Current current) => throw new ObjectNotExistException(current);
 
         //
         // AMD
@@ -54,13 +54,13 @@ namespace Ice.interceptor
         public async ValueTask<int> amdBadAddAsync(int x, int y, Current current)
         {
             await Task.Delay(10);
-            throw new Test.InvalidInputException();
+            throw new Test.InvalidInputException("amdBadAdd");
         }
 
         public async ValueTask<int> amdNotExistAddAsync(int x, int y, Current current)
         {
             await Task.Delay(10);
-            throw new ObjectNotExistException();
+            throw new ObjectNotExistException(current);
         }
     }
 }

--- a/csharp/test/Ice/metrics/MetricsAMDI.cs
+++ b/csharp/test/Ice/metrics/MetricsAMDI.cs
@@ -40,7 +40,7 @@ public sealed class Metrics : IMetrics
     public ValueTask opWithUserExceptionAsync(Ice.Current current) => throw new UserEx();
 
     public ValueTask opWithRequestFailedExceptionAsync(Ice.Current current) =>
-        throw new Ice.ObjectNotExistException();
+        throw new Ice.ObjectNotExistException(current);
 
     public ValueTask opWithLocalExceptionAsync(Ice.Current current) =>
         throw new Ice.InvalidConfigurationException("fake");

--- a/csharp/test/Ice/metrics/MetricsI.cs
+++ b/csharp/test/Ice/metrics/MetricsI.cs
@@ -37,7 +37,7 @@ public sealed class Metrics : IMetrics
 
     public void opWithUserException(Ice.Current current) => throw new UserEx();
 
-    public void opWithRequestFailedException(Ice.Current current) => throw new Ice.ObjectNotExistException();
+    public void opWithRequestFailedException(Ice.Current current) => throw new Ice.ObjectNotExistException(current);
 
     public void opWithLocalException(Ice.Current current) => throw new Ice.InvalidConfigurationException("fake");
 

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -273,7 +273,7 @@ namespace Ice
                     }
                     output.WriteLine("ok");
 
-                    output.Write("testing partial ice_initialize...");
+                    output.Write("testing partial Initialize...");
                     output.Flush();
                     var ib1 = new IBase();
                     TestHelper.Assert(ib1.id.Equals("My id"));
@@ -298,8 +298,7 @@ namespace Ice
                     output.Write("testing class containing complex dictionary... ");
                     output.Flush();
                     {
-                        var m = new M();
-                        m.v = new Dictionary<StructKey, L?>();
+                        var m = new M(new Dictionary<StructKey, L?>());
                         var k1 = new StructKey(1, "1");
                         m.v[k1] = new L("one");
                         var k2 = new StructKey(2, "2");

--- a/csharp/test/Ice/objects/Test.ice
+++ b/csharp/test/Ice/objects/Test.ice
@@ -4,10 +4,17 @@
 
 #pragma once
 
+#include <Ice/Identity.ice>
+
 [["cs:typeid-namespace:Ice.objects.TypeId", "suppress-warning:deprecated"]] // For classes with operations
 ["cs:namespace:Ice.objects"]
 module Test
 {
+
+class IdentityWrapper
+{
+    Ice::Identity myId;
+}
 
 struct S
 {
@@ -225,12 +232,12 @@ interface UnexpectedObjectExceptionTest
 
 class IBase
 {
-    string id;
+    string id = "";
 }
 
 class IDerived : IBase
 {
-    string name;
+    string name = "";
 }
 
 class IDerived2 : IBase

--- a/csharp/test/Ice/objects/Test.ice
+++ b/csharp/test/Ice/objects/Test.ice
@@ -14,6 +14,14 @@ module Test
 class IdentityWrapper
 {
     Ice::Identity myId;
+    string s = "";
+    int n;
+}
+
+class DerivedIdentityWrapper : IdentityWrapper
+{
+    string s2;
+    int n2;
 }
 
 struct S

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1447,10 +1447,7 @@ namespace Ice.operations
                 TestHelper.Assert(s.tesT.Equals("MyStruct1.s"));
                 TestHelper.Assert(s.myClass == null);
                 TestHelper.Assert(s.myStruct1.Equals("MyStruct1.myStruct1"));
-                Test.MyClass1? c = new Test.MyClass1();
-                c.tesT = "MyClass1.testT";
-                c.myClass = null;
-                c.myClass1 = "MyClass1.myClass1";
+                Test.MyClass1? c = new Test.MyClass1("MyClass1.testT", null, "MyClass1.myClass1");
                 c = d.opMyClass1(c);
                 TestHelper.Assert(c != null);
                 TestHelper.Assert(c.tesT.Equals("MyClass1.testT"));

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -23,24 +23,32 @@ namespace Ice.serialize
             var proxy = Test.IMyInterfacePrx.Parse("test", communicator);
 
             Test.MyException ex, ex2;
-            ex = new Test.MyException();
-            ex.name = "";
-            ex.vss = new Test.ValStruct[0];
-            ex.vsl = new List<Test.ValStruct>();
-            ex.vsll = new LinkedList<Test.ValStruct>();
-            ex.vssk = new Stack<Test.ValStruct>();
-            ex.vsq = new Queue<Test.ValStruct>();
-            ex.isd = new Dictionary<int, string>();
-            ex.ivd = new Dictionary<int, Test.ValStruct>();
-            ex.ipd = new Dictionary<int, Test.IMyInterfacePrx?>(); ;
-            ex.issd = new SortedDictionary<int, string>();
-            ex.optName = null;
-            ex.optInt = null;
-            ex.optValStruct = null;
-            ex.optRefStruct = null;
-            ex.optEnum = null;
-            ex.optClass = null;
-            ex.optProxy = null;
+            ex = new Test.MyException(name: "",
+                                      b: 0,
+                                      s: 0,
+                                      i: 0,
+                                      l: 0,
+                                      vs: default,
+                                      rs: default,
+                                      c: null,
+                                      p: null,
+                                      vss: new Test.ValStruct[0],
+                                      vsl: new List<Test.ValStruct>(),
+                                      vsll: new LinkedList<Test.ValStruct>(),
+                                      vssk: new Stack<Test.ValStruct>(),
+                                      vsq: new Queue<Test.ValStruct>(),
+                                      isd: new Dictionary<int, string>(),
+                                      ivd: new Dictionary<int, Test.ValStruct>(),
+                                      ipd: new Dictionary<int, Test.IMyInterfacePrx?>(),
+                                      issd: new SortedDictionary<int, string>(),
+                                      optName: null,
+                                      optInt: null,
+                                      optValStruct: null,
+                                      optRefStruct: null,
+                                      optEnum: null,
+                                      optClass: null,
+                                      optProxy: null);
+
             ex2 = inOut(ex, communicator);
 
             TestHelper.Assert(ex2.name == "");

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -10,44 +10,22 @@ public class AllTests
 {
     private class Relay : IRelay
     {
-        public void knownPreservedAsBase(Ice.Current current)
-        {
-            KnownPreservedDerived ex = new KnownPreservedDerived();
-            ex.b = "base";
-            ex.kp = "preserved";
-            ex.kpd = "derived";
-            throw ex;
-        }
+        public void knownPreservedAsBase(Ice.Current current) =>
+            throw new KnownPreservedDerived("base", "preserved", "derived");
 
-        public void knownPreservedAsKnownPreserved(Ice.Current current)
-        {
-            KnownPreservedDerived ex = new KnownPreservedDerived();
-            ex.b = "base";
-            ex.kp = "preserved";
-            ex.kpd = "derived";
-            throw ex;
-        }
+        public void knownPreservedAsKnownPreserved(Ice.Current current) =>
+            throw new KnownPreservedDerived("base", "preserved", "derived");
 
         public void unknownPreservedAsBase(Ice.Current current)
         {
-            Preserved2 ex = new Preserved2();
-            ex.b = "base";
-            ex.kp = "preserved";
-            ex.kpd = "derived";
-            ex.p1 = new PreservedClass("bc", "pc");
-            ex.p2 = ex.p1;
-            throw ex;
+            var p = new PreservedClass("bc", "pc");
+            throw new Preserved2("base", "preserved", "derived", p, p);
         }
 
         public void unknownPreservedAsKnownPreserved(Ice.Current current)
         {
-            Preserved2 ex = new Preserved2();
-            ex.b = "base";
-            ex.kp = "preserved";
-            ex.kpd = "derived";
-            ex.p1 = new PreservedClass("bc", "pc");
-            ex.p2 = ex.p1;
-            throw ex;
+            var p = new PreservedClass("bc", "pc");
+            throw new Preserved2("base", "preserved", "derived", p, p);
         }
 
         public void clientPrivateException(Ice.Current current) => throw new ClientPrivateException("ClientPrivate");

--- a/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
@@ -115,25 +115,15 @@ public sealed class TestIntf : ITestIntf
 
     public ValueTask unknownPreservedAsBaseAsync(Current current)
     {
-        var ex = new SPreserved2();
-        ex.b = "base";
-        ex.kp = "preserved";
-        ex.kpd = "derived";
-        ex.p1 = new SPreservedClass("bc", "spc");
-        ex.p2 = ex.p1;
-        throw ex;
+        var p = new SPreservedClass("bc", "spc");
+        throw new SPreserved2("base", "preserved", "derived", p, p);
     }
 
     public ValueTask
     unknownPreservedAsKnownPreservedAsync(Current current)
     {
-        var ex = new SPreserved2();
-        ex.b = "base";
-        ex.kp = "preserved";
-        ex.kpd = "derived";
-        ex.p1 = new SPreservedClass("bc", "spc");
-        ex.p2 = ex.p1;
-        throw ex;
+        var p = new SPreservedClass("bc", "spc");
+        throw new SPreserved2("base", "preserved", "derived", p, p);
     }
 
     public ValueTask

--- a/csharp/test/Ice/slicing/exceptions/TestI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestI.cs
@@ -110,24 +110,14 @@ public sealed class TestIntf : ITestIntf
 
     public void unknownPreservedAsBase(Current current)
     {
-        var ex = new SPreserved2();
-        ex.b = "base";
-        ex.kp = "preserved";
-        ex.kpd = "derived";
-        ex.p1 = new SPreservedClass("bc", "spc");
-        ex.p2 = ex.p1;
-        throw ex;
+        var p = new SPreservedClass("bc", "spc");
+        throw new SPreserved2("base", "preserved", "derived", p, p);
     }
 
     public void unknownPreservedAsKnownPreserved(Current current)
     {
-        var ex = new SPreserved2();
-        ex.b = "base";
-        ex.kp = "preserved";
-        ex.kpd = "derived";
-        ex.p1 = new SPreservedClass("bc", "spc");
-        ex.p2 = ex.p1;
-        throw ex;
+        var p = new SPreservedClass("bc", "spc");
+        throw new SPreserved2("base", "preserved", "derived", p, p);
     }
 
     public void relayUnknownPreservedAsBase(IRelayPrx? r, Current current)

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -1138,13 +1138,13 @@ public class AllTests
                     ss2d1.pd1 = ss1d3;
                     ss2d3.pd3 = ss1d1;
 
-                    SS1 ss1 = new SS1();
+                    SS1 ss1 = new SS1(Array.Empty<B>());
                     ss1.s = new B[3];
                     ss1.s[0] = ss1b;
                     ss1.s[1] = ss1d1;
                     ss1.s[2] = ss1d3;
 
-                    SS2 ss2 = new SS2();
+                    SS2 ss2 = new SS2(Array.Empty<B>());
                     ss2.s = new B[3];
                     ss2.s[0] = ss2b;
                     ss2.s[1] = ss2d1;
@@ -1227,13 +1227,13 @@ public class AllTests
                 ss2d1.pd1 = ss1d3;
                 ss2d3.pd3 = ss1d1;
 
-                SS1 ss1 = new SS1();
+                SS1 ss1 = new SS1(Array.Empty<B>());
                 ss1.s = new B[3];
                 ss1.s[0] = ss1b;
                 ss1.s[1] = ss1d1;
                 ss1.s[2] = ss1d3;
 
-                SS2 ss2 = new SS2();
+                SS2 ss2 = new SS2(Array.Empty<B>());
                 ss2.s = new B[3];
                 ss2.s[0] = ss2b;
                 ss2.s[1] = ss2d1;
@@ -1673,8 +1673,7 @@ public class AllTests
             // Server only knows the intermediate type Preserved. The object will be sliced to
             // Preserved for the 1.0 encoding; otherwise it should be returned intact.
             //
-            PCDerived pcd = new PCDerived();
-            pcd.pi = 3;
+            PCDerived pcd = new PCDerived(3, "", null, Array.Empty<PBase>());
             pcd.pbs = new PBase[] { pcd };
 
             PBase? r = testPrx.exchangePBase(pcd);
@@ -1693,8 +1692,7 @@ public class AllTests
             // Server only knows the intermediate type Preserved. The object will be sliced to
             // Preserved for the 1.0 encoding; otherwise it should be returned intact.
             //
-            CompactPCDerived pcd = new CompactPCDerived();
-            pcd.pi = 3;
+            CompactPCDerived pcd = new CompactPCDerived(3, "", null, Array.Empty<PBase>());
             pcd.pbs = new PBase[] { pcd };
 
             PBase? r = testPrx.exchangePBase(pcd);
@@ -1713,8 +1711,8 @@ public class AllTests
             // Send an object that will have multiple preserved slices in the server.
             // The object will be sliced to Preserved for the 1.0 encoding.
             //
-            PCDerived3 pcd = new PCDerived3();
-            pcd.pi = 3;
+            PCDerived3 pcd = new PCDerived3(3, "", null, Array.Empty<PBase>(), 0, null);
+
             //
             // Sending more than 254 objects exercises the encoding for object ids.
             //
@@ -1722,10 +1720,8 @@ public class AllTests
             int i;
             for (i = 0; i < 300; ++i)
             {
-                PCDerived2 p2 = new PCDerived2();
-                p2.pi = i;
+                PCDerived2 p2 = new PCDerived2(i, "", null, Array.Empty<PBase>(), i);
                 p2.pbs = new PBase?[] { null }; // Nil reference. This slice should not have an indirection table.
-                p2.pcd2 = i;
                 pcd.pbs[i] = p2;
             }
             pcd.pcd2 = pcd.pi;
@@ -1807,8 +1803,7 @@ public class AllTests
             // Server only knows the intermediate type Preserved. The object will be sliced to
             // Preserved for the 1.0 encoding; otherwise it should be returned intact.
             //
-            PCDerived pcd = new PCDerived();
-            pcd.pi = 3;
+            PCDerived pcd = new PCDerived(3, "", null, Array.Empty<PBase>());
             pcd.pbs = new PBase[] { pcd };
 
             PBase? r = testPrx.exchangePBaseAsync(pcd).Result;
@@ -1823,8 +1818,7 @@ public class AllTests
             // Server only knows the intermediate type Preserved. The object will be sliced to
             // Preserved for the 1.0 encoding; otherwise it should be returned intact.
             //
-            var pcd = new CompactPCDerived();
-            pcd.pi = 3;
+            var pcd = new CompactPCDerived(3, "", null, Array.Empty<PBase>());
             pcd.pbs = new PBase[] { pcd };
 
             PBase? r = testPrx.exchangePBaseAsync(pcd).Result;
@@ -1839,18 +1833,16 @@ public class AllTests
             // Send an object that will have multiple preserved slices in the server.
             // The object will be sliced to Preserved for the 1.0 encoding.
             //
-            var pcd = new PCDerived3();
-            pcd.pi = 3;
+            var pcd = new PCDerived3(3, "", null, Array.Empty<PBase>(), 0, null);
+
             //
             // Sending more than 254 objects exercises the encoding for object ids.
             //
             pcd.pbs = new PBase[300];
             for (int i = 0; i < 300; ++i)
             {
-                var p2 = new PCDerived2();
-                p2.pi = i;
+                var p2 = new PCDerived2(i, "", null, Array.Empty<PBase>(), i);
                 p2.pbs = new PBase?[] { null }; // Nil reference. This slice should not have an indirection table.
-                p2.pcd2 = i;
                 pcd.pbs[i] = p2;
             }
             pcd.pcd2 = pcd.pi;

--- a/csharp/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/csharp/test/Ice/slicing/objects/ClientPrivate.ice
@@ -16,14 +16,14 @@ class CUnknown : SBase
 
 class D3 : B
 {
-    string sd3;
+    string sd3 = "";
     B pd3;
 }
 
 ["preserve-slice"]
 class PCUnknown : PBase
 {
-    string pu;
+    string pu = "";
 }
 
 class PCDerived : PDerived

--- a/csharp/test/Ice/slicing/objects/ServerPrivate.ice
+++ b/csharp/test/Ice/slicing/objects/ServerPrivate.ice
@@ -22,7 +22,7 @@ class SUnknown
 
 class D2 : B
 {
-    string sd2;
+    string sd2 = "";
     B pd2;
 }
 

--- a/csharp/test/Ice/slicing/objects/ServerPrivateAMD.ice
+++ b/csharp/test/Ice/slicing/objects/ServerPrivateAMD.ice
@@ -22,7 +22,7 @@ class SUnknown
 
 class D2 : B
 {
-    string sd2;
+    string sd2 = "";
     B pd2;
 }
 

--- a/csharp/test/Ice/slicing/objects/Test.ice
+++ b/csharp/test/Ice/slicing/objects/Test.ice
@@ -9,23 +9,23 @@ module Test
 
 class SBase
 {
-    string sb;
+    string sb = "";
 }
 
 class SBSKnownDerived : SBase
 {
-    string sbskd;
+    string sbskd = "";
 }
 
 class B
 {
-    string sb;
+    string sb = "";
     B pb;
 }
 
 class D1 : B
 {
-    string sd1;
+    string sd1 = "";
     B pd1;
 }
 
@@ -73,7 +73,7 @@ sequence<PBase> PBaseSeq;
 ["preserve-slice"]
 class Preserved : PBase
 {
-    string ps;
+    string ps = "";
 }
 
 class PDerived : Preserved

--- a/csharp/test/Ice/slicing/objects/TestAMD.ice
+++ b/csharp/test/Ice/slicing/objects/TestAMD.ice
@@ -9,23 +9,23 @@ module Test
 
 class SBase
 {
-    string sb;
+    string sb = "";
 }
 
 class SBSKnownDerived : SBase
 {
-    string sbskd;
+    string sbskd = "";
 }
 
 class B
 {
-    string sb;
+    string sb = "";
     B pb;
 }
 
 class D1 : B
 {
-    string sd1;
+    string sd1 = "";
     B pd1;
 }
 

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -219,7 +219,7 @@ public sealed class TestIntf : ITestIntf
         d2.pd2 = d1;
         d1.pb = d2;
         d1.pd1 = d2;
-        return new ValueTask< (B ?, B ?, B ?)>((d1, d1, d2));
+        return new ValueTask<(B?, B?, B?)>((d1, d1, d2));
     }
 
     public ValueTask<B?>
@@ -264,12 +264,7 @@ public sealed class TestIntf : ITestIntf
     public ValueTask<Preserved?>
     PBSUnknownAsPreservedAsync(Ice.Current current)
     {
-        var r = new PSUnknown();
-        r.pi = 5;
-        r.ps = "preserved";
-        r.psu = "unknown";
-        r.graph = null;
-        r.cl = new MyClass(15);
+        var r = new PSUnknown(5, "preserved", "unknown", null, new MyClass(15));
         return new ValueTask<Preserved?>(r);
     }
 
@@ -289,14 +284,12 @@ public sealed class TestIntf : ITestIntf
     public ValueTask<Preserved?>
     PBSUnknownAsPreservedWithGraphAsync(Ice.Current current)
     {
-        var r = new PSUnknown();
-        r.pi = 5;
-        r.ps = "preserved";
-        r.psu = "unknown";
-        r.graph = new PNode();
-        r.graph.next = new PNode();
-        r.graph.next.next = new PNode();
-        r.graph.next.next.next = r.graph;
+        var graph = new PNode();
+        graph.next = new PNode();
+        graph.next.next = new PNode();
+        graph.next.next.next = graph;
+
+        var r = new PSUnknown(5, "preserved", "unknown", graph, null);
         return new ValueTask<Preserved?>(r);
     }
 
@@ -317,9 +310,7 @@ public sealed class TestIntf : ITestIntf
     public ValueTask<Preserved?>
     PBSUnknown2AsPreservedWithGraphAsync(Ice.Current current)
     {
-        var r = new PSUnknown2();
-        r.pi = 5;
-        r.ps = "preserved";
+        var r = new PSUnknown2(5, "preserved", null);
         r.pb = r;
         return new ValueTask<Preserved?>(r);
     }
@@ -340,45 +331,34 @@ public sealed class TestIntf : ITestIntf
 
     public ValueTask throwBaseAsBaseAsync(Ice.Current current)
     {
-        var be = new BaseException();
-        be.sbe = "sbe";
-        be.pb = new B();
-        be.pb.sb = "sb";
-        be.pb.pb = be.pb;
-        throw be;
+        var b = new B("sb", null);
+        b.pb = b;
+        throw new BaseException("sbe", b);
     }
 
     public ValueTask throwDerivedAsBaseAsync(Ice.Current current)
     {
-        var de = new DerivedException();
-        de.sbe = "sbe";
-        de.pb = new B();
-        de.pb.sb = "sb1";
-        de.pb.pb = de.pb;
-        de.sde = "sde1";
-        de.pd1 = new D1();
-        de.pd1.sb = "sb2";
-        de.pd1.pb = de.pd1;
-        de.pd1.sd1 = "sd2";
-        de.pd1.pd1 = de.pd1;
-        throw de;
+        var b = new B("sb1", null);
+        b.pb = b;
+
+        var d = new D1("sb2", null, "sd2", null);
+        d.pb = d;
+        d.pd1 = d;
+
+        throw new DerivedException("sbe", b, "sde1", d);
     }
 
     public ValueTask
     throwDerivedAsDerivedAsync(Ice.Current current)
     {
-        var de = new DerivedException();
-        de.sbe = "sbe";
-        de.pb = new B();
-        de.pb.sb = "sb1";
-        de.pb.pb = de.pb;
-        de.sde = "sde1";
-        de.pd1 = new D1();
-        de.pd1.sb = "sb2";
-        de.pd1.pb = de.pd1;
-        de.pd1.sd1 = "sd2";
-        de.pd1.pd1 = de.pd1;
-        throw de;
+        var b = new B("sb1", null);
+        b.pb = b;
+
+        var d = new D1("sb2", null, "sd2", null);
+        d.pb = d;
+        d.pd1 = d;
+
+        throw new DerivedException("sbe", b, "sde1", d);
     }
 
     public ValueTask throwUnknownDerivedAsBaseAsync(Ice.Current current)
@@ -389,23 +369,14 @@ public sealed class TestIntf : ITestIntf
         d2.sd2 = "sd2 d2";
         d2.pd2 = d2;
 
-        var ude = new UnknownDerivedException();
-        ude.sbe = "sbe";
-        ude.pb = d2;
-        ude.sude = "sude";
-        ude.pd2 = d2;
-
-        throw ude;
+        throw new UnknownDerivedException("sbe", d2, "sude", d2);
     }
 
     public ValueTask throwPreservedExceptionAsync(Ice.Current current)
     {
         var ue = new PSUnknownException();
-        ue.p = new PSUnknown2();
-        ue.p.pi = 5;
-        ue.p.ps = "preserved";
+        ue.p = new PSUnknown2(5, "preserved", null);
         ue.p.pb = ue.p;
-
         throw ue;
     }
 
@@ -424,8 +395,8 @@ public sealed class TestIntf : ITestIntf
 
 public sealed class TestIntf2 : ITestIntf2
 {
-    public ValueTask<SBase?> SBSUnknownDerivedAsSBaseAsync(Ice.Current current)
-        => new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
+    public ValueTask<SBase?> SBSUnknownDerivedAsSBaseAsync(Ice.Current current) =>
+        new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
 
     public ValueTask CUnknownAsSBaseAsync(SBase? cUnknown, Ice.Current current)
     {

--- a/csharp/test/Ice/slicing/objects/TestI.cs
+++ b/csharp/test/Ice/slicing/objects/TestI.cs
@@ -44,18 +44,12 @@ public sealed class TestIntf : ITestIntf
     public SBase SBSUnknownDerivedAsSBase(Ice.Current current)
         => new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud");
 
-    public SBase SBSUnknownDerivedAsSBaseCompact(Ice.Current current)
-    {
-        var sbsud = new SBSUnknownDerived();
-        sbsud.sb = "SBSUnknownDerived.sb";
-        sbsud.sbsud = "SBSUnknownDerived.sbsud";
-        return sbsud;
-    }
+    public SBase SBSUnknownDerivedAsSBaseCompact(Ice.Current current) =>
+        new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud");
 
     public Ice.AnyClass SUnknownAsObject(Ice.Current current)
     {
-        var su = new SUnknown();
-        su.su = "SUnknown.su";
+        var su = new SUnknown("SUnknown.su", null);
         su.cycle = su;
         return su;
     }
@@ -247,16 +241,8 @@ public sealed class TestIntf : ITestIntf
 
     public PBase? exchangePBase(PBase? pb, Ice.Current current) => pb;
 
-    public Preserved PBSUnknownAsPreserved(Ice.Current current)
-    {
-        var r = new PSUnknown();
-        r.pi = 5;
-        r.ps = "preserved";
-        r.psu = "unknown";
-        r.graph = null;
-        r.cl = new MyClass(15);
-        return r;
-    }
+    public Preserved PBSUnknownAsPreserved(Ice.Current current) =>
+        new PSUnknown(5, "preserved", "unknown", null, new MyClass(15));
 
     public void checkPBSUnknown(Preserved? p, Ice.Current current)
     {
@@ -273,14 +259,12 @@ public sealed class TestIntf : ITestIntf
     public ValueTask<Preserved?>
     PBSUnknownAsPreservedWithGraphAsync(Ice.Current current)
     {
-        var r = new PSUnknown();
-        r.pi = 5;
-        r.ps = "preserved";
-        r.psu = "unknown";
-        r.graph = new PNode();
-        r.graph.next = new PNode();
-        r.graph.next.next = new PNode();
-        r.graph.next.next.next = r.graph;
+        var graph = new PNode();
+        graph.next = new PNode();
+        graph.next.next = new PNode();
+        graph.next.next.next = graph;
+
+        var r = new PSUnknown(5, "preserved", "unknown", graph, null);
         return new ValueTask<Preserved?>(r);
     }
 
@@ -299,9 +283,7 @@ public sealed class TestIntf : ITestIntf
     public ValueTask<Preserved?>
     PBSUnknown2AsPreservedWithGraphAsync(Ice.Current current)
     {
-        var r = new PSUnknown2();
-        r.pi = 5;
-        r.ps = "preserved";
+        var r = new PSUnknown2(5, "preserved", null);
         r.pb = r;
         return new ValueTask<Preserved?>(r);
     }
@@ -319,44 +301,33 @@ public sealed class TestIntf : ITestIntf
 
     public void throwBaseAsBase(Ice.Current current)
     {
-        var be = new BaseException();
-        be.sbe = "sbe";
-        be.pb = new B();
-        be.pb.sb = "sb";
-        be.pb.pb = be.pb;
-        throw be;
+        var b = new B("sb", null);
+        b.pb = b;
+        throw new BaseException("sbe", b);
     }
 
     public void throwDerivedAsBase(Ice.Current current)
     {
-        var de = new DerivedException();
-        de.sbe = "sbe";
-        de.pb = new B();
-        de.pb.sb = "sb1";
-        de.pb.pb = de.pb;
-        de.sde = "sde1";
-        de.pd1 = new D1();
-        de.pd1.sb = "sb2";
-        de.pd1.pb = de.pd1;
-        de.pd1.sd1 = "sd2";
-        de.pd1.pd1 = de.pd1;
-        throw de;
+        var b = new B("sb1", null);
+        b.pb = b;
+
+        var d = new D1("sb2", null, "sd2", null);
+        d.pb = d;
+        d.pd1 = d;
+
+        throw new DerivedException("sbe", b, "sde1", d);
     }
 
     public void throwDerivedAsDerived(Ice.Current current)
     {
-        var de = new DerivedException();
-        de.sbe = "sbe";
-        de.pb = new B();
-        de.pb.sb = "sb1";
-        de.pb.pb = de.pb;
-        de.sde = "sde1";
-        de.pd1 = new D1();
-        de.pd1.sb = "sb2";
-        de.pd1.pb = de.pd1;
-        de.pd1.sd1 = "sd2";
-        de.pd1.pd1 = de.pd1;
-        throw de;
+        var b = new B("sb1", null);
+        b.pb = b;
+
+        var d = new D1("sb2", null, "sd2", null);
+        d.pb = d;
+        d.pd1 = d;
+
+        throw new DerivedException("sbe", b, "sde1", d);
     }
 
     public void throwUnknownDerivedAsBase(Ice.Current current)
@@ -367,21 +338,14 @@ public sealed class TestIntf : ITestIntf
         d2.sd2 = "sd2 d2";
         d2.pd2 = d2;
 
-        var ude = new UnknownDerivedException();
-        ude.sbe = "sbe";
-        ude.pb = d2;
-        ude.sude = "sude";
-        ude.pd2 = d2;
-        throw ude;
+        throw new UnknownDerivedException("sbe", d2, "sude", d2);
     }
 
     public ValueTask
     throwPreservedExceptionAsync(Ice.Current current)
     {
         var ue = new PSUnknownException();
-        ue.p = new PSUnknown2();
-        ue.p.pi = 5;
-        ue.p.ps = "preserved";
+        ue.p = new PSUnknown2(5, "preserved", null);
         ue.p.pb = ue.p;
         throw ue;
     }

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -33,7 +33,7 @@ module IceMX
     class Metrics
     {
         /// The metrics identifier.
-        string id;
+        string id = "";
 
         /// The total number of objects observed by this metrics. This includes
         /// the number of currently observed objects and the number of objects


### PR DESCRIPTION
This PR refactors the class and exception unmarshaling to no longer generate all the time a parameterless constructor for classes and exceptions in C#. It also subsumes PR #827.

With this PR, when a class/exception has a non-nullable data member without a Slice-specified default value nor a C# default value, slice2cs does not generate a parameterless constructor.

For example, a `string` data member without a default value specified in Slice suppresses this parameterless constructor. Same for a sequence or dictionary. Conversely, an int, bool, float or enum field is always default initialized in C#, so they don't suppress the generated parameterless constructor.

For consistency, a `struct` data member suppresses this parameterless constructor if one of its fields cannot be default initialized (e.g. it's a string or sequence). Note that Slice-specified default values for struct data members are ignored, since they are not used for the generated structs themselves.

Overall, each generated class gets 2 or 3 constructors:
1. public constructor that initializes all its fields and all the base class fields (if it has a base class); this constructor is parameterless when the class and its bases (if any) have no data members.
2. public constructor that initializes all the fields _without_ a default value (specified in Slice or implicit) unless this constructor is identical to the first one. This constructor can be parameterless.
3. protected internal constructor that takes an InputStream and a bool; this constructor is used for unmarshaling. 

Each generated exception class gets 4 to 6 constructors:
1. public constructor that takes a string message and a parameter for each field of the exception.
2. public constructor that takes a string message, a parameter for each field of the exception plus an inner exception.
3. public constructor that takes a parameter for each field of the exception (can be parameterless).
4. public parameterless constructor (if not generated above) that with a default value for each field. This constructor is not generated if some field does not have a default value (specified in Slice or implicit).
5. protected internal constructor that takes an InputStream and a bool; this constructor is used for unmarshaling. 
6. "serializable" protected constructor.
 
In a follow-up PR, I think we need to add the ability to specify an "empty" default value for sequence and dictionary data members. Without this option, it could be difficult to port some code (such as IceMX) from Ice 3.7 to 4.0 while maintaining compatibility with the 3.7 Slice.