### PR TITLE
Add support for dictionary with optional/nullable values in C#

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4307,7 +4307,6 @@ Slice::Optional::usesClasses() const
 size_t
 Slice::Optional::minWireSize() const
 {
-    // Should only be called for classes and proxies.
     if (_underlying->isClassType())
     {
         return 1;
@@ -4318,7 +4317,6 @@ Slice::Optional::minWireSize() const
     }
     else
     {
-        assert(0);
         return 0;
     }
 }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -858,6 +858,7 @@ public:
     std::string getTagFormat() const override;
     bool isVariableLength() const override;
     TypePtr underlying() const { return _underlying; }
+    bool encodedUsingBitSequence() const { return minWireSize() == 0; }
 
 private:
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1045,8 +1045,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output& out,
         {
             out << nl << stream << ".WriteTaggedSerializable(" << tag << ", " << param << ");";
         }
-        else if (auto optional = OptionalPtr::dynamicCast(elementType);
-                 optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+        else if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
         {
             TypePtr underlying = optional->underlying();
             out << nl << stream << ".WriteTaggedSequence(" << tag << ", " << param;
@@ -1091,8 +1090,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output& out,
 
         bool withBitSequence = false;
 
-        if (auto optional = OptionalPtr::dynamicCast(valueType);
-            optional && !optional->underlying()->isClassType() && !optional->underlying()->isClassType())
+        if (auto optional = OptionalPtr::dynamicCast(valueType); optional && optional->encodedUsingBitSequence())
         {
             withBitSequence = true;
             valueType = optional->underlying();
@@ -1184,8 +1182,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
         }
         else if (seq->hasMetaDataWithPrefix("cs:generic:"))
         {
-            if (auto optional = OptionalPtr::dynamicCast(elementType);
-                optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+            if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
             {
                 TypePtr underlying = optional->underlying();
                 out << stream << ".ReadTaggedSequence(" << tag << ", "
@@ -1208,8 +1205,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
         }
         else
         {
-            if (auto optional = OptionalPtr::dynamicCast(elementType);
-                optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+            if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
             {
                 TypePtr underlying = optional->underlying();
                 out << stream << ".ReadTaggedArray(" << tag << ", "
@@ -1232,8 +1228,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
         TypePtr valueType = d->valueType();
         bool withBitSequence = false;
 
-        if (auto optional = OptionalPtr::dynamicCast(valueType);
-            optional && !optional->underlying()->isClassType() && !optional->underlying()->isClassType())
+        if (auto optional = OptionalPtr::dynamicCast(valueType); optional && optional->encodedUsingBitSequence())
         {
             withBitSequence = true;
             valueType = optional->underlying();
@@ -1282,8 +1277,7 @@ Slice::CsGenerator::sequenceMarshalCode(const SequencePtr& seq, const string& sc
     {
         out << stream << ".WriteSerializable(" << param << ")";
     }
-    else if (auto optional = OptionalPtr::dynamicCast(type);
-             optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+    else if (auto optional = OptionalPtr::dynamicCast(type); optional && optional->encodedUsingBitSequence())
     {
         TypePtr underlying = optional->underlying();
         out << stream << ".WriteSequence(" << param;
@@ -1329,8 +1323,7 @@ Slice::CsGenerator::sequenceUnmarshalCode(const SequencePtr& seq, const string& 
         {
             out << stream << ".ReadArray<" << typeToString(builtin, scope) << ">()";
         }
-        else if (auto optional = OptionalPtr::dynamicCast(type);
-                 optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+        else if (auto optional = OptionalPtr::dynamicCast(type); optional && optional->encodedUsingBitSequence())
         {
             TypePtr underlying = optional->underlying();
             out << stream << ".ReadArray(" << (isReferenceType(underlying) ? "withBitSequence: true, " : "")
@@ -1356,8 +1349,7 @@ Slice::CsGenerator::sequenceUnmarshalCode(const SequencePtr& seq, const string& 
             // the collection elements one by one.
             out << stream << ".ReadArray<" << typeToString(builtin, scope) << ">()";
         }
-        else if (auto optional = OptionalPtr::dynamicCast(type);
-                 optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+        else if (auto optional = OptionalPtr::dynamicCast(type); optional && optional->encodedUsingBitSequence())
         {
             TypePtr underlying = optional->underlying();
             out << stream << ".ReadSequence(" << (isReferenceType(underlying) ? "withBitSequence: true, " : "")

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2121,8 +2121,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     TypePtr value = p->valueType();
 
     bool withBitSequence = false;
-    if (auto optional = OptionalPtr::dynamicCast(value);
-        optional && !optional->underlying()->isClassType() && !optional->underlying()->isClassType())
+    if (auto optional = OptionalPtr::dynamicCast(value); optional && optional->encodedUsingBitSequence())
     {
         withBitSequence = true;
         value = optional->underlying();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -587,7 +587,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                 for (int i = 0; i < sz; ++i)
+                for (int i = 0; i < sz; ++i)
                 {
                     TKey key = keyReader(this);
                     TValue value = valueReader(this);

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -480,6 +480,200 @@ namespace ZeroC.Ice
             }
         }
 
+        /// <summary>Writes a dictionary to the stream. The dictionary's value type is reference type.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
+        /// false.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue?> v,
+            bool withBitSequence,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : class
+        {
+            if (withBitSequence)
+            {
+                int count = v.Count();
+                WriteSize(count);
+                BitSequence bitSequence = WriteBitSequence(count);
+                int index = 0;
+                foreach ((TKey key, TValue? value) in v)
+                {
+                    keyWriter(this, key);
+                    if (value is TValue actualValue)
+                    {
+                        valueWriter(this, actualValue);
+                    }
+                    else
+                    {
+                        bitSequence[index] = false;
+                    }
+                    index++;
+                }
+            }
+            else
+            {
+                WriteDictionary((IReadOnlyDictionary<TKey, TValue>)v, keyWriter, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream. The dictionary's value type is nullable value type.
+        /// </summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue?> v,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : struct
+        {
+            int count = v.Count();
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach ((TKey key, TValue? value) in v)
+            {
+                keyWriter(this, key);
+                if (value is TValue actualValue)
+                {
+                    valueWriter(this, actualValue);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct and the
+        /// dictionary's value type is a reference type.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
+        /// false.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue?> v,
+            bool withBitSequence,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : class
+        {
+            if (withBitSequence)
+            {
+                int count = v.Count();
+                WriteSize(count);
+                BitSequence bitSequence = WriteBitSequence(count);
+                int index = 0;
+                foreach ((TKey key, TValue? value) in v)
+                {
+                    key.IceWrite(this);
+                    if (value is TValue actualValue)
+                    {
+                        valueWriter(this, actualValue);
+                    }
+                    else
+                    {
+                        bitSequence[index] = false;
+                    }
+                    index++;
+                }
+            }
+            else
+            {
+                WriteDictionary((IReadOnlyDictionary<TKey, TValue>)v, valueWriter);
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct and the
+        /// dictionary's value type is a nullable value type.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue?> v,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct
+        {
+            int count = v.Count();
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach ((TKey key, TValue? value) in v)
+            {
+                key.IceWrite(this);
+                if (value is TValue actualValue)
+                {
+                    valueWriter(this, actualValue);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream. The dictionary's value is a nullable mapped Slice struct.
+        /// </summary>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        public void WriteDictionary<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue?> v,
+            OutputStreamWriter<TKey> keyWriter)
+            where TKey : notnull
+            where TValue : struct, IStreamableStruct
+        {
+            int count = v.Count();
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach ((TKey key, TValue? value) in v)
+            {
+                keyWriter(this, key);
+                if (value is TValue actualValue)
+                {
+                    actualValue.IceWrite(this);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
+        /// <summary>Writes a dictionary to the stream. Both the dictionary's key and value are mapped Slice structs,
+        /// and the values are nullable.</summary>
+        /// <param name="v">The dictionary to write.</param>
+        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue?> v)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct, IStreamableStruct
+        {
+            int count = v.Count();
+            WriteSize(count);
+            BitSequence bitSequence = WriteBitSequence(count);
+            int index = 0;
+            foreach ((TKey key, TValue? value) in v)
+            {
+                key.IceWrite(this);
+                if (value is TValue actualValue)
+                {
+                    actualValue.IceWrite(this);
+                }
+                else
+                {
+                    bitSequence[index] = false;
+                }
+                index++;
+            }
+        }
+
         /// <summary>Writes an enumerator to the stream.</summary>
         /// <param name="v">The enumerator's int value.</param>
         public void WriteEnum(int v) => WriteSize(v);
@@ -902,6 +1096,138 @@ namespace ZeroC.Ice
             where TValue : struct, IStreamableStruct
         {
             if (v is IReadOnlyDictionary<TKey, TValue> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
+        /// false.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v,
+            bool withBitSequence,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : class
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict, withBitSequence, keyWriter, valueWriter);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream. The dictionary's value type is a nullable value type.
+        /// </summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v,
+            OutputStreamWriter<TKey> keyWriter,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : notnull
+            where TValue : struct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict, keyWriter, valueWriter);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream. The dictionary's key is a mapped Slice struct.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
+        /// false.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v,
+            bool withBitSequence,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : class
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict, withBitSequence, valueWriter);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream. The dictionary's key is a mapped Slice struct,
+        /// and the dictionary's value type is a nullable value type.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v,
+            OutputStreamWriter<TValue> valueWriter)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict, valueWriter);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream. The dictionary's value is a nullable mapped Slice struct.
+        /// </summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v,
+            OutputStreamWriter<TKey> keyWriter)
+            where TKey : notnull
+            where TValue : struct, IStreamableStruct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
+                Position pos = StartFixedLengthSize();
+                WriteDictionary(dict, keyWriter);
+                EndFixedLengthSize(pos);
+            }
+        }
+
+        /// <summary>Writes a tagged dictionary to the stream. Both the dictionary's key and value are mapped Slice
+        /// structs, and the value's type is nullable.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The dictionary to write.</param>
+        public void WriteTaggedDictionary<TKey, TValue>(
+            int tag,
+            IReadOnlyDictionary<TKey, TValue?>? v)
+            where TKey : struct, IStreamableStruct
+            where TValue : struct, IStreamableStruct
+        {
+            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
             {
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -503,9 +503,9 @@ namespace ZeroC.Ice
                 foreach ((TKey key, TValue? value) in v)
                 {
                     keyWriter(this, key);
-                    if (value is TValue actualValue)
+                    if (value != null)
                     {
-                        valueWriter(this, actualValue);
+                        valueWriter(this, value);
                     }
                     else
                     {
@@ -573,9 +573,9 @@ namespace ZeroC.Ice
                 foreach ((TKey key, TValue? value) in v)
                 {
                     key.IceWrite(this);
-                    if (value is TValue actualValue)
+                    if (value != null)
                     {
-                        valueWriter(this, actualValue);
+                        valueWriter(this, value);
                     }
                     else
                     {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Test;
@@ -162,6 +163,20 @@ namespace ZeroC.Ice.Test.Optional
 
             output.WriteLine("ok");
 
+            output.Write("testing operations with dictionary<K, V?> parameters... ");
+            Dictionary<int, int?> intIntDict = new Dictionary<int, int?> { { 1, -5 }, { 3, null }, { 5, 19 },
+                { 7, -35000 }};
+            TestHelper.Assert(test.OpIntOptIntDict(intIntDict).DictionaryEqual(intIntDict));
+            TestHelper.Assert(test.OpTaggedIntOptIntDict(intIntDict)!.DictionaryEqual(intIntDict));
+            TestHelper.Assert(test.OpTaggedIntOptIntDict(null) == null);
+
+            Dictionary<int, string?> intStringDict = new Dictionary<int, string?> { { 1, "foo" }, { 3, "test" },
+                { 5, null }, { 7, "bar" }};
+            TestHelper.Assert(test.OpIntOptStringDict(intStringDict).DictionaryEqual(intStringDict));
+            TestHelper.Assert(test.OpTaggedIntOptStringDict(intStringDict)!.DictionaryEqual(intStringDict));
+            TestHelper.Assert(test.OpTaggedIntOptStringDict(null) == null);
+
+            output.WriteLine("ok");
             return test;
         }
     }

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -17,6 +17,9 @@ module ZeroC::Ice::Test::Optional
     sequence<int?> OptIntSeq;
     sequence<string?> OptStringSeq;
 
+    dictionary<int, int?> IntOptIntDict;
+    dictionary<int, string?> IntOptStringDict;
+
     interface Test
     {
         void shutdown();
@@ -42,5 +45,11 @@ module ZeroC::Ice::Test::Optional
 
         OptStringSeq opOptStringSeq(OptStringSeq i1);
         tag(1) OptStringSeq? opTaggedOptStringSeq(tag(2) OptStringSeq? i1);
+
+        IntOptIntDict opIntOptIntDict(IntOptIntDict i1);
+        tag(1) IntOptIntDict? opTaggedIntOptIntDict(tag(2) IntOptIntDict? i1);
+
+        IntOptStringDict opIntOptStringDict(IntOptStringDict i1);
+        tag(1) IntOptStringDict? opTaggedIntOptStringDict(tag(2) IntOptStringDict? i1);
     }
 }

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -62,5 +62,16 @@ namespace ZeroC.Ice.Test.Optional
         public IEnumerable<string?> OpOptStringSeq(string?[] i1, Current current) => i1;
 
         public IEnumerable<string?>? OpTaggedOptStringSeq(string?[]? i1, Current current) => i1;
+
+        public IReadOnlyDictionary<int, int?> OpIntOptIntDict(Dictionary<int, int?> i1, Current current) => i1;
+
+        public IReadOnlyDictionary<int, int?>? OpTaggedIntOptIntDict(Dictionary<int, int?>? i1, Current current) => i1;
+
+        public IReadOnlyDictionary<int, string?> OpIntOptStringDict(Dictionary<int, string?> i1, Current current) =>
+            i1;
+
+        public IReadOnlyDictionary<int, string?>? OpTaggedIntOptStringDict(
+            Dictionary<int, string?>? i1,
+            Current current) => i1;
     }
 }

--- a/csharp/test/Ice/optional/msbuild/client/client.csproj
+++ b/csharp/test/Ice/optional/msbuild/client/client.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../../../TestCommon/TestHelper.cs" />
+    <Compile Include="../../../../TestCommon/DictionaryExtensions.cs" />
     <Compile Include="../../AllTests.cs" />
     <Compile Include="../../Client.cs" />
     <Compile Include="generated/Test.cs">

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -1507,8 +1507,10 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedDictionary(1, 8, fixedSize: true, istr => istr.ReadInt(), istr => istr.ReadInt()),
-                        istr.ReadTaggedDictionary(3, 8, fixedSize: true, istr => istr.ReadInt(), istr => istr.ReadInt())));
+                    (istr.ReadTaggedDictionary(1, 4, 4, fixedSize: true,
+                        istr => istr.ReadInt(), istr => istr.ReadInt()),
+                     istr.ReadTaggedDictionary(3, 4, 4, fixedSize: true,
+                         istr => istr.ReadInt(), istr => istr.ReadInt())));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1547,10 +1549,10 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                      (istr.ReadTaggedDictionary(1, 5, fixedSize: false, istr => istr.ReadString(),
-                                                                        istr => istr.ReadInt()),
-                            istr.ReadTaggedDictionary(3, 5, fixedSize: false, istr => istr.ReadString(),
-                                                                             istr => istr.ReadInt())));
+                      (istr.ReadTaggedDictionary(1, 1, 4, fixedSize: false, istr => istr.ReadString(),
+                                                                            istr => istr.ReadInt()),
+                       istr.ReadTaggedDictionary(3, 1, 4, fixedSize: false, istr => istr.ReadString(),
+                                                                            istr => istr.ReadInt())));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
             }
@@ -1585,10 +1587,10 @@ namespace ZeroC.Ice.tagged
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(istr =>
-                    (istr.ReadTaggedDictionary(1, 5, fixedSize: false, istr => istr.ReadInt(),
+                    (istr.ReadTaggedDictionary(1, 1, 4, fixedSize: false, istr => istr.ReadInt(),
                                                                      istr => istr.ReadNullableClass<OneTagged>()),
-                        istr.ReadTaggedDictionary(3, 5, fixedSize: false, istr => istr.ReadInt(),
-                                                                         istr => istr.ReadNullableClass<OneTagged>())));
+                     istr.ReadTaggedDictionary(3, 1, 4, fixedSize: false, istr => istr.ReadInt(),
+                                                                     istr => istr.ReadNullableClass<OneTagged>())));
                 TestHelper.Assert(p2![1]!.a == 58);
                 TestHelper.Assert(p3![1]!.a == 58);
             }


### PR DESCRIPTION
This PR adds support for dictionaries with optional (nullable) values in C#.

It's similar to the sequence<T?> support added previously. A dictionary<K, V?> is encoded using a bit sequence that indicates which values are null (and therefore not encoded at all). Keys are never optional.