### PR TITLE
Add C# ArraySegment as an available generic container

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -480,6 +480,11 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
                 return "global::System.Collections.Generic." + customType + "<" +
                     typeToString(seq->type(), package, optional, local) + ">";
             }
+            else if(customType == "ArraySegment")
+            {
+                return "global::System." + customType + "<" +
+                    typeToString(seq->type(), package, optional, local) + ">";
+            }
             else
             {
                 return "global::" + customType + "<" + typeToString(seq->type(), package, optional, local) + ">";
@@ -1317,6 +1322,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
     bool isStack = false;
     bool isList = false;
     bool isLinkedList = false;
+    bool isArraySegment = false;
     bool isCustom = false;
     if(isGeneric)
     {
@@ -1338,6 +1344,10 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
         else if(genericType == "List")
         {
             isList = true;
+        }
+        else if(genericType == "ArraySegment")
+        {
+            isArraySegment = true;
         }
         else
         {
@@ -1519,7 +1529,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
                 func[0] = static_cast<char>(toupper(static_cast<unsigned char>(typeS[0])));
                 if(marshal)
                 {
-                    if(isArray)
+                    if(isArray || isArraySegment)
                     {
                         out << nl << stream << ".write" << func << "Seq(" << param << ");";
                     }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1049,6 +1049,16 @@ namespace Ice
         }
 
         /// <summary>
+        /// Extracts a sequence of byte values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted byte sequence as an ArraySegment.</param>
+        public void readByteSeq(out ArraySegment<byte> l)
+        {
+            byte[] array = readByteSeq();
+            l = new ArraySegment<byte>(array);
+        }
+
+        /// <summary>
         /// Extracts an optional byte sequence from the stream.
         /// </summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
@@ -1233,6 +1243,16 @@ namespace Ice
         }
 
         /// <summary>
+        /// Extracts a sequence of boolean values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted boolean sequence as an ArraySegment.</param>
+        public void readBoolSeq(out ArraySegment<bool> l)
+        {
+            bool[] array = readBoolSeq();
+            l = new ArraySegment<bool>(array);
+        }
+
+        /// <summary>
         /// Extracts an optional boolean sequence from the stream.
         /// </summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
@@ -1392,6 +1412,16 @@ namespace Ice
             short[] array = readShortSeq();
             Array.Reverse(array);
             l = new Stack<short>(array);
+        }
+
+        /// <summary>
+        /// Extracts a sequence of short values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted short sequence as an ArraySegment.</param>
+        public void readShortSeq(out ArraySegment<short> l)
+        {
+            short[] array = readShortSeq();
+            l = new ArraySegment<short>(array);
         }
 
         /// <summary>
@@ -1579,6 +1609,16 @@ namespace Ice
         }
 
         /// <summary>
+        /// Extracts a sequence of int values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted int sequence as an ArraySegment.</param>
+        public void readIntSeq(out ArraySegment<int> l)
+        {
+            int[] array = readIntSeq();
+            l = new ArraySegment<int>(array);
+        }
+
+        /// <summary>
         /// Extracts an optional int sequence from the stream.
         /// </summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
@@ -1760,6 +1800,16 @@ namespace Ice
             long[] array = readLongSeq();
             Array.Reverse(array);
             l = new Stack<long>(array);
+        }
+
+        /// <summary>
+        /// Extracts a sequence of long values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted long sequence as an ArraySegment.</param>
+        public void readLongSeq(out ArraySegment<long> l)
+        {
+            long[] array = readLongSeq();
+            l = new ArraySegment<long>(array);
         }
 
         /// <summary>
@@ -1947,6 +1997,16 @@ namespace Ice
         }
 
         /// <summary>
+        /// Extracts a sequence of float values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted float sequence as an ArraySegment.</param>
+        public void readFloatSeq(out ArraySegment<float> l)
+        {
+            float[] array = readFloatSeq();
+            l = new ArraySegment<float>(array);
+        }
+
+        /// <summary>
         /// Extracts an optional float sequence from the stream.
         /// </summary>
         /// <param name="tag">The numeric tag associated with the value.</param>
@@ -2128,6 +2188,16 @@ namespace Ice
             double[] array = readDoubleSeq();
             Array.Reverse(array);
             l = new Stack<double>(array);
+        }
+
+        /// <summary>
+        /// Extracts a sequence of double values from the stream.
+        /// </summary>
+        /// <param name="l">The extracted double sequence as an ArraySegment.</param>
+        public void readDoubleSeq(out ArraySegment<double> l)
+        {
+            double[] array = readDoubleSeq();
+            l = new ArraySegment<double>(array);
         }
 
         /// <summary>
@@ -2333,6 +2403,16 @@ namespace Ice
             string[] array = readStringSeq();
             Array.Reverse(array);
             l = new Stack<string>(array);
+        }
+
+        /// <summary>
+        /// Extracts a sequence of strings from the stream.
+        /// </summary>
+        /// <param name="l">The extracted string sequence as an ArraySegment.</param>
+        public void readStringSeq(out ArraySegment<string> l)
+        {
+            string[] array = readStringSeq();
+            l = new ArraySegment<string>(array);
         }
 
         /// <summary>

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -582,15 +582,25 @@ namespace Ice
         /// Passing null causes an empty sequence to be written to the stream.</param>
         public void writeByteSeq(byte[] v)
         {
-            if(v == null)
+            writeByteSeq(v == null ? new ArraySegment<byte>() : new ArraySegment<byte>(v));
+        }
+
+
+        /// <summary>
+        /// Writes a byte sequence to the stream.
+        /// </summary>
+        /// <param name="v">The byte sequence to write to the stream</param>
+        public void writeByteSeq(ArraySegment<byte> v)
+        {
+            if (v.Count == 0)
             {
                 writeSize(0);
             }
             else
             {
-                writeSize(v.Length);
-                expand(v.Length);
-                _buf.b.put(v);
+                writeSize(v.Count);
+                expand(v.Count);
+                _buf.b.put(v.Array, v.Offset, v.Count);
             }
         }
 
@@ -802,6 +812,24 @@ namespace Ice
         }
 
         /// <summary>
+        /// Writes a bool sequence to the stream.
+        /// </summary>
+        /// <param name="v">The bool sequence to write to the stream</param>
+        public void writeBoolSeq(ArraySegment<bool> v)
+        {
+            if (v.Count == 0)
+            {
+                writeBoolSeq(null);
+            }
+            else
+            {
+                bool[] tmp = new bool[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeBoolSeq(tmp);
+            }
+        }
+
+        /// <summary>
         /// Writes a boolean sequence to the stream.
         /// </summary>
         /// <param name="count">The number of elements in the sequence.</param>
@@ -971,6 +999,24 @@ namespace Ice
                 writeSize(v.Length);
                 expand(v.Length * 2);
                 _buf.b.putShortSeq(v);
+            }
+        }
+
+        /// <summary>
+        /// Writes a short sequence to the stream.
+        /// </summary>
+        /// <param name="v">The short sequence to write to the stream</param>
+        public void writeShortSeq(ArraySegment<short> v)
+        {
+            if (v.Count == 0)
+            {
+                writeShortSeq(null);
+            }
+            else
+            {
+                short[] tmp = new short[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeShortSeq(tmp);
             }
         }
 
@@ -1161,6 +1207,24 @@ namespace Ice
         }
 
         /// <summary>
+        /// Writes a int sequence to the stream.
+        /// </summary>
+        /// <param name="v">The int sequence to write to the stream</param>
+        public void writeIntSeq(ArraySegment<int> v)
+        {
+            if (v.Count == 0)
+            {
+                writeIntSeq(null);
+            }
+            else
+            {
+                int[] tmp = new int[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeIntSeq(tmp);
+            }
+        }
+
+        /// <summary>
         /// Writes an int sequence to the stream.
         /// </summary>
         /// <param name="count">The number of elements in the sequence.</param>
@@ -1333,6 +1397,24 @@ namespace Ice
                 writeSize(v.Length);
                 expand(v.Length * 8);
                 _buf.b.putLongSeq(v);
+            }
+        }
+
+        /// <summary>
+        /// Writes a long sequence to the stream.
+        /// </summary>
+        /// <param name="v">The long sequence to write to the stream</param>
+        public void writeLongSeq(ArraySegment<long> v)
+        {
+            if (v.Count == 0)
+            {
+                writeLongSeq(null);
+            }
+            else
+            {
+                long[] tmp = new long[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeLongSeq(tmp);
             }
         }
 
@@ -1515,6 +1597,24 @@ namespace Ice
         /// <summary>
         /// Writes a float sequence to the stream.
         /// </summary>
+        /// <param name="v">The float sequence to write to the stream</param>
+        public void writeFloatSeq(ArraySegment<float> v)
+        {
+            if (v.Count == 0)
+            {
+                writeFloatSeq(null);
+            }
+            else
+            {
+                float[] tmp = new float[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeFloatSeq(tmp);
+            }
+        }
+
+        /// <summary>
+        /// Writes a float sequence to the stream.
+        /// </summary>
         /// <param name="count">The number of elements in the sequence.</param>
         /// <param name="v">An enumerator for the container holding the sequence.</param>
         public void writeFloatSeq(int count, IEnumerable<float> v)
@@ -1685,6 +1785,24 @@ namespace Ice
                 writeSize(v.Length);
                 expand(v.Length * 8);
                 _buf.b.putDoubleSeq(v);
+            }
+        }
+
+        /// <summary>
+        /// Writes a double sequence to the stream.
+        /// </summary>
+        /// <param name="v">The double sequence to write to the stream</param>
+        public void writeDoubleSeq(ArraySegment<double> v)
+        {
+            if (v.Count == 0)
+            {
+                writeDoubleSeq(null);
+            }
+            else
+            {
+                double[] tmp = new double[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeDoubleSeq(tmp);
             }
         }
 
@@ -1873,6 +1991,24 @@ namespace Ice
                 {
                     writeString(v[i]);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Writes a string sequence to the stream.
+        /// </summary>
+        /// <param name="v">The string sequence to write to the stream</param>
+        public void writeStringSeq(ArraySegment<string> v)
+        {
+            if (v.Count == 0)
+            {
+                writeStringSeq(null);
+            }
+            else
+            {
+                string[] tmp = new string[v.Count];
+                System.Buffer.BlockCopy(v.Array, v.Offset, tmp, 0, v.Count);
+                writeStringSeq(tmp);
             }
         }
 

--- a/csharp/test/Ice/seqMapping/Test.ice
+++ b/csharp/test/Ice/seqMapping/Test.ice
@@ -15,6 +15,7 @@ sequence<byte> AByteS;
 ["clr:generic:LinkedList"] sequence<byte> KByteS;
 ["clr:generic:Queue"] sequence<byte> QByteS;
 ["clr:generic:Stack"] sequence<byte> SByteS;
+["clr:generic:ArraySegment"] sequence<byte> ASByteS;
 ["clr:generic:Ice.seqMapping.Custom"] sequence<byte> CByteS;
 
 sequence<bool> ABoolS;


### PR DESCRIPTION
I'm happy to fill out the tests and also make the proper changes to make the code path for 

```
public void write{type}Seq(ArraySegment<string> v)
```

more similar to the

```
public void writeByteSeq(ArraySegment<string> v)
```

I couldn't do it without more effect because the downstream buffers didn't have methods to write with an offset and length.  Just wanted to make sure you guys were ok with this kind of a change before putting in that effort.