### PR TITLE
Simplify InputStream and OutputStream method names in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1209,9 +1209,9 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly new ZeroC.Ice.InputStreamReader<" << name << "?> IceReaderIntoOptional =";
+    _out << nl << "public static readonly new ZeroC.Ice.InputStreamReader<" << name << "?> IceReaderIntoNullable =";
     _out.inc();
-    _out << nl << "istr => istr.ReadOptionalClass<" << name << ">();";
+    _out << nl << "istr => istr.ReadNullableClass<" << name << ">();";
     _out.dec();
 
     // The writer is currently not useful; a future implementation for the 2.0 encoding will use the formal type to
@@ -1223,9 +1223,9 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly new ZeroC.Ice.OutputStreamWriter<" << name << "?> IceWriterFromOptional =";
+    _out << nl << "public static readonly new ZeroC.Ice.OutputStreamWriter<" << name << "?> IceWriterFromNullable =";
     _out.inc();
-    _out << nl << "(ostr, value) => ostr.WriteOptionalClass(value);";
+    _out << nl << "(ostr, value) => ostr.WriteNullableClass(value);";
     _out.dec();
 
     _out << sp;
@@ -2250,9 +2250,9 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     _out << sp;
-    _out << nl << "public static readonly new ZeroC.Ice.InputStreamReader<" << name << "?> IceReaderIntoOptional =";
+    _out << nl << "public static readonly new ZeroC.Ice.InputStreamReader<" << name << "?> IceReaderIntoNullable =";
     _out.inc();
-    _out << nl << "istr => istr.ReadOptionalProxy(Factory);";
+    _out << nl << "istr => istr.ReadNullableProxy(Factory);";
     _out.dec();
 
     _out << sp;

--- a/csharp/src/Ice/AnyClass.cs
+++ b/csharp/src/Ice/AnyClass.cs
@@ -15,15 +15,15 @@ namespace ZeroC.Ice
         public static readonly InputStreamReader<AnyClass> IceReader = (istr) => istr.ReadClass<AnyClass>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<AnyClass?> IceReaderIntoOptional =
-            (istr) => istr.ReadOptionalClass<AnyClass>();
+        public static readonly InputStreamReader<AnyClass?> IceReaderIntoNullable =
+            (istr) => istr.ReadNullableClass<AnyClass>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<AnyClass> IceWriter = (ostr, value) => ostr.WriteClass(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<AnyClass?> IceWriterFromOptional =
-            (ostr, value) => ostr.WriteOptionalClass(value);
+        public static readonly OutputStreamWriter<AnyClass?> IceWriterFromNullable =
+            (ostr, value) => ostr.WriteNullableClass(value);
 
         protected virtual SlicedData? IceSlicedData
         {

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -34,15 +34,15 @@ namespace ZeroC.Ice
         public static readonly InputStreamReader<IObjectPrx> IceReader = (istr) => istr.ReadProxy(Factory);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly InputStreamReader<IObjectPrx?> IceReaderIntoOptional =
-            (istr) => istr.ReadOptionalProxy(Factory);
+        public static readonly InputStreamReader<IObjectPrx?> IceReaderIntoNullable =
+            (istr) => istr.ReadNullableProxy(Factory);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<IObjectPrx> IceWriter = (ostr, value) => ostr.WriteProxy(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly OutputStreamWriter<IObjectPrx?> IceWriterFromOptional =
-            (ostr, value) => ostr.WriteOptionalProxy(value);
+        public static readonly OutputStreamWriter<IObjectPrx?> IceWriterFromNullable =
+            (ostr, value) => ostr.WriteNullableProxy(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Reference IceReference { get; }

--- a/csharp/src/Ice/InputStream-Class.cs
+++ b/csharp/src/Ice/InputStream-Class.cs
@@ -76,12 +76,12 @@ namespace ZeroC.Ice
         /// <summary>Reads a class instance from the stream.</summary>
         /// <returns>The class instance read from the stream.</returns>
         public T ReadClass<T>() where T : AnyClass =>
-            ReadOptionalClass<T>() ??
+            ReadNullableClass<T>() ??
                 throw new InvalidDataException("read a null class instance, but expected a non-null instance");
 
-        /// <summary>Reads an optional class instance from the stream.</summary>
+        /// <summary>Reads a nullable class instance from the stream.</summary>
         /// <returns>The class instance read from the stream, or null.</returns>
-        public T? ReadOptionalClass<T>() where T : AnyClass
+        public T? ReadNullableClass<T>() where T : AnyClass
         {
             AnyClass? obj = ReadAnyClass();
             if (obj is T result)

--- a/csharp/src/Ice/OutputStream-Class.cs
+++ b/csharp/src/Ice/OutputStream-Class.cs
@@ -195,7 +195,7 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a class instance to the stream, or null.</summary>
         /// <param name="v">The class instance to write, or null</param>
-        public void WriteOptionalClass(AnyClass? v)
+        public void WriteNullableClass(AnyClass? v)
         {
             Debug.Assert(InEncapsulation);
             if (v == null)

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -66,11 +66,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<bool[]> IceWriterFromBoolArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<bool>> IceWriterFromBoolSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<byte> IceWriterFromByte =
@@ -78,11 +78,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<byte[]> IceWriterFromByteArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<byte>> IceWriterFromByteSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<double> IceWriterFromDouble =
@@ -90,11 +90,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<double[]> IceWriterFromDoubleArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<double>> IceWriterFromDoubleSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<float> IceWriterFromFloat =
@@ -102,11 +102,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<float[]> IceWriterFromFloatArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<float>> IceWriterFromFloatSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int> IceWriterFromInt =
@@ -114,11 +114,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int[]> IceWriterFromIntArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<int>> IceWriterFromIntSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<long> IceWriterFromLong =
@@ -126,11 +126,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<long[]> IceWriterFromLongArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<long>> IceWriterFromLongSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<short> IceWriterFromShort =
@@ -138,11 +138,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<short[]> IceWriterFromShortArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<short>> IceWriterFromShortSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<string> IceWriterFromString =
@@ -154,11 +154,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<uint[]> IceWriterFromUIntArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<uint>> IceWriterFromUIntSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ulong> IceWriterFromULong =
@@ -166,11 +166,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ulong[]> IceWriterFromULongArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<ulong>> IceWriterFromULongSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ushort> IceWriterFromUShort =
@@ -178,11 +178,11 @@ namespace ZeroC.Ice
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ushort[]> IceWriterFromUShortArray =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueArray(value);
+            (ostr, value) => ostr.WriteArray(value);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<ReadOnlyMemory<ushort>> IceWriterFromUShortSequence =
-            (ostr, value) => ostr.WriteFixedSizeNumericValueSequence(value.Span);
+            (ostr, value) => ostr.WriteSequence(value.Span);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly OutputStreamWriter<int> IceWriterFromVarInt =
@@ -281,23 +281,23 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a double to the stream.</summary>
         /// <param name="v">The double to write to the stream.</param>
-        public void WriteDouble(double v) => WriteFixedSizeNumericValue(v);
+        public void WriteDouble(double v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a float to the stream.</summary>
         /// <param name="v">The float to write to the stream.</param>
-        public void WriteFloat(float v) => WriteFixedSizeNumericValue(v);
+        public void WriteFloat(float v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes an int to the stream.</summary>
         /// <param name="v">The int to write to the stream.</param>
-        public void WriteInt(int v) => WriteFixedSizeNumericValue(v);
+        public void WriteInt(int v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a long to the stream.</summary>
         /// <param name="v">The long to write to the stream.</param>
-        public void WriteLong(long v) => WriteFixedSizeNumericValue(v);
+        public void WriteLong(long v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a short to the stream.</summary>
         /// <param name="v">The short to write to the stream.</param>
-        public void WriteShort(short v) => WriteFixedSizeNumericValue(v);
+        public void WriteShort(short v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a string to the stream.</summary>
         /// <param name="v">The string to write to the stream.</param>
@@ -324,15 +324,15 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a uint to the stream.</summary>
         /// <param name="v">The uint to write to the stream.</param>
-        public void WriteUInt(uint v) => WriteFixedSizeNumericValue(v);
+        public void WriteUInt(uint v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a ulong to the stream.</summary>
         /// <param name="v">The ulong to write to the stream.</param>
-        public void WriteULong(ulong v) => WriteFixedSizeNumericValue(v);
+        public void WriteULong(ulong v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes a ushort to the stream.</summary>
         /// <param name="v">The ushort to write to the stream.</param>
-        public void WriteUShort(ushort v) => WriteFixedSizeNumericValue(v);
+        public void WriteUShort(ushort v) => WriteFixedSizeNumeric(v);
 
         /// <summary>Writes an int to stream, using Ice's variable-length integer encoding.</summary>
         /// <param name="v">The int to write to the stream.</param>
@@ -410,13 +410,19 @@ namespace ZeroC.Ice
         // Write methods for constructed types except class and exception
         //
 
+        /// <summary>Writes an array of fixed-size numeric values, such as int and long, to the stream.</summary>
+        /// <param name="v">The array of numeric values.</param>
+        public void WriteArray<T>(T[] v) where T : struct => WriteSequence(new ReadOnlySpan<T>(v));
+
         /// <summary>Writes a dictionary to the stream.</summary>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
-                                                  OutputStreamWriter<TKey> keyWriter,
-                                                  OutputStreamWriter<TValue> valueWriter) where TKey : notnull
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> v,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
         {
             WriteSize(v.Count);
             foreach ((TKey key, TValue value) in v)
@@ -429,8 +435,9 @@ namespace ZeroC.Ice
         /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct.</summary>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
-                                                  OutputStreamWriter<TValue> valueWriter)
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> v,
+            OutputStreamWriter<TValue> valueWriter)
             where TKey : struct, IStreamableStruct
         {
             WriteSize(v.Count);
@@ -444,8 +451,9 @@ namespace ZeroC.Ice
         /// <summary>Writes a dictionary to the stream. The dictionary's value is a mapped Slice struct.</summary>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v,
-                                                  OutputStreamWriter<TKey> keyWriter)
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> v,
+            OutputStreamWriter<TKey> keyWriter)
             where TKey : notnull
             where TValue : struct, IStreamableStruct
         {
@@ -476,47 +484,9 @@ namespace ZeroC.Ice
         /// <param name="v">The enumerator's int value.</param>
         public void WriteEnum(int v) => WriteSize(v);
 
-        /// <summary>Writes an array of fixed-size numeric values, such as int and long, to the stream.</summary>
-        /// <param name="v">The array of numeric values.</param>
-        public void WriteFixedSizeNumericValueArray<T>(T[] v) where T : struct =>
-            WriteFixedSizeNumericValueSequence(new ReadOnlySpan<T>(v));
-
-        /// <summary>Writes a sequence of fixed-size numeric values, such as int and long, to the stream.</summary>
-        /// <param name="v">The sequence of numeric values represented by a ReadOnlySpan.</param>
-        // This method works because (as long as) there is no padding in the memory representation of the
-        // ReadOnlySpan.
-        public void WriteFixedSizeNumericValueSequence<T>(ReadOnlySpan<T> v) where T : struct
-        {
-            WriteSize(v.Length);
-            WriteByteSpan(MemoryMarshal.AsBytes(v));
-        }
-
-        /// <summary>Writes a sequence of optional/nullable elements to the stream.</summary>
-        /// <param name="v">The sequence to write.</param>
-        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
-        public void WriteOptionalElementSequence<T>(IEnumerable<T?> v, OutputStreamWriter<T> writer) where T : class
-        {
-            int count = v.Count(); // potentially slow Linq Count()
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach (T? item in v)
-            {
-                if (item is T value)
-                {
-                    writer(this, value);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
-        /// <summary>Writes an optional proxy to the stream.</summary>
+        /// <summary>Writes a nullable proxy to the stream.</summary>
         /// <param name="v">The proxy to write, or null.</param>
-        public void WriteOptionalProxy<T>(T? v) where T : class, IObjectPrx
+        public void WriteNullableProxy<T>(T? v) where T : class, IObjectPrx
         {
             if (v != null)
             {
@@ -528,55 +498,19 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a sequence of optional/nullable values to the stream.</summary>
-        /// <param name="v">The sequence to write.</param>
-        /// <param name="writer">The delegate that writes each non-null value to the stream.</param>
-        public void WriteOptionalValueSequence<T>(IEnumerable<T?> v, OutputStreamWriter<T> writer) where T : struct
-        {
-            int count = v.Count(); // potentially slow Linq Count()
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach (T? item in v)
-            {
-                if (item is T value)
-                {
-                    writer(this, value);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
-        /// <summary>Writes a sequence of optional/nullable values to the stream. The values are mapped Slice structs.
-        /// </summary>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteOptionalValueSequence<T>(IEnumerable<T?> v) where T : struct, IStreamableStruct
-        {
-            int count = v.Count(); // potentially slow Linq Count()
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach (T? item in v)
-            {
-                if (item is T value)
-                {
-                    value.IceWrite(this);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
         /// <summary>Writes a proxy to the stream.</summary>
         /// <param name="v">The proxy to write. This proxy cannot be null.</param>
         public void WriteProxy<T>(T v) where T : class, IObjectPrx => v.IceWrite(this);
+
+        /// <summary>Writes a sequence of fixed-size numeric values, such as int and long, to the stream.</summary>
+        /// <param name="v">The sequence of numeric values represented by a ReadOnlySpan.</param>
+        // This method works because (as long as) there is no padding in the memory representation of the
+        // ReadOnlySpan.
+        public void WriteSequence<T>(ReadOnlySpan<T> v) where T : struct
+        {
+            WriteSize(v.Length);
+            WriteByteSpan(MemoryMarshal.AsBytes(v));
+        }
 
         /// <summary>Writes a sequence to the stream.</summary>
         /// <param name="v">The sequence to write.</param>
@@ -598,6 +532,83 @@ namespace ZeroC.Ice
             foreach (T item in v)
             {
                 item.IceWrite(this);
+            }
+        }
+
+        /// <summary>Writes a sequence of nullable elements to the stream.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="ofNullables">Must always be true.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteSequence<T>(IEnumerable<T?> v, bool ofNullables, OutputStreamWriter<T> writer) where T : class
+        {
+            // We need the always-true ofNullables parameter only for this overload, to avoid ambiguity with the
+            // unconstrained WriteSequence<T>(IEnumerable<T> v, OutputStreamWriter<T> writer).
+            Debug.Assert(ofNullables);
+
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    writer(this, value);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a sequence of nullable values to the stream.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="ofNullables">Must always be true.</param>
+        /// <param name="writer">The delegate that writes each non-null value to the stream.</param>
+        public void WriteSequence<T>(IEnumerable<T?> v, bool ofNullables, OutputStreamWriter<T> writer) where T : struct
+        {
+            Debug.Assert(ofNullables);
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    writer(this, value);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a sequence of nullable values to the stream. The values are mapped Slice structs.</summary>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="ofNullables">Must always be true.</param>
+        public void WriteSequence<T>(IEnumerable<T?> v, bool ofNullables) where T : struct, IStreamableStruct
+        {
+            Debug.Assert(ofNullables);
+            int count = v.Count(); // potentially slow Linq Count()
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach (T? item in v)
+            {
+                if (item is T value)
+                {
+                    value.IceWrite(this);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
             }
         }
 
@@ -719,17 +730,24 @@ namespace ZeroC.Ice
         // Write methods for tagged constructed types except class
         //
 
+        /// <summary>Writes a tagged array of fixed-size numeric values to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The array to write.</param>
+        public void WriteTaggedArray<T>(int tag, T[]? v) where T : struct =>
+            WriteTaggedSequence(tag, new ReadOnlySpan<T>(v));
+
         /// <summary>Writes a tagged dictionary with fixed-size entries to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        int entrySize,
-                                                        OutputStreamWriter<TKey> keyWriter,
-                                                        OutputStreamWriter<TValue> valueWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            int entrySize,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
         {
             Debug.Assert(entrySize > 1);
@@ -748,10 +766,11 @@ namespace ZeroC.Ice
         /// <param name="v">The dictionary to write.</param>
         /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        int entrySize,
-                                                        OutputStreamWriter<TValue> valueWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            int entrySize,
+            OutputStreamWriter<TValue> valueWriter)
             where TKey : struct, IStreamableStruct
         {
             Debug.Assert(entrySize > 1);
@@ -770,10 +789,11 @@ namespace ZeroC.Ice
         /// <param name="v">The dictionary to write.</param>
         /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        int entrySize,
-                                                        OutputStreamWriter<TKey> keyWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            int entrySize,
+            OutputStreamWriter<TKey> keyWriter)
             where TKey : notnull
             where TValue : struct, IStreamableStruct
         {
@@ -792,9 +812,10 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        int entrySize)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            int entrySize)
             where TKey : struct, IStreamableStruct
             where TValue : struct, IStreamableStruct
         {
@@ -813,10 +834,11 @@ namespace ZeroC.Ice
         /// <param name="v">The dictionary to write.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        OutputStreamWriter<TKey> keyWriter,
-                                                        OutputStreamWriter<TValue> valueWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
             where TKey : notnull
         {
             if (v is IReadOnlyDictionary<TKey, TValue> dict)
@@ -833,9 +855,10 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        OutputStreamWriter<TValue> valueWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            OutputStreamWriter<TValue> valueWriter)
             where TKey : struct, IStreamableStruct
         {
             if (v is IReadOnlyDictionary<TKey, TValue> dict)
@@ -852,9 +875,10 @@ namespace ZeroC.Ice
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v,
-                                                        OutputStreamWriter<TKey> keyWriter)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v,
+            OutputStreamWriter<TKey> keyWriter)
             where TKey : notnull
             where TValue : struct, IStreamableStruct
         {
@@ -871,8 +895,9 @@ namespace ZeroC.Ice
         /// value are mapped Slice structs.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(int tag,
-                                                        IReadOnlyDictionary<TKey, TValue>? v)
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue>? v)
             where TKey : struct, IStreamableStruct
             where TValue : struct, IStreamableStruct
         {
@@ -897,81 +922,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged array of fixed-size numeric values to the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The array to write.</param>
-        public void WriteTaggedFixedSizeNumericValueArray<T>(int tag, T[]? v) where T : struct =>
-            WriteTaggedFixedSizeNumericValueSequence(tag, new ReadOnlySpan<T>(v));
-
-        /// <summary>Writes a tagged sequence of fixed-size numeric values to the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedFixedSizeNumericValueSequence<T>(int tag, ReadOnlySpan<T> v) where T : struct
-        {
-            // A null T[]? or List<T>? is implicitly converted into a default aka null ReadOnlyMemory<T> or
-            // ReadOnlySpan<T>. Furthermore, the span of a default ReadOnlyMemory<T> is a default ReadOnlySpan<T>, which
-            // is distinct from the span of an empty sequence. This is why the "v != null" below works correctly.
-            if (v != null)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-                int elementSize = Unsafe.SizeOf<T>();
-                if (elementSize > 1)
-                {
-                    // This size is redundant and optimized out by the encoding when elementSize is 1.
-                    WriteSize(v.Length == 0 ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
-                }
-                WriteFixedSizeNumericValueSequence(v);
-            }
-        }
-
-        /// <summary>Writes a tagged sequence of optional elements to the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
-        public void WriteTaggedOptionalElementSequence<T>(int tag, IEnumerable<T?>? v, OutputStreamWriter<T> writer)
-            where T : class
-        {
-            if (v is IEnumerable<T?> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteOptionalElementSequence(value, writer);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged sequence of optional values to the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
-        public void WriteTaggedOptionalValueSequence<T>(int tag, IEnumerable<T?>? v, OutputStreamWriter<T> writer)
-            where T : struct
-        {
-            if (v is IEnumerable<T?> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteOptionalValueSequence(value, writer);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged sequence of optional values to the stream. Elements of the sequence are mapped
-        /// Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedOptionalValueSequence<T>(int tag, IEnumerable<T?>? v)
-            where T : struct, IStreamableStruct
-        {
-            if (v is IEnumerable<T?> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteOptionalValueSequence(value);
-                EndFixedLengthSize(pos);
-            }
-        }
-
         /// <summary>Writes a tagged proxy to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The proxy to write.</param>
@@ -986,12 +936,49 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged sequence of fixed-size elements to the stream.</summary>
+        /// <summary>Writes a tagged sequence of fixed-size numeric values to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        public void WriteTaggedSequence<T>(int tag, ReadOnlySpan<T> v) where T : struct
+        {
+            // A null T[]? or List<T>? is implicitly converted into a default aka null ReadOnlyMemory<T> or
+            // ReadOnlySpan<T>. Furthermore, the span of a default ReadOnlyMemory<T> is a default ReadOnlySpan<T>, which
+            // is distinct from the span of an empty sequence. This is why the "v != null" below works correctly.
+            if (v != null)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
+                int elementSize = Unsafe.SizeOf<T>();
+                if (elementSize > 1)
+                {
+                    // This size is redundant and optimized out by the encoding when elementSize is 1.
+                    WriteSize(v.Length == 0 ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
+                }
+                WriteSequence(v);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of variable-size elements to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="writer">The delegate that writes each element to the stream.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v, OutputStreamWriter<T> writer)
+        {
+            if (v is IEnumerable<T> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteSequence(value, writer);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of fixed-size values to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
         /// <param name="elementSize">The fixed size of each element of the sequence, in bytes.</param>
         /// <param name="writer">The delegate that writes each element to the stream.</param>
         public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v, int elementSize, OutputStreamWriter<T> writer)
+            where T : struct
         {
             Debug.Assert(elementSize > 0);
             if (v is IEnumerable<T> value)
@@ -1014,7 +1001,22 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged sequence of fixed-size elements to the stream. Elements of the sequence are
+        /// <summary>Writes a tagged sequence of variable-size values to the stream. Elements of the sequence are
+        /// mapped Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v) where T : struct, IStreamableStruct
+        {
+            if (v is IEnumerable<T> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteSequence(value);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of fixed-size values to the stream. Elements of the sequence are
         /// mapped Slice structs.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
@@ -1045,32 +1047,56 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged sequence of variable-size elements to the stream.</summary>
+        /// <summary>Writes a tagged sequence of nullable elements to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
-        /// <param name="writer">The delegate that writes each element to the stream.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v, OutputStreamWriter<T> writer)
+        /// <param name="ofNullables">Must always be true.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T?>? v, bool ofNullables, OutputStreamWriter<T> writer)
+            where T : class
         {
-            if (v is IEnumerable<T> value)
+            Debug.Assert(ofNullables);
+            if (v is IEnumerable<T?> value)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
-                WriteSequence(value, writer);
+                WriteSequence(value, ofNullables, writer);
                 EndFixedLengthSize(pos);
             }
         }
 
-        /// <summary>Writes a tagged sequence of variable-size elements to the stream. Elements of the sequence are
-        /// mapped Slice structs.</summary>
+        /// <summary>Writes a tagged sequence of nullable values to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v) where T : struct, IStreamableStruct
+        /// <param name="ofNullables">Must always be true.</param>
+        /// <param name="writer">The delegate that writes each non-null element to the stream.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T?>? v, bool ofNullables, OutputStreamWriter<T> writer)
+            where T : struct
         {
-            if (v is IEnumerable<T> value)
+            Debug.Assert(ofNullables);
+            if (v is IEnumerable<T?> value)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
-                WriteSequence(value);
+                WriteSequence(value, ofNullables, writer);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of nullable values to the stream. Elements of the sequence are mapped
+        /// Slice structs.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        /// <param name="ofNullables">Must always be true.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T?>? v, bool ofNullables)
+            where T : struct, IStreamableStruct
+        {
+            Debug.Assert(ofNullables);
+            if (v is IEnumerable<T?> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteSequence(value, ofNullables);
                 EndFixedLengthSize(pos);
             }
         }
@@ -1596,7 +1622,7 @@ namespace ZeroC.Ice
 
         /// <summary>Writes a fixed-size numeric value to the stream.</summary>
         /// <param name="v">The numeric value to write to the stream.</param>
-        private void WriteFixedSizeNumericValue<T>(T v) where T : struct
+        private void WriteFixedSizeNumeric<T>(T v) where T : struct
         {
             int elementSize = Unsafe.SizeOf<T>();
             Debug.Assert(elementSize > 1); // for size 1, we write the byte directly

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[normalize-case]]
-[[ice-prefix]]
+[[suppress-warning:reserved-identifier]]
 
 module ZeroC::Ice::Test::Optional
 {

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -321,27 +321,27 @@ namespace ZeroC.Ice.tagged
             factory.setEnabled(true);
             OutputStream os = new OutputStream(communicator);
             os.StartEncapsulation();
-            os.WriteOptionalClass(oo1);
+            os.WriteNullableClass(oo1);
             os.EndEncapsulation();
             byte[] inEncaps = os.Finished();
             byte[] outEncaps;
             test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
             InputStream
             responseFrame.InputStream.StartEncapsulation();
-            ReadOptionalClassCallbackI cb = new ReadOptionalClassCallbackI();
-            responseFrame.InputStream.ReadOptionalClass(cb.invoke);
+            ReadNullableClassCallbackI cb = new ReadNullableClassCallbackI();
+            responseFrame.InputStream.ReadNullableClass(cb.invoke);
             responseFrame.InputStream.EndEncapsulation();
             test(cb.obj != null && cb.obj is TestClassReader);
 
             os = new OutputStream(communicator);
             os.StartEncapsulation();
-            os.WriteOptionalClass(mo1);
+            os.WriteNullableClass(mo1);
             os.EndEncapsulation();
             inEncaps = os.Finished();
             test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
 
             responseFrame.InputStream.StartEncapsulation();
-            responseFrame.InputStream.ReadOptionalClass(cb.invoke);
+            responseFrame.InputStream.ReadNullableClass(cb.invoke);
             responseFrame.InputStream.EndEncapsulation();
             test(cb.obj != null && cb.obj is TestClassReader);
             factory.setEnabled(false);
@@ -422,13 +422,13 @@ namespace ZeroC.Ice.tagged
             factory.setEnabled(true);
             os = new OutputStream(communicator);
             os.StartEncapsulation();
-            os.WriteOptionalClass(mc);
+            os.WriteNullableClass(mc);
             os.EndEncapsulation();
             inEncaps = os.Finished();
             test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
 
             responseFrame.InputStream.StartEncapsulation();
-            responseFrame.InputStream.ReadOptionalClass(cb.invoke);
+            responseFrame.InputStream.ReadNullableClass(cb.invoke);
             responseFrame.InputStream.EndEncapsulation();
             test(cb.obj != null && cb.obj is TestClassReader);
             factory.setEnabled(false);
@@ -462,13 +462,13 @@ namespace ZeroC.Ice.tagged
                 factory.setEnabled(true);
                 os = new OutputStream(communicator);
                 os.StartEncapsulation();
-                os.WriteOptionalClass(b);
+                os.WriteNullableClass(b);
                 os.EndEncapsulation();
                 inEncaps = os.Finished();
                 test(initial.Invoke("pingPong", idempotent: false, inEncaps, out outEncaps));
 
                 responseFrame.InputStream.StartEncapsulation();
-                responseFrame.InputStream.ReadOptionalClass(cb.invoke);
+                responseFrame.InputStream.ReadNullableClass(cb.invoke);
                 responseFrame.InputStream.EndEncapsulation();
                 test(cb.obj != null);
                 factory.setEnabled(false);
@@ -493,13 +493,13 @@ namespace ZeroC.Ice.tagged
                 factory.setEnabled(true);
                 os = new OutputStream(communicator);
                 os.StartEncapsulation();
-                os.WriteOptionalClass(f);
+                os.WriteNullableClass(f);
                 os.EndEncapsulation();
                 inEncaps = os.Finished();
                 responseFrame.InputStream = new InputStream(communicator, inEncaps);
                 responseFrame.InputStream.StartEncapsulation();
-                ReadOptionalClassCallbackI rocb = new ReadOptionalClassCallbackI();
-                responseFrame.InputStream.ReadOptionalClass(rocb.invoke);
+                ReadNullableClassCallbackI rocb = new ReadNullableClassCallbackI();
+                responseFrame.InputStream.ReadNullableClass(rocb.invoke);
                 responseFrame.InputStream.EndEncapsulation();
                 factory.setEnabled(false);
                 rf = ((FClassReader)rocb.obj).getF();
@@ -866,8 +866,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeStruct(1, istr => new SmallStruct(istr)),
-                        istr.ReadTaggedFixedSizeStruct(3, istr => new SmallStruct(istr))));
+                    (istr.ReadTaggedStruct(1, fixedSize: true, istr => new SmallStruct(istr)),
+                        istr.ReadTaggedStruct(3, fixedSize: true, istr => new SmallStruct(istr))));
 
                 TestHelper.Assert(p2!.Value.m == 56);
                 TestHelper.Assert(p3!.Value.m == 56);
@@ -899,8 +899,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeStruct(1, istr => new FixedStruct(istr)),
-                        istr.ReadTaggedFixedSizeStruct(3, istr => new FixedStruct(istr))));
+                    (istr.ReadTaggedStruct(1, fixedSize: true, istr => new FixedStruct(istr)),
+                        istr.ReadTaggedStruct(3, fixedSize: true, istr => new FixedStruct(istr))));
                 TestHelper.Assert(p2!.Value.m == 56);
                 TestHelper.Assert(p3!.Value.m == 56);
             }
@@ -940,8 +940,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedVariableSizeStruct(1, istr => new VarStruct(istr)),
-                        istr.ReadTaggedVariableSizeStruct(3, istr => new VarStruct(istr))));
+                    (istr.ReadTaggedStruct(1, fixedSize: false, istr => new VarStruct(istr)),
+                        istr.ReadTaggedStruct(3, fixedSize: false, istr => new VarStruct(istr))));
                 TestHelper.Assert(p2!.Value.m.Equals("test"));
                 TestHelper.Assert(p3!.Value.m.Equals("test"));
 
@@ -954,16 +954,16 @@ namespace ZeroC.Ice.tagged
                 ostr = new OutputStream(communicator);
                 ostr.StartEncapsulation();
                 ostr.WriteTagged(1, TaggedFormat.Class);
-                ostr.WriteOptionalClass(f);
+                ostr.WriteNullableClass(f);
                 ostr.WriteTagged(2, TaggedFormat.Class);
-                ostr.WriteOptionalClass(f.ae);
+                ostr.WriteNullableClass(f.ae);
                 ostr.EndEncapsulation();
                 var inEncaps = ostr.ToArray();
 
                 var istr = new InputStream(communicator, inEncaps);
                 istr.StartEncapsulation();
                 test(istr.ReadTagged(2, TaggedFormat.Class));
-                var a = istr.ReadOptionalClass<A>();
+                var a = istr.ReadNullableClass<A>();
                 istr.EndEncapsulation();
                 test(a != null && a.requiredA == 56);*/
             }
@@ -1020,11 +1020,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opByteSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<byte>(1), istr.ReadTaggedFixedSizeNumericValueArray<byte>(3)));
+                    (istr.ReadTaggedArray<byte>(1), istr.ReadTaggedArray<byte>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1052,11 +1052,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opBoolSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<bool>(1), istr.ReadTaggedFixedSizeNumericValueArray<bool>(3)));
+                    (istr.ReadTaggedArray<bool>(1), istr.ReadTaggedArray<bool>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1084,11 +1084,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opShortSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, short[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<short>(1), istr.ReadTaggedFixedSizeNumericValueArray<short>(3)));
+                    (istr.ReadTaggedArray<short>(1), istr.ReadTaggedArray<short>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1115,11 +1115,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opIntSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, int[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<int>(1), istr.ReadTaggedFixedSizeNumericValueArray<int>(3)));
+                    (istr.ReadTaggedArray<int>(1), istr.ReadTaggedArray<int>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1146,11 +1146,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opLongSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, long[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<long>(1), istr.ReadTaggedFixedSizeNumericValueArray<long>(3)));
+                    (istr.ReadTaggedArray<long>(1), istr.ReadTaggedArray<long>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1177,11 +1177,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opFloatSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, float[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<float>(1), istr.ReadTaggedFixedSizeNumericValueArray<float>(3)));
+                    (istr.ReadTaggedArray<float>(1), istr.ReadTaggedArray<float>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1208,11 +1208,11 @@ namespace ZeroC.Ice.tagged
 
                 requestFrame = OutgoingRequestFrame.WithParamList(initial, "opDoubleSeq", idempotent: false,
                     format: null, context: null, p1,
-                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedFixedSizeNumericValueArray(2, p1));
+                    (OutputStream ostr, double[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeNumericValueArray<double>(1), istr.ReadTaggedFixedSizeNumericValueArray<double>(3)));
+                    (istr.ReadTaggedArray<double>(1), istr.ReadTaggedArray<double>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1245,8 +1245,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedVariableSizeElementArray(1, 1, istr => istr.ReadString()),
-                       istr.ReadTaggedVariableSizeElementArray(3, 1, istr => istr.ReadString())));
+                    (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => istr.ReadString()),
+                       istr.ReadTaggedArray(3, 1, fixedSize: false, istr => istr.ReadString())));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1278,8 +1278,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeValueArray(1, 1, istr => new SmallStruct(istr)),
-                        istr.ReadTaggedFixedSizeValueArray(3, 1, istr => new SmallStruct(istr))));
+                    (istr.ReadTaggedArray(1, 1, fixedSize: true, istr => new SmallStruct(istr)),
+                        istr.ReadTaggedArray(3, 1, fixedSize: true, istr => new SmallStruct(istr))));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1318,11 +1318,11 @@ namespace ZeroC.Ice.tagged
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
                     {
                         List<SmallStruct>? list1 =
-                            istr.ReadTaggedFixedSizeValueSequence(1, 1, istr => new SmallStruct(istr)) is
+                            istr.ReadTaggedSequence(1, 1, fixedSize: true, istr => new SmallStruct(istr)) is
                                 ICollection<SmallStruct> collection1 ? new List<SmallStruct>(collection1) : null;
 
                         List<SmallStruct>? list2 =
-                            istr.ReadTaggedFixedSizeValueSequence(3, 1, istr => new SmallStruct(istr)) is
+                            istr.ReadTaggedSequence(3, 1, fixedSize: true, istr => new SmallStruct(istr)) is
                                 ICollection<SmallStruct> collection2 ? new List<SmallStruct>(collection2) : null;
 
                         return (list1, list2);
@@ -1359,8 +1359,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeValueArray(1, 4, istr => new FixedStruct(istr)),
-                        istr.ReadTaggedFixedSizeValueArray(3, 4, istr => new FixedStruct(istr))));
+                    (istr.ReadTaggedArray(1, 4, fixedSize: true, istr => new FixedStruct(istr)),
+                        istr.ReadTaggedArray(3, 4, fixedSize: true, istr => new FixedStruct(istr))));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1399,11 +1399,11 @@ namespace ZeroC.Ice.tagged
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
                     {
                         LinkedList<FixedStruct>? list1 =
-                            istr.ReadTaggedFixedSizeValueSequence(1, 4, istr => new FixedStruct(istr)) is
+                            istr.ReadTaggedSequence(1, 4, fixedSize: true, istr => new FixedStruct(istr)) is
                                 ICollection<FixedStruct> collection1 ? new LinkedList<FixedStruct>(collection1) : null;
 
                         LinkedList<FixedStruct>? list2 =
-                            istr.ReadTaggedFixedSizeValueSequence(3, 4, istr => new FixedStruct(istr)) is
+                            istr.ReadTaggedSequence(3, 4, fixedSize: true, istr => new FixedStruct(istr)) is
                                 ICollection<FixedStruct> collection2 ? new LinkedList<FixedStruct>(collection2) : null;
 
                         return (list1, list2);
@@ -1439,8 +1439,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                      (istr.ReadTaggedVariableSizeElementArray(1, 1, istr => new VarStruct(istr)),
-                        istr.ReadTaggedVariableSizeElementArray(3, 1, istr => new VarStruct(istr))));
+                      (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => new VarStruct(istr)),
+                        istr.ReadTaggedArray(3, 1, fixedSize: false, istr => new VarStruct(istr))));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1507,8 +1507,8 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedFixedSizeEntryDictionary(1, 8, istr => istr.ReadInt(), istr => istr.ReadInt()),
-                        istr.ReadTaggedFixedSizeEntryDictionary(3, 8, istr => istr.ReadInt(), istr => istr.ReadInt())));
+                    (istr.ReadTaggedDictionary(1, 8, fixedSize: true, istr => istr.ReadInt(), istr => istr.ReadInt()),
+                        istr.ReadTaggedDictionary(3, 8, fixedSize: true, istr => istr.ReadInt(), istr => istr.ReadInt())));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1547,9 +1547,9 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                      (istr.ReadTaggedVariableSizeEntryDictionary(1, 5, istr => istr.ReadString(),
+                      (istr.ReadTaggedDictionary(1, 5, fixedSize: false, istr => istr.ReadString(),
                                                                         istr => istr.ReadInt()),
-                            istr.ReadTaggedVariableSizeEntryDictionary(3, 5, istr => istr.ReadString(),
+                            istr.ReadTaggedDictionary(3, 5, fixedSize: false, istr => istr.ReadString(),
                                                                              istr => istr.ReadInt())));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1581,14 +1581,14 @@ namespace ZeroC.Ice.tagged
                     format: null, context: null, p1,
                     (OutputStream ostr, Dictionary<int, OneTagged?>? p1) =>
                         ostr.WriteTaggedDictionary(
-                            2, p1, (ostr, k) => ostr.WriteInt(k), (ostr, v) => ostr.WriteOptionalClass(v)));
+                            2, p1, (ostr, k) => ostr.WriteInt(k), (ostr, v) => ostr.WriteNullableClass(v)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedVariableSizeEntryDictionary(1, 5, istr => istr.ReadInt(),
-                                                                     istr => istr.ReadOptionalClass<OneTagged>()),
-                        istr.ReadTaggedVariableSizeEntryDictionary(3, 5, istr => istr.ReadInt(),
-                                                                         istr => istr.ReadOptionalClass<OneTagged>())));
+                    (istr.ReadTaggedDictionary(1, 5, fixedSize: false, istr => istr.ReadInt(),
+                                                                     istr => istr.ReadNullableClass<OneTagged>()),
+                        istr.ReadTaggedDictionary(3, 5, fixedSize: false, istr => istr.ReadInt(),
+                                                                         istr => istr.ReadNullableClass<OneTagged>())));
                 TestHelper.Assert(p2![1]!.a == 58);
                 TestHelper.Assert(p3![1]!.a == 58);
             }


### PR DESCRIPTION
This PR simplifies the method names of InputStream and OutputStream, by removing all `FixedSizedNumericValue`, `OptionalElement`, `VariableSizeEntry` and similar qualifications.

With this PR, all methods reading and writing sequences are now called ReadSequence resp. WriteSequence; the tagged variants are called ReadTaggedSequence resp. WriteTaggedSequence. Likewise for dictionaries and structs.

The main downside is the introduction of a "useless" bool parameter on a few methods to avoid overload ambiguity: ofNullables in OutputStream and ofNullableValues in InputStream. See the corresponding comments in the code.
