### PR TITLE
Simplify data member marshaling/unmarshaling in C#

### DIFF
--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -642,3 +642,27 @@ Slice::snakeCase(const std::string& name)
     }
     return os.str();
 }
+
+DataMemberList
+Slice::sortForMarshaling(const DataMemberList& members)
+{
+    DataMemberList result = members;
+    result.sort([](const DataMemberPtr& lhs, const DataMemberPtr& rhs) -> bool
+    {
+        if (lhs->tagged() && rhs->tagged())
+        {
+            return lhs->tag() < rhs->tag();
+        }
+        else if (!lhs->tagged() && !rhs->tagged())
+        {
+            // sort keeps the order of unordered elements
+            return false;
+        }
+        else
+        {
+            // If only one is tagged, lhs < rhs when lhs is not tagged.
+            return !lhs->tagged();
+        }
+    });
+    return result;
+}

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -66,6 +66,11 @@ std::string camelCase(const std::string&);
 std::string pascalCase(const std::string&);
 std::string snakeCase(const std::string&);
 
+// Returns a new list of data members sorted as follows:
+// - non-tagged data members listed first but kept in the same order
+// - tagged data members listed last and sorted in tag order
+DataMemberList sortForMarshaling(const DataMemberList&);
+
 }
 
 #endif

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1121,8 +1121,6 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
     EnumPtr en = EnumPtr::dynamicCast(type);
     SequencePtr seq = SequencePtr::dynamicCast(type);
 
-    const string tmpName = (dataMember ? dataMember->name() : param) + "_";
-
     bool hasDefaultValue = dataMember && dataMember->defaultValueType();
 
     out << param << " = ";
@@ -1169,6 +1167,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
         }
         else if (seq->hasMetaDataWithPrefix("cs:generic:"))
         {
+            const string tmpName = (dataMember ? dataMember->name() : param) + "_";
             if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
             {
                 TypePtr underlying = optional->underlying();

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1121,6 +1121,8 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
     EnumPtr en = EnumPtr::dynamicCast(type);
     SequencePtr seq = SequencePtr::dynamicCast(type);
 
+    const string tmpName = (dataMember ? dataMember->name() : param) + "_";
+
     bool hasDefaultValue = dataMember && dataMember->defaultValueType();
 
     out << param << " = ";
@@ -1174,7 +1176,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
                     << (isReferenceType(underlying) ? "withBitSequence: true, " : "")
                     << inputStreamReader(elementType, scope)
                     << ") is global::System.Collections.Generic.ICollection<" << typeToString(elementType, scope)
-                    << "> " << param << "_ ? new " << typeToString(seq, scope) << "(" << param << "_)"
+                    << "> " << tmpName << " ? new " << typeToString(seq, scope) << "(" << tmpName << ")"
                     << " : null";
             }
             else
@@ -1184,7 +1186,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
                     << (elementType->isVariableLength() ? "false" : "true")
                     << ", " << inputStreamReader(elementType, scope)
                     << ") is global::System.Collections.Generic.ICollection<" << typeToString(elementType, scope)
-                    << "> " << param << "_ ? new " << typeToString(seq, scope) << "(" << param << "_)"
+                    << "> " << tmpName << " ? new " << typeToString(seq, scope) << "(" << tmpName << ")"
                     << " : null";
             }
         }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -262,39 +262,46 @@ Slice::CsVisitor::writeUnmarshalParams(const OperationPtr& op,
 }
 
 void
-Slice::CsVisitor::writeMarshalDataMember(const DataMemberPtr& member, const string& name, const string& ns,
-                                         const string& customStream)
+Slice::CsVisitor::writeMarshalDataMembers(const DataMemberList& p, const DataMemberList& sortedTaggedMembers,
+    const string& ns, unsigned int baseTypes)
 {
-    const string stream = customStream.empty() ? "ostr" : customStream;
-    if(member->tagged())
+    for (const auto& member : p)
     {
-        writeTaggedMarshalCode(_out, OptionalPtr::dynamicCast(member->type()), true, ns, "this." + name, member->tag(),
-            stream);
+        if (!member->tagged())
+        {
+            int bitSequenceIndex = -1; // TODO: temporary
+            writeMarshalCode(_out, member->type(), bitSequenceIndex, true, ns,
+                "this." + fixId(dataMemberName(member), baseTypes), "ostr");
+        }
     }
-    else
+
+    for (const auto& member : sortedTaggedMembers)
     {
-        // TODO: temporary
-        int bitSequenceIndex = -1;
-        writeMarshalCode(_out, member->type(), bitSequenceIndex, true, ns, "this." + name, stream);
+        writeTaggedMarshalCode(_out, OptionalPtr::dynamicCast(member->type()), true, ns,
+            "this." + fixId(dataMemberName(member), baseTypes), member->tag(), "ostr");
     }
 }
 
 void
-Slice::CsVisitor::writeUnmarshalDataMember(const DataMemberPtr& member, const string& name, const string& ns,
-                                           const string& customStream)
+Slice::CsVisitor::writeUnmarshalDataMembers(const DataMemberList& p, const DataMemberList& sortedTaggedMembers,
+    const string& ns, unsigned int baseTypes)
 {
-    const string stream = customStream.empty() ? "ostr" : customStream;
-    if (member->tagged())
+    for (const auto& member : p)
     {
-        _out << nl;
-        writeTaggedUnmarshalCode(_out, OptionalPtr::dynamicCast(member->type()), ns, name, member->tag(), member,
-            stream);
+        if (!member->tagged())
+        {
+            int bitSequenceIndex = -1; // TODO: temporary
+            _out << nl;
+            writeUnmarshalCode(_out, member->type(), bitSequenceIndex, ns,
+                "this." + fixId(dataMemberName(member), baseTypes), "istr");
+        }
     }
-    else
+
+    for (const auto& member : sortedTaggedMembers)
     {
-        int bitSequenceIndex = -1; // TODO: temporary
         _out << nl;
-        writeUnmarshalCode(_out, member->type(), bitSequenceIndex, ns, name, stream);
+        writeTaggedUnmarshalCode(_out, OptionalPtr::dynamicCast(member->type()), ns,
+            "this." + fixId(dataMemberName(member), baseTypes), member->tag(), member, "istr");
     }
 }
 
@@ -1395,12 +1402,12 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     }
 
     _out << sp;
-    _out << nl << "protected override void IceWrite(ZeroC.Ice.OutputStream iceP_ostr, bool iceP_firstSlice)";
+    _out << nl << "protected override void IceWrite(ZeroC.Ice.OutputStream ostr, bool firstSlice)";
     _out << sb;
-    _out << nl << "iceP_ostr.IceStartSlice" << spar << "_iceTypeId" << "iceP_firstSlice";
+    _out << nl << "ostr.IceStartSlice" << spar << "_iceTypeId" << "firstSlice";
     if (preserved || basePreserved)
     {
-        _out << "iceP_firstSlice ? IceSlicedData : null";
+        _out << "firstSlice ? IceSlicedData : null";
     }
     else
     {
@@ -1411,37 +1418,28 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
         _out << p->compactId();
     }
     _out << epar << ";";
-    for(auto m : members)
-    {
-        if(!m->tagged())
-        {
-            writeMarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_ostr");
-        }
-    }
 
-    for(auto m : taggedMembers)
-    {
-        writeMarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_ostr");
-    }
+    writeMarshalDataMembers(members, taggedMembers, ns, 0);
+
     if(base)
     {
-        _out << nl << "iceP_ostr.IceEndSlice(false);";
-        _out << nl << "base.IceWrite(iceP_ostr, false);";
+        _out << nl << "ostr.IceEndSlice(false);";
+        _out << nl << "base.IceWrite(ostr, false);";
     }
     else
     {
-         _out << nl << "iceP_ostr.IceEndSlice(true);"; // last slice
+         _out << nl << "ostr.IceEndSlice(true);"; // last slice
     }
     _out << eb;
 
     _out << sp;
 
-    _out << nl << "protected" << (base ? " new " : " ") << "void IceRead(ZeroC.Ice.InputStream iceP_istr, "
-         << "bool iceP_firstSlice)";
+    _out << nl << "protected" << (base ? " new " : " ") << "void IceRead(ZeroC.Ice.InputStream istr, "
+         << "bool firtSlice)";
     _out << sb;
-    _out << nl << "if (iceP_firstSlice)";
+    _out << nl << "if (firtSlice)";
     _out << sb;
-    _out << nl << "iceP_istr.IceStartFirstSlice" << spar << "_iceTypeId" << "this";
+    _out << nl << "istr.IceStartFirstSlice" << spar << "_iceTypeId" << "this";
     if (preserved || basePreserved)
     {
         _out << "setSlicedData: true";
@@ -1450,25 +1448,15 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     _out << eb;
     _out << nl << "else";
     _out << sb;
-    _out << nl << "iceP_istr.IceStartSlice" << spar << "_iceTypeId" << epar << ";";
+    _out << nl << "istr.IceStartSlice" << spar << "_iceTypeId" << epar << ";";
     _out << eb;
 
-    for(auto m : members)
-    {
-        if(!m->tagged())
-        {
-            writeUnmarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_istr");
-        }
-    }
+    writeUnmarshalDataMembers(members, taggedMembers, ns, 0);
 
-    for(auto m : taggedMembers)
-    {
-        writeUnmarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_istr");
-    }
-    _out << nl << "iceP_istr.IceEndSlice();";
+    _out << nl << "istr.IceEndSlice();";
     if (base)
     {
-        _out << nl << "base.IceRead(iceP_istr, false);";
+        _out << nl << "base.IceRead(istr, false);";
     }
     // This slice and its base slices (if any) are now fully initialized.
     if (!hasDataMemberWithName(p->allDataMembers(), "Initialize"))
@@ -1756,50 +1744,46 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     // Remote exceptions are always "preserved".
 
     _out << sp;
-    _out << nl << "protected override void IceWrite(ZeroC.Ice.OutputStream iceP_ostr, bool iceP_firstSlice)";
+    _out << nl << "protected override void IceWrite(ZeroC.Ice.OutputStream ostr, bool firstSlice)";
     _out << sb;
-    _out << nl << "iceP_ostr.IceStartSlice" << spar << "_iceTypeId" << "iceP_firstSlice";
-    _out << "iceP_firstSlice ? IceSlicedData : null";
+    _out << nl << "ostr.IceStartSlice" << spar << "_iceTypeId" << "firstSlice";
+    _out << "firstSlice ? IceSlicedData : null";
     _out << epar << ";";
 
-    for(DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
-    {
-        writeMarshalDataMember(*q, fixId(dataMemberName(*q), Slice::ExceptionType), ns, "iceP_ostr");
-    }
+    writeMarshalDataMembers(dataMembers, p->sortedTaggedDataMembers(), ns, Slice::ExceptionType);
+
     if(base)
     {
-        _out << nl << "iceP_ostr.IceEndSlice(false);"; // the current slice is not last slice
-        _out << nl << "base.IceWrite(iceP_ostr, false);"; // the next one is not the first slice
+        _out << nl << "ostr.IceEndSlice(false);"; // the current slice is not last slice
+        _out << nl << "base.IceWrite(ostr, false);"; // the next one is not the first slice
     }
     else
     {
-        _out << nl << "iceP_ostr.IceEndSlice(true);"; // this is the last slice.
+        _out << nl << "ostr.IceEndSlice(true);"; // this is the last slice.
     }
     _out << eb;
 
     _out << sp;
 
-    _out << nl << "protected " << (base ? "new " : "") << "void IceRead(ZeroC.Ice.InputStream iceP_istr, "
-         << "bool iceP_firstSlice)";
+    _out << nl << "protected " << (base ? "new " : "") << "void IceRead(ZeroC.Ice.InputStream istr, "
+         << "bool firtSlice)";
     _out << sb;
 
-    _out << nl << "if (iceP_firstSlice)";
+    _out << nl << "if (firtSlice)";
     _out << sb;
-    _out << nl << "IceSlicedData = iceP_istr.IceStartFirstSlice(_iceTypeId);";
+    _out << nl << "IceSlicedData = istr.IceStartFirstSlice(_iceTypeId);";
     _out << eb;
     _out << nl << "else";
     _out << sb;
-    _out << nl << "iceP_istr.IceStartSlice" << spar << "_iceTypeId" << epar << ";";
+    _out << nl << "istr.IceStartSlice" << spar << "_iceTypeId" << epar << ";";
     _out << eb;
 
-    for(DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
-    {
-        writeUnmarshalDataMember(*q, fixId(dataMemberName(*q), Slice::ExceptionType), ns, "iceP_istr");
-    }
-    _out << nl << "iceP_istr.IceEndSlice();";
+    writeUnmarshalDataMembers(dataMembers, p->sortedTaggedDataMembers(), ns, Slice::ExceptionType);
+
+    _out << nl << "istr.IceEndSlice();";
     if(base)
     {
-        _out << nl << "base.IceRead(iceP_istr, false);";
+        _out << nl << "base.IceRead(istr, false);";
     }
     _out << eb;
     _out << eb;
@@ -1878,12 +1862,10 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "public " << name << "(ZeroC.Ice.InputStream iceP_istr)";
+    _out << nl << "public " << name << "(ZeroC.Ice.InputStream istr)";
     _out << sb;
-    for(auto m : dataMembers)
-    {
-        writeUnmarshalDataMember(m, fixId(dataMemberName(m)) , ns, "iceP_istr");
-    }
+
+    writeUnmarshalDataMembers(dataMembers, DataMemberList(), ns, 0);
 
     if(partialInitialize)
     {
@@ -1955,12 +1937,11 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << " => !lhs.Equals(rhs);";
 
     _out << sp;
-    _out << nl << "public readonly void IceWrite(ZeroC.Ice.OutputStream iceP_ostr)";
+    _out << nl << "public readonly void IceWrite(ZeroC.Ice.OutputStream ostr)";
     _out << sb;
-    for(auto m : dataMembers)
-    {
-        writeMarshalDataMember(m, fixId(dataMemberName(m)), ns, "iceP_ostr");
-    }
+
+    writeMarshalDataMembers(dataMembers, DataMemberList(), ns, 0);
+
     _out << eb;
     _out << eb;
 }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1389,7 +1389,6 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     // Marshaling support
     //
     DataMemberList members = p->dataMembers();
-    DataMemberList taggedMembers = p->sortedTaggedDataMembers();
     const bool basePreserved = p->inheritsMetaData("preserve-slice");
     const bool preserved = p->hasMetaData("preserve-slice");
 
@@ -1419,7 +1418,7 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     }
     _out << epar << ";";
 
-    writeMarshalDataMembers(members, taggedMembers, ns, 0);
+    writeMarshalDataMembers(members, p->sortedTaggedDataMembers(), ns, 0);
 
     if(base)
     {
@@ -1451,7 +1450,7 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     _out << nl << "istr.IceStartSlice" << spar << "_iceTypeId" << epar << ";";
     _out << eb;
 
-    writeUnmarshalDataMembers(members, taggedMembers, ns, 0);
+    writeUnmarshalDataMembers(members, p->sortedTaggedDataMembers(), ns, 0);
 
     _out << nl << "istr.IceEndSlice();";
     if (base)

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -32,8 +32,8 @@ protected:
     void writeUnmarshalParams(const OperationPtr&, const std::list<ParamInfo>&, const std::list<ParamInfo>&,
                               const std::string& stream = "istr");
 
-    void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&, const std::string&, unsigned int);
-    void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&, const std::string&, unsigned int);
+    void writeMarshalDataMembers(const DataMemberList&, const std::string&, unsigned int);
+    void writeUnmarshalDataMembers(const DataMemberList&, const std::string&, unsigned int);
 
     void emitCommonAttributes(); // GeneratedCode and more if needed
     void emitCustomAttributes(const ContainedPtr&); // attributes specified through metadata

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -31,10 +31,9 @@ protected:
                             const std::string& stream = "ostr", const std::string& obj = "");
     void writeUnmarshalParams(const OperationPtr&, const std::list<ParamInfo>&, const std::list<ParamInfo>&,
                               const std::string& stream = "istr");
-    void writeMarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&,
-                                const std::string& stream = "ostr");
-    void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&,
-                                  const std::string& stream = "istr");
+
+    void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&, const std::string&, unsigned int);
+    void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&, const std::string&, unsigned int);
 
     void emitCommonAttributes(); // GeneratedCode and more if needed
     void emitCustomAttributes(const ContainedPtr&); // attributes specified through metadata


### PR DESCRIPTION
This small PR consolidates all the data member marshaling/unmarshaling in two functions: `writeMarshalDataMembers` and `writeUnmarshalDataMembers`.

It also uncovered an unfortunate bug in the marshaling/unmarshaling of tagged exception data members in 3.7/C# ... the generated code is bogus unless the tagged members are at the end with the correct tag sorting order. I also checked slice2cpp 3.7, which generates correct code (tagged data members are always read/written at the end in tag order).