### PR TITLE
Replace ICertificateVerifier by .NET native validation callback

### DIFF
--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using ZeroC.Ice;
@@ -27,7 +28,7 @@ namespace ZeroC.Glacier2
         /// <param name="observer">Optional communicator observer used for communicator initialization.</param>
         /// <param name="certificates">The user certificates to use with the SSL transport.</param>
         /// <param name="caCertificates">The certificate authorities to use with the SSL transport.</param>
-        /// <param name="certificateVerifier">The certificate verifier delegate to use with the SSL transport.</param>
+        /// <param name="certificateValidationCallback">The certificate validation callback to use with the SSL transport.</param>
         /// <param name="passwordCallback">The password callback delegate to use with the SSL transport.</param>
         /// <param name="finderStr">The stringified Ice.RouterFinder proxy.</param>
         /// <param name="useCallbacks">True if the session should create an object adapter for receiving callbacks.</param>
@@ -39,7 +40,7 @@ namespace ZeroC.Glacier2
             ICommunicatorObserver? observer = null,
             X509Certificate2Collection? certificates = null,
             X509Certificate2Collection? caCertificates = null,
-            ICertificateVerifier? certificateVerifier = null,
+            RemoteCertificateValidationCallback? certificateValidationCallback = null,
             IPasswordCallback? passwordCallback = null)
         {
             _callback = callback;
@@ -50,7 +51,7 @@ namespace ZeroC.Glacier2
             _observer = observer;
             _certificates = certificates;
             _caCertificates = caCertificates;
-            _certificateVerifier = certificateVerifier;
+            _certificateValidationCallback = certificateValidationCallback;
             _passwordCallback = passwordCallback;
         }
 
@@ -399,7 +400,7 @@ namespace ZeroC.Glacier2
                             observer: _observer,
                             certificates: _certificates,
                             caCertificates: _caCertificates,
-                            certificateVerifier: _certificateVerifier,
+                            certificateValidationCallback: _certificateValidationCallback,
                             passwordCallback: _passwordCallback);
                     }
                 }
@@ -474,7 +475,7 @@ namespace ZeroC.Glacier2
         private readonly ICommunicatorObserver? _observer;
         private readonly X509Certificate2Collection? _certificates;
         private readonly X509Certificate2Collection? _caCertificates;
-        private readonly ICertificateVerifier? _certificateVerifier;
+        private readonly RemoteCertificateValidationCallback? _certificateValidationCallback;
         private readonly IPasswordCallback? _passwordCallback;
 
         private readonly ISessionCallback _callback;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -586,6 +586,13 @@ namespace ZeroC.Ice
 
                 NetworkProxy = CreateNetworkProxy(IPVersion);
 
+                if (caCertificates != null && certificateValidationCallback != null)
+                {
+                    throw new ArgumentException(
+                        "The caCertificates argument cannot be set when certificateValidationCallback argument is set",
+                        nameof(caCertificates));
+                }
+
                 _sslEngine = new SslEngine(this, certificates, caCertificates, certificateValidationCallback, passwordCallback);
 
                 IceAddEndpointFactory(new TcpEndpointFactory(this));

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -216,7 +217,7 @@ namespace ZeroC.Ice
                             Instrumentation.ICommunicatorObserver? observer = null,
                             X509Certificate2Collection? certificates = null,
                             X509Certificate2Collection? caCertificates = null,
-                            ICertificateVerifier? certificateVerifier = null,
+                            RemoteCertificateValidationCallback? certificateValidationCallback = null,
                             IPasswordCallback? passwordCallback = null)
             : this(ref _emptyArgs,
                    null,
@@ -225,7 +226,7 @@ namespace ZeroC.Ice
                    observer,
                    certificates,
                    caCertificates,
-                   certificateVerifier,
+                   certificateValidationCallback,
                    passwordCallback)
         {
         }
@@ -236,7 +237,7 @@ namespace ZeroC.Ice
                             Instrumentation.ICommunicatorObserver? observer = null,
                             X509Certificate2Collection? certificates = null,
                             X509Certificate2Collection? caCertificates = null,
-                            ICertificateVerifier? certificateVerifier = null,
+                            RemoteCertificateValidationCallback? certificateValidationCallback = null,
                             IPasswordCallback? passwordCallback = null)
             : this(ref args,
                    null,
@@ -245,7 +246,7 @@ namespace ZeroC.Ice
                    observer,
                    certificates,
                    caCertificates,
-                   certificateVerifier,
+                   certificateValidationCallback,
                    passwordCallback)
         {
         }
@@ -256,7 +257,7 @@ namespace ZeroC.Ice
                             Instrumentation.ICommunicatorObserver? observer = null,
                             X509Certificate2Collection? certificates = null,
                             X509Certificate2Collection? caCertificates = null,
-                            ICertificateVerifier? certificateVerifier = null,
+                            RemoteCertificateValidationCallback? certificateValidationCallback = null,
                             IPasswordCallback? passwordCallback = null)
             : this(ref _emptyArgs,
                    appSettings,
@@ -265,7 +266,7 @@ namespace ZeroC.Ice
                    observer,
                    certificates,
                    caCertificates,
-                   certificateVerifier,
+                   certificateValidationCallback,
                    passwordCallback)
         {
         }
@@ -277,7 +278,7 @@ namespace ZeroC.Ice
                             Instrumentation.ICommunicatorObserver? observer = null,
                             X509Certificate2Collection? certificates = null,
                             X509Certificate2Collection? caCertificates = null,
-                            ICertificateVerifier? certificateVerifier = null,
+                            RemoteCertificateValidationCallback? certificateValidationCallback = null,
                             IPasswordCallback? passwordCallback = null)
         {
             _state = StateActive;
@@ -585,7 +586,7 @@ namespace ZeroC.Ice
 
                 NetworkProxy = CreateNetworkProxy(IPVersion);
 
-                _sslEngine = new SslEngine(this, certificates, caCertificates, certificateVerifier, passwordCallback);
+                _sslEngine = new SslEngine(this, certificates, caCertificates, certificateValidationCallback, passwordCallback);
 
                 IceAddEndpointFactory(new TcpEndpointFactory(this));
                 IceAddEndpointFactory(new UdpEndpointFactory(this));

--- a/csharp/src/Ice/SslEngine.cs
+++ b/csharp/src/Ice/SslEngine.cs
@@ -97,6 +97,12 @@ namespace ZeroC.Ice
             }
             _verifyDepthMax = verifyDepthMax ?? 3;
 
+            if (communicator.GetPropertyAsInt("IceSSL.VerifyPeer") != null && RemoteCertificateValidationCallback != null)
+            {
+                throw new InvalidConfigurationException(
+                    "The property IceSSL.VerifyDepthMax cannot be set when using a custom certificate validation callback");
+            }
+
             // CheckCRL determines whether the certificate revocation list is checked, and how strictly.
             CheckCRL = communicator.GetPropertyAsInt("IceSSL.CheckCRL") ?? 0;
 

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -48,10 +48,11 @@ namespace ZeroC.Ice
             {
                 try
                 {
-                    _sslStream = new SslStream(new NetworkStream(fd, false),
-                                               false,
-                                               new RemoteCertificateValidationCallback(ValidationCallback),
-                                               new LocalCertificateSelectionCallback(SelectCertificate));
+                    _sslStream = new SslStream(
+                        new NetworkStream(fd, false),
+                        false,
+                        _engine.RemoteCertificateValidationCallback ?? ValidationCallback,
+                        SelectCertificate);
                 }
                 catch (IOException ex)
                 {

--- a/csharp/test/Directory.Build.props
+++ b/csharp/test/Directory.Build.props
@@ -15,7 +15,6 @@
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/Glacier2.dll" />
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/Ice.dll" />
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceBox.dll" />
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceDiscovery.dll" />
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceGrid.dll" />
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceLocatorDiscovery.dll" />
                 <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceStorm.dll" />

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -1060,10 +1060,8 @@ namespace ZeroC.IceSSL.Test.Configuration
                 Console.Out.Write("testing custom certificate verifier... ");
                 Console.Out.Flush();
                 {
-                    //
                     // Verify that a server certificate is present.
-                    //
-                    clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
+                    clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
 
                     bool invoked = false;
                     bool hadCert = false;
@@ -1129,6 +1127,83 @@ namespace ZeroC.IceSSL.Test.Configuration
                     fact.destroyServer(server);
 
                     comm.Destroy();
+
+                    try
+                    {
+                        // Setting IceSSL.CAs and the certificate verifier results in InvalidConfigurationException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
+                        comm = new Communicator(ref args, clientProperties,
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+
+                    try
+                    {
+                        // Setting IceSSL.VerifyPeer and the certificate verifier results in InvalidConfigurationException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
+                        clientProperties["IceSSL.VerifyPeer"] = "2";
+                        comm = new Communicator(ref args, clientProperties,
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+
+                    try
+                    {
+                        // Setting IceSSL.VerifyDepthMax and the certificate verifier results in InvalidConfigurationException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
+                        clientProperties["IceSSL.VerifyDepthMax"] = "2";
+                        comm = new Communicator(ref args, clientProperties,
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+
+                    try
+                    {
+                        // Setting IceSSL.CheckCertName and the certificate verifier results in InvalidConfigurationException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
+                        clientProperties["IceSSL.CheckCertName"] = "1";
+                        comm = new Communicator(ref args, clientProperties,
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+
+                    try
+                    {
+                        // Setting IceSSL.UsePlatformCAs and the certificate verifier results in InvalidConfigurationException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
+                        clientProperties["IceSSL.UsePlatformCAs"] = "0";
+                        comm = new Communicator(ref args, clientProperties,
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+
+                    try
+                    {
+                        // Setting CA certificates and the certificate verifier results in ArgumentException
+                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
+                        comm = new Communicator(ref args, clientProperties,
+                            caCertificates: new X509Certificate2Collection(),
+                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
+                        TestHelper.Assert(false);
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
                 }
                 Console.Out.WriteLine("ok");
 

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -1068,9 +1068,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                     bool invoked = false;
                     bool hadCert = false;
                     var comm = new Communicator(ref args, clientProperties,
-                        certificateVerifier: info =>
+                        certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) =>
                         {
-                            hadCert = info.Certs != null;
+                            hadCert = certificate != null;
                             invoked = true;
                             return true;
                         });
@@ -1099,9 +1099,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                     // Have the verifier return false. Close the connection explicitly to force a new connection to be
                     // established.
                     comm = new Communicator(ref args, clientProperties,
-                        certificateVerifier: info =>
+                        certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) =>
                         {
-                            hadCert = info.Certs != null;
+                            hadCert = certificate != null;
                             invoked = true;
                             return false;
                         });


### PR DESCRIPTION
This small PR replaces our custom ICertificateVerifier interface by the [System.Net.Security.RemoteCertificateValidationCallback ](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.remotecertificatevalidationcallback?view=netcore-3.1)

With this change the behavior of when the certificate validation callback is called is also different, previously the certificate verifier was called from the default callback as a last check, the default checks were run and you have to set IceSSL.VerifyPeer=0 to ignore them and take control in the provided verifier.

With this change the certificate validation callback is directly pass to the .NET Core runtime and  the default validation callback provided by Ice runtime will not be used, given the user provided callback total control of the certificate validation.