### PR TITLE
Remove Current.RequestId in C#

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -141,7 +141,7 @@ namespace ZeroC.Ice
             try
             {
                 var incomingRequest = new IncomingRequestFrame(_adapter.Communicator, outgoingRequest);
-                var current = new Current(_adapter, incomingRequest, requestId, cancel);
+                var current = new Current(_adapter, incomingRequest, oneway: requestId == 0, cancel);
 
                 // Then notify and set dispatch observer, if any.
                 ICommunicatorObserver? communicatorObserver = _adapter.Communicator.Observer;

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -147,7 +147,9 @@ namespace ZeroC.Ice
                 ICommunicatorObserver? communicatorObserver = _adapter.Communicator.Observer;
                 if (communicatorObserver != null)
                 {
-                    dispatchObserver = communicatorObserver.GetDispatchObserver(current, incomingRequest.Size);
+                    dispatchObserver = communicatorObserver.GetDispatchObserver(current,
+                                                                                requestId,
+                                                                                incomingRequest.Size);
                     dispatchObserver?.Attach();
                 }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -911,7 +911,7 @@ namespace ZeroC.Ice
                 ICommunicatorObserver? communicatorObserver = _communicator.Observer;
                 if (communicatorObserver != null)
                 {
-                    dispatchObserver = communicatorObserver.GetDispatchObserver(current, request.Size);
+                    dispatchObserver = communicatorObserver.GetDispatchObserver(current, requestId, request.Size);
                     dispatchObserver?.Attach();
                 }
 

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -18,16 +18,14 @@ namespace ZeroC.Ice
         public string Facet { get; }
         public Identity Identity { get; }
         public bool IsIdempotent { get; }
-        public bool IsOneway => RequestId == 0;
+        public bool IsOneway { get; }
         public string Operation { get; }
         public Protocol Protocol { get; }
-
-        public int RequestId { get; }
 
         internal Current(
             ObjectAdapter adapter,
             IncomingRequestFrame request,
-            int requestId,
+            bool oneway,
             CancellationToken cancel,
             Connection? connection = null)
         {
@@ -41,7 +39,7 @@ namespace ZeroC.Ice
             IsIdempotent = request.IsIdempotent;
             Operation = request.Operation;
             Protocol = request.Protocol;
-            RequestId = requestId;
+            IsOneway = oneway;
         }
     }
 }

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -37,9 +37,9 @@ namespace ZeroC.Ice
             Facet = request.Facet;
             Identity = request.Identity;
             IsIdempotent = request.IsIdempotent;
+            IsOneway = oneway;
             Operation = request.Operation;
             Protocol = request.Protocol;
-            IsOneway = oneway;
         }
     }
 }

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -50,11 +50,12 @@ namespace ZeroC.Ice.Instrumentation
             IConnectionObserver? oldObserver);
 
         /// <summary>This method should return a dispatch observer for the given dispatch. The Ice run-time calls this
-        /// method each time it receives an incoming invocation to be dispatched for an Ice object.</summary>
-        /// <param name="current">The current object as provided to the Ice servant dispatching the invocation.</param>
+        /// method each time it receives an incoming request to be dispatched for an Ice object.</summary>
+        /// <param name="current">The current object as provided to the Ice servant dispatching the request.</param>
+        /// <param name="requestId">The request ID of the request being dispatched.</param>
         /// <param name="size">The size of the dispatch.</param>
         /// <returns>The dispatch observer to instrument the dispatch.</returns>
-        IDispatchObserver? GetDispatchObserver(Current current, int size);
+        IDispatchObserver? GetDispatchObserver(Current current, int requestId, int size);
 
         /// <summary>This method should return an observer for the given endpoint information. The Ice run-time calls
         /// this method to resolve an endpoint and obtain the list of connectors. For IP endpoints, this typically

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -385,8 +385,7 @@ namespace ZeroC.Ice
                         return current?.Identity.ToString(current.Adapter!.Communicator.ToStringMode);
                     });
                 Add("facet", obj => (obj as DispatchHelper)?._current.Facet);
-                Add("requestId", obj => (obj as DispatchHelper)?._current.RequestId);
-                Add("mode", obj => (obj as DispatchHelper)?._current.RequestId == 0 ? "oneway" : "twoway");
+                Add("mode", obj => (obj as DispatchHelper)?._current.IsOneway == true ? "oneway" : "twoway");
             }
         }
     }

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -135,14 +135,14 @@ namespace ZeroC.Ice
             return null;
         }
 
-        public IDispatchObserver? GetDispatchObserver(Current current, int size)
+        public IDispatchObserver? GetDispatchObserver(Current current, int requestId, int size)
         {
             if (_dispatch.IsEnabled)
             {
                 try
                 {
-                    return _dispatch.GetObserver(new DispatchHelper(current, size),
-                        _delegate?.GetDispatchObserver(current, size));
+                    return _dispatch.GetObserver(new DispatchHelper(current, requestId, size),
+                        _delegate?.GetDispatchObserver(current, requestId, size));
                 }
                 catch (Exception ex)
                 {
@@ -320,15 +320,18 @@ namespace ZeroC.Ice
         private static readonly AttributeResolver _attributeResolver = new AttributeResolverI();
 
         private readonly Current _current;
+        private readonly int _requestId;
+
         private string? _id;
         private readonly int _size;
 
         public override void InitMetrics(DispatchMetrics v) => v.Size += _size;
 
-        internal DispatchHelper(Current current, int size)
+        internal DispatchHelper(Current current, int requestId, int size)
             : base(_attributeResolver)
         {
             _current = current;
+            _requestId = requestId;
             _size = size;
         }
 
@@ -385,6 +388,7 @@ namespace ZeroC.Ice
                         return current?.Identity.ToString(current.Adapter!.Communicator.ToStringMode);
                     });
                 Add("facet", obj => (obj as DispatchHelper)?._current.Facet);
+                Add("requestId", obj => (obj as DispatchHelper)?._requestId);
                 Add("mode", obj => (obj as DispatchHelper)?._current.IsOneway == true ? "oneway" : "twoway");
             }
         }

--- a/csharp/test/Ice/metrics/InstrumentationI.cs
+++ b/csharp/test/Ice/metrics/InstrumentationI.cs
@@ -325,7 +325,7 @@ namespace ZeroC.Ice.Test.Metrics
         }
 
         public IDispatchObserver
-        GetDispatchObserver(Current current, int s)
+        GetDispatchObserver(Current current, int requestId, int s)
         {
             lock (this)
             {

--- a/csharp/test/Ice/retry/Instrumentation.cs
+++ b/csharp/test/Ice/retry/Instrumentation.cs
@@ -74,7 +74,7 @@ namespace ZeroC.Ice.Test.Retry
             public IInvocationObserver? GetInvocationObserver(IObjectPrx? p, string o,
                 IReadOnlyDictionary<string, string> c) => invocationObserver;
 
-            public IDispatchObserver? GetDispatchObserver(Current c, int i) => null;
+            public IDispatchObserver? GetDispatchObserver(Current c, int requestId, int i) => null;
 
             public void SetObserverUpdater(IObserverUpdater? u)
             {


### PR DESCRIPTION
This tiny PR removes Current.RequestId in C#, and replaces it with Current.IsOneway.

It also removes the requestId instrumentation attribute, which I think could be preserved if we really want to keep it.