### PR TITLE
Remove CheckCertName property, always check server certificate name

### DIFF
--- a/csharp/src/Ice/SslEngine.cs
+++ b/csharp/src/Ice/SslEngine.cs
@@ -25,7 +25,6 @@ namespace ZeroC.Ice
         internal X509Certificate2Collection? CaCerts { get; }
         internal X509Certificate2Collection? Certs { get; }
         internal RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; }
-        internal bool CheckCertName { get; }
         internal int CheckCRL { get; }
         internal IPasswordCallback? PasswordCallback { get; }
         internal int SecurityTraceLevel { get; }
@@ -78,15 +77,6 @@ namespace ZeroC.Ice
 
             // Protocols selects which protocols to enable
             SslProtocols = ParseProtocols(communicator.GetPropertyAsList("IceSSL.Protocols"));
-
-            // CheckCertName determines whether we compare the name in a peer's certificate against its hostname.
-            bool? checkCertName = communicator.GetPropertyAsBool("IceSSL.CheckCertName");
-            if (checkCertName != null && RemoteCertificateValidationCallback != null)
-            {
-                throw new InvalidConfigurationException(
-                    "the property `IceSSL.CheckCertName' check is incompatible with the custom remote certificate validation callback");
-            }
-            CheckCertName = checkCertName ?? false;
 
             // VerifyDepthMax establishes the maximum length of a peer's certificate chain, including the peer's
             // certificate. A value of 0 means there is no maximum.

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -586,7 +586,7 @@ namespace ZeroC.Ice
                             }
                             else
                             {
-                                _verified = !certificateNameMismatch;
+                                _verified = true;
                             }
                         }
                         else if (status.Status == X509ChainStatusFlags.Revoked)

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -552,32 +552,12 @@ namespace ZeroC.Ice
                 bool certificateNameMismatch = (errors & (int)SslPolicyErrors.RemoteCertificateNameMismatch) > 0;
                 if (certificateNameMismatch)
                 {
-                    if (_engine.CheckCertName && !string.IsNullOrEmpty(_host))
+                    if (_engine.SecurityTraceLevel >= 1)
                     {
-                        if (_engine.SecurityTraceLevel >= 1)
-                        {
-                            string msg = "SSL certificate validation failed - Hostname mismatch";
-                            if (_verifyPeer == 0)
-                            {
-                                msg += " (ignored)";
-                            }
-                            _communicator.Logger.Trace(_engine.SecurityTraceCategory, msg);
-                        }
-
-                        if (_verifyPeer > 0)
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            errors ^= (int)SslPolicyErrors.RemoteCertificateNameMismatch;
-                        }
+                        _communicator.Logger.Trace(_engine.SecurityTraceCategory,
+                            "SSL certificate validation failed - Hostname mismatch");
                     }
-                    else
-                    {
-                        errors ^= (int)SslPolicyErrors.RemoteCertificateNameMismatch;
-                        certificateNameMismatch = false;
-                    }
+                    return false;
                 }
 
                 if ((errors & (int)SslPolicyErrors.RemoteCertificateChainErrors) > 0 &&

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -549,8 +549,7 @@ namespace ZeroC.Ice
                     }
                 }
 
-                bool certificateNameMismatch = (errors & (int)SslPolicyErrors.RemoteCertificateNameMismatch) > 0;
-                if (certificateNameMismatch)
+                if ((errors & (int)SslPolicyErrors.RemoteCertificateNameMismatch) > 0)
                 {
                     if (_engine.SecurityTraceLevel >= 1)
                     {

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -597,12 +597,10 @@ namespace ZeroC.IceSSL.Test.Configuration
                         //
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName"] = "1";
                             comm = new Communicator(ref args, clientProperties);
 
                             fact = IServerFactoryPrx.Parse(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn5", "cacert1");
-                            serverProperties["IceSSL.CheckCertName"] = "1";
                             server = fact.createServer(serverProperties);
                             try
                             {
@@ -630,13 +628,11 @@ namespace ZeroC.IceSSL.Test.Configuration
                         //
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName", "1");
                             comm = new Communicator(ref args, initData);
 
                             fact = IServerFactoryPrxHelper.checkedCast(comm.stringToProxy(factoryRef));
                             TestHelper.Assert(fact != null);
                             serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1_cn6", "cacert1");
-                            d["IceSSL.CheckCertName"] = "1";
                             server = fact.createServer(d);
                             try
                             {
@@ -654,13 +650,11 @@ namespace ZeroC.IceSSL.Test.Configuration
                         //
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName", "1");
                             comm = new Communicator(ref args, initData);
 
                             fact = IServerFactoryPrxHelper.checkedCast(comm.stringToProxy(factoryRef));
                             TestHelper.Assert(fact != null);
                             serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1_cn7", "cacert1");
-                            d["IceSSL.CheckCertName"] = "1";
                             server = fact.createServer(d);
                             try
                             {
@@ -680,12 +674,10 @@ namespace ZeroC.IceSSL.Test.Configuration
                         //
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName"] = "1";
                             comm = new Communicator(ref args, clientProperties);
 
                             fact = IServerFactoryPrx.Parse(factoryRef, comm);
                             serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1_cn8", "cacert1");
-                            serverProperties["IceSSL.CheckCertName"] = "1";
                             server = fact.createServer(serverProperties);
                             try
                             {
@@ -707,13 +699,10 @@ namespace ZeroC.IceSSL.Test.Configuration
                         }
 
                         //
-                        // Target host does not match the certificate DNS altName, connection should succeed
-                        // because IceSSL.VerifyPeer is set to 0.
+                        // Target host does not match the certificate DNS altName, connection should fail.
                         //
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName"] = "1";
-                            clientProperties["IceSSL.VerifyPeer"] = "0";
                             comm = new Communicator(ref args, clientProperties);
 
                             fact = IServerFactoryPrx.Parse(factoryRef, comm);
@@ -722,34 +711,10 @@ namespace ZeroC.IceSSL.Test.Configuration
                             try
                             {
                                 server!.IcePing();
-                                var info = (SslConnectionInfo)server.GetConnection().GetConnectionInfo();
-                                TestHelper.Assert(!info.Verified);
-                            }
-                            catch (Exception ex)
-                            {
-                                Console.WriteLine(ex.ToString());
                                 TestHelper.Assert(false);
                             }
-                            fact.destroyServer(server);
-                            comm.Destroy();
-                        }
-
-                        //
-                        // Target host does not match the certificate DNS altName, connection should succeed
-                        // because IceSSL.CheckCertName is set to 0.
-                        //
-                        {
-                            clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            clientProperties["IceSSL.CheckCertName"] = "0";
-                            comm = new Communicator(ref args, clientProperties);
-
-                            fact = IServerFactoryPrx.Parse(factoryRef, comm);
-                            serverProperties = CreateProperties(props, "s_rsa_ca1_cn2", "cacert1");
-                            serverProperties["IceSSL.CheckCertName"] = "1";
-                            server = fact.createServer(serverProperties);
-                            try
+                            catch (TransportException)
                             {
-                                server!.IcePing();
                             }
                             catch (Exception ex)
                             {
@@ -1145,19 +1110,6 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // Setting IceSSL.VerifyDepthMax and the certificate verifier results in InvalidConfigurationException
                         clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
                         clientProperties["IceSSL.VerifyDepthMax"] = "2";
-                        comm = new Communicator(ref args, clientProperties,
-                            certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
-                        TestHelper.Assert(false);
-                    }
-                    catch (InvalidConfigurationException)
-                    {
-                    }
-
-                    try
-                    {
-                        // Setting IceSSL.CheckCertName and the certificate verifier results in InvalidConfigurationException
-                        clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
-                        clientProperties["IceSSL.CheckCertName"] = "1";
                         comm = new Communicator(ref args, clientProperties,
                             certificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) => false);
                         TestHelper.Assert(false);


### PR DESCRIPTION
This PR removes `IceSSL.CheckCertName` property, and the SSL Engine will always perform the server certificate name validation.

For users than need custom validation rules they will have to provide a validation callback on communicator initialization.