### PR TITLE
Logger cleanup

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -378,9 +378,7 @@ namespace ZeroC.Ice
                     }
                     else if (Runtime.Logger is Logger)
                     {
-                        //
                         // Ice.ConsoleListener is enabled by default.
-                        //
                         Logger = new TraceLogger(programName, GetPropertyAsBool("Ice.ConsoleListener") ?? true);
                     }
                     // else already set to process logger
@@ -398,7 +396,7 @@ namespace ZeroC.Ice
                     catch (Exception ex)
                     {
                         throw new InvalidConfigurationException(
-                            $"invalid value for for Ice.Default.Encoding: `{encoding}'", ex);
+                            $"invalid value for Ice.Default.Encoding: `{encoding}'", ex);
                     }
                 }
                 else
@@ -1013,7 +1011,7 @@ namespace ZeroC.Ice
             {
                 if (Logger is FileLogger fileLogger)
                 {
-                    fileLogger.Destroy();
+                    fileLogger.Dispose();
                 }
             }
             _currentContext.Dispose();

--- a/csharp/src/Ice/ILogger.cs
+++ b/csharp/src/Ice/ILogger.cs
@@ -6,6 +6,18 @@ namespace ZeroC.Ice
 {
     public interface ILogger
     {
+        /// <summary>Gets the logger's prefix.</summary>
+        string Prefix { get; }
+
+        /// <summary>Returns a clone of the logger with a new prefix.</summary>
+        /// <param name="prefix">The new prefix for the logger.</param>
+        /// <returns>A logger instance.</returns>
+        ILogger CloneWithPrefix(string prefix);
+
+        /// <summary>Log an error message.</summary>
+        /// <param name="message">The error message to log.</param>
+        void Error(string message);
+
         /// <summary>Print a message, the message is printed literally, without any decorations such as executable
         /// name or time stamp.</summary>
         /// <param name="message">The message to log.</param>
@@ -19,18 +31,5 @@ namespace ZeroC.Ice
         /// <summary>Log a warning message.</summary>
         /// <param name="message">The warning message to log.</param>
         void Warning(string message);
-
-        /// <summary>Log an error message.</summary>
-        /// <param name="message">The error message to log.</param>
-        void Error(string message);
-
-        /// <summary>Returns this logger's prefix.</summary>
-        /// <returns>The prefix.</returns>
-        string GetPrefix();
-
-        /// <summary>Returns a clone of the logger with a new prefix.</summary>
-        /// <param name="prefix">The new prefix for the logger.</param>
-        /// <returns>A logger instance.</returns>
-        ILogger CloneWithPrefix(string prefix);
     }
 }

--- a/csharp/src/Ice/Logger.cs
+++ b/csharp/src/Ice/Logger.cs
@@ -8,23 +8,71 @@ using System.IO;
 
 namespace ZeroC.Ice
 {
+    /// <summary>Represents a logger that writes messages to the standard error output stream.</summary>
+    public sealed class ConsoleLogger : Logger
+    {
+        /// <summary>Creates a new console logger.</summary>
+        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
+        public ConsoleLogger(string prefix)
+            : base(prefix)
+        {
+        }
+
+        public override ILogger CloneWithPrefix(string prefix) => new ConsoleLogger(prefix);
+
+        protected override void Write(string message) => System.Console.Error.WriteLine(message);
+    }
+
+    /// <summary>Represents a logger that writes messages to a file.</summary>
+    public sealed class FileLogger : Logger
+    {
+        private readonly string _file;
+        private readonly TextWriter _writer;
+
+        /// <summary>Creates a new file logger.</summary>
+        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
+        /// <param name="file">The file path to write to.</param>
+        public FileLogger(string prefix, string file)
+            : base(prefix)
+        {
+            _file = file;
+            _writer = new StreamWriter(new FileStream(file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
+        }
+
+        public override ILogger CloneWithPrefix(string prefix) => new FileLogger(prefix, _file);
+
+        /// <summary>Close the underlying stream an dispose all the resources associated with it.</summary>
+        public void Destroy() => _writer.Close();
+
+        protected override void Write(string message)
+        {
+            _writer.WriteLine(message);
+            _writer.Flush();
+        }
+    }
+
     public abstract class Logger : ILogger
     {
-        public Logger(string prefix)
-        {
-            Prefix = prefix;
+        public string Prefix { get; }
 
-            if (prefix.Length > 0)
+        protected const string Date = "d";
+        protected readonly string FormattedPrefix;
+        protected const string Time = "HH:mm:ss:fff";
+
+        protected static object GlobalMutex = new object();
+
+        public abstract ILogger CloneWithPrefix(string prefix);
+
+        public virtual void Error(string message)
+        {
+            string s = Format("!!", "error", message);
+            lock (GlobalMutex)
             {
-                FormattedPrefix = prefix + ": ";
-            }
-            else
-            {
-                FormattedPrefix = "";
+                Write(s);
             }
         }
 
-        public void Print(string message)
+        public virtual void Print(string message)
         {
             lock (GlobalMutex)
             {
@@ -50,16 +98,25 @@ namespace ZeroC.Ice
             }
         }
 
-        public virtual void Error(string message)
+        /// <summary>Creates a new logger, used only by derived classes.</summary>
+        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
+        protected Logger(string prefix)
         {
-            string s = Format("!!", "error", message);
-            lock (GlobalMutex)
+            Prefix = prefix;
+
+            if (prefix.Length > 0)
             {
-                Write(s);
+                FormattedPrefix = prefix + ": ";
+            }
+            else
+            {
+                FormattedPrefix = "";
             }
         }
 
-        public string GetPrefix() => Prefix;
+        /// <summary>Writes a message using this logger.</summary>
+        /// <param name="message">The message to write.</param>
+        protected abstract void Write(string message);
 
         private string Format(string prefix, string category, string message)
         {
@@ -76,93 +133,13 @@ namespace ZeroC.Ice
             s.Replace("\n", "\n   ");
             return s.ToString();
         }
-
-        public abstract ILogger CloneWithPrefix(string prefix);
-
-        protected abstract void Write(string message);
-
-        protected readonly string Prefix;
-        protected readonly string FormattedPrefix;
-        protected const string Date = "d";
-        protected const string Time = "HH:mm:ss:fff";
-
-        internal static object GlobalMutex = new object();
-    }
-
-    public sealed class ConsoleLogger : Logger
-    {
-        public ConsoleLogger(string prefix)
-            : base(prefix)
-        {
-        }
-
-        public override ILogger CloneWithPrefix(string prefix) => new ConsoleLogger(prefix);
-
-        protected override void Write(string message) => System.Console.Error.WriteLine(message);
-    }
-
-    public sealed class FileLogger : Logger
-    {
-        public FileLogger(string prefix, string file)
-            : base(prefix)
-        {
-            _file = file;
-            _writer = new StreamWriter(new FileStream(file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
-        }
-
-        public override ILogger CloneWithPrefix(string prefix) => new FileLogger(prefix, _file);
-
-        protected override void Write(string message)
-        {
-            _writer.WriteLine(message);
-            _writer.Flush();
-        }
-
-        public void Destroy() => _writer.Close();
-
-        private readonly string _file;
-        private readonly TextWriter _writer;
-    }
-
-    public class ConsoleListener : TraceListener
-    {
-        public override bool IsThreadSafe => true;
-
-        public override void TraceEvent(TraceEventCache cache, string source, TraceEventType type,
-                                        int id, string message)
-        {
-            System.Text.StringBuilder s;
-            if (type == TraceEventType.Error)
-            {
-                s = new System.Text.StringBuilder("!!");
-            }
-            else if (type == TraceEventType.Warning)
-            {
-                s = new System.Text.StringBuilder("-!");
-            }
-            else
-            {
-                s = new System.Text.StringBuilder("--");
-            }
-            s.Append(' ');
-            s.Append(System.DateTime.Now.ToString(Date, CultureInfo.CurrentCulture));
-            s.Append(' ');
-            s.Append(System.DateTime.Now.ToString(Time, CultureInfo.CurrentCulture));
-            s.Append(' ');
-            s.Append(message);
-            WriteLine(s.ToString());
-        }
-
-        public override void Write(string message) => System.Console.Error.Write(message);
-
-        public override void WriteLine(string message) => System.Console.Error.WriteLine(message);
-
-        private const string Date = "d";
-        private const string Time = "HH:mm:ss:fff";
     }
 
     public sealed class TraceLogger : Logger
     {
+        private readonly bool _console;
+        private static readonly ConsoleListener _consoleListener = new ConsoleListener();
+
         public TraceLogger(string prefix, bool console)
             : base(prefix)
         {
@@ -170,6 +147,16 @@ namespace ZeroC.Ice
             if (console && !System.Diagnostics.Trace.Listeners.Contains(_consoleListener))
             {
                 System.Diagnostics.Trace.Listeners.Add(_consoleListener);
+            }
+        }
+
+        public override ILogger CloneWithPrefix(string prefix) => new TraceLogger(prefix, _console);
+        public override void Error(string message)
+        {
+            string s = Format("error", message);
+            {
+                System.Diagnostics.Trace.TraceError(s);
+                System.Diagnostics.Trace.Flush();
             }
         }
 
@@ -184,17 +171,6 @@ namespace ZeroC.Ice
             System.Diagnostics.Trace.TraceWarning(Format("warning", message));
             System.Diagnostics.Trace.Flush();
         }
-
-        public override void Error(string message)
-        {
-            string s = Format("error", message);
-            {
-                System.Diagnostics.Trace.TraceError(s);
-                System.Diagnostics.Trace.Flush();
-            }
-        }
-
-        public override ILogger CloneWithPrefix(string prefix) => new TraceLogger(prefix, _console);
 
         protected override void Write(string message)
         {
@@ -211,8 +187,40 @@ namespace ZeroC.Ice
             s.Replace("\n", "\n   ");
             return s.ToString();
         }
+    }
 
-        private readonly bool _console;
-        private static readonly ConsoleListener _consoleListener = new ConsoleListener();
+    internal class ConsoleListener : TraceListener
+    {
+        public override bool IsThreadSafe => true;
+
+        private const string Date = "d";
+        private const string Time = "HH:mm:ss:fff";
+
+        public override void TraceEvent(
+            TraceEventCache cache,
+            string source,
+            TraceEventType type,
+            int id,
+            string message)
+        {
+            var s = new System.Text.StringBuilder(
+                type switch
+                {
+                    TraceEventType.Error => "!!",
+                    TraceEventType.Warning => "-!",
+                    _ => "--"
+                });
+            s.Append(' ');
+            s.Append(System.DateTime.Now.ToString(Date, CultureInfo.CurrentCulture));
+            s.Append(' ');
+            s.Append(System.DateTime.Now.ToString(Time, CultureInfo.CurrentCulture));
+            s.Append(' ');
+            s.Append(message);
+            WriteLine(s.ToString());
+        }
+
+        public override void Write(string message) => System.Console.Error.Write(message);
+
+        public override void WriteLine(string message) => System.Console.Error.WriteLine(message);
     }
 }

--- a/csharp/src/Ice/Logger.cs
+++ b/csharp/src/Ice/Logger.cs
@@ -65,10 +65,10 @@ namespace ZeroC.Ice
 
         public virtual void Error(string message)
         {
-            string s = Format("!!", "error", message);
+            string formattedMessage = Format("!!", "error", message);
             lock (GlobalMutex)
             {
-                Write(s);
+                Write(formattedMessage);
             }
         }
 
@@ -82,19 +82,19 @@ namespace ZeroC.Ice
 
         public virtual void Trace(string category, string message)
         {
-            string s = Format("--", category, message);
+            string formattedMessage = Format("--", category, message);
             lock (GlobalMutex)
             {
-                Write(s);
+                Write(formattedMessage);
             }
         }
 
         public virtual void Warning(string message)
         {
-            string s = Format("-!", "warning", message);
+            string formattedMessage = Format("-!", "warning", message);
             lock (GlobalMutex)
             {
-                Write(s);
+                Write(formattedMessage);
             }
         }
 
@@ -103,15 +103,7 @@ namespace ZeroC.Ice
         protected Logger(string prefix)
         {
             Prefix = prefix;
-
-            if (prefix.Length > 0)
-            {
-                FormattedPrefix = prefix + ": ";
-            }
-            else
-            {
-                FormattedPrefix = "";
-            }
+            FormattedPrefix = prefix.Length > 0 ? $"{prefix}: " : "";
         }
 
         /// <summary>Writes a message using this logger.</summary>
@@ -153,11 +145,8 @@ namespace ZeroC.Ice
         public override ILogger CloneWithPrefix(string prefix) => new TraceLogger(prefix, _console);
         public override void Error(string message)
         {
-            string s = Format("error", message);
-            {
-                System.Diagnostics.Trace.TraceError(s);
-                System.Diagnostics.Trace.Flush();
-            }
+            System.Diagnostics.Trace.TraceError(Format("error", message));
+            System.Diagnostics.Trace.Flush();
         }
 
         public override void Trace(string category, string message)

--- a/csharp/src/Ice/Logger.cs
+++ b/csharp/src/Ice/Logger.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace ZeroC.Ice
 {
-    public abstract class Logger : ILogger
+    internal abstract class Logger : ILogger
     {
         public string Prefix { get; }
 
@@ -58,40 +58,40 @@ namespace ZeroC.Ice
     }
 
     /// <summary>Represents a logger that writes messages to the standard error output stream.</summary>
-    public sealed class ConsoleLogger : Logger
+    internal sealed class ConsoleLogger : Logger
     {
-        /// <summary>Creates a new console logger.</summary>
-        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
-        public ConsoleLogger(string prefix)
-            : base(prefix)
-        {
-        }
-
         public override ILogger CloneWithPrefix(string prefix) => new ConsoleLogger(prefix);
 
         protected override void Write(string message) => Console.Error.WriteLine(message);
+
+        /// <summary>Creates a new console logger.</summary>
+        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
+        internal ConsoleLogger(string prefix)
+            : base(prefix)
+        {
+        }
     }
 
     /// <summary>Represents a logger that writes messages to a file.</summary>
-    public sealed class FileLogger : Logger, IDisposable
+    internal sealed class FileLogger : Logger, IDisposable
     {
         private readonly string _file;
         private readonly TextWriter _writer;
 
+        public override ILogger CloneWithPrefix(string prefix) => new FileLogger(prefix, _file, _writer);
+
+        public void Dispose() => _writer.Close();
+
         /// <summary>Creates a new file logger.</summary>
         /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
         /// <param name="file">The file path to write to.</param>
-        public FileLogger(string prefix, string file)
+        internal FileLogger(string prefix, string file)
             : base(prefix)
         {
             _file = file;
             _writer = TextWriter.Synchronized(
                 new StreamWriter(new FileStream(file, FileMode.Append, FileAccess.Write, FileShare.Read)));
         }
-
-        public override ILogger CloneWithPrefix(string prefix) => new FileLogger(prefix, _file, _writer);
-
-        public void Dispose() => _writer.Close();
 
         protected override void Write(string message)
         {
@@ -110,24 +110,10 @@ namespace ZeroC.Ice
 
     /// <summary>Creates a logger that trace messages using <see cref="System.Diagnostics.Trace"/> API,
     /// this is the default logger.</summary>
-    public sealed class TraceLogger : Logger
+    internal sealed class TraceLogger : Logger
     {
         private static readonly ConsoleListener _consoleListener = new ConsoleListener();
         private readonly bool _addConsoleListener;
-
-        /// <summary>Creates a new trace logger.</summary>
-        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
-        /// <param name="addConsoleListener">If true a listener that writes messages to the standard error is added
-        /// to trace listeners <see cref="Trace.Listeners"/> this is only done once per process.</param>
-        public TraceLogger(string prefix, bool addConsoleListener)
-            : base(prefix)
-        {
-            _addConsoleListener = addConsoleListener;
-            if (addConsoleListener && !System.Diagnostics.Trace.Listeners.Contains(_consoleListener))
-            {
-                System.Diagnostics.Trace.Listeners.Add(_consoleListener);
-            }
-        }
 
         public override ILogger CloneWithPrefix(string prefix) => new TraceLogger(prefix, _addConsoleListener);
         public override void Error(string message)
@@ -146,6 +132,20 @@ namespace ZeroC.Ice
         {
             System.Diagnostics.Trace.TraceWarning(Format("warning", message));
             System.Diagnostics.Trace.Flush();
+        }
+
+        /// <summary>Creates a new trace logger.</summary>
+        /// <param name="prefix">The prefix to perpend to messages write by this logger.</param>
+        /// <param name="addConsoleListener">If true a listener that writes messages to the standard error is added
+        /// to trace listeners <see cref="Trace.Listeners"/> this is only done once per process.</param>
+        internal TraceLogger(string prefix, bool addConsoleListener)
+            : base(prefix)
+        {
+            _addConsoleListener = addConsoleListener;
+            if (addConsoleListener && !System.Diagnostics.Trace.Listeners.Contains(_consoleListener))
+            {
+                System.Diagnostics.Trace.Listeners.Add(_consoleListener);
+            }
         }
 
         protected override void Write(string message)

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -171,7 +171,7 @@ namespace ZeroC.Ice
                 FilterLogMessages(initLogMessages, messageTypes, traceCategories, messageMax);
             }
 
-            logForwarder.Queue("init", _logger, prx => prx.InitAsync(_logger.GetPrefix(), initLogMessages.ToArray()));
+            logForwarder.Queue("init", _logger, prx => prx.InitAsync(_logger.Prefix, initLogMessages.ToArray()));
         }
 
         public bool DetachRemoteLogger(IRemoteLoggerPrx? remoteLogger, Current current)
@@ -216,15 +216,13 @@ namespace ZeroC.Ice
                 }
             }
 
-            string prefix = _logger.GetPrefix();
-
             if (logMessages.Count > 0)
             {
                 var messageTypes = new HashSet<LogMessageType>(types);
                 var traceCategories = new HashSet<string>(categories);
                 FilterLogMessages(logMessages, messageTypes, traceCategories, messageMax);
             }
-            return (logMessages.ToArray(), prefix);
+            return (logMessages.ToArray(), _logger.Prefix);
         }
 
         internal LoggerAdmin(Communicator communicator, LoggerAdminLogger logger)

--- a/csharp/src/Ice/LoggerAdminLogger.cs
+++ b/csharp/src/Ice/LoggerAdminLogger.cs
@@ -3,15 +3,16 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
 
 namespace ZeroC.Ice
 {
     internal sealed class LoggerAdminLogger : ILogger
     {
+        public string Prefix => LocalLogger.Prefix;
+
         internal ILogger LocalLogger { get; }
         private static long Now() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000;
         private readonly Channel<LogMessage> _channel;
@@ -31,8 +32,6 @@ namespace ZeroC.Ice
             LocalLogger.Error(message);
             Log(logMessage);
         }
-
-        public string GetPrefix() => LocalLogger.GetPrefix();
 
         public ILoggerAdmin GetFacet() => _loggerAdmin;
 

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -12,9 +12,9 @@ using Test;
 
 namespace ZeroC.Ice.Test.ACM
 {
-    public class LoggerI : ILogger
+    public class Logger : ILogger
     {
-        public LoggerI(string name, TextWriter output)
+        public Logger(string name, TextWriter output)
         {
             _name = name;
             _output = output;
@@ -101,7 +101,7 @@ namespace ZeroC.Ice.Test.ACM
             }
         }
 
-        public string GetPrefix() => "";
+        public string Prefix => "";
 
         public ILogger CloneWithPrefix(string prefix) => this;
 
@@ -129,7 +129,7 @@ namespace ZeroC.Ice.Test.ACM
             _name = name;
             _com = com;
             _output = helper.GetWriter();
-            _logger = new LoggerI(_name, _output);
+            _logger = new Logger(_name, _output);
             _helper = helper;
 
             _clientACMTimeout = -1;
@@ -259,7 +259,7 @@ namespace ZeroC.Ice.Test.ACM
         private readonly string _name;
         private readonly IRemoteCommunicatorPrx _com;
         private string? _msg;
-        private readonly LoggerI _logger;
+        private readonly Logger _logger;
         private readonly TestHelper _helper;
         private readonly TextWriter _output;
         private Thread? _thread;

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -108,7 +108,7 @@ namespace ZeroC.Ice.Test.Admin
             {
             }
 
-            public string GetPrefix() => "NullLogger";
+            public string Prefix => "";
 
             public ILogger CloneWithPrefix(string prefix) => this;
         }


### PR DESCRIPTION
This small PR cleanup logger classes

* Replace GetPrefix method by Prefix property
* Rework locks, the console logger use an static global lock, and the file logger use a instance lock
* Added doc comments to public logger classes, sort fields, ...