### PR TITLE
Remove Communicator from incoming frames in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2935,15 +2935,16 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     // skips tagged members, and needs to understand them.
     if(inParams.empty())
     {
-        _out << nl << "request.ReadEmptyParamList();";
+        _out << nl << "request.ReadEmptyParamList(current.Communicator);";
     }
     else if(inParams.size() == 1)
     {
-        _out << nl << "var " << inParams.front().name << " = request.ReadParamList(" << reader << ");";
+        _out << nl << "var " << inParams.front().name << " = request.ReadParamList(current.Communicator, "
+            << reader << ");";
     }
     else
     {
-        _out << nl << "var paramList = request.ReadParamList(" << reader << ");";
+        _out << nl << "var paramList = request.ReadParamList(current.Communicator, " << reader << ");";
     }
 
     // The 'this.' is necessary only when the operation name matches one of our local variable (current, istr etc.)

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -77,8 +77,7 @@ namespace ZeroC.Ice
                 if (oneway)
                 {
                     childObserver?.Detach();
-                    return IncomingResponseFrame.WithVoidReturnValue(_adapter.Communicator,
-                                                                     outgoingRequest.Protocol,
+                    return IncomingResponseFrame.WithVoidReturnValue(outgoingRequest.Protocol,
                                                                      outgoingRequest.Encoding);
                 }
             }
@@ -94,7 +93,6 @@ namespace ZeroC.Ice
                 OutgoingResponseFrame outgoingResponseFrame = await task.WaitAsync(cancel).ConfigureAwait(false);
 
                 var incomingResponseFrame = new IncomingResponseFrame(
-                    _adapter.Communicator,
                     outgoingRequest.Protocol,
                     VectoredBufferExtensions.ToArray(outgoingResponseFrame.Data));
 
@@ -141,7 +139,7 @@ namespace ZeroC.Ice
             IDispatchObserver? dispatchObserver = null;
             try
             {
-                var incomingRequest = new IncomingRequestFrame(_adapter.Communicator, outgoingRequest);
+                var incomingRequest = new IncomingRequestFrame(outgoingRequest);
                 var current = new Current(_adapter, incomingRequest, oneway: requestId == 0, cancel);
 
                 // Then notify and set dispatch observer, if any.

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -601,7 +601,7 @@ namespace ZeroC.Ice
             if (responseTask == null)
             {
                 childObserver?.Detach();
-                return IncomingResponseFrame.WithVoidReturnValue(_communicator, request.Protocol, request.Encoding);
+                return IncomingResponseFrame.WithVoidReturnValue(request.Protocol, request.Encoding);
             }
             else
             {
@@ -1034,8 +1034,8 @@ namespace ZeroC.Ice
                         }
                         else
                         {
-                            var request = new IncomingRequestFrame(_communicator, Endpoint.Protocol,
-                                readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
+                            var request = new IncomingRequestFrame(Endpoint.Protocol,
+                                                                   readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
                             ProtocolTrace.TraceFrame(_communicator, readBuffer, request);
                             if (_adapter == null)
                             {
@@ -1088,8 +1088,8 @@ namespace ZeroC.Ice
                     case Ice1Definitions.FrameType.Reply:
                     {
                         int requestId = InputStream.ReadInt(readBuffer.AsSpan(14, 4));
-                        var responseFrame = new IncomingResponseFrame(_communicator, Endpoint.Protocol,
-                            readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
+                        var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
+                                                                      readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
                         ProtocolTrace.TraceFrame(_communicator, readBuffer, responseFrame);
 
                         if (_requests.Remove(requestId,
@@ -1207,8 +1207,8 @@ namespace ZeroC.Ice
                         }
                         else
                         {
-                            var request = new IncomingRequestFrame(_communicator, Endpoint.Protocol,
-                                readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
+                            var request = new IncomingRequestFrame(Endpoint.Protocol,
+                                                                   readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
                             ProtocolTrace.TraceFrame(_communicator, readBuffer, request);
                             if (_adapter == null)
                             {
@@ -1237,8 +1237,8 @@ namespace ZeroC.Ice
                     case Ice2Definitions.FrameType.Reply:
                     {
                         int requestId = InputStream.ReadInt(readBuffer.AsSpan(14, 4));
-                        var responseFrame = new IncomingResponseFrame(_communicator, Endpoint.Protocol,
-                            readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
+                        var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
+                                                                      readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
                         ProtocolTrace.TraceFrame(_communicator, readBuffer, responseFrame);
 
                         if (_requests.Remove(requestId,

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -11,6 +11,7 @@ namespace ZeroC.Ice
     {
         public ObjectAdapter Adapter { get; }
         public CancellationToken CancellationToken { get; }
+        public Communicator Communicator => Adapter.Communicator;
         public Connection? Connection { get; }
         // TODO: should this be a IReadOnlyDictionary<string, string>?
         public Dictionary<string, string> Context { get; }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -221,7 +221,7 @@ namespace ZeroC.Ice
                     Debug.Assert(tail.Segment == 0 && tail.Offset == 8 + opaqueEndpoint.Bytes.Length);
 
                     return
-                        new InputStream(communicator, Ice1Definitions.Encoding, bufferList[0]).ReadEndpoint(protocol);
+                        new InputStream(Ice1Definitions.Encoding, bufferList[0]).ReadEndpoint(protocol, communicator);
                 }
                 else
                 {

--- a/csharp/src/Ice/EndpointFactory.cs
+++ b/csharp/src/Ice/EndpointFactory.cs
@@ -41,12 +41,12 @@ namespace ZeroC.Ice
             {
                 case Transport.TCP:
                 case Transport.SSL:
-                    return new TcpEndpoint(istr, transport, protocol);
+                    return new TcpEndpoint(istr, _communicator, transport, protocol);
                 case Transport.WS:
                 case Transport.WSS:
-                    return new WSEndpoint(istr, transport, protocol);
+                    return new WSEndpoint(istr, _communicator, transport, protocol);
                 case Transport.UDP:
-                    return new UdpEndpoint(istr, protocol);
+                    return new UdpEndpoint(istr, _communicator, protocol);
                 default:
                     Debug.Assert(false);
                     throw new NotSupportedException($"the transport `{transport}' is not supported");

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -73,14 +73,14 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_pingAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyParamList(current.Communicator);
             IcePing(current);
             return new ValueTask<OutgoingResponseFrame>(OutgoingResponseFrame.WithVoidReturnValue(current));
         }
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_isAAsync(IncomingRequestFrame request, Current current)
         {
-            string id = request.ReadParamList(InputStream.IceReaderIntoString);
+            string id = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
             bool ret = IceIsA(id, current);
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current, format: null, ret, OutputStream.IceWriterFromBool));
@@ -88,7 +88,7 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyParamList(current.Communicator);
             string ret = IceId(current);
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current, format: null, ret, OutputStream.IceWriterFromString));
@@ -96,7 +96,7 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idsAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyParamList(current.Communicator);
             IEnumerable<string> ret = IceIds(current);
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current, format: null, ret,

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -271,10 +271,10 @@ namespace ZeroC.Ice
             ConnectionId = connectionId;
         }
 
-        private protected IPEndpoint(InputStream istr, Protocol protocol)
+        private protected IPEndpoint(InputStream istr, Communicator communicator, Protocol protocol)
             : base(protocol)
         {
-            Communicator = istr.Communicator;
+            Communicator = communicator;
             Host = istr.ReadString();
             Port = istr.ReadInt();
         }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -11,10 +11,6 @@ namespace ZeroC.Ice
     /// <summary>Represents a response protocol frame sent by the application.</summary>
     public sealed class OutgoingResponseFrame
     {
-        private static readonly ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), OutgoingResponseFrame>
-            _cachedVoidReturnValueFrames =
-                new ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), OutgoingResponseFrame>();
-
         /// <summary>The encoding of the frame payload</summary>
         public Encoding Encoding { get; }
 
@@ -35,6 +31,10 @@ namespace ZeroC.Ice
 
         // Contents of the Frame
         internal List<ArraySegment<byte>> Data { get; private set; }
+
+        private static readonly ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), OutgoingResponseFrame>
+            _cachedVoidReturnValueFrames =
+                new ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), OutgoingResponseFrame>();
 
         /// <summary>Creates a new outgoing response frame with an OK reply status and a void return value.</summary>
         /// <param name="current">The Current object for the corresponding incoming request.</param>

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -663,8 +663,9 @@ namespace ZeroC.Ice
 
         /// <summary>Reads a reference from the input stream.</summary>
         /// <param name="istr">The input stream to read from.</param>
+        /// <param name="communicator">The communicator.</param>
         /// <returns>The reference read from the stream (can be null).</returns>
-        internal static Reference? Read(InputStream istr)
+        internal static Reference? Read(InputStream istr, Communicator communicator)
         {
             var identity = new Identity(istr);
             if (identity.Name.Length == 0)
@@ -702,7 +703,7 @@ namespace ZeroC.Ice
                 endpoints = new Endpoint[sz];
                 for (int i = 0; i < sz; i++)
                 {
-                    endpoints[i] = istr.ReadEndpoint(protocol);
+                    endpoints[i] = istr.ReadEndpoint(protocol, communicator);
                 }
             }
             else
@@ -711,9 +712,14 @@ namespace ZeroC.Ice
                 adapterId = istr.ReadString();
             }
 
-            return new Reference(adapterId: adapterId, communicator: istr.Communicator, encoding: encoding,
-                endpoints: endpoints, facet: facet, identity: identity, invocationMode: (InvocationMode)mode,
-                protocol: protocol);
+            return new Reference(adapterId,
+                                 communicator,
+                                 encoding,
+                                 endpoints,
+                                 facet,
+                                 identity,
+                                 invocationMode: (InvocationMode)mode,
+                                 protocol);
         }
 
         // Helper constructor for routable references, not bound to a connection. Uses the communicator's defaults.

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -125,8 +125,8 @@ namespace ZeroC.Ice
             Timeout = timeout;
         }
 
-        internal TcpEndpoint(InputStream istr, Transport transport, Protocol protocol)
-            : base(istr, protocol)
+        internal TcpEndpoint(InputStream istr, Communicator communicator, Transport transport, Protocol protocol)
+            : base(istr, communicator, protocol)
         {
             Transport = transport;
             Timeout = istr.ReadInt();

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -157,8 +157,8 @@ namespace ZeroC.Ice
             HasCompressionFlag = compressionFlag;
         }
 
-        internal UdpEndpoint(InputStream istr, Protocol protocol)
-            : base(istr, protocol)
+        internal UdpEndpoint(InputStream istr, Communicator communicator, Protocol protocol)
+            : base(istr, communicator, protocol)
         {
             _connect = false;
             HasCompressionFlag = istr.ReadBool();

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -103,8 +103,8 @@ namespace ZeroC.Ice
             }
         }
 
-        internal WSEndpoint(InputStream istr, Transport transport, Protocol protocol)
-            : base(istr, transport, protocol) =>
+        internal WSEndpoint(InputStream istr, Communicator communicator, Transport transport, Protocol protocol)
+            : base(istr, communicator, transport, protocol) =>
             Resource = istr.ReadString();
 
         private protected override IPEndpoint CreateIPEndpoint(

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.Invoke
                 request = OutgoingRequestFrame.WithParamList(cl, "opString", idempotent: false,
                     format: null, context: null, _testString, OutputStream.IceWriterFromString);
                 response = cl.Invoke(request);
-                (string s1, string s2) = response.ReadReturnValue(istr =>
+                (string s1, string s2) = response.ReadReturnValue(communicator, istr =>
                     {
                         string s1 = istr.ReadString();
                         string s2 = istr.ReadString();
@@ -66,7 +66,7 @@ namespace ZeroC.Ice.Test.Invoke
                 IncomingResponseFrame response = cl.Invoke(request);
                 try
                 {
-                    response.ReadVoidReturnValue();
+                    response.ReadVoidReturnValue(communicator);
                 }
                 catch (MyException)
                 {
@@ -99,7 +99,7 @@ namespace ZeroC.Ice.Test.Invoke
                     format: null, context: null, _testString, OutputStream.IceWriterFromString);
 
                 response = cl.InvokeAsync(request).Result;
-                (string s1, string s2) = response.ReadReturnValue(istr =>
+                (string s1, string s2) = response.ReadReturnValue(communicator, istr =>
                     {
                         string s1 = istr.ReadString();
                         string s2 = istr.ReadString();
@@ -115,7 +115,7 @@ namespace ZeroC.Ice.Test.Invoke
 
                 try
                 {
-                    response.ReadVoidReturnValue();
+                    response.ReadVoidReturnValue(communicator);
                     TestHelper.Assert(false);
                 }
                 catch (MyException)

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -21,7 +21,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
             else if (current.Operation.Equals("opString"))
             {
-                string s = request.ReadParamList(InputStream.IceReaderIntoString);
+                string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current, format: null, (s, s),
                     (OutputStream ostr, (string ReturnValue, string s2) value) =>
                     {
@@ -46,7 +46,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
             else if (current.Operation.Equals("ice_isA"))
             {
-                string s = request.ReadParamList(InputStream.IceReaderIntoString);
+                string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current, format: null,
                     s.Equals("::ZeroC::Ice::Test::Invoke::MyClass"), OutputStream.IceWriterFromBool);
                 return new ValueTask<OutgoingResponseFrame >(responseFrame);

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -588,7 +588,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, byte? p1) => ostr.WriteTaggedByte(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         byte? b1 = istr.ReadTaggedByte(1);
                         byte? b2 = istr.ReadTaggedByte(3);
@@ -623,7 +623,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, bool? p1) => ostr.WriteTaggedBool(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                 {
                     bool? b1 = istr.ReadTaggedBool(1);
                     bool? b2 = istr.ReadTaggedBool(3);
@@ -658,7 +658,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, short? p1) => ostr.WriteTaggedShort(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         short? s1 = istr.ReadTaggedShort(1);
                         short? s2 = istr.ReadTaggedShort(3);
@@ -693,7 +693,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, int? p1) => ostr.WriteTaggedInt(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p1, p2) = responseFrame.ReadReturnValue(istr =>
+                (p1, p2) = responseFrame.ReadReturnValue(communicator, istr =>
                 {
                     int? i1 = istr.ReadTaggedInt(1);
                     int? i2 = istr.ReadTaggedInt(3);
@@ -728,7 +728,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, long? p1) => ostr.WriteTaggedLong(1, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                 {
                     long? l1 = istr.ReadTaggedLong(2);
                     long? l2 = istr.ReadTaggedLong(3);
@@ -763,7 +763,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, float? p1) => ostr.WriteTaggedFloat(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         float? f1 = istr.ReadTaggedFloat(1);
                         float? f2 = istr.ReadTaggedFloat(3);
@@ -798,7 +798,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, double? p1) => ostr.WriteTaggedDouble(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         double? d1 = istr.ReadTaggedDouble(1);
                         double? d2 = istr.ReadTaggedDouble(3);
@@ -835,7 +835,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, string? p1) => ostr.WriteTaggedString(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                 {
                     string? s1 = istr.ReadTaggedString(1);
                     string? s2 = istr.ReadTaggedString(3);
@@ -870,7 +870,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, MyEnum? p1) => ostr.WriteTaggedSize(2, (int?) p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedSize(1)?.AsMyEnum(), istr.ReadTaggedSize(3)?.AsMyEnum()));
                 TestHelper.Assert(p2 == MyEnum.MyEnumMember);
                 TestHelper.Assert(p3 == MyEnum.MyEnumMember);
@@ -901,7 +901,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, SmallStruct? p1) => ostr.WriteTaggedStruct(2, p1, 1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedStruct(1, fixedSize: true, istr => new SmallStruct(istr)),
                         istr.ReadTaggedStruct(3, fixedSize: true, istr => new SmallStruct(istr))));
 
@@ -934,7 +934,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, FixedStruct? p1) => ostr.WriteTaggedStruct(2, p1, 4));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedStruct(1, fixedSize: true, istr => new FixedStruct(istr)),
                         istr.ReadTaggedStruct(3, fixedSize: true, istr => new FixedStruct(istr))));
                 TestHelper.Assert(p2!.Value.m == 56);
@@ -975,7 +975,7 @@ namespace ZeroC.Ice.Test.Tagged
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedStruct(1, fixedSize: false, istr => new VarStruct(istr)),
                         istr.ReadTaggedStruct(3, fixedSize: false, istr => new VarStruct(istr))));
                 TestHelper.Assert(p2!.Value.m.Equals("test"));
@@ -1029,7 +1029,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, OneTagged? p1) => ostr.WriteTaggedClass(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedClass<OneTagged>(1),
                     istr.ReadTaggedClass<OneTagged>(3)));
                 TestHelper.Assert(p2!.a == 58 && p3!.a == 58);
@@ -1060,7 +1060,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<byte>(1), istr.ReadTaggedArray<byte>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
@@ -1092,7 +1092,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<bool>(1), istr.ReadTaggedArray<bool>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1124,7 +1124,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, short[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<short>(1), istr.ReadTaggedArray<short>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1155,7 +1155,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, int[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<int>(1), istr.ReadTaggedArray<int>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1186,7 +1186,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, long[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<long>(1), istr.ReadTaggedArray<long>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1217,7 +1217,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, float[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<float>(1), istr.ReadTaggedArray<float>(3)));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
@@ -1248,7 +1248,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, double[]? p1) => ostr.WriteTaggedArray(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<double>(1), istr.ReadTaggedArray<double>(3)));
 
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
@@ -1281,7 +1281,7 @@ namespace ZeroC.Ice.Test.Tagged
                         ostr.WriteTaggedSequence(2, p1, (ost, s) => ostr.WriteString(s)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => istr.ReadString()),
                        istr.ReadTaggedArray(3, 1, fixedSize: false, istr => istr.ReadString())));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
@@ -1314,7 +1314,7 @@ namespace ZeroC.Ice.Test.Tagged
                         (ostr, st) => ostr.WriteStruct(st)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray(1, 1, fixedSize: true, istr => new SmallStruct(istr)),
                         istr.ReadTaggedArray(3, 1, fixedSize: true, istr => new SmallStruct(istr))));
 
@@ -1352,7 +1352,7 @@ namespace ZeroC.Ice.Test.Tagged
                         (ostr, st) => ostr.WriteStruct(st)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         List<SmallStruct>? list1 =
                             istr.ReadTaggedSequence(1, 1, fixedSize: true, istr => new SmallStruct(istr)) is
@@ -1395,7 +1395,7 @@ namespace ZeroC.Ice.Test.Tagged
                         (ostr, st) => ostr.WriteStruct(st)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray(1, 4, fixedSize: true, istr => new FixedStruct(istr)),
                         istr.ReadTaggedArray(3, 4, fixedSize: true, istr => new FixedStruct(istr))));
 
@@ -1433,7 +1433,7 @@ namespace ZeroC.Ice.Test.Tagged
                         (ostr, st) => ostr.WriteStruct(st)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     {
                         LinkedList<FixedStruct>? list1 =
                             istr.ReadTaggedSequence(1, 4, fixedSize: true, istr => new FixedStruct(istr)) is
@@ -1475,7 +1475,7 @@ namespace ZeroC.Ice.Test.Tagged
                         ostr.WriteTaggedSequence(2, p1, (ostr, vs) => ostr.WriteStruct(vs)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                       (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => new VarStruct(istr)),
                         istr.ReadTaggedArray(3, 1, fixedSize: false, istr => new VarStruct(istr))));
                 TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
@@ -1508,7 +1508,7 @@ namespace ZeroC.Ice.Test.Tagged
                     (OutputStream ostr, SerializableClass? p1) => ostr.WriteTaggedSerializable(2, p1));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedSerializable(1) as SerializableClass,
                         istr.ReadTaggedSerializable(3) as SerializableClass));
                 TestHelper.Assert(p2!.Equals(p1));
@@ -1543,7 +1543,7 @@ namespace ZeroC.Ice.Test.Tagged
                         (ostr, k) => ostr.WriteInt(k), (ostr, v) => ostr.WriteInt(v)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedDictionary(1, 4, 4, fixedSize: true,
                         istr => istr.ReadInt(), istr => istr.ReadInt()),
                      istr.ReadTaggedDictionary(3, 4, 4, fixedSize: true,
@@ -1585,7 +1585,7 @@ namespace ZeroC.Ice.Test.Tagged
                     });
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                       (istr.ReadTaggedDictionary(1, 1, 4, fixedSize: false, istr => istr.ReadString(),
                                                                             istr => istr.ReadInt()),
                        istr.ReadTaggedDictionary(3, 1, 4, fixedSize: false, istr => istr.ReadString(),
@@ -1624,7 +1624,7 @@ namespace ZeroC.Ice.Test.Tagged
                                 (ostr, v) => ostr.WriteNullableClass(v, OneTagged.IceTypeId)));
 
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(istr =>
+                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedDictionary(1, 1, 4, fixedSize: false, istr => istr.ReadInt(),
                         istr => istr.ReadNullableClass<OneTagged>(OneTagged.IceTypeId)),
                      istr.ReadTaggedDictionary(3, 1, 4, fixedSize: false, istr => istr.ReadInt(),


### PR DESCRIPTION
This PR removes the communicator field from IncomingRequestFrame and IncomingResponseFrame, which helps with the caching of empty frames. It also reworks InputStream to require a communicator only for reading encapsulations.