### PR TITLE
Fix Communicator to not use lock (this) pattern

### DIFF
--- a/csharp/src/Ice/Communicator-LocatorManager.cs
+++ b/csharp/src/Ice/Communicator-LocatorManager.cs
@@ -112,6 +112,7 @@ namespace ZeroC.Ice
         {
             protected readonly LocatorInfo LocatorInfo;
             protected readonly Reference Ref;
+            protected readonly object _mutex = new object();
 
             private readonly List<RequestCallback> _callbacks = new List<RequestCallback>();
             private Exception? _exception;
@@ -131,7 +132,7 @@ namespace ZeroC.Ice
             internal void AddCallback(Reference reference, Reference? wellKnownRef, int ttl, IGetEndpointsCallback? cb)
             {
                 var callback = new RequestCallback(reference, ttl, cb);
-                lock (this)
+                lock (_mutex)
                 {
                     if (!_response && _exception == null)
                     {
@@ -163,12 +164,12 @@ namespace ZeroC.Ice
 
             internal void Response(IObjectPrx? proxy)
             {
-                lock (this)
+                lock (_mutex)
                 {
                     LocatorInfo.FinishRequest(Ref, _wellKnownRefs, proxy, false);
                     _response = true;
                     _proxy = proxy;
-                    Monitor.PulseAll(this);
+                    Monitor.PulseAll(_mutex);
                 }
                 foreach (RequestCallback callback in _callbacks)
                 {
@@ -176,13 +177,13 @@ namespace ZeroC.Ice
                 }
             }
 
-            internal void Exception(System.Exception ex)
+            internal void Exception(Exception ex)
             {
-                lock (this)
+                lock (_mutex)
                 {
                     LocatorInfo.FinishRequest(Ref, _wellKnownRefs, null, ex is RemoteException);
                     _exception = ex;
-                    Monitor.PulseAll(this);
+                    Monitor.PulseAll(_mutex);
                 }
                 foreach (RequestCallback callback in _callbacks)
                 {
@@ -268,7 +269,7 @@ namespace ZeroC.Ice
 
         internal void Destroy()
         {
-            lock (this)
+            lock (_mutex)
             {
                 _locatorRegistry = null;
                 _table.Clear();
@@ -292,7 +293,7 @@ namespace ZeroC.Ice
 
         internal ILocatorRegistryPrx? GetLocatorRegistry()
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_locatorRegistry != null)
                 {
@@ -309,7 +310,7 @@ namespace ZeroC.Ice
                 return null;
             }
 
-            lock (this)
+            lock (_mutex)
             {
                 //
                 // The locator registry can't be located. We use ordered
@@ -519,7 +520,7 @@ namespace ZeroC.Ice
                 communicator.Logger.Trace(communicator.TraceLevels.LocationCat, s.ToString());
             }
 
-            lock (this)
+            lock (_mutex)
             {
                 if (_adapterRequests.TryGetValue(reference.AdapterId, out Request? request))
                 {
@@ -543,7 +544,7 @@ namespace ZeroC.Ice
                 communicator.Logger.Trace(communicator.TraceLevels.LocationCat, s.ToString());
             }
 
-            lock (this)
+            lock (_mutex)
             {
                 if (_objectRequests.TryGetValue(reference.Identity, out Request? request))
                 {
@@ -583,7 +584,7 @@ namespace ZeroC.Ice
                     _table.RemoveAdapterEndpoints(reference.AdapterId);
                 }
 
-                lock (this)
+                lock (_mutex)
                 {
                     Debug.Assert(_adapterRequests.ContainsKey(reference.AdapterId));
                     _adapterRequests.Remove(reference.AdapterId);
@@ -604,7 +605,7 @@ namespace ZeroC.Ice
                     _table.RemoveObjectReference(reference.Identity);
                 }
 
-                lock (this)
+                lock (_mutex)
                 {
                     Debug.Assert(_objectRequests.ContainsKey(reference.Identity));
                     _objectRequests.Remove(reference.Identity);
@@ -617,6 +618,7 @@ namespace ZeroC.Ice
         private readonly bool _background;
 
         private readonly Dictionary<string, Request> _adapterRequests = new Dictionary<string, Request>();
+        private readonly object _mutex = new object();
         private readonly Dictionary<Identity, Request> _objectRequests = new Dictionary<Identity, Request>();
     }
 
@@ -686,7 +688,7 @@ namespace ZeroC.Ice
     {
         internal void Clear()
         {
-            lock (this)
+            lock (_mutex)
             {
                 _adapterEndpointsTable.Clear();
                 _objectTable.Clear();
@@ -701,7 +703,7 @@ namespace ZeroC.Ice
                 return null;
             }
 
-            lock (this)
+            lock (_mutex)
             {
                 if (_adapterEndpointsTable.TryGetValue(adapter,
                     out (long Time, IReadOnlyList<Endpoint> Endpoints) entry))
@@ -716,7 +718,7 @@ namespace ZeroC.Ice
 
         internal void AddAdapterEndpoints(string adapter, IReadOnlyList<Endpoint> endpoints)
         {
-            lock (this)
+            lock (_mutex)
             {
                 _adapterEndpointsTable[adapter] = (Time.CurrentMonotonicTimeMillis(), endpoints);
             }
@@ -724,7 +726,7 @@ namespace ZeroC.Ice
 
         internal IReadOnlyList<Endpoint>? RemoveAdapterEndpoints(string adapter)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_adapterEndpointsTable.TryGetValue(adapter,
                     out (long Time, IReadOnlyList<Endpoint> Endpoints) entry))
@@ -744,7 +746,7 @@ namespace ZeroC.Ice
                 return null;
             }
 
-            lock (this)
+            lock (_mutex)
             {
                 if (_objectTable.TryGetValue(id, out (long Time, Reference Reference) entry))
                 {
@@ -758,7 +760,7 @@ namespace ZeroC.Ice
 
         internal void AddObjectReference(Identity id, Reference reference)
         {
-            lock (this)
+            lock (_mutex)
             {
                 _objectTable[id] = (Time.CurrentMonotonicTimeMillis(), reference);
             }
@@ -766,7 +768,7 @@ namespace ZeroC.Ice
 
         internal Reference? RemoveObjectReference(Identity id)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_objectTable.TryGetValue(id, out (long Time, Reference Reference) entry))
                 {
@@ -804,6 +806,7 @@ namespace ZeroC.Ice
 
         private readonly Dictionary<string, (long Time, IReadOnlyList<Endpoint> Endpoints)> _adapterEndpointsTable =
             new Dictionary<string, (long Time, IReadOnlyList<Endpoint> Endpoints)>();
+        private readonly object _mutex = new object();
         private readonly Dictionary<Identity, (long Time, Reference Reference)> _objectTable =
             new Dictionary<Identity, (long Time, Reference Reference)>();
     }

--- a/csharp/src/Ice/Communicator-PluginManager.cs
+++ b/csharp/src/Ice/Communicator-PluginManager.cs
@@ -9,15 +9,10 @@ using System.Linq;
 
 namespace ZeroC.Ice
 {
-    /// <summary>
-    /// Applications implement this interface to provide a plug-in factory
-    /// to the Ice run time.
-    /// </summary>
+    /// <summary>Applications implement this interface to provide a plug-in factory to the Ice run time.</summary>
     public interface IPluginFactory
     {
-        /// <summary>
-        /// Called by the Ice run time to create a new plug-in.
-        /// </summary>
+        /// <summary>Called by the Ice run time to create a new plug-in.</summary>
         ///
         /// <param name="communicator">The communicator that is in the process of being initialized.</param>
         /// <param name="name">The name of the plug-in.</param>
@@ -59,7 +54,7 @@ namespace ZeroC.Ice
                     initializedPlugins.Add(plugin);
                 }
             }
-            catch (System.Exception)
+            catch (Exception)
             {
                 //
                 // Destroy the plug-ins that have been successfully initialized, in the
@@ -72,7 +67,7 @@ namespace ZeroC.Ice
                     {
                         p.Destroy();
                     }
-                    catch (System.Exception)
+                    catch (Exception)
                     {
                         // Ignore.
                     }
@@ -86,7 +81,7 @@ namespace ZeroC.Ice
 
         public string[] GetPlugins()
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_state == StateDestroyed)
                 {
@@ -99,7 +94,7 @@ namespace ZeroC.Ice
 
         public IPlugin? GetPlugin(string name)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_state == StateDestroyed)
                 {
@@ -112,7 +107,7 @@ namespace ZeroC.Ice
 
         public void AddPlugin(string name, IPlugin plugin)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_state == StateDestroyed)
                 {

--- a/csharp/src/Ice/Communicator-RouterManager.cs
+++ b/csharp/src/Ice/Communicator-RouterManager.cs
@@ -25,7 +25,7 @@ namespace ZeroC.Ice
 
         public void Destroy()
         {
-            lock (this)
+            lock (_mutex)
             {
                 _clientEndpoints = System.Array.Empty<Endpoint>();
                 _adapter = null;
@@ -258,11 +258,12 @@ namespace ZeroC.Ice
             }
         }
 
-        private IReadOnlyList<Endpoint>? _clientEndpoints;
         private ObjectAdapter? _adapter;
-        private readonly HashSet<Identity> _identities = new HashSet<Identity>();
+        private IReadOnlyList<Endpoint>? _clientEndpoints;
         private readonly List<Identity> _evictedIdentities = new List<Identity>();
         private bool _hasRoutingTable;
+        private readonly HashSet<Identity> _identities = new HashSet<Identity>();
+        private readonly object _mutex = new object();
     }
 
     public sealed partial class Communicator

--- a/csharp/src/Ice/Communicator-RouterManager.cs
+++ b/csharp/src/Ice/Communicator-RouterManager.cs
@@ -40,7 +40,7 @@ namespace ZeroC.Ice
                 return true;
             }
 
-            return !(obj is RouterInfo rhs) ? false : Router.Equals(rhs.Router);
+            return obj is RouterInfo rhs && Router.Equals(rhs.Router);
         }
 
         public override int GetHashCode() => Router.GetHashCode();
@@ -50,7 +50,7 @@ namespace ZeroC.Ice
 
         public IReadOnlyList<Endpoint> GetClientEndpoints()
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_clientEndpoints != null) // Lazy initialization.
                 {
@@ -65,7 +65,7 @@ namespace ZeroC.Ice
         public void GetClientEndpoints(IGetClientEndpointsCallback callback)
         {
             IReadOnlyList<Endpoint>? clientEndpoints = null;
-            lock (this)
+            lock (_mutex)
             {
                 clientEndpoints = _clientEndpoints;
             }
@@ -107,7 +107,7 @@ namespace ZeroC.Ice
         public void AddProxy(IObjectPrx proxy)
         {
             Debug.Assert(proxy != null);
-            lock (this)
+            lock (_mutex)
             {
                 if (_identities.Contains(proxy.Identity))
                 {
@@ -124,7 +124,7 @@ namespace ZeroC.Ice
         public bool AddProxy(IObjectPrx proxy, IAddProxyCallback callback)
         {
             Debug.Assert(proxy != null);
-            lock (this)
+            lock (_mutex)
             {
                 if (!_hasRoutingTable)
                 {
@@ -160,14 +160,14 @@ namespace ZeroC.Ice
         {
             get
             {
-                lock (this)
+                lock (_mutex)
                 {
                     return _adapter;
                 }
             }
             set
             {
-                lock (this)
+                lock (_mutex)
                 {
                     _adapter = value;
                 }
@@ -176,7 +176,7 @@ namespace ZeroC.Ice
 
         public void ClearCache(Reference reference)
         {
-            lock (this)
+            lock (_mutex)
             {
                 _identities.Remove(reference.Identity);
             }
@@ -184,7 +184,7 @@ namespace ZeroC.Ice
 
         private IReadOnlyList<Endpoint> SetClientEndpoints(IObjectPrx clientProxy, bool hasRoutingTable)
         {
-            lock (this)
+            lock (_mutex)
             {
                 if (_clientEndpoints == null)
                 {
@@ -219,7 +219,7 @@ namespace ZeroC.Ice
 
         private void AddAndEvictProxies(IObjectPrx proxy, IObjectPrx[] evictedProxies)
         {
-            lock (this)
+            lock (_mutex)
             {
                 //
                 // Check if the proxy hasn't already been evicted by a


### PR DESCRIPTION
This small PR just replace the `lock (this)` pattern usage in Communicator implementation with `lock (_mutex)`