### PR TITLE
Preserve exception stack when unwrap InnerException

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -231,7 +232,7 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                throw ex.InnerException;
+                ExceptionDispatchInfo.Throw(ex.InnerException);
             }
         }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
-using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -232,7 +231,7 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                ExceptionDispatchInfo.Throw(ex.InnerException);
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
         }
 

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -178,7 +178,7 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                throw ex.InnerException;
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
 
             lock (_mutex)
@@ -406,7 +406,7 @@ namespace ZeroC.Ice
                             catch (AggregateException ex)
                             {
                                 Debug.Assert(ex.InnerException != null);
-                                throw ex.InnerException;
+                                throw ExceptionUtil.Throw(ex.InnerException);
                             }
                         }
 

--- a/csharp/src/Ice/ExceptionUtil.cs
+++ b/csharp/src/Ice/ExceptionUtil.cs
@@ -1,0 +1,23 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+
+namespace ZeroC.Ice
+{
+    internal static class ExceptionUtil
+    {
+        /// <summary>Helper function to re throw an exception and preserving the stack trace, use as
+        /// <code>throw ExceptionUtil.Throw(ex.AggregateException);</code>, this prevent the compiler error
+        /// of not all code path returning a value.</summary>
+        internal static Exception Throw(Exception ex)
+        {
+            ExceptionDispatchInfo.Throw(ex);
+            Debug.Assert(false);
+            return ex;
+        }
+    }
+}

--- a/csharp/src/Ice/LoggerAdminLogger.cs
+++ b/csharp/src/Ice/LoggerAdminLogger.cs
@@ -3,10 +3,9 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
 
 namespace ZeroC.Ice
 {

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace ZeroC.Ice
@@ -725,11 +724,8 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                ExceptionDispatchInfo.Throw(ex.InnerException);
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
-
-            Debug.Assert(false);
-            return null!;
         }
 
         public static async ValueTask<IEnumerable<IPEndPoint>> GetAddressesForClientEndpointAsync(string host, int port,
@@ -774,11 +770,8 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                ExceptionDispatchInfo.Throw(ex.InnerException);
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
-
-            Debug.Assert(false);
-            return null!;
         }
 
         public static async ValueTask<IEnumerable<IPEndPoint>> GetAddressesAsync(string host, int port, int ipVersion,

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace ZeroC.Ice
@@ -82,9 +83,9 @@ namespace ZeroC.Ice
             // In some cases the IOException has an inner exception that we can pass directly
             // to the other overloading of connectionLost().
             //
-            if (ex.InnerException != null && ex.InnerException is SocketException)
+            if (ex.InnerException is SocketException socketException)
             {
-                return ConnectionLost((SocketException)ex.InnerException);
+                return ConnectionLost(socketException);
             }
 
             //
@@ -723,8 +724,12 @@ namespace ZeroC.Ice
             }
             catch (AggregateException ex)
             {
-                throw ex.InnerException!;
+                Debug.Assert(ex.InnerException != null);
+                ExceptionDispatchInfo.Throw(ex.InnerException);
             }
+
+            Debug.Assert(false);
+            return null!;
         }
 
         public static async ValueTask<IEnumerable<IPEndPoint>> GetAddressesForClientEndpointAsync(string host, int port,
@@ -768,8 +773,12 @@ namespace ZeroC.Ice
             }
             catch (AggregateException ex)
             {
-                throw ex.InnerException!;
+                Debug.Assert(ex.InnerException != null);
+                ExceptionDispatchInfo.Throw(ex.InnerException);
             }
+
+            Debug.Assert(false);
+            return null!;
         }
 
         public static async ValueTask<IEnumerable<IPEndPoint>> GetAddressesAsync(string host, int port, int ipVersion,

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -275,11 +274,8 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                ExceptionDispatchInfo.Throw(ex.InnerException);
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
-
-            Debug.Assert(false);
-            return null;
         }
 
         /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
@@ -317,11 +313,8 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                ExceptionDispatchInfo.Throw(ex.InnerException);
+                throw ExceptionUtil.Throw(ex.InnerException);
             }
-
-            Debug.Assert(false);
-            return null!;
         }
 
         /// <summary>Sends a request asynchronously.</summary>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -274,8 +275,11 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                throw ex.InnerException;
+                ExceptionDispatchInfo.Throw(ex.InnerException);
             }
+
+            Debug.Assert(false);
+            return null;
         }
 
         /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
@@ -313,8 +317,11 @@ namespace ZeroC.Ice
             catch (AggregateException ex)
             {
                 Debug.Assert(ex.InnerException != null);
-                throw ex.InnerException;
+                ExceptionDispatchInfo.Throw(ex.InnerException);
             }
+
+            Debug.Assert(false);
+            return null!;
         }
 
         /// <summary>Sends a request asynchronously.</summary>
@@ -498,14 +505,18 @@ namespace ZeroC.Ice
                         if (invocationTimeout?.IsCancellationRequested ?? false)
                         {
                             ex = new TimeoutException();
+                            observer?.Failed(ex.GetType().FullName ?? "System.Exception");
+                            throw ex;
                         }
                         else if (proxy.Communicator.CancellationToken.IsCancellationRequested)
                         {
                             ex = new CommunicatorDestroyedException();
+                            observer?.Failed(ex.GetType().FullName ?? "System.Exception");
+                            throw ex;
                         }
                     }
                     observer?.Failed(ex.GetType().FullName ?? "System.Exception");
-                    throw ex;
+                    throw;
                 }
                 finally
                 {

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -768,7 +768,7 @@ namespace ZeroC.Ice
         {
         }
 
-        internal int CheckRetryAfterException(System.Exception ex, bool sent, bool idempotent, ref int cnt)
+        internal int CheckRetryAfterException(Exception ex, bool sent, bool idempotent, ref int cnt)
         {
             // TODO: revisit retry logic
 


### PR DESCRIPTION
This small PR fixes code to use ExceptionDispatchInfo to preserve exception stack when unwrapping InnerExceptions