### PR TITLE
sequence<T?> marshaling in C#

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4303,8 +4303,20 @@ Slice::Optional::usesClasses() const
 size_t
 Slice::Optional::minWireSize() const
 {
-    // TODO: should be 2 for proxies with the 1.1 encoding
-    return 1;
+    // Should only be called for classes and proxies.
+    if (_underlying->isClassType())
+    {
+        return 1;
+    }
+    else if (_underlying->isInterfaceType())
+    {
+        return 2;
+    }
+    else
+    {
+        assert(0);
+        return 0;
+    }
 }
 
 string

--- a/csharp/src/Ice/BitSequence.cs
+++ b/csharp/src/Ice/BitSequence.cs
@@ -8,6 +8,7 @@ using System.Text;
 namespace ZeroC.Ice
 {
     /// <summary>Presents one or two <see cref="Span{T}"/> of bytes as a continuous sequence of bits.</summary>
+    // BitSequence must be a ref struct as it holds two Span<byte>, and Span<T> is a ref struct.
     public readonly ref struct BitSequence
     {
         /// <summary>The first underlying span of bytes.</summary>

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -30,9 +30,10 @@ namespace ZeroC.Ice
         public static readonly InputStreamReader<bool> IceReaderIntoBool =
             istr => istr.ReadBool();
 
+        // TODO: rename to IceReaderIntoArrayOfBool etc.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<bool[]> IceReaderIntoBoolArray =
-            istr => istr.ReadFixedSizeNumericArray<bool>();
+            istr => istr.ReadFixedSizeNumericValueArray<bool>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<byte> IceReaderIntoByte =
@@ -40,7 +41,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<byte[]> IceReaderIntoByteArray =
-            istr => istr.ReadFixedSizeNumericArray<byte>();
+            istr => istr.ReadFixedSizeNumericValueArray<byte>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<double> IceReaderIntoDouble =
@@ -48,7 +49,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<double[]> IceReaderIntoDoubleArray =
-            istr => istr.ReadFixedSizeNumericArray<double>();
+            istr => istr.ReadFixedSizeNumericValueArray<double>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<float> IceReaderIntoFloat =
@@ -56,7 +57,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<float[]> IceReaderIntoFloatArray =
-            istr => istr.ReadFixedSizeNumericArray<float>();
+            istr => istr.ReadFixedSizeNumericValueArray<float>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<int> IceReaderIntoInt =
@@ -64,7 +65,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<int[]> IceReaderIntoIntArray =
-            istr => istr.ReadFixedSizeNumericArray<int>();
+            istr => istr.ReadFixedSizeNumericValueArray<int>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<long> IceReaderIntoLong =
@@ -72,7 +73,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<long[]> IceReaderIntoLongArray =
-            istr => istr.ReadFixedSizeNumericArray<long>();
+            istr => istr.ReadFixedSizeNumericValueArray<long>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<short> IceReaderIntoShort =
@@ -80,7 +81,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<short[]> IceReaderIntoShortArray =
-            istr => istr.ReadFixedSizeNumericArray<short>();
+            istr => istr.ReadFixedSizeNumericValueArray<short>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<string> IceReaderIntoString =
@@ -92,7 +93,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<uint[]> IceReaderIntoUIntArray =
-            istr => istr.ReadFixedSizeNumericArray<uint>();
+            istr => istr.ReadFixedSizeNumericValueArray<uint>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<ulong> IceReaderIntoULong =
@@ -100,7 +101,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<ulong[]> IceReaderIntoULongArray =
-            istr => istr.ReadFixedSizeNumericArray<ulong>();
+            istr => istr.ReadFixedSizeNumericValueArray<ulong>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<ushort> IceReaderIntoUShort =
@@ -108,7 +109,7 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<ushort[]> IceReaderIntoUShortArray =
-            istr => istr.ReadFixedSizeNumericArray<ushort>();
+            istr => istr.ReadFixedSizeNumericValueArray<ushort>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<int> IceReaderIntoVarInt =
@@ -363,6 +364,31 @@ namespace ZeroC.Ice
             return array;
         }
 
+        /// <summary>Reads a sequence of optional types from the stream and returns an array. These types correspond to
+        /// C# reference types other than mapped Slice classes and proxies, for example string, Dictionary{int},
+        /// Array{long}.</summary>
+        /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
+        /// <returns>The sequence read from the stream, as an array.</returns>
+        public T?[] ReadOptionalElementArray<T>(InputStreamReader<T> reader) where T : class
+        {
+            ICollection<T?> collection = ReadOptionalElementSequence(reader);
+            var array = new T?[collection.Count];
+            collection.CopyTo(array, 0);
+            return array;
+        }
+
+        /// <summary>Reads a sequence of optional types from the stream and returns an array. These types correspond to
+        /// value types such as int, struct, enum.</summary>
+        /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
+        /// <returns>The sequence read from the stream, as an array.</returns>
+        public T?[] ReadOptionalValueArray<T>(InputStreamReader<T> reader) where T : struct
+        {
+            ICollection<T?> collection = ReadOptionalValueSequence(reader);
+            var array = new T?[collection.Count];
+            collection.CopyTo(array, 0);
+            return array;
+        }
+
         /// <summary>Reads a dictionary from the stream.</summary>
         /// <param name="minEntrySize">The minimum size of each entry of the dictionary, in bytes.</param>
         /// <param name="keyReader">The input stream reader used to read each key of the dictionary.</param>
@@ -388,9 +414,9 @@ namespace ZeroC.Ice
         /// <returns>The enum value (int) read from the stream.</returns>
         public int ReadEnumValue() => ReadSize();
 
-        /// <summary>Reads a sequence of fixed-size numeric type from the stream and returns an array.</summary>
+        /// <summary>Reads a sequence of fixed-size numeric values from the stream and returns an array.</summary>
         /// <returns>The sequence read from the stream, as an array.</returns>
-        public T[] ReadFixedSizeNumericArray<T>() where T : struct
+        public T[] ReadFixedSizeNumericValueArray<T>() where T : struct
         {
             int elementSize = Unsafe.SizeOf<T>();
             var value = new T[ReadAndCheckSeqSize(elementSize)];
@@ -400,11 +426,32 @@ namespace ZeroC.Ice
             return value;
         }
 
+        /// <summary>Reads a sequence of optional elements from the stream. The element type is a reference type,
+        /// however, use <see cref="ReadSequence"/> for reading a sequence of optional class or optional proxy.
+        /// </summary>
+        /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
+        /// <returns>A collection that provides the size of the sequence and allows you read the sequence from the
+        /// the stream. The returned collection does not fully implement ICollection{T?}, in particular you can only
+        /// call GetEnumerator() once on this collection. You would typically use this collection to construct a
+        /// List{T?} or some other generic collection that can be constructed from an IEnumerable{T?}.</returns>
+        public ICollection<T?> ReadOptionalElementSequence<T>(InputStreamReader<T> reader) where T : class =>
+            new OptionalElementCollection<T>(this, reader);
+
         /// <summary>Reads an optional proxy from the stream.</summary>
         /// <param name="factory">The proxy factory used to create the typed proxy.</param>
         /// <returns>The proxy read from the stream, or null.</returns>
         public T? ReadOptionalProxy<T>(ProxyFactory<T> factory) where T : class, IObjectPrx =>
             Reference.Read(this) is Reference reference ? factory(reference) : null;
+
+        /// <summary>Reads a sequence of optional values from the stream.</summary>
+        /// <param name="reader">The input stream reader used to read each non-null element (value) of the sequence.
+        /// </param>
+        /// <returns>A collection that provides the size of the sequence and allows you read the sequence from the
+        /// the stream. The returned collection does not fully implement ICollection{T?}, in particular you can only
+        /// call GetEnumerator() once on this collection. You would typically use this collection to construct a
+        /// List{T?} or some other generic collection that can be constructed from an IEnumerable{T?}.</returns>
+        public ICollection<T?> ReadOptionalValueSequence<T>(InputStreamReader<T> reader) where T : struct =>
+            new OptionalValueCollection<T>(this, reader);
 
         /// <summary>Reads a proxy from the stream.</summary>
         /// <param name="factory">The proxy factory used to create the typed proxy.</param>
@@ -519,48 +566,6 @@ namespace ZeroC.Ice
         public T? ReadTaggedEnum<T>(int tag, InputStreamReader<T> reader) where T : struct, Enum =>
             ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.Size) ? reader(this) : (T?)null;
 
-        /// <summary>Reads a tagged sequence with fixed-size elements from the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="elementSize">The size of each element, in bytes.</param>
-        /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
-        /// <returns>The sequence read from the stream as an array, or null.</returns>
-        public T[]? ReadTaggedFixedSizeElementArray<T>(int tag, int elementSize, InputStreamReader<T> reader)
-        {
-            if (ReadTaggedFixedSizeElementSequence(tag, elementSize, reader) is ICollection<T> collection)
-            {
-                var array = new T[collection.Count];
-                collection.CopyTo(array, 0);
-                return array;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>Reads a tagged sequence with fixed-size elements from the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="elementSize">The size of each element, in bytes.</param>
-        /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
-        /// <returns>The sequence read from the stream as an ICollection{T}, or null.</returns>
-        public ICollection<T>? ReadTaggedFixedSizeElementSequence<T>(int tag,
-                                                                     int elementSize,
-                                                                     InputStreamReader<T> reader)
-        {
-            if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize))
-            {
-                if (elementSize > 1)
-                {
-                    SkipSize(); // this size represents the number of bytes in the tagged parameter.
-                }
-                return ReadSequence(elementSize, reader);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
         /// <summary>Reads a tagged dictionary with fixed-size entries from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="entrySize">The size of each entry, in bytes.</param>
@@ -610,7 +615,7 @@ namespace ZeroC.Ice
         /// <summary>Reads a tagged sequence of a fixed-size numeric type from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <returns>The sequence read from the stream as an array, or null.</returns>
-        public T[]? ReadTaggedFixedSizeNumericArray<T>(int tag) where T : struct
+        public T[]? ReadTaggedFixedSizeNumericValueArray<T>(int tag) where T : struct
         {
             int elementSize = Unsafe.SizeOf<T>();
             if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize))
@@ -621,7 +626,7 @@ namespace ZeroC.Ice
                     // parameter) that we skip.
                     SkipSize();
                 }
-                return ReadFixedSizeNumericArray<T>();
+                return ReadFixedSizeNumericValueArray<T>();
             }
             else
             {
@@ -646,6 +651,26 @@ namespace ZeroC.Ice
             }
         }
 
+        /// <summary>Reads a tagged sequence of fixed-size values from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="elementSize">The size of each value, in bytes.</param>
+        /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
+        /// <returns>The sequence read from the stream as an array, or null.</returns>
+        public T[]? ReadTaggedFixedSizeValueArray<T>(int tag, int elementSize, InputStreamReader<T> reader)
+            where T : struct
+        {
+            if (ReadTaggedFixedSizeValueSequence(tag, elementSize, reader) is ICollection<T> collection)
+            {
+                var array = new T[collection.Count];
+                collection.CopyTo(array, 0);
+                return array;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>Reads a tagged proxy from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="factory">The proxy factory used to create the typed proxy.</param>
@@ -663,13 +688,111 @@ namespace ZeroC.Ice
             }
         }
 
+        /// <summary>Reads a tagged sequence of fixed-size values from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="elementSize">The size of each element, in bytes.</param>
+        /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
+        /// <returns>The sequence read from the stream as an ICollection{T}, or null.</returns>
+        public ICollection<T>? ReadTaggedFixedSizeValueSequence<T>(
+            int tag,
+            int elementSize,
+            InputStreamReader<T> reader) where T : struct
+        {
+            if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize))
+            {
+                if (elementSize > 1)
+                {
+                    SkipSize(); // this size represents the number of bytes in the tagged parameter.
+                }
+                return ReadSequence(elementSize, reader);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Reads a tagged array of optional elements from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="reader">The input stream reader used to read each non-null element of the array.</param>
+        /// <returns>The array read from the stream, or null.</returns>
+        public T?[]? ReadTaggedOptionalElementArray<T>(int tag, InputStreamReader<T> reader)
+            where T : class
+        {
+            if (ReadTaggedOptionalElementSequence(tag, reader) is ICollection<T?> collection)
+            {
+                var array = new T?[collection.Count];
+                collection.CopyTo(array, 0);
+                return array;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Reads a tagged sequence of optional elements from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
+        /// <returns>The sequence read from the stream as an ICollection{T?}, or null.</returns>
+        public ICollection<T?>? ReadTaggedOptionalElementSequence<T>(int tag, InputStreamReader<T> reader)
+            where T : class
+        {
+            if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize))
+            {
+                SkipFixedLengthSize();
+                return ReadOptionalElementSequence(reader);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Reads a tagged array of optional values from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="reader">The input stream reader used to read each non-null value of the array.</param>
+        /// <returns>The array read from the stream, or null.</returns>
+        public T?[]? ReadTaggedOptionalValueArray<T>(int tag, InputStreamReader<T> reader)
+            where T : struct
+        {
+            if (ReadTaggedOptionalValueSequence(tag, reader) is ICollection<T?> collection)
+            {
+                var array = new T?[collection.Count];
+                collection.CopyTo(array, 0);
+                return array;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Reads a tagged sequence of optional values from the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="reader">The input stream reader used to read each non-null value of the sequence.</param>
+        /// <returns>The sequence read from the stream as an ICollection{T?}, or null.</returns>
+        public ICollection<T?>? ReadTaggedOptionalValueSequence<T>(int tag, InputStreamReader<T> reader)
+            where T : struct
+        {
+            if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize))
+            {
+                SkipFixedLengthSize();
+                return ReadOptionalValueSequence(reader);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>Reads a tagged serializable object from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <returns>The object read from the stream, or null.</returns>
         public object? ReadTaggedSerializable(int tag) =>
             ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize) ? ReadSerializable() : null;
 
-        /// <summary>Reads a tagged sequence with variable-size elements from the stream.</summary>
+        /// <summary>Reads a tagged array of variable-size elements from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="minElementSize">The minimum size of each element, in bytes.</param>
         /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
@@ -688,14 +811,15 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Reads a tagged sequence with variable-size elements from the stream.</summary>
+        /// <summary>Reads a tagged sequence of variable-size elements from the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="minElementSize">The minimum size of each element, in bytes.</param>
         /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
         /// <returns>The sequence read from the stream as an ICollection{T}, or null.</returns>
-        public ICollection<T>? ReadTaggedVariableSizeElementSequence<T>(int tag,
-                                                                        int minElementSize,
-                                                                        InputStreamReader<T> reader)
+        public ICollection<T>? ReadTaggedVariableSizeElementSequence<T>(
+            int tag,
+            int minElementSize,
+            InputStreamReader<T> reader)
         {
             if (ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize))
             {
@@ -781,9 +905,9 @@ namespace ZeroC.Ice
         public ReadOnlyBitSequence ReadBitSequence(int bitLength)
         {
             int size = (bitLength >> 3) + ((bitLength & 0x07) != 0 ? 1 : 0);
-            var bitSequence = new ReadOnlyBitSequence(_buffer.AsSpan(_pos, size));
+            int startPos = _pos;
             _pos += size;
-            return bitSequence;
+            return new ReadOnlyBitSequence(_buffer.AsSpan(startPos, size));
         }
 
         internal static string Read11String(ArraySegment<byte> buffer)
@@ -1057,7 +1181,8 @@ namespace ZeroC.Ice
         /// <summary>Reads a sequence size and makes sure there is enough space in the underlying buffer to read the
         /// sequence. This validation is performed to make sure we do not allocate a large container based on an
         /// invalid encoded size.</summary>
-        /// <param name="minElementSize">The minimum encoded size of an element of the sequence, in bytes.</param>
+        /// <param name="minElementSize">The minimum encoded size of an element of the sequence, in bytes. This value is
+        /// 0 for sequence of optional types other than mapped Slice classes and proxies.</param>
         /// <returns>The number of elements in the sequence.</returns>
         private int ReadAndCheckSeqSize(int minElementSize)
         {
@@ -1068,7 +1193,8 @@ namespace ZeroC.Ice
                 return 0;
             }
 
-            int minSize = sz * minElementSize;
+            // When minElementSize is 0, we only count of bytes that hold the bit sequence.
+            int minSize = minElementSize > 0 ? sz * minElementSize : (sz >> 3) + ((sz & 0x07) != 0 ? 1 : 0);
 
             // With _minTotalSeqSize, we make sure that multiple sequences within an InputStream can't trigger
             // maliciously the allocation of a large amount of memory before we read these sequences from the buffer.
@@ -1079,6 +1205,14 @@ namespace ZeroC.Ice
                 throw new InvalidDataException("invalid sequence size");
             }
             return sz;
+        }
+
+        private ReadOnlyMemory<byte> ReadBitSequenceMemory(int bitLength)
+        {
+            int size = (bitLength >> 3) + ((bitLength & 0x07) != 0 ? 1 : 0);
+            int startPos = _pos;
+            _pos += size;
+            return _buffer.AsMemory(startPos, size);
         }
 
         private int ReadSpan(Span<byte> span)
@@ -1259,11 +1393,8 @@ namespace ZeroC.Ice
             }
         }
 
-        // Collection<T> holds the size of a Slice sequence and reads the sequence elements from the InputStream
-        // on-demand. It does not fully implement IEnumerable<T> and ICollection<T> (i.e. some methods throw
-        // NotSupportedException) because it's not resettable: you can't use it to unmarshal the same bytes
-        // multiple times.
-        private sealed class Collection<T> : ICollection<T>, IEnumerator<T>
+        // Helper base class for the concrete collection implementations.
+        private abstract class CollectionBase<T> : ICollection<T>, IEnumerator<T>
         {
             public int Count { get; }
 
@@ -1281,23 +1412,11 @@ namespace ZeroC.Ice
 
             object? IEnumerator.Current => Current;
             public bool IsReadOnly => true;
+            protected readonly InputStream _inputStream;
+            protected int _pos = 0;
 
-            private T _current;
+            protected T _current;
             private bool _enumeratorRetrieved = false;
-            private readonly InputStream _inputStream;
-            private int _pos = 0;
-            private readonly InputStreamReader<T> _reader;
-
-            // Disable this warning as the _current field is never read before it is initialized in MoveNext. Declaring
-            // this field as nullable is not an option for a genericT  that can be used with reference and value types.
-#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
-            internal Collection(InputStream istr, int minElementSize, InputStreamReader<T> reader)
-#pragma warning restore CS8618
-            {
-                Count = istr.ReadAndCheckSeqSize(minElementSize);
-                _inputStream = istr;
-                _reader = reader;
-            }
 
             public IEnumerator<T> GetEnumerator()
             {
@@ -1327,22 +1446,103 @@ namespace ZeroC.Ice
             {
             }
 
-            public bool MoveNext()
-            {
-                if (++_pos > Count)
-                {
-                    _pos = Count + 1;
-                    return false;
-                }
-                else
-                {
-                    _current = _reader(_inputStream);
-                    return true;
-                }
-            }
+            public abstract bool MoveNext();
 
             public bool Remove(T item) => throw new NotSupportedException();
             public void Reset() => throw new NotSupportedException();
+
+            // Disable this warning as the _current field is never read before it is initialized in MoveNext. Declaring
+            // this field as nullable is not an option for a generic T that can be used with reference and value types.
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+            protected CollectionBase(InputStream istr, int minElementSize)
+#pragma warning restore CS8618
+            {
+                Count = istr.ReadAndCheckSeqSize(minElementSize);
+                _inputStream = istr;
+            }
+        }
+
+        // Collection<T> holds the size of a Slice sequence and reads the sequence elements from the InputStream
+        // on-demand. It does not fully implement IEnumerable<T> and ICollection<T> (i.e. some methods throw
+        // NotSupportedException) because it's not resettable: you can't use it to unmarshal the same bytes multiple
+        // times.
+        private sealed class Collection<T> : CollectionBase<T>
+        {
+            private readonly InputStreamReader<T> _reader;
+
+            internal Collection(InputStream istr, int minElementSize, InputStreamReader<T> reader)
+                : base(istr, minElementSize) => _reader = reader;
+
+            public override bool MoveNext()
+            {
+                if (_pos < Count)
+                {
+                    _current = _reader(_inputStream);
+                    _pos++;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Similar to Collection<T>, except we are reading a sequence<T?> where T is a reference type. T here must not
+        // correspond to a mapped Slice class or to a proxy class.
+        private sealed class OptionalElementCollection<T> : CollectionBase<T?> where T : class
+        {
+            private readonly ReadOnlyMemory<byte> _bitSequenceMemory;
+            private readonly InputStreamReader<T> _reader;
+
+            internal OptionalElementCollection(InputStream istr, InputStreamReader<T> reader)
+                : base(istr, 0)
+            {
+                _bitSequenceMemory = istr.ReadBitSequenceMemory(Count);
+                _reader = reader;
+            }
+
+            public override bool MoveNext()
+            {
+                if (_pos < Count)
+                {
+                    var bitSequence = new ReadOnlyBitSequence(_bitSequenceMemory.Span);
+                    _current = bitSequence[_pos++] ? _reader(_inputStream) : null;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Similar to Collection<T>, except we are reading a sequence<T?> where T is a value type.
+        private sealed class OptionalValueCollection<T> : CollectionBase<T?> where T : struct
+        {
+            private readonly ReadOnlyMemory<byte> _bitSequenceMemory;
+            private readonly InputStreamReader<T> _reader;
+
+            internal OptionalValueCollection(InputStream istr, InputStreamReader<T> reader)
+                : base(istr, 0)
+            {
+                _bitSequenceMemory = istr.ReadBitSequenceMemory(Count);
+                _reader = reader;
+            }
+
+            public override bool MoveNext()
+            {
+                if (_pos < Count)
+                {
+                    var bitSequence = new ReadOnlyBitSequence(_bitSequenceMemory.Span);
+                    _current = bitSequence[_pos++] ? _reader(_inputStream) : (T?)null;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
@@ -355,35 +356,20 @@ namespace ZeroC.Ice
         /// <param name="minElementSize">The minimum size of each element of the sequence, in bytes.</param>
         /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
         /// <returns>The sequence read from the stream, as an array.</returns>
-        public T[] ReadArray<T>(int minElementSize, InputStreamReader<T> reader)
-        {
-            ICollection<T> collection = ReadSequence(minElementSize, reader);
-            var array = new T[collection.Count];
-            collection.CopyTo(array, 0);
-            return array;
-        }
+        public T[] ReadArray<T>(int minElementSize, InputStreamReader<T> reader) =>
+            ReadSequence(minElementSize, reader).ToArray();
 
         /// <summary>Reads a sequence of optional/nullable elements from the stream and returns an array.</summary>
         /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
         /// <returns>The sequence read from the stream, as an array.</returns>
-        public T?[] ReadOptionalElementArray<T>(InputStreamReader<T> reader) where T : class
-        {
-            ICollection<T?> collection = ReadOptionalElementSequence(reader);
-            var array = new T?[collection.Count];
-            collection.CopyTo(array, 0);
-            return array;
-        }
+        public T?[] ReadOptionalElementArray<T>(InputStreamReader<T> reader) where T : class =>
+            ReadOptionalElementSequence(reader).ToArray();
 
         /// <summary>Reads a sequence of optional/nullable values from the stream and returns an array.</summary>
         /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
         /// <returns>The sequence read from the stream, as an array.</returns>
-        public T?[] ReadOptionalValueArray<T>(InputStreamReader<T> reader) where T : struct
-        {
-            ICollection<T?> collection = ReadOptionalValueSequence(reader);
-            var array = new T?[collection.Count];
-            collection.CopyTo(array, 0);
-            return array;
-        }
+        public T?[] ReadOptionalValueArray<T>(InputStreamReader<T> reader) where T : struct =>
+            ReadOptionalValueSequence(reader).ToArray();
 
         /// <summary>Reads a dictionary from the stream.</summary>
         /// <param name="minEntrySize">The minimum size of each entry of the dictionary, in bytes.</param>
@@ -653,19 +639,7 @@ namespace ZeroC.Ice
         /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
         /// <returns>The sequence read from the stream as an array, or null.</returns>
         public T[]? ReadTaggedFixedSizeValueArray<T>(int tag, int elementSize, InputStreamReader<T> reader)
-            where T : struct
-        {
-            if (ReadTaggedFixedSizeValueSequence(tag, elementSize, reader) is ICollection<T> collection)
-            {
-                var array = new T[collection.Count];
-                collection.CopyTo(array, 0);
-                return array;
-            }
-            else
-            {
-                return null;
-            }
-        }
+            where T : struct => ReadTaggedFixedSizeValueSequence(tag, elementSize, reader)?.ToArray();
 
         /// <summary>Reads a tagged proxy from the stream.</summary>
         /// <param name="tag">The tag.</param>
@@ -712,20 +686,8 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="reader">The input stream reader used to read each non-null element of the array.</param>
         /// <returns>The array read from the stream, or null.</returns>
-        public T?[]? ReadTaggedOptionalElementArray<T>(int tag, InputStreamReader<T> reader)
-            where T : class
-        {
-            if (ReadTaggedOptionalElementSequence(tag, reader) is ICollection<T?> collection)
-            {
-                var array = new T?[collection.Count];
-                collection.CopyTo(array, 0);
-                return array;
-            }
-            else
-            {
-                return null;
-            }
-        }
+        public T?[]? ReadTaggedOptionalElementArray<T>(int tag, InputStreamReader<T> reader) where T : class =>
+            ReadTaggedOptionalElementSequence(tag, reader)?.ToArray();
 
         /// <summary>Reads a tagged sequence of optional elements from the stream.</summary>
         /// <param name="tag">The tag.</param>
@@ -749,20 +711,8 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="reader">The input stream reader used to read each non-null value of the array.</param>
         /// <returns>The array read from the stream, or null.</returns>
-        public T?[]? ReadTaggedOptionalValueArray<T>(int tag, InputStreamReader<T> reader)
-            where T : struct
-        {
-            if (ReadTaggedOptionalValueSequence(tag, reader) is ICollection<T?> collection)
-            {
-                var array = new T?[collection.Count];
-                collection.CopyTo(array, 0);
-                return array;
-            }
-            else
-            {
-                return null;
-            }
-        }
+        public T?[]? ReadTaggedOptionalValueArray<T>(int tag, InputStreamReader<T> reader) where T : struct =>
+            ReadTaggedOptionalValueSequence(tag, reader)?.ToArray();
 
         /// <summary>Reads a tagged sequence of optional values from the stream.</summary>
         /// <param name="tag">The tag.</param>
@@ -793,19 +743,8 @@ namespace ZeroC.Ice
         /// <param name="minElementSize">The minimum size of each element, in bytes.</param>
         /// <param name="reader">The input stream reader used to read each element of the sequence.</param>
         /// <returns>The sequence read from the stream as an array, or null.</returns>
-        public T[]? ReadTaggedVariableSizeElementArray<T>(int tag, int minElementSize, InputStreamReader<T> reader)
-        {
-            if (ReadTaggedVariableSizeElementSequence(tag, minElementSize, reader) is ICollection<T> collection)
-            {
-                var array = new T[collection.Count];
-                collection.CopyTo(array, 0);
-                return array;
-            }
-            else
-            {
-                return null;
-            }
-        }
+        public T[]? ReadTaggedVariableSizeElementArray<T>(int tag, int minElementSize, InputStreamReader<T> reader) =>
+            ReadTaggedVariableSizeElementSequence(tag, minElementSize, reader)?.ToArray();
 
         /// <summary>Reads a tagged sequence of variable-size elements from the stream.</summary>
         /// <param name="tag">The tag.</param>
@@ -1398,20 +1337,21 @@ namespace ZeroC.Ice
             {
                 get
                 {
-                    if (_pos == 0 || _pos > Count)
+                    if (Pos == 0 || Pos > Count)
                     {
                         throw new InvalidOperationException();
                     }
                     return _current;
                 }
+
+                protected set => _current = value;
             }
 
             object? IEnumerator.Current => Current;
             public bool IsReadOnly => true;
-            protected readonly InputStream _inputStream;
-            protected int _pos = 0;
-
-            protected T _current;
+            protected readonly InputStream InputStream;
+            protected int Pos = 0;
+            private T _current;
             private bool _enumeratorRetrieved = false;
 
             public IEnumerator<T> GetEnumerator()
@@ -1454,7 +1394,7 @@ namespace ZeroC.Ice
 #pragma warning restore CS8618
             {
                 Count = istr.ReadAndCheckSeqSize(minElementSize);
-                _inputStream = istr;
+                InputStream = istr;
             }
         }
 
@@ -1471,10 +1411,10 @@ namespace ZeroC.Ice
 
             public override bool MoveNext()
             {
-                if (_pos < Count)
+                if (Pos < Count)
                 {
-                    _current = _reader(_inputStream);
-                    _pos++;
+                    Current = _reader(InputStream);
+                    Pos++;
                     return true;
                 }
                 else
@@ -1500,10 +1440,10 @@ namespace ZeroC.Ice
 
             public override bool MoveNext()
             {
-                if (_pos < Count)
+                if (Pos < Count)
                 {
                     var bitSequence = new ReadOnlyBitSequence(_bitSequenceMemory.Span);
-                    _current = bitSequence[_pos++] ? _reader(_inputStream) : null;
+                    Current = bitSequence[Pos++] ? _reader(InputStream) : null;
                     return true;
                 }
                 else
@@ -1528,10 +1468,10 @@ namespace ZeroC.Ice
 
             public override bool MoveNext()
             {
-                if (_pos < Count)
+                if (Pos < Count)
                 {
                     var bitSequence = new ReadOnlyBitSequence(_bitSequenceMemory.Span);
-                    _current = bitSequence[_pos++] ? _reader(_inputStream) : (T?)null;
+                    Current = bitSequence[Pos++] ? _reader(InputStream) : (T?)null;
                     return true;
                 }
                 else

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -30,7 +30,6 @@ namespace ZeroC.Ice
         public static readonly InputStreamReader<bool> IceReaderIntoBool =
             istr => istr.ReadBool();
 
-        // TODO: rename to IceReaderIntoArrayOfBool etc.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly InputStreamReader<bool[]> IceReaderIntoBoolArray =
             istr => istr.ReadFixedSizeNumericValueArray<bool>();
@@ -364,9 +363,7 @@ namespace ZeroC.Ice
             return array;
         }
 
-        /// <summary>Reads a sequence of optional types from the stream and returns an array. These types correspond to
-        /// C# reference types other than mapped Slice classes and proxies, for example string, Dictionary{int},
-        /// Array{long}.</summary>
+        /// <summary>Reads a sequence of optional/nullable elements from the stream and returns an array.</summary>
         /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
         /// <returns>The sequence read from the stream, as an array.</returns>
         public T?[] ReadOptionalElementArray<T>(InputStreamReader<T> reader) where T : class
@@ -377,8 +374,7 @@ namespace ZeroC.Ice
             return array;
         }
 
-        /// <summary>Reads a sequence of optional types from the stream and returns an array. These types correspond to
-        /// value types such as int, struct, enum.</summary>
+        /// <summary>Reads a sequence of optional/nullable values from the stream and returns an array.</summary>
         /// <param name="reader">The input stream reader used to read each non-null element of the sequence.</param>
         /// <returns>The sequence read from the stream, as an array.</returns>
         public T?[] ReadOptionalValueArray<T>(InputStreamReader<T> reader) where T : struct

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -900,8 +900,8 @@ namespace ZeroC.Ice
         /// <summary>Writes a tagged array of fixed-size numeric values to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The array to write.</param>
-        public void WriteTaggedFixedSizeNumericValueArray<T>(int tag, T[]? v) where T : struct
-            => WriteTaggedFixedSizeNumericValueSequence(tag, new ReadOnlySpan<T>(v));
+        public void WriteTaggedFixedSizeNumericValueArray<T>(int tag, T[]? v) where T : struct =>
+            WriteTaggedFixedSizeNumericValueSequence(tag, new ReadOnlySpan<T>(v));
 
         /// <summary>Writes a tagged sequence of fixed-size numeric values to the stream.</summary>
         /// <param name="tag">The tag.</param>

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -66,11 +66,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<bool[]> IceWriterFromBoolArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<bool>> IceWriterFromBoolSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<byte> IceWriterFromByte =
@@ -78,11 +78,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<byte[]> IceWriterFromByteArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<byte>> IceWriterFromByteSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<double> IceWriterFromDouble =
@@ -90,11 +90,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<double[]> IceWriterFromDoubleArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<double>> IceWriterFromDoubleSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<float> IceWriterFromFloat =
@@ -102,11 +102,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<float[]> IceWriterFromFloatArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<float>> IceWriterFromFloatSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int> IceWriterFromInt =
@@ -114,11 +114,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int[]> IceWriterFromIntArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<int>> IceWriterFromIntSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<long> IceWriterFromLong =
@@ -126,11 +126,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<long[]> IceWriterFromLongArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<long>> IceWriterFromLongSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<short> IceWriterFromShort =
@@ -138,11 +138,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<short[]> IceWriterFromShortArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<short>> IceWriterFromShortSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<string> IceWriterFromString =
@@ -154,11 +154,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<uint[]> IceWriterFromUIntArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<uint>> IceWriterFromUIntSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ulong> IceWriterFromULong =
@@ -166,11 +166,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ulong[]> IceWriterFromULongArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<ulong>> IceWriterFromULongSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ushort> IceWriterFromUShort =
@@ -178,11 +178,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ushort[]> IceWriterFromUShortArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericArray(value);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<ushort>> IceWriterFromUShortSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericSequence(value.Span);
+            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int> IceWriterFromVarInt =
@@ -281,23 +281,23 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a double to the stream.</summary>
         /// <param name="v">The double to write to the stream.</param>
-        public void WriteDouble(double v) => WriteFixedSizeNumeric(v);
+        public void WriteDouble(double v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a float to the stream.</summary>
         /// <param name="v">The float to write to the stream.</param>
-        public void WriteFloat(float v) => WriteFixedSizeNumeric(v);
+        public void WriteFloat(float v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes an int to the stream.</summary>
         /// <param name="v">The int to write to the stream.</param>
-        public void WriteInt(int v) => WriteFixedSizeNumeric(v);
+        public void WriteInt(int v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a long to the stream.</summary>
         /// <param name="v">The long to write to the stream.</param>
-        public void WriteLong(long v) => WriteFixedSizeNumeric(v);
+        public void WriteLong(long v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a short to the stream.</summary>
         /// <param name="v">The short to write to the stream.</param>
-        public void WriteShort(short v) => WriteFixedSizeNumeric(v);
+        public void WriteShort(short v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a string to the stream.</summary>
         /// <param name="v">The string to write to the stream.</param>
@@ -324,15 +324,15 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a uint to the stream.</summary>
         /// <param name="v">The uint to write to the stream.</param>
-        public void WriteUInt(uint v) => WriteFixedSizeNumeric(v);
+        public void WriteUInt(uint v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a ulong to the stream.</summary>
         /// <param name="v">The ulong to write to the stream.</param>
-        public void WriteULong(ulong v) => WriteFixedSizeNumeric(v);
+        public void WriteULong(ulong v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes a ushort to the stream.</summary>
         /// <param name="v">The ushort to write to the stream.</param>
-        public void WriteUShort(ushort v) => WriteFixedSizeNumeric(v);
+        public void WriteUShort(ushort v) => WriteFixedSizeNumericValue(v);
 
         /// <summary>Writes an int to stream, using Ice's variable-length integer encoding.</summary>
         /// <param name="v">The int to write to the stream.</param>
@@ -476,19 +476,42 @@ namespace ZeroC.Ice
         /// <param name="v">The enumerator's int value.</param>
         public void WriteEnum(int v) => WriteSize(v);
 
-        /// <summary>Writes an array of fixed-size numeric type, such as int and long, to the stream.</summary>
-        /// <param name="v">The array of numeric types.</param>
-        public void WriteFixedSizeNumericArray<T>(T[] v) where T : struct =>
-            WriteFixedSizeNumericSequence(new ReadOnlySpan<T>(v));
+        /// <summary>Writes an array of fixed-size numeric values, such as int and long, to the stream.</summary>
+        /// <param name="v">The array of numeric values.</param>
+        public void WriteFixedSizeNumericValueArray<T>(T[] v) where T : struct =>
+            WriteFixedSizeNumericValueSequence(new ReadOnlySpan<T>(v));
 
-        /// <summary>Writes a sequence of fixed-size numeric type, such as int and long, to the stream.</summary>
-        /// <param name="v">The sequence of numeric types represented by a ReadOnlySpan.</param>
+        /// <summary>Writes a sequence of fixed-size numeric values, such as int and long, to the stream.</summary>
+        /// <param name="v">The sequence of numeric values represented by a ReadOnlySpan.</param>
         // This method works because (as long as) there is no padding in the memory representation of the
         // ReadOnlySpan.
-        public void WriteFixedSizeNumericSequence<T>(ReadOnlySpan<T> v) where T : struct
+        public void WriteFixedSizeNumericValueSequence<T>(ReadOnlySpan<T> v) where T : struct
         {
             WriteSize(v.Length);
             WriteByteSpan(MemoryMarshal.AsBytes(v));
+        }
+
+        /// <summary>Writes a sequence of optional/nullable elements to the stream.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteOptionalElementSequence<T>(IEnumerable<T?> v, OutputStreamWriter<T> writer) where T : class
+        {
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    writer(this, value);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
         }
 
         /// <summary>Writes an optional proxy to the stream.</summary>
@@ -502,6 +525,52 @@ namespace ZeroC.Ice
             else
             {
                 Identity.Empty.IceWrite(this);
+            }
+        }
+
+        /// <summary>Writes a sequence of optional/nullable values to the stream.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each non-null value to the stream.</param>
+        public void WriteOptionalValueSequence<T>(IEnumerable<T?> v, OutputStreamWriter<T> writer) where T : struct
+        {
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    writer(this, value);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a sequence of optional/nullable values to the stream. The values are mapped Slice structs.
+        /// </summary>
+        /// <param name="v">The sequence to write.</param>
+        public void WriteOptionalValueSequence<T>(IEnumerable<T?> v) where T : struct, IStreamableStruct
+        {
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    value.IceWrite(this);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
             }
         }
 
@@ -523,8 +592,7 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a sequence to the stream. Elements of the sequence are mapped Slice structs.</summary>
         /// <param name="v">The sequence to write.</param>
-        public void WriteSequence<T>(IEnumerable<T> v)
-            where T : struct, IStreamableStruct
+        public void WriteSequence<T>(IEnumerable<T> v) where T : struct, IStreamableStruct
         {
             WriteSize(v.Count()); // potentially slow Linq Count()
             foreach (T item in v)
@@ -829,16 +897,16 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged array of fixed-size numeric type to the stream.</summary>
+        /// <summary>Writes a tagged array of fixed-size numeric values to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The array to write.</param>
-        public void WriteTaggedFixedSizeNumericArray<T>(int tag, T[]? v) where T : struct
-            => WriteTaggedFixedSizeNumericSequence(tag, new ReadOnlySpan<T>(v));
+        public void WriteTaggedFixedSizeNumericValueArray<T>(int tag, T[]? v) where T : struct
+            => WriteTaggedFixedSizeNumericValueSequence(tag, new ReadOnlySpan<T>(v));
 
-        /// <summary>Writes a tagged sequence of fixed-size numeric type to the stream.</summary>
+        /// <summary>Writes a tagged sequence of fixed-size numeric values to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedFixedSizeNumericSequence<T>(int tag, ReadOnlySpan<T> v) where T : struct
+        public void WriteTaggedFixedSizeNumericValueSequence<T>(int tag, ReadOnlySpan<T> v) where T : struct
         {
             // A null T[]? or List<T>? is implicitly converted into a default aka null ReadOnlyMemory<T> or
             // ReadOnlySpan<T>. Furthermore, the span of a default ReadOnlyMemory<T> is a default ReadOnlySpan<T>, which
@@ -852,7 +920,55 @@ namespace ZeroC.Ice
                     // This size is redundant and optimized out by the encoding when elementSize is 1.
                     WriteSize(v.Length == 0 ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
                 }
-                WriteFixedSizeNumericSequence(v);
+                WriteFixedSizeNumericValueSequence(v);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of optional elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteTaggedOptionalElementSequence<T>(int tag, IEnumerable<T?>? v, OutputStreamWriter<T> writer)
+            where T : class
+        {
+            if (v is IEnumerable<T?> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteOptionalElementSequence(value, writer);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of optional values to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteTaggedOptionalValueSequence<T>(int tag, IEnumerable<T?>? v, OutputStreamWriter<T> writer)
+            where T : struct
+        {
+            if (v is IEnumerable<T?> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteOptionalValueSequence(value, writer);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of optional values to the stream. Elements of the sequence are mapped
+        /// Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        public void WriteTaggedOptionalValueSequence<T>(int tag, IEnumerable<T?>? v)
+            where T : struct, IStreamableStruct
+        {
+            if (v is IEnumerable<T?> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteOptionalValueSequence(value);
+                EndFixedLengthSize(pos);
             }
         }
 
@@ -903,9 +1019,7 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
         /// <param name="elementSize">The fixed size of each element of the sequence, in bytes.</param>
-        public void WriteTaggedSequence<T>(int tag,
-                                           IEnumerable<T>? v,
-                                           int elementSize)
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v, int elementSize)
             where T : struct, IStreamableStruct
         {
             Debug.Assert(elementSize > 0);
@@ -950,8 +1064,7 @@ namespace ZeroC.Ice
         /// mapped Slice structs.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v)
-            where T : struct, IStreamableStruct
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v) where T : struct, IStreamableStruct
         {
             if (v is IEnumerable<T> value)
             {
@@ -1481,9 +1594,9 @@ namespace ZeroC.Ice
             WriteByte(encoding.Minor);
         }
 
-        /// <summary>Writes a fixed-size numeric to the stream.</summary>
+        /// <summary>Writes a fixed-size numeric value to the stream.</summary>
         /// <param name="v">The numeric value to write to the stream.</param>
-        private void WriteFixedSizeNumeric<T>(T v) where T : struct
+        private void WriteFixedSizeNumericValue<T>(T v) where T : struct
         {
             int elementSize = Unsafe.SizeOf<T>();
             Debug.Assert(elementSize > 1); // for size 1, we write the byte directly

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -149,6 +149,14 @@ namespace ZeroC.Ice.Test.Optional
 
             output.WriteLine("ok");
 
+            output.Write("testing operations with sequence<T?> parameters... ");
+            int?[] intSeq = new int?[] { 1, -5, null, 19, -35000 };
+            TestHelper.Assert(test.OpOptIntSeq(intSeq).SequenceEqual(intSeq));
+
+            TestHelper.Assert(test.OpTaggedOptIntSeq(intSeq)!.SequenceEqual(intSeq));
+            TestHelper.Assert(test.OpTaggedOptIntSeq(null) == null);
+            output.WriteLine("ok");
+
             return test;
         }
     }

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -152,9 +152,14 @@ namespace ZeroC.Ice.Test.Optional
             output.Write("testing operations with sequence<T?> parameters... ");
             int?[] intSeq = new int?[] { 1, -5, null, 19, -35000 };
             TestHelper.Assert(test.OpOptIntSeq(intSeq).SequenceEqual(intSeq));
-
             TestHelper.Assert(test.OpTaggedOptIntSeq(intSeq)!.SequenceEqual(intSeq));
             TestHelper.Assert(test.OpTaggedOptIntSeq(null) == null);
+
+            string?[] stringSeq = new string?[] { "foo", "test", null, "", "bar" };
+            TestHelper.Assert(test.OpOptStringSeq(stringSeq).SequenceEqual(stringSeq));
+            TestHelper.Assert(test.OpTaggedOptStringSeq(stringSeq)!.SequenceEqual(stringSeq));
+            TestHelper.Assert(test.OpTaggedOptStringSeq(null) == null);
+
             output.WriteLine("ok");
 
             return test;

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -14,6 +14,11 @@ module ZeroC::Ice::Test::Optional
         int x;
     }
 
+    sequence<C> CSeq;
+    sequence<C?> OptCSeq;
+    sequence<int> IntSeq;
+    sequence<int?> OptIntSeq;
+
     interface Test
     {
         void shutdown();
@@ -33,5 +38,8 @@ module ZeroC::Ice::Test::Optional
 
         Value? opAnyClass(Value i1, Value? i2);
         C? opC(C i1, C? i2);
+
+        OptIntSeq opOptIntSeq(OptIntSeq i1);
+        tag(1) OptIntSeq? opTaggedOptIntSeq(tag(2) OptIntSeq? i1);
     }
 }

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -14,10 +14,8 @@ module ZeroC::Ice::Test::Optional
         int x;
     }
 
-    sequence<C> CSeq;
-    sequence<C?> OptCSeq;
-    sequence<int> IntSeq;
     sequence<int?> OptIntSeq;
+    sequence<string?> OptStringSeq;
 
     interface Test
     {
@@ -41,5 +39,8 @@ module ZeroC::Ice::Test::Optional
 
         OptIntSeq opOptIntSeq(OptIntSeq i1);
         tag(1) OptIntSeq? opTaggedOptIntSeq(tag(2) OptIntSeq? i1);
+
+        OptStringSeq opOptStringSeq(OptStringSeq i1);
+        tag(1) OptStringSeq? opTaggedOptStringSeq(tag(2) OptStringSeq? i1);
     }
 }

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Collections.Generic;
 using Test;
 
 namespace ZeroC.Ice.Test.Optional
@@ -53,5 +54,9 @@ namespace ZeroC.Ice.Test.Optional
             TestHelper.Assert(i2 == null || i2 == i1);
             return i2;
         }
+
+        public IEnumerable<int?> OpOptIntSeq(int?[] i1, Current current) => i1;
+
+        public IEnumerable<int?>? OpTaggedOptIntSeq(int?[]? i1, Current current) => i1;
     }
 }

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -58,5 +58,9 @@ namespace ZeroC.Ice.Test.Optional
         public IEnumerable<int?> OpOptIntSeq(int?[] i1, Current current) => i1;
 
         public IEnumerable<int?>? OpTaggedOptIntSeq(int?[]? i1, Current current) => i1;
+
+        public IEnumerable<string?> OpOptStringSeq(string?[] i1, Current current) => i1;
+
+        public IEnumerable<string?>? OpTaggedOptStringSeq(string?[]? i1, Current current) => i1;
     }
 }

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -1020,11 +1020,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opByteSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<byte>(1), istr.ReadTaggedFixedSizeNumericArray<byte>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<byte>(1), istr.ReadTaggedFixedSizeNumericValueArray<byte>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1052,11 +1052,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opBoolSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<bool>(1), istr.ReadTaggedFixedSizeNumericArray<bool>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<bool>(1), istr.ReadTaggedFixedSizeNumericValueArray<bool>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1084,11 +1084,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opShortSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<short>(1), istr.ReadTaggedFixedSizeNumericArray<short>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<short>(1), istr.ReadTaggedFixedSizeNumericValueArray<short>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1115,11 +1115,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opIntSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<int>(1), istr.ReadTaggedFixedSizeNumericArray<int>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<int>(1), istr.ReadTaggedFixedSizeNumericValueArray<int>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1146,11 +1146,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opLongSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<long>(1), istr.ReadTaggedFixedSizeNumericArray<long>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<long>(1), istr.ReadTaggedFixedSizeNumericValueArray<long>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1177,11 +1177,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opFloatSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<float>(1), istr.ReadTaggedFixedSizeNumericArray<float>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<float>(1), istr.ReadTaggedFixedSizeNumericValueArray<float>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1208,11 +1208,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opDoubleSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedFixedSizeNumericArray(2, p1));
+                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericArray<double>(1), istr.ReadTaggedFixedSizeNumericArray<double>(3)));
+                    (istr.ReadTaggedFixedSizeNumericValueArray<double>(1), istr.ReadTaggedFixedSizeNumericValueArray<double>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1278,8 +1278,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeElementArray(1, 1, istr => new SmallStruct(istr)),
-                        istr.ReadTaggedFixedSizeElementArray(3, 1, istr => new SmallStruct(istr))));
+                    (istr.ReadTaggedFixedSizeValueArray(1, 1, istr => new SmallStruct(istr)),
+                        istr.ReadTaggedFixedSizeValueArray(3, 1, istr => new SmallStruct(istr))));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1318,11 +1318,11 @@ namespace ZeroC.Ice.tagged
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
                     {
                         List<SmallStruct>? list1 =
-                            istr.ReadTaggedFixedSizeElementSequence(1, 1, istr => new SmallStruct(istr)) is
+                            istr.ReadTaggedFixedSizeValueSequence(1, 1, istr => new SmallStruct(istr)) is
                                 ICollection<SmallStruct> collection1 ? new List<SmallStruct>(collection1) : null;
 
                         List<SmallStruct>? list2 =
-                            istr.ReadTaggedFixedSizeElementSequence(3, 1, istr => new SmallStruct(istr)) is
+                            istr.ReadTaggedFixedSizeValueSequence(3, 1, istr => new SmallStruct(istr)) is
                                 ICollection<SmallStruct> collection2 ? new List<SmallStruct>(collection2) : null;
 
                         return (list1, list2);
@@ -1359,8 +1359,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeElementArray(1, 4, istr => new FixedStruct(istr)),
-                        istr.ReadTaggedFixedSizeElementArray(3, 4, istr => new FixedStruct(istr))));
+                    (istr.ReadTaggedFixedSizeValueArray(1, 4, istr => new FixedStruct(istr)),
+                        istr.ReadTaggedFixedSizeValueArray(3, 4, istr => new FixedStruct(istr))));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1399,11 +1399,11 @@ namespace ZeroC.Ice.tagged
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
                     {
                         LinkedList<FixedStruct>? list1 =
-                            istr.ReadTaggedFixedSizeElementSequence(1, 4, istr => new FixedStruct(istr)) is
+                            istr.ReadTaggedFixedSizeValueSequence(1, 4, istr => new FixedStruct(istr)) is
                                 ICollection<FixedStruct> collection1 ? new LinkedList<FixedStruct>(collection1) : null;
 
                         LinkedList<FixedStruct>? list2 =
-                            istr.ReadTaggedFixedSizeElementSequence(3, 4, istr => new FixedStruct(istr)) is
+                            istr.ReadTaggedFixedSizeValueSequence(3, 4, istr => new FixedStruct(istr)) is
                                 ICollection<FixedStruct> collection2 ? new LinkedList<FixedStruct>(collection2) : null;
 
                         return (list1, list2);


### PR DESCRIPTION
This PR adds support for sequence<T?> and tagged sequence<T?> marshaling in C#.

Currently, only parameters are supported (data members are for a future PR).