### PR TITLE
Fix Destroy to account for Communicator not being fully initialize

### DIFF
--- a/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
+++ b/csharp/src/Ice/Communicator-EndpointFactoryManager.cs
@@ -12,7 +12,7 @@ namespace Ice
 {
     public sealed partial class Communicator
     {
-        private readonly List<IEndpointFactory> _endpointFactories;
+        private readonly List<IEndpointFactory> _endpointFactories = new List<IEndpointFactory>();
 
         public void AddEndpointFactory(IEndpointFactory factory)
         {


### PR DESCRIPTION
This small PR fixes Communicator.Destroy to account for communicator not being fully initialized when Destroy is called, this is typically the case if an exception is throw from the Communicator initialization.

See - #834