### PR TITLE
Removed 'typeid-namespace' metadata from C# mapping.

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -202,21 +202,6 @@ Slice::getNamespacePrefix(const ContainedPtr& cont)
 }
 
 string
-Slice::CsGenerator::getCustomTypeIdNamespace(const UnitPtr& ut)
-{
-    DefinitionContextPtr dc = ut->findDefinitionContext(ut->topLevelFile());
-    assert(dc);
-
-    static const string typeIdNsPrefix = "cs:typeid-namespace:";
-    string result = dc->findMetaData(typeIdNsPrefix);
-    if(!result.empty())
-    {
-        result = result.substr(typeIdNsPrefix.size());
-    }
-    return result;
-}
-
-string
 Slice::getNamespace(const ContainedPtr& cont)
 {
     string scope = fixId(cont->scope());
@@ -1463,9 +1448,7 @@ Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
             if(s.find(csPrefix) == 0)
             {
                 static const string csAttributePrefix = csPrefix + "attribute:";
-                static const string csTypeIdNsPrefix = csPrefix + "typeid-namespace:";
-                if(!(s.find(csTypeIdNsPrefix) == 0 && s.size() > csTypeIdNsPrefix.size()) &&
-                   !(s.find(csAttributePrefix) == 0 && s.size() > csAttributePrefix.size()))
+                if(!(s.find(csAttributePrefix) == 0 && s.size() > csAttributePrefix.size()))
                 {
                     dc->warning(InvalidMetaData, file, -1, "ignoring invalid global metadata `" + oldS + "'");
                     continue;

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -106,8 +106,6 @@ public:
 
 protected:
 
-    static std::string getCustomTypeIdNamespace(const UnitPtr&);
-
     //
     // Generate code to marshal or unmarshal a type
     //

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3124,14 +3124,10 @@ Slice::Gen::ClassFactoryVisitor::visitModuleStart(const ModulePtr& p)
     if (p->hasValueDefs())
     {
         string prefix;
+        // We are generating code for a top-level module
         if (!ContainedPtr::dynamicCast(p->container()))
         {
-            // We are generating code for a top-level module
-            prefix = getCustomTypeIdNamespace(p->unit());
-            if (prefix.empty())
-            {
-                prefix = "ZeroC.Ice.ClassFactory";
-            }
+            prefix = "ZeroC.Ice.ClassFactory";
         }
         openNamespace(p, prefix);
         return true;
@@ -3176,13 +3172,7 @@ Slice::Gen::CompactIdVisitor::visitUnitStart(const UnitPtr& p)
     // The CompactIdVisitor does not visit modules, only the unit.
     if (p->hasCompactTypeId())
     {
-        string typeIdNs = getCustomTypeIdNamespace(p);
-        if (typeIdNs.empty())
-        {
-            typeIdNs = "ZeroC.Ice.ClassFactory";
-        }
-
-        _out << sp << nl << "namespace " << typeIdNs;
+        _out << sp << nl << "namespace ZeroC.Ice.ClassFactory";
         _out << sb;
         return true;
     }
@@ -3224,14 +3214,10 @@ Slice::Gen::RemoteExceptionFactoryVisitor::visitModuleStart(const ModulePtr& p)
     if (p->hasExceptions())
     {
         string prefix;
+        // We are generating code for a top-level module
         if (!ContainedPtr::dynamicCast(p->container()))
         {
-            // We are generating code for a top-level module
-            prefix = getCustomTypeIdNamespace(p->unit());
-            if (prefix.empty())
-            {
-                prefix = "ZeroC.Ice.RemoteExceptionFactory";
-            }
+            prefix = "ZeroC.Ice.RemoteExceptionFactory";
         }
         openNamespace(p, prefix);
         return true;

--- a/csharp/src/Glacier2/SessionFactoryHelper.cs
+++ b/csharp/src/Glacier2/SessionFactoryHelper.cs
@@ -24,19 +24,15 @@ namespace ZeroC.Glacier2
         /// <param name="properties">Optional properties used for communicator initialization.</param>
         /// <param name="logger">Optional logger used for communicator initialization.</param>
         /// <param name="observer">Optional communicator observer used for communicator initialization.</param>
-        /// <param name="typeIdNamespaces">Optional list of TypeId namespaces used for communicator initialization. The
-        /// default is Ice.TypeId.</param>
         public SessionFactoryHelper(ISessionCallback callback,
                              Dictionary<string, string> properties,
                              ILogger? logger = null,
-                             ICommunicatorObserver? observer = null,
-                             string[]? typeIdNamespaces = null)
+                             ICommunicatorObserver? observer = null)
         {
             _callback = callback;
             _properties = properties;
             _logger = logger;
             _observer = observer;
-            _typeIdNamespaces = typeIdNamespaces;
 
             SetDefaultProperties();
         }
@@ -196,8 +192,7 @@ namespace ZeroC.Glacier2
                     _useCallbacks,
                     CreateProperties(),
                     _logger,
-                    _observer,
-                    _typeIdNamespaces);
+                    _observer);
                 session.Connect(_context);
                 return session;
             }
@@ -219,8 +214,7 @@ namespace ZeroC.Glacier2
                     _useCallbacks,
                     CreateProperties(),
                     _logger,
-                    _observer,
-                    _typeIdNamespaces);
+                    _observer);
                 session.Connect(username, password, _context);
                 return session;
             }
@@ -270,7 +264,6 @@ namespace ZeroC.Glacier2
         private readonly Dictionary<string, string> _properties;
         private readonly ILogger? _logger;
         private readonly ICommunicatorObserver? _observer;
-        private readonly string[]? _typeIdNamespaces;
 
         private string _routerHost = "localhost";
         private Identity? _identity = null;

--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -25,8 +25,6 @@ namespace ZeroC.Glacier2
         /// <param name="properties">Optional properties used for communicator initialization.</param>
         /// <param name="logger">Optional logger used for communicator initialization.</param>
         /// <param name="observer">Optional communicator observer used for communicator initialization.</param>
-        /// <param name="typeIdNamespaces">Optional list of TypeId namespaces used for communicator initialization.
-        /// The default is Ice.TypeId.</param>
         /// <param name="certificates">The user certificates to use with the SSL transport.</param>
         /// <param name="caCertificates">The certificate authorities to use with the SSL transport.</param>
         /// <param name="certificateVerifier">The certificate verifier delegate to use with the SSL transport.</param>
@@ -39,7 +37,6 @@ namespace ZeroC.Glacier2
             Dictionary<string, string> properties,
             ILogger? logger = null,
             ICommunicatorObserver? observer = null,
-            string[]? typeIdNamespaces = null,
             X509Certificate2Collection? certificates = null,
             X509Certificate2Collection? caCertificates = null,
             ICertificateVerifier? certificateVerifier = null,
@@ -51,7 +48,6 @@ namespace ZeroC.Glacier2
             _properties = properties;
             _logger = logger;
             _observer = observer;
-            _typeIdNamespaces = typeIdNamespaces;
             _certificates = certificates;
             _caCertificates = caCertificates;
             _certificateVerifier = certificateVerifier;
@@ -401,7 +397,6 @@ namespace ZeroC.Glacier2
                             properties: _properties,
                             logger: _logger,
                             observer: _observer,
-                            typeIdNamespaces: _typeIdNamespaces,
                             certificates: _certificates,
                             caCertificates: _caCertificates,
                             certificateVerifier: _certificateVerifier,
@@ -477,7 +472,6 @@ namespace ZeroC.Glacier2
         private readonly Dictionary<string, string> _properties;
         private readonly ILogger? _logger;
         private readonly ICommunicatorObserver? _observer;
-        private readonly string[]? _typeIdNamespaces;
         private readonly X509Certificate2Collection? _certificates;
         private readonly X509Certificate2Collection? _caCertificates;
         private readonly ICertificateVerifier? _certificateVerifier;

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -130,16 +130,14 @@ namespace Test
 
         public Communicator Initialize(ref string[] args,
             Dictionary<string, string>? defaults = null,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null,
-            string[]? typeIdNamespaces = null) =>
-            Initialize(CreateTestProperties(ref args, defaults), observer, typeIdNamespaces);
+            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null) =>
+            Initialize(CreateTestProperties(ref args, defaults), observer);
 
         public Communicator Initialize(
             Dictionary<string, string> properties,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null,
-            string[]? typeIdNamespaces = null)
+            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
         {
-            var communicator = new Communicator(properties, observer: observer, typeIdNamespaces: typeIdNamespaces);
+            var communicator = new Communicator(properties, observer: observer);
             if (_communicator == null)
             {
                 _communicator = communicator;


### PR DESCRIPTION
This PR removes the `typeid-namespace` metadata, and all it's related code from the C# mapping.
That's pretty much it.