### PR TITLE
Add GetPropertyAsByteSize

### DIFF
--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -66,7 +66,7 @@ namespace ZeroC.Ice
                     }
 
                     // Match an integer followed letters
-                    Match match = Regex.Match(pv.Val, @"^([0-9]+[\.|,]?[0-9]*)([A-Z]+)$");
+                    Match match = Regex.Match(pv.Val, @"^([0-9]+[\.]?[0-9]*)([A-Z]+)$");
 
                     if (!match.Success)
                     {
@@ -94,7 +94,7 @@ namespace ZeroC.Ice
 
                         if (size <= 0)
                         {
-                            throw new FormatException("size properties must be a positive numeric value greater than 0");
+                            throw new FormatException("size must be a positive numeric value greater than 0");
                         }
                         checked
                         {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -464,26 +464,12 @@ namespace ZeroC.Ice
                 ServerAcm = new Acm(this, "Ice.ACM.Server", new Acm(this, "Ice.ACM", Acm.ServerDefault));
 
                 int frameSizeMax = GetPropertyAsByteSize("Ice.MessageSizeMax") ?? 1024 * 1024;
-                if (frameSizeMax < 1 || frameSizeMax > 0x7fffffff / 1024)
-                {
-                    FrameSizeMax = 0x7fffffff;
-                }
-                else
-                {
-                    FrameSizeMax = frameSizeMax;
-                }
+                FrameSizeMax = frameSizeMax == 0 ? int.MaxValue : frameSizeMax;
 
                 // TODO: switch to 0 default
                 AcceptNonSecureConnections = GetPropertyAsBool("Ice.AcceptNonSecureConnections") ?? true;
                 int classGraphDepthMax = GetPropertyAsInt("Ice.ClassGraphDepthMax") ?? 100;
-                if (classGraphDepthMax < 1 || classGraphDepthMax > 0x7fffffff)
-                {
-                    ClassGraphDepthMax = 0x7fffffff;
-                }
-                else
-                {
-                    ClassGraphDepthMax = classGraphDepthMax;
-                }
+                ClassGraphDepthMax = classGraphDepthMax < 1 ? int.MaxValue : classGraphDepthMax;
 
                 ToStringMode = Enum.Parse<ToStringMode>(GetProperty("Ice.ToStringMode") ?? "Unicode");
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -463,31 +463,26 @@ namespace ZeroC.Ice
                 ClientAcm = new Acm(this, "Ice.ACM.Client", new Acm(this, "Ice.ACM", Acm.ClientDefault));
                 ServerAcm = new Acm(this, "Ice.ACM.Server", new Acm(this, "Ice.ACM", Acm.ServerDefault));
 
+                int frameSizeMax = GetPropertyAsByteSize("Ice.MessageSizeMax") ?? 1024 * 1024;
+                if (frameSizeMax < 1 || frameSizeMax > 0x7fffffff / 1024)
                 {
-                    int num = GetPropertyAsInt("Ice.MessageSizeMax") ?? 1024;
-                    if (num < 1 || num > 0x7fffffff / 1024)
-                    {
-                        FrameSizeMax = 0x7fffffff;
-                    }
-                    else
-                    {
-                        FrameSizeMax = num * 1024; // Property is in kilobytes, FrameSizeMax in bytes
-                    }
+                    FrameSizeMax = 0x7fffffff;
+                }
+                else
+                {
+                    FrameSizeMax = frameSizeMax;
                 }
 
                 // TODO: switch to 0 default
                 AcceptNonSecureConnections = GetPropertyAsBool("Ice.AcceptNonSecureConnections") ?? true;
-
+                int classGraphDepthMax = GetPropertyAsInt("Ice.ClassGraphDepthMax") ?? 100;
+                if (classGraphDepthMax < 1 || classGraphDepthMax > 0x7fffffff)
                 {
-                    int num = GetPropertyAsInt("Ice.ClassGraphDepthMax") ?? 100;
-                    if (num < 1 || num > 0x7fffffff)
-                    {
-                        ClassGraphDepthMax = 0x7fffffff;
-                    }
-                    else
-                    {
-                        ClassGraphDepthMax = num;
-                    }
+                    ClassGraphDepthMax = 0x7fffffff;
+                }
+                else
+                {
+                    ClassGraphDepthMax = classGraphDepthMax;
                 }
 
                 ToStringMode = Enum.Parse<ToStringMode>(GetProperty("Ice.ToStringMode") ?? "Unicode");

--- a/csharp/src/Ice/HttpParser.cs
+++ b/csharp/src/Ice/HttpParser.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace ZeroC.Ice
 {
-    public sealed class WebSocketException : System.Exception
+    public sealed class WebSocketException : Exception
     {
         internal WebSocketException()
             : base("", null)

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -712,20 +712,12 @@ namespace ZeroC.Ice
             return false;
         }
 
-        public static void
-        SetTcpBufSize(Socket socket, Communicator communicator)
+        public static void SetTcpBufSize(Socket socket, Communicator communicator)
         {
-            //
-            // By default, on Windows we use a 128KB buffer size. On Unix
-            // platforms, we use the system defaults.
-            //
-            int dfltBufSize = 0;
-            if (AssemblyUtil.IsWindows)
-            {
-                dfltBufSize = 128 * 1024;
-            }
-            int rcvSize = communicator.GetPropertyAsInt("Ice.TCP.RcvSize") ?? dfltBufSize;
-            int sndSize = communicator.GetPropertyAsInt("Ice.TCP.SndSize") ?? dfltBufSize;
+            // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
+            int dfltBufSize = AssemblyUtil.IsWindows ? 128 * 1024 : 0;
+            int rcvSize = communicator.GetPropertyAsByteSize("Ice.TCP.RcvSize") ?? dfltBufSize;
+            int sndSize = communicator.GetPropertyAsByteSize("Ice.TCP.SndSize") ?? dfltBufSize;
             SetTcpBufSize(socket, rcvSize, sndSize, communicator);
         }
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -786,18 +786,8 @@ namespace ZeroC.Ice
             _reference = Reference.Parse($"dummy {proxyOptions}", Communicator);
 
             _acm = new Acm(Communicator, $"{Name}.ACM", Communicator.ServerAcm);
-            {
-                int defaultFrameSizeMax = Communicator.FrameSizeMax;
-                int num = Communicator.GetPropertyAsByteSize($"{Name}.MessageSizeMax") ?? defaultFrameSizeMax;
-                if (num < 1 || num > 0x7fffffff / 1024)
-                {
-                    FrameSizeMax = 0x7fffffff;
-                }
-                else
-                {
-                    FrameSizeMax = num;
-                }
-            }
+            int frameSizeMax = Communicator.GetPropertyAsByteSize($"{Name}.MessageSizeMax") ?? Communicator.FrameSizeMax;
+            FrameSizeMax = frameSizeMax == 0 ? int.MaxValue : frameSizeMax;
 
             try
             {

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -787,15 +787,15 @@ namespace ZeroC.Ice
 
             _acm = new Acm(Communicator, $"{Name}.ACM", Communicator.ServerAcm);
             {
-                int defaultFrameSizeMax = Communicator.FrameSizeMax / 1024;
-                int num = Communicator.GetPropertyAsInt($"{Name}.MessageSizeMax") ?? defaultFrameSizeMax;
+                int defaultFrameSizeMax = Communicator.FrameSizeMax;
+                int num = Communicator.GetPropertyAsByteSize($"{Name}.MessageSizeMax") ?? defaultFrameSizeMax;
                 if (num < 1 || num > 0x7fffffff / 1024)
                 {
                     FrameSizeMax = 0x7fffffff;
                 }
                 else
                 {
-                    FrameSizeMax = num * 1024; // Property is in kilobytes, FrameSizeMax in bytes
+                    FrameSizeMax = num;
                 }
             }
 

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -693,7 +693,7 @@ namespace ZeroC.Ice
                 SetBufSize(-1, -1);
                 Network.SetBlock(_fd, false);
             }
-            catch (System.Exception)
+            catch
             {
                 if (_readEventArgs != null)
                 {
@@ -742,7 +742,7 @@ namespace ZeroC.Ice
                 //
                 if (sizeRequested == -1)
                 {
-                    sizeRequested = _communicator.GetPropertyAsInt(prop) ?? dfltSize;
+                    sizeRequested = _communicator.GetPropertyAsByteSize(prop) ?? dfltSize;
                 }
                 //
                 // Check for sanity.

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -9,7 +9,6 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace ZeroC.Ice

--- a/csharp/test/Ice/ami/Client.cs
+++ b/csharp/test/Ice/ami/Client.cs
@@ -15,11 +15,9 @@ namespace ZeroC.Ice.Test.AMI
             properties["Ice.Warn.AMICallback"] = "0";
             properties["Ice.Warn.Connections"] = "0";
 
-            //
-            // Limit the send buffer size, this test relies on the socket
-            // send() blocking after sending a given amount of data.
-            //
-            properties["Ice.TCP.SndSize"] = "50000";
+            // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
+            // of data.
+            properties["Ice.TCP.SndSize"] = "50MB";
             await using Communicator communicator = Initialize(properties);
             AllTests.allTests(this, false);
         }

--- a/csharp/test/Ice/ami/Client.cs
+++ b/csharp/test/Ice/ami/Client.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.AMI
 
             // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
             // of data.
-            properties["Ice.TCP.SndSize"] = "50MB";
+            properties["Ice.TCP.SndSize"] = "50KB";
             await using Communicator communicator = Initialize(properties);
             AllTests.allTests(this, false);
         }

--- a/csharp/test/Ice/ami/Client.cs
+++ b/csharp/test/Ice/ami/Client.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.AMI
 
             // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
             // of data.
-            properties["Ice.TCP.SndSize"] = "50KB";
+            properties["Ice.TCP.SndSize"] = "50K";
             await using Communicator communicator = Initialize(properties);
             AllTests.allTests(this, false);
         }

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the send buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.SndSize"] = "50KB";
+            properties["Ice.TCP.SndSize"] = "50K";
 
             await using Communicator communicator = Initialize(properties);
 

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the send buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.SndSize"] = "50MB";
+            properties["Ice.TCP.SndSize"] = "50KB";
 
             await using Communicator communicator = Initialize(properties);
 

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the send buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.SndSize"] = "50000";
+            properties["Ice.TCP.SndSize"] = "50MB";
 
             await using Communicator communicator = Initialize(properties);
 

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the recv buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.RcvSize"] = "50000";
+            properties["Ice.TCP.RcvSize"] = "50MB";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the recv buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.RcvSize"] = "50MB";
+            properties["Ice.TCP.RcvSize"] = "50KB";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.AMI
             // Limit the recv buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //
-            properties["Ice.TCP.RcvSize"] = "50KB";
+            properties["Ice.TCP.RcvSize"] = "50K";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/dictMapping/Client.cs
+++ b/csharp/test/Ice/dictMapping/Client.cs
@@ -9,16 +9,15 @@ namespace ZeroC.Ice.Test.DictMapping
 {
     public class Client : TestHelper
     {
-        public override Task RunAsync(string[] args)
+        public override async Task RunAsync(string[] args)
         {
-            using Communicator communicator = Initialize(ref args);
+            await using Communicator communicator = Initialize(ref args);
             System.IO.TextWriter output = GetWriter();
             IMyClassPrx myClass = AllTests.allTests(this, false);
             output.Write("shutting down server... ");
             output.Flush();
             myClass.shutdown();
             output.WriteLine("ok");
-            return Task.CompletedTask;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/exceptions/Client.cs
+++ b/csharp/test/Ice/exceptions/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Exceptions
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10"; // 10KB max
+            properties["Ice.MessageSizeMax"] = "10KB";
             using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             IThrowerPrx thrower = AllTests.allTests(this);

--- a/csharp/test/Ice/exceptions/Client.cs
+++ b/csharp/test/Ice/exceptions/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Exceptions
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10KB";
+            properties["Ice.MessageSizeMax"] = "10K";
             using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             IThrowerPrx thrower = AllTests.allTests(this);

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "10"; // 10KB max
+            properties["Ice.MessageSizeMax"] = "10KB";
             using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "10KB";
+            properties["Ice.MessageSizeMax"] = "10K";
             using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/exceptions/Server.cs
+++ b/csharp/test/Ice/exceptions/Server.cs
@@ -15,13 +15,13 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10"; // 10KB max
+            properties["Ice.MessageSizeMax"] = "10KB";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-            communicator.SetProperty("TestAdapter2.MessageSizeMax", "0");
+            communicator.SetProperty("TestAdapter2.MessageSizeMax", "unlimited");
             communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
-            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1");
+            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1KB");
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");

--- a/csharp/test/Ice/exceptions/Server.cs
+++ b/csharp/test/Ice/exceptions/Server.cs
@@ -15,13 +15,13 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10KB";
+            properties["Ice.MessageSizeMax"] = "10K";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-            communicator.SetProperty("TestAdapter2.MessageSizeMax", "unlimited");
+            communicator.SetProperty("TestAdapter2.MessageSizeMax", "0");
             communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
-            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1KB");
+            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1K");
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -15,13 +15,13 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10"; // 10KB max
+            properties["Ice.MessageSizeMax"] = "10KB";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-            communicator.SetProperty("TestAdapter2.MessageSizeMax", "0");
+            communicator.SetProperty("TestAdapter2.MessageSizeMax", "unlimited");
             communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
-            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1");
+            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1KB");
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -15,13 +15,13 @@ namespace ZeroC.Ice.Test.Exceptions
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.MessageSizeMax"] = "10KB";
+            properties["Ice.MessageSizeMax"] = "10K";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-            communicator.SetProperty("TestAdapter2.MessageSizeMax", "unlimited");
+            communicator.SetProperty("TestAdapter2.MessageSizeMax", "0");
             communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
-            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1KB");
+            communicator.SetProperty("TestAdapter3.MessageSizeMax", "1K");
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50MB";
+            properties["Ice.MessageSizeMax"] = "50KB";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50KB";
+            properties["Ice.MessageSizeMax"] = "50M";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50000";
+            properties["Ice.MessageSizeMax"] = "50MB";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50MB";
+            properties["Ice.MessageSizeMax"] = "50KB";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50KB";
+            properties["Ice.MessageSizeMax"] = "50M";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.MessageSizeMax"] = "50000";
+            properties["Ice.MessageSizeMax"] = "50MB";
             properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);

--- a/csharp/test/Ice/perf/Client.cs
+++ b/csharp/test/Ice/perf/Client.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Perf
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            AllTests.allTests(this).shutdown();
+            await AllTests.allTests(this).shutdownAsync();
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -155,6 +155,75 @@ namespace ZeroC.Ice.Test.Properties
 
                 Console.Out.WriteLine("ok");
             }
+
+            {
+                Console.Out.Write("testing configuration properties as byte size... ");
+                var sizeProperties = new Dictionary<string, string>
+                {
+                    { "Size.B", "1B" },
+                    { "Size.KB", "1KB" },
+                    { "Size.MB", "1MB" },
+                    { "Size.GB", "1GB" },
+
+                    { "Size.Double.B", "1.0B" },
+                    { "Size.Double.KB", "1.0KB" },
+                    { "Size.Double.MB", "1.0MB" },
+                    { "Size.Double.GB", "1.0GB" },
+
+                    { "Size.Unlimited", "unlimited" },
+
+                    { "Size.Bad.Word", "x"},
+                    { "Size.Bad.Negative", "-1B"},
+                    { "Size.Bad.Zero", "0B"},
+                    { "Size.Bad.InvalidUnit", "1b"},
+                    { "Size.Bad.NotANumber", "NaN"},
+                };
+
+                await using var communicator = new Communicator(sizeProperties);
+
+                {
+                    int? size = communicator.GetPropertyAsByteSize("Size.B");
+                    Assert(size == 1);
+
+                    size = communicator.GetPropertyAsByteSize("Size.KB");
+                    Assert(size == 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.MB");
+                    Assert(size == 1024 * 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.GB");
+                    Assert(size == 1024 * 1024 * 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Double.B");
+                    Assert(size == 1);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Double.KB");
+                    Assert(size == 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Double.MB");
+                    Assert(size == 1024 * 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Double.GB");
+                    Assert(size == 1024 * 1024 * 1024);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Unlimited");
+                    Assert(size == 0);
+                }
+
+                foreach (string property in communicator.GetProperties("Size.Bad").Keys)
+                {
+                    try
+                    {
+                        _ = communicator.GetPropertyAsTimeSpan(property);
+                        Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+                }
+
+                Console.Out.WriteLine("ok");
+            }
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -160,54 +160,62 @@ namespace ZeroC.Ice.Test.Properties
                 Console.Out.Write("testing configuration properties as byte size... ");
                 var sizeProperties = new Dictionary<string, string>
                 {
-                    { "Size.B", "1B" },
-                    { "Size.KB", "1KB" },
-                    { "Size.MB", "1MB" },
-                    { "Size.GB", "1GB" },
+                    { "Size", "1" },
+                    { "Size.K", "1K" },
+                    { "Size.M", "1M" },
+                    { "Size.G", "1G" },
 
-                    { "Size.Double.B", "1.0B" },
-                    { "Size.Double.KB", "1.0KB" },
-                    { "Size.Double.MB", "1.0MB" },
-                    { "Size.Double.GB", "1.0GB" },
+                    { "Size.Zero", "0" },
+                    { "Size.Zero.K", "0K" },
+                    { "Size.Zero.M", "0M" },
+                    { "Size.Zero.G", "0G" },
 
-                    { "Size.Unlimited", "unlimited" },
+                    { "Size.MaxValue.K", $"{int.MaxValue}K" },
+                    { "Size.MaxValue.M", $"{int.MaxValue}M" },
+                    { "Size.MaxValue.G", $"{int.MaxValue}G" },
 
                     { "Size.Bad.Word", "x"},
                     { "Size.Bad.Negative", "-1B"},
-                    { "Size.Bad.Zero", "0B"},
                     { "Size.Bad.InvalidUnit", "1b"},
                     { "Size.Bad.NotANumber", "NaN"},
+                    { "Size.Bad.Double.B", "1.0" },
                 };
 
                 await using var communicator = new Communicator(sizeProperties);
 
                 {
-                    int? size = communicator.GetPropertyAsByteSize("Size.B");
+                    int? size = communicator.GetPropertyAsByteSize("Size");
                     Assert(size == 1);
 
-                    size = communicator.GetPropertyAsByteSize("Size.KB");
+                    size = communicator.GetPropertyAsByteSize("Size.K");
                     Assert(size == 1024);
 
-                    size = communicator.GetPropertyAsByteSize("Size.MB");
+                    size = communicator.GetPropertyAsByteSize("Size.M");
                     Assert(size == 1024 * 1024);
 
-                    size = communicator.GetPropertyAsByteSize("Size.GB");
+                    size = communicator.GetPropertyAsByteSize("Size.G");
                     Assert(size == 1024 * 1024 * 1024);
 
-                    size = communicator.GetPropertyAsByteSize("Size.Double.B");
-                    Assert(size == 1);
-
-                    size = communicator.GetPropertyAsByteSize("Size.Double.KB");
-                    Assert(size == 1024);
-
-                    size = communicator.GetPropertyAsByteSize("Size.Double.MB");
-                    Assert(size == 1024 * 1024);
-
-                    size = communicator.GetPropertyAsByteSize("Size.Double.GB");
-                    Assert(size == 1024 * 1024 * 1024);
-
-                    size = communicator.GetPropertyAsByteSize("Size.Unlimited");
+                    size = communicator.GetPropertyAsByteSize("Size.Zero");
                     Assert(size == 0);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Zero.K");
+                    Assert(size == 0);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Zero.M");
+                    Assert(size == 0);
+
+                    size = communicator.GetPropertyAsByteSize("Size.Zero.G");
+                    Assert(size == 0);
+
+                    size = communicator.GetPropertyAsByteSize("Size.MaxValue.K");
+                    Assert(size == int.MaxValue);
+
+                    size = communicator.GetPropertyAsByteSize("Size.MaxValue.M");
+                    Assert(size == int.MaxValue);
+
+                    size = communicator.GetPropertyAsByteSize("Size.MaxValue.G");
+                    Assert(size == int.MaxValue);
                 }
 
                 foreach (string property in communicator.GetProperties("Size.Bad").Keys)

--- a/csharp/test/Ice/timeout/Client.cs
+++ b/csharp/test/Ice/timeout/Client.cs
@@ -21,7 +21,7 @@ namespace ZeroC.Ice.Test.Timeout
 
             // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
             // of data.
-            properties["Ice.TCP.SndSize"] = "50KB";
+            properties["Ice.TCP.SndSize"] = "50K";
             await using Communicator communicator = Initialize(properties);
             AllTests.allTests(this);
         }

--- a/csharp/test/Ice/timeout/Client.cs
+++ b/csharp/test/Ice/timeout/Client.cs
@@ -21,7 +21,7 @@ namespace ZeroC.Ice.Test.Timeout
 
             // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
             // of data.
-            properties["Ice.TCP.SndSize"] = "50000";
+            properties["Ice.TCP.SndSize"] = "50KB";
             await using Communicator communicator = Initialize(properties);
             AllTests.allTests(this);
         }

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -17,11 +17,11 @@ namespace ZeroC.Ice.Test.Timeout
             properties["Ice.Warn.Connections"] = "0";
 
             // The client sends large messages to cause the transport buffers to fill up.
-            properties["Ice.MessageSizeMax"] = "20000";
+            properties["Ice.MessageSizeMax"] = "20MB";
 
             // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given
             // amount of data.
-            properties["Ice.TCP.RcvSize"] = "50000";
+            properties["Ice.TCP.RcvSize"] = "50MB";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -21,7 +21,7 @@ namespace ZeroC.Ice.Test.Timeout
 
             // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given
             // amount of data.
-            properties["Ice.TCP.RcvSize"] = "50MB";
+            properties["Ice.TCP.RcvSize"] = "50KB";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -17,11 +17,11 @@ namespace ZeroC.Ice.Test.Timeout
             properties["Ice.Warn.Connections"] = "0";
 
             // The client sends large messages to cause the transport buffers to fill up.
-            properties["Ice.MessageSizeMax"] = "20MB";
+            properties["Ice.MessageSizeMax"] = "20M";
 
             // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given
             // amount of data.
-            properties["Ice.TCP.RcvSize"] = "50KB";
+            properties["Ice.TCP.RcvSize"] = "50K";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -129,7 +129,7 @@ namespace ZeroC.Ice.Test.UDP
                     TestHelper.Assert(seq.Length > 16384);
                 }
                 obj.GetConnection()!.Close(ConnectionClose.GracefullyWithWait);
-                communicator.SetProperty("Ice.UDP.SndSize", "64000");
+                communicator.SetProperty("Ice.UDP.SndSize", "64KB");
                 seq = new byte[50000];
                 try
                 {

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -129,7 +129,7 @@ namespace ZeroC.Ice.Test.UDP
                     TestHelper.Assert(seq.Length > 16384);
                 }
                 obj.GetConnection()!.Close(ConnectionClose.GracefullyWithWait);
-                communicator.SetProperty("Ice.UDP.SndSize", "64KB");
+                communicator.SetProperty("Ice.UDP.SndSize", "64K");
                 seq = new byte[50000];
                 try
                 {

--- a/csharp/test/Ice/udp/Client.cs
+++ b/csharp/test/Ice/udp/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.UDP.SndSize"] = "16384";
+            properties["Ice.UDP.SndSize"] = "16KB";
             await using var communicator = Initialize(properties);
             AllTests.allTests(this);
 

--- a/csharp/test/Ice/udp/Client.cs
+++ b/csharp/test/Ice/udp/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.UDP.SndSize"] = "16KB";
+            properties["Ice.UDP.SndSize"] = "16K";
             await using var communicator = Initialize(properties);
             AllTests.allTests(this);
 

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.UDP.RcvSize"] = "16384";
+            properties["Ice.UDP.RcvSize"] = "16KB";
 
             string? value;
             int ipv6;

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.UDP.RcvSize"] = "16KB";
+            properties["Ice.UDP.RcvSize"] = "16K";
 
             string? value;
             int ipv6;


### PR DESCRIPTION
This PR adds GetPropertyAsByteSize method that allows to convert the value of a property to byte size accepted size units are B, KB, MB, GB