### PR TITLE
slice2cs Compiler Additionally Generates AMD-only Servant

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1050,8 +1050,11 @@ Slice::Gen::generate(const UnitPtr& p)
     ProxyVisitor proxyVisitor(_out);
     p->visit(&proxyVisitor, false);
 
-    DispatcherVisitor dispatcherVisitor(_out);
+    DispatcherVisitor dispatcherVisitor(_out, false);
     p->visit(&dispatcherVisitor, false);
+
+    DispatcherVisitor asyncDispatcherVisitor(_out, true);
+    p->visit(&asyncDispatcherVisitor, false);
 
     ClassFactoryVisitor classFactoryVisitor(_out);
     p->visit(&classFactoryVisitor, false);
@@ -2578,8 +2581,8 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestReader(const OperationPtr& operati
     }
 }
 
-Slice::Gen::DispatcherVisitor::DispatcherVisitor(::IceUtilInternal::Output& out) :
-    CsVisitor(out)
+Slice::Gen::DispatcherVisitor::DispatcherVisitor(::IceUtilInternal::Output& out, bool generateAsync) :
+    CsVisitor(out), _generateAsync(generateAsync)
 {
 }
 
@@ -2605,7 +2608,7 @@ bool
 Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
-    string name = interfaceName(p);
+    string name = interfaceName(p) + (_generateAsync ? "Async" : "");
     string ns = getNamespace(p);
 
     _out << sp;
@@ -2622,7 +2625,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for(InterfaceList::const_iterator q = bases.begin(); q != bases.end();)
         {
-            _out << getUnqualified(getNamespace(*q) + "." + interfaceName(*q), ns);
+            _out << getUnqualified(getNamespace(*q) + "." + (interfaceName(*q) + (_generateAsync ? "Async" : "")), ns);
             if(++q != bases.end())
             {
                 _out << ", ";
@@ -2747,7 +2750,7 @@ Slice::Gen::DispatcherVisitor::writeMethodDeclaration(const OperationPtr& operat
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(interface);
     string deprecateReason = getDeprecateReason(operation, interface, "operation");
-    bool amd = interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
     const string name = fixId(operationName(operation) + (amd ? "Async" : ""));
     list<ParamInfo> inParams = getAllInParams(operation, false);
 
@@ -2777,7 +2780,7 @@ void
 Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
-    bool amd = interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
     string ns = getNamespace(interface);
     string opName = operationName(operation);
     string name = fixId(opName + (amd ? "Async" : ""));

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2581,8 +2581,8 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestReader(const OperationPtr& operati
     }
 }
 
-Slice::Gen::DispatcherVisitor::DispatcherVisitor(::IceUtilInternal::Output& out, bool generateAsync) :
-    CsVisitor(out), _generateAsync(generateAsync)
+Slice::Gen::DispatcherVisitor::DispatcherVisitor(::IceUtilInternal::Output& out, bool generateAllAsync) :
+    CsVisitor(out), _generateAllAsync(generateAllAsync)
 {
 }
 
@@ -2608,7 +2608,7 @@ bool
 Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
-    string name = interfaceName(p) + (_generateAsync ? "Async" : "");
+    string name = interfaceName(p) + (_generateAllAsync ? "Async" : "");
     string ns = getNamespace(p);
 
     _out << sp;
@@ -2625,7 +2625,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for(InterfaceList::const_iterator q = bases.begin(); q != bases.end();)
         {
-            _out << getUnqualified(getNamespace(*q) + "." + (interfaceName(*q) + (_generateAsync ? "Async" : "")), ns);
+            _out << getUnqualified(getNamespace(*q) + "." + (interfaceName(*q) + (_generateAllAsync ? "Async" : "")), ns);
             if(++q != bases.end())
             {
                 _out << ", ";
@@ -2750,7 +2750,7 @@ Slice::Gen::DispatcherVisitor::writeMethodDeclaration(const OperationPtr& operat
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(interface);
     string deprecateReason = getDeprecateReason(operation, interface, "operation");
-    bool amd = _generateAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAllAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
     const string name = fixId(operationName(operation) + (amd ? "Async" : ""));
     list<ParamInfo> inParams = getAllInParams(operation, false);
 
@@ -2780,7 +2780,7 @@ void
 Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
-    bool amd = _generateAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAllAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
     string ns = getNamespace(interface);
     string opName = operationName(operation);
     string name = fixId(opName + (amd ? "Async" : ""));

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -146,7 +146,7 @@ private:
     {
     public:
 
-        DispatcherVisitor(::IceUtilInternal::Output&);
+        DispatcherVisitor(::IceUtilInternal::Output&, bool);
 
         virtual bool visitModuleStart(const ModulePtr&);
         virtual void visitModuleEnd(const ModulePtr&);
@@ -158,6 +158,10 @@ private:
 
         void writeReturnValueStruct(const OperationPtr&);
         void writeMethodDeclaration(const OperationPtr&);
+
+    private:
+
+        const bool _generateAsync;
     };
 
     class ImplVisitor : public CsVisitor

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -161,7 +161,7 @@ private:
 
     private:
 
-        const bool _generateAsync;
+        const bool _generateAllAsync;
     };
 
     class ImplVisitor : public CsVisitor


### PR DESCRIPTION
This actually small PR causes the `slice2cs` compiler to generate an AMD-only servant (one where all the operations are generated as if they were marked with `[amd]`) in addition to the original servant which is generated true to the Slice file.

This PR in no way affects the originally generated servant skeleton `I<interfaceName>` and so is backwards compatible. The new servant is named `I<interfaceName>Async` and generated directly afterwards. This gives users the ability to choose between implementing entirely asynchronous servants, or those that stay true to the Slice definition.

This is inspired by #60 