### PR TITLE
C# IceDiscovery plug-in cleanup

### DIFF
--- a/csharp/src/IceDiscovery/Locator.cs
+++ b/csharp/src/IceDiscovery/Locator.cs
@@ -58,7 +58,7 @@ namespace ZeroC.IceDiscovery
         }
 
         public ValueTask SetReplicatedAdapterDirectProxyAsync(string adapterId, string replicaGroupId, IObjectPrx? proxy,
-                                             Current current)
+            Current current)
         {
             lock (this)
             {
@@ -89,8 +89,8 @@ namespace ZeroC.IceDiscovery
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask SetServerProcessProxyAsync(string id, IProcessPrx? process, Current current)
-            => new ValueTask(Task.CompletedTask);
+        public ValueTask SetServerProcessProxyAsync(string id, IProcessPrx? process, Current current) =>
+            new ValueTask(Task.CompletedTask);
 
         internal IObjectPrx? FindAdapter(string adapterId, out bool isReplicaGroup)
         {
@@ -151,8 +151,9 @@ namespace ZeroC.IceDiscovery
                         prx.Clone(adapterId: entry.Key).IcePing();
                         adapterIds.Add(entry.Key);
                     }
-                    catch (System.Exception)
+                    catch
                     {
+                        // Ignore.
                     }
                 }
                 if (adapterIds.Count == 0)
@@ -164,8 +165,9 @@ namespace ZeroC.IceDiscovery
                             prx.Clone(adapterId: entry.Key).IcePing();
                             adapterIds.Add(entry.Key);
                         }
-                        catch (System.Exception)
+                        catch
                         {
+                            // Ignore.
                         }
                     }
                 }

--- a/csharp/src/IceDiscovery/Locator.cs
+++ b/csharp/src/IceDiscovery/Locator.cs
@@ -16,9 +16,9 @@ namespace ZeroC.IceDiscovery
         private readonly ILocatorRegistryPrx _registry;
 
         public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string adapterId, Current current) =>
-            _lookup.FindAdapter(adapterId);
+            _lookup.FindAdapterAsync(adapterId);
 
-        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current) => _lookup.FindObject(id);
+        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current) => _lookup.FindObjectAsync(id);
 
         public ILocatorRegistryPrx? GetRegistry(Current current) => _registry;
 
@@ -54,7 +54,7 @@ namespace ZeroC.IceDiscovery
                     _adapters.Remove(adapterId);
                 }
             }
-            return new ValueTask(Task.CompletedTask);
+            return new ValueTask();
         }
 
         public ValueTask SetReplicatedAdapterDirectProxyAsync(string adapterId, string replicaGroupId, IObjectPrx? proxy,
@@ -86,7 +86,7 @@ namespace ZeroC.IceDiscovery
                     }
                 }
             }
-            return new ValueTask(Task.CompletedTask);
+            return new ValueTask();
         }
 
         public ValueTask SetServerProcessProxyAsync(string id, IProcessPrx? process, Current current) =>

--- a/csharp/src/IceDiscovery/Locator.cs
+++ b/csharp/src/IceDiscovery/Locator.cs
@@ -12,14 +12,106 @@ namespace ZeroC.IceDiscovery
 {
     internal class LocatorRegistry : ILocatorRegistry
     {
-        public
-        LocatorRegistry(Communicator com) =>
+        private readonly Dictionary<string, IObjectPrx> _adapters = new Dictionary<string, IObjectPrx>();
+        private readonly object _mutex = new object();
+        private readonly Dictionary<string, HashSet<string>> _replicaGroups =
+            new Dictionary<string, HashSet<string>>();
+        private readonly IObjectPrx _wellKnownProxy;
+
+        internal IObjectPrx? FindAdapter(string adapterId, out bool isReplicaGroup)
+        {
+            lock (_mutex)
+            {
+                if (_adapters.TryGetValue(adapterId, out IObjectPrx? result))
+                {
+                    isReplicaGroup = false;
+                    return result;
+                }
+
+                if (_replicaGroups.TryGetValue(adapterId, out HashSet<string>? adapterIds))
+                {
+                    var endpoints = new List<Endpoint>();
+                    foreach (string a in adapterIds)
+                    {
+                        if (!_adapters.TryGetValue(a, out IObjectPrx? proxy))
+                        {
+                            continue; // TODO: Inconsistency
+                        }
+
+                        if (result == null)
+                        {
+                            result = proxy;
+                        }
+
+                        endpoints.AddRange(proxy.Endpoints);
+                    }
+
+                    if (result != null)
+                    {
+                        isReplicaGroup = true;
+                        return result.Clone(endpoints: endpoints);
+                    }
+                }
+
+                isReplicaGroup = false;
+                return null;
+            }
+        }
+
+        internal IObjectPrx? FindObject(Identity identity)
+        {
+            lock (_mutex)
+            {
+                if (identity.Name.Length == 0)
+                {
+                    return null;
+                }
+
+                IObjectPrx prx = _wellKnownProxy.Clone(identity, IObjectPrx.Factory);
+
+                var adapterIds = new List<string>();
+                foreach (KeyValuePair<string, HashSet<string>> entry in _replicaGroups)
+                {
+                    try
+                    {
+                        prx.Clone(adapterId: entry.Key).IcePing();
+                        adapterIds.Add(entry.Key);
+                    }
+                    catch (System.Exception)
+                    {
+                    }
+                }
+                if (adapterIds.Count == 0)
+                {
+                    foreach (KeyValuePair<string, IObjectPrx> entry in _adapters)
+                    {
+                        try
+                        {
+                            prx.Clone(adapterId: entry.Key).IcePing();
+                            adapterIds.Add(entry.Key);
+                        }
+                        catch (System.Exception)
+                        {
+                        }
+                    }
+                }
+
+                if (adapterIds.Count == 0)
+                {
+                    return null;
+                }
+
+                return prx.Clone(adapterId: adapterIds.Shuffle().First());
+            }
+        }
+
+        public LocatorRegistry(Communicator com) =>
             _wellKnownProxy = IObjectPrx.Parse("p", com).Clone(
                 clearLocator: true, clearRouter: true, collocationOptimized: true);
 
         public ValueTask SetAdapterDirectProxyAsync(string adapterId, IObjectPrx? proxy, Current current)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (proxy != null)
                 {
@@ -67,116 +159,24 @@ namespace ZeroC.IceDiscovery
 
         public ValueTask SetServerProcessProxyAsync(string id, IProcessPrx? process, Current current)
             => new ValueTask(Task.CompletedTask);
-
-        internal IObjectPrx? FindObject(Identity identity)
-        {
-            lock (this)
-            {
-                if (identity.Name.Length == 0)
-                {
-                    return null;
-                }
-
-                IObjectPrx prx = _wellKnownProxy.Clone(identity, IObjectPrx.Factory);
-
-                var adapterIds = new List<string>();
-                foreach (KeyValuePair<string, HashSet<string>> entry in _replicaGroups)
-                {
-                    try
-                    {
-                        prx.Clone(adapterId: entry.Key).IcePing();
-                        adapterIds.Add(entry.Key);
-                    }
-                    catch (System.Exception)
-                    {
-                    }
-                }
-                if (adapterIds.Count == 0)
-                {
-                    foreach (KeyValuePair<string, IObjectPrx> entry in _adapters)
-                    {
-                        try
-                        {
-                            prx.Clone(adapterId: entry.Key).IcePing();
-                            adapterIds.Add(entry.Key);
-                        }
-                        catch (System.Exception)
-                        {
-                        }
-                    }
-                }
-
-                if (adapterIds.Count == 0)
-                {
-                    return null;
-                }
-
-                return prx.Clone(adapterId: adapterIds.Shuffle().First());
-            }
-        }
-
-        internal IObjectPrx? FindAdapter(string adapterId, out bool isReplicaGroup)
-        {
-            lock (this)
-            {
-                if (_adapters.TryGetValue(adapterId, out IObjectPrx? result))
-                {
-                    isReplicaGroup = false;
-                    return result;
-                }
-
-                if (_replicaGroups.TryGetValue(adapterId, out HashSet<string>? adapterIds))
-                {
-                    var endpoints = new List<Endpoint>();
-                    foreach (string a in adapterIds)
-                    {
-                        if (!_adapters.TryGetValue(a, out IObjectPrx? proxy))
-                        {
-                            continue; // TODO: Inconsistency
-                        }
-
-                        if (result == null)
-                        {
-                            result = proxy;
-                        }
-
-                        endpoints.AddRange(proxy.Endpoints);
-                    }
-
-                    if (result != null)
-                    {
-                        isReplicaGroup = true;
-                        return result.Clone(endpoints: endpoints);
-                    }
-                }
-
-                isReplicaGroup = false;
-                return null;
-            }
-        }
-
-        private readonly IObjectPrx _wellKnownProxy;
-        private readonly Dictionary<string, IObjectPrx> _adapters = new Dictionary<string, IObjectPrx>();
-        private readonly Dictionary<string, HashSet<string>> _replicaGroups = new Dictionary<string, HashSet<string>>();
     }
 
     internal class Locator : ILocator
     {
+        private readonly Lookup _lookup;
+        private readonly ILocatorRegistryPrx _registry;
+
         public Locator(Lookup lookup, ILocatorRegistryPrx registry)
         {
             _lookup = lookup;
             _registry = registry;
         }
 
-        public ValueTask<IObjectPrx?>
-        FindObjectByIdAsync(Identity id, Current current) => _lookup.FindObject(id);
+        public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string adapterId, Current current) =>
+            _lookup.FindAdapter(adapterId);
 
-        public ValueTask<IObjectPrx?>
-        FindAdapterByIdAsync(string adapterId, Current current) => _lookup.FindAdapter(adapterId);
+        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current) => _lookup.FindObject(id);
 
         public ILocatorRegistryPrx? GetRegistry(Current current) => _registry;
-
-        private readonly Lookup _lookup;
-        private readonly ILocatorRegistryPrx _registry;
     }
 }

--- a/csharp/src/IceDiscovery/Lookup.cs
+++ b/csharp/src/IceDiscovery/Lookup.cs
@@ -126,9 +126,7 @@ namespace ZeroC.IceDiscovery
             IObjectPrx? proxy = _registry.FindObject(id);
             if (proxy != null)
             {
-                //
                 // Reply to the mulicast request using the given proxy.
-                //
                 try
                 {
                     Debug.Assert(reply != null);
@@ -151,15 +149,13 @@ namespace ZeroC.IceDiscovery
             IObjectPrx? proxy = _registry.FindAdapter(adapterId, out bool isReplicaGroup);
             if (proxy != null)
             {
-                //
                 // Reply to the multicast request using the given proxy.
-                //
                 try
                 {
                     Debug.Assert(reply != null);
                     reply.FoundAdapterByIdAsync(adapterId, proxy, isReplicaGroup);
                 }
-                catch (Exception)
+                catch
                 {
                     // Ignore.
                 }
@@ -176,10 +172,8 @@ namespace ZeroC.IceDiscovery
             _domainId = communicator.GetProperty("IceDiscovery.DomainId") ?? "";
             Timer = lookup.Communicator.Timer();
 
-            //
             // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
             // datagram on each endpoint.
-            //
             var single = new Endpoint[1];
             foreach (Endpoint endpt in lookup.Endpoints)
             {
@@ -200,7 +194,7 @@ namespace ZeroC.IceDiscovery
 
                 if (request.Exception())
                 {
-                    if (_warnOnce)
+                    if (_warnOnce) // TODO remove this _warnOnce setting?
                     {
                         var s = new StringBuilder();
                         s.Append("failed to lookup adapter `");
@@ -235,8 +229,9 @@ namespace ZeroC.IceDiscovery
                         Timer.Schedule(request, _timeout);
                         return;
                     }
-                    catch (Exception)
+                    catch
                     {
+                        // Ignore.
                     }
                 }
 
@@ -264,7 +259,7 @@ namespace ZeroC.IceDiscovery
                         request.Invoke(_domainId, _lookups);
                         Timer.Schedule(request, _timeout);
                     }
-                    catch (Exception)
+                    catch
                     {
                         request.Finished(null);
                         _adapterRequests.Remove(adapterId);
@@ -292,7 +287,7 @@ namespace ZeroC.IceDiscovery
                         request.Invoke(_domainId, _lookups);
                         Timer.Schedule(request, _timeout);
                     }
-                    catch (Exception)
+                    catch
                     {
                         request.Finished(null);
                         _objectRequests.Remove(id);
@@ -343,7 +338,7 @@ namespace ZeroC.IceDiscovery
 
                 if (request.Exception())
                 {
-                    if (_warnOnce)
+                    if (_warnOnce) // TODO remove this _warnOnce setting?
                     {
                         var s = new StringBuilder();
                         s.Append("failed to lookup object `");
@@ -378,8 +373,9 @@ namespace ZeroC.IceDiscovery
                         Timer.Schedule(request, _timeout);
                         return;
                     }
-                    catch (Exception)
+                    catch
                     {
+                        // Ignore.
                     }
                 }
 

--- a/csharp/src/IceDiscovery/Lookup.cs
+++ b/csharp/src/IceDiscovery/Lookup.cs
@@ -89,11 +89,11 @@ namespace ZeroC.IceDiscovery
 
         private void SendResponse(IObjectPrx? proxy)
         {
-            foreach (TaskCompletionSource<IObjectPrx?> cb in Callbacks)
+            foreach (TaskCompletionSource<IObjectPrx?> cb in Sources)
             {
                 cb.SetResult(proxy);
             }
-            Callbacks.Clear();
+            Sources.Clear();
         }
     }
 
@@ -241,7 +241,7 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal ValueTask<IObjectPrx?> FindAdapter(string adapterId)
+        internal ValueTask<IObjectPrx?> FindAdapterAsync(string adapterId)
         {
             lock (_mutex)
             {
@@ -269,7 +269,7 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal ValueTask<IObjectPrx?> FindObject(Identity id)
+        internal ValueTask<IObjectPrx?> FindObjectAsync(Identity id)
         {
             lock (_mutex)
             {
@@ -432,11 +432,11 @@ namespace ZeroC.IceDiscovery
 
         public override void Finished(IObjectPrx? proxy)
         {
-            foreach (TaskCompletionSource<IObjectPrx?> cb in Callbacks)
+            foreach (TaskCompletionSource<IObjectPrx?> source in Sources)
             {
-                cb.SetResult(proxy);
+                source.SetResult(proxy);
             }
-            Callbacks.Clear();
+            Sources.Clear();
         }
 
         public void RunTimerTask() => Lookup.ObjectRequestTimedOut(this);
@@ -465,16 +465,16 @@ namespace ZeroC.IceDiscovery
         public T Id { get; }
         public string RequestId { get; }
 
-        protected List<TaskCompletionSource<IObjectPrx?>> Callbacks = new List<TaskCompletionSource<IObjectPrx?>>();
+        protected List<TaskCompletionSource<IObjectPrx?>> Sources = new List<TaskCompletionSource<IObjectPrx?>>();
         protected int FailureCount;
         protected Lookup Lookup;
         protected int LookupCount;
         protected int RetryCount;
 
-        public bool AddCallback(TaskCompletionSource<IObjectPrx?> cb)
+        public bool AddCallback(TaskCompletionSource<IObjectPrx?> source)
         {
-            Callbacks.Add(cb);
-            return Callbacks.Count == 1;
+            Sources.Add(source);
+            return Sources.Count == 1;
         }
 
         public bool Exception()

--- a/csharp/src/IceDiscovery/Lookup.cs
+++ b/csharp/src/IceDiscovery/Lookup.cs
@@ -12,91 +12,16 @@ using ZeroC.Ice;
 
 namespace ZeroC.IceDiscovery
 {
-    internal abstract class Request<T>
-    {
-        protected Request(Lookup lookup, T id, int retryCount)
-        {
-            Lookup = lookup;
-            RetryCount = retryCount;
-            Id = id;
-            _requestId = Guid.NewGuid().ToString();
-        }
-
-        public T GetId() => Id;
-
-        public bool AddCallback(TaskCompletionSource<IObjectPrx?> cb)
-        {
-            Callbacks.Add(cb);
-            return Callbacks.Count == 1;
-        }
-
-        public virtual bool Retry() => --RetryCount >= 0;
-
-        public void Invoke(string domainId, Dictionary<ILookupPrx, ILookupReplyPrx?> lookups)
-        {
-            LookupCount = lookups.Count;
-            FailureCount = 0;
-            var identity = new Identity(_requestId, "");
-            foreach (KeyValuePair<ILookupPrx, ILookupReplyPrx?> entry in lookups)
-            {
-                InvokeWithLookup(domainId, entry.Key, entry.Value!.Clone(identity, ILookupReplyPrx.Factory));
-            }
-        }
-
-        public bool Exception()
-        {
-            if (++FailureCount == LookupCount)
-            {
-                Finished(null);
-                return true;
-            }
-            return false;
-        }
-
-        public string GetRequestId() => _requestId;
-
-        public abstract void Finished(IObjectPrx? proxy);
-
-        protected abstract Task InvokeWithLookup(string domainId, ILookupPrx lookup, ILookupReplyPrx lookupReply);
-
-        private readonly string _requestId;
-
-        protected Lookup Lookup;
-        protected int RetryCount;
-        protected int LookupCount;
-        protected int FailureCount;
-        protected List<TaskCompletionSource<IObjectPrx?>> Callbacks = new List<TaskCompletionSource<IObjectPrx?>>();
-
-        protected T Id;
-    }
-
     internal class AdapterRequest : Request<string>, ITimerTask
     {
+        // We use a HashSet because the same IceDiscovery plugin might return multiple times the same proxy if it's
+        // accessible through multiple network interfaces and if we also sent the request to multiple interfaces.
+        private long _latency;
+        private readonly HashSet<IObjectPrx> _proxies = new HashSet<IObjectPrx>();
+        private readonly long _start;
+
         public AdapterRequest(Lookup lookup, string id, int retryCount)
             : base(lookup, id, retryCount) => _start = DateTime.Now.Ticks;
-
-        public override bool Retry() => _proxies.Count == 0 && --RetryCount >= 0;
-
-        public bool Response(IObjectPrx proxy, bool isReplicaGroup)
-        {
-            if (isReplicaGroup)
-            {
-                _proxies.Add(proxy);
-                if (_latency == 0)
-                {
-                    _latency = (long)((DateTime.Now.Ticks - _start) * Lookup.LatencyMultiplier() / 10000.0);
-                    if (_latency == 0)
-                    {
-                        _latency = 1; // 1ms
-                    }
-                    Lookup.Timer().Cancel(this);
-                    Lookup.Timer().Schedule(this, _latency);
-                }
-                return false;
-            }
-            Finished(proxy);
-            return true;
-        }
 
         public override void Finished(IObjectPrx? proxy)
         {
@@ -125,6 +50,29 @@ namespace ZeroC.IceDiscovery
             }
         }
 
+        public bool Response(IObjectPrx proxy, bool isReplicaGroup)
+        {
+            if (isReplicaGroup)
+            {
+                _proxies.Add(proxy);
+                if (_latency == 0)
+                {
+                    _latency = (long)((DateTime.Now.Ticks - _start) * Lookup.LatencyMultiplier / 10000.0);
+                    if (_latency == 0)
+                    {
+                        _latency = 1; // 1ms
+                    }
+                    Lookup.Timer.Cancel(this);
+                    Lookup.Timer.Schedule(this, _latency);
+                }
+                return false;
+            }
+            Finished(proxy);
+            return true;
+        }
+
+        public override bool Retry() => _proxies.Count == 0 && --RetryCount >= 0;
+
         public void RunTimerTask() => Lookup.AdapterRequestTimedOut(this);
 
         protected override async Task InvokeWithLookup(string domainId, ILookupPrx lookup, ILookupReplyPrx lookupReply)
@@ -147,56 +95,16 @@ namespace ZeroC.IceDiscovery
             }
             Callbacks.Clear();
         }
-
-        //
-        // We use a HashSet because the same IceDiscovery plugin might return multiple times
-        // the same proxy if it's accessible through multiple network interfaces and if we
-        // also sent the request to multiple interfaces.
-        //
-        private readonly HashSet<IObjectPrx> _proxies = new HashSet<IObjectPrx>();
-        private readonly long _start;
-        private long _latency;
-    }
-
-    internal class ObjectRequest : Request<Identity>, ITimerTask
-    {
-        public ObjectRequest(Lookup lookup, Identity id, int retryCount)
-            : base(lookup, id, retryCount)
-        {
-        }
-
-        public void Response(IObjectPrx proxy) => Finished(proxy);
-
-        public override void Finished(IObjectPrx? proxy)
-        {
-            foreach (TaskCompletionSource<IObjectPrx?> cb in Callbacks)
-            {
-                cb.SetResult(proxy);
-            }
-            Callbacks.Clear();
-        }
-
-        public void RunTimerTask() => Lookup.ObjectRequestTimedOut(this);
-
-        protected override async Task InvokeWithLookup(string domainId, ILookupPrx lookup, ILookupReplyPrx lookupReply)
-        {
-            try
-            {
-                await lookup.FindObjectByIdAsync(domainId, Id, lookupReply).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Lookup.ObjectRequestException(this, ex);
-            }
-        }
     }
 
     internal class Lookup : ILookup
     {
+        internal int LatencyMultiplier { get; }
+        internal Timer Timer { get; }
+
         private readonly Dictionary<string, AdapterRequest> _adapterRequests =
             new Dictionary<string, AdapterRequest>();
         private readonly string _domainId;
-        private readonly int _latencyMultiplier;
         private readonly ILookupPrx _lookup;
         private readonly Dictionary<ILookupPrx, ILookupReplyPrx?> _lookups =
             new Dictionary<ILookupPrx, ILookupReplyPrx?>();
@@ -206,58 +114,7 @@ namespace ZeroC.IceDiscovery
         private readonly LocatorRegistry _registry;
         private readonly int _retryCount;
         private readonly int _timeout;
-        private readonly Timer _timer;
         private bool _warnOnce = true;
-
-        public Lookup(LocatorRegistry registry, ILookupPrx lookup, Communicator communicator)
-        {
-            _registry = registry;
-            _lookup = lookup;
-            _timeout = communicator.GetPropertyAsInt("IceDiscovery.Timeout") ?? 300;
-            _retryCount = communicator.GetPropertyAsInt("IceDiscovery.RetryCount") ?? 3;
-            _latencyMultiplier = communicator.GetPropertyAsInt("IceDiscovery.LatencyMultiplier") ?? 1;
-            _domainId = communicator.GetProperty("IceDiscovery.DomainId") ?? "";
-            _timer = lookup.Communicator.Timer();
-
-            //
-            // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
-            // datagram on each endpoint.
-            //
-            var single = new Endpoint[1];
-            foreach (Endpoint endpt in lookup.Endpoints)
-            {
-                single[0] = endpt;
-                _lookups[lookup.Clone(endpoints: single)] = null;
-            }
-            Debug.Assert(_lookups.Count > 0);
-        }
-
-        public void SetLookupReply(ILookupReplyPrx lookupReply)
-        {
-            // Use a lookup reply proxy whose address matches the interface used to send multicast datagrams.
-            var single = new Endpoint[1];
-            foreach (ILookupPrx key in _lookups.Keys.ToArray())
-            {
-                var endpoint = (UdpEndpoint)key.Endpoints[0];
-                if (endpoint.McastInterface.Length > 0)
-                {
-                    Endpoint? q = lookupReply.Endpoints.FirstOrDefault(e =>
-                        e is IPEndpoint ipEndpoint && ipEndpoint.Host.Equals(endpoint.McastInterface));
-
-                    if (q != null)
-                    {
-                        single[0] = q;
-                        _lookups[key] = lookupReply.Clone(endpoints: single);
-                    }
-                }
-
-                if (_lookups[key] == null)
-                {
-                    // Fallback: just use the given lookup reply proxy if no matching endpoint found.
-                    _lookups[key] = lookupReply;
-                }
-            }
-        }
 
         public void FindObjectById(string domainId, Identity id, ILookupReplyPrx? reply, Current current)
         {
@@ -277,7 +134,7 @@ namespace ZeroC.IceDiscovery
                     Debug.Assert(reply != null);
                     reply.FoundObjectByIdAsync(id, proxy);
                 }
-                catch (Exception)
+                catch
                 {
                     // Ignore.
                 }
@@ -309,31 +166,83 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal ValueTask<IObjectPrx?> FindObject(Identity id)
+        internal Lookup(LocatorRegistry registry, ILookupPrx lookup, Communicator communicator)
+        {
+            _registry = registry;
+            _lookup = lookup;
+            _timeout = communicator.GetPropertyAsInt("IceDiscovery.Timeout") ?? 300;
+            _retryCount = communicator.GetPropertyAsInt("IceDiscovery.RetryCount") ?? 3;
+            LatencyMultiplier = communicator.GetPropertyAsInt("IceDiscovery.LatencyMultiplier") ?? 1;
+            _domainId = communicator.GetProperty("IceDiscovery.DomainId") ?? "";
+            Timer = lookup.Communicator.Timer();
+
+            //
+            // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
+            // datagram on each endpoint.
+            //
+            var single = new Endpoint[1];
+            foreach (Endpoint endpt in lookup.Endpoints)
+            {
+                single[0] = endpt;
+                _lookups[lookup.Clone(endpoints: single)] = null;
+            }
+            Debug.Assert(_lookups.Count > 0);
+        }
+
+        internal void AdapterRequestException(AdapterRequest request, Exception ex)
         {
             lock (_mutex)
             {
-                if (!_objectRequests.TryGetValue(id, out ObjectRequest? request))
+                if (!_adapterRequests.TryGetValue(request.Id, out AdapterRequest? r) || r != request)
                 {
-                    request = new ObjectRequest(this, id, _retryCount);
-                    _objectRequests.Add(id, request);
+                    return;
                 }
 
-                var task = new TaskCompletionSource<IObjectPrx?>();
-                if (request.AddCallback(task))
+                if (request.Exception())
+                {
+                    if (_warnOnce)
+                    {
+                        var s = new StringBuilder();
+                        s.Append("failed to lookup adapter `");
+                        s.Append(request.Id);
+                        s.Append("' with lookup proxy `");
+                        s.Append(_lookup);
+                        s.Append("':\n");
+                        s.Append(ex.ToString());
+                        _lookup.Communicator.Logger.Warning(s.ToString());
+                        _warnOnce = false;
+                    }
+                    Timer.Cancel(request);
+                    _adapterRequests.Remove(request.Id);
+                }
+            }
+        }
+
+        internal void AdapterRequestTimedOut(AdapterRequest request)
+        {
+            lock (_mutex)
+            {
+                if (!_adapterRequests.TryGetValue(request.Id, out AdapterRequest? r) || r != request)
+                {
+                    return;
+                }
+
+                if (request.Retry())
                 {
                     try
                     {
                         request.Invoke(_domainId, _lookups);
-                        _timer.Schedule(request, _timeout);
+                        Timer.Schedule(request, _timeout);
+                        return;
                     }
                     catch (Exception)
                     {
-                        request.Finished(null);
-                        _objectRequests.Remove(id);
                     }
                 }
-                return new ValueTask<IObjectPrx?>(task.Task);
+
+                request.Finished(null);
+                _adapterRequests.Remove(request.Id);
+                Timer.Cancel(request);
             }
         }
 
@@ -353,7 +262,7 @@ namespace ZeroC.IceDiscovery
                     try
                     {
                         request.Invoke(_domainId, _lookups);
-                        _timer.Schedule(request, _timeout);
+                        Timer.Schedule(request, _timeout);
                     }
                     catch (Exception)
                     {
@@ -365,17 +274,31 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal void FoundObject(Identity id, string requestId, IObjectPrx proxy)
+        internal ValueTask<IObjectPrx?> FindObject(Identity id)
         {
             lock (_mutex)
             {
-                if (_objectRequests.TryGetValue(id, out ObjectRequest? request) && request.GetRequestId() == requestId)
+                if (!_objectRequests.TryGetValue(id, out ObjectRequest? request))
                 {
-                    request.Response(proxy);
-                    _timer.Cancel(request);
-                    _objectRequests.Remove(id);
+                    request = new ObjectRequest(this, id, _retryCount);
+                    _objectRequests.Add(id, request);
                 }
-                // else ignore responses from old requests
+
+                var task = new TaskCompletionSource<IObjectPrx?>();
+                if (request.AddCallback(task))
+                {
+                    try
+                    {
+                        request.Invoke(_domainId, _lookups);
+                        Timer.Schedule(request, _timeout);
+                    }
+                    catch (Exception)
+                    {
+                        request.Finished(null);
+                        _objectRequests.Remove(id);
+                    }
+                }
+                return new ValueTask<IObjectPrx?>(task.Task);
             }
         }
 
@@ -383,43 +306,29 @@ namespace ZeroC.IceDiscovery
         {
             lock (_mutex)
             {
-                if (_adapterRequests.TryGetValue(adapterId, out AdapterRequest? request) && request.GetRequestId() == requestId)
+                if (_adapterRequests.TryGetValue(adapterId, out AdapterRequest? request) && request.RequestId == requestId)
                 {
                     if (request.Response(proxy, isReplicaGroup))
                     {
-                        _timer.Cancel(request);
-                        _adapterRequests.Remove(request.GetId());
+                        Timer.Cancel(request);
+                        _adapterRequests.Remove(request.Id);
                     }
                 }
                 // else ignore responses from old requests
             }
         }
 
-        internal void ObjectRequestTimedOut(ObjectRequest request)
+        internal void FoundObject(Identity id, string requestId, IObjectPrx proxy)
         {
             lock (_mutex)
             {
-                if (!_objectRequests.TryGetValue(request.GetId(), out ObjectRequest? r) || r != request)
+                if (_objectRequests.TryGetValue(id, out ObjectRequest? request) && request.RequestId == requestId)
                 {
-                    return;
+                    request.Response(proxy);
+                    Timer.Cancel(request);
+                    _objectRequests.Remove(id);
                 }
-
-                if (request.Retry())
-                {
-                    try
-                    {
-                        request.Invoke(_domainId, _lookups);
-                        _timer.Schedule(request, _timeout);
-                        return;
-                    }
-                    catch (Exception)
-                    {
-                    }
-                }
-
-                request.Finished(null);
-                _objectRequests.Remove(request.GetId());
-                _timer.Cancel(request);
+                // else ignore responses from old requests
             }
         }
 
@@ -427,7 +336,7 @@ namespace ZeroC.IceDiscovery
         {
             lock (_mutex)
             {
-                if (!_objectRequests.TryGetValue(request.GetId(), out ObjectRequest? r) || r != request)
+                if (!_objectRequests.TryGetValue(request.Id, out ObjectRequest? r) || r != request)
                 {
                     return;
                 }
@@ -438,7 +347,7 @@ namespace ZeroC.IceDiscovery
                     {
                         var s = new StringBuilder();
                         s.Append("failed to lookup object `");
-                        s.Append(request.GetId().ToString(_lookup.Communicator.ToStringMode));
+                        s.Append(request.Id.ToString(_lookup.Communicator.ToStringMode));
                         s.Append("' with lookup proxy `");
                         s.Append(_lookup);
                         s.Append("':\n");
@@ -446,17 +355,17 @@ namespace ZeroC.IceDiscovery
                         _lookup.Communicator.Logger.Warning(s.ToString());
                         _warnOnce = false;
                     }
-                    _timer.Cancel(request);
-                    _objectRequests.Remove(request.GetId());
+                    Timer.Cancel(request);
+                    _objectRequests.Remove(request.Id);
                 }
             }
         }
 
-        internal void AdapterRequestTimedOut(AdapterRequest request)
+        internal void ObjectRequestTimedOut(ObjectRequest request)
         {
             lock (_mutex)
             {
-                if (!_adapterRequests.TryGetValue(request.GetId(), out AdapterRequest? r) || r != request)
+                if (!_objectRequests.TryGetValue(request.Id, out ObjectRequest? r) || r != request)
                 {
                     return;
                 }
@@ -466,7 +375,7 @@ namespace ZeroC.IceDiscovery
                     try
                     {
                         request.Invoke(_domainId, _lookups);
-                        _timer.Schedule(request, _timeout);
+                        Timer.Schedule(request, _timeout);
                         return;
                     }
                     catch (Exception)
@@ -475,43 +384,37 @@ namespace ZeroC.IceDiscovery
                 }
 
                 request.Finished(null);
-                _adapterRequests.Remove(request.GetId());
-                _timer.Cancel(request);
+                _objectRequests.Remove(request.Id);
+                Timer.Cancel(request);
             }
         }
 
-        internal void AdapterRequestException(AdapterRequest request, Exception ex)
+        internal void SetLookupReply(ILookupReplyPrx lookupReply)
         {
-            lock (_mutex)
+            // Use a lookup reply proxy whose address matches the interface used to send multicast datagrams.
+            var single = new Endpoint[1];
+            foreach (ILookupPrx key in _lookups.Keys.ToArray())
             {
-                if (!_adapterRequests.TryGetValue(request.GetId(), out AdapterRequest? r) || r != request)
+                var endpoint = (UdpEndpoint)key.Endpoints[0];
+                if (endpoint.McastInterface.Length > 0)
                 {
-                    return;
+                    Endpoint? q = lookupReply.Endpoints.FirstOrDefault(e =>
+                        e is IPEndpoint ipEndpoint && ipEndpoint.Host.Equals(endpoint.McastInterface));
+
+                    if (q != null)
+                    {
+                        single[0] = q;
+                        _lookups[key] = lookupReply.Clone(endpoints: single);
+                    }
                 }
 
-                if (request.Exception())
+                if (_lookups[key] == null)
                 {
-                    if (_warnOnce)
-                    {
-                        var s = new StringBuilder();
-                        s.Append("failed to lookup adapter `");
-                        s.Append(request.GetId());
-                        s.Append("' with lookup proxy `");
-                        s.Append(_lookup);
-                        s.Append("':\n");
-                        s.Append(ex.ToString());
-                        _lookup.Communicator.Logger.Warning(s.ToString());
-                        _warnOnce = false;
-                    }
-                    _timer.Cancel(request);
-                    _adapterRequests.Remove(request.GetId());
+                    // Fallback: just use the given lookup reply proxy if no matching endpoint found.
+                    _lookups[key] = lookupReply;
                 }
             }
         }
-
-        internal Timer Timer() => _timer;
-
-        internal int LatencyMultiplier() => _latencyMultiplier;
     }
 
     internal class LookupReply : ILookupReply
@@ -520,10 +423,97 @@ namespace ZeroC.IceDiscovery
 
         public LookupReply(Lookup lookup) => _lookup = lookup;
 
-        public void FoundObjectById(Identity id, IObjectPrx? proxy, Current c)
-            => _lookup.FoundObject(id, c.Identity.Name, proxy!); // proxy cannot be null
+        public void FoundObjectById(Identity id, IObjectPrx? proxy, Current c) =>
+            _lookup.FoundObject(id, c.Identity.Name, proxy!); // proxy cannot be null
 
         public void FoundAdapterById(string adapterId, IObjectPrx? proxy, bool isReplicaGroup, Current c) =>
             _lookup.FoundAdapter(adapterId, c.Identity.Name, proxy!, isReplicaGroup); // proxy cannot be null
+    }
+
+    internal class ObjectRequest : Request<Identity>, ITimerTask
+    {
+        public void Response(IObjectPrx proxy) => Finished(proxy);
+
+        public override void Finished(IObjectPrx? proxy)
+        {
+            foreach (TaskCompletionSource<IObjectPrx?> cb in Callbacks)
+            {
+                cb.SetResult(proxy);
+            }
+            Callbacks.Clear();
+        }
+
+        public void RunTimerTask() => Lookup.ObjectRequestTimedOut(this);
+
+        protected override async Task InvokeWithLookup(string domainId, ILookupPrx lookup, ILookupReplyPrx lookupReply)
+        {
+            try
+            {
+                await lookup.FindObjectByIdAsync(domainId, Id, lookupReply).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Lookup.ObjectRequestException(this, ex);
+            }
+        }
+
+        internal ObjectRequest(Lookup lookup, Identity id, int retryCount)
+            : base(lookup, id, retryCount)
+        {
+        }
+
+    }
+
+    internal abstract class Request<T>
+    {
+        public T Id { get; }
+        public string RequestId { get; }
+
+        protected List<TaskCompletionSource<IObjectPrx?>> Callbacks = new List<TaskCompletionSource<IObjectPrx?>>();
+        protected int FailureCount;
+        protected Lookup Lookup;
+        protected int LookupCount;
+        protected int RetryCount;
+
+        public bool AddCallback(TaskCompletionSource<IObjectPrx?> cb)
+        {
+            Callbacks.Add(cb);
+            return Callbacks.Count == 1;
+        }
+
+        public bool Exception()
+        {
+            if (++FailureCount == LookupCount)
+            {
+                Finished(null);
+                return true;
+            }
+            return false;
+        }
+
+        public abstract void Finished(IObjectPrx? proxy);
+
+        public void Invoke(string domainId, Dictionary<ILookupPrx, ILookupReplyPrx?> lookups)
+        {
+            LookupCount = lookups.Count;
+            FailureCount = 0;
+            var identity = new Identity(RequestId, "");
+            foreach (KeyValuePair<ILookupPrx, ILookupReplyPrx?> entry in lookups)
+            {
+                InvokeWithLookup(domainId, entry.Key, entry.Value!.Clone(identity, ILookupReplyPrx.Factory));
+            }
+        }
+
+        public virtual bool Retry() => --RetryCount >= 0;
+
+        protected Request(Lookup lookup, T id, int retryCount)
+        {
+            Lookup = lookup;
+            RetryCount = retryCount;
+            Id = id;
+            RequestId = Guid.NewGuid().ToString();
+        }
+
+        protected abstract Task InvokeWithLookup(string domainId, ILookupPrx lookup, ILookupReplyPrx lookupReply);
     }
 }

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -9,14 +9,6 @@ using ZeroC.Ice;
 
 namespace ZeroC.IceDiscovery
 {
-    public sealed class PluginFactory : IPluginFactory
-    {
-        public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(communicator);
-
-        public static void Register(bool loadOnInitialize) =>
-            Communicator.RegisterPluginFactory("IceDiscovery", new PluginFactory(), loadOnInitialize);
-    }
-
     internal sealed class Plugin : IPlugin
     {
         private readonly Communicator _communicator;
@@ -25,8 +17,6 @@ namespace ZeroC.IceDiscovery
         private ILocatorPrx? _locator;
         private ObjectAdapter? _locatorAdapter;
         private ObjectAdapter? _replyAdapter;
-
-        public Plugin(Communicator communicator) => _communicator = communicator;
 
         public void Destroy()
         {
@@ -129,5 +119,15 @@ namespace ZeroC.IceDiscovery
             _replyAdapter.Activate();
             _locatorAdapter.Activate();
         }
+
+        internal Plugin(Communicator communicator) => _communicator = communicator;
+    }
+
+    public sealed class PluginFactory : IPluginFactory
+    {
+        public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(communicator);
+
+        public static void Register(bool loadOnInitialize) =>
+            Communicator.RegisterPluginFactory("IceDiscovery", new PluginFactory(), loadOnInitialize);
     }
 }

--- a/csharp/src/IceDiscovery/Plugin.cs
+++ b/csharp/src/IceDiscovery/Plugin.cs
@@ -13,9 +13,9 @@ namespace ZeroC.IceDiscovery
     {
         private readonly Communicator _communicator;
         private ILocatorPrx? _defaultLocator;
-        private ObjectAdapter? _multicastAdapter;
         private ILocatorPrx? _locator;
         private ObjectAdapter? _locatorAdapter;
+        private ObjectAdapter? _multicastAdapter;
         private ObjectAdapter? _replyAdapter;
 
         public void Destroy()
@@ -125,9 +125,9 @@ namespace ZeroC.IceDiscovery
 
     public sealed class PluginFactory : IPluginFactory
     {
-        public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(communicator);
-
         public static void Register(bool loadOnInitialize) =>
             Communicator.RegisterPluginFactory("IceDiscovery", new PluginFactory(), loadOnInitialize);
+
+        public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(communicator);
     }
 }


### PR DESCRIPTION
This PR do some minor cleanup of the IceDiscovery plug-in:

- Sort the properties methods
- Replace `lock (this)` with `lock (_mutex)`
- Remove the Util class and place the static Register method in the plugin factory
- make the plug-in class internal, only the factory needs to be public visible for this plug-in