### PR TITLE
Data members with optional types in C#

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -5477,7 +5477,7 @@ Slice::Operation::interface() const
 }
 
 size_t
-Slice::Operation::inBitSequenceLength() const
+Slice::Operation::inBitSequenceSize() const
 {
     size_t length = 0;
     for (const auto& p : inParameters())
@@ -5497,7 +5497,7 @@ Slice::Operation::inBitSequenceLength() const
 }
 
 size_t
-Slice::Operation::returnBitSequenceLength() const
+Slice::Operation::returnBitSequenceSize() const
 {
     size_t length = 0;
     for (const auto& p : outParameters())

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -758,11 +758,11 @@ public:
 
     // The "in" bit sequence length. It corresponds to the number of in-parameters with optional types that are not
     // class/proxy and that are not tagged.
-    size_t inBitSequenceLength() const;
+    size_t inBitSequenceSize() const;
 
     // The "return" bit sequence length. It corresponds to the number of return parameters with optional types that are
     // not class/proxy and that are not tagged.
-    size_t returnBitSequenceLength() const;
+    size_t returnBitSequenceSize() const;
 
     TypePtr returnType() const;
     bool returnIsTagged() const;

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -666,3 +666,21 @@ Slice::sortForMarshaling(const DataMemberList& members)
     });
     return result;
 }
+
+size_t
+Slice::getBitSequenceSize(const DataMemberList& members)
+{
+    size_t result = 0;
+    for (const auto& member : members)
+    {
+        if (!member->tagged())
+        {
+            auto optional = OptionalPtr::dynamicCast(member->type());
+            if (optional && !optional->underlying()->isClassType() && !optional->underlying()->isInterfaceType())
+            {
+                result++;
+            }
+        }
+    }
+    return result;
+}

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -71,6 +71,9 @@ std::string snakeCase(const std::string&);
 // - tagged data members listed last and sorted in tag order
 DataMemberList sortForMarshaling(const DataMemberList&);
 
+// Returns the size of the bit sequence used to encode the optional elements in this data member list.
+size_t getBitSequenceSize(const DataMemberList&);
+
 }
 
 #endif

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -974,9 +974,9 @@ Slice::CsGenerator::writeUnmarshalCode(Output &out,
     }
     else
     {
-        auto constructed = ConstructedPtr::dynamicCast(type);
+        auto constructed = ConstructedPtr::dynamicCast(underlying);
         assert(constructed);
-        out << helperName(type, scope) << ".Read" << constructed->name() << "(" << stream << ")";
+        out << helperName(underlying, scope) << ".Read" << constructed->name() << "(" << stream << ")";
     }
 
     if (optional)

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -292,7 +292,7 @@ namespace ZeroC.Ice
             return value;
         }
 
-        /// <summary>Reads an int from the stream. This int is encoded using Ice's variable-length integer encoding.
+        /// <summary>Reads an int from the stream. This int is encoded using Ice's variable-size integer encoding.
         /// </summary>
         /// <returns>The int read from the stream.</returns>
         public int ReadVarInt()
@@ -310,7 +310,7 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Reads a long from the stream. This long is encoded using Ice's variable-length integer encoding.
+        /// <summary>Reads a long from the stream. This long is encoded using Ice's variable-size integer encoding.
         /// </summary>
         /// <returns>The long read from the stream.</returns>
         public long ReadVarLong() =>
@@ -322,7 +322,7 @@ namespace ZeroC.Ice
                 _ => ReadLong() >> 2
             };
 
-        /// <summary>Reads a uint from the stream. This uint is encoded using Ice's variable-length integer encoding.
+        /// <summary>Reads a uint from the stream. This uint is encoded using Ice's variable-size integer encoding.
         /// </summary>
         /// <returns>The uint read from the stream.</returns>
         public uint ReadVarUInt()
@@ -340,7 +340,7 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Reads a ulong from the stream. This ulong is encoded using Ice's variable-length integer encoding.
+        /// <summary>Reads a ulong from the stream. This ulong is encoded using Ice's variable-size integer encoding.
         /// </summary>
         /// <returns>The ulong read from the stream.</returns>
         public ulong ReadVarULong() =>
@@ -1006,11 +1006,11 @@ namespace ZeroC.Ice
         //
 
         /// <summary>Reads a bit sequence from the stream.</summary>
-        /// <param name="bitLength">The minimum number of bits in the sequence.</param>
+        /// <param name="bitSequenceSize">The minimum number of bits in the sequence.</param>
         /// <returns>The read-only bit sequence read from the stream.</returns>
-        public ReadOnlyBitSequence ReadBitSequence(int bitLength)
+        public ReadOnlyBitSequence ReadBitSequence(int bitSequenceSize)
         {
-            int size = (bitLength >> 3) + ((bitLength & 0x07) != 0 ? 1 : 0);
+            int size = (bitSequenceSize >> 3) + ((bitSequenceSize & 0x07) != 0 ? 1 : 0);
             int startPos = _pos;
             _pos += size;
             return new ReadOnlyBitSequence(_buffer.AsSpan(startPos, size));
@@ -1111,11 +1111,11 @@ namespace ZeroC.Ice
             (int Size, Encoding Encoding) result = ReadEncapsulationHeader(Encoding, _buffer.Slice(_pos));
             if (OldEncoding)
             {
-                _pos += 6; // 4 (size length) + 2 (encoding length)
+                _pos += 6; // 4 (size length) + 2 (encoding bytes)
             }
             else
             {
-                _pos += (1 << (_buffer[_pos] & 0x03)) + 2; // size length + encoding length
+                _pos += (1 << (_buffer[_pos] & 0x03)) + 2; // size length + encoding bytes
             }
             return result;
         }
@@ -1309,9 +1309,9 @@ namespace ZeroC.Ice
             return sz;
         }
 
-        private ReadOnlyMemory<byte> ReadBitSequenceMemory(int bitLength)
+        private ReadOnlyMemory<byte> ReadBitSequenceMemory(int bitSequenceSize)
         {
-            int size = (bitLength >> 3) + ((bitLength & 0x07) != 0 ? 1 : 0);
+            int size = (bitSequenceSize >> 3) + ((bitSequenceSize & 0x07) != 0 ? 1 : 0);
             int startPos = _pos;
             _pos += size;
             return _buffer.AsMemory(startPos, size);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -177,6 +177,72 @@ namespace ZeroC.Ice.Test.Optional
             TestHelper.Assert(test.OpTaggedIntOptStringDict(null) == null);
 
             output.WriteLine("ok");
+
+            output.Write("testing struct with optional data members... ");
+            var myStruct = new MyStruct(test, null, new string?[] { "foo", null, "bar"});
+            MyStruct myStructResult = test.OpMyStruct(myStruct);
+            TestHelper.Assert(myStruct != myStructResult); // the proxies and arrays can't be identical
+            TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
+                myStructResult.X == myStruct.X &&
+                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq));
+
+            myStructResult = test.OpOptMyStruct(myStruct)!.Value;
+            TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
+                myStructResult.X == myStruct.X &&
+                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq));
+
+            TestHelper.Assert(test.OpOptMyStruct(null) == null);
+            output.WriteLine("ok");
+
+            output.Write("testing class with optional data members... ");
+            var derived = new Derived(test, null, new string?[] { "foo", null, "bar"}, null, "test");
+            Derived derivedResult = test.OpDerived(derived);
+            TestHelper.Assert(derivedResult.Proxy!.Equals(derived.Proxy) &&
+                derivedResult.X == derived.X &&
+                derivedResult.StringSeq!.SequenceEqual(derived.StringSeq) &&
+                derivedResult.SomeClass == null &&
+                derivedResult.S == derived.S);
+
+            derivedResult = test.OpOptDerived(derived)!;
+            TestHelper.Assert(derivedResult.Proxy!.Equals(derived.Proxy) &&
+                derivedResult.X == derived.X &&
+                derivedResult.StringSeq!.SequenceEqual(derived.StringSeq) &&
+                derivedResult.SomeClass == null &&
+                derivedResult.S == derived.S);
+
+            TestHelper.Assert(test.OpOptDerived(null) == null);
+            output.WriteLine("ok");
+
+            output.Write("testing exception with optional data members... ");
+            try
+            {
+                test.OpDerivedEx();
+                TestHelper.Assert(false);
+            }
+            catch (DerivedEx ex)
+            {
+                TestHelper.Assert(ex.Proxy == null &&
+                    ex.X == 5 &&
+                    ex.StringSeq!.SequenceEqual(new string?[] { "foo", null, "bar" }) &&
+                    ex.SomeClass is C someClass && someClass.X == 42 &&
+                    ex.S == "test");
+            }
+
+            try
+            {
+                test.OpDerivedEx(context: new Dictionary<string, string> { { "all null", "yes" } });
+                TestHelper.Assert(false);
+            }
+            catch (DerivedEx ex)
+            {
+                TestHelper.Assert(ex.Proxy == null &&
+                    ex.X == null &&
+                    ex.StringSeq == null &&
+                    ex.SomeClass == null &&
+                    ex.S == null);
+            }
+
+            output.WriteLine("ok");
             return test;
         }
     }

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -9,16 +9,49 @@
 
 module ZeroC::Ice::Test::Optional
 {
-    class C
-    {
-        int x;
-    }
-
     sequence<int?> OptIntSeq;
     sequence<string?> OptStringSeq;
 
     dictionary<int, int?> IntOptIntDict;
     dictionary<int, string?> IntOptStringDict;
+
+    class C
+    {
+        int x;
+    }
+
+    struct MyStruct
+    {
+        Object? proxy;
+        int? x;
+        OptStringSeq? stringSeq;
+    }
+
+    class Base
+    {
+        Object? proxy;
+        int? x;
+        OptStringSeq? stringSeq;
+    }
+
+    class Derived : Base
+    {
+        Value? someClass;
+        string? s;
+    }
+
+    exception BaseEx
+    {
+        Object? proxy;
+        int? x;
+        OptStringSeq? stringSeq;
+    }
+
+    exception DerivedEx : BaseEx
+    {
+        Value? someClass;
+        string? s;
+    }
 
     interface Test
     {
@@ -51,5 +84,11 @@ module ZeroC::Ice::Test::Optional
 
         IntOptStringDict opIntOptStringDict(IntOptStringDict i1);
         tag(1) IntOptStringDict? opTaggedIntOptStringDict(tag(2) IntOptStringDict? i1);
+
+        MyStruct opMyStruct(MyStruct i1);
+        MyStruct? opOptMyStruct(MyStruct? i1);
+        Derived opDerived(Derived i1);
+        Derived? opOptDerived(Derived? i1);
+        void opDerivedEx();
     }
 }

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -73,5 +73,25 @@ namespace ZeroC.Ice.Test.Optional
         public IReadOnlyDictionary<int, string?>? OpTaggedIntOptStringDict(
             Dictionary<int, string?>? i1,
             Current current) => i1;
+
+        public MyStruct OpMyStruct(MyStruct i1, Current current) => i1;
+
+        public MyStruct? OpOptMyStruct(MyStruct? i1, Current current) => i1;
+
+        public Derived OpDerived(Derived i1, Current current) => i1;
+
+        public Derived? OpOptDerived(Derived? i1, Current current) => i1;
+
+        public void OpDerivedEx(Current current)
+        {
+            if (current.Context.ContainsKey("all null"))
+            {
+                throw new DerivedEx();
+            }
+            else
+            {
+                throw new DerivedEx(null, 5, new string?[] { "foo", null, "bar" }, new C(42), "test");
+            }
+        }
     }
 }


### PR DESCRIPTION
This small PR adds support for data members with optional types (such a int? and string?).

It also renames some Length to Size for consistency: we use size for everything except for the size of a size that is called length (as in fixed length size).