### PR TITLE
Remove ability to disable colocation optimization in C#

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -93,8 +93,6 @@ namespace ZeroC.Ice
             }
         }
 
-        public bool DefaultCollocationOptimized { get; }
-
         /// <summary>The default context for proxies created using this communicator. Changing the value of
         /// DefaultContext does not change the context of previously created proxies.</summary>
         public IReadOnlyDictionary<string, string> DefaultContext
@@ -173,7 +171,6 @@ namespace ZeroC.Ice
             "InvocationTimeout",
             "Locator",
             "Router",
-            "CollocationOptimized",
             "Context\\..*"
         };
         private static readonly object _staticLock = new object();
@@ -390,8 +387,6 @@ namespace ZeroC.Ice
                 }
 
                 TraceLevels = new TraceLevels(this);
-
-                DefaultCollocationOptimized = GetPropertyAsBool("Ice.Default.CollocationOptimized") ?? true;
 
                 if (GetProperty("Ice.Default.Encoding") is string encoding)
                 {

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -196,10 +196,6 @@ namespace ZeroC.Ice
         /// this proxy.</summary>
         public ILocatorPrx? Locator => IceReference.LocatorInfo?.Locator;
 
-        /// <summary>Indicates whether this proxy uses collocation optimization.</summary>
-        /// <value>When true, the proxy uses collocation optimization; otherwise, the value is false.</value>
-        public bool IsCollocationOptimized => IceReference.IsCollocationOptimized;
-
         /// <summary>Indicates whether or not using this proxy to invoke an operation that does not return anything
         /// waits for an empty response from the target Ice object.</summary>
         /// <value>When true, invoking such an operation does not wait for the response from the target object. This

--- a/csharp/src/Ice/IceDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceDiscovery/Locator.cs
@@ -38,8 +38,7 @@ namespace ZeroC.IceDiscovery
         private readonly IObjectPrx _wellKnownProxy;
 
         public LocatorRegistry(Communicator com) =>
-            _wellKnownProxy = IObjectPrx.Parse("p", com).Clone(
-                clearLocator: true, clearRouter: true, collocationOptimized: true);
+            _wellKnownProxy = IObjectPrx.Parse("p", com).Clone(clearLocator: true, clearRouter: true);
 
         public ValueTask SetAdapterDirectProxyAsync(string adapterId, IObjectPrx? proxy, Current current)
         {

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -90,14 +90,13 @@ namespace ZeroC.IceDiscovery
             _replyAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Reply");
             _locatorAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Locator");
 
-            // Setup locatory registry.
+            // Setup locator registry.
             var locatorRegistry = new LocatorRegistry(_communicator);
             ILocatorRegistryPrx locatorRegistryPrx =
                 _locatorAdapter.AddWithUUID(locatorRegistry, ILocatorRegistryPrx.Factory);
 
-            ILookupPrx lookupPrx = ILookupPrx.Parse("IceDiscovery/Lookup -d:" + lookupEndpoints, _communicator).Clone(
-                clearRouter: true,
-                collocationOptimized: false); // No collocated optimization or router for the multicast proxy!
+            ILookupPrx lookupPrx =
+                ILookupPrx.Parse($"IceDiscovery/Lookup -d:{lookupEndpoints}", _communicator).Clone(clearRouter: true);
 
             // Add lookup Ice object
             var lookup = new Lookup(locatorRegistry, lookupPrx, _communicator, _replyAdapter);

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -425,8 +425,7 @@ namespace ZeroC.IceLocatorDiscovery
             _locatorAdapter.Locator = null;
 
             var lookupPrx = ILookupPrx.Parse($"IceLocatorDiscovery/Lookup -d:{lookupEndpoints}", _communicator);
-            // No collocation optimization or router for the multicast proxy!
-            lookupPrx = lookupPrx.Clone(clearRouter: false, collocationOptimized: false);
+            lookupPrx = lookupPrx.Clone(clearRouter: false);
 
             ILocatorPrx voidLocator = _locatorAdapter.AddWithUUID(new VoidLocator(), ILocatorPrx.Factory);
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -54,7 +54,6 @@ namespace ZeroC.Ice
             "Locator.EndpointSelection",
             "Locator.ConnectionCached",
             "Locator.PreferNonSecure",
-            "Locator.CollocationOptimized",
             "Locator.Router",
             "MessageSizeMax",
             "PublishedEndpoints",
@@ -64,12 +63,10 @@ namespace ZeroC.Ice
             "Router.EndpointSelection",
             "Router.ConnectionCached",
             "Router.PreferNonSecure",
-            "Router.CollocationOptimized",
             "Router.Locator",
             "Router.Locator.EndpointSelection",
             "Router.Locator.ConnectionCached",
             "Router.Locator.PreferNonSecure",
-            "Router.Locator.CollocationOptimized",
             "Router.Locator.LocatorCacheTimeout",
             "Router.Locator.InvocationTimeout",
             "Router.LocatorCacheTimeout",
@@ -1131,7 +1128,7 @@ namespace ZeroC.Ice
             }
             catch (ObjectAdapterDeactivatedException)
             {
-                // Expected if collocated call and OA is deactivated, ignore.
+                // Expected if colocated call and OA is deactivated, ignore.
             }
             catch (CommunicatorDestroyedException)
             {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -26,8 +26,6 @@ namespace ZeroC.Ice
         /// </param>
         /// <param name="clearRouter">When set to true, the clone does not have an associated router proxy (optional).
         /// </param>
-        /// <param name="collocationOptimized">Determines whether or not the clone can use collocation optimization
-        /// (optional).</param>
         /// <param name="compress">Determines whether or not the clone compresses requests (optional).</param>
         /// <param name="connectionId">The connection ID of the clone (optional).</param>
         /// <param name="connectionTimeout">The connection timeout of the clone (optional).</param>
@@ -56,7 +54,6 @@ namespace ZeroC.Ice
                                  bool? cacheConnection = null,
                                  bool clearLocator = false,
                                  bool clearRouter = false,
-                                 bool? collocationOptimized = null,
                                  bool? compress = null,
                                  string? connectionId = null,
                                  int? connectionTimeout = null,
@@ -79,7 +76,6 @@ namespace ZeroC.Ice
                                                   cacheConnection,
                                                   clearLocator,
                                                   clearRouter,
-                                                  collocationOptimized,
                                                   compress,
                                                   connectionId,
                                                   connectionTimeout,
@@ -111,8 +107,6 @@ namespace ZeroC.Ice
         /// </param>
         /// <param name="clearRouter">When set to true, the clone does not have an associated router proxy (optional).
         /// </param>
-        /// <param name="collocationOptimized">Determines whether or not the clone can use collocation optimization
-        /// (optional).</param>
         /// <param name="compress">Determines whether or not the clone compresses requests (optional).</param>
         /// <param name="connectionId">The connection ID of the clone (optional).</param>
         /// <param name="connectionTimeout">The connection timeout of the clone (optional).</param>
@@ -140,7 +134,6 @@ namespace ZeroC.Ice
                                  bool? cacheConnection = null,
                                  bool clearLocator = false,
                                  bool clearRouter = false,
-                                 bool? collocationOptimized = null,
                                  bool? compress = null,
                                  string? connectionId = null,
                                  int? connectionTimeout = null,
@@ -162,7 +155,6 @@ namespace ZeroC.Ice
                                                   cacheConnection,
                                                   clearLocator,
                                                   clearRouter,
-                                                  collocationOptimized,
                                                   compress,
                                                   connectionId,
                                                   connectionTimeout,
@@ -193,8 +185,6 @@ namespace ZeroC.Ice
         /// </param>
         /// <param name="clearRouter">When set to true, the clone does not have an associated router proxy (optional).
         /// </param>
-        /// <param name="collocationOptimized">Determines whether or not the clone can use collocation optimization
-        /// (optional).</param>
         /// <param name="compress">Determines whether or not the clone compresses requests (optional).</param>
         /// <param name="connectionId">The connection ID of the clone (optional).</param>
         /// <param name="connectionTimeout">The connection timeout of the clone (optional).</param>
@@ -220,7 +210,6 @@ namespace ZeroC.Ice
                                  bool? cacheConnection = null,
                                  bool clearLocator = false,
                                  bool clearRouter = false,
-                                 bool? collocationOptimized = null,
                                  bool? compress = null,
                                  string? connectionId = null,
                                  int? connectionTimeout = null,
@@ -242,7 +231,6 @@ namespace ZeroC.Ice
                                                      cacheConnection,
                                                      clearLocator,
                                                      clearRouter,
-                                                     collocationOptimized,
                                                      compress,
                                                      connectionId,
                                                      connectionTimeout,
@@ -268,7 +256,7 @@ namespace ZeroC.Ice
 
         /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
         /// it first attempts to create a connection.</summary>
-        /// <returns>The Connection for this proxy or null if collocation optimization is used.</returns>
+        /// <returns>The Connection for this proxy or null if colocation optimization is used.</returns>
         public static Connection? GetConnection(this IObjectPrx prx)
         {
             try
@@ -290,11 +278,9 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>
-        /// Returns the Connection for this proxy. If the proxy does not yet have an established connection,
-        /// it first attempts to create a connection.
-        /// </summary>
-        /// <returns>The Connection for this proxy or null if collocation optimization is used.</returns>
+        /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
+        /// it first attempts to create a connection.</summary>
+        /// <returns>The Connection for this proxy or null if colocation optimization is used.</returns>
         public static async ValueTask<Connection?> GetConnectionAsync(this IObjectPrx prx,
                                                                       CancellationToken cancel = default)
         {
@@ -302,10 +288,8 @@ namespace ZeroC.Ice
             return (handler as ConnectionRequestHandler)?.GetConnection();
         }
 
-        /// <summary>
-        /// Returns the cached Connection for this proxy. If the proxy does not yet have an established
-        /// connection, it does not attempt to create a connection.
-        /// </summary>
+        /// <summary>Returns the cached Connection for this proxy. If the proxy does not yet have an established
+        /// connection, it does not attempt to create a connection.</summary>
         /// <returns>The cached Connection for this proxy (null if the proxy does not have
         /// an established connection).</returns>
         public static Connection? GetCachedConnection(this IObjectPrx prx) => prx.IceReference.GetCachedConnection();

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -879,7 +879,7 @@ namespace ZeroC.Ice.Test.Binding
                     var prx = oa.CreateProxy("dummy", IObjectPrx.Factory);
                     try
                     {
-                        prx.Clone(collocationOptimized: false).IcePing();
+                        prx.IcePing();
                     }
                     catch (DNSException) // TODO: is this really an expected exception?
                     {

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -162,19 +162,8 @@ namespace ZeroC.Ice.Test.Interceptor
 
             System.IO.TextWriter output = GetWriter();
 
-            output.WriteLine("Collocation optimization on");
+            output.WriteLine("With sync dispatch");
             runTest(prx, interceptor);
-            output.WriteLine("Now with AMD");
-            interceptor.clear();
-            runAmdAssert(prx, interceptor);
-
-            oa.Activate(); // Only necessary for non-collocation optimized tests
-
-            output.WriteLine("Collocation optimization off");
-            interceptor.clear();
-            prx = prx.Clone(collocationOptimized: false);
-            runTest(prx, interceptor);
-
             output.WriteLine("Now with AMD");
             interceptor.clear();
             runAmdAssert(prx, interceptor);


### PR DESCRIPTION
This PR removes the ability to disable colocation optimization in C#. It's now all automatic, and impossible to disable. It removes the corresponding proxy option, `Clone` parameter and more.

It also removes colocation optimization for datagram proxies, which was the one remaining situation where disabling colocation optimization was useful (for multicast datagrams).

A future PR will rename collocated to colocated and collocation to colocation.