### PR TITLE
Unify Connection.State and ConnectionState definitions

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -102,6 +102,21 @@ namespace ZeroC.Ice
         GracefullyWithWait
     }
 
+    /// <summary>The state of an Ice connection</summary>
+    public enum ConnectionState : byte
+    {
+        /// <summary>The connection is being validated.</summary>
+        Validating = 0,
+        /// <summary>The connection is active and can send and receive messages.</summary>
+        Active,
+        /// <summary>The connection is being gracefully shutdown and waits for the peer to close its end of the
+        /// connection.</summary>
+        Closing,
+        /// <summary>The connection is closed and waits for potential dispatch to be finished before being destroyed
+        /// and detached from the observer.</summary>
+        Closed
+    }
+
     /// <summary>Represents a connection used to send and receive Ice frames.</summary>
     public abstract class Connection
     {
@@ -119,12 +134,12 @@ namespace ZeroC.Ice
             {
                 lock (_mutex)
                 {
-                    if (_monitor == null || _state >= State.Closed)
+                    if (_monitor == null || _state >= ConnectionState.Closed)
                     {
                         return;
                     }
 
-                    if (_state == State.Active)
+                    if (_state == ConnectionState.Active)
                     {
                         _monitor.Remove(this);
                     }
@@ -136,12 +151,13 @@ namespace ZeroC.Ice
                         // Disable the recording of last activity.
                         _acmLastActivity = System.Threading.Timeout.InfiniteTimeSpan;
                     }
-                    else if (_state == State.Active && _acmLastActivity == System.Threading.Timeout.InfiniteTimeSpan)
+                    else if (_state == ConnectionState.Active &&
+                             _acmLastActivity == System.Threading.Timeout.InfiniteTimeSpan)
                     {
                         _acmLastActivity = Time.Elapsed;
                     }
 
-                    if (_state == State.Active)
+                    if (_state == ConnectionState.Active)
                     {
                         _monitor.Add(this);
                     }
@@ -205,7 +221,7 @@ namespace ZeroC.Ice
             {
                 lock (_mutex)
                 {
-                    return _state > State.NotInitialized && _state < State.Closing;
+                    return _state > ConnectionState.Validating && _state < ConnectionState.Closing;
                 }
             }
         }
@@ -234,19 +250,10 @@ namespace ZeroC.Ice
         private readonly Dictionary<int, (TaskCompletionSource<IncomingResponseFrame>, bool)> _requests =
             new Dictionary<int, (TaskCompletionSource<IncomingResponseFrame>, bool)>();
         private Task _sendTask = Task.CompletedTask;
-        private State _state; // The current state.
+        private ConnectionState _state; // The current state.
         private bool _validated = false;
         private readonly bool _warn;
         private readonly bool _warnUdp;
-
-        // Map internal connection states to Ice.Instrumentation.ConnectionState state values.
-        private static readonly ConnectionState[] _connectionStateMap = new ConnectionState[]
-        {
-            ConnectionState.Validating,   // State.NotInitialized
-            ConnectionState.Active,       // State.Active
-            ConnectionState.Closing,      // State.Closing
-            ConnectionState.Closed,       // State.Closed
-        };
 
         private static readonly List<ArraySegment<byte>> _closeConnectionFrameIce1 =
             new List<ArraySegment<byte>> { Ice1Definitions.CloseConnectionFrame };
@@ -337,7 +344,7 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     if (callback != null)
                     {
@@ -368,7 +375,7 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     return;
                 }
@@ -386,7 +393,7 @@ namespace ZeroC.Ice
             {
                 if (_exception != null)
                 {
-                    Debug.Assert(_state >= State.Closing);
+                    Debug.Assert(_state >= ConnectionState.Closing);
                     throw _exception;
                 }
             }
@@ -428,7 +435,7 @@ namespace ZeroC.Ice
             _nextRequestId = 1;
             _frameSizeMax = adapter != null ? adapter.FrameSizeMax : _communicator.FrameSizeMax;
             _dispatchCount = 0;
-            _state = State.NotInitialized;
+            _state = ConnectionState.Validating;
 
             _compressionLevel = _communicator.GetPropertyAsInt("Ice.Compression.Level") ?? 1;
             if (_compressionLevel < 1)
@@ -462,9 +469,9 @@ namespace ZeroC.Ice
                     Task? closingTask = null;
                     lock (_mutex)
                     {
-                        if (_state == State.Active)
+                        if (_state == ConnectionState.Active)
                         {
-                            SetState(State.Closing, exception);
+                            SetState(ConnectionState.Closing, exception);
                             if (_dispatchCount > 0)
                             {
                                 _dispatchTaskCompletionSource = new TaskCompletionSource<bool>();
@@ -477,7 +484,7 @@ namespace ZeroC.Ice
                                 _closeTask = closingTask;
                             }
                         }
-                        else if (_state == State.Closing)
+                        else if (_state == ConnectionState.Closing)
                         {
                             closingTask = _closeTask;
                         }
@@ -500,7 +507,7 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
-                if (_state < State.Active || _state >= State.Closed)
+                if (_state < ConnectionState.Active || _state >= ConnectionState.Closed)
                 {
                     return;
                 }
@@ -512,13 +519,13 @@ namespace ZeroC.Ice
                 //
                 // Note that this doesn't imply that we are sending 4 heartbeats per timeout period because the
                 // monitor() method is still only called every (timeout / 2) period.
-                if (_state == State.Active &&
+                if (_state == ConnectionState.Active &&
                     (acm.Heartbeat == AcmHeartbeat.Always ||
                     (acm.Heartbeat != AcmHeartbeat.Off && now >= (_acmLastActivity + (acm.Timeout / 4)))))
                 {
                     if (acm.Heartbeat != AcmHeartbeat.OnDispatch || _dispatchCount > 0)
                     {
-                        Debug.Assert(_state == State.Active);
+                        Debug.Assert(_state == ConnectionState.Active);
                         if (!Endpoint.IsDatagram)
                         {
                             try
@@ -537,17 +544,18 @@ namespace ZeroC.Ice
                 // TODO: We still rely on the endpoint timeout here, remove and change the override close timeout to
                 // Ice.CloseTimeout (or just rely on ACM timeout)
                 TimeSpan timeout = acm.Timeout;
-                if (_state >= State.Closing)
+                if (_state >= ConnectionState.Closing)
                 {
                     timeout = TimeSpan.FromMilliseconds(
                         _communicator.OverrideCloseTimeout ?? Endpoint.Timeout);
                 }
 
                 // ACM close is always enabled when in the closing state for connection close timeouts.
-                if ((_state >= State.Closing || acm.Close != AcmClose.Off) && now >= _acmLastActivity + timeout)
+                if ((_state >= ConnectionState.Closing || acm.Close != AcmClose.Off) &&
+                    now >= _acmLastActivity + timeout)
                 {
-                    if (_state == State.Closing || acm.Close == AcmClose.OnIdleForceful ||
-                       (acm.Close != AcmClose.OnIdle && (_requests.Count > 0)))
+                    if (_state == ConnectionState.Closing || acm.Close == AcmClose.OnIdleForceful ||
+                        (acm.Close != AcmClose.OnIdle && (_requests.Count > 0)))
                     {
                         // Close the connection if we didn't receive a heartbeat or if read/write didn't update the
                         // ACM activity in the last period.
@@ -585,8 +593,8 @@ namespace ZeroC.Ice
                     throw new RetryException(_exception);
                 }
 
-                Debug.Assert(_state > State.NotInitialized);
-                Debug.Assert(_state < State.Closing);
+                Debug.Assert(_state > ConnectionState.Validating);
+                Debug.Assert(_state < ConnectionState.Closing);
 
                 // Ensure the frame isn't bigger than what we can send with the transport.
                 // TODO: remove?
@@ -781,7 +789,7 @@ namespace ZeroC.Ice
 
                 lock (_mutex)
                 {
-                    if (_state >= State.Closed)
+                    if (_state >= ConnectionState.Closed)
                     {
                         throw _exception!;
                     }
@@ -834,7 +842,7 @@ namespace ZeroC.Ice
                         _validated = true;
                     }
 
-                    SetState(State.Active);
+                    SetState(ConnectionState.Active);
                 }
             }
             catch (OperationCanceledException)
@@ -855,19 +863,13 @@ namespace ZeroC.Ice
             {
                 // The observer is attached once the connection is active and detached when closed and the last
                 // dispatch completed.
-                if (_state < State.Active || (_state == State.Closed && _dispatchCount == 0))
+                if (_state < ConnectionState.Active || (_state == ConnectionState.Closed && _dispatchCount == 0))
                 {
                     return;
                 }
 
-                _observer = _communicator.Observer?.GetConnectionObserver(
-                    this,
-                    _connectionStateMap[(int)_state],
-                    _observer);
-                if (_observer != null)
-                {
-                    _observer.Attach();
-                }
+                _observer = _communicator.Observer?.GetConnectionObserver(this, _state, _observer);
+                _observer?.Attach();
             }
         }
 
@@ -875,9 +877,9 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
-                if (_state < State.Closed)
+                if (_state < ConnectionState.Closed)
                 {
-                    SetState(State.Closed, exception ?? _exception!);
+                    SetState(ConnectionState.Closed, exception ?? _exception!);
                     if (_dispatchCount > 0)
                     {
                         _dispatchTaskCompletionSource ??= new TaskCompletionSource<bool>();
@@ -995,7 +997,7 @@ namespace ZeroC.Ice
                 lock (_mutex)
                 {
                     // Send the response if there's a response
-                    if (_state < State.Closed && response != null)
+                    if (_state < ConnectionState.Closed && response != null)
                     {
                         try
                         {
@@ -1011,7 +1013,7 @@ namespace ZeroC.Ice
                     Debug.Assert(_dispatchCount > 0);
                     if (--_dispatchCount == 0 && _dispatchTaskCompletionSource != null)
                     {
-                        Debug.Assert(_state > State.Active);
+                        Debug.Assert(_state > ConnectionState.Active);
                         _dispatchTaskCompletionSource.SetResult(true);
                     }
                 }
@@ -1027,7 +1029,7 @@ namespace ZeroC.Ice
             ObjectAdapter? adapter = null;
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     throw _exception!;
                 }
@@ -1069,7 +1071,7 @@ namespace ZeroC.Ice
 
                     case Ice1Definitions.FrameType.Request:
                     {
-                        if (_state >= State.Closing)
+                        if (_state >= ConnectionState.Closing)
                         {
                             ProtocolTrace.Trace(
                                 "received request during closing\n(ignored by server, client will retry)",
@@ -1108,7 +1110,7 @@ namespace ZeroC.Ice
 
                     case Ice1Definitions.FrameType.RequestBatch:
                     {
-                        if (_state >= State.Closing)
+                        if (_state >= ConnectionState.Closing)
                         {
                             ProtocolTrace.Trace(
                                 "received batch request during closing\n(ignored by server, client will retry)",
@@ -1212,7 +1214,7 @@ namespace ZeroC.Ice
             ObjectAdapter? adapter = null;
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     throw _exception!;
                 }
@@ -1242,7 +1244,7 @@ namespace ZeroC.Ice
 
                     case Ice2Definitions.FrameType.Request:
                     {
-                        if (_state >= State.Closing)
+                        if (_state >= ConnectionState.Closing)
                         {
                             ProtocolTrace.Trace(
                                 "received request during closing\n(ignored by server, client will retry)",
@@ -1363,7 +1365,7 @@ namespace ZeroC.Ice
                 _communicator.Logger.Error($"unexpected connection exception:\n{ex}\n{Transceiver}");
             }
 
-            if (_state > State.NotInitialized && _communicator.TraceLevels.Network >= 1)
+            if (_state > ConnectionState.Validating && _communicator.TraceLevels.Network >= 1)
             {
                 var s = new StringBuilder();
                 s.Append("closed ");
@@ -1540,7 +1542,7 @@ namespace ZeroC.Ice
 
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     Debug.Assert(_exception != null);
                     throw _exception;
@@ -1585,7 +1587,7 @@ namespace ZeroC.Ice
                     // of data here.
                     lock (_mutex)
                     {
-                        if (_state >= State.Closed)
+                        if (_state >= ConnectionState.Closed)
                         {
                             Debug.Assert(_exception != null);
                             throw _exception;
@@ -1616,7 +1618,7 @@ namespace ZeroC.Ice
             bool compress;
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     throw _exception!;
                 }
@@ -1653,7 +1655,7 @@ namespace ZeroC.Ice
                 offset += bytesSent;
                 lock (_mutex)
                 {
-                    if (_state > State.Closing)
+                    if (_state > ConnectionState.Closing)
                     {
                         return;
                     }
@@ -1744,7 +1746,7 @@ namespace ZeroC.Ice
             Task<ArraySegment<byte>> task;
             lock (_mutex)
             {
-                if (_state == State.Closed)
+                if (_state == ConnectionState.Closed)
                 {
                     throw _exception!;
                 }
@@ -1786,7 +1788,7 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
-                if (_state >= State.Closed)
+                if (_state >= ConnectionState.Closed)
                 {
                     throw _exception!;
                 }
@@ -1829,15 +1831,16 @@ namespace ZeroC.Ice
             }
         }
 
-        private void SetState(State state, Exception? exception = null)
+        private void SetState(ConnectionState state, Exception? exception = null)
         {
             // If SetState() is called with an exception, then only closed and closing states are permissible.
-            Debug.Assert((exception == null && state < State.Closing) || (exception != null && state >= State.Closing));
+            Debug.Assert((exception == null && state < ConnectionState.Closing) ||
+                         (exception != null && state >= ConnectionState.Closing));
 
             if (_exception == null && exception != null)
             {
                 // If we are in closed state, an exception must be set.
-                Debug.Assert(_state != State.Closed);
+                Debug.Assert(_state != ConnectionState.Closed);
 
                 _exception = exception;
 
@@ -1849,7 +1852,7 @@ namespace ZeroC.Ice
                          _exception is ConnectionIdleException ||
                          _exception is CommunicatorDestroyedException ||
                          _exception is ObjectAdapterDeactivatedException ||
-                         (_exception is ConnectionLostException && _state >= State.Closing)))
+                         (_exception is ConnectionLostException && _state >= ConnectionState.Closing)))
                     {
                         _communicator.Logger.Warning($"connection exception:\n{_exception}\n{this}");
                     }
@@ -1859,30 +1862,30 @@ namespace ZeroC.Ice
             Debug.Assert(_state != state); // Don't switch twice.
             switch (state)
             {
-                case State.NotInitialized:
+                case ConnectionState.Validating:
                 {
                     Debug.Assert(false);
                     break;
                 }
 
-                case State.Active:
+                case ConnectionState.Active:
                 {
-                    Debug.Assert(_state == State.NotInitialized);
+                    Debug.Assert(_state == ConnectionState.Validating);
                     // Start the asynchronous operation from the thread pool to prevent eventually reading
                     // synchronously new frames from this thread.
                     _ = Task.Run(ReceiveAndDispatchFrameAsync);
                     break;
                 }
 
-                case State.Closing:
+                case ConnectionState.Closing:
                 {
-                    Debug.Assert(_state == State.Active);
+                    Debug.Assert(_state == ConnectionState.Active);
                     break;
                 }
 
-                case State.Closed:
+                case ConnectionState.Closed:
                 {
-                    Debug.Assert(_state < State.Closed);
+                    Debug.Assert(_state < ConnectionState.Closed);
                     break;
                 }
             }
@@ -1892,7 +1895,7 @@ namespace ZeroC.Ice
             // validation are implemented with a timer instead and setup in the outgoing connection factory.
             if (_monitor != null)
             {
-                if (state == State.Active)
+                if (state == ConnectionState.Active)
                 {
                     if (_acmLastActivity != System.Threading.Timeout.InfiniteTimeSpan)
                     {
@@ -1900,7 +1903,7 @@ namespace ZeroC.Ice
                     }
                     _monitor.Add(this);
                 }
-                else if (state == State.Closed)
+                else if (state == ConnectionState.Closed)
                 {
                     _monitor.Remove(this);
                 }
@@ -1908,23 +1911,21 @@ namespace ZeroC.Ice
 
             if (_communicator.Observer != null)
             {
-                ConnectionState oldState = _connectionStateMap[(int)_state];
-                ConnectionState newState = _connectionStateMap[(int)state];
-                if (oldState != newState)
+                if (_state != state)
                 {
-                    _observer = _communicator.Observer!.GetConnectionObserver(this, newState, _observer);
+                    _observer = _communicator.Observer!.GetConnectionObserver(this, state, _observer);
                     if (_observer != null)
                     {
                         _observer.Attach();
                     }
                 }
-                if (_observer != null && state == State.Closed && _exception != null)
+                if (_observer != null && state == ConnectionState.Closed && _exception != null)
                 {
                     if (!(_exception is ConnectionClosedException ||
                          _exception is ConnectionIdleException ||
                          _exception is CommunicatorDestroyedException ||
                          _exception is ObjectAdapterDeactivatedException ||
-                         (_exception is ConnectionLostException && _state >= State.Closing)))
+                         (_exception is ConnectionLostException && _state >= ConnectionState.Closing)))
                     {
                         _observer.Failed(_exception.GetType().FullName!);
                     }
@@ -1960,14 +1961,6 @@ namespace ZeroC.Ice
                 _observer.SentBytes(length);
             }
         }
-
-        private enum State
-        {
-            NotInitialized,
-            Active,
-            Closing,
-            Closed
-        };
     }
 
     /// <summary>Represents a connection to an IP-endpoint.</summary>

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -112,8 +112,8 @@ namespace ZeroC.Ice
         /// <summary>The connection is being gracefully shutdown and waits for the peer to close its end of the
         /// connection.</summary>
         Closing,
-        /// <summary>The connection is closed and waits for potential dispatch to be finished before being destroyed
-        /// and detached from the observer.</summary>
+        /// <summary>The connection is closed and eventually waits for potential dispatch to be finished before being
+        /// destroyed.</summary>
         Closed
     }
 

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -6,15 +6,6 @@ using System.Collections.Generic;
 
 namespace ZeroC.Ice.Instrumentation
 {
-    /// <summary>The state of a connection</summary>
-    public enum ConnectionState : byte
-    {
-        Validating = 0,
-        Active,
-        Closing,
-        Closed
-    }
-
     public interface IChildInvocationObserver : IObserver
     {
         /// <summary>Reply notification.</summary>


### PR DESCRIPTION
This small PR replaces the internal `Conection.State` usage by the public `ConnectionState` definition