### PR TITLE
Update C# analyzers and fix new warnings in sources

### DIFF
--- a/csharp/msbuild/ice.common.props
+++ b/csharp/msbuild/ice.common.props
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0-beta2.final" PrivateAssets="All"/>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     </ItemGroup>

--- a/csharp/src/Glacier2/SessionFactoryHelper.cs
+++ b/csharp/src/Glacier2/SessionFactoryHelper.cs
@@ -178,11 +178,11 @@ namespace ZeroC.Glacier2
 
         private readonly ISessionCallback _callback;
         private IReadOnlyDictionary<string, string>? _context;
-        private Identity? _identity = null;
+        private Identity? _identity;
         private readonly ILogger? _logger;
         private readonly object _mutex = new object();
         private readonly ICommunicatorObserver? _observer;
-        private int _port = 0;
+        private int _port;
         private readonly Dictionary<string, string> _properties;
         private string _routerHost = "localhost";
         private readonly TlsClientOptions? _tlsClientOptions;

--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -55,8 +55,8 @@ namespace ZeroC.Glacier2
         private readonly ISessionCallback _callback;
         private string? _category;
         private Communicator? _communicator;
-        private bool _connected = false;
-        private bool _destroy = false;
+        private bool _connected;
+        private bool _destroy;
         private readonly string _finderStr;
         private readonly ILogger? _logger;
         private readonly object _mutex = new object();

--- a/csharp/src/Ice/BitSequence.cs
+++ b/csharp/src/Ice/BitSequence.cs
@@ -88,7 +88,7 @@ namespace ZeroC.Ice
             var sb = new StringBuilder();
             foreach (byte b in Span)
             {
-                sb.Append(Convert.ToString(b, 2).PadLeft(8, '0')).Append(" ");
+                sb.Append(Convert.ToString(b, 2).PadLeft(8, '0')).Append(' ');
             }
             return sb.ToString();
         }

--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -533,7 +533,7 @@ namespace ZeroC.Ice
             {
                 if (arg.StartsWith(prefix, StringComparison.Ordinal))
                 {
-                    (string name, string value) = ParseLine((arg.IndexOf('=') == -1 ? $"{arg}=1" : arg).Substring(2));
+                    (string name, string value) = ParseLine((arg.Contains('=') ? arg : $"{arg}=1").Substring(2));
                     if (name.Length > 0)
                     {
                         parsedArgs[name] = value;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -177,7 +177,7 @@ namespace ZeroC.Ice
         private readonly HashSet<string> _adapterNamesInUse = new HashSet<string>();
         private readonly List<ObjectAdapter> _adapters = new List<ObjectAdapter>();
         private ObjectAdapter? _adminAdapter;
-        private readonly bool _adminEnabled = false;
+        private readonly bool _adminEnabled;
         private readonly HashSet<string> _adminFacetFilter = new HashSet<string>();
         private readonly Dictionary<string, IObject> _adminFacets = new Dictionary<string, IObject>();
         private Identity? _adminIdentity;
@@ -199,8 +199,8 @@ namespace ZeroC.Ice
         private readonly ConcurrentDictionary<(Identity, Encoding), LocatorTable> _locatorTableMap =
             new ConcurrentDictionary<(Identity, Encoding), LocatorTable>();
         private readonly object _mutex = new object();
-        private static bool _oneOffDone = false;
-        private static bool _printProcessIdDone = false;
+        private static bool _oneOffDone;
+        private static bool _printProcessIdDone;
         private readonly ConcurrentDictionary<string, IRemoteExceptionFactory?> _remoteExceptionFactoryCache =
             new ConcurrentDictionary<string, IRemoteExceptionFactory?>();
         private readonly ConcurrentDictionary<IRouterPrx, RouterInfo> _routerInfoTable =

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -156,7 +156,7 @@ namespace ZeroC.Ice
         private TimeSpan _acmLastActivity;
         private ObjectAdapter? _adapter;
         private EventHandler? _closed;
-        private Task? _closeTask = null;
+        private Task? _closeTask;
         private readonly Communicator _communicator;
         private readonly int _compressionLevel;
         private readonly IConnector? _connector;
@@ -174,7 +174,7 @@ namespace ZeroC.Ice
             new Dictionary<int, (TaskCompletionSource<IncomingResponseFrame>, bool)>();
         private Task _sendTask = Task.CompletedTask;
         private ConnectionState _state; // The current state.
-        private bool _validated = false;
+        private bool _validated;
         private readonly bool _warn;
         private readonly bool _warnUdp;
 
@@ -696,7 +696,7 @@ namespace ZeroC.Ice
                         {
                             s.Append("starting to ");
                             s.Append(_connector != null ? "send" : "receive");
-                            s.Append(" ");
+                            s.Append(' ');
                             s.Append(Endpoint.TransportName);
                             s.Append(" datagrams\n");
                             s.Append(Transceiver.ToDetailedString());
@@ -704,7 +704,7 @@ namespace ZeroC.Ice
                         else
                         {
                             s.Append(_connector != null ? "established" : "accepted");
-                            s.Append(" ");
+                            s.Append(' ');
                             s.Append(Endpoint.TransportName);
                             s.Append(" connection\n");
                             s.Append(ToString());
@@ -1255,7 +1255,7 @@ namespace ZeroC.Ice
                       _exception is ConnectionIdleException ||
                       _exception is ObjectDisposedException))
                 {
-                    s.Append("\n");
+                    s.Append('\n');
                     s.Append(_exception);
                 }
 

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -29,7 +29,7 @@ namespace ZeroC.Ice
             new MultiDictionary<(IConnector, string), Connection>();
         private readonly MultiDictionary<(Endpoint, string), Connection> _connectionsByEndpoint =
             new MultiDictionary<(Endpoint, string), Connection>();
-        private Task? _disposeTask = null;
+        private Task? _disposeTask;
         private readonly object _mutex = new object();
         private readonly Dictionary<(IConnector, string), Task<Connection>> _pending =
             new Dictionary<(IConnector, string), Task<Connection>>();
@@ -456,7 +456,7 @@ namespace ZeroC.Ice
         private readonly ObjectAdapter _adapter;
         private readonly Communicator _communicator;
         private readonly HashSet<Connection> _connections = new HashSet<Connection>();
-        private Task? _disposeTask = null;
+        private Task? _disposeTask;
         private readonly Endpoint _endpoint;
         private readonly object _mutex = new object();
         private readonly Endpoint? _publishedEndpoint;

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -331,12 +331,12 @@ namespace ZeroC.Ice
             {
                 if (sb.Length > 0)
                 {
-                    sb.Append(" ");
+                    sb.Append(' ');
                 }
                 sb.Append(option);
                 if (argument != null)
                 {
-                    sb.Append(" ");
+                    sb.Append(' ');
                     sb.Append(argument);
                 }
             }

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -178,12 +178,12 @@ namespace ZeroC.Ice
                     bool addQuote = Host.IndexOf(':') != -1;
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                     sb.Append(Host);
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                 }
 
@@ -197,12 +197,12 @@ namespace ZeroC.Ice
                     sb.Append(" --sourceAddress ");
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                     sb.Append(sourceAddr);
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                 }
             }

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -51,7 +51,7 @@ namespace ZeroC.Ice
             {
                 output.Append("\nremote address: ").Append(remoteEndpoint);
             }
-            output.Append("\n");
+            output.Append('\n');
             output.Append(ex.ToString());
             current.Adapter.Communicator.Logger.Warning(output.ToString());
         }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -181,7 +181,7 @@ namespace ZeroC.Ice
         private InstanceData _current;
 
         // The current depth when reading nested class/exception instances.
-        private int _classGraphDepth = 0;
+        private int _classGraphDepth;
 
         // Map of class instance ID to class instance.
         // When reading a top-level encapsulation:
@@ -193,13 +193,13 @@ namespace ZeroC.Ice
 
         // The sum of all the minimum sizes (in bytes) of the sequences read in this buffer. Must not exceed the buffer
         // size.
-        private int _minTotalSeqSize = 0;
+        private int _minTotalSeqSize;
 
         // The 0-based index in the buffer.
         private int _pos;
 
         // See ReadTypeId11.
-        private int _posAfterLatestInsertedTypeId11 = 0;
+        private int _posAfterLatestInsertedTypeId11;
 
         // Map of type ID index to type ID sequence, used only for classes.
         // We assign a type ID index (starting with 1) to each type ID (type ID sequence) we read, in order.
@@ -1380,7 +1380,7 @@ namespace ZeroC.Ice
         {
             if (withBitSequence)
             {
-                var bitSequence = ReadBitSequence(size);
+                ReadOnlyBitSequence bitSequence = ReadBitSequence(size);
                 for (int i = 0; i < size; ++i)
                 {
                     TKey key = keyReader(this);
@@ -1409,7 +1409,7 @@ namespace ZeroC.Ice
             where TKey : notnull
             where TValue : struct
         {
-            var bitSequence = ReadBitSequence(size);
+            ReadOnlyBitSequence bitSequence = ReadBitSequence(size);
             for (int i = 0; i < size; ++i)
             {
                 TKey key = keyReader(this);
@@ -1632,9 +1632,9 @@ namespace ZeroC.Ice
             object? IEnumerator.Current => Current;
             public bool IsReadOnly => true;
             protected readonly InputStream InputStream;
-            protected int Pos = 0;
+            protected int Pos;
             private T _current;
-            private bool _enumeratorRetrieved = false;
+            private bool _enumeratorRetrieved;
 
             public IEnumerator<T> GetEnumerator()
             {

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -225,7 +225,7 @@ namespace ZeroC.Ice
 
                     if (_connection.ConnectionId.Length > 0)
                     {
-                        os.Append(" [").Append(_connection.ConnectionId).Append("]");
+                        os.Append(" [").Append(_connection.ConnectionId).Append(']');
                     }
                     _id = os.ToString();
                 }
@@ -250,10 +250,7 @@ namespace ZeroC.Ice
         {
             internal AttributeResolverI()
             {
-                Add("parent", obj =>
-                    {
-                        return (obj as ConnectionHelper)?._connection?.Adapter?.Name ?? "Communicator";
-                    });
+                Add("parent", obj => (obj as ConnectionHelper)?._connection?.Adapter?.Name ?? "Communicator");
                 Add("id", obj => (obj as ConnectionHelper)?.Id);
                 Add("state", obj => (obj as ConnectionHelper)?._state.ToString().ToLowerInvariant());
                 Add("incoming", obj => (obj as ConnectionHelper)?._connection.IsIncoming);

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -271,7 +271,9 @@ namespace ZeroC.Ice
                 try
                 {
                     // TODO: Fix FindAdapterById to return non-null proxy
-                    IObjectPrx? proxy = await Locator.FindAdapterByIdAsync(reference.AdapterId).ConfigureAwait(false);
+                    IObjectPrx? proxy = await Locator.FindAdapterByIdAsync(
+                        reference.AdapterId,
+                        cancel: CancellationToken.None).ConfigureAwait(false);
                     if (proxy != null && !proxy.IceReference.IsIndirect)
                     {
                         // Cache the adapter endpoints.
@@ -347,7 +349,9 @@ namespace ZeroC.Ice
                 try
                 {
                     // TODO: Fix FindObjectById to return non-null proxy
-                    IObjectPrx? proxy = await Locator.FindObjectByIdAsync(reference.Identity).ConfigureAwait(false);
+                    IObjectPrx? proxy = await Locator.FindObjectByIdAsync(
+                        reference.Identity,
+                        cancel: CancellationToken.None).ConfigureAwait(false);
                     if (proxy != null && !proxy.IceReference.IsWellKnown)
                     {
                         // Cache the object reference.
@@ -412,10 +416,10 @@ namespace ZeroC.Ice
             Debug.Assert(r.IsWellKnown);
             var s = new System.Text.StringBuilder();
             s.Append(msg);
-            s.Append("\n");
+            s.Append('\n');
             s.Append("well-known proxy = ");
             s.Append(r.ToString());
-            s.Append("\n");
+            s.Append('\n');
             s.Append("adapter = ");
             s.Append(resolved.AdapterId);
             r.Communicator.Logger.Trace(r.Communicator.TraceLevels.LocationCategory, s.ToString());

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -96,18 +96,18 @@ namespace ZeroC.Ice
     {
         internal int TraceLevel { get; }
         internal const string TraceCategory = "Admin.Logger";
-        private bool _destroyed = false;
-        private int _logCount = 0; // non-trace messages
+        private bool _destroyed;
+        private int _logCount; // non-trace messages
         private readonly LoggerAdminLogger _logger;
         private readonly int _maxLogCount;
         private readonly int _maxTraceCount;
         private readonly object _mutex = new object();
-        private LinkedListNode<LogMessage>? _oldestTrace = null;
-        private LinkedListNode<LogMessage>? _oldestLog = null;
+        private LinkedListNode<LogMessage>? _oldestTrace;
+        private LinkedListNode<LogMessage>? _oldestLog;
         private readonly LinkedList<LogMessage> _queue = new LinkedList<LogMessage>();
         private readonly Dictionary<Identity, LogForwarder> _logForwarderMap = new Dictionary<Identity, LogForwarder>();
-        private Communicator? _sendLogCommunicator = null;
-        private int _traceCount = 0;
+        private Communicator? _sendLogCommunicator;
+        private int _traceCount;
 
         public void AttachRemoteLogger(
             IRemoteLoggerPrx? prx,

--- a/csharp/src/Ice/MetricsObserver.cs
+++ b/csharp/src/Ice/MetricsObserver.cs
@@ -56,7 +56,7 @@ namespace ZeroC.IceMX
         public delegate void MetricsUpdate(T m);
 
         private List<MetricsMap<T>.Entry>? _entries;
-        private long _previousDelay = 0;
+        private long _previousDelay;
 
         public virtual void Attach() => Start();
 

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -72,14 +72,10 @@ namespace ZeroC.Ice
 
         public static bool RecvTruncated(SocketException ex) => SocketErrorCode(ex) == SocketError.MessageSize;
 
-        public static bool Timeout(System.IO.IOException ex)
-        {
-            //
+        public static bool Timeout(System.IO.IOException ex) =>
             // TODO: Instead of testing for an English substring, we need to examine the inner
             // exception (if there is one).
-            //
-            return ex.Message.IndexOf("period of time", StringComparison.Ordinal) >= 0;
-        }
+            ex.Message.Contains("period of time");
 
         public static bool IsMulticast(IPEndPoint addr)
         {

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice
             option switch
             {
                 "transport" => ((short)Transport).ToString(CultureInfo.InvariantCulture),
-                "value" => Value.Length > 0 ? Convert.ToBase64String(Value.Span) : null,
+                "value" => Value.IsEmpty ? null : Convert.ToBase64String(Value.Span),
                 "value-encoding" => ValueEncoding.ToString(),
                 _ => null,
             };
@@ -42,7 +42,7 @@ namespace ZeroC.Ice
 
         internal Encoding ValueEncoding { get; }
 
-        private int _hashCode = 0; // 0 is a special value that means not initialized.
+        private int _hashCode; // 0 is a special value that means not initialized.
 
         public override bool Equals(Endpoint? other)
         {
@@ -106,7 +106,7 @@ namespace ZeroC.Ice
 
             sb.Append(" -e ");
             sb.Append(ValueEncoding.ToString());
-            if (Value.Length > 0)
+            if (!Value.IsEmpty)
             {
                 sb.Append(" -v ");
                 sb.Append(Convert.ToBase64String(Value.Span));

--- a/csharp/src/Ice/Options.cs
+++ b/csharp/src/Ice/Options.cs
@@ -274,7 +274,7 @@ namespace ZeroC.Ice
                                             case 'x':
                                                 {
                                                     const string hexDigits = "0123456789abcdefABCDEF";
-                                                    if (i < l.Length - 1 && hexDigits.IndexOf(l[i + 1]) == -1)
+                                                    if (i < l.Length - 1 && !hexDigits.Contains(l[i + 1]))
                                                     {
                                                         arg += '\\';
                                                         arg += 'x';

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1329,7 +1329,7 @@ namespace ZeroC.Ice
                 if (elementSize > 1)
                 {
                     // This size is redundant and optimized out by the encoding when elementSize is 1.
-                    WriteSize(v.Length == 0 ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
+                    WriteSize(v.IsEmpty ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
                 }
                 WriteSequence(v);
             }
@@ -1660,7 +1660,7 @@ namespace ZeroC.Ice
 
                     // 0 is a placeholder for the size.
                     WriteEncapsulationHeader(0, payloadEncoding, sizeLength);
-                    var previousEncoding = Encoding;
+                    Encoding previousEncoding = Encoding;
                     Encoding = payloadEncoding;
                     if (endpoint.Protocol == Protocol.Ice1)
                     {

--- a/csharp/src/Ice/RFC2253.cs
+++ b/csharp/src/Ice/RFC2253.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice
         internal class RDNEntry
         {
             internal List<RDNPair> Rdn = new List<RDNPair>();
-            internal bool Negate = false;
+            internal bool Negate;
         }
 
         internal static List<RDNEntry> Parse(string data)
@@ -388,7 +388,7 @@ namespace ZeroC.Ice
                     {
                         result.Append(ParsePair(data, ref pos));
                     }
-                    else if (Special.IndexOf(data[pos]) == -1 && data[pos] != '"')
+                    else if (!Special.Contains(data[pos]) && data[pos] != '"')
                     {
                         result.Append(data[pos]);
                         ++pos;

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -41,7 +41,7 @@ namespace ZeroC.Ice
         internal Protocol Protocol { get; }
         internal RouterInfo? RouterInfo { get; }
         private readonly Connection? _fixedConnection;
-        private int _hashCode = 0;
+        private int _hashCode;
         private volatile IRequestHandler? _requestHandler; // readonly when IsFixed is true
 
         public static bool operator ==(Reference? lhs, Reference? rhs)
@@ -322,7 +322,7 @@ namespace ZeroC.Ice
                 {
                     foreach (Endpoint e in Endpoints)
                     {
-                        sb.Append(":");
+                        sb.Append(':');
                         sb.Append(e);
                     }
                 }

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice
         /// it into an Ice.UnhandledException. When false, Ice marshals this remote exception as-is. true is the
         /// default for exceptions unmarshaled by Ice, while false is the default for exceptions that did not originate
         /// in a remote server.</summary>
-        public bool ConvertToUnhandled { get; set; } = false;
+        public bool ConvertToUnhandled { get; set; }
 
         /// <summary>When DefaultMessage is not null and the application does construct the exception with a constructor
         /// that takes a message parameter, Message returns DefaultMessage. This property should be overridden in
@@ -29,12 +29,12 @@ namespace ZeroC.Ice
         protected SlicedData? IceSlicedData { get; set; }
         internal SlicedData? SlicedData => IceSlicedData;
 
-        private readonly bool _hasCustomMessage = false;
+        private readonly bool _hasCustomMessage;
 
         /// <summary>Constructs a remote exception with the provided message.</summary>
         /// <param name="message">Message that describes the exception.</param>
         protected internal RemoteException(string? message)
-            : base(message) => _hasCustomMessage = (message != null);
+            : base(message) => _hasCustomMessage = message != null;
 
         /// <summary>Constructs a remote exception with the default system message.</summary>
         protected RemoteException()
@@ -45,7 +45,7 @@ namespace ZeroC.Ice
         /// <param name="message">Message that describes the exception.</param>
         /// <param name="innerException">The inner exception.</param>
         protected RemoteException(string? message, Exception? innerException)
-            : base(message, innerException) => _hasCustomMessage = (message != null);
+            : base(message, innerException) => _hasCustomMessage = message != null;
 
         /// <summary>Initializes a new instance of the remote exception with serialized data.</summary>
         /// <param name="info">Holds the serialized object data about the exception being thrown.</param>

--- a/csharp/src/Ice/Runtime.cs
+++ b/csharp/src/Ice/Runtime.cs
@@ -33,6 +33,6 @@ namespace ZeroC.Ice
         /// <returns>The Ice version.</returns>
         public const string StringVersion = "4.0.0-alpha.0"; // "A.B.C", with A=major, B=minor, C=patch
 
-        private static volatile ILogger? _processLogger = null;
+        private static volatile ILogger? _processLogger;
     }
 }

--- a/csharp/src/Ice/SslEngine.cs
+++ b/csharp/src/Ice/SslEngine.cs
@@ -193,15 +193,15 @@ namespace ZeroC.Ice
             s.Append("SSL connection summary");
             if (description.Length > 0)
             {
-                s.Append("\n").Append(description);
+                s.Append('\n').Append(description);
             }
             s.Append("\nauthenticated = ").Append(stream.IsAuthenticated ? "yes" : "no");
             s.Append("\nencrypted = ").Append(stream.IsEncrypted ? "yes" : "no");
             s.Append("\nsigned = ").Append(stream.IsSigned ? "yes" : "no");
             s.Append("\nmutually authenticated = ").Append(stream.IsMutuallyAuthenticated ? "yes" : "no");
-            s.Append("\nhash algorithm = ").Append(stream.HashAlgorithm).Append("/").Append(stream.HashStrength);
-            s.Append("\ncipher algorithm = ").Append(stream.CipherAlgorithm).Append("/").Append(stream.CipherStrength);
-            s.Append("\nkey exchange algorithm = ").Append(stream.KeyExchangeAlgorithm).Append("/").Append(
+            s.Append("\nhash algorithm = ").Append(stream.HashAlgorithm).Append('/').Append(stream.HashStrength);
+            s.Append("\ncipher algorithm = ").Append(stream.CipherAlgorithm).Append('/').Append(stream.CipherStrength);
+            s.Append("\nkey exchange algorithm = ").Append(stream.KeyExchangeAlgorithm).Append('/').Append(
                 stream.KeyExchangeStrength);
             s.Append("\nprotocol = ").Append(stream.SslProtocol);
             _logger.Trace(SecurityTraceCategory, s.ToString());

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -49,7 +49,7 @@ namespace ZeroC.Ice
             for (int i = start; i < len; i++)
             {
                 char ch = str[i];
-                if (match.IndexOf(ch) == -1)
+                if (!match.Contains(ch))
                 {
                     return i;
                 }
@@ -487,7 +487,7 @@ namespace ZeroC.Ice
                         }
                     default:
                         {
-                            if (string.IsNullOrEmpty(special) || special.IndexOf(c) == -1)
+                            if (string.IsNullOrEmpty(special) || !special.Contains(c))
                             {
                                 result.Append('\\'); // not in special, so we keep the backslash
                             }

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -13,13 +13,13 @@ namespace ZeroC.Ice
     /// <summary>The Endpoint class for the TCP transport.</summary>
     internal class TcpEndpoint : IPEndpoint
     {
-        public override bool HasCompressionFlag { get; } = false;
+        public override bool HasCompressionFlag { get; }
         public override bool IsDatagram => false;
         public override bool IsSecure => Transport == Transport.SSL;
         public override TimeSpan Timeout { get; } = DefaultTimeout;
         public override Transport Transport { get; }
 
-        private int _hashCode = 0;
+        private int _hashCode;
 
         public override bool Equals(Endpoint? other)
         {

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -35,7 +35,7 @@ namespace ZeroC.Ice
         internal int McastTtl { get; } = -1;
 
         private readonly bool _connect;
-        private int _hashCode = 0;
+        private int _hashCode;
 
         public override bool Equals(Endpoint? other)
         {
@@ -89,12 +89,12 @@ namespace ZeroC.Ice
                 sb.Append(" --interface ");
                 if (addQuote)
                 {
-                    sb.Append("\"");
+                    sb.Append('"');
                 }
                 sb.Append(McastInterface);
                 if (addQuote)
                 {
-                    sb.Append("\"");
+                    sb.Append('"');
                 }
             }
 

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice
 {
     internal sealed class UdpTransceiver : ITransceiver
     {
-        internal System.Net.IPEndPoint? McastAddress { get; private set; } = null;
+        internal System.Net.IPEndPoint? McastAddress { get; private set; }
 
         public Connection CreateConnection(
             IConnectionManager manager,
@@ -830,11 +830,11 @@ namespace ZeroC.Ice
         private readonly Socket _fd;
         private System.Net.EndPoint _addr;
         private readonly System.Net.IPEndPoint? _sourceAddr;
-        private System.Net.EndPoint? _peerAddr = null;
-        private readonly string? _mcastInterface = null;
+        private System.Net.EndPoint? _peerAddr;
+        private readonly string? _mcastInterface;
 
-        private readonly int _port = 0;
-        private bool _bound = false;
+        private readonly int _port;
+        private bool _bound;
 
         private SocketAsyncEventArgs? _writeEventArgs;
         private readonly SocketAsyncEventArgs _readEventArgs;

--- a/csharp/src/Ice/UniversalEndpoint.cs
+++ b/csharp/src/Ice/UniversalEndpoint.cs
@@ -37,7 +37,7 @@ namespace ZeroC.Ice
 
         internal const ushort DefaultUniversalPort = 0;
 
-        private int _hashCode = 0; // 0 is a special value that means not initialized.
+        private int _hashCode; // 0 is a special value that means not initialized.
 
         private readonly IReadOnlyList<string> _options = Array.Empty<string>();
 

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -69,12 +69,12 @@ namespace ZeroC.Ice
                     bool addQuote = _resource.IndexOf(':') != -1;
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                     sb.Append(_resource);
                     if (addQuote)
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                 }
                 else

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -758,7 +758,7 @@ namespace ZeroC.Ice
             {
                 throw new WebSocketException("missing value for Connection field");
             }
-            else if (value.IndexOf("upgrade") == -1)
+            else if (!value.Contains("upgrade"))
             {
                 throw new WebSocketException($"invalid value `{value}' for Connection field");
             }
@@ -912,7 +912,7 @@ namespace ZeroC.Ice
             {
                 throw new WebSocketException("missing value for Connection field");
             }
-            else if (value.IndexOf("upgrade") == -1)
+            else if (!value.Contains("upgrade"))
             {
                 throw new WebSocketException($"invalid value `{value}' for Connection field");
             }

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -16,17 +16,17 @@ namespace ZeroC.IceBox
 {
     public sealed class ServiceManager : IServiceManager
     {
-        private readonly bool _adminEnabled = false;
-        private readonly HashSet<string>? _adminFacetFilter = null;
+        private readonly bool _adminEnabled;
+        private readonly HashSet<string>? _adminFacetFilter;
         private readonly string[] _argv; // Filtered server argument vector
         private readonly Communicator _communicator;
         private readonly ILogger _logger;
         private readonly object _mutex = new object();
         private readonly HashSet<IServiceObserverPrx> _observers = new HashSet<IServiceObserverPrx>();
-        private bool _pendingStatusChanges = false;
+        private bool _pendingStatusChanges;
         private readonly List<ServiceInfo> _services = new List<ServiceInfo>();
-        private Communicator? _sharedCommunicator = null;
-        private readonly int _traceServiceObserver = 0;
+        private Communicator? _sharedCommunicator;
+        private readonly int _traceServiceObserver;
 
         public ServiceManager(Communicator communicator, string[] args)
         {


### PR DESCRIPTION
This small PR updates C# analyzers version and fix the new reported warnings

CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string.
CA1805: Member '_hashCode' is explicitly initialized to its default value.
CA2016: Forward the CancellationToken parameter to methods that take one
CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability	
CA1836: Prefer 'IsEmpty' over 'Count' to determine whether the object contains or not any items.
