### PR TITLE
Add read/write specializations for C# System.ArraySegment

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1317,6 +1317,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
     bool isStack = false;
     bool isList = false;
     bool isLinkedList = false;
+    bool isArraySegment = false;
     bool isCustom = false;
     if(isGeneric)
     {
@@ -1338,6 +1339,10 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
         else if(genericType == "List")
         {
             isList = true;
+        }
+        else if(genericType == "System.ArraySegment")
+        {
+            isArraySegment = true;
         }
         else
         {
@@ -1519,7 +1524,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
                 func[0] = static_cast<char>(toupper(static_cast<unsigned char>(typeS[0])));
                 if(marshal)
                 {
-                    if(isArray)
+                    if(isArray || isArraySegment)
                     {
                         out << nl << stream << ".write" << func << "Seq(" << param << ");";
                     }
@@ -1540,6 +1545,11 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
                     if(isArray)
                     {
                         out << nl << param << " = " << stream << ".read" << func << "Seq();";
+                    }
+                    else if(isArraySegment)
+                    {
+                        out << nl << param << " = new " << "global::" << genericType << "<" << typeToString(type, scope) << ">("
+                            << stream << ".read" << func << "Seq());";
                     }
                     else if(isCustom)
                     {

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -10,6 +10,7 @@
 
 namespace Slice
 {
+const int TypeContextDispatchParam = 1;
 
 class CsGenerator : private ::IceUtil::noncopyable
 {
@@ -54,7 +55,7 @@ protected:
     static std::string getOptionalFormat(const TypePtr&, const std::string&);
     static std::string getStaticId(const TypePtr&);
     static std::string typeToString(const TypePtr&, const std::string&, bool = false, bool = false,
-                                    const StringList& = StringList());
+                                    const StringList& = StringList(), int = 0);
     static bool isClassType(const TypePtr&);
     static bool isValueType(const TypePtr&);
 

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -28,7 +28,7 @@ protected:
     virtual void writeDispatch(const ClassDefPtr&);
     virtual void writeMarshaling(const ClassDefPtr&);
 
-    static std::vector<std::string> getParams(const OperationPtr&, const std::string&);
+    static std::vector<std::string> getParams(const OperationPtr&, const std::string&, int = 0);
     static std::vector<std::string> getInParams(const OperationPtr&, const std::string&, bool = false);
     static std::vector<std::string> getOutParams(const OperationPtr&, const std::string&, bool, bool);
     static std::vector<std::string> getArgs(const OperationPtr&);

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -582,15 +582,24 @@ namespace Ice
         /// Passing null causes an empty sequence to be written to the stream.</param>
         public void writeByteSeq(byte[] v)
         {
-            if(v == null)
+            writeByteSeq(v == null ? new ArraySegment<byte>() : new ArraySegment<byte>(v));
+        }
+
+        /// <summary>
+        /// Writes a byte sequence to the stream.
+        /// </summary>
+        /// <param name="v">The byte sequence to write to the stream.</param>
+        public void writeByteSeq(ArraySegment<byte> v)
+        {
+            if (v.Count == 0)
             {
                 writeSize(0);
             }
             else
             {
-                writeSize(v.Length);
-                expand(v.Length);
-                _buf.b.put(v);
+                writeSize(v.Count);
+                expand(v.Count);
+                _buf.b.put(v.Array, v.Offset, v.Count);
             }
         }
 

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -144,6 +144,20 @@ namespace Ice
                 return r;
             }
 
+            public override byte[] opByteSArraySegment(byte[] p1, byte[] p2, out byte[] p3, Current current = null)
+            {
+                p3 = new byte[p1.Length];
+                for (int i = 0; i < p1.Length; i++)
+                {
+                    p3[i] = p1[p1.Length - (i + 1)];
+                }
+
+                byte[] r = new byte[p1.Length + p2.Length];
+                Array.Copy(p1, r, p1.Length);
+                Array.Copy(p2, 0, r, p1.Length, p2.Length);
+                return r;
+            }
+
             public override byte[][] opByteSS(byte[][] p1, byte[][] p2, out byte[][] p3, Ice.Current current)
             {
                 p3 = new byte[p1.Length][];

--- a/csharp/test/Ice/operations/MyDerivedClassTieI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassTieI.cs
@@ -132,6 +132,20 @@ namespace Ice
                     return r;
                 }
 
+                public byte[] opByteSArraySegment(byte[] p1, byte[] p2, out byte[] p3, Current current = null)
+                {
+                    p3 = new byte[p1.Length];
+                    for (int i = 0; i < p1.Length; i++)
+                    {
+                        p3[i] = p1[p1.Length - (i + 1)];
+                    }
+
+                    byte[] r = new byte[p1.Length + p2.Length];
+                    Array.Copy(p1, r, p1.Length);
+                    Array.Copy(p2, 0, r, p1.Length, p2.Length);
+                    return r;
+                }
+
                 public byte[][] opByteSS(byte[][] p1, byte[][] p2, out byte[][] p3, Ice.Current current)
                 {
                     p3 = new byte[p1.Length][];

--- a/csharp/test/Ice/operations/Test.ice
+++ b/csharp/test/Ice/operations/Test.ice
@@ -125,6 +125,9 @@ interface MyClass
     ByteS opByteS(ByteS p1, ByteS p2,
                   out ByteS p3);
 
+    ByteS opByteSArraySegment(ByteS p1, ["cs:ArraySegment"] ByteS p2,
+                              out ByteS p3);
+
     BoolS opBoolS(BoolS p1, BoolS p2,
                   out BoolS p3);
 


### PR DESCRIPTION
@bernardnormier , so in my previous pull request (https://github.com/zeroc-ice/ice/pull/912), you had suggested making the `cs:ArraySegment` an operation parameter metadata.  After investigating it more, I don't think that will work since the read/write operations are constructed in the Helper of the class type and the type itself must be `System.ArraySegment` to avoid any copies.

Is this pull request more in the spirit of what you're suggesting though?  It doesn't treat ArraySegment as some special supported container like List, LinkedList, etc but only includes the read/write directives that would make it work if you chose to make it a custom container for `System.ArraySegment<byte>`.

I agree this would not be need on master as this kind of functionality is already supported.