### PR TITLE
Call Initialize after class unmarshaling

### DIFF
--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -129,10 +129,13 @@ protected:
     void writeTaggedMarshalCode(::IceUtilInternal::Output&, const TypePtr&, bool, const std::string&,
                                 const std::string&, int, const std::string& = "ostr");
     void writeTaggedUnmarshalCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&,
-                                    int, const std::string& = "istr");
+                                    int, const DataMemberPtr&, const std::string& = "istr");
 
     std::string sequenceMarshalCode(const SequencePtr&, const std::string&, const std::string&, const std::string&);
     std::string sequenceUnmarshalCode(const SequencePtr&, const std::string&, const std::string&);
+
+    void writeConstantValue(::IceUtilInternal::Output&, const TypePtr&, const SyntaxTreeBasePtr&, const std::string&,
+        const std::string& ns);
 
 private:
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -472,8 +472,8 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& members, con
 
             if (seq || dict || (builtin && builtin->kind() == Builtin::KindString))
             {
-                _out << nl << "this." << fixId(dataMemberName(p), baseTypes)
-                    << " = null!; // suppress compiler warning";
+                // This is to suppress compiler warnings for non-nullable fields.
+                _out << nl << "this." << fixId(dataMemberName(p), baseTypes) << " = null!;";
             }
         }
         else if (p->defaultValueType())
@@ -1287,7 +1287,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     }
     _out << sb;
 
-    // This initialization is only for tagged data members; for other data members, we are about to read them all.
+    // This initialization suppresses warnings (with = null!) for non-nullable data members such a string.
     writeDataMemberInitializers(dataMembers, ns, ObjectType, true);
     _out << nl << "if (mostDerived)";
     _out << sb;
@@ -1583,7 +1583,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         _out.dec();
     }
     _out << sb;
-    // This initialization is only for tagged data members with default values and to suppress warnings.
+    // This initialization suppresses warnings (with = null!) for non-nullable data members such a string.
     writeDataMemberInitializers(dataMembers, ns, Slice::ExceptionType, true);
     _out << nl << "if (mostDerived)";
     _out << sb;

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -43,8 +43,6 @@ protected:
 
     std::string writeValue(const TypePtr&, const std::string&);
 
-    void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&, const std::string& ns);
-
     //
     // Generate assignment statements for those data members that have default values.
     //

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -514,13 +514,13 @@ namespace Ice.optional
                 var wd = (WD?)initial.pingPong(new WD());
                 TestHelper.Assert(wd != null);
                 TestHelper.Assert(wd.a == 5);
-                TestHelper.Assert(wd.s!.Equals("test"));
+                TestHelper.Assert(wd.s! == "test");
                 wd.a = null;
                 wd.s = null;
                 wd = (WD?)initial.pingPong(wd);
                 TestHelper.Assert(wd != null);
-                TestHelper.Assert(wd.a == null);
-                TestHelper.Assert(wd.s == null);
+                TestHelper.Assert(wd.a == 5);
+                TestHelper.Assert(wd.s! == "test");
             }
             output.WriteLine("ok");
 
@@ -723,7 +723,7 @@ namespace Ice.optional
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opFloat", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, float? p1) =>  ostr.WriteTaggedFloat(2, p1));
+                    (OutputStream ostr, float? p1) => ostr.WriteTaggedFloat(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
@@ -1640,7 +1640,7 @@ namespace Ice.optional
                 }
                 catch (OptionalException ex)
                 {
-                    TestHelper.Assert(ex.a == null);
+                    TestHelper.Assert(ex.a == 5);
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
                 }
@@ -1668,10 +1668,10 @@ namespace Ice.optional
                 }
                 catch (DerivedException ex)
                 {
-                    TestHelper.Assert(ex.a == null);
+                    TestHelper.Assert(ex.a == 5);
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
-                    TestHelper.Assert(ex.ss == null);
+                    TestHelper.Assert(ex.ss == "test");
                     TestHelper.Assert(ex.o2 == null);
                 }
 
@@ -1700,7 +1700,7 @@ namespace Ice.optional
                 }
                 catch (RequiredException ex)
                 {
-                    TestHelper.Assert(ex.a == null);
+                    TestHelper.Assert(ex.a == 5);
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
                     TestHelper.Assert(ex.ss == "test");


### PR DESCRIPTION
This is a follow-up to PR #829.

This small PR corrects the call to Initialize(): it's now called in `IceRead` after the class instance is fully unmarshaled. I also updated the generated exception unmarshaling ctor to be like the class unmarshaling ctor.