### PR TITLE
More Endpoint refactoring in C#

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -202,18 +202,18 @@ namespace ZeroC.Ice
         private readonly ConcurrentDictionary<string, IRemoteExceptionFactory?> _remoteExceptionFactoryCache =
             new ConcurrentDictionary<string, IRemoteExceptionFactory?>();
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private readonly Dictionary<EndpointType, BufSizeWarnInfo> _setBufSizeWarn =
-            new Dictionary<EndpointType, BufSizeWarnInfo>();
+        private readonly Dictionary<Transport, BufSizeWarnInfo> _setBufSizeWarn =
+            new Dictionary<Transport, BufSizeWarnInfo>();
 
         private readonly SslEngine _sslEngine;
         private int _state;
         private readonly Timer _timer;
 
-        private readonly IDictionary<string, IEndpointFactory> _transportToEndpointFactory =
-            new ConcurrentDictionary<string, IEndpointFactory>();
+        private readonly IDictionary<Transport, IEndpointFactory> _transportToEndpointFactory =
+            new ConcurrentDictionary<Transport, IEndpointFactory>();
 
-        private readonly IDictionary<EndpointType, IEndpointFactory> _typeToEndpointFactory =
-            new ConcurrentDictionary<EndpointType, IEndpointFactory>();
+        private readonly IDictionary<string, (IEndpointFactory, Transport)> _transportNameToEndpointFactory =
+            new ConcurrentDictionary<string, (IEndpointFactory, Transport)>();
 
         public Communicator(Dictionary<string, string>? properties,
                             ILogger? logger = null,
@@ -628,12 +628,12 @@ namespace ZeroC.Ice
                     certificateValidationCallback,
                     passwordCallback);
 
-                IceAddEndpointFactory(new TcpEndpointFactory(this));
-                IceAddEndpointFactory(new UdpEndpointFactory(this));
-                IceAddEndpointFactory(new WSEndpointFactory(this));
+                IceAddEndpointFactory(Transport.TCP, "tcp", new TcpEndpointFactory(this));
+                IceAddEndpointFactory(Transport.UDP, "udp", new UdpEndpointFactory(this));
+                IceAddEndpointFactory(Transport.WS, "ws", new WSEndpointFactory(this));
 
-                IceAddEndpointFactory(new SslEndpointFactory(this, _sslEngine));
-                IceAddEndpointFactory(new WSSEndpointFactory(this, _sslEngine));
+                IceAddEndpointFactory(Transport.SSL, "ssl", new SslEndpointFactory(this, _sslEngine));
+                IceAddEndpointFactory(Transport.WSS, "wss", new WSSEndpointFactory(this, _sslEngine));
 
                 _outgoingConnectionFactory = new OutgoingConnectionFactory(this);
 
@@ -967,8 +967,8 @@ namespace ZeroC.Ice
                 _locatorTableMap.Clear();
             }
 
-            _typeToEndpointFactory.Clear();
             _transportToEndpointFactory.Clear();
+            _transportNameToEndpointFactory.Clear();
 
             if (GetPropertyAsBool("Ice.Warn.UnusedProperties") ?? false)
             {
@@ -1193,37 +1193,49 @@ namespace ZeroC.Ice
         }
 
         // Registers an endpoint factory.
-        public void IceAddEndpointFactory(IEndpointFactory factory)
+        public void IceAddEndpointFactory(Transport transport, string transportName, IEndpointFactory factory)
         {
-            _typeToEndpointFactory.Add(factory.Type, factory);
-            _transportToEndpointFactory.Add(factory.Name, factory);
+            _transportNameToEndpointFactory.Add(transportName, (factory, transport));
+            _transportToEndpointFactory.Add(transport, factory);
         }
 
         // Finds an endpoint factory previously registered using IceAddEndpointFactory.
-        public IEndpointFactory? IceFindEndpointFactory(string transport) =>
+        public IEndpointFactory? IceFindEndpointFactory(Transport transport) =>
             _transportToEndpointFactory.TryGetValue(transport, out IEndpointFactory? factory) ? factory : null;
 
-        // Finds an endpoint factory previously registered using IceAddEndpointFactory.
-        public IEndpointFactory? IceFindEndpointFactory(EndpointType type) =>
-            _typeToEndpointFactory.TryGetValue(type, out IEndpointFactory? factory) ? factory : null;
+        // Finds an endpoint factory previously registered using IceAddEndpointFactory, using the transport's name.
+        internal IEndpointFactory? FindEndpointFactory(string transportName, out Transport transport)
+        {
+            if (_transportNameToEndpointFactory.TryGetValue(transportName,
+                out (IEndpointFactory Factory, Transport Transport) value))
+            {
+                transport = value.Transport;
+                return value.Factory;
+            }
+            else
+            {
+                transport = default;
+                return null;
+            }
+        }
 
-        internal BufSizeWarnInfo GetBufSizeWarn(EndpointType type)
+        internal BufSizeWarnInfo GetBufSizeWarn(Transport transport)
         {
             lock (_setBufSizeWarn)
             {
                 BufSizeWarnInfo info;
-                if (!_setBufSizeWarn.ContainsKey(type))
+                if (!_setBufSizeWarn.ContainsKey(transport))
                 {
                     info = new BufSizeWarnInfo();
                     info.SndWarn = false;
                     info.SndSize = -1;
                     info.RcvWarn = false;
                     info.RcvSize = -1;
-                    _setBufSizeWarn.Add(type, info);
+                    _setBufSizeWarn.Add(transport, info);
                 }
                 else
                 {
-                    info = _setBufSizeWarn[type];
+                    info = _setBufSizeWarn[transport];
                 }
                 return info;
             }
@@ -1277,14 +1289,14 @@ namespace ZeroC.Ice
                 return null;
             });
 
-        internal void SetRcvBufSizeWarn(EndpointType type, int size)
+        internal void SetRcvBufSizeWarn(Transport transport, int size)
         {
             lock (_setBufSizeWarn)
             {
-                BufSizeWarnInfo info = GetBufSizeWarn(type);
+                BufSizeWarnInfo info = GetBufSizeWarn(transport);
                 info.RcvWarn = true;
                 info.RcvSize = size;
-                _setBufSizeWarn[type] = info;
+                _setBufSizeWarn[transport] = info;
             }
         }
 
@@ -1322,14 +1334,14 @@ namespace ZeroC.Ice
             }
         }
 
-        internal void SetSndBufSizeWarn(EndpointType type, int size)
+        internal void SetSndBufSizeWarn(Transport transport, int size)
         {
             lock (_setBufSizeWarn)
             {
-                BufSizeWarnInfo info = GetBufSizeWarn(type);
+                BufSizeWarnInfo info = GetBufSizeWarn(transport);
                 info.SndWarn = true;
                 info.SndSize = size;
-                _setBufSizeWarn[type] = info;
+                _setBufSizeWarn[transport] = info;
             }
         }
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1204,20 +1204,10 @@ namespace ZeroC.Ice
             _transportToEndpointFactory.TryGetValue(transport, out IEndpointFactory? factory) ? factory : null;
 
         // Finds an endpoint factory previously registered using IceAddEndpointFactory, using the transport's name.
-        internal IEndpointFactory? FindEndpointFactory(string transportName, out Transport transport)
-        {
-            if (_transportNameToEndpointFactory.TryGetValue(transportName,
-                out (IEndpointFactory Factory, Transport Transport) value))
-            {
-                transport = value.Transport;
-                return value.Factory;
-            }
-            else
-            {
-                transport = default;
-                return null;
-            }
-        }
+        internal (IEndpointFactory Factory, Transport Transport)? FindEndpointFactory(string transportName) =>
+            _transportNameToEndpointFactory.TryGetValue(transportName,
+                out (IEndpointFactory Factory, Transport Transport) value) ? value :
+                    ((IEndpointFactory Factory, Transport Transport)?)null;
 
         internal BufSizeWarnInfo GetBufSizeWarn(Transport transport)
         {

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -379,7 +379,7 @@ namespace ZeroC.Ice
         /// <returns>The description of the connection as human readable text.</returns>
         public override string ToString() => _transceiver.ToString()!;
 
-        /// <summary>Returns the transport's name. This corresponds "tcp", "udp", etc.</summary>
+        /// <summary>Returns the transport's name. This corresponds to "tcp", "udp", etc.</summary>
         /// <returns>The transport name.</returns>
         public string TransportName => _transceiver.TransportName;
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -379,10 +379,9 @@ namespace ZeroC.Ice
         /// <returns>The description of the connection as human readable text.</returns>
         public override string ToString() => _transceiver.ToString()!;
 
-        /// <summary>Returns the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.
-        /// </summary>
-        /// <returns>The type of the connection.</returns>
-        public string Type() => _transceiver.Transport; // No mutex lock, _type is immutable.
+        /// <summary>Returns the transport's name. This corresponds "tcp", "udp", etc.</summary>
+        /// <returns>The transport name.</returns>
+        public string TransportName => _transceiver.TransportName;
 
         internal Connection(Communicator communicator,
                             IACMMonitor? monitor,
@@ -717,7 +716,7 @@ namespace ZeroC.Ice
                             s.Append("starting to ");
                             s.Append(_connector != null ? "send" : "receive");
                             s.Append(" ");
-                            s.Append(Endpoint.Name);
+                            s.Append(Endpoint.TransportName);
                             s.Append(" messages\n");
                             s.Append(_transceiver.ToDetailedString());
                         }
@@ -725,7 +724,7 @@ namespace ZeroC.Ice
                         {
                             s.Append(_connector != null ? "established" : "accepted");
                             s.Append(" ");
-                            s.Append(Endpoint.Name);
+                            s.Append(Endpoint.TransportName);
                             s.Append(" connection\n");
                             s.Append(ToString());
                         }
@@ -1146,7 +1145,7 @@ namespace ZeroC.Ice
             {
                 var s = new StringBuilder();
                 s.Append("closed ");
-                s.Append(Endpoint.Name);
+                s.Append(Endpoint.TransportName);
                 s.Append(" connection\n");
                 s.Append(ToString());
 
@@ -1633,7 +1632,7 @@ namespace ZeroC.Ice
             if (_communicator.TraceLevels.Network >= 3 && length > 0)
             {
                 _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                    $"received {length} bytes via {Endpoint.Name}\n{this}");
+                    $"received {length} bytes via {Endpoint.TransportName}\n{this}");
             }
 
             if (_observer != null && length > 0)
@@ -1647,7 +1646,7 @@ namespace ZeroC.Ice
             if (_communicator.TraceLevels.Network >= 3 && length > 0)
             {
                 _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                    $"sent {length} bytes via {Endpoint.Name}\n{this}");
+                    $"sent {length} bytes via {Endpoint.TransportName}\n{this}");
             }
 
             if (_observer != null && length > 0)

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -379,10 +379,6 @@ namespace ZeroC.Ice
         /// <returns>The description of the connection as human readable text.</returns>
         public override string ToString() => _transceiver.ToString()!;
 
-        /// <summary>Returns the transport's name. This corresponds to "tcp", "udp", etc.</summary>
-        /// <returns>The transport name.</returns>
-        public string TransportName => _transceiver.TransportName;
-
         internal Connection(Communicator communicator,
                             IACMMonitor? monitor,
                             ITransceiver transceiver,

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -861,7 +861,7 @@ namespace ZeroC.Ice
                         if (_factory._communicator.TraceLevels.Network >= 2)
                         {
                             _factory._communicator.Logger.Trace(_factory._communicator.TraceLevels.NetworkCat,
-                                $"trying to establish {connector.Endpoint.Name} connection to " +
+                                $"trying to establish {connector.Endpoint.TransportName} connection to " +
                                 $"{connector.Connector}");
                         }
 
@@ -888,7 +888,7 @@ namespace ZeroC.Ice
                         {
                             Debug.Assert(connector != null);
                             _factory._communicator.Logger.Trace(_factory._communicator.TraceLevels.NetworkCat,
-                                $"failed to establish {connector.Endpoint.Name} connection to " +
+                                $"failed to establish {connector.Endpoint.TransportName} connection to " +
                                 $"{connector.Connector}\n{ex}");
                         }
                         if (_observer != null)
@@ -966,7 +966,7 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 2)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"attempting to bind to {_endpoint.Name} socket\n{_transceiver}");
+                            $"attempting to bind to {_endpoint.TransportName} socket\n{_transceiver}");
                     }
                     _endpoint = _transceiver.Bind();
 
@@ -981,14 +981,14 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 2)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"attempting to bind to {_endpoint.Name} socket {_acceptor}");
+                            $"attempting to bind to {_endpoint.TransportName} socket {_acceptor}");
                     }
                     _endpoint = _acceptor!.Listen();
 
                     if (_communicator.TraceLevels.Network >= 1)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"listening for {_endpoint.Name} connections\n{_acceptor!.ToDetailedString()}");
+                            $"listening for {_endpoint.TransportName} connections\n{_acceptor!.ToDetailedString()}");
                     }
                 }
             }
@@ -1024,7 +1024,7 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 1)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"accepting {_endpoint.Name} connections at {_acceptor}");
+                            $"accepting {_endpoint.TransportName} connections at {_acceptor}");
                     }
 
                     // Start the asynchronous operation from the thread pool to prevent eventually accepting
@@ -1044,7 +1044,7 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 1)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"stopping to accept {_endpoint.Name} connections at {_acceptor}");
+                            $"stopping to accept {_endpoint.TransportName} connections at {_acceptor}");
                     }
 
                     _acceptor.Close();
@@ -1194,7 +1194,7 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 2)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"trying to accept {_endpoint.Name} connection\n{transceiver}");
+                            $"trying to accept {_endpoint.TransportName} connection\n{transceiver}");
                     }
 
                     try
@@ -1239,7 +1239,7 @@ namespace ZeroC.Ice
                     if (_communicator.TraceLevels.Network >= 2)
                     {
                         _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                            $"failed to accept {_endpoint.Name} connection\n{connection}\n{ex}");
+                            $"failed to accept {_endpoint.TransportName} connection\n{connection}\n{ex}");
                     }
                 }
             }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -40,7 +40,7 @@ namespace ZeroC.Ice
         /// <summary>The timeout for the endpoint in milliseconds. 0 means non-blocking, -1 means no timeout.</summary>
         public abstract int Timeout { get; }
 
-        /// <summary>The <see cref="Transport"></see> of this endpoint.</summary>
+        /// <summary>The <see cref="ZeroC.Ice.Transport"></see> of this endpoint.</summary>
         public abstract Transport Transport { get; }
 
         /// <summary>The name of the endpoint's transport in lowercase, or "opaque" when the transport's name is
@@ -63,7 +63,7 @@ namespace ZeroC.Ice
 
         public static bool operator !=(Endpoint? lhs, Endpoint? rhs) => !(lhs == rhs);
 
-        public override bool Equals(object? obj) => obj != null && obj is Endpoint other && Equals(other);
+        public override bool Equals(object? obj) => obj is Endpoint other && Equals(other);
 
         public virtual bool Equals(Endpoint? other) => Protocol == other?.Protocol;
 
@@ -113,15 +113,12 @@ namespace ZeroC.Ice
         // acceptor.
         public abstract ITransceiver? GetTransceiver();
 
-        protected Endpoint(Protocol protocol)
-        {
-            Protocol = protocol;
-        }
+        protected Endpoint(Protocol protocol) => Protocol = protocol;
 
         /// <summary>Creates an endpoint from a string.</summary>
         /// <param name="endpointString">The string parsed by this method.</param>
         /// <param name="protocol">The Ice protocol of the enclosing proxy.</param>
-        /// <param name="communicator">The communicator that this proxy will use to make remote invocation.</param>
+        /// <param name="communicator">The communicator of the enclosing proxy or object adapter.</param>
         /// <param name="oaEndpoint">When true, endpointString represents an object adapter's endpoint configuration;
         /// when false, endpointString represents a proxy endpoint.</param>
         /// <returns>The new endpoint.</returns>
@@ -181,7 +178,7 @@ namespace ZeroC.Ice
                 }
             }
 
-            if (communicator.FindEndpointFactory(transportName, out Transport transport) is IEndpointFactory factory)
+            if (communicator.FindEndpointFactory(transportName) is (IEndpointFactory factory, Transport transport))
             {
                 Endpoint endpoint = factory.Create(transport, protocol, options, oaEndpoint, endpointString);
                 if (options.Count > 0)

--- a/csharp/src/Ice/IAcceptor.cs
+++ b/csharp/src/Ice/IAcceptor.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice
         bool StartAccept(AsyncCallback callback, object state);
         void FinishAccept();
         ITransceiver Accept();
-        string Transport { get; }
+        string TransportName { get; }
         string ToString();
         string ToDetailedString();
 

--- a/csharp/src/Ice/IConnector.cs
+++ b/csharp/src/Ice/IConnector.cs
@@ -6,13 +6,8 @@ namespace ZeroC.Ice
 {
     public interface IConnector
     {
-        //
-        // Create a transceiver without blocking. The transceiver may not be fully connected
-        // until its initialize method is called.
-        //
+        /// <summary>Creates a transceiver without blocking. The transceiver may not be fully connected until its
+        /// Initialize method is called.</summary>
         ITransceiver Connect();
-
-        EndpointType Type { get; }
-        string Transport { get; }
     }
 }

--- a/csharp/src/Ice/IEndpointFactory.cs
+++ b/csharp/src/Ice/IEndpointFactory.cs
@@ -2,20 +2,35 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Collections.Generic;
 
 namespace ZeroC.Ice
 {
+    /// <summary>Creates endpoints from strings or encoded bytes. A single factory object can support multiple
+    /// transports. This is a publicly visible Ice-internal interface implemented by Ice transports.</summary>
     public interface IEndpointFactory
     {
-        /// <summary>The <see cref="EndpointType">type</see> of this endpoint.</summary>
-        EndpointType Type { get; }
-        /// <summary>The name of the endpoint's transport in lowercase.</summary>
-        string Name { get; }
-        Endpoint Create(string endpointString, Dictionary<string, string?> options, bool oaEndpoint);
-        /// <summary>Read and endpoint from the given input stream.</summary>
+        /// <summary>Creates a new endpoint from an already parsed endpoint string.</summary>
+        /// <param name="transport">The transport of the new endpoint.</param>
+        /// <param name="protocol">The protocol of the new endpoint.</param>
+        /// <param name="options">Options specified in the string representation of the endpoint.</param>
+        /// <param name="oaEndpoint">When true, the new endpoints corresponds to an object adapter's endpoint
+        /// configuration; when false, endpointString represents a proxy endpoint.</param>
+        /// <param name="endpointString">The original endpoint string, for error messages and tracing.</param>
+        /// <returns>The new endpoint.</returns>
+        /// <exception cref="NotSupportedException">Thrown when transport and protocol are not compatible.</exception>
+        Endpoint Create(
+            Transport transport,
+            Protocol protocol,
+            Dictionary<string, string?> options,
+            bool oaEndpoint,
+            string endpointString);
+
+        /// <summary>Reads an endpoint from the given input stream.</summary>
         /// <param name="istr">The input stream to read from.</param>
+        /// <param name="protocol">The protocol of the enclosing proxy.</param>
         /// <returns>Returns the endpoint read from the stream</returns>
-        Endpoint Read(InputStream istr);
+        Endpoint Read(InputStream istr, Protocol protocol);
     }
 }

--- a/csharp/src/Ice/ITransceiver.cs
+++ b/csharp/src/Ice/ITransceiver.cs
@@ -300,7 +300,7 @@ namespace ZeroC.Ice
             }
         }
 
-        string Transport { get; }
+        string TransportName { get; }
         string ToDetailedString();
         ConnectionInfo GetInfo();
         void CheckSendSize(int size);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1140,13 +1140,13 @@ namespace ZeroC.Ice
 
         /// <summary>Reads an endpoint from the stream.</summary>
         /// <returns>The endpoint read from the stream.</returns>
-        internal Endpoint ReadEndpoint()
+        internal Endpoint ReadEndpoint(Protocol protocol)
         {
-            var type = (EndpointType)ReadShort();
+            var transport = (Transport)ReadShort();
             (int size, Encoding encoding) = ReadEncapsulationHeader();
 
             Endpoint endpoint;
-            if (encoding.IsSupported && Communicator.IceFindEndpointFactory(type) is IEndpointFactory factory)
+            if (encoding.IsSupported && Communicator.IceFindEndpointFactory(transport) is IEndpointFactory factory)
             {
                 Encoding oldEncoding = Encoding;
                 ArraySegment<byte> oldBuffer = _buffer;
@@ -1157,7 +1157,7 @@ namespace ZeroC.Ice
                 _pos = 0;
                 _minTotalSeqSize = 0;
 
-                endpoint = factory.Read(this);
+                endpoint = factory.Read(this, protocol);
                 CheckEndOfBuffer();
 
                 // Exceptions when reading InputStream are considered fatal to the InputStream so no need to restore
@@ -1169,7 +1169,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                endpoint = new OpaqueEndpoint(type, encoding, _buffer.Slice(_pos, size - 2).ToArray());
+                endpoint = new OpaqueEndpoint(transport, protocol, encoding, _buffer.Slice(_pos, size - 2).ToArray());
                 _pos += size - 2;
             }
 

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -122,7 +122,7 @@ namespace ZeroC.Ice
 
             Type cli = typeof(Endpoint);
 
-            r.Add("endpointType", cl.GetMethod("GetEndpoint")!, cli.GetProperty("Type")!);
+            r.Add("endpointTransport", cl.GetMethod("GetEndpoint")!, cli.GetProperty("Transport")!);
             r.Add("endpointIsDatagram", cl.GetMethod("GetEndpoint")!, cli.GetProperty("IsDatagram")!);
             r.Add("endpointIsSecure", cl.GetMethod("GetEndpoint")!, cli.GetProperty("IsSecure")!);
             r.Add("endpointTimeout", cl.GetMethod("GetEndpoint")!, cli.GetProperty("Timeout")!);

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -931,12 +931,12 @@ namespace ZeroC.Ice
                 {
                     // Warn if the size that was set is less than the requested size and
                     // we have not already warned.
-                    BufSizeWarnInfo winfo = communicator.GetBufSizeWarn(EndpointType.TCP);
+                    BufSizeWarnInfo winfo = communicator.GetBufSizeWarn(Transport.TCP);
                     if (!winfo.RcvWarn || rcvSize != winfo.RcvSize)
                     {
                         communicator.Logger.Warning(
                             $"TCP receive buffer size: requested size of {rcvSize} adjusted to {size}");
-                        communicator.SetRcvBufSizeWarn(EndpointType.TCP, rcvSize);
+                        communicator.SetRcvBufSizeWarn(Transport.TCP, rcvSize);
                     }
                 }
             }
@@ -954,12 +954,12 @@ namespace ZeroC.Ice
                 {
                     // Warn if the size that was set is less than the requested size and
                     // we have not already warned.
-                    BufSizeWarnInfo winfo = communicator.GetBufSizeWarn(EndpointType.TCP);
+                    BufSizeWarnInfo winfo = communicator.GetBufSizeWarn(Transport.TCP);
                     if (!winfo.SndWarn || sndSize != winfo.SndSize)
                     {
                         communicator.Logger.Warning(
                             $"TCP send buffer size: requested size of {sndSize} adjusted to {size}");
-                        communicator.SetSndBufSizeWarn(EndpointType.TCP, sndSize);
+                        communicator.SetSndBufSizeWarn(Transport.TCP, sndSize);
                     }
                 }
             }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1051,7 +1051,7 @@ namespace ZeroC.Ice
                 }
 
                 string s = endpts[beg..end];
-                endpoints.Add(Endpoint.Parse(s, Communicator, oaEndpoints));
+                endpoints.Add(Endpoint.Parse(s, Protocol.Ice1, Communicator, oaEndpoints));
                 ++end;
             }
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1636,7 +1636,7 @@ namespace ZeroC.Ice
 
             // Encoding does not change at all in this method.
 
-            WriteShort((short)endpoint.Type);
+            WriteShort((short)endpoint.Transport);
             if (endpoint is OpaqueEndpoint opaqueEndpoint)
             {
                 // 2 bytes for the encoding value (e.g. 20 for 2.0)

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -611,7 +611,7 @@ namespace ZeroC.Ice
                     }
 
                     string es = s[beg..end];
-                    endpoints.Add(Endpoint.Parse(es, communicator, false));
+                    endpoints.Add(Endpoint.Parse(es, protocol, communicator, false));
                 }
 
                 Debug.Assert(endpoints.Count > 0);
@@ -709,7 +709,7 @@ namespace ZeroC.Ice
                 endpoints = new Endpoint[sz];
                 for (int i = 0; i < sz; i++)
                 {
-                    endpoints[i] = istr.ReadEndpoint();
+                    endpoints[i] = istr.ReadEndpoint(protocol);
                 }
             }
             else

--- a/csharp/src/Ice/SslEndpoint.cs
+++ b/csharp/src/Ice/SslEndpoint.cs
@@ -3,15 +3,17 @@
 //
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 
 namespace ZeroC.Ice
 {
-    /// <summary> Endpoint represents a TLS layer over another endpoint.</summary>
+    /// <summary>Endpoint represents a TLS layer over another endpoint.</summary>
+    // TODO: fix summary
     public class SslEndpoint : TcpEndpoint
     {
         public override bool IsSecure => true;
-        public override EndpointType Type => EndpointType.SSL;
+        public override Transport Transport => Transport.SSL;
 
         private protected SslEngine SslEngine { get; }
 
@@ -28,33 +30,56 @@ namespace ZeroC.Ice
 
         public override ITransceiver? GetTransceiver() => null;
 
-        internal SslEndpoint(SslEngine engine, Communicator communicator, string host, int port, IPAddress? sourceAddress,
-            int timeout, string connectionId, bool compressionFlag)
-            : base(communicator, host, port, sourceAddress, timeout, connectionId, compressionFlag) =>
+        internal SslEndpoint(
+            SslEngine engine,
+            Communicator communicator,
+            Protocol protocol,
+            string host,
+            int port,
+            IPAddress? sourceAddress,
+            int timeout,
+            string connectionId,
+            bool compressionFlag)
+            : base(communicator, protocol, host, port, sourceAddress, timeout, connectionId, compressionFlag) =>
             SslEngine = engine;
 
-        internal SslEndpoint(SslEngine engine, Communicator communicator, InputStream istr)
-            : base(communicator, istr) => SslEngine = engine;
+        internal SslEndpoint(SslEngine engine, InputStream istr, Protocol protocol)
+            : base(istr, protocol) => SslEngine = engine;
 
-        internal SslEndpoint(SslEngine engine, Communicator communicator, string endpointString,
-            Dictionary<string, string?> options, bool oaEndpoint)
-            : base(communicator, endpointString, options, oaEndpoint) => SslEngine = engine;
+        internal SslEndpoint(
+            SslEngine engine,
+            Communicator communicator,
+            Protocol protocol,
+            Dictionary<string, string?> options,
+            bool oaEndpoint,
+            string endpointString)
+            : base(communicator, protocol, options, oaEndpoint, endpointString) => SslEngine = engine;
 
-        private protected override IPEndpoint CreateEndpoint(string host, int port, string connectionId,
-            bool compressionFlag, int timeout) =>
-            new SslEndpoint(SslEngine, Communicator, host, port, SourceAddress, timeout, connectionId,
-                compressionFlag);
+        private protected override IPEndpoint CreateIPEndpoint(
+            string host,
+            int port,
+            string connectionId,
+            bool compressionFlag,
+            int timeout) =>
+            new SslEndpoint(SslEngine,
+                            Communicator,
+                            Protocol,
+                            host,
+                            port,
+                            SourceAddress,
+                            timeout,
+                            connectionId,
+                            compressionFlag);
 
         internal override ITransceiver CreateTransceiver(string transport, StreamSocket socket, string? adapterName) =>
-            new SslTransceiver(Communicator, SslEngine, base.CreateTransceiver(transport, socket, adapterName),
-                adapterName ?? Host, adapterName != null);
+            new SslTransceiver(Communicator,
+                               SslEngine,
+                               base.CreateTransceiver(transport, socket, adapterName),
+                               adapterName ?? Host, adapterName != null);
     }
 
     internal sealed class SslEndpointFactory : IEndpointFactory
     {
-        public EndpointType Type => EndpointType.SSL;
-        public string Name => "ssl";
-
         private SslEngine SslEngine { get; }
         private Communicator Communicator { get; }
 
@@ -64,8 +89,17 @@ namespace ZeroC.Ice
             SslEngine = engine;
         }
 
-        public Endpoint Create(string endpointString, Dictionary<string, string?> options, bool oaEndpoint) =>
-            new SslEndpoint(SslEngine, Communicator, endpointString, options, oaEndpoint);
-        public Endpoint Read(InputStream istr) => new SslEndpoint(SslEngine, Communicator, istr);
+        public Endpoint Create(
+            Transport transport,
+            Protocol protocol,
+            Dictionary<string, string?> options,
+            bool oaEndpoint,
+            string endpointString)
+        {
+            Debug.Assert(transport == Transport.SSL);
+            return new SslEndpoint(SslEngine, Communicator, protocol, options, oaEndpoint, endpointString);
+        }
+
+        public Endpoint Read(InputStream istr, Protocol protocol) => new SslEndpoint(SslEngine, istr, protocol);
     }
 }

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -290,7 +290,7 @@ namespace ZeroC.Ice
             }
         }
 
-        public string Transport => _delegate.Transport;
+        public string TransportName => _delegate.TransportName;
 
         public ConnectionInfo GetInfo()
         {

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -90,11 +90,11 @@ namespace ZeroC.Ice
             Socket acceptFd = _acceptFd;
             _acceptFd = null;
             _acceptError = null;
-            return _endpoint.CreateTransceiver(Transport,
+            return _endpoint.CreateTransceiver(TransportName,
                 new StreamSocket(_communicator, acceptFd), _adapterName);
         }
 
-        public string Transport { get; }
+        public string TransportName => _endpoint.TransportName;
 
         public override string ToString() => Network.AddrToString(_addr);
 
@@ -118,7 +118,6 @@ namespace ZeroC.Ice
         internal TcpAcceptor(
             TcpEndpoint endpoint,
             Communicator communicator,
-            string transport,
             string host,
             int port,
             string adapterName)
@@ -126,7 +125,6 @@ namespace ZeroC.Ice
             _adapterName = adapterName;
             _endpoint = endpoint;
             _communicator = communicator;
-            Transport = transport;
             _backlog = communicator.GetPropertyAsInt("Ice.TCP.Backlog") ?? 511;
 
             try

--- a/csharp/src/Ice/TcpConnector.cs
+++ b/csharp/src/Ice/TcpConnector.cs
@@ -9,20 +9,14 @@ namespace ZeroC.Ice
     internal sealed class TcpConnector : IConnector
     {
         public ITransceiver Connect() =>
-            _endpoint.CreateTransceiver(Transport,
+            _endpoint.CreateTransceiver(
+                _endpoint.TransportName,
                 new StreamSocket(_communicator, _proxy, _addr, _sourceAddr), null);
 
-        public EndpointType Type { get; }
-        public string Transport { get; }
-
-        //
-        // Only for use by TcpEndpoint
-        //
+        // TODO: why are we copying all these readonly fields of the endpoint?
         internal TcpConnector(
             TcpEndpoint endpoint,
             Communicator communicator,
-            string transport,
-            EndpointType type,
             EndPoint addr,
             INetworkProxy? proxy,
             IPAddress? sourceAddr,
@@ -31,8 +25,6 @@ namespace ZeroC.Ice
         {
             _endpoint = endpoint;
             _communicator = communicator;
-            Transport = transport;
-            Type = type;
             _addr = addr;
             _proxy = proxy;
             _sourceAddr = sourceAddr;

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -17,7 +18,7 @@ namespace ZeroC.Ice
         public override bool IsDatagram => false;
         public override bool HasCompressionFlag { get; }
         public override int Timeout { get; }
-        public override EndpointType Type => EndpointType.TCP;
+        public override Transport Transport => Transport.TCP;
 
         private int _hashCode = 0;
 
@@ -98,28 +99,41 @@ namespace ZeroC.Ice
         }
 
         public override Endpoint NewTimeout(int timeout) =>
-            timeout == Timeout ? this : CreateEndpoint(Host, Port, ConnectionId, HasCompressionFlag, timeout);
+            timeout == Timeout ? this : CreateIPEndpoint(Host, Port, ConnectionId, HasCompressionFlag, timeout);
 
         public override IAcceptor GetAcceptor(string adapterName) =>
-            new TcpAcceptor(this, Communicator, Name, Host, Port, adapterName);
+            new TcpAcceptor(this, Communicator, Host, Port, adapterName);
         public override ITransceiver? GetTransceiver() => null;
 
-        internal TcpEndpoint(Communicator communicator, string host, int port, IPAddress? sourceAddress, int timeout,
-            string connectionId, bool compressionFlag) :
-            base(communicator, host, port, sourceAddress, connectionId)
+        internal TcpEndpoint(
+            Communicator communicator,
+            Protocol protocol,
+            string host,
+            int port,
+            IPAddress? sourceAddress,
+            int timeout,
+            string connectionId,
+            bool compressionFlag)
+            : base(communicator, protocol, host, port, sourceAddress, connectionId)
         {
             Timeout = timeout;
             HasCompressionFlag = compressionFlag;
         }
 
-        internal TcpEndpoint(Communicator communicator, InputStream istr) : base(communicator, istr)
+        internal TcpEndpoint(InputStream istr, Protocol protocol)
+            : base(istr, protocol)
         {
             Timeout = istr.ReadInt();
             HasCompressionFlag = istr.ReadBool();
         }
 
-        internal TcpEndpoint(Communicator communicator, string endpointString, Dictionary<string, string?> options,
-            bool oaEndpoint) : base(communicator, endpointString, options, oaEndpoint)
+        internal TcpEndpoint(
+            Communicator communicator,
+            Protocol protocol,
+            Dictionary<string, string?> options,
+            bool oaEndpoint,
+            string endpointString)
+            : base(communicator, protocol, options, oaEndpoint, endpointString)
         {
             if (options.TryGetValue("-t", out string? argument))
             {
@@ -167,10 +181,21 @@ namespace ZeroC.Ice
         }
 
         private protected override IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy) =>
-            new TcpConnector(this, Communicator, Name, Type, addr, proxy, SourceAddress, Timeout, ConnectionId);
-        private protected override IPEndpoint CreateEndpoint(string host, int port, string connectionId,
-            bool compressionFlag, int timeout) =>
-            new TcpEndpoint(Communicator, host, port, SourceAddress, timeout, connectionId, compressionFlag);
+            new TcpConnector(this,
+                            Communicator,
+                            addr,
+                            proxy,
+                            SourceAddress,
+                            Timeout,
+                            ConnectionId);
+
+        private protected override IPEndpoint CreateIPEndpoint(
+            string host,
+            int port,
+            string connectionId,
+            bool compressionFlag,
+            int timeout) =>
+            new TcpEndpoint(Communicator, Protocol, host, port, SourceAddress, timeout, connectionId, compressionFlag);
 
         internal virtual ITransceiver CreateTransceiver(
             string transport,
@@ -181,16 +206,21 @@ namespace ZeroC.Ice
 
     internal sealed class TcpEndpointFactory : IEndpointFactory
     {
-        public EndpointType Type => EndpointType.TCP;
-        public string Name => "tcp";
+        private Communicator _communicator;
 
-        private Communicator Communicator { get; }
+        public Endpoint Create(
+            Transport transport,
+            Protocol protocol,
+            Dictionary<string, string?> options,
+            bool oaEndpoint,
+            string endpointString)
+        {
+            Debug.Assert(transport == Transport.TCP); // we currently register this factory only for TCP
+            return new TcpEndpoint(_communicator, protocol, options, oaEndpoint, endpointString);
+        }
 
-        public Endpoint Create(string endpointString, Dictionary<string, string?> options, bool oaEndpoint) =>
-            new TcpEndpoint(Communicator, endpointString, options, oaEndpoint);
+        public Endpoint Read(InputStream istr, Protocol protocol) => new TcpEndpoint(istr, protocol);
 
-        public Endpoint Read(InputStream istr) => new TcpEndpoint(Communicator, istr);
-
-        internal TcpEndpointFactory(Communicator communicator) => Communicator = communicator;
+        internal TcpEndpointFactory(Communicator communicator) => _communicator = communicator;
     }
 }

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -182,12 +182,12 @@ namespace ZeroC.Ice
 
         private protected override IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy) =>
             new TcpConnector(this,
-                            Communicator,
-                            addr,
-                            proxy,
-                            SourceAddress,
-                            Timeout,
-                            ConnectionId);
+                             Communicator,
+                             addr,
+                             proxy,
+                             SourceAddress,
+                             Timeout,
+                             ConnectionId);
 
         private protected override IPEndpoint CreateIPEndpoint(
             string host,

--- a/csharp/src/Ice/TcpTransceiver.cs
+++ b/csharp/src/Ice/TcpTransceiver.cs
@@ -50,7 +50,7 @@ namespace ZeroC.Ice
         public void FinishWrite(IList<ArraySegment<byte>> buffer, ref int offset) =>
             _stream.FinishWrite(buffer, ref offset);
 
-        public string Transport { get; }
+        public string TransportName { get; }
 
         public ConnectionInfo GetInfo()
         {
@@ -83,9 +83,9 @@ namespace ZeroC.Ice
         //
         // Only for use by TcpConnector, TcpAcceptor
         //
-        internal TcpTransceiver(string transport, StreamSocket stream)
+        internal TcpTransceiver(string transportName, StreamSocket stream)
         {
-            Transport = transport;
+            TransportName = transportName;
             _stream = stream;
         }
 

--- a/csharp/src/Ice/Transport.cs
+++ b/csharp/src/Ice/Transport.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+namespace ZeroC.Ice
+{
+    /// <summary>Identifies a transport protocol that Ice can use to send requests and receive responses. The
+    /// enumerators of Transport correspond to the transports that the Ice runtime knows and implements. Other
+    /// transports, with short values not represented by these enumerators, can be implemented and registered using
+    /// transport plug-ins.</summary>
+    public enum Transport : short
+    {
+        TCP = 1,
+        SSL = 2,
+        UDP = 3,
+        WS = 4,
+        WSS = 5,
+        BT = 6,
+        BTS = 7,
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+        iAP = 8,
+        iAPS = 9
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+    }
+}

--- a/csharp/src/Ice/UdpConnector.cs
+++ b/csharp/src/Ice/UdpConnector.cs
@@ -9,20 +9,22 @@ namespace ZeroC.Ice
     internal sealed class UdpConnector : IConnector
     {
         public ITransceiver Connect() =>
-            new UdpTransceiver(_communicator, Transport, _addr, _sourceAddr, _mcastInterface, _mcastTtl);
-
-        public EndpointType Type { get; }
-        public string Transport { get; }
+            new UdpTransceiver(_communicator, _transportName, _addr, _sourceAddr, _mcastInterface, _mcastTtl);
 
         //
         // Only for use by UdpEndpointI
         //
-        internal UdpConnector(Communicator communicator, string transport, EndpointType type, EndPoint addr,
-            IPAddress? sourceAddr, string mcastInterface, int mcastTtl, string connectionId)
+        internal UdpConnector(
+            Communicator communicator,
+            string transportName,
+            EndPoint addr,
+            IPAddress? sourceAddr,
+            string mcastInterface,
+            int mcastTtl,
+            string connectionId)
         {
             _communicator = communicator;
-            Transport = transport;
-            Type = type;
+            _transportName = transportName;
             _addr = addr;
             _sourceAddr = sourceAddr;
             _mcastInterface = mcastInterface;
@@ -88,5 +90,7 @@ namespace ZeroC.Ice
         private readonly int _mcastTtl;
         private readonly string _connectionId;
         private readonly int _hashCode;
+
+        private readonly string _transportName;
     }
 }

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -281,7 +281,7 @@ namespace ZeroC.Ice
                 if (_communicator.TraceLevels.Network >= 1)
                 {
                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                        $"connected {Transport} socket\n{this}");
+                        $"connected {TransportName} socket\n{this}");
                 }
             }
 
@@ -408,7 +408,7 @@ namespace ZeroC.Ice
                 if (_communicator.TraceLevels.Network >= 1)
                 {
                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                        $"connected {Transport} socket\n{this}");
+                        $"connected {TransportName} socket\n{this}");
                 }
             }
 
@@ -544,7 +544,7 @@ namespace ZeroC.Ice
             return;
         }
 
-        public string Transport { get; }
+        public string TransportName { get; }
 
         public ConnectionInfo GetInfo()
         {
@@ -659,11 +659,11 @@ namespace ZeroC.Ice
         //
         // Only for use by UdpConnector.
         //
-        internal UdpTransceiver(Communicator communicator, string transport, EndPoint addr, IPAddress? sourceAddr,
+        internal UdpTransceiver(Communicator communicator, string transportName, EndPoint addr, IPAddress? sourceAddr,
             string mcastInterface, int mcastTtl)
         {
             _communicator = communicator;
-            Transport = transport;
+            TransportName = transportName;
             _addr = addr;
             if (sourceAddr != null)
             {
@@ -701,12 +701,12 @@ namespace ZeroC.Ice
         //
         // Only for use by UdpEndpoint.
         //
-        internal UdpTransceiver(UdpEndpoint endpoint, Communicator communicator, string transport, string host,
+        internal UdpTransceiver(UdpEndpoint endpoint, Communicator communicator, string host,
             int port, string mcastInterface, bool connect)
         {
             _endpoint = endpoint;
             _communicator = communicator;
-            Transport = transport;
+            TransportName = endpoint.TransportName;
             _state = connect ? StateNeedConnect : StateNotConnected;
             _mcastInterface = mcastInterface;
             _incoming = true;
@@ -815,7 +815,7 @@ namespace ZeroC.Ice
                     //
                     if (sizeSet < sizeRequested)
                     {
-                        BufSizeWarnInfo winfo = _communicator.GetBufSizeWarn(EndpointType.UDP);
+                        BufSizeWarnInfo winfo = _communicator.GetBufSizeWarn(Transport.UDP);
                         if ((isSnd && (!winfo.SndWarn || winfo.SndSize != sizeRequested)) ||
                            (!isSnd && (!winfo.RcvWarn || winfo.RcvSize != sizeRequested)))
                         {
@@ -824,11 +824,11 @@ namespace ZeroC.Ice
 
                             if (isSnd)
                             {
-                                _communicator.SetSndBufSizeWarn(EndpointType.UDP, sizeRequested);
+                                _communicator.SetSndBufSizeWarn(Transport.UDP, sizeRequested);
                             }
                             else
                             {
-                                _communicator.SetRcvBufSizeWarn(EndpointType.UDP, sizeRequested);
+                                _communicator.SetRcvBufSizeWarn(Transport.UDP, sizeRequested);
                             }
                         }
                     }

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -222,7 +222,7 @@ namespace ZeroC.Ice
                 if (_communicator.TraceLevels.Network >= 2)
                 {
                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                        $"{Transport} connection HTTP upgrade request failed\n{this}\n{ex}");
+                        $"{TransportName} connection HTTP upgrade request failed\n{this}\n{ex}");
                 }
                 throw;
             }
@@ -232,12 +232,12 @@ namespace ZeroC.Ice
                 if (_incoming)
                 {
                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                        $"accepted {Transport} connection HTTP upgrade request\n{this}");
+                        $"accepted {TransportName} connection HTTP upgrade request\n{this}");
                 }
                 else
                 {
                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                        $"{Transport} connection HTTP upgrade request accepted\n{this}");
+                        $"{TransportName} connection HTTP upgrade request accepted\n{this}");
                 }
             }
 
@@ -249,7 +249,7 @@ namespace ZeroC.Ice
             if (_communicator.TraceLevels.Network >= 1)
             {
                 _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                    $"gracefully closing {Transport} connection\n{this}");
+                    $"gracefully closing {TransportName} connection\n{this}");
             }
 
             int s = _nextState == StateOpened ? _state : _nextState;
@@ -656,7 +656,7 @@ namespace ZeroC.Ice
             PostWrite(size, ref offset, SocketOperation.None);
         }
 
-        public string Transport => _delegate.Transport;
+        public string TransportName => _delegate.TransportName;
 
         public ConnectionInfo GetInfo()
         {
@@ -1095,7 +1095,7 @@ namespace ZeroC.Ice
                                 if (_communicator.TraceLevels.Network >= 2)
                                 {
                                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                        "received " + Transport + (_readOpCode == OP_DATA ? " data" : " continuation") +
+                                        "received " + TransportName + (_readOpCode == OP_DATA ? " data" : " continuation") +
                                         " frame with payload length of " + _readPayloadLength +
                                         " bytes\n" + ToString());
                                 }
@@ -1114,7 +1114,7 @@ namespace ZeroC.Ice
                                 if (_communicator.TraceLevels.Network >= 2)
                                 {
                                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                        $"received {Transport} connection close frame\n{this}");
+                                        $"received {TransportName} connection close frame\n{this}");
                                 }
 
                                 _readState = ReadStateControlFrame;
@@ -1150,7 +1150,7 @@ namespace ZeroC.Ice
                                 if (_communicator.TraceLevels.Network >= 2)
                                 {
                                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                        $"received {Transport} connection ping frame\n{this}");
+                                        $"received {TransportName} connection ping frame\n{this}");
                                 }
                                 _readState = ReadStateControlFrame;
                                 break;
@@ -1160,7 +1160,7 @@ namespace ZeroC.Ice
                                 if (_communicator.TraceLevels.Network >= 2)
                                 {
                                     _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                        $"received {Transport} connection pong frame\n{this}");
+                                        $"received {TransportName} connection pong frame\n{this}");
                                 }
                                 _readState = ReadStateControlFrame;
                                 break;
@@ -1399,7 +1399,7 @@ namespace ZeroC.Ice
                         if (_communicator.TraceLevels.Network >= 2)
                         {
                             _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                $"sent {Transport} connection ping frame\n{this}");
+                                $"sent {TransportName} connection ping frame\n{this}");
                         }
                     }
                     else if (_state == StatePongPending)
@@ -1407,7 +1407,7 @@ namespace ZeroC.Ice
                         if (_communicator.TraceLevels.Network >= 2)
                         {
                             _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                $"sent {Transport} connection pong frame\n{this}");
+                                $"sent {TransportName} connection pong frame\n{this}");
                         }
                     }
                     else if ((_state == StateClosingRequestPending && !_closingInitiator) ||
@@ -1416,7 +1416,7 @@ namespace ZeroC.Ice
                         if (_communicator.TraceLevels.Network >= 2)
                         {
                             _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCat,
-                                $"sent {Transport} connection close frame\n{this}");
+                                $"sent {TransportName} connection close frame\n{this}");
                         }
 
                         if (_state == StateClosingRequestPending && !_closingInitiator)

--- a/csharp/test/Ice/background/Acceptor.cs
+++ b/csharp/test/Ice/background/Acceptor.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Background
             return new Transceiver(_acceptor.Accept());
         }
 
-        public string Transport => _acceptor.Transport;
+        public string TransportName => _acceptor.TransportName;
 
         public override string ToString() => _acceptor.ToString();
 

--- a/csharp/test/Ice/background/Connector.cs
+++ b/csharp/test/Ice/background/Connector.cs
@@ -12,9 +12,6 @@ namespace ZeroC.Ice.Test.Background
             return new Transceiver(_connector.Connect());
         }
 
-        public string Transport => "";
-        public EndpointType Type => (EndpointType)(Endpoint.TYPE_BASE + (short)_connector.Type);
-
         //
         // Only for use by Endpoint
         //

--- a/csharp/test/Ice/background/Endpoint.cs
+++ b/csharp/test/Ice/background/Endpoint.cs
@@ -10,6 +10,7 @@ using Test;
 
 namespace ZeroC.Ice.Test.Background
 {
+    // TODO: Endpoint is an awful name for this class.
     internal class Endpoint : ZeroC.Ice.Endpoint
     {
         public override string ConnectionId => _endpoint.ConnectionId;
@@ -19,9 +20,9 @@ namespace ZeroC.Ice.Test.Background
         public override bool IsSecure => _endpoint.IsSecure;
 
         public override int Timeout => _endpoint.Timeout;
-        public override EndpointType Type => (EndpointType)(TYPE_BASE + (short)_endpoint.Type);
+        public override Transport Transport => (Transport)(TransportBase + (short)_endpoint.Transport);
 
-        internal static short TYPE_BASE = 100;
+        internal const short TransportBase = 100;
         private readonly ZeroC.Ice.Endpoint _endpoint;
         private readonly Configuration _configuration;
 
@@ -61,7 +62,7 @@ namespace ZeroC.Ice.Test.Background
 
         public override void IceWritePayload(OutputStream ostr)
         {
-            ostr.WriteShort((short)_endpoint.Type);
+            ostr.WriteShort((short)_endpoint.Transport);
             _endpoint.IceWritePayload(ostr);
         }
 
@@ -146,6 +147,7 @@ namespace ZeroC.Ice.Test.Background
         }
 
         internal Endpoint(ZeroC.Ice.Endpoint endpoint)
+            : base(endpoint.Protocol)
         {
             _endpoint = endpoint;
             _configuration = Configuration.GetInstance();

--- a/csharp/test/Ice/background/PluginI.cs
+++ b/csharp/test/Ice/background/PluginI.cs
@@ -12,10 +12,12 @@ namespace ZeroC.Ice.Test.Background
         {
             for (short s = 0; s < 100; ++s)
             {
-                IEndpointFactory? factory = _communicator.IceFindEndpointFactory((EndpointType)s);
+                var transport = (Transport)s;
+                IEndpointFactory? factory = _communicator.IceFindEndpointFactory(transport);
                 if (factory != null)
                 {
-                    _communicator.IceAddEndpointFactory(new EndpointFactory(factory));
+                    var wrapper = new EndpointFactory(factory, transport);
+                    _communicator.IceAddEndpointFactory(wrapper.Transport, wrapper.TransportName, wrapper);
                 }
             }
         }

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -174,7 +174,7 @@ namespace ZeroC.Ice.Test.Background
             _transceiver.FinishWrite(buf, ref offset);
         }
 
-        public string Transport => "test-" + _transceiver.Transport;
+        public string TransportName => "test-" + _transceiver.TransportName;
 
         public ConnectionInfo GetInfo() => _transceiver.GetInfo();
 

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -206,8 +206,8 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(ctx["remotePort"].Equals(ipInfo.LocalPort.ToString()));
                 TestHelper.Assert(ctx["localPort"].Equals(ipInfo.RemotePort.ToString()));
 
-                if (testIntf.GetConnection()!.TransportName.Equals("ws") ||
-                    testIntf.GetConnection()!.TransportName.Equals("wss"))
+                if (testIntf.GetConnection()!.Endpoint.TransportName.Equals("ws") ||
+                    testIntf.GetConnection()!.Endpoint.TransportName.Equals("wss"))
                 {
                     Dictionary<string, string> headers = ((WSConnectionInfo)info).Headers!;
                     TestHelper.Assert(headers["Upgrade"].Equals("websocket"));

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -56,14 +56,14 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(tcpEndpoint.HasCompressionFlag);
                 TestHelper.Assert(!tcpEndpoint.IsDatagram);
 
-                TestHelper.Assert(tcpEndpoint.Type == EndpointType.TCP && !tcpEndpoint.IsSecure ||
-                        tcpEndpoint.Type == EndpointType.SSL && tcpEndpoint.IsSecure ||
-                        tcpEndpoint.Type == EndpointType.WS && !tcpEndpoint.IsSecure ||
-                        tcpEndpoint.Type == EndpointType.WSS && tcpEndpoint.IsSecure);
-                TestHelper.Assert(tcpEndpoint.Type == EndpointType.TCP && endpoint is TcpEndpoint ||
-                        tcpEndpoint.Type == EndpointType.SSL && endpoint is SslEndpoint ||
-                        tcpEndpoint.Type == EndpointType.WS && endpoint is WSEndpoint ||
-                        tcpEndpoint.Type == EndpointType.WSS && endpoint is WSEndpoint);
+                TestHelper.Assert(tcpEndpoint.Transport == Transport.TCP && !tcpEndpoint.IsSecure ||
+                        tcpEndpoint.Transport == Transport.SSL && tcpEndpoint.IsSecure ||
+                        tcpEndpoint.Transport == Transport.WS && !tcpEndpoint.IsSecure ||
+                        tcpEndpoint.Transport == Transport.WSS && tcpEndpoint.IsSecure);
+                TestHelper.Assert(tcpEndpoint.Transport == Transport.TCP && endpoint is TcpEndpoint ||
+                        tcpEndpoint.Transport == Transport.SSL && endpoint is SslEndpoint ||
+                        tcpEndpoint.Transport == Transport.WS && endpoint is WSEndpoint ||
+                        tcpEndpoint.Transport == Transport.WSS && endpoint is WSEndpoint);
 
                 UdpEndpoint udpEndpoint = (UdpEndpoint)endps[1];
                 TestHelper.Assert(udpEndpoint.Host.Equals("udphost"));
@@ -75,7 +75,7 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(!udpEndpoint.HasCompressionFlag);
                 TestHelper.Assert(!udpEndpoint.IsSecure);
                 TestHelper.Assert(udpEndpoint.IsDatagram);
-                TestHelper.Assert(udpEndpoint.Type == EndpointType.UDP);
+                TestHelper.Assert(udpEndpoint.Transport == Transport.UDP);
 
                 OpaqueEndpoint opaqueEndpoint = (OpaqueEndpoint)endps[2];
                 TestHelper.Assert(opaqueEndpoint.Bytes.Length > 0);
@@ -100,10 +100,10 @@ namespace ZeroC.Ice.Test.Info
                 TcpEndpoint? tcpEndpoint = getTCPEndpoint(endpoints[0]);
                 TestHelper.Assert(tcpEndpoint != null);
                 TestHelper.Assert(
-                        tcpEndpoint.Type == EndpointType.TCP ||
-                        tcpEndpoint.Type == EndpointType.SSL ||
-                        tcpEndpoint.Type == EndpointType.WS ||
-                        tcpEndpoint.Type == EndpointType.WSS);
+                        tcpEndpoint.Transport == Transport.TCP ||
+                        tcpEndpoint.Transport == Transport.SSL ||
+                        tcpEndpoint.Transport == Transport.WS ||
+                        tcpEndpoint.Transport == Transport.WSS);
 
                 TestHelper.Assert(tcpEndpoint.Host.Equals(host));
                 TestHelper.Assert(tcpEndpoint.Port > 0);
@@ -206,7 +206,8 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(ctx["remotePort"].Equals(ipInfo.LocalPort.ToString()));
                 TestHelper.Assert(ctx["localPort"].Equals(ipInfo.RemotePort.ToString()));
 
-                if (testIntf.GetConnection()!.Type().Equals("ws") || testIntf.GetConnection()!.Type().Equals("wss"))
+                if (testIntf.GetConnection()!.TransportName.Equals("ws") ||
+                    testIntf.GetConnection()!.TransportName.Equals("wss"))
                 {
                     Dictionary<string, string> headers = ((WSConnectionInfo)info).Headers!;
                     TestHelper.Assert(headers["Upgrade"].Equals("websocket"));

--- a/csharp/test/Ice/info/TestI.cs
+++ b/csharp/test/Ice/info/TestI.cs
@@ -41,7 +41,7 @@ namespace ZeroC.Ice.Test.Info
             ctx["compress"] = endpoint.HasCompressionFlag ? "true" : "false";
             ctx["datagram"] = endpoint.IsDatagram ? "true" : "false";
             ctx["secure"] = endpoint.IsDatagram ? "true" : "false";
-            ctx["type"] = endpoint.Type.ToString();
+            ctx["transport"] = endpoint.Transport.ToString();
 
             IPEndpoint? ipEndpoint = getIPEndpoint(endpoint);
             TestHelper.Assert(ipEndpoint != null);

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -463,12 +463,12 @@ namespace ZeroC.Ice.Test.Metrics
 
             output.WriteLine("ok");
 
-            string type = "";
+            string transportName = "";
             string isSecure = "";
             if (!collocated)
             {
                 Endpoint connectionEndpoint = metrics.GetConnection()!.Endpoint;
-                type = connectionEndpoint.Type.ToString();
+                transportName = connectionEndpoint.Transport.ToString();
                 isSecure = connectionEndpoint.IsSecure ? "True" : "False";
             }
 
@@ -600,7 +600,7 @@ namespace ZeroC.Ice.Test.Metrics
                 testAttribute(clientMetrics, clientProps, update, "Connection", "endpoint",
                             endpoint + " -t 500", output);
 
-                testAttribute(clientMetrics, clientProps, update, "Connection", "endpointType", type, output);
+                testAttribute(clientMetrics, clientProps, update, "Connection", "endpointTransport", transportName, output);
                 testAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsDatagram", "False", output);
                 testAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsSecure", isSecure, output);
                 testAttribute(clientMetrics, clientProps, update, "Connection", "endpointTimeout", "500", output);
@@ -666,7 +666,7 @@ namespace ZeroC.Ice.Test.Metrics
                 testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpoint",
                             endpoint + " -t " + timeout, c, output);
 
-                testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointType", type, c, output);
+                testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTransport", transportName, c, output);
                 testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsDatagram", "False",
                             c, output);
                 testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsSecure", isSecure,
@@ -735,7 +735,7 @@ namespace ZeroC.Ice.Test.Metrics
                 testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpoint",
                             prx.GetConnection()!.Endpoint.ToString(), c, output);
 
-                testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointType", type, c, output);
+                testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointTransport", transportName, c, output);
                 testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsDatagram", "False", c, output);
                 testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsSecure", isSecure, c, output);
                 testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointTimeout", "500", c, output);
@@ -838,7 +838,7 @@ namespace ZeroC.Ice.Test.Metrics
                             endpoint + " -t 60000", op, output);
                 //testAttribute(serverMetrics, serverProps, update, "Dispatch", "connection", "", op);
 
-                testAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointType", type, op, output);
+                testAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointTransport", transportName, op, output);
                 testAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointIsDatagram", "False", op, output);
                 testAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointIsSecure", isSecure, op, output);
                 testAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointTimeout", "60000", op, output);


### PR DESCRIPTION
This PR:
- renames the `EndpointType` enum to `Transport` (a more logical name), and renames the corresponding lowercase name (called Name or Transport or even Type) to `TransportName`.
- makes Endpoints protocol-specific, i.e. each Endpoint is given its Ice protocol when created, and keeps this protocol. Two endpoints that are identical except for their protocols are different.
- changes the IEndpointFactory API and communicator endpoint factory registry to allow a single factory to handle multiple transports.

An endpoint factory is not protocol-specific. The desired protocol is given when creating an endpoint with a factory, and the endpoint creation can fail with an exception. For example, an attempt to create a udp endpoint with a protocol other than ice1 throws `NotSupportException`.

This is primarily a "clean-up" PR.  I anticipate that follow-up PRs will:
- take advantage of the new IEndpointFactory API to merge SslEndpoint into TcpEndpoint and WssEndpoint into WsEndpoint. And the factory registration will become:
```
// The same endpoint factory handles both tcp and ssl:
var tcpEndpointFactory = ...
IceAddEndpointFactory(Transport.TCP, "tcp", tcpEndpointFactory);
IceAddEndpointFactory(Transport.SSL, "ssl", tcpEndpointFactory);

// The same endpoint factory handles both ws and wss:
var wsEndpointFactory = ...
IceAddEndpointFactory(Transport.WS, "ws", wsEndpointFactory);
IceAddEndpointFactory(Transport.WSS, "wss", wsEndpointFactory));
```

- take advantage of the endpoint protocol to optimize the marshaling/unmarshaling of endpoints with the 2.0 encoding when protocol != ice1. (Can drop ice1-only options such as -t and -z).

- update the proxy/reference Clone methods to ensure that Endpoints have the same protocol as the enclosing proxy. For example, changing a proxy's protocol would drop all its endpoints (or alternatively, fail). And attaching ice1 endpoints to an ice2 proxy will fail.