### PR TITLE
Remove IceInternal and IceUtilInternal namespaces

### DIFF
--- a/csharp/src/Ice/ACM.cs
+++ b/csharp/src/Ice/ACM.cs
@@ -6,11 +6,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public sealed class ACMConfig
+    internal sealed class ACMConfig
     {
         internal ACMConfig(bool server)
         {
@@ -81,7 +79,7 @@ namespace IceInternal
         ACM GetACM();
     }
 
-    public class FactoryACMMonitor : IACMMonitor
+    internal class FactoryACMMonitor : IACMMonitor
     {
         internal class Change
         {
@@ -109,7 +107,7 @@ namespace IceInternal
                 {
                     //
                     // Ensure all the connections have been cleared, it's important to wait here
-                    // to prevent the timer destruction in IceInternal::Instance::destroy.
+                    // to prevent the timer destruction in Instance::destroy.
                     //
                     while (_connections.Count > 0)
                     {

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -2,16 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using ZeroC.Ice.Instrumentation;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public class CollocatedRequestHandler : IRequestHandler
+    internal class CollocatedRequestHandler : IRequestHandler
     {
         public
         CollocatedRequestHandler(Reference reference, ObjectAdapter adapter)

--- a/csharp/src/Ice/Communicator-LocatorManager.cs
+++ b/csharp/src/Ice/Communicator-LocatorManager.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/csharp/src/Ice/Communicator-PluginManager.cs
+++ b/csharp/src/Ice/Communicator-PluginManager.cs
@@ -276,7 +276,7 @@ namespace ZeroC.Ice
                 //
                 try
                 {
-                    args = IceUtilInternal.Options.Split(pluginSpec);
+                    args = Options.Split(pluginSpec);
                 }
                 catch (FormatException ex)
                 {

--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -91,7 +91,7 @@ namespace ZeroC.Ice
                 if (_properties.TryGetValue(name, out PropertyValue? pv))
                 {
                     pv.Used = true;
-                    return IceUtilInternal.StringUtil.SplitString(pv.Val, ", \t\r\n");
+                    return StringUtil.SplitString(pv.Val, ", \t\r\n");
                 }
                 return null;
             }

--- a/csharp/src/Ice/Communicator-RetryQueue.cs
+++ b/csharp/src/Ice/Communicator-RetryQueue.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;

--- a/csharp/src/Ice/Communicator-RouterManager.cs
+++ b/csharp/src/Ice/Communicator-RouterManager.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -202,7 +201,7 @@ namespace ZeroC.Ice
         private readonly Dictionary<EndpointType, BufSizeWarnInfo> _setBufSizeWarn =
             new Dictionary<EndpointType, BufSizeWarnInfo>();
         private int _state;
-        private readonly IceInternal.Timer _timer;
+        private readonly Timer _timer;
 
         private readonly IDictionary<string, IEndpointFactory> _transportToEndpointFactory =
             new ConcurrentDictionary<string, IEndpointFactory>();
@@ -686,8 +685,7 @@ namespace ZeroC.Ice
                 //
                 try
                 {
-                    _timer = new IceInternal.Timer(this, IceInternal.Util.StringToThreadPriority(
-                                                   GetProperty("Ice.ThreadPriority")));
+                    _timer = new Timer(this, Util.StringToThreadPriority(GetProperty("Ice.ThreadPriority")));
                 }
                 catch (Exception ex)
                 {
@@ -1161,7 +1159,7 @@ namespace ZeroC.Ice
             }
         }
 
-        public IceInternal.Timer Timer()
+        public Timer Timer()
         {
             lock (this)
             {

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice.Instrumentation;
-using IceInternal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,6 +9,8 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using ZeroC.Ice.Instrumentation;
 
 namespace ZeroC.Ice
 {

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -2,17 +2,16 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-using ZeroC.Ice.Instrumentation;
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace IceInternal
+using ZeroC.Ice.Instrumentation;
+
+namespace ZeroC.Ice
 {
-    public class MultiDictionary<TKey, TValue> : Dictionary<TKey, ICollection<TValue>> where TKey : notnull
+    internal class MultiDictionary<TKey, TValue> : Dictionary<TKey, ICollection<TValue>> where TKey : notnull
     {
         public void
         Add(TKey key, TValue value)
@@ -37,7 +36,7 @@ namespace IceInternal
         }
     }
 
-    public sealed class OutgoingConnectionFactory
+    internal sealed class OutgoingConnectionFactory
     {
         public interface ICreateConnectionCallback
         {

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -2,9 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public class ConnectionRequestHandler : IRequestHandler
+    internal class ConnectionRequestHandler : IRequestHandler
     {
         public IRequestHandler? Update(IRequestHandler previousHandler, IRequestHandler? newHandler)
         {
@@ -37,15 +37,15 @@ namespace IceInternal
         public void AsyncRequestCanceled(OutgoingAsyncBase outAsync, System.Exception ex) =>
             _connection.AsyncRequestCanceled(outAsync, ex);
 
-        public ZeroC.Ice.Connection GetConnection() => _connection;
+        public Connection GetConnection() => _connection;
 
-        public ConnectionRequestHandler(ZeroC.Ice.Connection connection, bool compress)
+        public ConnectionRequestHandler(Connection connection, bool compress)
         {
             _connection = connection;
             _compress = compress;
         }
 
-        private readonly ZeroC.Ice.Connection _connection;
+        private readonly Connection _connection;
         private readonly bool _compress;
     }
 }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -134,7 +132,7 @@ namespace ZeroC.Ice
         // Creates an endpoint from a string.
         internal static Endpoint Parse(string endpointString, Communicator communicator, bool oaEndpoint)
         {
-            string[]? args = IceUtilInternal.StringUtil.SplitString(endpointString, " \t\r\n");
+            string[]? args = StringUtil.SplitString(endpointString, " \t\r\n");
             if (args == null)
             {
                 throw new FormatException($"mismatched quote in endpoint `{endpointString}'");

--- a/csharp/src/Ice/HttpParser.cs
+++ b/csharp/src/Ice/HttpParser.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public sealed class WebSocketException : System.Exception
     {

--- a/csharp/src/Ice/IAcceptor.cs
+++ b/csharp/src/Ice/IAcceptor.cs
@@ -3,9 +3,8 @@
 //
 
 using System.Threading.Tasks;
-using ZeroC.Ice;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface IAcceptor
     {

--- a/csharp/src/Ice/IConnector.cs
+++ b/csharp/src/Ice/IConnector.cs
@@ -2,9 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface IConnector
     {

--- a/csharp/src/Ice/IEndpointFactory.cs
+++ b/csharp/src/Ice/IEndpointFactory.cs
@@ -2,11 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface IEndpointFactory
     {

--- a/csharp/src/Ice/INetworkProxy.cs
+++ b/csharp/src/Ice/INetworkProxy.cs
@@ -1,7 +1,7 @@
 //
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
-using ZeroC.Ice;
+
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Linq;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface INetworkProxy
     {
@@ -64,7 +64,7 @@ namespace IceInternal
         int GetIPVersion();
     }
 
-    public sealed class SOCKSNetworkProxy : INetworkProxy
+    internal sealed class SOCKSNetworkProxy : INetworkProxy
     {
         public SOCKSNetworkProxy(string host, int port)
         {
@@ -145,7 +145,7 @@ namespace IceInternal
         private readonly EndPoint? _address;
     }
 
-    public sealed class HTTPNetworkProxy : INetworkProxy
+    internal sealed class HTTPNetworkProxy : INetworkProxy
     {
         public HTTPNetworkProxy(string host, int port)
         {

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/csharp/src/Ice/IPlugin.cs
+++ b/csharp/src/Ice/IPlugin.cs
@@ -1,6 +1,7 @@
 //
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
+
 namespace ZeroC.Ice
 {
     public partial interface IPlugin

--- a/csharp/src/Ice/IRequestHandler.cs
+++ b/csharp/src/Ice/IRequestHandler.cs
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface ICancellationHandler
     {
@@ -15,6 +15,6 @@ namespace IceInternal
 
         void SendAsyncRequest(ProxyOutgoingAsyncBase @out);
 
-        ZeroC.Ice.Connection? GetConnection();
+        Connection? GetConnection();
     }
 }

--- a/csharp/src/Ice/ITransceiver.cs
+++ b/csharp/src/Ice/ITransceiver.cs
@@ -8,9 +8,7 @@ using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     // TODO: Benoit: Remove with the transport refactoring
     public delegate void AsyncCallback(object state);

--- a/csharp/src/Ice/ITransportPluginFacade.cs
+++ b/csharp/src/Ice/ITransportPluginFacade.cs
@@ -2,9 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface ITransportPluginFacade
     {

--- a/csharp/src/Ice/Identity.cs
+++ b/csharp/src/Ice/Identity.cs
@@ -50,7 +50,7 @@ namespace ZeroC.Ice
             {
                 try
                 {
-                    name = IceUtilInternal.StringUtil.UnescapeString(s, 0, s.Length, "/");
+                    name = StringUtil.UnescapeString(s, 0, s.Length, "/");
                 }
                 catch (ArgumentException ex)
                 {
@@ -62,7 +62,7 @@ namespace ZeroC.Ice
             {
                 try
                 {
-                    category = IceUtilInternal.StringUtil.UnescapeString(s, 0, slash, "/");
+                    category = StringUtil.UnescapeString(s, 0, slash, "/");
                 }
                 catch (ArgumentException ex)
                 {
@@ -73,7 +73,7 @@ namespace ZeroC.Ice
                 {
                     try
                     {
-                        name = IceUtilInternal.StringUtil.UnescapeString(s, slash + 1, s.Length, "/");
+                        name = StringUtil.UnescapeString(s, slash + 1, s.Length, "/");
                     }
                     catch (ArgumentException ex)
                     {
@@ -115,12 +115,12 @@ namespace ZeroC.Ice
         {
             if (string.IsNullOrEmpty(Category))
             {
-                return IceUtilInternal.StringUtil.EscapeString(Name, "/", mode);
+                return StringUtil.EscapeString(Name, "/", mode);
             }
             else
             {
-                return IceUtilInternal.StringUtil.EscapeString(Category, "/", mode) + '/' +
-                       IceUtilInternal.StringUtil.EscapeString(Name, "/", mode);
+                return StringUtil.EscapeString(Category, "/", mode) + '/' +
+                       StringUtil.EscapeString(Name, "/", mode);
             }
         }
     }

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Diagnostics;
-using ZeroC.Ice;
+
 using ZeroC.Ice.Instrumentation;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal static class Incoming
     {
@@ -43,7 +43,7 @@ namespace IceInternal
 
             output.Append("dispatch exception:");
             output.Append("\nidentity: ").Append(current.Identity.ToString(current.Adapter.Communicator.ToStringMode));
-            output.Append("\nfacet: ").Append(IceUtilInternal.StringUtil.EscapeString(current.Facet, "",
+            output.Append("\nfacet: ").Append(StringUtil.EscapeString(current.Facet, "",
                 current.Adapter.Communicator.ToStringMode));
             output.Append("\noperation: ").Append(current.Operation);
             if (current.Connection != null)

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using ZeroC.Ice.Instrumentation;
 using ZeroC.IceMX;
 using System;
@@ -22,11 +21,11 @@ namespace ZeroC.IceMX
     }
 }
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public class ObserverWithDelegate<T, O> : Observer<T>
+    internal class ObserverWithDelegate<T, O> : Observer<T>
         where T : Metrics, new()
-        where O : class, ZeroC.Ice.Instrumentation.IObserver
+        where O : class, IObserver
     {
         public override void
         Attach()
@@ -81,7 +80,7 @@ namespace IceInternal
         protected O? Delegate;
     }
 
-    public class ObserverFactoryWithDelegate<T, OImpl, O> : ObserverFactory<T, OImpl>
+    internal class ObserverFactoryWithDelegate<T, OImpl, O> : ObserverFactory<T, OImpl>
         where T : Metrics, new()
         where OImpl : ObserverWithDelegate<T, O>, O, new()
         where O : class, IObserver
@@ -709,11 +708,11 @@ namespace IceInternal
         private readonly string _id;
     }
 
-    public class ObserverWithDelegateI : ObserverWithDelegate<Metrics, IObserver>
+    internal class ObserverWithDelegateI : ObserverWithDelegate<Metrics, IObserver>
     {
     }
 
-    public class ConnectionObserverI : ObserverWithDelegate<ConnectionMetrics, IConnectionObserver>,
+    internal class ConnectionObserverI : ObserverWithDelegate<ConnectionMetrics, IConnectionObserver>,
         IConnectionObserver
     {
         public void SentBytes(int num)
@@ -744,7 +743,7 @@ namespace IceInternal
         private int _receivedBytes;
     }
 
-    public class DispatchObserverI : ObserverWithDelegate<DispatchMetrics, IDispatchObserver>, IDispatchObserver
+    internal class DispatchObserverI : ObserverWithDelegate<DispatchMetrics, IDispatchObserver>, IDispatchObserver
     {
         public void
         RemoteException()
@@ -768,7 +767,7 @@ namespace IceInternal
         private void RemoteException(DispatchMetrics v) => ++v.UserException;
     }
 
-    public class RemoteObserverI : ObserverWithDelegate<RemoteMetrics, IRemoteObserver>, IRemoteObserver
+    internal class RemoteObserverI : ObserverWithDelegate<RemoteMetrics, IRemoteObserver>, IRemoteObserver
     {
         public void Reply(int size)
         {
@@ -780,7 +779,7 @@ namespace IceInternal
         }
     }
 
-    public class CollocatedObserverI : ObserverWithDelegate<CollocatedMetrics, ICollocatedObserver>,
+    internal class CollocatedObserverI : ObserverWithDelegate<CollocatedMetrics, ICollocatedObserver>,
         ICollocatedObserver
     {
         public void Reply(int size)
@@ -793,7 +792,7 @@ namespace IceInternal
         }
     }
 
-    public class InvocationObserverI : ObserverWithDelegate<InvocationMetrics, IInvocationObserver>,
+    internal class InvocationObserverI : ObserverWithDelegate<InvocationMetrics, IInvocationObserver>,
         IInvocationObserver
     {
         public void
@@ -843,10 +842,9 @@ namespace IceInternal
         private void RemoteException(InvocationMetrics v) => ++v.UserException;
     }
 
-    public class ThreadObserverI : ObserverWithDelegate<ThreadMetrics, IThreadObserver>, IThreadObserver
+    internal class ThreadObserverI : ObserverWithDelegate<ThreadMetrics, IThreadObserver>, IThreadObserver
     {
-        public void StateChanged(ZeroC.Ice.Instrumentation.ThreadState oldState,
-            ZeroC.Ice.Instrumentation.ThreadState newState)
+        public void StateChanged(Instrumentation.ThreadState oldState, Instrumentation.ThreadState newState)
         {
             _oldState = oldState;
             _newState = newState;

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -2,13 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class LoggerAdmin : ILoggerAdmin
     {

--- a/csharp/src/Ice/LoggerAdminLogger.cs
+++ b/csharp/src/Ice/LoggerAdminLogger.cs
@@ -7,9 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal interface ILoggerAdminLogger : ILogger
     {

--- a/csharp/src/Ice/MetricsAdminI.cs
+++ b/csharp/src/Ice/MetricsAdminI.cs
@@ -2,16 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-using ZeroC.IceMX;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace IceInternal
+using ZeroC.IceMX;
+
+namespace ZeroC.Ice
 {
     internal interface IMetricsMap
     {
@@ -640,7 +639,7 @@ namespace IceInternal
                 bool valid = false;
                 foreach (string suffix in _suffixes)
                 {
-                    if (IceUtilInternal.StringUtil.Match(prop, prefix + suffix, false))
+                    if (StringUtil.Match(prop, prefix + suffix, false))
                     {
                         valid = true;
                         break;

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using IceInternal;
+using ZeroC.Ice;
 
 namespace ZeroC.IceMX
 {

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -11,9 +11,8 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using ZeroC.Ice;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public static class Network
     {

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -993,7 +992,7 @@ namespace ZeroC.Ice
             var endpoints = new List<Endpoint>();
             while (end < endpts.Length)
             {
-                beg = IceUtilInternal.StringUtil.FindFirstNotOf(endpts, delim, end);
+                beg = StringUtil.FindFirstNotOf(endpts, delim, end);
                 if (beg == -1)
                 {
                     if (endpoints.Count != 0)

--- a/csharp/src/Ice/ObserverHelper.cs
+++ b/csharp/src/Ice/ObserverHelper.cs
@@ -6,11 +6,11 @@ using ZeroC.Ice.Instrumentation;
 
 using System.Collections.Generic;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal static class ObserverHelper
     {
-        internal static IInvocationObserver? GetInvocationObserver(ZeroC.Ice.IObjectPrx proxy, string op,
+        internal static IInvocationObserver? GetInvocationObserver(IObjectPrx proxy, string op,
                                                                    IReadOnlyDictionary<string, string> context)
         {
             if (proxy.Communicator.Observer is ICommunicatorObserver communicatorObserver)

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/csharp/src/Ice/Options.cs
+++ b/csharp/src/Ice/Options.cs
@@ -7,9 +7,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
-namespace IceUtilInternal
+namespace ZeroC.Ice
 {
-    public sealed class Options
+    public static class Options
     {
         public enum State
         {

--- a/csharp/src/Ice/OutgoingAsync.cs
+++ b/csharp/src/Ice/OutgoingAsync.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using ZeroC.Ice.Instrumentation;
 using System;
 using System.Collections.Generic;
@@ -10,7 +9,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface IOutgoingAsyncCompletionCallback
     {
@@ -327,8 +326,8 @@ namespace IceInternal
     {
         public OutgoingRequestFrame RequestFrame { get; protected set; }
         public IncomingResponseFrame? ResponseFrame { get; protected set; }
-        public abstract void InvokeRemote(Connection connection, bool compress, bool response);
-        public abstract void InvokeCollocated(CollocatedRequestHandler handler);
+        internal abstract void InvokeRemote(Connection connection, bool compress, bool response);
+        internal abstract void InvokeCollocated(CollocatedRequestHandler handler);
 
         public override List<ArraySegment<byte>> GetRequestData(int requestId) =>
             Ice1Definitions.GetRequestData(RequestFrame, requestId);
@@ -634,13 +633,13 @@ namespace IceInternal
             }
         }
 
-        public override void InvokeRemote(Connection connection, bool compress, bool response)
+        internal override void InvokeRemote(Connection connection, bool compress, bool response)
         {
             CachedConnection = connection;
             connection.SendAsyncRequest(this, compress, response);
         }
 
-        public override void InvokeCollocated(CollocatedRequestHandler handler)
+        internal override void InvokeCollocated(CollocatedRequestHandler handler)
         {
             // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
             if (IsOneway || Proxy.IceReference.InvocationTimeout != -1)
@@ -730,7 +729,7 @@ namespace IceInternal
         public ProxyGetConnection(IObjectPrx prx, IOutgoingAsyncCompletionCallback completionCallback)
             : base(prx, completionCallback, null!) => IsIdempotent = false;
 
-        public override void InvokeRemote(Connection connection, bool compress, bool response)
+        internal override void InvokeRemote(Connection connection, bool compress, bool response)
         {
             CachedConnection = connection;
             if (ResponseImpl(false, true, true))
@@ -739,7 +738,7 @@ namespace IceInternal
             }
         }
 
-        public override void InvokeCollocated(CollocatedRequestHandler handler)
+        internal override void InvokeCollocated(CollocatedRequestHandler handler)
         {
             if (ResponseImpl(false, true, true))
             {

--- a/csharp/src/Ice/ProtocolTrace.cs
+++ b/csharp/src/Ice/ProtocolTrace.cs
@@ -122,7 +122,7 @@ namespace ZeroC.Ice
                 s.Append("\nfacet = ");
                 if (facet.Length > 0)
                 {
-                    s.Append(IceUtilInternal.StringUtil.EscapeString(facet, "", toStringMode));
+                    s.Append(StringUtil.EscapeString(facet, "", toStringMode));
                 }
 
                 s.Append("\noperation = ");

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-using IceUtilInternal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -21,7 +19,7 @@ namespace ZeroC.Ice
         internal interface IGetConnectionCallback
         {
             void SetConnection(Connection connection, bool compress);
-            void SetException(System.Exception ex);
+            void SetException(Exception ex);
         }
 
         internal static readonly IReadOnlyDictionary<string, string> EmptyContext = new Dictionary<string, string>();
@@ -366,7 +364,7 @@ namespace ZeroC.Ice
             int beg;
             int end = 0;
 
-            beg = IceUtilInternal.StringUtil.FindFirstNotOf(s, delim, end);
+            beg = StringUtil.FindFirstNotOf(s, delim, end);
             if (beg == -1)
             {
                 throw new FormatException($"no non-whitespace characters found in `{s}'");
@@ -374,14 +372,14 @@ namespace ZeroC.Ice
 
             // Extract the identity, which may be enclosed in single or double quotation marks.
             string identityString;
-            end = IceUtilInternal.StringUtil.CheckQuote(s, beg);
+            end = StringUtil.CheckQuote(s, beg);
             if (end == -1)
             {
                 throw new FormatException($"mismatched quotes around identity in `{s} '");
             }
             else if (end == 0)
             {
-                end = IceUtilInternal.StringUtil.FindFirstOf(s, delim + ":@", beg);
+                end = StringUtil.FindFirstOf(s, delim + ":@", beg);
                 if (end == -1)
                 {
                     end = s.Length;
@@ -411,7 +409,7 @@ namespace ZeroC.Ice
 
             while (true)
             {
-                beg = IceUtilInternal.StringUtil.FindFirstNotOf(s, delim, end);
+                beg = StringUtil.FindFirstNotOf(s, delim, end);
                 if (beg == -1)
                 {
                     break;
@@ -422,7 +420,7 @@ namespace ZeroC.Ice
                     break;
                 }
 
-                end = IceUtilInternal.StringUtil.FindFirstOf(s, delim + ":@", beg);
+                end = StringUtil.FindFirstOf(s, delim + ":@", beg);
                 if (end == -1)
                 {
                     end = s.Length;
@@ -442,21 +440,21 @@ namespace ZeroC.Ice
                 // Check for the presence of an option argument. The argument may be enclosed in single or double
                 // quotation marks.
                 string? argument = null;
-                int argumentBeg = IceUtilInternal.StringUtil.FindFirstNotOf(s, delim, end);
+                int argumentBeg = StringUtil.FindFirstNotOf(s, delim, end);
                 if (argumentBeg != -1)
                 {
                     char ch = s[argumentBeg];
                     if (ch != '@' && ch != ':' && ch != '-')
                     {
                         beg = argumentBeg;
-                        end = IceUtilInternal.StringUtil.CheckQuote(s, beg);
+                        end = StringUtil.CheckQuote(s, beg);
                         if (end == -1)
                         {
                             throw new FormatException($"mismatched quotes around value for {option} option in `{s}'");
                         }
                         else if (end == 0)
                         {
-                            end = IceUtilInternal.StringUtil.FindFirstOf(s, delim + ":@", beg);
+                            end = StringUtil.FindFirstOf(s, delim + ":@", beg);
                             if (end == -1)
                             {
                                 end = s.Length;
@@ -479,7 +477,7 @@ namespace ZeroC.Ice
                         {
                             throw new FormatException($"no argument provided for -f option in `{s}'");
                         }
-                        facet = IceUtilInternal.StringUtil.UnescapeString(argument, 0, argument.Length, "");
+                        facet = StringUtil.UnescapeString(argument, 0, argument.Length, "");
                         break;
 
                     case 't':
@@ -627,21 +625,21 @@ namespace ZeroC.Ice
             }
             else if (s[beg] == '@')
             {
-                beg = IceUtilInternal.StringUtil.FindFirstNotOf(s, delim, beg + 1);
+                beg = StringUtil.FindFirstNotOf(s, delim, beg + 1);
                 if (beg == -1)
                 {
                     throw new FormatException($"missing adapter id in `{s}'");
                 }
 
                 string adapterstr;
-                end = IceUtilInternal.StringUtil.CheckQuote(s, beg);
+                end = StringUtil.CheckQuote(s, beg);
                 if (end == -1)
                 {
                     throw new FormatException($"mismatched quotes around adapter id in `{s}'");
                 }
                 else if (end == 0)
                 {
-                    end = IceUtilInternal.StringUtil.FindFirstOf(s, delim, beg);
+                    end = StringUtil.FindFirstOf(s, delim, beg);
                     if (end == -1)
                     {
                         end = s.Length;
@@ -655,13 +653,13 @@ namespace ZeroC.Ice
                     end++; // Skip trailing quote
                 }
 
-                if (end != s.Length && IceUtilInternal.StringUtil.FindFirstNotOf(s, delim, end) != -1)
+                if (end != s.Length && StringUtil.FindFirstNotOf(s, delim, end) != -1)
                 {
                     throw new FormatException(
                         $"invalid trailing characters after `{s.Substring(0, end + 1)}' in `{s}'");
                 }
 
-                adapterId = IceUtilInternal.StringUtil.UnescapeString(adapterstr, 0, adapterstr.Length, "");
+                adapterId = StringUtil.UnescapeString(adapterstr, 0, adapterstr.Length, "");
 
                 if (adapterId.Length == 0)
                 {

--- a/csharp/src/Ice/SSLAcceptor.cs
+++ b/csharp/src/Ice/SSLAcceptor.cs
@@ -4,7 +4,7 @@
 
 namespace ZeroC.IceSSL
 {
-    internal class Acceptor : IceInternal.IAcceptor
+    internal class Acceptor : Ice.IAcceptor
     {
         public void Close() => _delegate.Close();
 
@@ -14,7 +14,7 @@ namespace ZeroC.IceSSL
             return _endpoint;
         }
 
-        public bool StartAccept(IceInternal.AsyncCallback callback, object state)
+        public bool StartAccept(Ice.AsyncCallback callback, object state)
         {
             //
             // The plug-in may not be fully initialized.
@@ -28,7 +28,7 @@ namespace ZeroC.IceSSL
 
         public void FinishAccept() => _delegate.FinishAccept();
 
-        public IceInternal.ITransceiver Accept() => new Transceiver(_instance, _delegate.Accept(), _adapterName, true);
+        public Ice.ITransceiver Accept() => new Transceiver(_instance, _delegate.Accept(), _adapterName, true);
 
         public string Transport() => _delegate.Transport();
 
@@ -36,7 +36,7 @@ namespace ZeroC.IceSSL
 
         public string ToDetailedString() => _delegate.ToDetailedString();
 
-        internal Acceptor(Endpoint endpoint, Instance instance, IceInternal.IAcceptor del, string adapterName)
+        internal Acceptor(Endpoint endpoint, Instance instance, Ice.IAcceptor del, string adapterName)
         {
             _endpoint = endpoint;
             _delegate = del;
@@ -54,7 +54,7 @@ namespace ZeroC.IceSSL
         }
 
         private Endpoint _endpoint;
-        private readonly IceInternal.IAcceptor _delegate;
+        private readonly Ice.IAcceptor _delegate;
         private readonly Instance _instance;
         private readonly string _adapterName;
     }

--- a/csharp/src/Ice/SSLConnector.cs
+++ b/csharp/src/Ice/SSLConnector.cs
@@ -4,9 +4,9 @@
 
 namespace ZeroC.IceSSL
 {
-    internal sealed class Connector : IceInternal.IConnector
+    internal sealed class Connector : Ice.IConnector
     {
-        public IceInternal.ITransceiver Connect()
+        public Ice.ITransceiver Connect()
         {
             //
             // The plug-in may not be fully initialized.
@@ -24,7 +24,7 @@ namespace ZeroC.IceSSL
         //
         // Only for use by EndpointI.
         //
-        internal Connector(Instance instance, IceInternal.IConnector del, string host)
+        internal Connector(Instance instance, Ice.IConnector del, string host)
         {
             _instance = instance;
             _delegate = del;
@@ -52,7 +52,7 @@ namespace ZeroC.IceSSL
         public override int GetHashCode() => _delegate.GetHashCode();
 
         private readonly Instance _instance;
-        private readonly IceInternal.IConnector _delegate;
+        private readonly Ice.IConnector _delegate;
         private readonly string _host;
     }
 }

--- a/csharp/src/Ice/SSLEngine.cs
+++ b/csharp/src/Ice/SSLEngine.cs
@@ -16,7 +16,7 @@ namespace ZeroC.IceSSL
 {
     internal class SSLEngine
     {
-        internal SSLEngine(IceInternal.ITransportPluginFacade facade)
+        internal SSLEngine(ITransportPluginFacade facade)
         {
             _communicator = facade.Communicator;
             _logger = _communicator.Logger;
@@ -794,9 +794,9 @@ namespace ZeroC.IceSSL
             return result;
         }
 
-        private readonly Ice.Communicator _communicator;
-        private readonly Ice.ILogger _logger;
-        private readonly IceInternal.ITransportPluginFacade _facade;
+        private readonly Communicator _communicator;
+        private readonly ILogger _logger;
+        private readonly ITransportPluginFacade _facade;
         private readonly int _securityTraceLevel;
         private readonly string _securityTraceCategory;
         private bool _initialized;

--- a/csharp/src/Ice/SSLInstance.cs
+++ b/csharp/src/Ice/SSLInstance.cs
@@ -7,7 +7,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace ZeroC.IceSSL
 {
-    internal class Instance : IceInternal.TransportInstance
+    internal class Instance : Ice.TransportInstance
     {
         internal Instance(SSLEngine engine, Ice.EndpointType type, string transport)
             : base(engine.Communicator(), type, transport, true) => _engine = engine;

--- a/csharp/src/Ice/SSLPlugin.cs
+++ b/csharp/src/Ice/SSLPlugin.cs
@@ -56,7 +56,7 @@ namespace ZeroC.IceSSL
     {
         internal Plugin(Communicator communicator)
         {
-            IceInternal.ITransportPluginFacade facade = IceInternal.Util.GetTransportPluginFacade(communicator);
+            ITransportPluginFacade facade = Util.GetTransportPluginFacade(communicator);
 
             _engine = new SSLEngine(facade);
 

--- a/csharp/src/Ice/SocketOperation.cs
+++ b/csharp/src/Ice/SocketOperation.cs
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public static class SocketOperation
     {

--- a/csharp/src/Ice/StreamSocket.cs
+++ b/csharp/src/Ice/StreamSocket.cs
@@ -2,16 +2,15 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public sealed class StreamSocket
+    internal sealed class StreamSocket
     {
         public StreamSocket(TransportInstance instance, INetworkProxy? proxy, EndPoint addr, IPAddress? sourceAddr)
         {

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -6,11 +6,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-using ZeroC.Ice;
-
-namespace IceUtilInternal
+namespace ZeroC.Ice
 {
-    public static class StringUtil
+    internal static class StringUtil
     {
         //
         // Return the index of the first character in str to

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,7 +9,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal class TcpAcceptor : IAcceptor
     {

--- a/csharp/src/Ice/TcpConnector.cs
+++ b/csharp/src/Ice/TcpConnector.cs
@@ -2,11 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
 using System.Net;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class TcpConnector : IConnector
     {

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/csharp/src/Ice/TcpTransceiver.cs
+++ b/csharp/src/Ice/TcpTransceiver.cs
@@ -2,15 +2,13 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class TcpTransceiver : ITransceiver
     {

--- a/csharp/src/Ice/Time.cs
+++ b/csharp/src/Ice/Time.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public sealed class Time
     {

--- a/csharp/src/Ice/Timer.cs
+++ b/csharp/src/Ice/Timer.cs
@@ -12,10 +12,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
-using ZeroC.Ice;
 using ZeroC.Ice.Instrumentation;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public interface ITimerTask
     {
@@ -144,7 +143,7 @@ namespace IceInternal
                 Debug.Assert(obsv != null);
                 _observer = obsv.GetThreadObserver("Communicator",
                                                    _thread.Name!,
-                                                   ZeroC.Ice.Instrumentation.ThreadState.ThreadStateIdle,
+                                                   Instrumentation.ThreadState.ThreadStateIdle,
                                                    _observer);
                 if (_observer != null)
                 {

--- a/csharp/src/Ice/TraceLevels.cs
+++ b/csharp/src/Ice/TraceLevels.cs
@@ -2,11 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
-    public sealed class TraceLevels
+    internal sealed class TraceLevels
     {
         internal TraceLevels(Communicator communicator)
         {

--- a/csharp/src/Ice/TransportInstance.cs
+++ b/csharp/src/Ice/TransportInstance.cs
@@ -2,10 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System.Net;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     public class TransportInstance
     {

--- a/csharp/src/Ice/UdpConnector.cs
+++ b/csharp/src/Ice/UdpConnector.cs
@@ -2,11 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
 using System.Net;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class UdpConnector : IConnector
     {

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,7 +9,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class UdpTransceiver : ITransceiver
     {

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -58,14 +58,8 @@ namespace ZeroC.Ice
 
         private static readonly object _processLoggerMutex = new object();
         private static ILogger? _processLogger = null;
-    }
-}
 
-namespace IceInternal
-{
-    public sealed class Util
-    {
-        public static ITransportPluginFacade GetTransportPluginFacade(ZeroC.Ice.Communicator communicator) =>
+        public static ITransportPluginFacade GetTransportPluginFacade(Communicator communicator) =>
             new TransportPluginFacade(communicator);
 
         public static ThreadPriority StringToThreadPriority(string? s)

--- a/csharp/src/Ice/WSAcceptor.cs
+++ b/csharp/src/Ice/WSAcceptor.cs
@@ -2,9 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal class WSAcceptor : IAcceptor
     {

--- a/csharp/src/Ice/WSConnector.cs
+++ b/csharp/src/Ice/WSConnector.cs
@@ -2,9 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
-
-namespace IceInternal
+namespace ZeroC.Ice
 {
     internal sealed class WSConnector : IConnector
     {

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using IceInternal;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,7 +10,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace IceInternal
+namespace ZeroC.Ice
 {
     // TODO: refactor and eliminate these exceptions
     public sealed class WSProtocolException : Exception
@@ -772,7 +771,7 @@ namespace IceInternal
             value = _parser.GetHeader("Sec-WebSocket-Protocol", true);
             if (value != null)
             {
-                string[]? protocols = IceUtilInternal.StringUtil.SplitString(value, ",");
+                string[]? protocols = StringUtil.SplitString(value, ",");
                 if (protocols == null)
                 {
                     throw new WebSocketException($"invalid value `{value}' for WebSocket protocol");

--- a/csharp/src/IceDiscovery/Lookup.cs
+++ b/csharp/src/IceDiscovery/Lookup.cs
@@ -70,7 +70,7 @@ namespace ZeroC.IceDiscovery
         protected T Id;
     }
 
-    internal class AdapterRequest : Request<string>, IceInternal.ITimerTask
+    internal class AdapterRequest : Request<string>, ITimerTask
     {
         public AdapterRequest(Lookup lookup, string id, int retryCount)
             : base(lookup, id, retryCount) => _start = DateTime.Now.Ticks;
@@ -158,7 +158,7 @@ namespace ZeroC.IceDiscovery
         private long _latency;
     }
 
-    internal class ObjectRequest : Request<Identity>, IceInternal.ITimerTask
+    internal class ObjectRequest : Request<Identity>, ITimerTask
     {
         public ObjectRequest(Lookup lookup, Identity id, int retryCount)
             : base(lookup, id, retryCount)
@@ -493,7 +493,7 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal IceInternal.Timer Timer() => _timer;
+        internal Timer Timer() => _timer;
 
         internal int LatencyMultiplier() => _latencyMultiplier;
 
@@ -505,7 +505,7 @@ namespace ZeroC.IceDiscovery
         private readonly int _latencyMultiplier;
         private readonly string _domainId;
 
-        private readonly IceInternal.Timer _timer;
+        private readonly Timer _timer;
         private bool _warnOnce = true;
         private readonly Dictionary<Identity, ObjectRequest> _objectRequests = new Dictionary<Identity, ObjectRequest>();
         private readonly Dictionary<string, AdapterRequest> _adapterRequests = new Dictionary<string, AdapterRequest>();

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -52,8 +52,8 @@ namespace ZeroC.IceDiscovery
             string lookupEndpoints = _communicator.GetProperty("IceDiscovery.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = ipv4 && !preferIPv6 ? IceInternal.Network.EnableIPv4 : IceInternal.Network.EnableIPv6;
-                List<string> interfaces = IceInternal.Network.GetInterfacesForMulticast(intf, ipVersion);
+                int ipVersion = ipv4 && !preferIPv6 ? Network.EnableIPv4 : Network.EnableIPv6;
+                List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 foreach (string p in interfaces)
                 {
                     if (p != interfaces[0])

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -113,7 +113,7 @@ namespace ZeroC.IceLocatorDiscovery
         public ILocatorRegistryPrx? GetRegistry(Current current) => null;
     }
 
-    internal class LocatorI : IObject, IceInternal.ITimerTask
+    internal class LocatorI : IObject, ITimerTask
     {
         public LocatorI(string name, ILookupPrx lookup, Communicator communicator, string instanceName,
             ILocatorPrx voidLocator)
@@ -360,7 +360,7 @@ namespace ZeroC.IceLocatorDiscovery
                 {
                     _ = request.Invoke(_locator);
                 }
-                else if (request != null && IceInternal.Time.CurrentMonotonicTimeMillis() < _nextRetry)
+                else if (request != null && Time.CurrentMonotonicTimeMillis() < _nextRetry)
                 {
                     _ = request.Invoke(_voidLocator); // Don't retry to find a locator before the retry delay expires
                 }
@@ -553,14 +553,14 @@ namespace ZeroC.IceLocatorDiscovery
                     }
                     _pendingRequests.Clear();
                 }
-                _nextRetry = IceInternal.Time.CurrentMonotonicTimeMillis() + _retryDelay;
+                _nextRetry = Ice.Time.CurrentMonotonicTimeMillis() + _retryDelay;
             }
         }
 
         private readonly ILookupPrx _lookup;
         private readonly Dictionary<ILookupPrx, ILookupReplyPrx?> _lookups = new Dictionary<ILookupPrx, ILookupReplyPrx?>();
         private readonly int _timeout;
-        private readonly IceInternal.Timer _timer;
+        private readonly Ice.Timer _timer;
         private readonly int _traceLevel;
         private readonly int _retryCount;
         private readonly int _retryDelay;
@@ -619,8 +619,8 @@ namespace ZeroC.IceLocatorDiscovery
             string lookupEndpoints = _communicator.GetProperty($"{_name}.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = ipv4 && !preferIPv6 ? IceInternal.Network.EnableIPv4 : IceInternal.Network.EnableIPv6;
-                List<string> interfaces = IceInternal.Network.GetInterfacesForMulticast(intf, ipVersion);
+                int ipVersion = ipv4 && !preferIPv6 ? Network.EnableIPv4 : Network.EnableIPv6;
+                List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 foreach (string p in interfaces)
                 {
                     if (p != interfaces[0])

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -759,7 +759,7 @@ namespace ZeroC.IceBox
 
                 try
                 {
-                    Args = IceUtilInternal.Options.Split(value);
+                    Args = Options.Split(value);
                 }
                 catch (FormatException ex)
                 {

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -227,11 +227,11 @@ namespace ZeroC.Ice.acm
         {
             lock (this)
             {
-                long now = IceInternal.Time.CurrentMonotonicTimeMillis();
+                long now = Time.CurrentMonotonicTimeMillis();
                 while (!Closed)
                 {
                     Monitor.Wait(this, 30000);
-                    if (IceInternal.Time.CurrentMonotonicTimeMillis() - now > 30000)
+                    if (Time.CurrentMonotonicTimeMillis() - now > 30000)
                     {
                         TestHelper.Assert(false); // Waited for more than 30s for close, something's wrong.
                         throw new Exception();

--- a/csharp/test/Ice/background/Acceptor.cs
+++ b/csharp/test/Ice/background/Acceptor.cs
@@ -2,7 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-internal class Acceptor : IceInternal.IAcceptor
+using ZeroC.Ice;
+
+internal class Acceptor : IAcceptor
 {
     public void Close()
     {
@@ -15,7 +17,7 @@ internal class Acceptor : IceInternal.IAcceptor
         return _endpoint;
     }
 
-    public bool StartAccept(IceInternal.AsyncCallback callback, object state)
+    public bool StartAccept(AsyncCallback callback, object state)
     {
         return _acceptor.StartAccept(callback, state);
     }
@@ -25,7 +27,7 @@ internal class Acceptor : IceInternal.IAcceptor
         _acceptor.FinishAccept();
     }
 
-    public IceInternal.ITransceiver Accept()
+    public ITransceiver Accept()
     {
         return new Transceiver(_acceptor.Accept());
     }
@@ -45,12 +47,12 @@ internal class Acceptor : IceInternal.IAcceptor
         return _acceptor.ToDetailedString();
     }
 
-    internal Acceptor(Endpoint endpoint, IceInternal.IAcceptor acceptor)
+    internal Acceptor(Endpoint endpoint, IAcceptor acceptor)
     {
         _endpoint = endpoint;
         _acceptor = acceptor;
     }
 
     private Endpoint _endpoint;
-    private IceInternal.IAcceptor _acceptor;
+    private IAcceptor _acceptor;
 }

--- a/csharp/test/Ice/background/Connector.cs
+++ b/csharp/test/Ice/background/Connector.cs
@@ -4,9 +4,9 @@
 
 using ZeroC.Ice;
 
-internal class Connector : IceInternal.IConnector
+internal class Connector : IConnector
 {
-    public IceInternal.ITransceiver Connect()
+    public ITransceiver Connect()
     {
         _configuration.CheckConnectException();
         return new Transceiver(_connector.Connect());
@@ -17,7 +17,7 @@ internal class Connector : IceInternal.IConnector
     //
     // Only for use by Endpoint
     //
-    internal Connector(IceInternal.IConnector connector)
+    internal Connector(IConnector connector)
     {
         _configuration = Configuration.GetInstance();
         _connector = connector;
@@ -41,6 +41,6 @@ internal class Connector : IceInternal.IConnector
 
     public override int GetHashCode() => _connector.GetHashCode();
 
-    private readonly IceInternal.IConnector _connector;
+    private readonly IConnector _connector;
     private readonly Configuration _configuration;
 }

--- a/csharp/test/Ice/background/Endpoint.cs
+++ b/csharp/test/Ice/background/Endpoint.cs
@@ -104,18 +104,18 @@ internal class Endpoint : ZeroC.Ice.Endpoint
         }
     }
 
-    public override IceInternal.IAcceptor GetAcceptor(string adapterName)
+    public override IAcceptor GetAcceptor(string adapterName)
     {
         var acceptor = _endpoint.GetAcceptor(adapterName);
         TestHelper.Assert(acceptor != null);
         return new Acceptor(this, acceptor);
     }
 
-    public override async ValueTask<IEnumerable<IceInternal.IConnector>>
+    public override async ValueTask<IEnumerable<IConnector>>
         ConnectorsAsync(EndpointSelectionType selType)
     {
         _configuration.CheckConnectorsException();
-        IEnumerable<IceInternal.IConnector> connectors = await _endpoint.ConnectorsAsync(selType).ConfigureAwait(false);
+        IEnumerable<IConnector> connectors = await _endpoint.ConnectorsAsync(selType).ConfigureAwait(false);
         return connectors.Select(item => new Connector(item));
     }
 
@@ -132,9 +132,9 @@ internal class Endpoint : ZeroC.Ice.Endpoint
     public override IEnumerable<ZeroC.Ice.Endpoint> ExpandIfWildcard() =>
         _endpoint.ExpandIfWildcard().Select(endpoint => GetEndpoint(endpoint));
 
-    public override IceInternal.ITransceiver? GetTransceiver()
+    public override ITransceiver? GetTransceiver()
     {
-        IceInternal.ITransceiver? transceiver = _endpoint.GetTransceiver();
+        ITransceiver? transceiver = _endpoint.GetTransceiver();
         if (transceiver != null)
         {
             return new Transceiver(transceiver);

--- a/csharp/test/Ice/background/EndpointFactory.cs
+++ b/csharp/test/Ice/background/EndpointFactory.cs
@@ -7,9 +7,9 @@ using ZeroC.Ice;
 using System.Collections.Generic;
 using Test;
 
-internal class EndpointFactory : IceInternal.IEndpointFactory
+internal class EndpointFactory : IEndpointFactory
 {
-    internal EndpointFactory(IceInternal.IEndpointFactory factory)
+    internal EndpointFactory(IEndpointFactory factory)
     {
         _factory = factory;
     }
@@ -43,10 +43,7 @@ internal class EndpointFactory : IceInternal.IEndpointFactory
     {
     }
 
-    public IceInternal.IEndpointFactory Clone(IceInternal.TransportInstance instance)
-    {
-        return this;
-    }
+    public IEndpointFactory Clone(TransportInstance instance) => this;
 
-    private IceInternal.IEndpointFactory _factory;
+    private IEndpointFactory _factory;
 }

--- a/csharp/test/Ice/background/PluginI.cs
+++ b/csharp/test/Ice/background/PluginI.cs
@@ -10,10 +10,10 @@ internal class Plugin : IPlugin
 
     public void Initialize()
     {
-        IceInternal.ITransportPluginFacade facade = IceInternal.Util.GetTransportPluginFacade(_communicator);
+        ITransportPluginFacade facade = Util.GetTransportPluginFacade(_communicator);
         for (short s = 0; s < 100; ++s)
         {
-            IceInternal.IEndpointFactory? factory = facade.GetEndpointFactory((EndpointType)s);
+            IEndpointFactory? factory = facade.GetEndpointFactory((EndpointType)s);
             if (factory != null)
             {
                 facade.AddEndpointFactory(new EndpointFactory(factory));

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using Test;
 using System.Net.Sockets;
 
-internal class Transceiver : IceInternal.ITransceiver
+internal class Transceiver : ITransceiver
 {
     public Socket? Fd() => _transceiver.Fd();
 
@@ -19,13 +19,13 @@ internal class Transceiver : IceInternal.ITransceiver
         if (!_initialized)
         {
             int status = _transceiver.Initialize(ref readBuffer, writeBuffer);
-            if (status != IceInternal.SocketOperation.None)
+            if (status != SocketOperation.None)
             {
                 return status;
             }
             _initialized = true;
         }
-        return IceInternal.SocketOperation.None;
+        return SocketOperation.None;
     }
 
     public int Closing(bool initiator, System.Exception? ex) => _transceiver.Closing(initiator, ex);
@@ -39,7 +39,7 @@ internal class Transceiver : IceInternal.ITransceiver
         int remaining = buf.GetByteCount() - offset;
         if (!_configuration.WriteReady() && remaining > 0)
         {
-            return IceInternal.SocketOperation.Write;
+            return SocketOperation.Write;
         }
 
         _configuration.CheckWriteException();
@@ -50,7 +50,7 @@ internal class Transceiver : IceInternal.ITransceiver
     {
         if (!_configuration.ReadReady() && offset < buffer.Count)
         {
-            return IceInternal.SocketOperation.Read;
+            return SocketOperation.Read;
         }
 
         _configuration.CheckReadException();
@@ -66,7 +66,7 @@ internal class Transceiver : IceInternal.ITransceiver
                     _transceiver.Read(ref _readBuffer, ref _readBufferOffset);
                     if (_readBufferPos == _readBufferOffset)
                     {
-                        return IceInternal.SocketOperation.Read;
+                        return SocketOperation.Read;
                     }
                 }
 
@@ -82,7 +82,7 @@ internal class Transceiver : IceInternal.ITransceiver
                 offset += available;
                 _readBufferPos += available;
             }
-            return IceInternal.SocketOperation.None;
+            return SocketOperation.None;
         }
         else
         {
@@ -90,7 +90,7 @@ internal class Transceiver : IceInternal.ITransceiver
         }
     }
 
-    public bool StartRead(ref ArraySegment<byte> buffer, ref int offset, IceInternal.AsyncCallback callback,
+    public bool StartRead(ref ArraySegment<byte> buffer, ref int offset, ZeroC.Ice.AsyncCallback callback,
         object state)
     {
         if (_configuration.ReadReady())
@@ -161,7 +161,7 @@ internal class Transceiver : IceInternal.ITransceiver
         }
     }
 
-    public bool StartWrite(IList<ArraySegment<byte>> buf, int offset, IceInternal.AsyncCallback callback,
+    public bool StartWrite(IList<ArraySegment<byte>> buf, int offset, ZeroC.Ice.AsyncCallback callback,
         object state, out bool completed)
     {
         _configuration.CheckWriteException();
@@ -188,12 +188,12 @@ internal class Transceiver : IceInternal.ITransceiver
 
     public void Destroy() => _transceiver.Destroy();
 
-    public IceInternal.ITransceiver GetDelegate() => _transceiver;
+    public ITransceiver GetDelegate() => _transceiver;
 
     //
     // Only for use by Connector, Acceptor
     //
-    internal Transceiver(IceInternal.ITransceiver transceiver)
+    internal Transceiver(ITransceiver transceiver)
     {
         _transceiver = transceiver;
         _configuration = Configuration.GetInstance();
@@ -204,7 +204,7 @@ internal class Transceiver : IceInternal.ITransceiver
         _buffered = _configuration.Buffered();
     }
 
-    private readonly IceInternal.ITransceiver _transceiver;
+    private readonly ITransceiver _transceiver;
     private readonly Configuration _configuration;
     private bool _initialized;
     private ArraySegment<byte> _readBuffer;

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -34,10 +34,10 @@ namespace ZeroC.Ice.udp
             {
                 lock (this)
                 {
-                    long end = IceInternal.Time.CurrentMonotonicTimeMillis() + timeout;
+                    long end = Time.CurrentMonotonicTimeMillis() + timeout;
                     while (_replies < expectedReplies)
                     {
-                        int delay = (int)(end - IceInternal.Time.CurrentMonotonicTimeMillis());
+                        int delay = (int)(end - Time.CurrentMonotonicTimeMillis());
                         if (delay > 0)
                         {
                             System.Threading.Monitor.Wait(this, delay);

--- a/csharp/test/IceUtil/inputUtil/Client.cs
+++ b/csharp/test/IceUtil/inputUtil/Client.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using ZeroC.Ice;
 
 public class Client : Test.TestHelper
 {
@@ -14,56 +15,56 @@ public class Client : Test.TestHelper
 
         try
         {
-            Assert(IceUtilInternal.Options.Split("").Length == 0);
+            Assert(Options.Split("").Length == 0);
 
-            args = IceUtilInternal.Options.Split("\"\"");
+            args = Options.Split("\"\"");
             Assert(args.Length == 1 && args[0].Equals(""));
-            args = IceUtilInternal.Options.Split("''");
+            args = Options.Split("''");
             Assert(args.Length == 1 && args[0].Equals(""));
-            args = IceUtilInternal.Options.Split("$''");
+            args = Options.Split("$''");
             Assert(args.Length == 1 && args[0].Equals(""));
 
-            args = IceUtilInternal.Options.Split("-a -b -c");
+            args = Options.Split("-a -b -c");
             Assert(args.Length == 3 && args[0].Equals("-a") && args[1].Equals("-b") && args[2].Equals("-c"));
-            args = IceUtilInternal.Options.Split("\"-a\" '-b' $'-c'");
+            args = Options.Split("\"-a\" '-b' $'-c'");
             Assert(args.Length == 3 && args[0].Equals("-a") && args[1].Equals("-b") && args[2].Equals("-c"));
-            args = IceUtilInternal.Options.Split("  '-b' \"-a\" $'-c' ");
+            args = Options.Split("  '-b' \"-a\" $'-c' ");
             Assert(args.Length == 3 && args[0].Equals("-b") && args[1].Equals("-a") && args[2].Equals("-c"));
-            args = IceUtilInternal.Options.Split(" $'-c' '-b' \"-a\"  ");
+            args = Options.Split(" $'-c' '-b' \"-a\"  ");
             Assert(args.Length == 3 && args[0].Equals("-c") && args[1].Equals("-b") && args[2].Equals("-a"));
 
             // Testing single quote
-            args = IceUtilInternal.Options.Split("-Dir='C:\\\\test\\\\file'"); // -Dir='C:\\test\\file'
+            args = Options.Split("-Dir='C:\\\\test\\\\file'"); // -Dir='C:\\test\\file'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\\\test\\\\file")); // -Dir=C:\\test\\file
-            args = IceUtilInternal.Options.Split("-Dir='C:\\test\\file'"); // -Dir='C:\test\file'
+            args = Options.Split("-Dir='C:\\test\\file'"); // -Dir='C:\test\file'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir='C:\\test\\filewith\"quote'"); // -Dir='C:\test\filewith"quote'
+            args = Options.Split("-Dir='C:\\test\\filewith\"quote'"); // -Dir='C:\test\filewith"quote'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\filewith\"quote")); // -Dir=C:\test\filewith"quote
 
             // Testing double quote
-            args = IceUtilInternal.Options.Split("-Dir=\"C:\\\\test\\\\file\""); // -Dir="C:\\test\\file"
+            args = Options.Split("-Dir=\"C:\\\\test\\\\file\""); // -Dir="C:\\test\\file"
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir=\"C:\\test\\file\""); // -Dir="C:\test\file"
+            args = Options.Split("-Dir=\"C:\\test\\file\""); // -Dir="C:\test\file"
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir=\"C:\\test\\filewith\\\"quote\""); // -Dir="C:\test\filewith\"quote"
+            args = Options.Split("-Dir=\"C:\\test\\filewith\\\"quote\""); // -Dir="C:\test\filewith\"quote"
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\filewith\"quote")); // -Dir=C:\test\filewith"quote
 
             // Testing ANSI quote
-            args = IceUtilInternal.Options.Split("-Dir=$'C:\\\\test\\\\file'"); // -Dir=$'C:\\test\\file'
+            args = Options.Split("-Dir=$'C:\\\\test\\\\file'"); // -Dir=$'C:\\test\\file'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir=$'C:\\oest\\oile'"); // -Dir='C:\oest\oile'
+            args = Options.Split("-Dir=$'C:\\oest\\oile'"); // -Dir='C:\oest\oile'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\oest\\oile")); // -Dir=C:\oest\oile
-            args = IceUtilInternal.Options.Split("-Dir=$'C:\\oest\\oilewith\"quote'"); // -Dir=$'C:\oest\oilewith"quote'
+            args = Options.Split("-Dir=$'C:\\oest\\oilewith\"quote'"); // -Dir=$'C:\oest\oilewith"quote'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\oest\\oilewith\"quote")); // -Dir=C:\oest\oilewith"quote
-            args = IceUtilInternal.Options.Split("-Dir=$'\\103\\072\\134\\164\\145\\163\\164\\134\\146\\151\\154\\145'");
+            args = Options.Split("-Dir=$'\\103\\072\\134\\164\\145\\163\\164\\134\\146\\151\\154\\145'");
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir=$'\\x43\\x3A\\x5C\\x74\\x65\\x73\\x74\\x5C\\x66\\x69\\x6C\\x65'");
+            args = Options.Split("-Dir=$'\\x43\\x3A\\x5C\\x74\\x65\\x73\\x74\\x5C\\x66\\x69\\x6C\\x65'");
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
-            args = IceUtilInternal.Options.Split("-Dir=$'\\cM\\c_'"); // Control characters
+            args = Options.Split("-Dir=$'\\cM\\c_'"); // Control characters
             Assert(args.Length == 1 && args[0].Equals("-Dir=\x0D\x1F"));
-            args = IceUtilInternal.Options.Split("-Dir=$'C:\\\\\\146\\x66\\cMi'"); // -Dir=$'C:\\\146\x66i\cMi'
+            args = Options.Split("-Dir=$'C:\\\\\\146\\x66\\cMi'"); // -Dir=$'C:\\\146\x66i\cMi'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\ff\x0Di"));
-            args = IceUtilInternal.Options.Split("-Dir=$'C:\\\\\\cM\\x66\\146i'"); // -Dir=$'C:\\\cM\x66\146i'
+            args = Options.Split("-Dir=$'C:\\\\\\cM\\x66\\146i'"); // -Dir=$'C:\\\cM\x66\146i'
             Assert(args.Length == 1 && args[0].Equals("-Dir=C:\\\x000Dffi"));
         }
         catch (FormatException)
@@ -82,72 +83,12 @@ public class Client : Test.TestHelper
         {
             try
             {
-                IceUtilInternal.Options.Split(badQuoteCommands[i]);
+                Options.Split(badQuoteCommands[i]);
                 Assert(false);
             }
             catch (FormatException)
             {
             }
-        }
-
-        Console.Out.WriteLine("ok");
-
-        Console.Out.Write("checking string splitting... ");
-        Console.Out.Flush();
-        {
-            string[]? arr;
-
-            arr = IceUtilInternal.StringUtil.SplitString("", "");
-            Assert(arr != null && arr.Length == 0);
-            arr = IceUtilInternal.StringUtil.SplitString("", ":");
-            Assert(arr != null && arr.Length == 0);
-            arr = IceUtilInternal.StringUtil.SplitString("a", "");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a"));
-            arr = IceUtilInternal.StringUtil.SplitString("a", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a"));
-            arr = IceUtilInternal.StringUtil.SplitString("ab", "");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("ab"));
-            arr = IceUtilInternal.StringUtil.SplitString("ab:", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("ab"));
-            arr = IceUtilInternal.StringUtil.SplitString(":ab", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("ab"));
-            arr = IceUtilInternal.StringUtil.SplitString("a:b", ":");
-            Assert(arr != null && arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
-            arr = IceUtilInternal.StringUtil.SplitString(":a:b:", ":");
-            Assert(arr != null && arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
-
-            arr = IceUtilInternal.StringUtil.SplitString("\"a\"", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"a\":b", ":");
-            Assert(arr != null && arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"a\":\"b\"", ":");
-            Assert(arr != null && arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"a:b\"", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a:b"));
-            arr = IceUtilInternal.StringUtil.SplitString("a=\"a:b\"", ":")!;
-            Assert(arr.Length == 1 && arr[0].Equals("a=a:b"));
-
-            arr = IceUtilInternal.StringUtil.SplitString("'a'", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a"));
-            arr = IceUtilInternal.StringUtil.SplitString("'\"a'", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("\"a"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"'a\"", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("'a"));
-
-            arr = IceUtilInternal.StringUtil.SplitString("a\\'b", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a'b"));
-            arr = IceUtilInternal.StringUtil.SplitString("'a:b\\'c'", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a:b'c"));
-            arr = IceUtilInternal.StringUtil.SplitString("a\\\"b", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a\"b"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"a:b\\\"c\"", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a:b\"c"));
-            arr = IceUtilInternal.StringUtil.SplitString("'a:b\"c'", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a:b\"c"));
-            arr = IceUtilInternal.StringUtil.SplitString("\"a:b'c\"", ":");
-            Assert(arr != null && arr.Length == 1 && arr[0].Equals("a:b'c"));
-
-            Assert(IceUtilInternal.StringUtil.SplitString("a\"b", ":") == null);
         }
         Console.Out.WriteLine("ok");
     }


### PR DESCRIPTION
This PR removes IceInternal and IceUtilInternal namespaces and move the contents to ZeroC.Ice using `internal` access modifier when appropriate and possible.

One caveat here is Network class, currently keep as public, it is only used outside of Ice assembly for `GetInterfacesForMulticast` in discovery plug-ins.  I think keeping it public is the fine as it must be useful for implementing a transport in a separate plug-in