### PR TITLE
Implement marshaling of new integer types in C#

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -609,8 +609,8 @@ bool
 Slice::isMappedToReadOnlyMemory(const SequencePtr& seq)
 {
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(seq->type());
-    return builtin && builtin->isNumericTypeOrBool() && !seq->hasMetaDataWithPrefix("cs:serializable") &&
-        !seq->hasMetaDataWithPrefix("cs:generic");
+    return builtin && builtin->isNumericTypeOrBool() && !builtin->isVariableLength() &&
+        !seq->hasMetaDataWithPrefix("cs:serializable") && !seq->hasMetaDataWithPrefix("cs:generic");
 }
 
 Slice::ParamInfo::ParamInfo(const OperationPtr& pOperation,

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2040,22 +2040,23 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
         _out << sb;
 
         _out << sp;
-        _out << nl << "public static void Write(this Ice.OutputStream ostr, " << seqReadOnly << " sequence) =>";
+        _out << nl << "public static void Write(this global::Ice.OutputStream ostr, " << seqReadOnly << " sequence) =>";
         _out.inc();
         _out << nl << sequenceMarshalCode(p, scope, "sequence", "ostr") << ";";
         _out.dec();
 
         _out << sp;
-        _out << nl << "public static readonly Ice.OutputStreamWriter<" << seqReadOnly << "> IceWriter = Write;";
+        _out << nl << "public static readonly global::Ice.OutputStreamWriter<" << seqReadOnly << "> IceWriter = Write;";
 
         _out << sp;
-        _out << nl << "public static " << seqS << " Read" << name << "(this Ice.InputStream istr) =>";
+        _out << nl << "public static " << seqS << " Read" << name << "(this global::Ice.InputStream istr) =>";
         _out.inc();
         _out << nl << sequenceUnmarshalCode(p, scope, "istr") << ";";
         _out.dec();
 
         _out << sp;
-        _out << nl << "public static readonly Ice.InputStreamReader<" << seqS << "> IceReader = Read" << name << ";";
+        _out << nl << "public static readonly global::Ice.InputStreamReader<" << seqS << "> IceReader = Read"
+            << name << ";";
 
         _out << eb;
     }
@@ -2076,7 +2077,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     emitCommonAttributes();
     _out << nl << "public static class " << name << "Helper";
     _out << sb;
-    _out << nl << "public static void Write(this Ice.OutputStream ostr, "<< readOnlyDictS << " dictionary) =>";
+    _out << nl << "public static void Write(this global::Ice.OutputStream ostr, "<< readOnlyDictS << " dictionary) =>";
     _out.inc();
     _out << nl << "ostr.WriteDictionary(dictionary";
     if (!StructPtr::dynamicCast(key))
@@ -2091,10 +2092,10 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly Ice.OutputStreamWriter<" << readOnlyDictS << "> IceWriter = Write;";
+    _out << nl << "public static readonly global::Ice.OutputStreamWriter<" << readOnlyDictS << "> IceWriter = Write;";
 
     _out << sp;
-    _out << nl << "public static " << dictS << " Read" << name << "(this Ice.InputStream istr) =>";
+    _out << nl << "public static " << dictS << " Read" << name << "(this global::Ice.InputStream istr) =>";
     _out.inc();
     if(generic == "SortedDictionary")
     {
@@ -2110,7 +2111,8 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly Ice.InputStreamReader<" << dictS << "> IceReader = Read" << name << ";";
+    _out << nl << "public static readonly global::Ice.InputStreamReader<" << dictS << "> IceReader = Read"
+        << name << ";";
 
     _out << eb;
 }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -230,7 +230,8 @@ namespace IceInternal
                         Ice1Definitions.GetResponseData(responseFrame, requestId));
                 if (_traceLevels.Protocol >= 1)
                 {
-                    var istr = new InputStream(_adapter.Communicator, responseBuffer, Ice1Definitions.HeaderSize + 4);
+                    var istr = new InputStream(_adapter.Communicator, Ice1Definitions.Encoding, responseBuffer,
+                        Ice1Definitions.HeaderSize + 4);
                     TraceUtil.TraceRecv(istr, _logger, _traceLevels);
                 }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -2195,7 +2195,8 @@ namespace Ice
                 {
                     case Ice1Definitions.MessageType.CloseConnectionMessage:
                         {
-                            TraceUtil.TraceRecv(new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                            TraceUtil.TraceRecv(new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                _logger, _traceLevels);
                             if (_endpoint.IsDatagram)
                             {
                                 if (_warn)
@@ -2226,12 +2227,13 @@ namespace Ice
                             {
                                 TraceUtil.Trace("received request during closing\n" +
                                                 "(ignored by server, client will retry)",
-                                                new InputStream(_communicator, info.Data),
+                                                new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
                                                 _logger, _traceLevels);
                             }
                             else
                             {
-                                TraceUtil.TraceRecv(new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                                TraceUtil.TraceRecv(new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                    _logger, _traceLevels);
                                 info.RequestId = InputStream.ReadInt(info.Data.AsSpan(Ice1Definitions.HeaderSize, 4));
                                 info.InvokeNum = 1;
                                 info.Adapter = _adapter;
@@ -2246,12 +2248,13 @@ namespace Ice
                             {
                                 TraceUtil.Trace("received batch request during closing\n" +
                                                 "(ignored by server, client will retry)",
-                                                new InputStream(_communicator, info.Data),
+                                                new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
                                                 _logger, _traceLevels);
                             }
                             else
                             {
-                                TraceUtil.TraceRecv(new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                                TraceUtil.TraceRecv(new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                    _logger, _traceLevels);
                                 info.InvokeNum = InputStream.ReadInt(info.Data.AsSpan(Ice1Definitions.HeaderSize, 4));
                                 if (info.InvokeNum < 0)
                                 {
@@ -2268,7 +2271,8 @@ namespace Ice
 
                     case Ice1Definitions.MessageType.ReplyMessage:
                         {
-                            TraceUtil.TraceRecv(new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                            TraceUtil.TraceRecv(new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                _logger, _traceLevels);
                             info.RequestId = InputStream.ReadInt(info.Data.AsSpan(Ice1Definitions.HeaderSize, 4));
                             if (_asyncRequests.TryGetValue(info.RequestId, out info.OutAsync))
                             {
@@ -2300,7 +2304,8 @@ namespace Ice
 
                     case Ice1Definitions.MessageType.ValidateConnectionMessage:
                         {
-                            TraceUtil.TraceRecv(new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                            TraceUtil.TraceRecv(new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                _logger, _traceLevels);
                             if (_heartbeatCallback != null)
                             {
                                 info.HeartbeatCallback = _heartbeatCallback;
@@ -2312,7 +2317,8 @@ namespace Ice
                     default:
                         {
                             TraceUtil.Trace("received unknown message\n(invalid, closing connection)",
-                                            new InputStream(_communicator, info.Data), _logger, _traceLevels);
+                                            new InputStream(_communicator, Ice1Definitions.Encoding, info.Data),
+                                                _logger, _traceLevels);
                             throw new InvalidDataException(
                                 $"received ice1 frame with unknown message type `{messageType}'");
                         }

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -12,7 +12,7 @@ namespace Ice
     [System.Serializable]
     public readonly struct Encoding : System.IEquatable<Encoding>
     {
-        // The encodings known to the Ice runtime. Don't reference them from other static variables!
+        // The encodings known to the Ice runtime.
 
         /// <summary>Version 1.0 of the Ice encoding, supported by Ice 1.0 to Ice 3.7.</summary>
         public static readonly Encoding V1_0 = new Encoding(1, 0);
@@ -24,7 +24,7 @@ namespace Ice
         public static readonly Encoding V2_0 = new Encoding(2, 0);
 
         /// <summary>The most recent version of the Ice encoding.</summary>
-        public static readonly Encoding Latest = new Encoding(1, 1); // for now, will upgrade to 2.0
+        public static readonly Encoding Latest = V2_0;
 
         /// <summary>The major version number of this version of the Ice encoding.</summary>
         public readonly byte Major;
@@ -32,7 +32,7 @@ namespace Ice
         /// <summary>The minor version number of this version of the Ice encoding.</summary>
         public readonly byte Minor;
 
-        internal bool IsSupported => this == V1_1; // TODO: add 2.0
+        internal bool IsSupported => this == V1_1 || this == V2_0;
 
         /// <summary>Parses a string into an Encoding.</summary>
         /// <param name="str">The string to parse.</param>

--- a/csharp/src/Ice/EncodingDefinitions.cs
+++ b/csharp/src/Ice/EncodingDefinitions.cs
@@ -8,6 +8,11 @@ namespace Ice
 {
     internal static class EncodingDefinitions
     {
+        internal const long VarLongMinValue = -2_305_843_009_213_693_952; // -2^61
+        internal const long VarLongMaxValue = 2_305_843_009_213_693_951; // 2^61 - 1
+        internal const ulong VarULongMinValue = 0;
+        internal const ulong VarULongMaxValue = 4_611_686_018_427_387_903; // 2^62 - 1
+
         internal const byte TaggedEndMarker = 0xFF;
 
         [Flags]

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -214,7 +214,7 @@ namespace Ice
                     // unmarshal it from this buffer.
                     var bufferList = new List<ArraySegment<byte>>
                     {
-                        // 8 = size of short + size of encapsulation header
+                        // 8 = size of short + size of encapsulation header with 1.1 encoding
                         new byte[8 + opaqueEndpoint.Bytes.Length]
                     };
 
@@ -224,7 +224,7 @@ namespace Ice
                     Debug.Assert(bufferList.Count == 1);
                     Debug.Assert(tail.Segment == 0 && tail.Offset == 8 + opaqueEndpoint.Bytes.Length);
 
-                    return new InputStream(communicator, bufferList[0]).ReadEndpoint();
+                    return new InputStream(communicator, Ice1Definitions.Encoding, bufferList[0]).ReadEndpoint();
                 }
                 else
                 {

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -34,7 +34,7 @@ namespace Ice
         internal ArraySegment<byte> Data { get; }
         private readonly Communicator _communicator;
 
-        /// <summary>Creates a new OutgoingRequestFrame.</summary>
+        /// <summary>Creates a new IncomingRequestFrame.</summary>
         /// <param name="communicator">The communicator to use when initializing the stream.</param>
         /// <param name="data">The frame data as an array segment.</param>
         public IncomingRequestFrame(Communicator communicator, ArraySegment<byte> data)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -41,7 +41,7 @@ namespace Ice
         {
             _communicator = communicator;
             Data = data;
-            var istr = new InputStream(communicator, data);
+            var istr = new InputStream(communicator, Ice1Definitions.Encoding, data);
 
             Identity = new Identity(istr);
             Facet = istr.ReadFacet();
@@ -66,7 +66,8 @@ namespace Ice
 
         /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload
         /// correspond to the empty parameter list.</summary>
-        public void ReadEmptyParamList() => InputStream.ReadEmptyEncapsulation(_communicator, Payload);
+        public void ReadEmptyParamList() =>
+            InputStream.ReadEmptyEncapsulation(_communicator, Ice1Definitions.Encoding, Payload);
 
         /// <summary>Reads the request frame parameter list.</summary>
         /// <param name="reader">An InputStreamReader delegate used to read the request frame
@@ -74,6 +75,6 @@ namespace Ice
         /// <returns>The request parameters, when the frame parameter list contains multiple parameters
         /// they must be return as a tuple.</returns>
         public T ReadParamList<T>(InputStreamReader<T> reader) =>
-            InputStream.ReadEncapsulation(_communicator, Payload, reader);
+            InputStream.ReadEncapsulation(_communicator, Ice1Definitions.Encoding, Payload, reader);
     }
 }

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -38,7 +38,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                return InputStream.ReadEncapsulation(_communicator, Payload.Slice(1), reader);
+                return InputStream.ReadEncapsulation(_communicator, Ice1Definitions.Encoding, Payload.Slice(1), reader);
             }
             else
             {
@@ -52,7 +52,7 @@ namespace Ice
         {
             if (ReplyStatus == ReplyStatus.OK)
             {
-                InputStream.ReadEmptyEncapsulation(_communicator, Payload.Slice(1));
+                InputStream.ReadEmptyEncapsulation(_communicator, Ice1Definitions.Encoding, Payload.Slice(1));
             }
             else
             {
@@ -85,7 +85,7 @@ namespace Ice
             }
             else
             {
-                Encoding = Encoding.V1_1;
+                Encoding = Ice1Definitions.Encoding;
             }
         }
 
@@ -102,7 +102,8 @@ namespace Ice
             {
                 case ReplyStatus.UserException:
                 {
-                    return InputStream.ReadEncapsulation(_communicator, Payload.Slice(1), istr => istr.ReadException());
+                    return InputStream.ReadEncapsulation(_communicator, Ice1Definitions.Encoding, Payload.Slice(1),
+                        istr => istr.ReadException());
                 }
                 case ReplyStatus.ObjectNotExistException:
                 case ReplyStatus.FacetNotExistException:
@@ -121,11 +122,11 @@ namespace Ice
         }
 
         internal UnhandledException ReadUnhandledException() =>
-            new UnhandledException(InputStream.ReadString(Payload.Slice(1), Encoding), Identity.Empty, "", "");
+            new UnhandledException(InputStream.ReadString(Encoding, Payload.Slice(1)), Identity.Empty, "", "");
 
         internal DispatchException ReadDispatchException()
         {
-            var istr = new InputStream(_communicator, Payload, 1);
+            var istr = new InputStream(_communicator, Ice1Definitions.Encoding, Payload, 1);
             var identity = new Identity(istr);
             string facet = istr.ReadFacet();
             string operation = istr.ReadString();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -337,8 +337,8 @@ namespace Ice
         public ulong ReadVarULong() => OldEncoding ? ReadULong() :
             (_buffer[_pos] & 0x03) switch
             {
-                0 => (uint)ReadByte() >> 2,
-                1 => (uint)ReadUShort() >> 2,
+                0 => (uint)ReadByte() >> 2,   // cast to uint to use operator >> for uint instead of int, which is
+                1 => (uint)ReadUShort() >> 2, // later implicitly converted to ulong
                 2 => ReadUInt() >> 2,
                 _ => ReadULong() >> 2
             };

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -29,56 +29,104 @@ namespace Ice
         //
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<bool> IceReaderIntoBool = (istr) => istr.ReadBool();
+        public static readonly InputStreamReader<bool> IceReaderIntoBool =
+            istr => istr.ReadBool();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<bool[]> IceReaderIntoBoolArray =
-            (istr) => istr.ReadFixedSizeNumericArray<bool>();
+            istr => istr.ReadFixedSizeNumericArray<bool>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<byte> IceReaderIntoByte = (istr) => istr.ReadByte();
+        public static readonly InputStreamReader<byte> IceReaderIntoByte =
+            istr => istr.ReadByte();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<byte[]> IceReaderIntoByteArray =
-            (istr) => istr.ReadFixedSizeNumericArray<byte>();
+            istr => istr.ReadFixedSizeNumericArray<byte>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<double> IceReaderIntoDouble = (istr) => istr.ReadDouble();
+        public static readonly InputStreamReader<double> IceReaderIntoDouble =
+            istr => istr.ReadDouble();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<double[]> IceReaderIntoDoubleArray =
-            (istr) => istr.ReadFixedSizeNumericArray<double>();
+            istr => istr.ReadFixedSizeNumericArray<double>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<float> IceReaderIntoFloat = (istr) => istr.ReadFloat();
+        public static readonly InputStreamReader<float> IceReaderIntoFloat =
+            istr => istr.ReadFloat();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<float[]> IceReaderIntoFloatArray =
-            (istr) => istr.ReadFixedSizeNumericArray<float>();
+            istr => istr.ReadFixedSizeNumericArray<float>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<int> IceReaderIntoInt = (istr) => istr.ReadInt();
+        public static readonly InputStreamReader<int> IceReaderIntoInt =
+            istr => istr.ReadInt();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<int[]> IceReaderIntoIntArray =
-            (istr) => istr.ReadFixedSizeNumericArray<int>();
+            istr => istr.ReadFixedSizeNumericArray<int>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<long> IceReaderIntoLong = (istr) => istr.ReadLong();
+        public static readonly InputStreamReader<long> IceReaderIntoLong =
+            istr => istr.ReadLong();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<long[]> IceReaderIntoLongArray =
-            (istr) => istr.ReadFixedSizeNumericArray<long>();
+            istr => istr.ReadFixedSizeNumericArray<long>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<short> IceReaderIntoShort = (istr) => istr.ReadShort();
+        public static readonly InputStreamReader<short> IceReaderIntoShort =
+            istr => istr.ReadShort();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<short[]> IceReaderIntoShortArray =
-            (istr) => istr.ReadFixedSizeNumericArray<short>();
+            istr => istr.ReadFixedSizeNumericArray<short>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<string> IceReaderIntoString = (istr) => istr.ReadString();
+        public static readonly InputStreamReader<string> IceReaderIntoString =
+            istr => istr.ReadString();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<uint> IceReaderIntoUInt =
+            istr => istr.ReadUInt();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<uint[]> IceReaderIntoUIntArray =
+            istr => istr.ReadFixedSizeNumericArray<uint>();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<ulong> IceReaderIntoULong =
+            istr => istr.ReadULong();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<ulong[]> IceReaderIntoULongArray =
+            istr => istr.ReadFixedSizeNumericArray<ulong>();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<ushort> IceReaderIntoUShort =
+            istr => istr.ReadUShort();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<ushort[]> IceReaderIntoUShortArray =
+            istr => istr.ReadFixedSizeNumericArray<ushort>();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<int> IceReaderIntoVarInt =
+            istr => istr.ReadVarInt();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<long> IceReaderIntoVarLong =
+            istr => istr.ReadVarLong();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<uint> IceReaderIntoVarUInt =
+            istr => istr.ReadVarUInt();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly InputStreamReader<ulong> IceReaderIntoVarULong =
+            istr => istr.ReadVarULong();
 
         /// <summary>The communicator associated with this stream.</summary>
         /// <value>The communicator.</value>
@@ -107,6 +155,8 @@ namespace Ice
 
         // True when reading a top-level encapsulation; otherwise, false.
         private bool InEncapsulation { get; }
+
+        private bool OldEncoding => Encoding == Encoding.V1_1;
 
         // The byte buffer we are reading.
         private ArraySegment<byte> _buffer;
@@ -157,7 +207,6 @@ namespace Ice
         /// <returns>The double read from the stream.</returns>
         public double ReadDouble()
         {
-            Debug.Assert(_buffer.Array != null);
             double value = BitConverter.ToDouble(_buffer.AsSpan(_pos, sizeof(double)));
             _pos += sizeof(double);
             return value;
@@ -167,7 +216,6 @@ namespace Ice
         /// <returns>The float read from the stream.</returns>
         public float ReadFloat()
         {
-            Debug.Assert(_buffer.Array != null);
             float value = BitConverter.ToSingle(_buffer.AsSpan(_pos, sizeof(float)));
             _pos += sizeof(float);
             return value;
@@ -177,7 +225,6 @@ namespace Ice
         /// <returns>The int read from the stream.</returns>
         public int ReadInt()
         {
-            Debug.Assert(_buffer.Array != null);
             int value = BitConverter.ToInt32(_buffer.AsSpan(_pos, sizeof(int)));
             _pos += sizeof(int);
             return value;
@@ -187,7 +234,6 @@ namespace Ice
         /// <returns>The long read from the stream.</returns>
         public long ReadLong()
         {
-            Debug.Assert(_buffer.Array != null);
             long value = BitConverter.ToInt64(_buffer.AsSpan(_pos, sizeof(long)));
             _pos += sizeof(long);
             return value;
@@ -197,7 +243,6 @@ namespace Ice
         /// <returns>The short read from the stream.</returns>
         public short ReadShort()
         {
-            Debug.Assert(_buffer.Array != null);
             short value = BitConverter.ToInt16(_buffer.AsSpan(_pos, sizeof(short)));
             _pos += sizeof(short);
             return value;
@@ -216,6 +261,87 @@ namespace Ice
             _pos += size;
             return value;
         }
+
+        /// <summary>Reads a uint from the stream.</summary>
+        /// <returns>The uint read from the stream.</returns>
+        public uint ReadUInt()
+        {
+            uint value = BitConverter.ToUInt32(_buffer.AsSpan(_pos, sizeof(uint)));
+            _pos += sizeof(uint);
+            return value;
+        }
+
+        /// <summary>Reads a ulong from the stream.</summary>
+        /// <returns>The ulong read from the stream.</returns>
+        public ulong ReadULong()
+        {
+            ulong value = BitConverter.ToUInt64(_buffer.AsSpan(_pos, sizeof(ulong)));
+            _pos += sizeof(ulong);
+            return value;
+        }
+
+        /// <summary>Reads a ushort from the stream.</summary>
+        /// <returns>The ushort read from the stream.</returns>
+        public ushort ReadUShort()
+        {
+            ushort value = BitConverter.ToUInt16(_buffer.AsSpan(_pos, sizeof(ushort)));
+            _pos += sizeof(ushort);
+            return value;
+        }
+
+        /// <summary>Reads an int from the stream. This int is encoded using Ice's variable-length integer encoding.
+        /// </summary>
+        /// <returns>The int read from the stream.</returns>
+        public int ReadVarInt()
+        {
+            try
+            {
+                return (int)ReadVarLong();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException("varint value is out of range", ex);
+            }
+        }
+
+        /// <summary>Reads a long from the stream. This long is encoded using Ice's variable-length integer encoding.
+        /// </summary>
+        /// <returns>The long read from the stream.</returns>
+        public long ReadVarLong() => OldEncoding ? ReadLong() :
+            (_buffer[_pos] & 0x03) switch
+            {
+                0 => (sbyte)ReadByte() >> 2,
+                1 => ReadShort() >> 2,
+                2 => ReadInt() >> 2,
+                _ => ReadLong() >> 2
+            };
+
+        /// <summary>Reads a uint from the stream. This uint is encoded using Ice's variable-length integer encoding.
+        /// </summary>
+        /// <returns>The uint read from the stream.</returns>
+        public uint ReadVarUInt()
+        {
+            try
+            {
+                return (uint)ReadVarULong();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException("varuint value is out of range", ex);
+            }
+        }
+
+        /// <summary>Reads a ulong from the stream. This ulong is encoded using Ice's variable-length integer encoding.
+        /// </summary>
+        /// <returns>The ulong read from the stream.</returns>
+        public ulong ReadVarULong() => OldEncoding ? ReadULong() :
+            (_buffer[_pos] & 0x03) switch
+            {
+                0 => (uint)ReadByte() >> 2,
+                1 => (uint)ReadUShort() >> 2,
+                2 => ReadUInt() >> 2,
+                _ => ReadULong() >> 2
+            };
 
         //
         // Read methods for constructed types except class and exception
@@ -642,23 +768,25 @@ namespace Ice
 
         /// <summary>Reads an empty encapsulation from the provided byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
+        /// <param name="encoding">The encoding of the buffer.</param>
         /// <param name="buffer">The byte buffer.</param>
-        internal static void ReadEmptyEncapsulation(Communicator communicator, ArraySegment<byte> buffer)
+        internal static void ReadEmptyEncapsulation(
+            Communicator communicator, Encoding encoding, ArraySegment<byte> buffer)
         {
-            var istr = new InputStream(communicator, buffer, startEncaps: true, 0);
+            var istr = new InputStream(communicator, encoding, buffer, startEncaps: true, 0);
             istr.SkipTaggedParams();
             istr.CheckEndOfBuffer();
         }
 
         /// <summary>Reads the contents of an encapsulation from the provided byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
+        /// <param name="encoding">The encoding of the buffer.</param>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="payloadReader">The reader used to read the payload of this encapsulation.</param>
-        internal static T ReadEncapsulation<T>(Communicator communicator,
-                                               ArraySegment<byte> buffer,
-                                               InputStreamReader<T> payloadReader)
+        internal static T ReadEncapsulation<T>(
+            Communicator communicator, Encoding encoding, ArraySegment<byte> buffer, InputStreamReader<T> payloadReader)
         {
-            var istr = new InputStream(communicator, buffer, startEncaps: true, 0);
+            var istr = new InputStream(communicator, encoding, buffer, startEncaps: true, 0);
             T result = payloadReader(istr);
             istr.SkipTaggedParams();
             istr.CheckEndOfBuffer();
@@ -669,9 +797,9 @@ namespace Ice
         internal static long ReadLong(ReadOnlySpan<byte> buffer) => BitConverter.ToInt64(buffer);
         internal static short ReadShort(ReadOnlySpan<byte> buffer) => BitConverter.ToInt16(buffer);
 
-        internal static string ReadString(ArraySegment<byte> buffer, Encoding encoding)
+        internal static string ReadString(Encoding encoding, ArraySegment<byte> buffer)
         {
-            int size = ReadSize(buffer, encoding);
+            int size = ReadSize(encoding, buffer);
             if (size == 0)
             {
                 return "";
@@ -684,10 +812,11 @@ namespace Ice
 
         /// <summary>Constructs a new InputStream over a byte buffer.</summary>
         /// <param name="communicator">The communicator.</param>
+        /// <param name="encoding">The encoding of the buffer.</param>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="pos">The initial position in the buffer.</param>
-        internal InputStream(Communicator communicator, ArraySegment<byte> buffer, int pos = 0)
-            : this(communicator, buffer, false, pos)
+        internal InputStream(Communicator communicator, Encoding encoding, ArraySegment<byte> buffer, int pos = 0)
+            : this(communicator, encoding, buffer, false, pos)
         {
             // TODO: pos should always be 0 and buffer should be a slice as needed.
             // Currently this does not work because of the tracing code that resets Pos to 0 to read the protocol frame
@@ -698,7 +827,7 @@ namespace Ice
         /// <returns>The encapsulation header read from the stream.</returns>
         internal (Encoding Encoding, int Size) ReadEncapsulationHeader()
         {
-            (Encoding Encoding, int Size) result = ReadEncapsulationHeader(_buffer.Slice(_pos), Encoding);
+            (Encoding Encoding, int Size) result = ReadEncapsulationHeader(Encoding, _buffer.Slice(_pos));
             _pos += 6;
             return result;
         }
@@ -784,10 +913,10 @@ namespace Ice
             return encoding;
         }
 
-        private static (Encoding Encoding, int Size) ReadEncapsulationHeader(ReadOnlySpan<byte> buffer,
-                                                                             Encoding encoding)
+        private static (Encoding Encoding, int Size) ReadEncapsulationHeader(
+            Encoding encoding, ReadOnlySpan<byte> buffer)
         {
-            Debug.Assert(encoding == Encoding.V1_1); // temporary
+            Debug.Assert(encoding == Encoding.V1_1 || encoding == Encoding.V2_0); // for now, only endpoints use 2.0
 
             // With the 1.1 encoding, the encapsulation size is encoded on a 4-bytes int and not on a variable-length
             // size, for ease of marshaling.
@@ -807,9 +936,9 @@ namespace Ice
             return (new Encoding(buffer[4], buffer[5]), size);
         }
 
-        private static int ReadSize(ArraySegment<byte> buffer, Encoding encoding)
+        private static int ReadSize(Encoding encoding, ArraySegment<byte> buffer)
         {
-            Debug.Assert(encoding == Encoding.V1_1);
+            Debug.Assert(encoding == Encoding.V1_1 || encoding == Encoding.V2_0); // to silence warning
 
             byte b = buffer[0];
             if (b < 255)
@@ -825,7 +954,8 @@ namespace Ice
             return size;
         }
 
-        private InputStream(Communicator communicator, ArraySegment<byte> buffer, bool startEncaps, int pos)
+        private InputStream(
+            Communicator communicator, Encoding encoding, ArraySegment<byte> buffer, bool startEncaps, int pos)
         {
             Debug.Assert(pos == 0 || !startEncaps); // while pos is still there, it's 0 when startEncaps is true
             Communicator = communicator;
@@ -834,7 +964,7 @@ namespace Ice
             {
                 _pos = 0;
                 int size;
-                (Encoding, size) = ReadEncapsulationHeader(buffer, Encoding.V1_1);
+                (Encoding, size) = ReadEncapsulationHeader(encoding, buffer);
                 Encoding.CheckSupported();
                 // We slice the provided buffer to the encapsulation (minus its header). This way, we can easily prevent
                 // reads past the end of the encapsulation.
@@ -845,7 +975,7 @@ namespace Ice
             {
                 _buffer = buffer;
                 _pos = pos;
-                Encoding = Encoding.V1_1;
+                Encoding = encoding;
                 InEncapsulation = false;
             }
         }

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -60,57 +60,11 @@ namespace Ice
         //
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<bool> IceWriterFromBool = (ostr, value) => ostr.WriteBool(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<byte> IceWriterFromByte = (ostr, value) => ostr.WriteByte(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<short> IceWriterFromShort = (ostr, value) => ostr.WriteShort(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<int> IceWriterFromInt = (ostr, value) => ostr.WriteInt(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<long> IceWriterFromLong = (ostr, value) => ostr.WriteLong(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<float> IceWriterFromFloat = (ostr, value) => ostr.WriteFloat(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<double> IceWriterFromDouble =
-            (ostr, value) => ostr.WriteDouble(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<string> IceWriterFromString =
-            (ostr, value) => ostr.WriteString(value);
+        public static readonly OutputStreamWriter<bool> IceWriterFromBool =
+            (ostr, value) => ostr.WriteBool(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<bool[]> IceWriterFromBoolArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<byte[]> IceWriterFromByteArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<short[]> IceWriterFromShortArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<int[]> IceWriterFromIntArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<long[]> IceWriterFromLongArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<float[]> IceWriterFromFloatArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<double[]> IceWriterFromDoubleArray =
             (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -118,28 +72,132 @@ namespace Ice
             (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<byte> IceWriterFromByte =
+            (ostr, value) => ostr.WriteByte(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<byte[]> IceWriterFromByteArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<byte>> IceWriterFromByteSequence =
             (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<ReadOnlyMemory<short>> IceWriterFromShortSequence =
+        public static readonly OutputStreamWriter<double> IceWriterFromDouble =
+            (ostr, value) => ostr.WriteDouble(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<double[]> IceWriterFromDoubleArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<double>> IceWriterFromDoubleSequence =
             (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<ReadOnlyMemory<int>> IceWriterFromIntSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+        public static readonly OutputStreamWriter<float> IceWriterFromFloat =
+            (ostr, value) => ostr.WriteFloat(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<ReadOnlyMemory<long>> IceWriterFromLongSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+        public static readonly OutputStreamWriter<float[]> IceWriterFromFloatArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<float>> IceWriterFromFloatSequence =
             (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<ReadOnlyMemory<double>> IceWriterFromDoubleSequence =
+        public static readonly OutputStreamWriter<int> IceWriterFromInt =
+            (ostr, value) => ostr.WriteInt(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<int[]> IceWriterFromIntArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<int>> IceWriterFromIntSequence =
             (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<long> IceWriterFromLong =
+            (ostr, value) => ostr.WriteLong(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<long[]> IceWriterFromLongArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<long>> IceWriterFromLongSequence =
+            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<short> IceWriterFromShort =
+            (ostr, value) => ostr.WriteShort(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<short[]> IceWriterFromShortArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<short>> IceWriterFromShortSequence =
+            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<string> IceWriterFromString =
+            (ostr, value) => ostr.WriteString(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<uint> IceWriterFromUInt =
+            (ostr, value) => ostr.WriteUInt(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<uint[]> IceWriterFromUIntArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<uint>> IceWriterFromUIntSequence =
+            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ulong> IceWriterFromULong =
+            (ostr, value) => ostr.WriteULong(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ulong[]> IceWriterFromULongArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<ulong>> IceWriterFromULongSequence =
+            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ushort> IceWriterFromUShort =
+            (ostr, value) => ostr.WriteUShort(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ushort[]> IceWriterFromUShortArray =
+            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ReadOnlyMemory<ushort>> IceWriterFromUShortSequence =
+            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<int> IceWriterFromVarInt =
+            (ostr, value) => ostr.WriteVarInt(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<long> IceWriterFromVarLong =
+            (ostr, value) => ostr.WriteVarLong(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<uint> IceWriterFromVarUInt =
+            (ostr, value) => ostr.WriteVarUInt(value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly OutputStreamWriter<ulong> IceWriterFromVarULong =
+            (ostr, value) => ostr.WriteVarULong(value);
 
         /// <summary>The encoding used when writing to this stream.</summary>
         /// <value>The encoding.</value>
@@ -158,6 +216,8 @@ namespace Ice
         private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
 
         private bool InEncapsulation => _startPos != null;
+
+        private bool OldEncoding => Encoding == Encoding.V1_1;
 
         // The number of bytes that the stream can hold.
         private int _capacity;
@@ -261,6 +321,90 @@ namespace Ice
                 byte[] data = _utf8.GetBytes(v);
                 WriteSize(data.Length);
                 WriteByteSpan(data.AsSpan());
+            }
+        }
+
+        /// <summary>Writes a uint to the stream.</summary>
+        /// <param name="v">The uint to write to the stream.</param>
+        public void WriteUInt(uint v) => WriteFixedSizeNumeric(v);
+
+        /// <summary>Writes a ulong to the stream.</summary>
+        /// <param name="v">The long to write to the stream.</param>
+        public void WriteULong(ulong v) => WriteFixedSizeNumeric(v);
+
+        /// <summary>Writes a ushort to the stream.</summary>
+        /// <param name="v">The ushort to write to the stream.</param>
+        public void WriteUShort(ushort v) => WriteFixedSizeNumeric(v);
+
+        /// <summary>Writes an int to stream, using Ice's variable-length encoding.</summary>
+        /// <param name="v">The int to write to the stream.</param>
+        public void WriteVarInt(int v) => WriteVarLong(v);
+
+        /// <summary>Writes a long to stream, using Ice's variable-length encoding, with the minimum number of bytes
+        /// required by the encoding.</summary>
+        /// <param name="v">The long to write to the stream. It must be in the range [2^61..2^61 - 1].</param>
+        public void WriteVarLong(long v)
+        {
+            if (v < EncodingDefinitions.VarLongMinValue || v > EncodingDefinitions.VarLongMaxValue)
+            {
+                throw new ArgumentOutOfRangeException($"varlong value `{v}' is out of range", nameof(v));
+            }
+
+            if (OldEncoding)
+            {
+                WriteLong(v);
+            }
+            else
+            {
+                v <<= 2;
+                int encodedLength = v switch
+                {
+                    long b when b >= sbyte.MinValue && b <= sbyte.MaxValue => 0,
+                    long s when s >= short.MinValue && s <= short.MaxValue => 1,
+                    long i when i >= int.MinValue && i <= int.MaxValue => 2,
+                    _ => 3
+                };
+
+                v |= (uint)encodedLength;
+                Span<byte> data = stackalloc byte[sizeof(long)];
+                MemoryMarshal.Write(data, ref v);
+                WriteByteSpan(data.Slice(0, 1 << encodedLength));
+            }
+        }
+
+        /// <summary>Writes a uint to stream, using Ice's variable-length encoding.</summary>
+        /// <param name="v">The uint to write to the stream.</param>
+        public void WriteVarUInt(uint v) => WriteVarULong(v);
+
+        /// <summary>Writes a ulong to stream, using Ice's variable-length encoding, with the minimum number of bytes
+        /// required by the encoding.</summary>
+        /// <param name="v">The ulong to write to the stream. It must be in the range [0..2^62 - 1].</param>
+        public void WriteVarULong(ulong v)
+        {
+            if (v > EncodingDefinitions.VarULongMaxValue)
+            {
+                throw new ArgumentOutOfRangeException($"varulong value `{v}' is out of range", nameof(v));
+            }
+
+            if (OldEncoding)
+            {
+                WriteULong(v);
+            }
+            else
+            {
+                v <<= 2;
+                int encodedLength = v switch
+                {
+                    ulong b when b <= byte.MaxValue => 0,
+                    ulong s when s <= ushort.MaxValue => 1,
+                    ulong i when i <= uint.MaxValue => 2,
+                    _ => 3
+                };
+
+                v |= (uint)encodedLength;
+                Span<byte> data = stackalloc byte[sizeof(ulong)];
+                MemoryMarshal.Write(data, ref v);
+                WriteByteSpan(data.Slice(0, 1 << encodedLength));
             }
         }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -329,7 +329,7 @@ namespace Ice
         public void WriteUInt(uint v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a ulong to the stream.</summary>
-        /// <param name="v">The long to write to the stream.</param>
+        /// <param name="v">The ulong to write to the stream.</param>
         public void WriteULong(ulong v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a ushort to the stream.</summary>
@@ -340,9 +340,9 @@ namespace Ice
         /// <param name="v">The int to write to the stream.</param>
         public void WriteVarInt(int v) => WriteVarLong(v);
 
-        /// <summary>Writes a long to stream, using Ice's variable-length encoding, with the minimum number of bytes
-        /// required by the encoding.</summary>
-        /// <param name="v">The long to write to the stream. It must be in the range [2^61..2^61 - 1].</param>
+        /// <summary>Writes a long to stream, using Ice's variable-length integer encoding, with the minimum number of
+        /// bytes required by the encoding.</summary>
+        /// <param name="v">The long to write to the stream. It must be in the range [-2^61..2^61 - 1].</param>
         public void WriteVarLong(long v)
         {
             if (v < EncodingDefinitions.VarLongMinValue || v > EncodingDefinitions.VarLongMaxValue)

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Globalization;
 
 namespace Ice
@@ -18,8 +19,19 @@ namespace Ice
         Ice2 = 2
     }
 
-    internal static class ProtocolExtensions
+    public static class ProtocolExtensions
     {
+        /// <summary>Returns the Ice encoding that this protocol uses for its headers.</summary>
+        /// <param name="protocol">The protocol.</param>
+        public static Encoding GetEncoding(this Protocol protocol) =>
+            protocol switch
+            {
+                Protocol.Ice1 => Encoding.V1_1,
+                Protocol.Ice2 => Encoding.V2_0,
+                _ => throw new NotSupportedException(@$"Ice protocol `{protocol.ToString().ToLower()
+                    }' is not supported by this Ice runtime ({Util.StringVersion()})")
+            };
+
         /// <summary>Checks if this protocol is supported by the Ice runtime. If not supported, throws
         /// NotSupportedException.</summary>
         /// <param name="protocol">The protocol.</param>
@@ -28,7 +40,7 @@ namespace Ice
             // For now, we support only ice1
             if (protocol != Protocol.Ice1)
             {
-                throw new System.NotSupportedException(@$"Ice protocol `{protocol.ToString().ToLower()
+                throw new NotSupportedException(@$"Ice protocol `{protocol.ToString().ToLower()
                     }' is not supported by this Ice runtime ({Util.StringVersion()})");
             }
         }

--- a/csharp/src/Ice/TraceUtil.cs
+++ b/csharp/src/Ice/TraceUtil.cs
@@ -16,7 +16,7 @@ namespace IceInternal
         {
             if (tl.Protocol >= 1)
             {
-                var iss = new InputStream(communicator, buffer);
+                var iss = new InputStream(communicator, Ice1Definitions.Encoding, buffer);
                 iss.Pos = 0;
 
                 using var s = new System.IO.StringWriter(CultureInfo.CurrentCulture);

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -25,7 +25,7 @@ public class Client : TestHelper
             {
                 Console.Out.Write("testing stringToProxy for router... ");
                 Console.Out.Flush();
-                routerBase = IObjectPrx.Parse($"Glacier2/router:{GetTestEndpoint(50)}", communicator);
+                routerBase = IObjectPrx.Parse($"Glacier2/router -e 1.1:{GetTestEndpoint(50)}", communicator);
                 Console.Out.WriteLine("ok");
             }
 
@@ -41,7 +41,8 @@ public class Client : TestHelper
             {
                 Console.Out.Write("testing router finder... ");
                 Console.Out.Flush();
-                IRouterFinderPrx finder = IRouterFinderPrx.Parse($"Ice/RouterFinder:{GetTestEndpoint(50)}", communicator);
+                IRouterFinderPrx finder = IRouterFinderPrx.Parse($"Ice/RouterFinder -e 1.1:{GetTestEndpoint(50)}",
+                    communicator);
                 Assert(finder.GetRouter()!.Identity.Equals(router.Identity));
                 Console.Out.WriteLine("ok");
             }
@@ -380,7 +381,8 @@ public class Client : TestHelper
                 IProcessPrx process;
                 {
                     Console.Out.Write("testing stringToProxy for admin object... ");
-                    process = IProcessPrx.Parse($"Glacier2/admin -f Process:{GetTestEndpoint(51)}", communicator);
+                    process = IProcessPrx.Parse($"Glacier2/admin -e 1.1 -f Process:{GetTestEndpoint(51)}",
+                        communicator);
                     Console.Out.WriteLine("ok");
                 }
 

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -151,6 +151,7 @@ public class Client : TestHelper
     {
         System.Collections.Generic.Dictionary<string, string> properties = CreateTestProperties(ref args);
         properties["Ice.Warn.Connections"] = "0";
+        properties["Ice.Default.Encoding"] = "1.1";
         properties["Ice.Default.Router"] = $"Glacier2/router:{GetTestEndpoint(properties, 50)}";
 
         using Communicator communicator = Initialize(properties);
@@ -337,7 +338,7 @@ public class Client : TestHelper
             IProcessPrx process;
             {
                 Console.Out.Write("testing stringToProxy for process object... ");
-                process = IProcessPrx.Parse($"Glacier2/admin -f Process:{GetTestEndpoint(51)}", communicator);
+                process = IProcessPrx.Parse($"Glacier2/admin -e 1.1 -f Process:{GetTestEndpoint(51)}", communicator);
                 Console.Out.WriteLine("ok");
             }
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -1033,16 +1033,16 @@ public class AllTests
         }
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);
-        testAttribute(clientMetrics, clientProps, update, "Invocation", "id", "metrics -t -p ice1 -e 1.1 [op]", op,
+        testAttribute(clientMetrics, clientProps, update, "Invocation", "id", "metrics -t -p ice1 -e 2.0 [op]", op,
             output);
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "operation", "op", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "identity", "metrics", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "facet", "", op, output);
-        testAttribute(clientMetrics, clientProps, update, "Invocation", "encoding", "1.1", op, output);
+        testAttribute(clientMetrics, clientProps, update, "Invocation", "encoding", "2.0", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "mode", "twoway", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "proxy",
-                      "metrics -t -p ice1 -e 1.1:" + endpoint + " -t " + timeout, op, output);
+                      "metrics -t -p ice1 -e 2.0:" + endpoint + " -t " + timeout, op, output);
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry1", "test", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry2", "", op, output);

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -240,6 +240,23 @@ namespace Ice.operations.AMD
             return ToReturnValue(r, p3);
         }
 
+        public ValueTask<(IReadOnlyDictionary<ulong, float>, IReadOnlyDictionary<ulong, float>)>
+        opULongFloatDAsync(Dictionary<ulong, float> p1, Dictionary<ulong, float> p2, Current current)
+        {
+            var p3 = p1;
+            var r = new Dictionary<ulong, float>();
+            foreach (KeyValuePair<ulong, float> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ulong, float> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+
+            return ToReturnValue(r, p3);
+        }
+
         public ValueTask<(Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?)>
         opMyClassAsync(Test.IMyClassPrx? p1, Current current)
         {
@@ -268,8 +285,33 @@ namespace Ice.operations.AMD
             return ToReturnValue(r, p3);
         }
 
-        public ValueTask<(long, short, int, long)>
-        opShortIntLongAsync(short p1, int p2, long p3, Current current) => MakeValueTask((p3, p1, p2, p3));
+        public ValueTask<(IReadOnlyDictionary<ushort, uint>, IReadOnlyDictionary<ushort, uint>)>
+        opUShortUIntDAsync(Dictionary<ushort, uint> p1, Dictionary<ushort, uint> p2, Current current)
+        {
+            var p3 = p1;
+            var r = new Dictionary<ushort, uint>();
+            foreach (KeyValuePair<ushort, uint> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ushort, uint> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return ToReturnValue(r, p3);
+        }
+
+        public ValueTask<(long, short, int, long)> opShortIntLongAsync(short p1, int p2, long p3, Current current) =>
+            MakeValueTask((p3, p1, p2, p3));
+
+        public ValueTask<(ulong, ushort, uint, ulong)> opUShortUIntULongAsync(
+            ushort p1, uint p2, ulong p3, Current current) =>
+            MakeValueTask((p3, p1, p2, p3));
+
+        public ValueTask<int> opVarIntAsync(int v, Current current) => MakeValueTask(v);
+        public ValueTask<uint> opVarUIntAsync(uint v, Current current) => MakeValueTask(v);
+        public ValueTask<long> opVarLongAsync(long v, Current current) => MakeValueTask(v);
+        public ValueTask<ulong> opVarULongAsync(ulong v, Current current) => MakeValueTask(v);
 
         public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<short>, ReadOnlyMemory<int>, ReadOnlyMemory<long>)>
         opShortIntLongSAsync(short[] p1, int[] p2, long[] p3, Current current)
@@ -285,6 +327,54 @@ namespace Ice.operations.AMD
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
             return MakeValueTask(((ReadOnlyMemory<long>)p3, (ReadOnlyMemory<short>)p4, (ReadOnlyMemory<int>)p5,
                 (ReadOnlyMemory<long>)p6));
+        }
+
+        public ValueTask<(ReadOnlyMemory<ulong>, ReadOnlyMemory<ushort>, ReadOnlyMemory<uint>, ReadOnlyMemory<ulong>)>
+        opUShortUIntULongSAsync(ushort[] p1, uint[] p2, ulong[] p3, Current current)
+        {
+            var p4 = p1;
+            var p5 = new uint[p2.Length];
+            for (int i = 0; i < p2.Length; i++)
+            {
+                p5[i] = p2[p2.Length - (i + 1)];
+            }
+            var p6 = new ulong[p3.Length + p3.Length];
+            Array.Copy(p3, p6, p3.Length);
+            Array.Copy(p3, 0, p6, p3.Length, p3.Length);
+            return MakeValueTask(((ReadOnlyMemory<ulong>)p3, (ReadOnlyMemory<ushort>)p4, (ReadOnlyMemory<uint>)p5,
+                (ReadOnlyMemory<ulong>)p6));
+        }
+
+        public ValueTask<(IEnumerable<long>, IEnumerable<int>, IEnumerable<long>)>
+        opVarIntVarLongSAsync(int[] p1, long[] p2, Current current)
+        {
+            var p4 = new int[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                p4[i] = p1[p1.Length - (i + 1)];
+            }
+
+            var p5 = new long[p2.Length + p2.Length];
+            Array.Copy(p2, p5, p2.Length);
+            Array.Copy(p2, 0, p5, p2.Length, p2.Length);
+
+            return MakeValueTask(((IEnumerable<long>)p2, (IEnumerable<int>)p4, (IEnumerable<long>)p5));
+        }
+
+        public ValueTask<(IEnumerable<ulong>, IEnumerable<uint>, IEnumerable<ulong>)>
+        opVarUIntVarULongSAsync(uint[] p1, ulong[] p2, Current current)
+        {
+            var p4 = new uint[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                p4[i] = p1[p1.Length - (i + 1)];
+            }
+
+            var p5 = new ulong[p2.Length + p2.Length];
+            Array.Copy(p2, p5, p2.Length);
+            Array.Copy(p2, 0, p5, p2.Length, p2.Length);
+
+            return MakeValueTask(((IEnumerable<ulong>)p2, (IEnumerable<uint>)p4, (IEnumerable<ulong>)p5));
         }
 
         public ValueTask<(IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>)>
@@ -303,6 +393,24 @@ namespace Ice.operations.AMD
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
             return MakeValueTask((p3 as IEnumerable<long[]>, p4 as IEnumerable<short[]>, p5 as IEnumerable<int[]>,
                 p6 as IEnumerable<long[]>));
+        }
+
+        public ValueTask<(IEnumerable<ulong[]>, IEnumerable<ushort[]>, IEnumerable<uint[]>, IEnumerable<ulong[]>)>
+        opUShortUIntULongSSAsync(ushort[][] p1, uint[][] p2, ulong[][] p3, Current current)
+        {
+            var p4 = p1;
+
+            var p5 = new uint[p2.Length][];
+            for (int i = 0; i < p2.Length; i++)
+            {
+                p5[i] = p2[p2.Length - (i + 1)];
+            }
+
+            var p6 = new ulong[p3.Length + p3.Length][];
+            Array.Copy(p3, p6, p3.Length);
+            Array.Copy(p3, 0, p6, p3.Length, p3.Length);
+            return MakeValueTask((p3 as IEnumerable<ulong[]>, p4 as IEnumerable<ushort[]>, p5 as IEnumerable<uint[]>,
+                p6 as IEnumerable<ulong[]>));
         }
 
         public ValueTask<(string, string)>
@@ -387,6 +495,21 @@ namespace Ice.operations.AMD
             return ToReturnValue(r, p3);
         }
 
+        public ValueTask<(IEnumerable<Dictionary<ushort, uint>>, IEnumerable<Dictionary<ushort, uint>>)>
+        opUShortUIntDSAsync(Dictionary<ushort, uint>[] p1, Dictionary<ushort, uint>[] p2, Current current)
+        {
+            var p3 = new Dictionary<ushort, uint>[p1.Length + p2.Length];
+            Array.Copy(p2, p3, p2.Length);
+            Array.Copy(p1, 0, p3, p2.Length, p1.Length);
+
+            var r = new Dictionary<ushort, uint>[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                r[i] = p1[p1.Length - (i + 1)];
+            }
+            return ToReturnValue(r, p3);
+        }
+
         public ValueTask<(IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>)>
         opLongFloatDSAsync(Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
         {
@@ -395,6 +518,21 @@ namespace Ice.operations.AMD
             Array.Copy(p1, 0, p3, p2.Length, p1.Length);
 
             var r = new Dictionary<long, float>[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                r[i] = p1[p1.Length - (i + 1)];
+            }
+            return ToReturnValue(r, p3);
+        }
+
+        public ValueTask<(IEnumerable<Dictionary<ulong, float>>, IEnumerable<Dictionary<ulong, float>>)>
+        opULongFloatDSAsync(Dictionary<ulong, float>[] p1, Dictionary<ulong, float>[] p2, Current current)
+        {
+            var p3 = new Dictionary<ulong, float>[p1.Length + p2.Length];
+            Array.Copy(p2, p3, p2.Length);
+            Array.Copy(p1, 0, p3, p2.Length, p1.Length);
+
+            var r = new Dictionary<ulong, float>[p1.Length];
             for (int i = 0; i < p1.Length; i++)
             {
                 r[i] = p1[p1.Length - (i + 1)];
@@ -512,6 +650,22 @@ namespace Ice.operations.AMD
             return ToReturnValue(r, p3);
         }
 
+        public ValueTask<(IReadOnlyDictionary<ushort, ushort[]>, IReadOnlyDictionary<ushort, ushort[]>)>
+        opUShortUShortSDAsync(Dictionary<ushort, ushort[]> p1, Dictionary<ushort, ushort[]> p2, Current current)
+        {
+            var p3 = p2;
+            var r = new Dictionary<ushort, ushort[]>();
+            foreach (var e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (var e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return ToReturnValue(r, p3);
+        }
+
         public ValueTask<(IReadOnlyDictionary<int, int[]>, IReadOnlyDictionary<int, int[]>)>
         opIntIntSDAsync(Dictionary<int, int[]> p1, Dictionary<int, int[]> p2, Current current)
         {
@@ -528,11 +682,43 @@ namespace Ice.operations.AMD
             return ToReturnValue(r, p3);
         }
 
+        public ValueTask<(IReadOnlyDictionary<uint, uint[]>, IReadOnlyDictionary<uint, uint[]>)>
+        opUIntUIntSDAsync(Dictionary<uint, uint[]> p1, Dictionary<uint, uint[]> p2, Current current)
+        {
+            var p3 = p2;
+            var r = new Dictionary<uint, uint[]>();
+            foreach (var e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (var e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return ToReturnValue(r, p3);
+        }
+
         public ValueTask<(IReadOnlyDictionary<long, long[]>, IReadOnlyDictionary<long, long[]>)>
         opLongLongSDAsync(Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current)
         {
             var p3 = p2;
             var r = new Dictionary<long, long[]>();
+            foreach (var e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (var e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return ToReturnValue(r, p3);
+        }
+
+        public ValueTask<(IReadOnlyDictionary<ulong, ulong[]>, IReadOnlyDictionary<ulong, ulong[]>)>
+        opULongULongSDAsync(Dictionary<ulong, ulong[]> p1, Dictionary<ulong, ulong[]> p2, Current current)
+        {
+            var p3 = p2;
+            var r = new Dictionary<ulong, ulong[]>();
             foreach (var e in p1)
             {
                 r[e.Key] = e.Value;
@@ -745,14 +931,13 @@ namespace Ice.operations.AMD
         public ValueTask<byte>
         opByte1Async(byte value, Current current) => MakeValueTask(value);
 
-        public ValueTask<short>
-        opShort1Async(short value, Current current) => MakeValueTask(value);
+        public ValueTask<short> opShort1Async(short value, Current current) => MakeValueTask(value);
+        public ValueTask<int> opInt1Async(int value, Current current) => MakeValueTask(value);
+        public ValueTask<long> opLong1Async(long value, Current current) => MakeValueTask(value);
 
-        public ValueTask<int>
-        opInt1Async(int value, Current current) => MakeValueTask(value);
-
-        public ValueTask<long>
-        opLong1Async(long value, Current current) => MakeValueTask(value);
+        public ValueTask<ushort> opUShort1Async(ushort value, Current current) => MakeValueTask(value);
+        public ValueTask<uint> opUInt1Async(uint value, Current current) => MakeValueTask(value);
+        public ValueTask<ulong> opULong1Async(ulong value, Current current) => MakeValueTask(value);
 
         public ValueTask<float>
         opFloat1Async(float value, Current current) => MakeValueTask(value);

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -172,6 +172,21 @@ namespace Ice.operations
             return (r, p1);
         }
 
+        public (IReadOnlyDictionary<ulong, float>, IReadOnlyDictionary<ulong, float>) opULongFloatD(
+            Dictionary<ulong, float> p1, Dictionary<ulong, float> p2, Current current)
+        {
+            var r = new Dictionary<ulong, float>();
+            foreach (KeyValuePair<ulong, float> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ulong, float> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return (r, p1);
+        }
+
         public (Test.IMyClassPrx?, Test.IMyClassPrx?, Test.IMyClassPrx?) opMyClass(Test.IMyClassPrx? p1,
             Current current) =>
             (current.Adapter.CreateProxy(current.Identity, Test.IMyClassPrx.Factory),
@@ -195,10 +210,35 @@ namespace Ice.operations
             return (r, p1);
         }
 
+        public (IReadOnlyDictionary<ushort, uint>, IReadOnlyDictionary<ushort, uint>) opUShortUIntD(
+            Dictionary<ushort, uint> p1,
+            Dictionary<ushort, uint> p2,
+            Current current)
+        {
+            var r = new Dictionary<ushort, uint>();
+            foreach (KeyValuePair<ushort, uint> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ushort, uint> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return (r, p1);
+        }
+
         public (long, short, int, long) opShortIntLong(short p1, int p2, long p3, Current current) => (p3, p1, p2, p3);
 
-        public (ReadOnlyMemory<long>, ReadOnlyMemory<short>, ReadOnlyMemory<int>, ReadOnlyMemory<long>) opShortIntLongS(
-            short[] p1, int[] p2, long[] p3, Current current)
+        public (ulong, ushort, uint, ulong) opUShortUIntULong(ushort p1, uint p2, ulong p3, Current current) =>
+            (p3, p1, p2, p3);
+
+        public int opVarInt(int v, Current current) => v;
+        public uint opVarUInt(uint v, Current current) => v;
+        public long opVarLong(long v, Current current) => v;
+        public ulong opVarULong(ulong v, Current current) => v;
+
+        public (ReadOnlyMemory<long>, ReadOnlyMemory<short>, ReadOnlyMemory<int>, ReadOnlyMemory<long>)
+        opShortIntLongS(short[] p1, int[] p2, long[] p3, Current current)
         {
             var p5 = new int[p2.Length];
             for (int i = 0; i < p2.Length; i++)
@@ -213,6 +253,54 @@ namespace Ice.operations
             return (p3, p1, p5, p6);
         }
 
+        public (ReadOnlyMemory<ulong>, ReadOnlyMemory<ushort>, ReadOnlyMemory<uint>, ReadOnlyMemory<ulong>)
+        opUShortUIntULongS(ushort[] p1, uint[] p2, ulong[] p3, Current current)
+        {
+            var p5 = new uint[p2.Length];
+            for (int i = 0; i < p2.Length; i++)
+            {
+                p5[i] = p2[p2.Length - (i + 1)];
+            }
+
+            var p6 = new ulong[p3.Length + p3.Length];
+            Array.Copy(p3, p6, p3.Length);
+            Array.Copy(p3, 0, p6, p3.Length, p3.Length);
+
+            return (p3, p1, p5, p6);
+        }
+
+        public (IEnumerable<long>, IEnumerable<int>, IEnumerable<long>)
+        opVarIntVarLongS(int[] p1, long[] p2, Current current)
+        {
+            var p4 = new int[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                p4[i] = p1[p1.Length - (i + 1)];
+            }
+
+            var p5 = new long[p2.Length + p2.Length];
+            Array.Copy(p2, p5, p2.Length);
+            Array.Copy(p2, 0, p5, p2.Length, p2.Length);
+
+            return (p2, p4, p5);
+        }
+
+        public (IEnumerable<ulong>, IEnumerable<uint>, IEnumerable<ulong>)
+        opVarUIntVarULongS(uint[] p1, ulong[] p2, Current current)
+        {
+            var p4 = new uint[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                p4[i] = p1[p1.Length - (i + 1)];
+            }
+
+            var p5 = new ulong[p2.Length + p2.Length];
+            Array.Copy(p2, p5, p2.Length);
+            Array.Copy(p2, 0, p5, p2.Length, p2.Length);
+
+            return (p2, p4, p5);
+        }
+
         public (IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>) opShortIntLongSS(
             short[][] p1, int[][] p2, long[][] p3, Current current)
         {
@@ -223,6 +311,22 @@ namespace Ice.operations
             }
 
             var p6 = new long[p3.Length + p3.Length][];
+            Array.Copy(p3, p6, p3.Length);
+            Array.Copy(p3, 0, p6, p3.Length, p3.Length);
+
+            return (p3, p1, p5, p6);
+        }
+
+        public (IEnumerable<ulong[]>, IEnumerable<ushort[]>, IEnumerable<uint[]>, IEnumerable<ulong[]>)
+        opUShortUIntULongSS(ushort[][] p1, uint[][] p2, ulong[][] p3, Current current)
+        {
+            var p5 = new uint[p2.Length][];
+            for (int i = 0; i < p2.Length; i++)
+            {
+                p5[i] = p2[p2.Length - (i + 1)];
+            }
+
+            var p6 = new ulong[p3.Length + p3.Length][];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
 
@@ -307,6 +411,21 @@ namespace Ice.operations
             return (r, p3);
         }
 
+        public (IEnumerable<Dictionary<ushort, uint>>, IEnumerable<Dictionary<ushort, uint>>) opUShortUIntDS(
+            Dictionary<ushort, uint>[] p1, Dictionary<ushort, uint>[] p2, Current current)
+        {
+            var p3 = new Dictionary<ushort, uint>[p1.Length + p2.Length];
+            Array.Copy(p2, p3, p2.Length);
+            Array.Copy(p1, 0, p3, p2.Length, p1.Length);
+
+            var r = new Dictionary<ushort, uint>[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                r[i] = p1[p1.Length - (i + 1)];
+            }
+            return (r, p3);
+        }
+
         public (IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>) opLongFloatDS(
             Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
         {
@@ -315,6 +434,21 @@ namespace Ice.operations
             Array.Copy(p1, 0, p3, p2.Length, p1.Length);
 
             var r = new Dictionary<long, float>[p1.Length];
+            for (int i = 0; i < p1.Length; i++)
+            {
+                r[i] = p1[p1.Length - (i + 1)];
+            }
+            return (r, p3);
+        }
+
+        public (IEnumerable<Dictionary<ulong, float>>, IEnumerable<Dictionary<ulong, float>>) opULongFloatDS(
+            Dictionary<ulong, float>[] p1, Dictionary<ulong, float>[] p2, Current current)
+        {
+            var p3 = new Dictionary<ulong, float>[p1.Length + p2.Length];
+            Array.Copy(p2, p3, p2.Length);
+            Array.Copy(p1, 0, p3, p2.Length, p1.Length);
+
+            var r = new Dictionary<ulong, float>[p1.Length];
             for (int i = 0; i < p1.Length; i++)
             {
                 r[i] = p1[p1.Length - (i + 1)];
@@ -434,6 +568,21 @@ namespace Ice.operations
             return (r, p2);
         }
 
+        public (IReadOnlyDictionary<ushort, ushort[]>, IReadOnlyDictionary<ushort, ushort[]>) opUShortUShortSD(
+            Dictionary<ushort, ushort[]> p1, Dictionary<ushort, ushort[]> p2, Current current)
+        {
+            var r = new Dictionary<ushort, ushort[]>();
+            foreach (KeyValuePair<ushort, ushort[]> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ushort, ushort[]> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return (r, p2);
+        }
+
         public (IReadOnlyDictionary<int, int[]>, IReadOnlyDictionary<int, int[]>) opIntIntSD(Dictionary<int, int[]> p1,
             Dictionary<int, int[]> p2,
             Current current)
@@ -450,6 +599,23 @@ namespace Ice.operations
             return (r, p2);
         }
 
+        public (IReadOnlyDictionary<uint, uint[]>, IReadOnlyDictionary<uint, uint[]>) opUIntUIntSD(
+            Dictionary<uint, uint[]> p1,
+            Dictionary<uint, uint[]> p2,
+            Current current)
+        {
+            var r = new Dictionary<uint, uint[]>();
+            foreach (KeyValuePair<uint, uint[]> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<uint, uint[]> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return (r, p2);
+        }
+
         public (IReadOnlyDictionary<long, long[]>, IReadOnlyDictionary<long, long[]>) opLongLongSD(
             Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current)
         {
@@ -459,6 +625,21 @@ namespace Ice.operations
                 r[e.Key] = e.Value;
             }
             foreach (KeyValuePair<long, long[]> e in p2)
+            {
+                r[e.Key] = e.Value;
+            }
+            return (r, p2);
+        }
+
+        public (IReadOnlyDictionary<ulong, ulong[]>, IReadOnlyDictionary<ulong, ulong[]>) opULongULongSD(
+            Dictionary<ulong, ulong[]> p1, Dictionary<ulong, ulong[]> p2, Current current)
+        {
+            var r = new Dictionary<ulong, ulong[]>();
+            foreach (KeyValuePair<ulong, ulong[]> e in p1)
+            {
+                r[e.Key] = e.Value;
+            }
+            foreach (KeyValuePair<ulong, ulong[]> e in p2)
             {
                 r[e.Key] = e.Value;
             }
@@ -652,10 +833,13 @@ namespace Ice.operations
         public byte opByte1(byte opByte1, Current current) => opByte1;
 
         public short opShort1(short opShort1, Current current) => opShort1;
+        public ushort opUShort1(ushort opUShort1, Current current) => opUShort1;
 
         public int opInt1(int opInt1, Current current) => opInt1;
+        public uint opUInt1(uint opUInt1, Current current) => opUInt1;
 
         public long opLong1(long opLong1, Current current) => opLong1;
+        public ulong opULong1(ulong opULong1, Current current) => opULong1;
 
         public float opFloat1(float opFloat1, Current current) => opFloat1;
 

--- a/csharp/test/Ice/operations/Test.ice
+++ b/csharp/test/Ice/operations/Test.ice
@@ -38,7 +38,14 @@ sequence<byte> ByteS;
 sequence<bool> BoolS;
 sequence<short> ShortS;
 sequence<int> IntS;
+sequence<varint> VarIntS;
 sequence<long> LongS;
+sequence<varlong> VarLongS;
+sequence<ushort> UShortS;
+sequence<uint> UIntS;
+sequence<varuint> VarUIntS;
+sequence<ulong> ULongS;
+sequence<varulong> VarULongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
@@ -50,6 +57,11 @@ sequence<BoolS> BoolSS;
 sequence<ShortS> ShortSS;
 sequence<IntS> IntSS;
 sequence<LongS> LongSS;
+sequence<VarLongS> VarLongSS;
+sequence<UShortS> UShortSS;
+sequence<UIntS> UIntSS;
+sequence<ULongS> ULongSS;
+sequence<VarULongS> VarULongSS;
 sequence<FloatS> FloatSS;
 sequence<DoubleS> DoubleSS;
 sequence<StringS> StringSS;
@@ -67,6 +79,8 @@ struct MyStruct
 dictionary<byte, bool> ByteBoolD;
 dictionary<short, int> ShortIntD;
 dictionary<long, float> LongFloatD;
+dictionary<ushort, uint> UShortUIntD;
+dictionary<ulong, float> ULongFloatD;
 dictionary<string, string> StringStringD;
 dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
@@ -74,7 +88,9 @@ dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
 sequence<ByteBoolD> ByteBoolDS;
 sequence<ShortIntD> ShortIntDS;
+sequence<UShortUIntD> UShortUIntDS;
 sequence<LongFloatD> LongFloatDS;
+sequence<ULongFloatD> ULongFloatDS;
 sequence<StringStringD> StringStringDS;
 sequence<StringMyEnumD> StringMyEnumDS;
 sequence<MyEnumStringD> MyEnumStringDS;
@@ -85,6 +101,9 @@ dictionary<bool, BoolS> BoolBoolSD;
 dictionary<short, ShortS> ShortShortSD;
 dictionary<int, IntS> IntIntSD;
 dictionary<long, LongS> LongLongSD;
+dictionary<ushort, UShortS> UShortUShortSD;
+dictionary<uint, UIntS> UIntUIntSD;
+dictionary<ulong, ULongS> ULongULongSD;
 dictionary<string, FloatS> StringFloatSD;
 dictionary<string, DoubleS> StringDoubleSD;
 dictionary<string, StringS> StringStringSD;
@@ -106,8 +125,14 @@ interface MyClass
     bool opBool(bool p1, bool p2,
                 out bool p3);
 
-    long opShortIntLong(short p1, int p2, long p3,
-                        out short p4, out int p5, out long p6);
+    long opShortIntLong(short p1, int p2, long p3, out short p4, out int p5, out long p6);
+    ulong opUShortUIntULong(ushort p1, uint p2, ulong p3, out ushort p4, out uint p5, out ulong p6);
+
+    varint opVarInt(varint v);
+    varuint opVarUInt(varuint v);
+
+    varlong opVarLong(varlong v);
+    varulong opVarULong(varulong v);
 
     double opFloatDouble(float p1, double p2,
                          out float p3, out double p4);
@@ -128,8 +153,12 @@ interface MyClass
     BoolS opBoolS(BoolS p1, BoolS p2,
                   out BoolS p3);
 
-    LongS opShortIntLongS(Test::ShortS p1, IntS p2, LongS p3,
-                          out ::Test::ShortS p4, out IntS p5, out LongS p6);
+    LongS opShortIntLongS(Test::ShortS p1, IntS p2, LongS p3, out ::Test::ShortS p4, out IntS p5, out LongS p6);
+    ULongS opUShortUIntULongS(
+        Test::UShortS p1, UIntS p2, ULongS p3, out ::Test::UShortS p4, out UIntS p5, out ULongS p6);
+
+    VarLongS opVarIntVarLongS(VarIntS p1, VarLongS p2, out VarIntS p3, out VarLongS p4);
+    VarULongS opVarUIntVarULongS(VarUIntS p1, VarULongS p2, out VarUIntS p3, out VarULongS p4);
 
     DoubleS opFloatDoubleS(FloatS p1, DoubleS p2,
                            out FloatS p3, out DoubleS p4);
@@ -143,8 +172,8 @@ interface MyClass
     BoolSS opBoolSS(BoolSS p1, BoolSS p2,
                     out BoolSS p3);
 
-    LongSS opShortIntLongSS(ShortSS p1, IntSS p2, LongSS p3,
-                            out ShortSS p4, out IntSS p5, out LongSS p6);
+    LongSS opShortIntLongSS(ShortSS p1, IntSS p2, LongSS p3, out ShortSS p4, out IntSS p5, out LongSS p6);
+    ULongSS opUShortUIntULongSS(UShortSS p1, UIntSS p2, ULongSS p3, out UShortSS p4, out UIntSS p5, out ULongSS p6);
 
     DoubleSS opFloatDoubleSS(FloatSS p1, DoubleSS p2,
                              out FloatSS p3, out DoubleSS p4);
@@ -158,11 +187,11 @@ interface MyClass
     ByteBoolD opByteBoolD(ByteBoolD p1, ByteBoolD p2,
                           out ByteBoolD p3);
 
-    ShortIntD opShortIntD(ShortIntD p1, ShortIntD p2,
-                          out ShortIntD p3);
+    ShortIntD opShortIntD(ShortIntD p1, ShortIntD p2, out ShortIntD p3);
+    UShortUIntD opUShortUIntD(UShortUIntD p1, UShortUIntD p2, out UShortUIntD p3);
 
-    LongFloatD opLongFloatD(LongFloatD p1, LongFloatD p2,
-                            out LongFloatD p3);
+    LongFloatD opLongFloatD(LongFloatD p1, LongFloatD p2, out LongFloatD p3);
+    ULongFloatD opULongFloatD(ULongFloatD p1, ULongFloatD p2, out ULongFloatD p3);
 
     StringStringD opStringStringD(StringStringD p1, StringStringD p2,
                                   out StringStringD p3);
@@ -179,11 +208,11 @@ interface MyClass
     ByteBoolDS opByteBoolDS(ByteBoolDS p1, ByteBoolDS p2,
                             out ByteBoolDS p3);
 
-    ShortIntDS opShortIntDS(ShortIntDS p1, ShortIntDS p2,
-                            out ShortIntDS p3);
+    ShortIntDS opShortIntDS(ShortIntDS p1, ShortIntDS p2, out ShortIntDS p3);
+    UShortUIntDS opUShortUIntDS(UShortUIntDS p1, UShortUIntDS p2, out UShortUIntDS p3);
 
-    LongFloatDS opLongFloatDS(LongFloatDS p1, LongFloatDS p2,
-                              out LongFloatDS p3);
+    LongFloatDS opLongFloatDS(LongFloatDS p1, LongFloatDS p2, out LongFloatDS p3);
+    ULongFloatDS opULongFloatDS(ULongFloatDS p1, ULongFloatDS p2, out ULongFloatDS p3);
 
     StringStringDS opStringStringDS(StringStringDS p1, StringStringDS p2,
                                     out StringStringDS p3);
@@ -203,14 +232,14 @@ interface MyClass
     BoolBoolSD opBoolBoolSD(BoolBoolSD p1, BoolBoolSD p2,
                             out BoolBoolSD p3);
 
-    ShortShortSD opShortShortSD(ShortShortSD p1, ShortShortSD p2,
-                                out ShortShortSD p3);
+    ShortShortSD opShortShortSD(ShortShortSD p1, ShortShortSD p2, out ShortShortSD p3);
+    UShortUShortSD opUShortUShortSD(UShortUShortSD p1, UShortUShortSD p2, out UShortUShortSD p3);
 
-    IntIntSD opIntIntSD(IntIntSD p1, IntIntSD p2,
-                        out IntIntSD p3);
+    IntIntSD opIntIntSD(IntIntSD p1, IntIntSD p2, out IntIntSD p3);
+    UIntUIntSD opUIntUIntSD(UIntUIntSD p1, UIntUIntSD p2, out UIntUIntSD p3);
 
-    LongLongSD opLongLongSD(LongLongSD p1, LongLongSD p2,
-                            out LongLongSD p3);
+    LongLongSD opLongLongSD(LongLongSD p1, LongLongSD p2, out LongLongSD p3);
+    ULongULongSD opULongULongSD(ULongULongSD p1, ULongULongSD p2, out ULongULongSD p3);
 
     StringFloatSD opStringFloatSD(StringFloatSD p1, StringFloatSD p2,
                                   out StringFloatSD p3);
@@ -245,6 +274,9 @@ interface MyClass
     short opShort1(short opShort1);
     int opInt1(int opInt1);
     long opLong1(long opLong1);
+    ushort opUShort1(ushort opUShort1);
+    uint opUInt1(uint opUInt1);
+    ulong opULong1(ulong opULong1);
     float opFloat1(float opFloat1);
     double opDouble1(double opDouble1);
     string opString1(string opString1);

--- a/csharp/test/Ice/operations/TestAMD.ice
+++ b/csharp/test/Ice/operations/TestAMD.ice
@@ -38,7 +38,14 @@ sequence<byte> ByteS;
 sequence<bool> BoolS;
 sequence<short> ShortS;
 sequence<int> IntS;
+sequence<varint> VarIntS;
 sequence<long> LongS;
+sequence<varlong> VarLongS;
+sequence<ushort> UShortS;
+sequence<uint> UIntS;
+sequence<varuint> VarUIntS;
+sequence<ulong> ULongS;
+sequence<varulong> VarULongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
@@ -50,6 +57,11 @@ sequence<BoolS> BoolSS;
 sequence<ShortS> ShortSS;
 sequence<IntS> IntSS;
 sequence<LongS> LongSS;
+sequence<VarLongS> VarLongSS;
+sequence<UShortS> UShortSS;
+sequence<UIntS> UIntSS;
+sequence<ULongS> ULongSS;
+sequence<VarULongS> VarULongSS;
 sequence<FloatS> FloatSS;
 sequence<DoubleS> DoubleSS;
 sequence<StringS> StringSS;
@@ -67,6 +79,8 @@ struct MyStruct
 dictionary<byte, bool> ByteBoolD;
 dictionary<short, int> ShortIntD;
 dictionary<long, float> LongFloatD;
+dictionary<ushort, uint> UShortUIntD;
+dictionary<ulong, float> ULongFloatD;
 dictionary<string, string> StringStringD;
 dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
@@ -74,7 +88,9 @@ dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
 sequence<ByteBoolD> ByteBoolDS;
 sequence<ShortIntD> ShortIntDS;
+sequence<UShortUIntD> UShortUIntDS;
 sequence<LongFloatD> LongFloatDS;
+sequence<ULongFloatD> ULongFloatDS;
 sequence<StringStringD> StringStringDS;
 sequence<StringMyEnumD> StringMyEnumDS;
 sequence<MyEnumStringD> MyEnumStringDS;
@@ -85,6 +101,9 @@ dictionary<bool, BoolS> BoolBoolSD;
 dictionary<short, ShortS> ShortShortSD;
 dictionary<int, IntS> IntIntSD;
 dictionary<long, LongS> LongLongSD;
+dictionary<ushort, UShortS> UShortUShortSD;
+dictionary<uint, UIntS> UIntUIntSD;
+dictionary<ulong, ULongS> ULongULongSD;
 dictionary<string, FloatS> StringFloatSD;
 dictionary<string, DoubleS> StringDoubleSD;
 dictionary<string, StringS> StringStringSD;
@@ -106,8 +125,14 @@ exception SomeException {}
     bool opBool(bool p1, bool p2,
                 out bool p3);
 
-    long opShortIntLong(short p1, int p2, long p3,
-                        out short p4, out int p5, out long p6);
+    long opShortIntLong(short p1, int p2, long p3, out short p4, out int p5, out long p6);
+    ulong opUShortUIntULong(ushort p1, uint p2, ulong p3, out ushort p4, out uint p5, out ulong p6);
+
+    varint opVarInt(varint v);
+    varuint opVarUInt(varuint v);
+
+    varlong opVarLong(varlong v);
+    varulong opVarULong(varulong v);
 
     double opFloatDouble(float p1, double p2,
                          out float p3, out double p4);
@@ -128,8 +153,9 @@ exception SomeException {}
     BoolS opBoolS(BoolS p1, BoolS p2,
                   out BoolS p3);
 
-    LongS opShortIntLongS(Test::ShortS p1, IntS p2, LongS p3,
-                          out ::Test::ShortS p4, out IntS p5, out LongS p6);
+    LongS opShortIntLongS(Test::ShortS p1, IntS p2, LongS p3, out ::Test::ShortS p4, out IntS p5, out LongS p6);
+    ULongS opUShortUIntULongS(
+        Test::UShortS p1, UIntS p2, ULongS p3, out ::Test::UShortS p4, out UIntS p5, out ULongS p6);
 
     DoubleS opFloatDoubleS(FloatS p1, DoubleS p2,
                            out FloatS p3, out DoubleS p4);
@@ -143,8 +169,11 @@ exception SomeException {}
     BoolSS opBoolSS(BoolSS p1, BoolSS p2,
                     out BoolSS p3);
 
-    LongSS opShortIntLongSS(ShortSS p1, IntSS p2, LongSS p3,
-                            out ShortSS p4, out IntSS p5, out LongSS p6);
+    LongSS opShortIntLongSS(ShortSS p1, IntSS p2, LongSS p3, out ShortSS p4, out IntSS p5, out LongSS p6);
+    ULongSS opUShortUIntULongSS(UShortSS p1, UIntSS p2, ULongSS p3, out UShortSS p4, out UIntSS p5, out ULongSS p6);
+
+    VarLongS opVarIntVarLongS(VarIntS p1, VarLongS p2, out VarIntS p3, out VarLongS p4);
+    VarULongS opVarUIntVarULongS(VarUIntS p1, VarULongS p2, out VarUIntS p3, out VarULongS p4);
 
     DoubleSS opFloatDoubleSS(FloatSS p1, DoubleSS p2,
                              out FloatSS p3, out DoubleSS p4);
@@ -158,11 +187,11 @@ exception SomeException {}
     ByteBoolD opByteBoolD(ByteBoolD p1, ByteBoolD p2,
                           out ByteBoolD p3);
 
-    ShortIntD opShortIntD(ShortIntD p1, ShortIntD p2,
-                          out ShortIntD p3);
+    ShortIntD opShortIntD(ShortIntD p1, ShortIntD p2, out ShortIntD p3);
+    UShortUIntD opUShortUIntD(UShortUIntD p1, UShortUIntD p2, out UShortUIntD p3);
 
-    LongFloatD opLongFloatD(LongFloatD p1, LongFloatD p2,
-                            out LongFloatD p3);
+    LongFloatD opLongFloatD(LongFloatD p1, LongFloatD p2, out LongFloatD p3);
+    ULongFloatD opULongFloatD(ULongFloatD p1, ULongFloatD p2, out ULongFloatD p3);
 
     StringStringD opStringStringD(StringStringD p1, StringStringD p2,
                                   out StringStringD p3);
@@ -179,11 +208,11 @@ exception SomeException {}
     ByteBoolDS opByteBoolDS(ByteBoolDS p1, ByteBoolDS p2,
                             out ByteBoolDS p3);
 
-    ShortIntDS opShortIntDS(ShortIntDS p1, ShortIntDS p2,
-                            out ShortIntDS p3);
+    ShortIntDS opShortIntDS(ShortIntDS p1, ShortIntDS p2, out ShortIntDS p3);
+    UShortUIntDS opUShortUIntDS(UShortUIntDS p1, UShortUIntDS p2, out UShortUIntDS p3);
 
-    LongFloatDS opLongFloatDS(LongFloatDS p1, LongFloatDS p2,
-                              out LongFloatDS p3);
+    LongFloatDS opLongFloatDS(LongFloatDS p1, LongFloatDS p2, out LongFloatDS p3);
+    ULongFloatDS opULongFloatDS(ULongFloatDS p1, ULongFloatDS p2, out ULongFloatDS p3);
 
     StringStringDS opStringStringDS(StringStringDS p1, StringStringDS p2,
                                     out StringStringDS p3);
@@ -203,14 +232,14 @@ exception SomeException {}
     BoolBoolSD opBoolBoolSD(BoolBoolSD p1, BoolBoolSD p2,
                             out BoolBoolSD p3);
 
-    ShortShortSD opShortShortSD(ShortShortSD p1, ShortShortSD p2,
-                                out ShortShortSD p3);
+    ShortShortSD opShortShortSD(ShortShortSD p1, ShortShortSD p2, out ShortShortSD p3);
+    UShortUShortSD opUShortUShortSD(UShortUShortSD p1, UShortUShortSD p2, out UShortUShortSD p3);
 
-    IntIntSD opIntIntSD(IntIntSD p1, IntIntSD p2,
-                        out IntIntSD p3);
+    IntIntSD opIntIntSD(IntIntSD p1, IntIntSD p2, out IntIntSD p3);
+    UIntUIntSD opUIntUIntSD(UIntUIntSD p1, UIntUIntSD p2, out UIntUIntSD p3);
 
-    LongLongSD opLongLongSD(LongLongSD p1, LongLongSD p2,
-                            out LongLongSD p3);
+    LongLongSD opLongLongSD(LongLongSD p1, LongLongSD p2, out LongLongSD p3);
+    ULongULongSD opULongULongSD(ULongULongSD p1, ULongULongSD p2, out ULongULongSD p3);
 
     StringFloatSD opStringFloatSD(StringFloatSD p1, StringFloatSD p2,
                                   out StringFloatSD p3);
@@ -245,6 +274,9 @@ exception SomeException {}
     short opShort1(short opShort1);
     int opInt1(int opInt1);
     long opLong1(long opLong1);
+    ushort opUShort1(ushort opUShort1);
+    uint opUInt1(uint opUInt1);
+    ulong opULong1(ulong opULong1);
     float opFloat1(float opFloat1);
     double opDouble1(double opDouble1);
     string opString1(string opString1);

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -154,6 +154,92 @@ namespace Ice.operations
                 TestHelper.Assert(r == long.MaxValue);
             }
 
+             {
+                ushort s;
+                uint i;
+                ulong l;
+                ulong r;
+
+                (r, s, i, l) = p.opUShortUIntULong(10, 11, 12UL);
+                TestHelper.Assert(s == 10);
+                TestHelper.Assert(i == 11);
+                TestHelper.Assert(l == 12);
+                TestHelper.Assert(r == 12UL);
+
+                (r, s, i, l) = p.opUShortUIntULong(ushort.MinValue, uint.MinValue, ulong.MinValue);
+                TestHelper.Assert(s == ushort.MinValue);
+                TestHelper.Assert(i == uint.MinValue);
+                TestHelper.Assert(l == ulong.MinValue);
+                TestHelper.Assert(r == ulong.MinValue);
+
+                (r, s, i, l) = p.opUShortUIntULong(ushort.MaxValue, uint.MaxValue, ulong.MaxValue);
+                TestHelper.Assert(s == ushort.MaxValue);
+                TestHelper.Assert(i == uint.MaxValue);
+                TestHelper.Assert(l == ulong.MaxValue);
+                TestHelper.Assert(r == ulong.MaxValue);
+            }
+
+            {
+                TestHelper.Assert(p.opVarInt(0) == 0);
+                TestHelper.Assert(p.opVarInt(1) == 1);
+                TestHelper.Assert(p.opVarInt(-1) == -1);
+                TestHelper.Assert(p.opVarInt(5) == 5);
+                TestHelper.Assert(p.opVarInt(-5) == -5);
+                TestHelper.Assert(p.opVarInt(50) == 50);
+                TestHelper.Assert(p.opVarInt(-50) == -50);
+                TestHelper.Assert(p.opVarInt(500_000) == 500_000);
+                TestHelper.Assert(p.opVarInt(-500_000) == -500_000);
+                TestHelper.Assert(p.opVarInt(int.MaxValue) == int.MaxValue);
+                TestHelper.Assert(p.opVarInt(int.MinValue) == int.MinValue);
+
+                TestHelper.Assert(p.opVarLong(500_000) == 500_000);
+                TestHelper.Assert(p.opVarLong(-500_000) == -500_000);
+                TestHelper.Assert(p.opVarLong(2_305_843_009_213_693_951) == 2_305_843_009_213_693_951);
+                TestHelper.Assert(p.opVarLong(-2_305_843_009_213_693_952) == -2_305_843_009_213_693_952);
+
+                try
+                {
+                    p.opVarLong(long.MinValue);
+                    TestHelper.Assert(false);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // expected
+                }
+
+                try
+                {
+                    p.opVarLong(long.MaxValue);
+                    TestHelper.Assert(false);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // expected
+                }
+            }
+
+            {
+                TestHelper.Assert(p.opVarUInt(0) == 0);
+                TestHelper.Assert(p.opVarUInt(1) == 1);
+                TestHelper.Assert(p.opVarUInt(5) == 5);
+                TestHelper.Assert(p.opVarUInt(50) == 50);
+                TestHelper.Assert(p.opVarUInt(500_000) == 500_000);
+                TestHelper.Assert(p.opVarUInt(uint.MaxValue) == uint.MaxValue);
+
+                TestHelper.Assert(p.opVarULong(500_000) == 500_000);
+                TestHelper.Assert(p.opVarULong(4_611_686_018_427_387_903) == 4_611_686_018_427_387_903);
+
+                try
+                {
+                    p.opVarULong(ulong.MaxValue);
+                    TestHelper.Assert(false);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // expected
+                }
+            }
+
             {
                 float f;
                 double d;
@@ -339,6 +425,93 @@ namespace Ice.operations
             }
 
             {
+                ushort[] ssi = new ushort[] { 1, 2, 3 };
+                uint[] isi = new uint[] { 5, 6, 7, 8 };
+                ulong[] lsi = new ulong[] { 10, 30, 20 };
+
+                ushort[] sso;
+                uint[] iso;
+                ulong[] lso;
+                ulong[] rso;
+
+                (rso, sso, iso, lso) = p.opUShortUIntULongS(ssi, isi, lsi);
+                TestHelper.Assert(sso.Length == 3);
+                TestHelper.Assert(sso[0] == 1);
+                TestHelper.Assert(sso[1] == 2);
+                TestHelper.Assert(sso[2] == 3);
+                TestHelper.Assert(iso.Length == 4);
+                TestHelper.Assert(iso[0] == 8);
+                TestHelper.Assert(iso[1] == 7);
+                TestHelper.Assert(iso[2] == 6);
+                TestHelper.Assert(iso[3] == 5);
+                TestHelper.Assert(lso.Length == 6);
+                TestHelper.Assert(lso[0] == 10);
+                TestHelper.Assert(lso[1] == 30);
+                TestHelper.Assert(lso[2] == 20);
+                TestHelper.Assert(lso[3] == 10);
+                TestHelper.Assert(lso[4] == 30);
+                TestHelper.Assert(lso[5] == 20);
+                TestHelper.Assert(rso.Length == 3);
+                TestHelper.Assert(rso[0] == 10);
+                TestHelper.Assert(rso[1] == 30);
+                TestHelper.Assert(rso[2] == 20);
+            }
+
+            {
+                int[] isi = new int[] { 5, 6, 7, 8 };
+                long[] lsi = new long[] { 1_000, 3_000_000_000_000, -200_000 };
+
+                int[] iso;
+                long[] lso;
+                long[] rso;
+
+                (rso, iso, lso) = p.opVarIntVarLongS(isi, lsi);
+                TestHelper.Assert(iso.Length == 4);
+                TestHelper.Assert(iso[0] == 8);
+                TestHelper.Assert(iso[1] == 7);
+                TestHelper.Assert(iso[2] == 6);
+                TestHelper.Assert(iso[3] == 5);
+                TestHelper.Assert(lso.Length == 6);
+                TestHelper.Assert(lso[0] == 1_000);
+                TestHelper.Assert(lso[1] == 3_000_000_000_000);
+                TestHelper.Assert(lso[2] == -200_000);
+                TestHelper.Assert(lso[3] == 1_000);
+                TestHelper.Assert(lso[4] == 3_000_000_000_000);
+                TestHelper.Assert(lso[5] == -200_000);
+                TestHelper.Assert(rso.Length == 3);
+                TestHelper.Assert(rso[0] == 1_000);
+                TestHelper.Assert(rso[1] == 3_000_000_000_000);
+                TestHelper.Assert(rso[2] == -200_000);
+            }
+
+            {
+                uint[] isi = new uint[] { 5, 6, 7, 8 };
+                ulong[] lsi = new ulong[] { 1_000, 3_000_000_000_000, 200_000 };
+
+                uint[] iso;
+                ulong[] lso;
+                ulong[] rso;
+
+                (rso, iso, lso) = p.opVarUIntVarULongS(isi, lsi);
+                TestHelper.Assert(iso.Length == 4);
+                TestHelper.Assert(iso[0] == 8);
+                TestHelper.Assert(iso[1] == 7);
+                TestHelper.Assert(iso[2] == 6);
+                TestHelper.Assert(iso[3] == 5);
+                TestHelper.Assert(lso.Length == 6);
+                TestHelper.Assert(lso[0] == 1_000);
+                TestHelper.Assert(lso[1] == 3_000_000_000_000);
+                TestHelper.Assert(lso[2] == 200_000);
+                TestHelper.Assert(lso[3] == 1_000);
+                TestHelper.Assert(lso[4] == 3_000_000_000_000);
+                TestHelper.Assert(lso[5] == 200_000);
+                TestHelper.Assert(rso.Length == 3);
+                TestHelper.Assert(rso[0] == 1_000);
+                TestHelper.Assert(rso[1] == 3_000_000_000_000);
+                TestHelper.Assert(rso[2] == 200_000);
+            }
+
+            {
                 float[] fsi = new float[] { 3.14f, 1.11f };
                 double[] dsi = new double[] { 1.1e10, 1.2e10, 1.3e10 };
 
@@ -469,6 +642,52 @@ namespace Ice.operations
                 long[][] rso;
 
                 (rso, sso, iso, lso) = p.opShortIntLongSS(ssi, isi, lsi);
+                TestHelper.Assert(rso.Length == 1);
+                TestHelper.Assert(rso[0].Length == 2);
+                TestHelper.Assert(rso[0][0] == 496);
+                TestHelper.Assert(rso[0][1] == 1729);
+                TestHelper.Assert(sso.Length == 3);
+                TestHelper.Assert(sso[0].Length == 3);
+                TestHelper.Assert(sso[0][0] == 1);
+                TestHelper.Assert(sso[0][1] == 2);
+                TestHelper.Assert(sso[0][2] == 5);
+                TestHelper.Assert(sso[1].Length == 1);
+                TestHelper.Assert(sso[1][0] == 13);
+                TestHelper.Assert(sso[2].Length == 0);
+                TestHelper.Assert(iso.Length == 2);
+                TestHelper.Assert(iso[0].Length == 1);
+                TestHelper.Assert(iso[0][0] == 42);
+                TestHelper.Assert(iso[1].Length == 2);
+                TestHelper.Assert(iso[1][0] == 24);
+                TestHelper.Assert(iso[1][1] == 98);
+                TestHelper.Assert(lso.Length == 2);
+                TestHelper.Assert(lso[0].Length == 2);
+                TestHelper.Assert(lso[0][0] == 496);
+                TestHelper.Assert(lso[0][1] == 1729);
+                TestHelper.Assert(lso[1].Length == 2);
+                TestHelper.Assert(lso[1][0] == 496);
+                TestHelper.Assert(lso[1][1] == 1729);
+            }
+
+            {
+                ushort[] s11 = new ushort[] { 1, 2, 5 };
+                ushort[] s12 = new ushort[] { 13 };
+                ushort[] s13 = new ushort[] { };
+                ushort[][] ssi = new ushort[][] { s11, s12, s13 };
+
+                uint[] i11 = new uint[] { 24, 98 };
+                uint[] i12 = new uint[] { 42 };
+                uint[][] isi = new uint[][] { i11, i12 };
+
+                ulong[] l11 = new ulong[] { 496, 1729 };
+                ulong[][] lsi = new ulong[][] { l11 };
+
+                ushort[][] sso;
+                uint[][] iso;
+                ulong[][] lso;
+                ulong[][] rso;
+
+                (rso, sso, iso, lso) = p.opUShortUIntULongSS(ssi, isi, lsi);
                 TestHelper.Assert(rso.Length == 1);
                 TestHelper.Assert(rso[0].Length == 2);
                 TestHelper.Assert(rso[0][0] == 496);
@@ -656,6 +875,25 @@ namespace Ice.operations
             }
 
             {
+                Dictionary<ushort, uint> di1 = new Dictionary<ushort, uint>();
+                di1[110] = 1;
+                di1[1100] = 123123;
+                Dictionary<ushort, uint> di2 = new Dictionary<ushort, uint>();
+                di2[110] = 1;
+                di2[111] = 100;
+                di2[1101] = 0;
+
+                var (ro, _do) = p.opUShortUIntD(di1, di2);
+
+                TestHelper.Assert(_do.DictionaryEqual(di1));
+                TestHelper.Assert(ro.Count == 4);
+                TestHelper.Assert(ro[110] == 1);
+                TestHelper.Assert(ro[111] == 100);
+                TestHelper.Assert(ro[1100] == 123123);
+                TestHelper.Assert(ro[1101] == 0);
+            }
+
+            {
                 Dictionary<long, float> di1 = new Dictionary<long, float>();
                 di1[999999110L] = -1.1f;
                 di1[999999111L] = 123123.2f;
@@ -837,6 +1075,47 @@ namespace Ice.operations
             }
 
             {
+                Dictionary<ushort, uint>[] dsi1 = new Dictionary<ushort, uint>[2];
+                Dictionary<ushort, uint>[] dsi2 = new Dictionary<ushort, uint>[1];
+
+                Dictionary<ushort, uint> di1 = new Dictionary<ushort, uint>();
+                di1[110] = 1;
+                di1[1100] = 123123;
+                Dictionary<ushort, uint> di2 = new Dictionary<ushort, uint>();
+                di2[110] = 1;
+                di2[111] = 100;
+                di2[1101] = 0;
+                Dictionary<ushort, uint> di3 = new Dictionary<ushort, uint>();
+                di3[100] = 1001;
+
+                dsi1[0] = di1;
+                dsi1[1] = di2;
+                dsi2[0] = di3;
+
+                var (ro, _do) = p.opUShortUIntDS(dsi1, dsi2);
+
+                TestHelper.Assert(ro.Length == 2);
+                TestHelper.Assert(ro[0].Count == 3);
+                TestHelper.Assert(ro[0][110] == 1);
+                TestHelper.Assert(ro[0][111] == 100);
+                TestHelper.Assert(ro[0][1101] == 0);
+                TestHelper.Assert(ro[1].Count == 2);
+                TestHelper.Assert(ro[1][110] == 1);
+                TestHelper.Assert(ro[1][1100] == 123123);
+
+                TestHelper.Assert(_do.Length == 3);
+                TestHelper.Assert(_do[0].Count == 1);
+                TestHelper.Assert(_do[0][100] == 1001);
+                TestHelper.Assert(_do[1].Count == 2);
+                TestHelper.Assert(_do[1][110] == 1);
+                TestHelper.Assert(_do[1][1100] == 123123);
+                TestHelper.Assert(_do[2].Count == 3);
+                TestHelper.Assert(_do[2][110] == 1);
+                TestHelper.Assert(_do[2][111] == 100);
+                TestHelper.Assert(_do[2][1101] == 0);
+            }
+
+            {
                 Dictionary<long, float>[] dsi1 = new Dictionary<long, float>[2];
                 Dictionary<long, float>[] dsi2 = new Dictionary<long, float>[1];
 
@@ -875,7 +1154,47 @@ namespace Ice.operations
                 TestHelper.Assert(_do[2][999999110L] == -1.1f);
                 TestHelper.Assert(_do[2][999999120L] == -100.4f);
                 TestHelper.Assert(_do[2][999999130L] == 0.5f);
+            }
 
+            {
+                Dictionary<ulong, float>[] dsi1 = new Dictionary<ulong, float>[2];
+                Dictionary<ulong, float>[] dsi2 = new Dictionary<ulong, float>[1];
+
+                Dictionary<ulong, float> di1 = new Dictionary<ulong, float>();
+                di1[999999110L] = -1.1f;
+                di1[999999111L] = 123123.2f;
+                Dictionary<ulong, float> di2 = new Dictionary<ulong, float>();
+                di2[999999110L] = -1.1f;
+                di2[999999120L] = -100.4f;
+                di2[999999130L] = 0.5f;
+                Dictionary<ulong, float> di3 = new Dictionary<ulong, float>();
+                di3[999999140L] = 3.14f;
+
+                dsi1[0] = di1;
+                dsi1[1] = di2;
+                dsi2[0] = di3;
+
+                var (ro, _do) = p.opULongFloatDS(dsi1, dsi2);
+
+                TestHelper.Assert(ro.Length == 2);
+                TestHelper.Assert(ro[0].Count == 3);
+                TestHelper.Assert(ro[0][999999110L] == -1.1f);
+                TestHelper.Assert(ro[0][999999120L] == -100.4f);
+                TestHelper.Assert(ro[0][999999130L] == 0.5f);
+                TestHelper.Assert(ro[1].Count == 2);
+                TestHelper.Assert(ro[1][999999110L] == -1.1f);
+                TestHelper.Assert(ro[1][999999111L] == 123123.2f);
+
+                TestHelper.Assert(_do.Length == 3);
+                TestHelper.Assert(_do[0].Count == 1);
+                TestHelper.Assert(_do[0][999999140L] == 3.14f);
+                TestHelper.Assert(_do[1].Count == 2);
+                TestHelper.Assert(_do[1][999999110L] == -1.1f);
+                TestHelper.Assert(_do[1][999999111L] == 123123.2f);
+                TestHelper.Assert(_do[2].Count == 3);
+                TestHelper.Assert(_do[2][999999110L] == -1.1f);
+                TestHelper.Assert(_do[2][999999120L] == -100.4f);
+                TestHelper.Assert(_do[2][999999130L] == 0.5f);
             }
 
             {
@@ -1132,6 +1451,38 @@ namespace Ice.operations
             }
 
             {
+                var sdi1 = new Dictionary<ushort, ushort[]>();
+                var sdi2 = new Dictionary<ushort, ushort[]>();
+
+                ushort[] si1 = new ushort[] { 1, 2, 3 };
+                ushort[] si2 = new ushort[] { 4, 5 };
+                ushort[] si3 = new ushort[] { 6, 7 };
+
+                sdi1[1] = si1;
+                sdi1[2] = si2;
+                sdi2[4] = si3;
+
+                var (ro, _do) = p.opUShortUShortSD(sdi1, sdi2);
+
+                TestHelper.Assert(_do.Count == 1);
+                TestHelper.Assert(_do[4].Length == 2);
+                TestHelper.Assert(_do[4][0] == 6);
+                TestHelper.Assert(_do[4][1] == 7);
+
+                TestHelper.Assert(ro.Count == 3);
+                TestHelper.Assert(ro[1].Length == 3);
+                TestHelper.Assert(ro[1][0] == 1);
+                TestHelper.Assert(ro[1][1] == 2);
+                TestHelper.Assert(ro[1][2] == 3);
+                TestHelper.Assert(ro[2].Length == 2);
+                TestHelper.Assert(ro[2][0] == 4);
+                TestHelper.Assert(ro[2][1] == 5);
+                TestHelper.Assert(ro[4].Length == 2);
+                TestHelper.Assert(ro[4][0] == 6);
+                TestHelper.Assert(ro[4][1] == 7);
+            }
+
+            {
                 var sdi1 = new Dictionary<int, int[]>();
                 var sdi2 = new Dictionary<int, int[]>();
 
@@ -1164,6 +1515,38 @@ namespace Ice.operations
             }
 
             {
+                var sdi1 = new Dictionary<uint, uint[]>();
+                var sdi2 = new Dictionary<uint, uint[]>();
+
+                uint[] si1 = new uint[] { 100, 200, 300 };
+                uint[] si2 = new uint[] { 400, 500 };
+                uint[] si3 = new uint[] { 600, 700 };
+
+                sdi1[100] = si1;
+                sdi1[200] = si2;
+                sdi2[400] = si3;
+
+                var (ro, _do) = p.opUIntUIntSD(sdi1, sdi2);
+
+                TestHelper.Assert(_do.Count == 1);
+                TestHelper.Assert(_do[400].Length == 2);
+                TestHelper.Assert(_do[400][0] == 600);
+                TestHelper.Assert(_do[400][1] == 700);
+
+                TestHelper.Assert(ro.Count == 3);
+                TestHelper.Assert(ro[100].Length == 3);
+                TestHelper.Assert(ro[100][0] == 100);
+                TestHelper.Assert(ro[100][1] == 200);
+                TestHelper.Assert(ro[100][2] == 300);
+                TestHelper.Assert(ro[200].Length == 2);
+                TestHelper.Assert(ro[200][0] == 400);
+                TestHelper.Assert(ro[200][1] == 500);
+                TestHelper.Assert(ro[400].Length == 2);
+                TestHelper.Assert(ro[400][0] == 600);
+                TestHelper.Assert(ro[400][1] == 700);
+            }
+
+            {
                 var sdi1 = new Dictionary<long, long[]>();
                 var sdi2 = new Dictionary<long, long[]>();
 
@@ -1176,6 +1559,37 @@ namespace Ice.operations
                 sdi2[999999992L] = si3;
 
                 var (ro, _do) = p.opLongLongSD(sdi1, sdi2);
+
+                TestHelper.Assert(_do.Count == 1);
+                TestHelper.Assert(_do[999999992L].Length == 2);
+                TestHelper.Assert(_do[999999992L][0] == 999999110L);
+                TestHelper.Assert(_do[999999992L][1] == 999999120L);
+                TestHelper.Assert(ro.Count == 3);
+                TestHelper.Assert(ro[999999990L].Length == 3);
+                TestHelper.Assert(ro[999999990L][0] == 999999110L);
+                TestHelper.Assert(ro[999999990L][1] == 999999111L);
+                TestHelper.Assert(ro[999999990L][2] == 999999110L);
+                TestHelper.Assert(ro[999999991L].Length == 2);
+                TestHelper.Assert(ro[999999991L][0] == 999999120L);
+                TestHelper.Assert(ro[999999991L][1] == 999999130L);
+                TestHelper.Assert(ro[999999992L].Length == 2);
+                TestHelper.Assert(ro[999999992L][0] == 999999110L);
+                TestHelper.Assert(ro[999999992L][1] == 999999120L);
+            }
+
+             {
+                var sdi1 = new Dictionary<ulong, ulong[]>();
+                var sdi2 = new Dictionary<ulong, ulong[]>();
+
+                var si1 = new ulong[] { 999999110L, 999999111L, 999999110L };
+                var si2 = new ulong[] { 999999120L, 999999130L };
+                ulong[] si3 = new ulong[] { 999999110L, 999999120L };
+
+                sdi1[999999990L] = si1;
+                sdi1[999999991L] = si2;
+                sdi2[999999992L] = si3;
+
+                var (ro, _do) = p.opULongULongSD(sdi1, sdi2);
 
                 TestHelper.Assert(_do.Count == 1);
                 TestHelper.Assert(_do[999999992L].Length == 2);
@@ -1428,8 +1842,11 @@ namespace Ice.operations
             {
                 TestHelper.Assert(p.opByte1(0xFF) == 0xFF);
                 TestHelper.Assert(p.opShort1(0x7FFF) == 0x7FFF);
+                TestHelper.Assert(p.opUShort1(ushort.MaxValue) == ushort.MaxValue);
                 TestHelper.Assert(p.opInt1(0x7FFFFFFF) == 0x7FFFFFFF);
+                TestHelper.Assert(p.opUInt1(uint.MaxValue) == uint.MaxValue);
                 TestHelper.Assert(p.opLong1(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF);
+                TestHelper.Assert(p.opULong1(ulong.MaxValue) == ulong.MaxValue);
                 TestHelper.Assert(p.opFloat1(1.0f) == 1.0f);
                 TestHelper.Assert(p.opDouble1(1.0d) == 1.0d);
                 TestHelper.Assert(p.opString1("opString1").Equals("opString1"));

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -120,6 +120,15 @@ namespace Ice.operations
                 called();
             }
 
+            public void opUShortUIntULong(ulong r, ushort s, uint i, ulong l)
+            {
+                TestHelper.Assert(s == 10);
+                TestHelper.Assert(i == 11);
+                TestHelper.Assert(l == 12);
+                TestHelper.Assert(r == 12);
+                called();
+            }
+
             public void opFloatDouble(double r, float f, double d)
             {
                 TestHelper.Assert(f == 3.14f);
@@ -971,6 +980,12 @@ namespace Ice.operations
                 var cb = new Callback();
                 var ret = p.opShortIntLongAsync(10, 11, 12).Result;
                 cb.opShortIntLong(ret.ReturnValue, ret.p4, ret.p5, ret.p6);
+            }
+
+            {
+                var cb = new Callback();
+                var ret = p.opUShortUIntULongAsync(10, 11, 12).Result;
+                cb.opUShortUIntULong(ret.ReturnValue, ret.p4, ret.p5, ret.p6);
             }
 
             {

--- a/csharp/test/IceGrid/simple/Client.cs
+++ b/csharp/test/IceGrid/simple/Client.cs
@@ -2,13 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Collections.Generic;
 using System.Linq;
 
 public class Client : Test.TestHelper
 {
     public override void Run(string[] args)
     {
-        using var communicator = Initialize(ref args);
+        using var communicator = Initialize(ref args,
+            new Dictionary<string, string> { ["Ice.Default.Encoding"] = "1.1" });
         if (args.Any(v => v.Equals("--with-deploy")))
         {
             AllTests.allTestsWithDeploy(this);

--- a/csharp/test/IceGrid/simple/Server.cs
+++ b/csharp/test/IceGrid/simple/Server.cs
@@ -13,6 +13,7 @@ public class Server : TestHelper
     {
         var properties = new Dictionary<string, string>();
         properties.ParseArgs(ref args, "TestAdapter");
+        properties.Add("Ice.Default.Encoding", "1.1");
 
         using var communicator = Initialize(ref args, properties);
         ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");


### PR DESCRIPTION
This PR implements marshaling/unmarshaling for ushort, uint, ulong, varint, varlong, varuint and varulong, and makes the 2.0 encoding the default encoding.