### PR TITLE
Refactor IceLocatorDiscovery plug-in

### DIFF
--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using ZeroC.Ice;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,53 +9,64 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ZeroC.Ice;
 
 namespace ZeroC.IceLocatorDiscovery
 {
     public sealed class PluginFactory : IPluginFactory
     {
-        public Ice.IPlugin
-        Create(Communicator communicator, string name, string[] args) => new PluginI(name, communicator);
-    }
+        public IPlugin Create(Communicator communicator, string name, string[] args) =>
+            new Plugin(name, communicator);
 
-    public interface IPlugin : Ice.IPlugin
-    {
-        List<ILocatorPrx> GetLocators(string instanceName, int waitTime);
+        public static void Register(bool loadOnInitialize) =>
+           Communicator.RegisterPluginFactory("IceLocatorDiscovery", new PluginFactory(), loadOnInitialize);
     }
 
     internal class Request : TaskCompletionSource<IncomingResponseFrame>
     {
-        private readonly LocatorI _locator;
-        private readonly ArraySegment<byte> _payload;
         private readonly Current _current;
-
-        private ILocatorPrx? _locatorPrx;
         private Exception? _exception;
+        private readonly Locator _locator;
+        private ILocatorPrx? _locatorPrx;
+        private readonly ArraySegment<byte> _payload;
 
-        internal Request(LocatorI locator,
-                         ArraySegment<byte> payload,
-                         Current current)
+        internal Request(Locator locator, ArraySegment<byte> payload, Current current)
         {
             _locator = locator;
             _payload = payload;
             _current = current;
         }
 
-        internal async Task Invoke(ILocatorPrx l)
+        internal async Task Invoke(ILocatorPrx locatorPrx)
         {
-            if (_locatorPrx == null || !_locatorPrx.Equals(l))
+            if (_locatorPrx == null || !_locatorPrx.Equals(locatorPrx))
             {
-                _locatorPrx = l;
-                var requestFrame = new OutgoingRequestFrame(l, _current.Operation, _current.IsIdempotent,
+                _locatorPrx = locatorPrx;
+                var requestFrame = new OutgoingRequestFrame(locatorPrx, _current.Operation, _current.IsIdempotent,
                     _current.Context, _payload);
 
                 try
                 {
-                    SetResult(await l.InvokeAsync(requestFrame).ConfigureAwait(false));
+                    SetResult(await locatorPrx.InvokeAsync(requestFrame).ConfigureAwait(false));
                 }
                 catch (Exception ex)
                 {
-                    Exception(ex);
+                    switch (ex)
+                    {
+                        case DispatchException e:
+                            SetException(e);
+                            break;
+                        case NoEndpointException _:
+                        case ObjectAdapterDeactivatedException _:
+                        case CommunicatorDestroyedException _:
+                            SetException(new ObjectNotExistException(_current));
+                            break;
+                        default:
+                            // Retry with a new locator proxy
+                            _exception = ex;
+                            await _locator.Invoke(_locatorPrx, this).ConfigureAwait(false);
+                            break;
+                    }
                 }
             }
             else
@@ -65,58 +75,42 @@ namespace ZeroC.IceLocatorDiscovery
                 throw _exception;
             }
         }
-
-        private void Exception(System.Exception ex)
-        {
-            try
-            {
-                throw ex;
-            }
-            catch (Ice.DispatchException exc)
-            {
-                SetException(exc);
-            }
-            catch (Ice.NoEndpointException)
-            {
-                SetException(new Ice.ObjectNotExistException(_current));
-            }
-            catch (Ice.ObjectAdapterDeactivatedException)
-            {
-                SetException(new Ice.ObjectNotExistException(_current));
-            }
-            catch (Ice.CommunicatorDestroyedException)
-            {
-                SetException(new Ice.ObjectNotExistException(_current));
-            }
-            catch (System.Exception exc)
-            {
-                _exception = exc;
-                _locator.Invoke(_locatorPrx, this); // Retry with new locator proxy
-            }
-        }
     }
 
-    internal class VoidLocatorI : ILocator
+    internal class VoidLocator : ILocator
     {
-        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current)
-        {
-            IObjectPrx? prx = null;
-            return new ValueTask<IObjectPrx?>(prx);
-        }
-
-        public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string id, Current current)
-        {
-            IObjectPrx? prx = null;
-            return new ValueTask<IObjectPrx?>(prx);
-        }
-
+        public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string id, Current current) =>
+            new ValueTask<IObjectPrx?>((IObjectPrx?)null);
+        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current) =>
+            new ValueTask<IObjectPrx?>((IObjectPrx?)null);
         public ILocatorRegistryPrx? GetRegistry(Current current) => null;
     }
 
-    internal class LocatorI : IObject, ITimerTask
+    internal class Locator : IObject
     {
-        public LocatorI(string name, ILookupPrx lookup, Communicator communicator, string instanceName,
-            ILocatorPrx voidLocator)
+        private string _instanceName;
+        private ILocatorPrx? _locator;
+        private readonly ILookupPrx _lookup;
+        private readonly Dictionary<ILookupPrx, ILookupReplyPrx> _lookups =
+            new Dictionary<ILookupPrx, ILookupReplyPrx>();
+        private readonly object _mutex = new object();
+        private long _nextRetry;
+        private readonly List<Request> _pendingRequests = new List<Request>();
+        private readonly int _retryCount;
+        private readonly int _retryDelay;
+        private readonly int _timeout;
+        private readonly int _traceLevel;
+        private readonly ILocatorPrx _voidLocator;
+        private bool _warned;
+        private CancellationTokenSource? _cancellationSource;
+
+        public Locator(
+            string name,
+            ILookupPrx lookup,
+            Communicator communicator,
+            string instanceName,
+            ILocatorPrx voidLocator,
+            ILookupReplyPrx lookupReply)
         {
             _lookup = lookup;
             _timeout = communicator.GetPropertyAsInt($"{name}.Timeout") ?? 300;
@@ -124,124 +118,53 @@ namespace ZeroC.IceLocatorDiscovery
             {
                 _timeout = 300;
             }
-            _retryCount = communicator.GetPropertyAsInt("${name}.RetryCount") ?? 3;
-            if (_retryCount < 0)
-            {
-                _retryCount = 0;
-            }
-            _retryDelay = communicator.GetPropertyAsInt($"{name}.RetryDelay") ?? 2000;
-            if (_retryDelay < 0)
-            {
-                _retryDelay = 0;
-            }
-            _timer = lookup.Communicator.Timer();
+            _retryCount = Math.Max(communicator.GetPropertyAsInt($"{name}.RetryCount") ?? 3, 1);
+            _retryDelay = Math.Max(communicator.GetPropertyAsInt($"{name}.RetryDelay") ?? 2000, 0);
             _traceLevel = communicator.GetPropertyAsInt($"{name}.Trace.Lookup") ?? 0;
             _instanceName = instanceName;
             _warned = false;
             _locator = lookup.Communicator.DefaultLocator;
             _voidLocator = voidLocator;
-            _pending = false;
-            _pendingRetryCount = 0;
-            _failureCount = 0;
-            _warnOnce = true;
 
-            //
             // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
             // datagram on each endpoint.
-            //
             var single = new Endpoint[1];
-            foreach (Endpoint endpt in lookup.Endpoints)
+            foreach (UdpEndpoint endpoint in lookup.Endpoints.Cast<UdpEndpoint>())
             {
-                single[0] = endpt;
-                _lookups[lookup.Clone(endpoints: single)] = null;
-            }
-            Debug.Assert(_lookups.Count > 0);
-        }
-
-        public void SetLookupReply(ILookupReplyPrx lookupReply)
-        {
-            //
-            // Use a lookup reply proxy whose address matches the interface used to send multicast datagrams.
-            //
-            var single = new Endpoint[1];
-            foreach (ILookupPrx key in new List<ILookupPrx>(_lookups.Keys))
-            {
-                var endpoint = (UdpEndpoint)key.Endpoints[0];
+                single[0] = endpoint;
+                ILookupPrx key = lookup.Clone(endpoints: single);
                 if (endpoint.McastInterface.Length > 0)
                 {
-                    foreach (Endpoint q in lookupReply.Endpoints)
+                    IPEndpoint? q = lookupReply.Endpoints.Cast<IPEndpoint>().FirstOrDefault(
+                        e => e is IPEndpoint ipEndpoint && ipEndpoint.Host.Equals(endpoint.McastInterface));
+
+                    if (q != null)
                     {
-                        if (q is IPEndpoint && ((IPEndpoint)q).Host.Equals(endpoint.McastInterface))
-                        {
-                            single[0] = q;
-                            _lookups[key] = lookupReply.Clone(endpoints: single);
-                        }
+                        single[0] = q;
+                        _lookups[key] = lookupReply.Clone(endpoints: single);
                     }
                 }
 
-                if (_lookups[key] == null)
+                if (!_lookups.ContainsKey(key))
                 {
                     // Fallback: just use the given lookup reply proxy if no matching endpoint found.
                     _lookups[key] = lookupReply;
                 }
             }
+            Debug.Assert(_lookups.Count > 0);
         }
 
         public async ValueTask<OutgoingResponseFrame> DispatchAsync(IncomingRequestFrame requestFrame, Current current)
         {
             var request = new Request(this, requestFrame.Payload, current);
-            Invoke(null, request);
+            await Invoke(null, request);
             IncomingResponseFrame incomingResponseFrame = await request.Task.ConfigureAwait(false);
             return new OutgoingResponseFrame(current.Encoding, incomingResponseFrame.Payload);
         }
 
-        public List<Ice.ILocatorPrx>
-        GetLocators(string instanceName, int waitTime)
+        public void FoundLocator(ILocatorPrx? locator)
         {
-            //
-            // Clear locators from previous search.
-            //
-            lock (this)
-            {
-                _locators.Clear();
-            }
-
-            //
-            // Find a locator
-            //
-            Invoke(null, null);
-
-            //
-            // Wait for responses
-            //
-            if (instanceName.Length == 0)
-            {
-                Thread.Sleep(waitTime);
-            }
-            else
-            {
-                lock (this)
-                {
-                    while (!_locators.ContainsKey(instanceName) && _pending)
-                    {
-                        Monitor.Wait(this, waitTime);
-                    }
-                }
-            }
-
-            //
-            // Return found locators
-            //
-            lock (this)
-            {
-                return new List<Ice.ILocatorPrx>(_locators.Values);
-            }
-        }
-
-        public void
-        FoundLocator(ILocatorPrx? locator)
-        {
-            lock (this)
+            lock (_mutex)
             {
                 if (locator == null)
                 {
@@ -256,18 +179,15 @@ namespace ZeroC.IceLocatorDiscovery
                 {
                     if (_traceLevel > 2)
                     {
-                        var s = new StringBuilder("ignoring locator reply: instance name doesn't match\n");
-                        s.Append("expected = ").Append(_instanceName);
-                        s.Append("received = ").Append(locator.Identity.Category);
-                        _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
+                        _lookup.Communicator.Logger.Trace("Lookup",
+                            @$"ignoring locator reply: instance name doesn't match\nexpected = {_instanceName
+                            } received = {locator.Identity.Category}");
                     }
                     return;
                 }
 
-                //
-                // If we already have a locator assigned, ensure the given locator
-                // has the same identity, otherwise ignore it.
-                //
+                // If we already have a locator assigned, ensure the given locator has the same identity, otherwise
+                // ignore it.
                 if (_pendingRequests.Count > 0 &&
                     _locator != null && !locator.Identity.Category.Equals(_locator.Identity.Category))
                 {
@@ -275,331 +195,221 @@ namespace ZeroC.IceLocatorDiscovery
                     {
                         _warned = true; // Only warn once
 
-                        locator.Communicator.Logger.Warning(
-                            "received Ice locator with different instance name:\n" +
-                            "using = `" + _locator.Identity.Category + "'\n" +
-                            "received = `" + locator.Identity.Category + "'\n" +
-                            "This is typically the case if multiple Ice locators with different " +
-                            "instance names are deployed and the property `IceLocatorDiscovery.InstanceName'" +
-                            "is not set.");
+                        var s = new StringBuilder();
+                        s.Append("received Ice locator with different instance name:\n")
+                         .Append("using = `").Append(_locator.Identity.Category).Append("'\n")
+                         .Append("received = `").Append(locator.Identity.Category).Append("'\n")
+                         .Append("This is typically the case if multiple Ice locators with different ")
+                         .Append("instance names are deployed and the property `IceLocatorDiscovery.InstanceName' ")
+                         .Append("is not set.");
+                        locator.Communicator.Logger.Warning(s.ToString());
                     }
                     return;
-                }
-
-                if (_pending) // No need to continue, we found a locator
-                {
-                    _timer.Cancel(this);
-                    _pendingRetryCount = 0;
-                    _pending = false;
                 }
 
                 if (_traceLevel > 0)
                 {
                     var s = new StringBuilder("locator lookup succeeded:\nlocator = ");
                     s.Append(locator);
-                    if (_instanceName.Length == 0)
+                    if (_instanceName.Length > 0)
                     {
                         s.Append("\ninstance name = ").Append(_instanceName);
                     }
                     _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
                 }
 
-                ILocatorPrx? l = null;
-                if (_pendingRequests.Count == 0)
+                if (_locator == null)
                 {
-                    _locators.TryGetValue(locator.Identity.Category, out _locator);
-                }
-                else
-                {
-                    l = _locator;
-                }
-
-                if (l != null)
-                {
-                    // We found another locator replica, append its endpoints to the current locator proxy endpoints,
-                    // while eliminating duplicates.
-                    var newEndpoints = l.Endpoints.Concat(locator.Endpoints).Distinct();
-                    l = l.Clone(endpoints: newEndpoints);
-                }
-                else
-                {
-                    l = locator;
-                }
-
-                if (_pendingRequests.Count == 0)
-                {
-                    _locators[locator.Identity.Category] = l;
-                    Monitor.Pulse(this);
-                }
-                else
-                {
-                    _locator = l;
+                    // No need to continue, we found a locator
+                    Debug.Assert(_cancellationSource != null);
+                    _cancellationSource.Cancel();
+                    _cancellationSource = null;
+                    _locator = locator;
                     if (_instanceName.Length == 0)
                     {
                         _instanceName = _locator.Identity.Category; // Stick to the first locator
                     }
 
-                    //
                     // Send pending requests if any.
-                    //
                     foreach (Request req in _pendingRequests)
                     {
                         _ = req.Invoke(_locator);
                     }
                     _pendingRequests.Clear();
                 }
+                else
+                {
+                    Debug.Assert(_pendingRequests.Count == 0);
+                    // We found another locator replica, append its endpoints to the current locator proxy endpoints,
+                    // while eliminating duplicates.
+                    _locator = _locator.Clone(endpoints: _locator.Endpoints.Concat(locator.Endpoints).Distinct());
+                }
             }
         }
 
-        public void
-        Invoke(ILocatorPrx? locator, Request? request)
+        public async Task Invoke(ILocatorPrx? locator, Request request)
         {
-            lock (this)
+            bool invoke = false;
+            lock (_mutex)
             {
-                if (request != null && _locator != null && _locator != locator)
+                // If we already have a locator forward the request to it, locator == _locator means that an attempt to
+                // forward the request to this locator was made but it failed and we should start a new lookup.
+                if (_locator != null && _locator != locator)
                 {
                     _ = request.Invoke(_locator);
                 }
-                else if (request != null && Time.CurrentMonotonicTimeMillis() < _nextRetry)
+                // If the retry delay has not elapsed since the last failure we forward the request to the void locator
+                // that always replies with a null proxy.
+                else if (Time.CurrentMonotonicTimeMillis() < _nextRetry)
                 {
-                    _ = request.Invoke(_voidLocator); // Don't retry to find a locator before the retry delay expires
+                    _ = request.Invoke(_voidLocator);
                 }
                 else
                 {
                     _locator = null;
 
-                    if (request != null)
+                    _pendingRequests.Add(request);
+                    if (!invoke)
                     {
-                        _pendingRequests.Add(request);
-                    }
-
-                    if (!_pending) // No request in progress
-                    {
-                        _pending = true;
-                        _pendingRetryCount = _retryCount;
-                        _failureCount = 0;
-                        try
-                        {
-                            if (_traceLevel > 1)
-                            {
-                                var s = new StringBuilder("looking up locator:\nlookup = ");
-                                s.Append(_lookup);
-                                if (_instanceName.Length == 0)
-                                {
-                                    s.Append("\ninstance name = ").Append(_instanceName);
-                                }
-                                _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
-                            }
-
-                            foreach (KeyValuePair<ILookupPrx, ILookupReplyPrx?> l in _lookups)
-                            {
-                                _ = FindLocator(l.Key, l.Value!); // Send multicast request.
-                            }
-                            _timer.Schedule(this, _timeout);
-                        }
-                        catch (System.Exception ex)
-                        {
-                            if (_traceLevel > 0)
-                            {
-                                var s = new StringBuilder("locator lookup failed:\nlookup = ");
-                                s.Append(_lookup);
-                                if (_instanceName.Length == 0)
-                                {
-                                    s.Append("\ninstance name = ").Append(_instanceName);
-                                }
-                                s.Append("\n").Append(ex);
-                                _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
-                            }
-
-                            foreach (Request req in _pendingRequests)
-                            {
-                                _ = req.Invoke(_voidLocator);
-                            }
-                            _pendingRequests.Clear();
-                            _pendingRetryCount = 0;
-                            _pending = false;
-                        }
+                        invoke = true;
                     }
                 }
             }
-        }
 
-        private void Exception(System.Exception ex)
-        {
-            lock (this)
+            if (invoke)
             {
-                if (++_failureCount == _lookups.Count && _pending)
+                if (_traceLevel > 1)
                 {
-                    //
-                    // All the lookup calls failed, cancel the timer and propagate the error to the requests.
-                    //
-                    _timer.Cancel(this);
-                    _pendingRetryCount = 0;
-                    _pending = false;
-
-                    if (_warnOnce)
-                    {
-                        var builder = new StringBuilder();
-                        builder.Append("failed to lookup locator with lookup proxy `");
-                        builder.Append(_lookup);
-                        builder.Append("':\n");
-                        builder.Append(ex);
-                        _lookup.Communicator.Logger.Warning(builder.ToString());
-                        _warnOnce = false;
-                    }
-
-                    if (_traceLevel > 0)
-                    {
-                        var s = new StringBuilder("locator lookup failed:\nlookup = ");
-                        s.Append(_lookup);
-                        if (_instanceName.Length == 0)
-                        {
-                            s.Append("\ninstance name = ").Append(_instanceName);
-                        }
-                        s.Append("\n").Append(ex);
-                        _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
-                    }
-
-                    if (_pendingRequests.Count == 0)
-                    {
-                        Monitor.Pulse(this);
-                    }
-                    else
-                    {
-                        foreach (Request req in _pendingRequests)
-                        {
-                            _ = req.Invoke(_voidLocator);
-                        }
-                        _pendingRequests.Clear();
-                    }
-                }
-            }
-        }
-
-        private async Task FindLocator(ILookupPrx lookup, ILookupReplyPrx reply)
-        {
-            try
-            {
-                await lookup.FindLocatorAsync(_instanceName, reply).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Exception(ex);
-            }
-        }
-        public void RunTimerTask()
-        {
-            lock (this)
-            {
-                if (!_pending)
-                {
-                    Debug.Assert(_pendingRequests.Count == 0);
-                    return; // Request failed
-                }
-
-                if (_pendingRetryCount > 0)
-                {
-                    --_pendingRetryCount;
-                    try
-                    {
-                        if (_traceLevel > 1)
-                        {
-                            var s = new StringBuilder("retrying locator lookup:\nlookup = ");
-                            s.Append(_lookup);
-                            s.Append("\nretry count = ").Append(_retryCount);
-                            if (_instanceName.Length == 0)
-                            {
-                                s.Append("\ninstance name = ").Append(_instanceName);
-                            }
-                            _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
-                        }
-
-                        foreach (KeyValuePair<ILookupPrx, ILookupReplyPrx?> l in _lookups)
-                        {
-                            _ = FindLocator(l.Key, l.Value!); // Sent multicast request
-                        }
-                        _timer.Schedule(this, _timeout);
-                        return;
-                    }
-                    catch (Exception)
-                    {
-                    }
-                    _pendingRetryCount = 0;
-                }
-
-                Debug.Assert(_pendingRetryCount == 0);
-                _pending = false;
-
-                if (_traceLevel > 0)
-                {
-                    var s = new StringBuilder("locator lookup timed out:\nlookup = ");
+                    var s = new StringBuilder("looking up locator:\nlookup = ");
                     s.Append(_lookup);
-                    if (_instanceName.Length == 0)
+                    if (_instanceName.Length > 0)
                     {
                         s.Append("\ninstance name = ").Append(_instanceName);
                     }
                     _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
                 }
 
-                if (_pendingRequests.Count == 0)
+                int failureCount = 0;
+                for (int i = 0; i < _retryCount; ++i)
                 {
-                    Monitor.Pulse(this);
+                    foreach ((ILookupPrx lookup, ILookupReplyPrx lookupReply) in _lookups)
+                    {
+                        try
+                        {
+                            await lookup.FindLocatorAsync(_instanceName, lookupReply).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            lock (_mutex)
+                            {
+                                if (++failureCount == _lookups.Count)
+                                {
+                                    // All the lookup calls failed propagate the error to the requests.
+                                    if (_traceLevel > 0)
+                                    {
+                                        var s = new StringBuilder("locator lookup failed:\nlookup = ");
+                                        s.Append(_lookup);
+                                        if (_instanceName.Length > 0)
+                                        {
+                                            s.Append("\ninstance name = ").Append(_instanceName);
+                                        }
+                                        s.Append("\nwith lookup proxy `{_lookup}':\n");
+                                        s.Append(ex);
+                                        _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
+                                    }
+
+                                    foreach (Request req in _pendingRequests)
+                                    {
+                                        _ = req.Invoke(_voidLocator);
+                                    }
+                                    _pendingRequests.Clear();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+
+                    Task t;
+                    lock (_mutex)
+                    {
+                        if (_locator != null)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            _cancellationSource = new CancellationTokenSource();
+                            t = Task.Delay(_timeout, _cancellationSource.Token);
+                        }
+                    }
+
+                    try
+                    {
+                        await t.ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // If the delay timeout was canceled it means we already found a locator
+                        return;
+                    }
                 }
-                else
+
+                // Locator lookup timeout and no more retries
+                if (_traceLevel > 0)
                 {
+                    var s = new StringBuilder("locator lookup timed out:\nlookup = ");
+                    s.Append(_lookup);
+                    if (_instanceName.Length > 0)
+                    {
+                        s.Append("\ninstance name = ").Append(_instanceName);
+                    }
+                    _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
+                }
+
+                lock (_mutex)
+                {
+                    _cancellationSource = null;
                     foreach (Request req in _pendingRequests)
                     {
                         _ = req.Invoke(_voidLocator);
                     }
                     _pendingRequests.Clear();
+                    _nextRetry = Time.CurrentMonotonicTimeMillis() + _retryDelay;
                 }
-                _nextRetry = Ice.Time.CurrentMonotonicTimeMillis() + _retryDelay;
+            }
+        }
+    }
+
+    internal class LookupReply : ILookupReply
+    {
+        private readonly Locator _locator;
+        public void FoundLocator(ILocatorPrx? locator, Current current) => _locator.FoundLocator(locator);
+        internal LookupReply(Locator locator) => _locator = locator;
+    }
+
+    internal class Plugin : IPlugin
+    {
+        private readonly Communicator _communicator;
+        private ILocatorPrx? _defaultLocator;
+        private Locator? _locator;
+        private ObjectAdapter? _locatorAdapter;
+        private ILocatorPrx? _locatorPrx;
+        private readonly string _name;
+        private ObjectAdapter? _replyAdapter;
+
+        public void Destroy()
+        {
+            _replyAdapter?.Destroy();
+            _locatorAdapter?.Destroy();
+
+            if (IObjectPrx.Equals(_communicator.DefaultLocator, _locatorPrx))
+            {
+                // Restore original default locator proxy, if the user didn't change it in the meantime
+                _communicator.DefaultLocator = _defaultLocator;
             }
         }
 
-        private readonly ILookupPrx _lookup;
-        private readonly Dictionary<ILookupPrx, ILookupReplyPrx?> _lookups = new Dictionary<ILookupPrx, ILookupReplyPrx?>();
-        private readonly int _timeout;
-        private readonly Ice.Timer _timer;
-        private readonly int _traceLevel;
-        private readonly int _retryCount;
-        private readonly int _retryDelay;
-
-        private string _instanceName;
-        private bool _warned;
-        private ILocatorPrx? _locator;
-        private readonly ILocatorPrx _voidLocator;
-        private readonly Dictionary<string, ILocatorPrx> _locators = new Dictionary<string, ILocatorPrx>();
-
-        private bool _pending;
-        private int _pendingRetryCount;
-        private int _failureCount;
-        private bool _warnOnce = true;
-        private readonly List<Request> _pendingRequests = new List<Request>();
-        private long _nextRetry;
-    }
-
-    internal class LookupReplyI : ILookupReply
-    {
-        public LookupReplyI(LocatorI locator) => _locator = locator;
-
-        public void
-        FoundLocator(ILocatorPrx? locator, Current current) => _locator.FoundLocator(locator);
-
-        private readonly LocatorI _locator;
-    }
-
-    internal class PluginI : Ice.IPlugin
-    {
-        public
-        PluginI(string name, Communicator communicator)
-        {
-            _name = name;
-            _communicator = communicator;
-        }
-
-        public void
-        Initialize()
+        public void Initialize()
         {
             bool ipv4 = _communicator.GetPropertyAsBool("Ice.IPv4") ?? true;
             bool preferIPv6 = _communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
@@ -621,14 +431,8 @@ namespace ZeroC.IceLocatorDiscovery
             {
                 int ipVersion = ipv4 && !preferIPv6 ? Network.EnableIPv4 : Network.EnableIPv6;
                 List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
-                foreach (string p in interfaces)
-                {
-                    if (p != interfaces[0])
-                    {
-                        lookupEndpoints += ":";
-                    }
-                    lookupEndpoints += "udp -h \"" + address + "\" -p " + port + " --interface \"" + p + "\"";
-                }
+                lookupEndpoints = string.Join(":", interfaces.Select(
+                    intf => $"udp -h \"{address}\" -p {port} --interface \"{intf}\""));
             }
 
             if (_communicator.GetProperty($"{_name}.Reply.Endpoints") == null)
@@ -650,59 +454,32 @@ namespace ZeroC.IceLocatorDiscovery
             _locatorAdapter.Locator = null;
 
             var lookupPrx = ILookupPrx.Parse($"IceLocatorDiscovery/Lookup -d:{lookupEndpoints}", _communicator);
-            // No colloc optimization or router for the multicast proxy!
+            // No collocation optimization or router for the multicast proxy!
             lookupPrx = lookupPrx.Clone(clearRouter: false, collocationOptimized: false);
 
-            ILocatorPrx voidLo = _locatorAdapter.AddWithUUID(new VoidLocatorI(), ILocatorPrx.Factory);
+            ILocatorPrx voidLocator = _locatorAdapter.AddWithUUID(new VoidLocator(), ILocatorPrx.Factory);
+
+            var lookupReplyId = new Identity(Guid.NewGuid().ToString(), "");
+            ILookupReplyPrx? locatorReplyPrx = _replyAdapter.CreateProxy(lookupReplyId, ILookupReplyPrx.Factory).Clone(
+                invocationMode: InvocationMode.Datagram);
+            _defaultLocator = _communicator.DefaultLocator;
 
             string instanceName = _communicator.GetProperty($"{_name}.InstanceName") ?? "";
-            var id = new Identity("Locator", instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString());
-
-            _defaultLocator = _communicator.DefaultLocator;
-            _locator = new LocatorI(_name, lookupPrx, _communicator, instanceName, voidLo);
-            _locatorPrx = _locatorAdapter.AddWithUUID(_locator, ILocatorPrx.Factory);
+            var locatorId = new Identity("Locator", instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString());
+            _locator = new Locator(_name, lookupPrx, _communicator, instanceName, voidLocator, locatorReplyPrx);
+            _locatorPrx = _locatorAdapter.Add(locatorId, _locator, ILocatorPrx.Factory);
             _communicator.DefaultLocator = _locatorPrx;
 
-            ILookupReply lookupReplyI = new LookupReplyI(_locator);
-            _locator.SetLookupReply(_replyAdapter.AddWithUUID(lookupReplyI, ILookupReplyPrx.Factory)
-                .Clone(invocationMode: InvocationMode.Datagram));
+            _replyAdapter.Add(lookupReplyId, new LookupReply(_locator));
 
             _replyAdapter.Activate();
             _locatorAdapter.Activate();
         }
 
-        public void Destroy()
+        internal Plugin(string name, Communicator communicator)
         {
-            if (_replyAdapter != null)
-            {
-                _replyAdapter.Destroy();
-            }
-            if (_locatorAdapter != null)
-            {
-                _locatorAdapter.Destroy();
-            }
-
-            if (IObjectPrx.Equals(_communicator.DefaultLocator, _locatorPrx))
-            {
-                // Restore original default locator proxy, if the user didn't change it in the meantime
-                _communicator.DefaultLocator = _defaultLocator;
-            }
+            _name = name;
+            _communicator = communicator;
         }
-
-        private readonly string _name;
-        private readonly Communicator _communicator;
-        private ObjectAdapter? _locatorAdapter;
-        private ObjectAdapter? _replyAdapter;
-        private LocatorI? _locator;
-        private ILocatorPrx? _locatorPrx;
-        private ILocatorPrx? _defaultLocator;
-    }
-
-    public static class Util
-    {
-        // TODO remove this a add static Register to the factory class
-        public static void
-        RegisterIceLocatorDiscovery(bool loadOnInitialize) =>
-            Communicator.RegisterPluginFactory("IceLocatorDiscovery", new PluginFactory(), loadOnInitialize);
     }
 }


### PR DESCRIPTION
This PR simplifies the IceLocatorDiscovery plug-in

* Get rid of the getAllLocators internal method that was not used in C#
* Replace the Timer by a delay task and simplifies the retry logic to use a look and await