### PR TITLE
Restore 3.7 unmarshaling behavior for tagged data members ...

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1160,7 +1160,7 @@ Slice::CsGenerator::writeTaggedMarshalCode(Output& out,
 }
 
 void
-Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
+Slice::CsGenerator::writeTaggedUnmarshalCode(Output& out,
                                              const OptionalPtr& optionalType,
                                              const string& scope,
                                              const string& param,
@@ -1174,9 +1174,6 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
     StructPtr st = StructPtr::dynamicCast(type);
     SequencePtr seq = SequencePtr::dynamicCast(type);
-
-    // TODO: default value should be irrelevant when reading tagged data members.
-    bool hasDefaultValue = dataMember && dataMember->defaultValueType();
 
     out << param << " = ";
 
@@ -1303,12 +1300,6 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(Output &out,
             out << ", fixedSize: " << (fixedSize ? "true" : "false");
         }
         out << ", " << inputStreamReader(keyType, scope) << ", " << inputStreamReader(valueType, scope) << ")";
-    }
-
-    if (hasDefaultValue)
-    {
-        out << " ?? ";
-        writeConstantValue(out, type, dataMember->defaultValueType(), dataMember->defaultValue(), scope);
     }
     out << ";";
 }

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -42,11 +42,11 @@ protected:
 
     std::string writeValue(const TypePtr&, const std::string&);
 
-    //
     // Generate assignment statements for those data members that have default values.
-    //
-    bool requiresDataMemberInitializers(const DataMemberList&);
-    void writeDataMemberInitializers(const DataMemberList&, const std::string&, unsigned int, bool);
+    void writeDataMemberDefaultValues(const DataMemberList&, const std::string&, unsigned int);
+
+    // Generate this.X = null! for non-nullable fields.
+    void writeSuppressNonNullableWarnings(const DataMemberList&, unsigned int);
 
     void writeProxyDocComment(const InterfaceDefPtr&, const std::string&);
     void writeServantDocComment(const InterfaceDefPtr&, const std::string&);

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -553,8 +553,11 @@ namespace ZeroC.Ice.Test.Tagged
                 wd.s = null;
                 wd = (WD?)initial.pingPong(wd);
                 TestHelper.Assert(wd != null);
-                TestHelper.Assert(wd.a == 5);
-                TestHelper.Assert(wd.s! == "test");
+                // When a tagged member is set to null (equivalent to not set) explicitly, it remains null / not set,
+                // even when it has a default value. This is consistent with the behavior for non-tagged optional
+                // parameters / data members with default values.
+                TestHelper.Assert(wd.a == null);
+                TestHelper.Assert(wd.s == null);
             }
             output.WriteLine("ok");
 
@@ -1643,7 +1646,8 @@ namespace ZeroC.Ice.Test.Tagged
                 }
                 catch (TaggedException ex)
                 {
-                    TestHelper.Assert(ex.a == 5);
+                    TestHelper.Assert(ex.a == null); // don't use default value for 'a' data member since set explicitly
+                                                     // to null by server
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
                 }
@@ -1671,10 +1675,11 @@ namespace ZeroC.Ice.Test.Tagged
                 }
                 catch (DerivedException ex)
                 {
-                    TestHelper.Assert(ex.a == 5);
+                    TestHelper.Assert(ex.a == null); // don't use default value for 'a' data member since set explicitly
+                                                     // to null by server
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
-                    TestHelper.Assert(ex.ss == "test");
+                    TestHelper.Assert(ex.ss == null);
                     TestHelper.Assert(ex.o2 == null);
                 }
 
@@ -1703,7 +1708,7 @@ namespace ZeroC.Ice.Test.Tagged
                 }
                 catch (RequiredException ex)
                 {
-                    TestHelper.Assert(ex.a == 5);
+                    TestHelper.Assert(ex.a == null);
                     TestHelper.Assert(ex.b == null);
                     TestHelper.Assert(ex.o == null);
                     TestHelper.Assert(ex.ss == "test");

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -555,7 +555,7 @@ namespace ZeroC.Ice.Test.Tagged
                 TestHelper.Assert(wd != null);
                 // When a tagged member is set to null (equivalent to not set) explicitly, it remains null / not set,
                 // even when it has a default value. This is consistent with the behavior for non-tagged optional
-                // parameters / data members with default values.
+                // data members with default values.
                 TestHelper.Assert(wd.a == null);
                 TestHelper.Assert(wd.s == null);
             }


### PR DESCRIPTION
with default values.

With this PR, default values are once again ignored when unmarshaling tagged data members. If a tagged data member is transmitted as "not set"/missing, the corresponding C# field is set to null, not the Slice-specified default value (if any).

Default values are used only when creating new instances directly.

The behavior is identical for non-tagged data members with optional types and default values.