### PR TITLE
Optimize marshaling of small strings in C#

### DIFF
--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -251,7 +251,7 @@ namespace Ice
             }
             else if (v.Length <= 100)
             {
-                Span<byte> data = stackalloc byte[v.Length * 4]; // there is at most 4 UTF-8 bytes per codepoint.
+                Span<byte> data = stackalloc byte[_utf8.GetMaxByteCount(v.Length)];
                 int written = _utf8.GetBytes(v, data);
                 WriteSize(written);
                 WriteByteSpan(data.Slice(0, written));

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -249,6 +249,13 @@ namespace Ice
             {
                 WriteSize(0);
             }
+            else if (v.Length <= 100)
+            {
+                Span<byte> data = stackalloc byte[v.Length * 4]; // there is at most 4 UTF-8 bytes per codepoint.
+                int written = _utf8.GetBytes(v, data);
+                WriteSize(written);
+                WriteByteSpan(data.Slice(0, written));
+            }
             else
             {
                 byte[] data = _utf8.GetBytes(v);


### PR DESCRIPTION
This tiny PR avoids the allocation of a byte array when marshaling a small string.