### PR TITLE
Added binary connection support to split the support for ice1/ice2

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -186,7 +186,7 @@ namespace ZeroC.Ice
 
                     if (requestId != 0)
                     {
-                        outgoingResponseFrame = new OutgoingResponseFrame(current, actualEx);
+                        outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -73,16 +73,6 @@ namespace ZeroC.Ice
                     _monitor = value == _manager.AcmMonitor.Acm ?
                         _manager.AcmMonitor : new ConnectionAcmMonitor(value, _communicator.Logger);
 
-                    if (_monitor.Acm.IsDisabled)
-                    {
-                        // Disable the recording of last activity.
-                        _acmLastActivity = Timeout.InfiniteTimeSpan;
-                    }
-                    else if (_state == ConnectionState.Active && _acmLastActivity == Timeout.InfiniteTimeSpan)
-                    {
-                        _acmLastActivity = Time.Elapsed;
-                    }
-
                     if (_state == ConnectionState.Active)
                     {
                         _monitor.Add(this);
@@ -149,46 +139,26 @@ namespace ZeroC.Ice
             }
         }
 
-        protected ITransceiver Transceiver { get; }
-
-        private bool OldProtocol => Endpoint.Protocol == Protocol.Ice1;
+        protected IBinaryConnection BinaryConnection { get; }
 
         private TimeSpan _acmLastActivity;
         private ObjectAdapter? _adapter;
         private EventHandler? _closed;
         private Task? _closeTask;
         private readonly Communicator _communicator;
-        private readonly int _compressionLevel;
         private readonly IConnector? _connector;
         private int _dispatchCount;
         private TaskCompletionSource<bool>? _dispatchTaskCompletionSource;
         private Exception? _exception;
         private readonly IConnectionManager _manager;
-        private readonly int _frameSizeMax;
         private IAcmMonitor _monitor;
         private readonly object _mutex = new object();
-        private int _nextRequestId;
         private IConnectionObserver? _observer;
-        private Task _receiveTask = Task.CompletedTask;
         private readonly Dictionary<int, (TaskCompletionSource<IncomingResponseFrame>, bool)> _requests =
             new Dictionary<int, (TaskCompletionSource<IncomingResponseFrame>, bool)>();
-        private Task _sendTask = Task.CompletedTask;
         private ConnectionState _state; // The current state.
         private bool _validated;
         private readonly bool _warn;
-        private readonly bool _warnUdp;
-
-        private static readonly List<ArraySegment<byte>> _closeConnectionFrameIce1 =
-            new List<ArraySegment<byte>> { Ice1Definitions.CloseConnectionFrame };
-
-        private static readonly List<ArraySegment<byte>> _closeConnectionFrameIce2 =
-            new List<ArraySegment<byte>> { Ice2Definitions.CloseConnectionFrame };
-
-        private static readonly List<ArraySegment<byte>> _validateConnectionFrameIce1 =
-            new List<ArraySegment<byte>> { Ice1Definitions.ValidateConnectionFrame };
-
-        private static readonly List<ArraySegment<byte>> _validateConnectionFrameIce2 =
-            new List<ArraySegment<byte>> { Ice2Definitions.ValidateConnectionFrame };
 
         /// <summary>Manually closes the connection using the specified closure mode.</summary>
         /// <param name="mode">Determines how the connection will be closed.</param>
@@ -253,9 +223,7 @@ namespace ZeroC.Ice
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         public async ValueTask HeartbeatAsync(IProgress<bool>? progress = null, CancellationToken cancel = default)
         {
-            await SendFrameAsync(() => GetProtocolFrameData(OldProtocol ? _validateConnectionFrameIce1 :
-                                                            _validateConnectionFrameIce2),
-                                 cancel).ConfigureAwait(false);
+            await BinaryConnection.HeartbeatAsync(cancel).ConfigureAwait(false);
             progress?.Report(true);
         }
 
@@ -301,12 +269,12 @@ namespace ZeroC.Ice
         /// <summary>Returns a description of the connection as human readable text, suitable for logging or error
         /// messages.</summary>
         /// <returns>The description of the connection as human readable text.</returns>
-        public override string ToString() => Transceiver.ToString()!;
+        public override string ToString() => BinaryConnection.ToString()!;
 
         internal Connection(
             IConnectionManager manager,
             Endpoint endpoint,
-            ITransceiver transceiver,
+            IBinaryConnection connection,
             IConnector? connector,
             string connectionId,
             ObjectAdapter? adapter)
@@ -314,29 +282,15 @@ namespace ZeroC.Ice
             _communicator = endpoint.Communicator;
             _manager = manager;
             _monitor = manager.AcmMonitor;
-            Transceiver = transceiver;
+            BinaryConnection = connection;
             _connector = connector;
             ConnectionId = connectionId;
             Endpoint = endpoint;
             Endpoints = new List<Endpoint>() { endpoint };
             _adapter = adapter;
             _warn = _communicator.GetPropertyAsBool("Ice.Warn.Connections") ?? false;
-            _warnUdp = _communicator.GetPropertyAsBool("Ice.Warn.Datagrams") ?? false;
-            _acmLastActivity = _monitor.Acm.IsDisabled ? Timeout.InfiniteTimeSpan : Time.Elapsed;
-            _nextRequestId = 1;
-            _frameSizeMax = adapter != null ? adapter.FrameSizeMax : _communicator.FrameSizeMax;
             _dispatchCount = 0;
             _state = ConnectionState.Validating;
-
-            _compressionLevel = _communicator.GetPropertyAsInt("Ice.Compression.Level") ?? 1;
-            if (_compressionLevel < 1)
-            {
-                _compressionLevel = 1;
-            }
-            else if (_compressionLevel > 9)
-            {
-                _compressionLevel = 9;
-            }
         }
 
         internal void ClearAdapter(ObjectAdapter adapter)
@@ -419,15 +373,7 @@ namespace ZeroC.Ice
                         Debug.Assert(_state == ConnectionState.Active);
                         if (!Endpoint.IsDatagram)
                         {
-                            try
-                            {
-                                SendFrameAsync(() => GetProtocolFrameData(
-                                    OldProtocol ? _validateConnectionFrameIce1 : _validateConnectionFrameIce2));
-                            }
-                            catch
-                            {
-                                // Ignore
-                            }
+                            ValueTask ignored = BinaryConnection.HeartbeatAsync(default);
                         }
                     }
                 }
@@ -452,7 +398,6 @@ namespace ZeroC.Ice
         internal async ValueTask<IncomingResponseFrame> SendRequestAsync(
             OutgoingRequestFrame request,
             bool oneway,
-            bool compress,
             bool synchronous,
             IInvocationObserver? observer,
             IProgress<bool> progress,
@@ -461,6 +406,7 @@ namespace ZeroC.Ice
             IChildInvocationObserver? childObserver = null;
             Task writeTask;
             Task<IncomingResponseFrame>? responseTask = null;
+            int streamId;
             lock (_mutex)
             {
                 //
@@ -475,58 +421,76 @@ namespace ZeroC.Ice
                 Debug.Assert(_state > ConnectionState.Validating);
                 Debug.Assert(_state < ConnectionState.Closing);
 
+                streamId = BinaryConnection.NewStream(!oneway);
+                if (streamId > 0)
+                {
+                    var responseTaskSource = new TaskCompletionSource<IncomingResponseFrame>();
+                    _requests[streamId] = (responseTaskSource, synchronous);
+                    responseTask = responseTaskSource.Task;
+                }
+
+                if (observer != null)
+                {
+                    childObserver = observer.GetRemoteObserver(this, streamId, request.Size);
+                    childObserver?.Attach();
+                }
+
                 // Ensure the frame isn't bigger than what we can send with the transport.
-                // TODO: remove?
-                if (OldProtocol)
-                {
-                    Transceiver.CheckSendSize(request.Size + Ice1Definitions.HeaderSize + 4);
-                }
-                else
-                {
-                    Transceiver.CheckSendSize(request.Size + Ice2Definitions.HeaderSize + 4);
-                }
-
-                writeTask = SendFrameAsync(() =>
-                {
-                    // This is called with _mutex locked.
-
-                    int requestId = 0;
-                    if (!oneway)
-                    {
-                        //
-                        // Create a new unique request ID.
-                        //
-                        requestId = _nextRequestId++;
-                        if (requestId <= 0)
-                        {
-                            _nextRequestId = 1;
-                            requestId = _nextRequestId++;
-                        }
-
-                        var responseTaskSource = new TaskCompletionSource<IncomingResponseFrame>();
-                        _requests[requestId] = (responseTaskSource, synchronous);
-                        responseTask = responseTaskSource.Task;
-                    }
-
-                    if (observer != null)
-                    {
-                        childObserver = observer.GetRemoteObserver(this, requestId, request.Size);
-                        childObserver?.Attach();
-                    }
-
-                    return GetRequestFrameData(request, requestId, compress);
-                }, cancel);
+                // TODO: XXX: remove?
+                // if (OldProtocol)
+                // {
+                //     Transceiver.CheckSendSize(request.Size + Ice1Definitions.HeaderSize + 4);
+                // }
+                // else
+                // {
+                //     Transceiver.CheckSendSize(request.Size + Ice2Definitions.HeaderSize + 4);
+                // }
+                // TODO: this returns a ValueTask
+                // TODO: fin = oneway isn't correct for ice2
+                writeTask = BinaryConnection.SendAsync(streamId, request, oneway, cancel).AsTask();
             }
 
             try
             {
                 await writeTask.ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (OperationCanceledException ex)
             {
                 childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
                 childObserver?.Detach();
-                throw;
+                lock (_mutex)
+                {
+                    _requests.Remove(streamId);
+                    if (_requests.Count == 0)
+                    {
+                        System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
+                    }
+                    throw;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex is OperationCanceledException || ex is DatagramLimitException)
+                {
+                    // Non fatal exception, remove the request from the request map.
+                    lock (_mutex)
+                    {
+                        _requests.Remove(streamId);
+                        if (_requests.Count == 0)
+                        {
+                            System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
+                        }
+                    }
+                }
+                else
+                {
+                    // If it's a fatal exception, we close the connection and rethrow the connection's exception
+                    _ = CloseAsync(ex);
+                    ex = _exception!;
+                }
+                childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
+                childObserver?.Detach();
+                throw ExceptionUtil.Throw(ex);
             }
 
             // The request is sent
@@ -562,109 +526,17 @@ namespace ZeroC.Ice
             CancellationTokenSource? source = null;
             try
             {
-                CancellationToken timeoutToken;
+                CancellationToken token;
                 TimeSpan timeout = _communicator.ConnectTimeout;
                 if (timeout > TimeSpan.Zero)
                 {
                     source = new CancellationTokenSource();
                     source.CancelAfter(timeout);
-                    timeoutToken = source.Token;
+                    token = source.Token;
                 }
 
                 // Initialize the transport
-                await Transceiver.InitializeAsync(timeoutToken).ConfigureAwait(false);
-
-                ArraySegment<byte> readBuffer = default;
-                if (!Endpoint.IsDatagram) // Datagram connections are always implicitly validated.
-                {
-                    if (OldProtocol)
-                    {
-                        if (_connector == null) // The server side has the active role for connection validation.
-                        {
-                            int offset = 0;
-                            while (offset < _validateConnectionFrameIce1.GetByteCount())
-                            {
-                                offset += await Transceiver.WriteAsync(_validateConnectionFrameIce1,
-                                                                       offset,
-                                                                       timeoutToken).ConfigureAwait(false);
-                            }
-                            Debug.Assert(offset == _validateConnectionFrameIce1.GetByteCount());
-                        }
-                        else // The client side has the passive role for connection validation.
-                        {
-                            readBuffer = new ArraySegment<byte>(new byte[Ice1Definitions.HeaderSize]);
-                            int offset = 0;
-                            while (offset < Ice1Definitions.HeaderSize)
-                            {
-                                offset += await Transceiver.ReadAsync(readBuffer,
-                                                                      offset,
-                                                                      timeoutToken).ConfigureAwait(false);
-                            }
-
-                            Ice1Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-                            var frameType = (Ice1Definitions.FrameType)readBuffer[8];
-                            if (frameType != Ice1Definitions.FrameType.ValidateConnection)
-                            {
-                                throw new InvalidDataException(@$"received ice1 frame with frame type `{frameType
-                                    }' before receiving the validate connection frame");
-                            }
-
-                            int size = InputStream.ReadInt(readBuffer.AsSpan(10, 4));
-                            if (size != Ice1Definitions.HeaderSize)
-                            {
-                                throw new InvalidDataException(
-                                    @$"received an ice1 frame with validate connection type and a size of `{size
-                                    }' bytes");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // TODO: for now ice2 is identical to ice1!
-                        if (_connector == null) // The server side has the active role for connection validation.
-                        {
-                            int offset = 0;
-                            while (offset < _validateConnectionFrameIce2.GetByteCount())
-                            {
-                                offset += await Transceiver.WriteAsync(_validateConnectionFrameIce2,
-                                                                       offset,
-                                                                       timeoutToken).ConfigureAwait(false);
-                            }
-                            Debug.Assert(offset == _validateConnectionFrameIce2.GetByteCount());
-                        }
-                        else // The client side has the passive role for connection validation.
-                        {
-                            readBuffer = new ArraySegment<byte>(new byte[Ice2Definitions.HeaderSize]);
-                            int offset = 0;
-                            while (offset < Ice2Definitions.HeaderSize)
-                            {
-                                offset += await Transceiver.ReadAsync(readBuffer,
-                                                                      offset,
-                                                                      timeoutToken).ConfigureAwait(false);
-                            }
-
-                            Ice2Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-                            var frameType = (Ice2Definitions.FrameType)readBuffer[8];
-                            if (frameType != Ice2Definitions.FrameType.ValidateConnection)
-                            {
-                                throw new InvalidDataException(@$"received ice2 frame with frame type `{frameType
-                                    }' before receiving the validate connection frame");
-                            }
-
-                            // TODO: this is temporary code. With the 2.0 encoding, sizes are always variable-length
-                            // with the length encoded on the first 2 bits of the size. Assuming the size is encoded
-                            // on 4 bytes (like we do below) is not correct.
-                            int size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(),
-                                                                       readBuffer.AsSpan(10, 4));
-                            if (size != Ice2Definitions.HeaderSize)
-                            {
-                                throw new InvalidDataException(
-                                    @$"received an ice2 frame with validate connection type and a size of `{size
-                                    }' bytes");
-                            }
-                        }
-                    }
-                }
+                await BinaryConnection.InitializeAsync(OnHeartbeat, OnSent, OnReceived, token).ConfigureAwait(false);
 
                 lock (_mutex)
                 {
@@ -672,55 +544,6 @@ namespace ZeroC.Ice
                     {
                         throw _exception!;
                     }
-
-                    if (!Endpoint.IsDatagram) // Datagram connections are always implicitly validated.
-                    {
-                        if (_connector == null) // The server side has the active role for connection validation.
-                        {
-                            byte[] frame = OldProtocol ? Ice1Definitions.ValidateConnectionFrame :
-                                Ice2Definitions.ValidateConnectionFrame;
-                            TraceSentAndUpdateObserver(frame.Length);
-                            ProtocolTrace.TraceSend(_communicator, Endpoint.Protocol, frame);
-                        }
-                        else
-                        {
-                            TraceReceivedAndUpdateObserver(readBuffer.Count);
-                            ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                        }
-                    }
-
-                    if (_communicator.TraceLevels.Network >= 1)
-                    {
-                        var s = new StringBuilder();
-                        if (Endpoint.IsDatagram)
-                        {
-                            s.Append("starting to ");
-                            s.Append(_connector != null ? "send" : "receive");
-                            s.Append(' ');
-                            s.Append(Endpoint.TransportName);
-                            s.Append(" datagrams\n");
-                            s.Append(Transceiver.ToDetailedString());
-                        }
-                        else
-                        {
-                            s.Append(_connector != null ? "established" : "accepted");
-                            s.Append(' ');
-                            s.Append(Endpoint.TransportName);
-                            s.Append(" connection\n");
-                            s.Append(ToString());
-                        }
-                        _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory, s.ToString());
-                    }
-
-                    if (_acmLastActivity != Timeout.InfiniteTimeSpan)
-                    {
-                        _acmLastActivity = Time.Elapsed;
-                    }
-                    if (_connector != null)
-                    {
-                        _validated = true;
-                    }
-
                     SetState(ConnectionState.Active);
                 }
             }
@@ -773,58 +596,7 @@ namespace ZeroC.Ice
             await _closeTask!.ConfigureAwait(false);
         }
 
-        private (List<ArraySegment<byte>>, bool) GetProtocolFrameData(List<ArraySegment<byte>> frame)
-        {
-            // TODO: Review the protocol tracing? We print out the trace when the frame is about to be sent. It would
-            // be simpler to trace the frame before it's queued. This would avoid having these GetXxxData methods.
-            // This would also allow to compress the frame from the user thread.
-            if (_communicator.TraceLevels.Protocol > 0)
-            {
-                ProtocolTrace.TraceSend(_communicator, Endpoint.Protocol, frame[0]);
-            }
-            return (frame, false);
-        }
-
-        private (List<ArraySegment<byte>>, bool) GetRequestFrameData(
-            OutgoingRequestFrame request,
-            int requestId,
-            bool compress)
-        {
-            // TODO: Review the protocol tracing? We print out the trace when the frame is about to be sent. It would
-            // be simpler to trace the frame before it's queued. This would avoid having these GetXxxData methods.
-            // This would also allow to compress the frame from the user thread.
-            List<ArraySegment<byte>> writeBuffer = OldProtocol ?
-                Ice1Definitions.GetRequestData(request, requestId) : Ice2Definitions.GetRequestData(request, requestId);
-
-            if (_communicator.TraceLevels.Protocol >= 1)
-            {
-                ProtocolTrace.TraceFrame(_communicator, writeBuffer[0], request);
-            }
-            return (writeBuffer, compress);
-        }
-
-        private (List<ArraySegment<byte>>, bool) GetResponseFrameData(
-            OutgoingResponseFrame response,
-            int requestId,
-            bool compress)
-        {
-            // TODO: Review the protocol tracing? We print out the trace when the frame is about to be sent. It would
-            // be simpler to trace the frame before it's queued. This would avoid having these GetXxxData methods.
-            // This would also allow to compress the frame from the user thread.
-            List<ArraySegment<byte>> writeBuffer = OldProtocol ? Ice1Definitions.GetResponseData(response, requestId) :
-                Ice2Definitions.GetResponseData(response, requestId);
-            if (_communicator.TraceLevels.Protocol > 0)
-            {
-                ProtocolTrace.TraceFrame(_communicator, writeBuffer[0], response);
-            }
-            return (writeBuffer, compress);
-        }
-
-        private async ValueTask InvokeAsync(
-            IncomingRequestFrame request,
-            Current current,
-            int requestId,
-            byte compressionStatus)
+        private async ValueTask InvokeAsync(IncomingRequestFrame request, Current current, int requestId)
         {
             IDispatchObserver? dispatchObserver = null;
             OutgoingResponseFrame? response = null;
@@ -866,7 +638,7 @@ namespace ZeroC.Ice
                             actualEx = new UnhandledException(current.Identity, current.Facet, current.Operation, ex);
                         }
                         Incoming.ReportException(actualEx, dispatchObserver, current);
-                        response = new OutgoingResponseFrame(current, actualEx);
+                        response = new OutgoingResponseFrame(request, actualEx);
                     }
                 }
 
@@ -882,14 +654,7 @@ namespace ZeroC.Ice
                     // Send the response if there's a response
                     if (_state < ConnectionState.Closed && response != null)
                     {
-                        try
-                        {
-                            SendFrameAsync(() => GetResponseFrameData(response, requestId, compressionStatus > 0));
-                        }
-                        catch
-                        {
-                            // Ignore
-                        }
+                        _ = SendResponse(requestId, response);
                     }
 
                     // Decrease the dispatch count
@@ -903,341 +668,31 @@ namespace ZeroC.Ice
 
                 dispatchObserver?.Detach();
             }
-        }
 
-        private (Func<ValueTask>?, ObjectAdapter?) ParseFrameIce1(ArraySegment<byte> readBuffer)
-        {
-            Debug.Assert(OldProtocol);
-            Func<ValueTask>? incoming = null;
-            ObjectAdapter? adapter = null;
-            lock (_mutex)
+            async Task SendResponse(int requestId, OutgoingResponseFrame response)
             {
-                if (_state >= ConnectionState.Closed)
+                try
                 {
-                    throw _exception!;
+                    // TODO: support for cancellation
+                    await BinaryConnection.SendAsync(requestId, response, fin: true, cancel: default);
                 }
-
-                // The magic and version fields have already been checked.
-                var frameType = (Ice1Definitions.FrameType)readBuffer[8];
-                byte compressionStatus = readBuffer[9];
-                if (compressionStatus == 2)
+                catch (Exception ex)
                 {
-                    if (BZip2.IsLoaded)
-                    {
-                        readBuffer = BZip2.Decompress(readBuffer, Ice1Definitions.HeaderSize, _frameSizeMax);
-                    }
-                    else
-                    {
-                        throw new LoadException("compression not supported, bzip2 library not found");
-                    }
-                }
-
-                switch (frameType)
-                {
-                    case Ice1Definitions.FrameType.CloseConnection:
-                    {
-                        ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                        if (Endpoint.IsDatagram)
-                        {
-                            if (_warn)
-                            {
-                                _communicator.Logger.Warning(
-                                    $"ignoring close connection frame for datagram connection:\n{this}");
-                            }
-                        }
-                        else
-                        {
-                            throw new ConnectionClosedByPeerException();
-                        }
-                        break;
-                    }
-
-                    case Ice1Definitions.FrameType.Request:
-                    {
-                        if (_state >= ConnectionState.Closing)
-                        {
-                            ProtocolTrace.Trace(
-                                "received request during closing\n(ignored by server, client will retry)",
-                                _communicator,
-                                Endpoint.Protocol,
-                                readBuffer);
-                        }
-                        else
-                        {
-                            var request = new IncomingRequestFrame(Endpoint.Protocol,
-                                                                   readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
-                            ProtocolTrace.TraceFrame(_communicator, readBuffer, request);
-                            if (_adapter == null)
-                            {
-                                throw new ObjectNotExistException(request.Identity, request.Facet,
-                                    request.Operation);
-                            }
-                            else
-                            {
-                                adapter = _adapter;
-                                int requestId = InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4));
-                                // TODO: instead of a default cancellation token, we'll have to create a cancellation
-                                // token source here and keep track of them in a dictionnary for each dispatch. When a
-                                // stream is cancelled with ice2, we'll request cancellation on the cached token source.
-                                var current = new Current(_adapter,
-                                                          request,
-                                                          oneway: requestId == 0,
-                                                          cancel: default,
-                                                          this);
-                                incoming = () => InvokeAsync(request, current, requestId, compressionStatus);
-                                ++_dispatchCount;
-                            }
-                        }
-                        break;
-                    }
-
-                    case Ice1Definitions.FrameType.RequestBatch:
-                    {
-                        if (_state >= ConnectionState.Closing)
-                        {
-                            ProtocolTrace.Trace(
-                                "received batch request during closing\n(ignored by server, client will retry)",
-                                _communicator,
-                                Endpoint.Protocol,
-                                readBuffer);
-                        }
-                        else
-                        {
-                            ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                            int invokeNum = InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4));
-                            if (invokeNum < 0)
-                            {
-                                throw new InvalidDataException(
-                                    $"received ice1 RequestBatchMessage with {invokeNum} batch requests");
-                            }
-                            Debug.Assert(false); // TODO: deal with batch requests
-                        }
-                        break;
-                    }
-
-                    case Ice1Definitions.FrameType.Reply:
-                    {
-                        int requestId = InputStream.ReadInt(readBuffer.AsSpan(14, 4));
-                        var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
-                                                                      readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
-                        ProtocolTrace.TraceFrame(_communicator, readBuffer, responseFrame);
-
-                        if (_requests.Remove(requestId,
-                                out (TaskCompletionSource<IncomingResponseFrame> TaskCompletionSource,
-                                     bool Synchronous) request))
-                        {
-                            // We can't call SetResult directly from here as it might be trigger the continuations
-                            // to run synchronously and it wouldn't be safe to run a continuation with the mutex
-                            // locked.
-                            //
-                            if (request.Synchronous)
-                            {
-                                request.TaskCompletionSource.SetResult(responseFrame);
-                            }
-                            else
-                            {
-                                incoming = () =>
-                                {
-                                    request.TaskCompletionSource.SetResult(responseFrame);
-                                    return new ValueTask(Task.CompletedTask);
-                                };
-                            }
-                            if (_requests.Count == 0)
-                            {
-                                System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
-                            }
-                        }
-                        break;
-                    }
-
-                    case Ice1Definitions.FrameType.ValidateConnection:
-                    {
-                        ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                        incoming = () =>
-                        {
-                            try
-                            {
-                                HeartbeatReceived?.Invoke(this, EventArgs.Empty);
-                            }
-                            catch (Exception ex)
-                            {
-                                _communicator.Logger.Error($"connection callback exception:\n{ex}\n{this}");
-                            }
-                            return default;
-                        };
-                        break;
-                    }
-
-                    default:
-                    {
-                        ProtocolTrace.Trace(
-                            "received unknown frame\n(invalid, closing connection)",
-                            _communicator,
-                            Endpoint.Protocol,
-                            readBuffer);
-                        throw new InvalidDataException(
-                            $"received ice1 frame with unknown frame type `{frameType}'");
-                    }
+                    _ = CloseAsync(ex);
                 }
             }
-            return (incoming, adapter);
-        }
-
-        private (Func<ValueTask>?, ObjectAdapter?) ParseFrameIce2(ArraySegment<byte> readBuffer)
-        {
-            // TODO: for now, it's just a slightly simplified version of ParseFrameIce1, with no compression or
-            // batch.
-
-            Debug.Assert(!OldProtocol);
-            Func<ValueTask>? incoming = null;
-            ObjectAdapter? adapter = null;
-            lock (_mutex)
-            {
-                if (_state >= ConnectionState.Closed)
-                {
-                    throw _exception!;
-                }
-
-                // The magic and version fields have already been checked.
-                var frameType = (Ice2Definitions.FrameType)readBuffer[8];
-
-                switch (frameType)
-                {
-                    case Ice2Definitions.FrameType.CloseConnection:
-                    {
-                        ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                        if (Endpoint.IsDatagram)
-                        {
-                            if (_warn)
-                            {
-                                _communicator.Logger.Warning(
-                                    $"ignoring close connection frame for datagram connection:\n{this}");
-                            }
-                        }
-                        else
-                        {
-                            throw new ConnectionClosedByPeerException();
-                        }
-                        break;
-                    }
-
-                    case Ice2Definitions.FrameType.Request:
-                    {
-                        if (_state >= ConnectionState.Closing)
-                        {
-                            ProtocolTrace.Trace(
-                                "received request during closing\n(ignored by server, client will retry)",
-                                _communicator,
-                                Endpoint.Protocol,
-                                readBuffer);
-                        }
-                        else
-                        {
-                            var request = new IncomingRequestFrame(Endpoint.Protocol,
-                                                                   readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
-                            ProtocolTrace.TraceFrame(_communicator, readBuffer, request);
-                            if (_adapter == null)
-                            {
-                                throw new ObjectNotExistException(request.Identity, request.Facet,
-                                    request.Operation);
-                            }
-                            else
-                            {
-                                adapter = _adapter;
-                                int requestId = InputStream.ReadInt(readBuffer.AsSpan(Ice2Definitions.HeaderSize, 4));
-                                // TODO: instead of a default cancellation token, we'll have to create a cancellation
-                                // token source here and keep track of them in a dictionnary for each dispatch. When a
-                                // stream is cancelled with ice2, we'll request cancellation on the cached token source.
-                                var current = new Current(_adapter,
-                                                          request,
-                                                          oneway: requestId == 0,
-                                                          cancel: default,
-                                                          this);
-                                incoming = () => InvokeAsync(request, current, requestId, compressionStatus: 0);
-                                ++_dispatchCount;
-                            }
-                        }
-                        break;
-                    }
-
-                    case Ice2Definitions.FrameType.Reply:
-                    {
-                        int requestId = InputStream.ReadInt(readBuffer.AsSpan(14, 4));
-                        var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
-                                                                      readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
-                        ProtocolTrace.TraceFrame(_communicator, readBuffer, responseFrame);
-
-                        if (_requests.Remove(requestId,
-                                out (TaskCompletionSource<IncomingResponseFrame> TaskCompletionSource,
-                                     bool Synchronous) request))
-                        {
-                            // We can't call SetResult directly from here as it might be trigger the continuations
-                            // to run synchronously and it wouldn't be safe to run a continuation with the mutex
-                            // locked.
-                            //
-                            if (request.Synchronous)
-                            {
-                                request.TaskCompletionSource.SetResult(responseFrame);
-                            }
-                            else
-                            {
-                                incoming = () =>
-                                {
-                                    request.TaskCompletionSource.SetResult(responseFrame);
-                                    return new ValueTask(Task.CompletedTask);
-                                };
-                            }
-                            if (_requests.Count == 0)
-                            {
-                                System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
-                            }
-                        }
-                        break;
-                    }
-
-                    case Ice2Definitions.FrameType.ValidateConnection:
-                    {
-                        ProtocolTrace.TraceReceived(_communicator, Endpoint.Protocol, readBuffer);
-                        incoming = () =>
-                        {
-                            try
-                            {
-                                HeartbeatReceived?.Invoke(this, EventArgs.Empty);
-                            }
-                            catch (Exception ex)
-                            {
-                                _communicator.Logger.Error($"connection callback exception:\n{ex}\n{this}");
-                            }
-                            return default;
-                        };
-                        break;
-                    }
-
-                    default:
-                    {
-                        ProtocolTrace.Trace(
-                            "received unknown frame\n(invalid, closing connection)",
-                            _communicator,
-                            Endpoint.Protocol,
-                            readBuffer);
-                        throw new InvalidDataException(
-                            $"received ice2 frame with unknown frame type `{frameType}'");
-                    }
-                }
-            }
-            return (incoming, adapter);
         }
 
         private async Task PerformCloseAsync()
         {
-            // Close the transceiver, this should cause pending IO async calls to return.
+            // Close the transport
             try
             {
-                Transceiver.ThreadSafeClose();
+                await BinaryConnection.DisposeAsync();
             }
             catch (Exception ex)
             {
-                _communicator.Logger.Error($"unexpected connection exception:\n{ex}\n{Transceiver}");
+                _communicator.Logger.Error($"unexpected connection exception:\n{ex}\n{BinaryConnection}");
             }
 
             if (_state > ConnectionState.Validating && _communicator.TraceLevels.Network >= 1)
@@ -1260,32 +715,6 @@ namespace ZeroC.Ice
                 }
 
                 _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory, s.ToString());
-            }
-
-            // Wait for pending receives and sends to complete
-            try
-            {
-                await _sendTask.ConfigureAwait(false);
-            }
-            catch
-            {
-            }
-            try
-            {
-                await _receiveTask.ConfigureAwait(false);
-            }
-            catch
-            {
-            }
-
-            // Destroy the transport
-            try
-            {
-                Transceiver.Destroy();
-            }
-            catch (Exception ex)
-            {
-                _communicator.Logger.Error($"unexpected connection exception:\n{ex}\n{Transceiver}");
             }
 
             // Yield to ensure the code below is executed from a separate thread pool thread. PerformCloseAsync
@@ -1343,224 +772,9 @@ namespace ZeroC.Ice
                 timeoutToken = source.Token;
             }
 
-            if (!(_exception is ConnectionClosedByPeerException))
-            {
-                // Write and wait for the close connection frame to be written
-                try
-                {
-                    await SendFrameAsync(() => GetProtocolFrameData(
-                        OldProtocol ? _closeConnectionFrameIce1 : _closeConnectionFrameIce2),
-                        timeoutToken).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Ignore
-                }
-            }
-
-            // Notify the transport of the graceful connection closure.
-            try
-            {
-                await Transceiver.ClosingAsync(_exception!, timeoutToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ignore
-            }
-
-            // Wait for the connection closure from the peer
-            try
-            {
-                await _receiveTask.WaitAsync(timeoutToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ignore
-            }
+            await BinaryConnection.CloseAsync(_exception!, timeoutToken);
 
             source?.Dispose();
-        }
-
-        private async ValueTask<ArraySegment<byte>> PerformReceiveFrameAsync()
-        {
-            // Read header
-            ArraySegment<byte> readBuffer;
-            if (Endpoint.IsDatagram)
-            {
-                readBuffer = await Transceiver.ReadAsync().ConfigureAwait(false);
-            }
-            else if (OldProtocol)
-            {
-                readBuffer = new ArraySegment<byte>(new byte[256], 0, Ice1Definitions.HeaderSize);
-                int offset = 0;
-                while (offset < Ice1Definitions.HeaderSize)
-                {
-                    offset += await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                readBuffer = new ArraySegment<byte>(new byte[256], 0, Ice2Definitions.HeaderSize);
-                int offset = 0;
-                while (offset < Ice2Definitions.HeaderSize)
-                {
-                    offset += await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
-                }
-            }
-
-            // Check header
-            int size;
-            if (OldProtocol)
-            {
-                Ice1Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-                size = InputStream.ReadInt(readBuffer.Slice(10, 4));
-                if (size < Ice1Definitions.HeaderSize)
-                {
-                    throw new InvalidDataException($"received ice1 frame with only {size} bytes");
-                }
-            }
-            else
-            {
-                Ice2Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-                size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(), readBuffer.Slice(10, 4));
-                if (size < Ice2Definitions.HeaderSize)
-                {
-                    throw new InvalidDataException($"received ice1 frame with only {size} bytes");
-                }
-            }
-
-            if (size > _frameSizeMax)
-            {
-                throw new InvalidDataException($"frame with {size} bytes exceeds Ice.MessageSizeMax value");
-            }
-
-            lock (_mutex)
-            {
-                if (_state >= ConnectionState.Closed)
-                {
-                    Debug.Assert(_exception != null);
-                    throw _exception;
-                }
-
-                TraceReceivedAndUpdateObserver(readBuffer.Count);
-                if (_acmLastActivity != Timeout.InfiniteTimeSpan)
-                {
-                    _acmLastActivity = Time.Elapsed;
-                }
-
-                // Connection is validated on the first frame. This is only used by setState() to check whether or
-                // not we can print a connection warning (a client might close the connection forcefully if the
-                // connection isn't validated, we don't want to print a warning in this case).
-                _validated = true;
-            }
-
-            // Read the remainder of the frame if needed
-            if (!Endpoint.IsDatagram)
-            {
-                if (size > readBuffer.Array!.Length)
-                {
-                    // Allocate a new array and copy the header over
-                    var buffer = new ArraySegment<byte>(new byte[size], 0, size);
-                    readBuffer.AsSpan().CopyTo(buffer.AsSpan(0,
-                        OldProtocol ? Ice1Definitions.HeaderSize : Ice2Definitions.HeaderSize));
-                    readBuffer = buffer;
-                }
-                else if (size > readBuffer.Count)
-                {
-                    readBuffer = new ArraySegment<byte>(readBuffer.Array!, 0, size);
-                }
-                Debug.Assert(size == readBuffer.Count);
-
-                int offset = OldProtocol ? Ice1Definitions.HeaderSize : Ice2Definitions.HeaderSize;
-                while (offset < readBuffer.Count)
-                {
-                    int bytesReceived = await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
-                    offset += bytesReceived;
-
-                    // Trace the receive progress within the loop as we might be receiving significant amount
-                    // of data here.
-                    lock (_mutex)
-                    {
-                        if (_state >= ConnectionState.Closed)
-                        {
-                            Debug.Assert(_exception != null);
-                            throw _exception;
-                        }
-
-                        TraceReceivedAndUpdateObserver(bytesReceived);
-                        if (_acmLastActivity != Timeout.InfiniteTimeSpan)
-                        {
-                            _acmLastActivity = Time.Elapsed;
-                        }
-                    }
-                }
-            }
-            else if (size > readBuffer.Count)
-            {
-                if (_warnUdp)
-                {
-                    _communicator.Logger.Warning($"maximum datagram size of {readBuffer.Count} exceeded");
-                }
-                return default;
-            }
-            return readBuffer;
-        }
-
-        private async ValueTask PerformSendFrameAsync(Func<(List<ArraySegment<byte>>, bool)> getFrameData)
-        {
-            List<ArraySegment<byte>> writeBuffer;
-            bool compress;
-            lock (_mutex)
-            {
-                if (_state >= ConnectionState.Closed)
-                {
-                    throw _exception!;
-                }
-                (writeBuffer, compress) = getFrameData();
-            }
-
-            // Compress the frame if needed and possible
-            int size = writeBuffer.GetByteCount();
-            if (OldProtocol && BZip2.IsLoaded && compress)
-            {
-                List<ArraySegment<byte>>? compressed = null;
-                if (size >= 100)
-                {
-                    compressed = BZip2.Compress(writeBuffer, size, Ice1Definitions.HeaderSize, _compressionLevel);
-                }
-
-                if (compressed != null)
-                {
-                    writeBuffer = compressed!;
-                    size = writeBuffer.GetByteCount();
-                }
-                else // Message not compressed, request compressed response, if any.
-                {
-                    ArraySegment<byte> header = writeBuffer[0];
-                    header[9] = 1; // Write the compression status
-                }
-            }
-
-            // Write the frame
-            int offset = 0;
-            while (offset < size)
-            {
-                int bytesSent = await Transceiver.WriteAsync(writeBuffer, offset).ConfigureAwait(false);
-                offset += bytesSent;
-                lock (_mutex)
-                {
-                    if (_state >= ConnectionState.Closed)
-                    {
-                        throw _exception!;
-                    }
-
-                    TraceSentAndUpdateObserver(bytesSent);
-                    if (_acmLastActivity != Timeout.InfiniteTimeSpan)
-                    {
-                        _acmLastActivity = Time.Elapsed;
-                    }
-                }
-            }
         }
 
         private async ValueTask ReceiveAndDispatchFrameAsync()
@@ -1569,16 +783,76 @@ namespace ZeroC.Ice
             {
                 while (true)
                 {
-                    ArraySegment<byte> readBuffer = await ReceiveFrameAsync().ConfigureAwait(false);
-                    if (readBuffer.Count == 0)
+                    (int streamId, object? frame, bool fin) =
+                        await BinaryConnection.ReceiveAsync(default).ConfigureAwait(false);
+
+                    Func<ValueTask>? incoming = null;
+                    ObjectAdapter? adapter = null;
+                    lock (_mutex)
                     {
-                        // If received without reading, start another receive. This can occur with datagram transports
-                        // if the datagram was truncated.
-                        continue;
+                        if (frame == null)
+                        {
+                            Debug.Assert(fin);
+                            // TODO: this indicates that the stream was reset.
+                        }
+                        else if (frame is IncomingRequestFrame requestFrame)
+                        {
+                            if (_adapter == null)
+                            {
+                                throw new ObjectNotExistException(requestFrame.Identity,
+                                                                  requestFrame.Facet,
+                                                                  requestFrame.Operation);
+                            }
+                            else
+                            {
+                                adapter = _adapter;
+                                // TODO: if fin != false, we need to keep track of the stream in a dictionnary. The
+                                // cancellation token provided here will have to be a token created for a stream to
+                                // allow cancelling the request if the stream is closed.
+                                var current = new Current(_adapter,
+                                                          requestFrame,
+                                                          oneway: fin,
+                                                          cancel: default,
+                                                          this);
+                                incoming = () => InvokeAsync(requestFrame, current, streamId);
+                                ++_dispatchCount;
+                            }
+                        }
+                        else if (frame is IncomingResponseFrame responseFrame)
+                        {
+                            if (_requests.Remove(streamId,
+                                    out (TaskCompletionSource<IncomingResponseFrame> TaskCompletionSource,
+                                        bool Synchronous) request))
+                            {
+                                // We can't call SetResult directly from here as it might be trigger the continuations
+                                // to run synchronously and it wouldn't be safe to run a continuation with the mutex
+                                // locked.
+                                //
+                                if (request.Synchronous)
+                                {
+                                    request.TaskCompletionSource.SetResult(responseFrame);
+                                }
+                                else
+                                {
+                                    incoming = () =>
+                                    {
+                                        request.TaskCompletionSource.SetResult(responseFrame);
+                                        return new ValueTask(Task.CompletedTask);
+                                    };
+                                }
+                                if (_requests.Count == 0)
+                                {
+                                    System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // TODO: handle data frames for streaming
+                            Debug.Assert(false);
+                        }
                     }
 
-                    (Func<ValueTask>? incoming, ObjectAdapter? adapter) =
-                        OldProtocol ? ParseFrameIce1(readBuffer) : ParseFrameIce2(readBuffer);
                     if (incoming != null)
                     {
                         bool serialize = adapter?.SerializeDispatch ?? false;
@@ -1619,6 +893,10 @@ namespace ZeroC.Ice
                     }
                 }
             }
+            catch (ConnectionClosedByPeerException ex)
+            {
+                await GracefulCloseAsync(ex);
+            }
             catch (Exception ex)
             {
                 await CloseAsync(ex);
@@ -1632,96 +910,6 @@ namespace ZeroC.Ice
 
                 // Now wait for the async dispatch to complete.
                 await task.ConfigureAwait(false);
-            }
-        }
-
-        private async ValueTask<ArraySegment<byte>> ReceiveFrameAsync()
-        {
-            Task<ArraySegment<byte>> task;
-            lock (_mutex)
-            {
-                if (_state == ConnectionState.Closed)
-                {
-                    throw _exception!;
-                }
-                ValueTask<ArraySegment<byte>> readTask = PerformAsync(this);
-                if (readTask.IsCompletedSuccessfully)
-                {
-                    _receiveTask = Task.CompletedTask;
-                    return readTask.Result;
-                }
-                else
-                {
-                    _receiveTask = task = readTask.AsTask();
-                }
-            }
-            return await task.ConfigureAwait(false);
-
-            static async ValueTask<ArraySegment<byte>> PerformAsync(Connection self)
-            {
-                try
-                {
-                    return await self.PerformReceiveFrameAsync().ConfigureAwait(false);
-                }
-                catch (ConnectionClosedByPeerException ex)
-                {
-                    _ = self.GracefulCloseAsync(ex);
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _ = self.CloseAsync(ex);
-                    throw;
-                }
-            }
-        }
-
-        private Task SendFrameAsync(
-            Func<(List<ArraySegment<byte>>, bool)> getFrameData,
-            CancellationToken cancel = default)
-        {
-            lock (_mutex)
-            {
-                if (_state >= ConnectionState.Closed)
-                {
-                    throw _exception!;
-                }
-                cancel.ThrowIfCancellationRequested();
-                ValueTask sendTask = QueueAsync(this, _sendTask, getFrameData, cancel);
-                _sendTask = sendTask.IsCompletedSuccessfully ? Task.CompletedTask : sendTask.AsTask();
-                return _sendTask;
-            }
-
-            static async ValueTask QueueAsync(
-                Connection self,
-                Task previous,
-                Func<(List<ArraySegment<byte>>, bool)> getFrameData,
-                CancellationToken cancel)
-            {
-                // Wait for the previous send to complete
-                try
-                {
-                    await previous.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // If the previous send was canceled, ignore and continue sending.
-                }
-
-                // If the send got cancelled, throw now. This isn't a fatal connection error, the next pending
-                // outgoing will be sent because we ignore the cancelation exception above.
-                cancel.ThrowIfCancellationRequested();
-
-                // Perform the write
-                try
-                {
-                    await self.PerformSendFrameAsync(getFrameData).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _ = self.CloseAsync(ex);
-                    throw;
-                }
             }
         }
 
@@ -1786,21 +974,14 @@ namespace ZeroC.Ice
             // We register with the connection monitor if our new state is State.Active. ACM monitors the connection
             // once it's initialized and validated and until it's closed. Timeouts for connection establishment and
             // validation are implemented with a timer instead and setup in the outgoing connection factory.
-            if (_monitor != null)
+            if (state == ConnectionState.Active)
             {
-                if (state == ConnectionState.Active)
-                {
-                    if (_acmLastActivity != Timeout.InfiniteTimeSpan)
-                    {
-                        _acmLastActivity = Time.Elapsed;
-                    }
-                    _monitor.Add(this);
-                }
-                else if (_state == ConnectionState.Active)
-                {
-                    Debug.Assert(state > ConnectionState.Active);
-                    _monitor.Remove(this);
-                }
+                _monitor.Add(this);
+            }
+            else if (_state == ConnectionState.Active)
+            {
+                Debug.Assert(state > ConnectionState.Active);
+                _monitor.Remove(this);
             }
 
             if (_communicator.Observer != null)
@@ -1827,31 +1008,58 @@ namespace ZeroC.Ice
             _state = state;
         }
 
-        private void TraceReceivedAndUpdateObserver(int length)
+        private void OnHeartbeat()
         {
-            if (_communicator.TraceLevels.Network >= 3 && length > 0)
+            Task.Run(() =>
             {
-                _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory,
-                    $"received {length} bytes via {Endpoint.TransportName}\n{this}");
-            }
+                try
+                {
+                    HeartbeatReceived?.Invoke(this, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    _communicator.Logger.Error($"connection callback exception:\n{ex}\n{this}");
+                }
+            });
+        }
 
-            if (_observer != null && length > 0)
+        private void OnReceived(int length)
+        {
+            lock (_mutex)
             {
-                _observer.ReceivedBytes(length);
+                _acmLastActivity = Time.Elapsed;
+
+                _validated = true;
+
+                if (_communicator.TraceLevels.Network >= 3 && length > 0)
+                {
+                    _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory,
+                        $"received {length} bytes via {Endpoint.TransportName}\n{this}");
+                }
+
+                if (_observer != null && length > 0)
+                {
+                    _observer.ReceivedBytes(length);
+                }
             }
         }
 
-        private void TraceSentAndUpdateObserver(int length)
+        private void OnSent(int length)
         {
-            if (_communicator.TraceLevels.Network >= 3 && length > 0)
+            lock (_mutex)
             {
-                _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory,
-                    $"sent {length} bytes via {Endpoint.TransportName}\n{this}");
-            }
+                _acmLastActivity = Time.Elapsed;
 
-            if (_observer != null && length > 0)
-            {
-                _observer.SentBytes(length);
+                if (_communicator.TraceLevels.Network >= 3 && length > 0)
+                {
+                    _communicator.Logger.Trace(_communicator.TraceLevels.NetworkCategory,
+                        $"sent {length} bytes via {Endpoint.TransportName}\n{this}");
+                }
+
+                if (_observer != null && length > 0)
+                {
+                    _observer.SentBytes(length);
+                }
             }
         }
     }
@@ -1866,7 +1074,7 @@ namespace ZeroC.Ice
             {
                 try
                 {
-                    return Transceiver.Fd()?.LocalEndPoint as System.Net.IPEndPoint;
+                    return BinaryConnection.Transceiver.Fd()?.LocalEndPoint as System.Net.IPEndPoint;
                 }
                 catch
                 {
@@ -1882,7 +1090,7 @@ namespace ZeroC.Ice
             {
                 try
                 {
-                    return Transceiver.Fd()?.RemoteEndPoint as System.Net.IPEndPoint;
+                    return BinaryConnection.Transceiver.Fd()?.RemoteEndPoint as System.Net.IPEndPoint;
                 }
                 catch
                 {
@@ -1894,11 +1102,11 @@ namespace ZeroC.Ice
         protected IPConnection(
             IConnectionManager manager,
             Endpoint endpoint,
-            ITransceiver transceiver,
+            IBinaryConnection connection,
             IConnector? connector,
             string connectionId,
             ObjectAdapter? adapter)
-            : base(manager, endpoint, transceiver, connector, connectionId, adapter)
+            : base(manager, endpoint, connection, connector, connectionId, adapter)
         {
         }
     }
@@ -1934,17 +1142,17 @@ namespace ZeroC.Ice
         /// null if the connection is not secure.</summary>
         public SslProtocols? SslProtocol => SslStream?.SslProtocol;
 
-        private SslStream? SslStream => (Transceiver as SslTransceiver)?.SslStream ??
-            (Transceiver as WSTransceiver)?.SslStream;
+        private SslStream? SslStream => (BinaryConnection.Transceiver as SslTransceiver)?.SslStream ??
+            (BinaryConnection.Transceiver as WSTransceiver)?.SslStream;
 
         protected internal TcpConnection(
             IConnectionManager manager,
             Endpoint endpoint,
-            ITransceiver transceiver,
+            IBinaryConnection connection,
             IConnector? connector,
             string connectionId,
             ObjectAdapter? adapter)
-            : base(manager, endpoint, transceiver, connector, connectionId, adapter)
+            : base(manager, endpoint, connection, connector, connectionId, adapter)
         {
         }
     }
@@ -1953,16 +1161,16 @@ namespace ZeroC.Ice
     public class UdpConnection : IPConnection
     {
         /// <summary>The multicast IP-endpoint for a multicast connection otherwise null.</summary>
-        public System.Net.IPEndPoint? McastEndpoint => (Transceiver as UdpTransceiver)?.McastAddress;
+        public System.Net.IPEndPoint? McastEndpoint => (BinaryConnection.Transceiver as UdpTransceiver)?.McastAddress;
 
         protected internal UdpConnection(
             IConnectionManager manager,
             Endpoint endpoint,
-            ITransceiver transceiver,
+            IBinaryConnection connection,
             IConnector? connector,
             string connectionId,
             ObjectAdapter? adapter)
-            : base(manager, endpoint, transceiver, connector, connectionId, adapter)
+            : base(manager, endpoint, connection, connector, connectionId, adapter)
         {
         }
     }
@@ -1971,16 +1179,16 @@ namespace ZeroC.Ice
     public class WSConnection : TcpConnection
     {
         /// <summary>The HTTP headers in the WebSocket upgrade request.</summary>
-        public IReadOnlyDictionary<string, string> Headers => ((WSTransceiver)Transceiver).Headers;
+        public IReadOnlyDictionary<string, string> Headers => ((WSTransceiver)BinaryConnection.Transceiver).Headers;
 
         protected internal WSConnection(
             IConnectionManager manager,
             Endpoint endpoint,
-            ITransceiver transceiver,
+            IBinaryConnection connection,
             IConnector? connector,
             string connectionId,
             ObjectAdapter? adapter)
-            : base(manager, endpoint, transceiver, connector, connectionId, adapter)
+            : base(manager, endpoint, connection, connector, connectionId, adapter)
         {
         }
     }

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -10,6 +10,8 @@ using ZeroC.Ice.Instrumentation;
 
 namespace ZeroC.Ice
 {
+    // TODO: eliminate this class and change Connection to implement IRequestHandler? Or could it be useful for
+    // upcoming client interceptors?
     internal class ConnectionRequestHandler : IRequestHandler
     {
         public ValueTask<IncomingResponseFrame> SendRequestAsync(
@@ -21,7 +23,6 @@ namespace ZeroC.Ice
             CancellationToken cancel) =>
             _connection.SendRequestAsync(outgoingRequestFrame,
                                          oneway,
-                                         _compress,
                                          synchronous,
                                          observer,
                                          progress,
@@ -29,13 +30,11 @@ namespace ZeroC.Ice
 
         public Connection GetConnection() => _connection;
 
-        public ConnectionRequestHandler(Connection connection, bool compress)
+        public ConnectionRequestHandler(Connection connection)
         {
             _connection = connection;
-            _compress = compress;
         }
 
         private readonly Connection _connection;
-        private readonly bool _compress;
     }
 }

--- a/csharp/src/Ice/ConnectionRequestHandler.cs
+++ b/csharp/src/Ice/ConnectionRequestHandler.cs
@@ -30,10 +30,7 @@ namespace ZeroC.Ice
 
         public Connection GetConnection() => _connection;
 
-        public ConnectionRequestHandler(Connection connection)
-        {
-            _connection = connection;
-        }
+        public ConnectionRequestHandler(Connection connection) => _connection = connection;
 
         private readonly Connection _connection;
     }

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -15,13 +15,15 @@ namespace ZeroC.Ice
         public Connection? Connection { get; }
         // TODO: should this be a IReadOnlyDictionary<string, string>?
         public Dictionary<string, string> Context { get; }
-        public Encoding Encoding { get; }
-        public string Facet { get; }
-        public Identity Identity { get; }
-        public bool IsIdempotent { get; }
+        public Encoding Encoding => Request.Encoding;
+        public string Facet => Request.Facet;
+        public Identity Identity => Request.Identity;
+        public bool IsIdempotent => Request.IsIdempotent;
         public bool IsOneway { get; }
-        public string Operation { get; }
-        public Protocol Protocol { get; }
+        public string Operation => Request.Operation;
+        public Protocol Protocol => Request.Protocol;
+
+        internal IncomingRequestFrame Request { get; }
 
         internal Current(
             ObjectAdapter adapter,
@@ -34,13 +36,8 @@ namespace ZeroC.Ice
             CancellationToken = cancel;
             Connection = connection;
             Context = new Dictionary<string, string>(request.Context);
-            Encoding = request.Encoding;
-            Facet = request.Facet;
-            Identity = request.Identity;
-            IsIdempotent = request.IsIdempotent;
             IsOneway = oneway;
-            Operation = request.Operation;
-            Protocol = request.Protocol;
+            Request = request;
         }
     }
 }

--- a/csharp/src/Ice/Current.cs
+++ b/csharp/src/Ice/Current.cs
@@ -15,19 +15,19 @@ namespace ZeroC.Ice
         public Connection? Connection { get; }
         // TODO: should this be a IReadOnlyDictionary<string, string>?
         public Dictionary<string, string> Context { get; }
-        public Encoding Encoding => Request.Encoding;
-        public string Facet => Request.Facet;
-        public Identity Identity => Request.Identity;
-        public bool IsIdempotent => Request.IsIdempotent;
+        public Encoding Encoding => IncomingRequestFrame.Encoding;
+        public string Facet => IncomingRequestFrame.Facet;
+        public Identity Identity => IncomingRequestFrame.Identity;
+        public bool IsIdempotent => IncomingRequestFrame.IsIdempotent;
         public bool IsOneway { get; }
-        public string Operation => Request.Operation;
-        public Protocol Protocol => Request.Protocol;
+        public string Operation => IncomingRequestFrame.Operation;
+        public Protocol Protocol => IncomingRequestFrame.Protocol;
 
-        internal IncomingRequestFrame Request { get; }
+        internal IncomingRequestFrame IncomingRequestFrame { get; }
 
         internal Current(
             ObjectAdapter adapter,
-            IncomingRequestFrame request,
+            IncomingRequestFrame incomingRequestFrame,
             bool oneway,
             CancellationToken cancel,
             Connection? connection = null)
@@ -35,9 +35,9 @@ namespace ZeroC.Ice
             Adapter = adapter;
             CancellationToken = cancel;
             Connection = connection;
-            Context = new Dictionary<string, string>(request.Context);
+            Context = new Dictionary<string, string>(incomingRequestFrame.Context);
             IsOneway = oneway;
-            Request = request;
+            IncomingRequestFrame = incomingRequestFrame;
         }
     }
 }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -176,6 +176,23 @@ namespace ZeroC.Ice
         // Returns a connector for this endpoint, or empty list if no connector is available.
         public abstract ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType endpointSelection);
 
+        /// <summary>Creates a new connection to the given endpoint.</summary>
+        /// <param name="manager">The connection manager which owns the connection.</param>
+        /// <param name="transceiver">The transceiver to use for the connection.</param>
+        /// <param name="connector">The connector associated with the new connection, this is always null for incoming
+        /// connections.</param>
+        /// <param name="connectionId">The connection ID associated with the new connection. This is always an empty
+        /// string for incoming connections.</param>
+        /// <param name="adapter">The adapter associated with the new connection, this is always null for outgoing
+        /// connections.</param>
+        /// <returns>A new connection to the given endpoint.</returns>
+        public abstract Connection CreateConnection(
+            IConnectionManager manager,
+            ITransceiver? transceiver,
+            IConnector? connector,
+            string connectionId,
+            ObjectAdapter? adapter);
+
         // Expands endpoint out in to separate endpoints for each local host if listening on INADDR_ANY on server side
         // or if no host was specified on client side.
         public abstract IEnumerable<Endpoint> ExpandIfWildcard();
@@ -185,9 +202,6 @@ namespace ZeroC.Ice
         // used to connect to these endpoints (e.g.: with the IP endpoint, it returns this endpoint if it uses a fixed
         // port, null otherwise).
         public abstract IEnumerable<Endpoint> ExpandHost(out Endpoint? publishedEndpoint);
-
-        // Returns an acceptor for this endpoint, or null if no acceptor is available.
-        public abstract IAcceptor? GetAcceptor(string adapterName);
 
         // Return a server side transceiver for this endpoint, or null if a transceiver can only be created by an
         // acceptor.

--- a/csharp/src/Ice/IAcceptor.cs
+++ b/csharp/src/Ice/IAcceptor.cs
@@ -2,49 +2,18 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Threading.Tasks;
 
 namespace ZeroC.Ice
 {
-    public interface IAcceptor
+    public interface IAcceptor : IDisposable
     {
-        void Close();
-        Endpoint Listen();
-        bool StartAccept(AsyncCallback callback, object state);
-        void FinishAccept();
-        ITransceiver Accept();
-        string ToString();
-        string ToDetailedString();
+        Endpoint Endpoint { get; }
 
-        // TODO: temporary hack, it will be removed with the transport refactoring
-        Task<ITransceiver> AcceptAsync()
-        {
-            var result = new TaskCompletionSource<ITransceiver>();
-            if (StartAccept(state =>
-            {
-                try
-                {
-                    var acceptor = (IAcceptor)state;
-                    acceptor.FinishAccept();
-                    result.SetResult(acceptor.Accept());
-                }
-                catch (System.Exception ex)
-                {
-                    result.SetException(ex);
-                }
-            }, this))
-            {
-                try
-                {
-                    FinishAccept();
-                    result.SetResult(Accept());
-                }
-                catch (System.Exception ex)
-                {
-                    result.SetException(ex);
-                }
-            }
-            return result.Task;
-        }
+        /// <summary>Accepts a new transport</summary>
+        ValueTask<ITransceiver> AcceptAsync();
+
+        string ToDetailedString();
     }
 }

--- a/csharp/src/Ice/IAcceptor.cs
+++ b/csharp/src/Ice/IAcceptor.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice
     {
         Endpoint Endpoint { get; }
 
-        /// <summary>Accepts a new transport</summary>
+        /// <summary>Accepts a new connection.</summary>
         ValueTask<ITransceiver> AcceptAsync();
 
         string ToDetailedString();

--- a/csharp/src/Ice/IBinaryConnection.cs
+++ b/csharp/src/Ice/IBinaryConnection.cs
@@ -34,15 +34,15 @@ namespace ZeroC.Ice
             CancellationToken cancel);
 
         /// <summary>Receives a new frame.</summary>
-        ValueTask<(int StreamId, object? Frame, bool Fin)> ReceiveAsync(CancellationToken cancel);
+        ValueTask<(long StreamId, object? Frame, bool Fin)> ReceiveAsync(CancellationToken cancel);
 
         /// <summary>Creates a new stream.</summary>
-        int NewStream(bool bidirectional);
+        long NewStream(bool bidirectional);
 
         /// <summary>Resets the given stream.</summary>
-        ValueTask ResetAsync(int streamId);
+        ValueTask ResetAsync(long streamId);
 
         /// <summary>Sends the given frame on an existing stream.</summary>
-        ValueTask SendAsync(int streamId, object frame, bool fin, CancellationToken cancel);
+        ValueTask SendAsync(long streamId, object frame, bool fin, CancellationToken cancel);
     }
 }

--- a/csharp/src/Ice/IBinaryConnection.cs
+++ b/csharp/src/Ice/IBinaryConnection.cs
@@ -1,0 +1,48 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroC.Ice.Instrumentation;
+
+namespace ZeroC.Ice
+{
+    public interface IBinaryConnection : IDisposable, IAsyncDisposable
+    {
+        Endpoint Endpoint { get; }
+        ITransceiver Transceiver { get; }
+
+        /// <summary>Gracefully closes the transport.</summary>
+        ValueTask CloseAsync(Exception exception, CancellationToken cancel);
+
+        void IDisposable.Dispose()
+        {
+            GC.SuppressFinalize(this);
+            DisposeAsync().AsTask().Wait();
+        }
+
+        /// <summary>Sends a heartbeat.</summary>
+        ValueTask HeartbeatAsync(CancellationToken cancel);
+
+        /// <summary>Initializes the transport.</summary>
+        ValueTask InitializeAsync(
+            Action heartbeatCallback,
+            Action<int> sentCallback,
+            Action<int> receivedCallback,
+            CancellationToken cancel);
+
+        /// <summary>Receives a new frame.</summary>
+        ValueTask<(int StreamId, object? Frame, bool Fin)> ReceiveAsync(CancellationToken cancel);
+
+        /// <summary>Creates a new stream.</summary>
+        int NewStream(bool bidirectional);
+
+        /// <summary>Resets the given stream.</summary>
+        ValueTask ResetAsync(int streamId);
+
+        /// <summary>Sends the given frame on an existing stream.</summary>
+        ValueTask SendAsync(int streamId, object frame, bool fin, CancellationToken cancel);
+    }
+}

--- a/csharp/src/Ice/ITransceiver.cs
+++ b/csharp/src/Ice/ITransceiver.cs
@@ -16,22 +16,6 @@ namespace ZeroC.Ice
 
     public interface ITransceiver
     {
-        /// <summary>Creates a new connection to the given endpoint.</summary>
-        /// <param name="manager">The connection manager which owns the connection.</param>
-        /// <param name="endpoint">The endpoint to connect to.</param>
-        /// <param name="connector">The connector associated with the new connection, this is always null for incoming
-        /// connections.</param>
-        /// <param name="connectionId">The connection ID associated with the new connection. This is always an empty
-        /// string for incoming connections.</param>
-        /// <param name="adapter">The adapter associated with the new connection, this is always null for outgoing
-        /// connections.</param>
-        /// <returns>A new connection to the given endpoint.</returns>
-        public Connection CreateConnection(
-            IConnectionManager manager,
-            Endpoint endpoint,
-            IConnector? connector,
-            string connectionId,
-            ObjectAdapter? adapter);
         Socket? Fd();
 
         /// <summary>

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -1,0 +1,497 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace ZeroC.Ice
+{
+    internal class Ice1BinaryConnection : IBinaryConnection
+    {
+        public Endpoint Endpoint { get; }
+        public ITransceiver Transceiver { get; }
+
+        private readonly int _compressionLevel;
+        private readonly int _frameSizeMax;
+        private Action _heartbeatCallback;
+        private readonly bool _incoming;
+        private int _nextStreamId;
+        private Task _receiveTask = Task.CompletedTask;
+        private Action<int> _receivedCallback;
+        private Task _sendTask = Task.CompletedTask;
+        private Action<int> _sentCallback;
+        private readonly bool _warn;
+        private readonly bool _warnUdp;
+
+        private static readonly List<ArraySegment<byte>> _closeConnectionFrame =
+            new List<ArraySegment<byte>> { Ice1Definitions.CloseConnectionFrame };
+
+        private static readonly List<ArraySegment<byte>> _validateConnectionFrame =
+            new List<ArraySegment<byte>> { Ice1Definitions.ValidateConnectionFrame };
+
+        public async ValueTask CloseAsync(Exception exception, CancellationToken cancel)
+        {
+            if (!(exception is ConnectionClosedByPeerException))
+            {
+                // Write and wait for the close connection frame to be written
+                try
+                {
+                    await SendFrameAsync(0, _closeConnectionFrame, cancel).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Ignore
+                }
+            }
+
+            // Notify the transport of the graceful connection closure.
+            try
+            {
+                await Transceiver.ClosingAsync(exception, cancel).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore
+            }
+
+            // Wait for the connection closure from the peer
+            try
+            {
+                await _receiveTask.WaitAsync(cancel).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Transceiver.ThreadSafeClose();
+            Transceiver.Destroy();
+            return default;
+        }
+
+        public async ValueTask HeartbeatAsync(CancellationToken cancel) =>
+            await SendFrameAsync(0, _validateConnectionFrame, cancel).ConfigureAwait(false);
+
+        public async ValueTask InitializeAsync(
+            Action heartbeatCallback,
+            Action<int> sentCallback,
+            Action<int> receivedCallback,
+            CancellationToken cancel)
+        {
+            _heartbeatCallback = heartbeatCallback;
+            _sentCallback = sentCallback;
+            _receivedCallback = receivedCallback;
+
+            // Initialize the transport
+            await Transceiver.InitializeAsync(cancel).ConfigureAwait(false);
+
+            ArraySegment<byte> readBuffer = default;
+            if (!Endpoint.IsDatagram) // Datagram connections are always implicitly validated.
+            {
+                if (_incoming) // The server side has the active role for connection validation.
+                {
+                    int offset = 0;
+                    while (offset < _validateConnectionFrame.GetByteCount())
+                    {
+                        offset += await Transceiver.WriteAsync(_validateConnectionFrame,
+                                                                offset,
+                                                                cancel).ConfigureAwait(false);
+                    }
+                    Debug.Assert(offset == _validateConnectionFrame.GetByteCount());
+                }
+                else // The client side has the passive role for connection validation.
+                {
+                    readBuffer = new ArraySegment<byte>(new byte[Ice1Definitions.HeaderSize]);
+                    int offset = 0;
+                    while (offset < Ice1Definitions.HeaderSize)
+                    {
+                        offset += await Transceiver.ReadAsync(readBuffer,
+                                                                offset,
+                                                                cancel).ConfigureAwait(false);
+                    }
+
+                    Ice1Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
+                    var frameType = (Ice1Definitions.FrameType)readBuffer[8];
+                    if (frameType != Ice1Definitions.FrameType.ValidateConnection)
+                    {
+                        throw new InvalidDataException(@$"received ice1 frame with frame type `{frameType
+                            }' before receiving the validate connection frame");
+                    }
+
+                    int size = InputStream.ReadInt(readBuffer.AsSpan(10, 4));
+                    if (size != Ice1Definitions.HeaderSize)
+                    {
+                        throw new InvalidDataException(
+                            @$"received an ice1 frame with validate connection type and a size of `{size
+                            }' bytes");
+                    }
+                }
+            }
+
+            if (!Endpoint.IsDatagram) // Datagram connections are always implicitly validated.
+            {
+                if (_incoming) // The server side has the active role for connection validation.
+                {
+                    ProtocolTrace.TraceSend(Endpoint.Communicator,
+                                            Endpoint.Protocol,
+                                            Ice1Definitions.ValidateConnectionFrame);
+                    _sentCallback(Ice1Definitions.ValidateConnectionFrame.Length);
+                }
+                else
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    _receivedCallback(readBuffer.Count);
+                }
+            }
+
+            if (Endpoint.Communicator.TraceLevels.Network >= 1)
+            {
+                var s = new StringBuilder();
+                if (Endpoint.IsDatagram)
+                {
+                    s.Append("starting to ");
+                    s.Append(_incoming ? "send" : "receive");
+                    s.Append(' ');
+                    s.Append(Endpoint.TransportName);
+                    s.Append(" datagrams\n");
+                    s.Append(Transceiver.ToDetailedString());
+                }
+                else
+                {
+                    s.Append(_incoming ? "established" : "accepted");
+                    s.Append(' ');
+                    s.Append(Endpoint.TransportName);
+                    s.Append(" connection\n");
+                    s.Append(ToString());
+                }
+                Endpoint.Communicator.Logger.Trace(Endpoint.Communicator.TraceLevels.NetworkCategory,
+                                                    s.ToString());
+            }
+        }
+
+        public async ValueTask<(int StreamId, object? Frame, bool Fin)> ReceiveAsync(CancellationToken cancel)
+        {
+            while (true)
+            {
+                int requestId = 0;
+                object? frame = null;
+                Task<ArraySegment<byte>>? task = null;
+                ValueTask<ArraySegment<byte>> receiveTask = PerformReceiveFrameAsync();
+                if (receiveTask.IsCompletedSuccessfully)
+                {
+                    _receiveTask = Task.CompletedTask;
+                    (requestId, frame) = ParseFrame(receiveTask.Result);
+                }
+                else
+                {
+                    _receiveTask = task = receiveTask.AsTask();
+                }
+
+                if (task != null)
+                {
+                    (requestId, frame) = ParseFrame(await task.ConfigureAwait(false));
+                }
+
+                if (frame != null)
+                {
+                    return (StreamId: requestId, Frame: frame, Fin: requestId == 0 || frame is IncomingResponseFrame);
+                }
+            }
+        }
+
+        public int NewStream(bool bidirectional) => bidirectional ? ++_nextStreamId : 0;
+
+        public ValueTask ResetAsync(int streamId) =>
+            throw new NotSupportedException("ice1 transports don't support stream reset");
+
+        public async ValueTask SendAsync(int streamId, object frame, bool fin, CancellationToken cancel) =>
+            await SendFrameAsync(streamId, frame, cancel);
+
+        public override string ToString() => Transceiver.ToString()!;
+
+        internal Ice1BinaryConnection(ITransceiver transceiver, Endpoint endpoint, ObjectAdapter? adapter)
+        {
+            Transceiver = transceiver;
+            Endpoint = endpoint;
+
+            _incoming = adapter != null;
+            _frameSizeMax = adapter?.FrameSizeMax ?? Endpoint.Communicator.FrameSizeMax;
+            _warn = Endpoint.Communicator.GetPropertyAsBool("Ice.Warn.Connections") ?? false;
+            _warnUdp = Endpoint.Communicator.GetPropertyAsBool("Ice.Warn.Datagrams") ?? false;
+            _compressionLevel = Endpoint.Communicator.GetPropertyAsInt("Ice.Compression.Level") ?? 1;
+            _sentCallback = _receivedCallback = _ => {};
+            _heartbeatCallback = () => {};
+
+            if (_compressionLevel < 1)
+            {
+                _compressionLevel = 1;
+            }
+            else if (_compressionLevel > 9)
+            {
+                _compressionLevel = 9;
+            }
+        }
+
+        private (int, object?) ParseFrame(ArraySegment<byte> readBuffer)
+        {
+            // The magic and version fields have already been checked.
+            var frameType = (Ice1Definitions.FrameType)readBuffer[8];
+            byte compressionStatus = readBuffer[9];
+            if (compressionStatus == 2)
+            {
+                if (BZip2.IsLoaded)
+                {
+                    readBuffer = BZip2.Decompress(readBuffer, Ice1Definitions.HeaderSize, _frameSizeMax);
+                }
+                else
+                {
+                    throw new LoadException("compression not supported, bzip2 library not found");
+                }
+            }
+
+            switch (frameType)
+            {
+                case Ice1Definitions.FrameType.CloseConnection:
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    if (Endpoint.IsDatagram)
+                    {
+                        if (_warn)
+                        {
+                            Endpoint.Communicator.Logger.Warning(
+                                $"ignoring close connection frame for datagram connection:\n{this}");
+                        }
+                    }
+                    else
+                    {
+                        throw new ConnectionClosedByPeerException();
+                    }
+                    return default;
+                }
+
+                case Ice1Definitions.FrameType.Request:
+                {
+                    var request = new IncomingRequestFrame(Endpoint.Protocol,
+                                                           readBuffer.Slice(Ice1Definitions.HeaderSize + 4),
+                                                           compressionStatus);
+                    ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, request);
+                    return (InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4)), request);
+                }
+
+                case Ice1Definitions.FrameType.RequestBatch:
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    int invokeNum = InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4));
+                    if (invokeNum < 0)
+                    {
+                        throw new InvalidDataException(
+                            $"received ice1 RequestBatchMessage with {invokeNum} batch requests");
+                    }
+                    Debug.Assert(false); // TODO: deal with batch requests
+                    return default;
+                }
+
+                case Ice1Definitions.FrameType.Reply:
+                {
+                    var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
+                                                                  readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
+                    ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, responseFrame);
+                    return (InputStream.ReadInt(readBuffer.AsSpan(14, 4)), responseFrame);
+                }
+
+                case Ice1Definitions.FrameType.ValidateConnection:
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    _heartbeatCallback();
+                    return default;
+                }
+
+                default:
+                {
+                    ProtocolTrace.Trace(
+                        "received unknown frame\n(invalid, closing connection)",
+                        Endpoint.Communicator,
+                        Endpoint.Protocol,
+                        readBuffer);
+                    throw new InvalidDataException(
+                        $"received ice1 frame with unknown frame type `{frameType}'");
+                }
+            }
+        }
+
+        private async ValueTask<ArraySegment<byte>> PerformReceiveFrameAsync()
+        {
+            // Read header
+            ArraySegment<byte> readBuffer;
+            if (Endpoint.IsDatagram)
+            {
+                readBuffer = await Transceiver.ReadAsync().ConfigureAwait(false);
+                _receivedCallback(readBuffer.Count);
+            }
+            else
+            {
+                readBuffer = new ArraySegment<byte>(new byte[256], 0, Ice1Definitions.HeaderSize);
+                int offset = 0;
+                while (offset < Ice1Definitions.HeaderSize)
+                {
+                    offset += await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
+                    _receivedCallback(readBuffer.Count);
+                }
+            }
+
+            // Check header
+            Ice1Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
+            int size = InputStream.ReadInt(readBuffer.Slice(10, 4));
+            if (size < Ice1Definitions.HeaderSize)
+            {
+                throw new InvalidDataException($"received ice1 frame with only {size} bytes");
+            }
+
+            if (size > _frameSizeMax)
+            {
+                throw new InvalidDataException($"frame with {size} bytes exceeds Ice.MessageSizeMax value");
+            }
+
+            // Read the remainder of the frame if needed
+            if (!Endpoint.IsDatagram)
+            {
+                if (size > readBuffer.Array!.Length)
+                {
+                    // Allocate a new array and copy the header over
+                    var buffer = new ArraySegment<byte>(new byte[size], 0, size);
+                    readBuffer.AsSpan().CopyTo(buffer.AsSpan(0, Ice1Definitions.HeaderSize));
+                    readBuffer = buffer;
+                }
+                else if (size > readBuffer.Count)
+                {
+                    readBuffer = new ArraySegment<byte>(readBuffer.Array!, 0, size);
+                }
+                Debug.Assert(size == readBuffer.Count);
+
+                int offset = Ice1Definitions.HeaderSize;
+                while (offset < readBuffer.Count)
+                {
+                    int bytesReceived = await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
+                    offset += bytesReceived;
+
+                    // Trace the receive progress within the loop as we might be receiving significant amount
+                    // of data here.
+                    _receivedCallback(bytesReceived);
+                }
+            }
+            else if (size > readBuffer.Count)
+            {
+                if (_warnUdp)
+                {
+                    Endpoint.Communicator.Logger.Warning($"maximum datagram size of {readBuffer.Count} exceeded");
+                }
+                return default;
+            }
+            return readBuffer;
+        }
+
+        private async ValueTask PerformSendFrameAsync(int streamId, object frame)
+        {
+            List<ArraySegment<byte>> writeBuffer;
+
+            // TODO: add abstract OutgoingFrame class with an abstract GetRequestData(streamId) method?
+            bool compress = false;
+            if (frame is OutgoingRequestFrame requestFrame)
+            {
+                writeBuffer = Ice1Definitions.GetRequestData(requestFrame, streamId);
+                // TODO: Add support for OutgoingRequestFrame.Compress
+                //compress = requestFrame.Compress;
+                ProtocolTrace.TraceFrame(Endpoint.Communicator, writeBuffer[0], requestFrame);
+            }
+            else if (frame is OutgoingResponseFrame responseFrame)
+            {
+                Debug.Assert(streamId > 0);
+                writeBuffer = Ice1Definitions.GetResponseData(responseFrame, streamId);
+                compress = responseFrame.CompressionStatus > 0;
+                ProtocolTrace.TraceFrame(Endpoint.Communicator, writeBuffer[0], responseFrame);
+            }
+            else
+            {
+                Debug.Assert(frame is List<ArraySegment<byte>>);
+                writeBuffer = (List<ArraySegment<byte>>)frame;
+                ProtocolTrace.TraceSend(Endpoint.Communicator, Endpoint.Protocol, writeBuffer[0]);
+            }
+
+            // Compress the frame if needed and possible
+            int size = writeBuffer.GetByteCount();
+            if (BZip2.IsLoaded && compress)
+            {
+                List<ArraySegment<byte>>? compressed = null;
+                if (size >= 100)
+                {
+                    compressed = BZip2.Compress(writeBuffer, size, Ice1Definitions.HeaderSize, _compressionLevel);
+                }
+
+                if (compressed != null)
+                {
+                    writeBuffer = compressed!;
+                    size = writeBuffer.GetByteCount();
+                }
+                else // Message not compressed, request compressed response, if any.
+                {
+                    ArraySegment<byte> header = writeBuffer[0];
+                    header[9] = 1; // Write the compression status
+                }
+            }
+
+            // Ensure the frame isn't bigger than what we can send with the transport.
+            Transceiver.CheckSendSize(size);
+
+            // Write the frame
+            int offset = 0;
+            while (offset < size)
+            {
+                int bytesSent = await Transceiver.WriteAsync(writeBuffer, offset).ConfigureAwait(false);
+                offset += bytesSent;
+                _sentCallback(bytesSent);
+            }
+        }
+
+        private Task SendFrameAsync(int streamId, object frame, CancellationToken cancel)
+        {
+            cancel.ThrowIfCancellationRequested();
+            ValueTask sendTask = QueueAsync(streamId, frame, cancel);
+            _sendTask = sendTask.IsCompletedSuccessfully ? Task.CompletedTask : sendTask.AsTask();
+            return _sendTask;
+
+            async ValueTask QueueAsync(int streamId, object frame, CancellationToken cancel)
+            {
+                // Wait for the previous send to complete
+                try
+                {
+                    await _sendTask.ConfigureAwait(false);
+                }
+                catch (DatagramLimitException)
+                {
+                    // If the send failed because the datagram was too large, ignore and continue sending.
+                }
+                catch (OperationCanceledException)
+                {
+                    // If the send was canceled, ignore and continue sending.
+                }
+
+                // If the send got cancelled, throw now. This isn't a fatal connection error, the next pending
+                // outgoing will be sent because we ignore the cancelation exception above.
+                // TODO: is it really a good idea to cancel the request here? The stream/request ID assigned for the
+                // the request won't be used.
+                cancel.ThrowIfCancellationRequested();
+
+                // Perform the write
+                await PerformSendFrameAsync(streamId, frame).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -484,8 +484,8 @@ namespace ZeroC.Ice
 
                 // If the send got cancelled, throw now. This isn't a fatal connection error, the next pending
                 // outgoing will be sent because we ignore the cancelation exception above.
-                // TODO: is it really a good idea to cancel the request here? The stream/request ID assigned for the
-                // the request won't be used.
+                // TODO: is it really a good idea to cancel the request here with ice1?  The stream/request ID assigned
+                // for the request won't be used.
                 cancel.ThrowIfCancellationRequested();
 
                 // Perform the write

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -407,8 +407,7 @@ namespace ZeroC.Ice
             if (frame is OutgoingRequestFrame requestFrame)
             {
                 writeBuffer = Ice1Definitions.GetRequestData(requestFrame, streamId);
-                // TODO: Add support for OutgoingRequestFrame.Compress
-                //compress = requestFrame.Compress;
+                compress = requestFrame.Compress;
                 ProtocolTrace.TraceFrame(Endpoint.Communicator, writeBuffer[0], requestFrame);
             }
             else if (frame is OutgoingResponseFrame responseFrame)

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -102,26 +102,28 @@ namespace ZeroC.Ice
             }
         }
 
-        internal static List<ArraySegment<byte>> GetRequestData(OutgoingRequestFrame frame, int requestId)
+        internal static List<ArraySegment<byte>> GetRequestData(OutgoingRequestFrame frame, long streamId)
         {
             byte[] headerData = new byte[HeaderSize + 4];
             RequestHeader.CopyTo(headerData.AsSpan());
 
             OutputStream.WriteSize20(frame.Size + HeaderSize + 4, headerData.AsSpan(10, 4));
-            OutputStream.WriteInt(requestId, headerData.AsSpan(HeaderSize, 4));
+            // TODO: Fix to support long streamId
+            OutputStream.WriteInt((int)streamId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
             data.AddRange(frame.Data);
             return data;
         }
 
-        internal static List<ArraySegment<byte>> GetResponseData(OutgoingResponseFrame frame, int requestId)
+        internal static List<ArraySegment<byte>> GetResponseData(OutgoingResponseFrame frame, long streamId)
         {
             byte[] headerData = new byte[HeaderSize + 4];
             ReplyHeader.CopyTo(headerData.AsSpan());
 
             OutputStream.WriteSize20(frame.Size + HeaderSize + 4, headerData.AsSpan(10, 4));
-            OutputStream.WriteInt(requestId, headerData.AsSpan(HeaderSize, 4));
+            // TODO: Fix to support long streamId
+            OutputStream.WriteInt((int)streamId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
             data.AddRange(frame.Data);

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -116,7 +116,7 @@ namespace ZeroC.IceLocatorDiscovery
                     {
                         IncomingResponseFrame incomingResponse =
                             await newLocator.InvokeAsync(outgoingRequest).ConfigureAwait(false);
-                        return new OutgoingResponseFrame(current.Protocol, current.Encoding, incomingResponse.Payload);
+                        return new OutgoingResponseFrame(incomingRequest, incomingResponse.Payload);
                     }
                     catch (DispatchException)
                     {

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 
 namespace ZeroC.Ice
@@ -34,6 +35,7 @@ namespace ZeroC.Ice
         /// <summary>The frame byte count</summary>
         public int Size => Data.Count;
 
+        internal byte CompressionStatus { get; }
         internal ArraySegment<byte> Data { get; }
 
         /// <summary>Creates a new IncomingRequestFrame.</summary>
@@ -61,6 +63,7 @@ namespace ZeroC.Ice
             else
             {
                 // TODO: with ice2, the payload is followed by a context, and the size is not fixed-length.
+                // TODO: read the compression status from the encapsulation data
             }
             Encoding = encoding;
         }
@@ -70,6 +73,15 @@ namespace ZeroC.Ice
         internal IncomingRequestFrame(OutgoingRequestFrame frame)
             : this(frame.Protocol, VectoredBufferExtensions.ToArray(frame.Data))
         {
+        }
+
+        internal IncomingRequestFrame(Protocol protocol, ArraySegment<byte> data, byte compressionStatus)
+            : this(protocol, data)
+        {
+            // IncomingRequestFrame with compression status is only supported with Ice1, compression is handled
+            // by the 2.0 encoding with Ice2.
+            Debug.Assert(protocol == Protocol.Ice1);
+            CompressionStatus = compressionStatus;
         }
 
         /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload

--- a/csharp/src/Ice/Instrumentation.cs
+++ b/csharp/src/Ice/Instrumentation.cs
@@ -46,7 +46,7 @@ namespace ZeroC.Ice.Instrumentation
         /// <param name="requestId">The request ID of the request being dispatched.</param>
         /// <param name="size">The size of the dispatch.</param>
         /// <returns>The dispatch observer to instrument the dispatch.</returns>
-        IDispatchObserver? GetDispatchObserver(Current current, int requestId, int size);
+        IDispatchObserver? GetDispatchObserver(Current current, long requestId, int size);
 
         /// <summary>This method should return an observer for the given endpoint information. The Ice run-time calls
         /// this method to resolve an endpoint and obtain the list of connectors. For IP endpoints, this typically
@@ -102,14 +102,14 @@ namespace ZeroC.Ice.Instrumentation
         /// <param name="requestId">The ID of the invocation.</param>
         /// <param name="size">The size of the invocation in bytes.</param>
         /// <returns>The observer to instrument the collocated invocation.</returns>
-        ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, int requestId, int size);
+        ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, long requestId, int size);
 
         /// <summary>Get a remote observer for this invocation.</summary>
         /// <param name="connection">The connection information.</param>
         /// <param name="requestId">The invocation request ID.</param>
         /// <param name="size">The size of the invocation in bytes.</param>
         /// <returns>The observer to instrument the remote invocation.</returns>
-        IRemoteObserver? GetRemoteObserver(Connection connection, int requestId, int size);
+        IRemoteObserver? GetRemoteObserver(Connection connection, long requestId, int size);
 
         /// <summary>Remote exception notification.</summary>
         void RemoteException();

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -25,13 +25,13 @@ namespace ZeroC.Ice
     internal class CollocatedInvocationHelper : MetricsHelper<CollocatedMetrics>
     {
         private static readonly AttributeResolver _attributeResolver = new AttributeResolverI();
-        private readonly int _requestId;
+        private readonly long _requestId;
         private readonly string _id;
         private readonly int _size;
 
         public override void InitMetrics(CollocatedMetrics v) => v.Size += _size;
 
-        internal CollocatedInvocationHelper(ObjectAdapter adapter, int requestId, int size)
+        internal CollocatedInvocationHelper(ObjectAdapter adapter, long requestId, int size)
             : base(_attributeResolver)
         {
             _id = adapter.Name;
@@ -135,7 +135,7 @@ namespace ZeroC.Ice
             return null;
         }
 
-        public IDispatchObserver? GetDispatchObserver(Current current, int requestId, int size)
+        public IDispatchObserver? GetDispatchObserver(Current current, long requestId, int size)
         {
             if (_dispatch.IsEnabled)
             {
@@ -321,14 +321,14 @@ namespace ZeroC.Ice
         private static readonly AttributeResolver _attributeResolver = new AttributeResolverI();
 
         private readonly Current _current;
-        private readonly int _requestId;
+        private readonly long _requestId;
 
         private string? _id;
         private readonly int _size;
 
         public override void InitMetrics(DispatchMetrics v) => v.Size += _size;
 
-        internal DispatchHelper(Current current, int requestId, int size)
+        internal DispatchHelper(Current current, long requestId, int size)
             : base(_attributeResolver)
         {
             _current = current;
@@ -524,7 +524,7 @@ namespace ZeroC.Ice
     internal class InvocationObserver : ObserverWithDelegate<InvocationMetrics, IInvocationObserver>,
         IInvocationObserver
     {
-        public ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, int requestId, int size) =>
+        public ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, long requestId, int size) =>
             GetObserver<CollocatedMetrics, CollocatedObserver, ICollocatedObserver>(
                 "Collocated",
                 new CollocatedInvocationHelper(adapter, requestId, size),
@@ -532,7 +532,7 @@ namespace ZeroC.Ice
 
         public IRemoteObserver? GetRemoteObserver(
             Connection connection,
-            int requestId,
+            long requestId,
             int size) =>
             GetObserver<RemoteMetrics, RemoteObserver, IRemoteObserver>(
                 "Remote",
@@ -643,13 +643,13 @@ namespace ZeroC.Ice
         private static readonly AttributeResolver _attributeResolver = new AttributeResolverI();
 
         private readonly Connection _connection;
-        private readonly int _requestId;
+        private readonly long _requestId;
         private readonly int _size;
         private string? _id;
 
         public override void InitMetrics(RemoteMetrics v) => v.Size += _size;
 
-        internal RemoteInvocationHelper(Connection connection, int requestId, int size)
+        internal RemoteInvocationHelper(Connection connection, long requestId, int size)
             : base(_attributeResolver)
         {
             _connection = connection;

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -96,7 +96,11 @@ namespace ZeroC.Ice
 
         public override IEnumerable<Endpoint> ExpandIfWildcard() => new Endpoint[] { this };
 
-        public override IAcceptor? GetAcceptor(string adapterName) => null;
+        public override Connection CreateConnection(IConnectionManager manager,
+                                                    ITransceiver? transceiver,
+                                                    IConnector? connector,
+                                                    string connectionId,
+                                                    ObjectAdapter? adapter) => null!;
         public override ITransceiver? GetTransceiver() => null;
 
         protected internal override void AppendOptions(StringBuilder sb, char optionSeparator)

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -72,7 +72,7 @@ namespace ZeroC.Ice
         public int Size { get; private set; }
 
         // Whether or not to Compress the content of the frame with Ice1
-        internal bool Compress;
+        internal bool Compress { get; }
 
         // Contents of the Frame
         internal List<ArraySegment<byte>> Data { get; private set; }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -71,6 +71,9 @@ namespace ZeroC.Ice
         /// <summary>The frame byte count.</summary>
         public int Size { get; private set; }
 
+        // Whether or not to Compress the content of the frame with Ice1
+        internal bool Compress;
+
         // Contents of the Frame
         internal List<ArraySegment<byte>> Data { get; private set; }
 
@@ -193,6 +196,10 @@ namespace ZeroC.Ice
             Protocol = proxy.Protocol;
             Protocol.CheckSupported();
             Encoding = proxy.Encoding;
+            // TODO: when we add back compression support on the client side, assign to true for Ice1 requests to
+            // get the connection to compress the request at the protocol level. The Ice1BinaryConnection checks
+            // this property to figure out if the request needs to be compressed.
+            Compress = false;
             Data = new List<ArraySegment<byte>>();
             Identity = proxy.Identity;
             Facet = proxy.Facet;

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -48,7 +48,7 @@ namespace ZeroC.Ice
                 var ostr = new OutputStream(key.Protocol.GetEncoding(), data, new OutputStream.Position(0, 0));
                 ostr.WriteByte((byte)ReplyStatus.OK);
                 _ = ostr.WriteEmptyEncapsulation(key.Encoding);
-                return new OutgoingResponseFrame(current.Request, data);
+                return new OutgoingResponseFrame(current.IncomingRequestFrame, data);
             });
 
         /// <summary>Creates a new outgoing response frame with an OK reply status and a return value.</summary>
@@ -63,7 +63,7 @@ namespace ZeroC.Ice
                                                                T value,
                                                                OutputStreamWriter<T> writer)
         {
-            var response = new OutgoingResponseFrame(current.Request);
+            var response = new OutgoingResponseFrame(current.IncomingRequestFrame);
             byte[] buffer = new byte[256];
             buffer[0] = (byte)ReplyStatus.OK;
             response.Data.Add(buffer);
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
                                                                OutputStreamValueWriter<T> writer)
             where T : struct
         {
-            var response = new OutgoingResponseFrame(current.Request);
+            var response = new OutgoingResponseFrame(current.IncomingRequestFrame);
             byte[] buffer = new byte[256];
             buffer[0] = (byte)ReplyStatus.OK;
             response.Data.Add(buffer);

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -344,7 +344,7 @@ namespace ZeroC.Ice
             {
                 // TODO: need protocol bridging when the protocols are not the same.
                 IncomingResponseFrame response = await task.ConfigureAwait(false);
-                return new OutgoingResponseFrame(request.Protocol, request.Encoding, response.Payload);
+                return new OutgoingResponseFrame(request, response.Payload);
             }
         }
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1383,17 +1383,7 @@ namespace ZeroC.Ice
                     }
                 }
 
-                // If it's an Ice1 proxy, we check if the connection matches an endpoint with the compression flag
-                // enabled. If it's the case, we'll use compression.
-                bool compress = false;
-                if (Protocol == Protocol.Ice1)
-                {
-                    // Use compression if the first matching endpoint uses compression. We make sure to compare
-                    // endpoints with the same timeout value to ignore the timeout.
-                    compress = endpoints.First(endpoint => connection.Endpoints.Exists(connectionEndpoint =>
-                        endpoint.NewTimeout(connectionEndpoint.Timeout).Equals(connectionEndpoint))).HasCompressionFlag;
-                }
-                return new ConnectionRequestHandler(connection, compress);
+                return new ConnectionRequestHandler(connection);
             }
             catch (Exception ex)
             {
@@ -1706,7 +1696,7 @@ namespace ZeroC.Ice
             }
 
             _fixedConnection.ThrowException(); // Throw in case our connection is already destroyed.
-            _requestHandler = new ConnectionRequestHandler(_fixedConnection, false);
+            _requestHandler = new ConnectionRequestHandler(_fixedConnection);
         }
     }
 }

--- a/csharp/src/Ice/SlicBinaryConnection.cs
+++ b/csharp/src/Ice/SlicBinaryConnection.cs
@@ -1,0 +1,378 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace ZeroC.Ice
+{
+    internal class SlicBinaryConnection : IBinaryConnection
+    {
+        public Endpoint Endpoint { get; }
+        public ITransceiver Transceiver { get; }
+
+        private readonly int _frameSizeMax;
+        private Action _heartbeatCallback;
+        private readonly bool _incoming;
+        private int _nextStreamId;
+        private Task _receiveTask = Task.CompletedTask;
+        private Action<int> _receivedCallback;
+        private Task _sendTask = Task.CompletedTask;
+        private Action<int> _sentCallback;
+
+        private static readonly List<ArraySegment<byte>> _closeConnectionFrame =
+            new List<ArraySegment<byte>> { Ice2Definitions.CloseConnectionFrame };
+
+        private static readonly List<ArraySegment<byte>> _validateConnectionFrame =
+            new List<ArraySegment<byte>> { Ice2Definitions.ValidateConnectionFrame };
+
+        public async ValueTask CloseAsync(Exception exception, CancellationToken cancel)
+        {
+            if (!(exception is ConnectionClosedByPeerException))
+            {
+                // Write and wait for the close connection frame to be written
+                try
+                {
+                    await SendFrameAsync(0, _closeConnectionFrame, cancel).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Ignore
+                }
+            }
+
+            // Notify the transport of the graceful connection closure.
+            try
+            {
+                await Transceiver.ClosingAsync(exception, cancel).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore
+            }
+
+            // Wait for the connection closure from the peer
+            try
+            {
+                await _receiveTask.WaitAsync(cancel).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Transceiver.ThreadSafeClose();
+            Transceiver.Destroy();
+            return default;
+        }
+
+        public async ValueTask HeartbeatAsync(CancellationToken cancel) =>
+            await SendFrameAsync(0, _validateConnectionFrame, cancel).ConfigureAwait(false);
+
+        public async ValueTask InitializeAsync(
+            Action heartbeatCallback,
+            Action<int> sentCallback,
+            Action<int> receivedCallback,
+            CancellationToken cancel)
+        {
+            _heartbeatCallback = heartbeatCallback;
+            _sentCallback = sentCallback;
+            _receivedCallback = receivedCallback;
+
+            // Initialize the transport
+            await Transceiver.InitializeAsync(cancel).ConfigureAwait(false);
+
+            ArraySegment<byte> readBuffer = default;
+            if (_incoming) // The server side has the active role for connection validation.
+            {
+                int offset = 0;
+                while (offset < _validateConnectionFrame.GetByteCount())
+                {
+                    offset += await Transceiver.WriteAsync(_validateConnectionFrame,
+                                                           offset,
+                                                           cancel).ConfigureAwait(false);
+                }
+                Debug.Assert(offset == _validateConnectionFrame.GetByteCount());
+            }
+            else // The client side has the passive role for connection validation.
+            {
+                readBuffer = new ArraySegment<byte>(new byte[Ice2Definitions.HeaderSize]);
+                int offset = 0;
+                while (offset < Ice2Definitions.HeaderSize)
+                {
+                    offset += await Transceiver.ReadAsync(readBuffer,
+                                                          offset,
+                                                          cancel).ConfigureAwait(false);
+                }
+
+                Ice2Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
+                var frameType = (Ice2Definitions.FrameType)readBuffer[8];
+                if (frameType != Ice2Definitions.FrameType.ValidateConnection)
+                {
+                    throw new InvalidDataException(@$"received ice2 frame with frame type `{frameType
+                        }' before receiving the validate connection frame");
+                }
+
+                // TODO: this is temporary code. With the 2.0 encoding, sizes are always variable-length
+                // with the length encoded on the first 2 bits of the size. Assuming the size is encoded
+                // on 4 bytes (like we do below) is not correct.
+                int size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(),
+                                                           readBuffer.AsSpan(10, 4));
+                if (size != Ice2Definitions.HeaderSize)
+                {
+                    throw new InvalidDataException(
+                        @$"received an ice2 frame with validate connection type and a size of `{size
+                        }' bytes");
+                }
+            }
+
+            if (_incoming) // The server side has the active role for connection validation.
+            {
+                ProtocolTrace.TraceSend(Endpoint.Communicator,
+                                        Endpoint.Protocol,
+                                        Ice2Definitions.ValidateConnectionFrame);
+                _sentCallback(Ice2Definitions.ValidateConnectionFrame.Length);
+            }
+            else
+            {
+                ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                _receivedCallback(readBuffer.Count);
+            }
+
+            if (Endpoint.Communicator.TraceLevels.Network >= 1)
+            {
+                var s = new StringBuilder();
+                s.Append(_incoming ? "established" : "accepted");
+                s.Append(' ');
+                s.Append(Endpoint.TransportName);
+                s.Append(" connection\n");
+                s.Append(ToString());
+                Endpoint.Communicator.Logger.Trace(Endpoint.Communicator.TraceLevels.NetworkCategory, s.ToString());
+            }
+        }
+
+        public async ValueTask<(int StreamId, object? Frame, bool Fin)> ReceiveAsync(CancellationToken cancel)
+        {
+            while (true)
+            {
+                int requestId = 0;
+                object? frame = null;
+                Task<ArraySegment<byte>>? task = null;
+                ValueTask<ArraySegment<byte>> receiveTask = PerformReceiveFrameAsync();
+                if (receiveTask.IsCompletedSuccessfully)
+                {
+                    _receiveTask = Task.CompletedTask;
+                    (requestId, frame) = ParseFrame(receiveTask.Result);
+                }
+                else
+                {
+                    _receiveTask = task = receiveTask.AsTask();
+                }
+
+                if (task != null)
+                {
+                    (requestId, frame) = ParseFrame(await task.ConfigureAwait(false));
+                }
+
+                if (frame != null)
+                {
+                    return (StreamId: requestId, Frame: frame, Fin: requestId == 0 || frame is IncomingResponseFrame);
+                }
+            }
+        }
+
+        public int NewStream(bool bidirectional) => bidirectional ? ++_nextStreamId : 0;
+
+        public ValueTask ResetAsync(int streamId) =>
+            throw new NotSupportedException("ice2 transports don't support stream reset");
+
+        public async ValueTask SendAsync(int streamId, object frame, bool fin, CancellationToken cancel) =>
+            await SendFrameAsync(streamId, frame, cancel);
+
+        public override string ToString() => Transceiver.ToString()!;
+
+        internal SlicBinaryConnection(ITransceiver transceiver, Endpoint endpoint, ObjectAdapter? adapter)
+        {
+            Transceiver = transceiver;
+            Endpoint = endpoint;
+
+            _incoming = adapter != null;
+            _frameSizeMax = adapter?.FrameSizeMax ?? Endpoint.Communicator.FrameSizeMax;
+            _sentCallback = _receivedCallback = _ => {};
+            _heartbeatCallback = () => {};
+        }
+
+        private (int, object?) ParseFrame(ArraySegment<byte> readBuffer)
+        {
+            // The magic and version fields have already been checked.
+            var frameType = (Ice2Definitions.FrameType)readBuffer[8];
+
+            switch (frameType)
+            {
+                case Ice2Definitions.FrameType.CloseConnection:
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    throw new ConnectionClosedByPeerException();
+                }
+
+                case Ice2Definitions.FrameType.Request:
+                {
+                    var request = new IncomingRequestFrame(Endpoint.Protocol,
+                                                           readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
+                    ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, request);
+                    return (InputStream.ReadInt(readBuffer.AsSpan(Ice2Definitions.HeaderSize, 4)), request);
+                }
+
+                case Ice2Definitions.FrameType.Reply:
+                {
+                    var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
+                                                                  readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
+                    ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, responseFrame);
+                    return (InputStream.ReadInt(readBuffer.AsSpan(14, 4)), responseFrame);
+                }
+
+                case Ice2Definitions.FrameType.ValidateConnection:
+                {
+                    ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
+                    _heartbeatCallback();
+                    return default;
+                }
+
+                default:
+                {
+                    ProtocolTrace.Trace(
+                        "received unknown frame\n(invalid, closing connection)",
+                        Endpoint.Communicator,
+                        Endpoint.Protocol,
+                        readBuffer);
+                    throw new InvalidDataException(
+                        $"received ice2 frame with unknown frame type `{frameType}'");
+                }
+            }
+        }
+
+        private async ValueTask<ArraySegment<byte>> PerformReceiveFrameAsync()
+        {
+            // Read header
+            ArraySegment<byte> readBuffer;
+            readBuffer = new ArraySegment<byte>(new byte[256], 0, Ice2Definitions.HeaderSize);
+            int offset = 0;
+            while (offset < Ice2Definitions.HeaderSize)
+            {
+                offset += await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
+                _receivedCallback(readBuffer.Count);
+            }
+
+            // Check header
+            Ice2Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
+            int size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(), readBuffer.Slice(10, 4));
+            if (size < Ice2Definitions.HeaderSize)
+            {
+                throw new InvalidDataException($"received ice2 frame with only {size} bytes");
+            }
+
+            if (size > _frameSizeMax)
+            {
+                throw new InvalidDataException($"frame with {size} bytes exceeds Ice.MessageSizeMax value");
+            }
+
+            // Read the remainder of the frame if needed
+            if (size > readBuffer.Array!.Length)
+            {
+                // Allocate a new array and copy the header over
+                var buffer = new ArraySegment<byte>(new byte[size], 0, size);
+                readBuffer.AsSpan().CopyTo(buffer.AsSpan(0, Ice2Definitions.HeaderSize));
+                readBuffer = buffer;
+            }
+            else if (size > readBuffer.Count)
+            {
+                readBuffer = new ArraySegment<byte>(readBuffer.Array!, 0, size);
+            }
+            Debug.Assert(size == readBuffer.Count);
+
+            offset = Ice2Definitions.HeaderSize;
+            while (offset < readBuffer.Count)
+            {
+                int bytesReceived = await Transceiver.ReadAsync(readBuffer, offset).ConfigureAwait(false);
+                offset += bytesReceived;
+
+                // Trace the receive progress within the loop as we might be receiving significant amount
+                // of data here.
+                _receivedCallback(bytesReceived);
+            }
+            return readBuffer;
+        }
+
+        private async ValueTask PerformSendFrameAsync(int streamId, object frame)
+        {
+            List<ArraySegment<byte>> writeBuffer;
+
+            // TODO: add abstract OutgoingFrame class with an abstract GetRequestData(streamId) method?
+            if (frame is OutgoingRequestFrame requestFrame)
+            {
+                writeBuffer = Ice2Definitions.GetRequestData(requestFrame, streamId);
+                ProtocolTrace.TraceFrame(Endpoint.Communicator, writeBuffer[0], requestFrame);
+            }
+            else if (frame is OutgoingResponseFrame responseFrame)
+            {
+                Debug.Assert(streamId > 0);
+                writeBuffer = Ice2Definitions.GetResponseData(responseFrame, streamId);
+                ProtocolTrace.TraceFrame(Endpoint.Communicator, writeBuffer[0], responseFrame);
+            }
+            else
+            {
+                Debug.Assert(frame is List<ArraySegment<byte>>);
+                writeBuffer = (List<ArraySegment<byte>>)frame;
+                ProtocolTrace.TraceSend(Endpoint.Communicator, Endpoint.Protocol, writeBuffer[0]);
+            }
+
+            // Write the frame
+            int size = writeBuffer.GetByteCount();
+            int offset = 0;
+            while (offset < size)
+            {
+                int bytesSent = await Transceiver.WriteAsync(writeBuffer, offset).ConfigureAwait(false);
+                offset += bytesSent;
+                _sentCallback(bytesSent);
+            }
+        }
+
+        private Task SendFrameAsync(int streamId, object frame, CancellationToken cancel)
+        {
+            cancel.ThrowIfCancellationRequested();
+            ValueTask sendTask = QueueAsync(streamId, frame, cancel);
+            _sendTask = sendTask.IsCompletedSuccessfully ? Task.CompletedTask : sendTask.AsTask();
+            return _sendTask;
+
+            async ValueTask QueueAsync(int streamId, object frame, CancellationToken cancel)
+            {
+                // Wait for the previous send to complete
+                try
+                {
+                    await _sendTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // If the send was canceled, ignore and continue sending.
+                }
+
+                // If the send got cancelled, throw now. This isn't a fatal connection error, the next pending
+                // outgoing will be sent because we ignore the cancelation exception above.
+                // TODO: is it really a good idea to cancel the request here? The stream/request ID assigned for the
+                // the request won't be used.
+                cancel.ThrowIfCancellationRequested();
+
+                // Perform the write
+                await PerformSendFrameAsync(streamId, frame).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -33,17 +33,6 @@ namespace ZeroC.Ice
         private AsyncCallback? _writeCallback;
         private IAsyncResult? _writeResult;
 
-        public Connection CreateConnection(
-            IConnectionManager manager,
-            Endpoint endpoint,
-            IConnector? connector,
-            string connectionId,
-            ObjectAdapter? adapter)
-        {
-            Debug.Assert(endpoint.IsSecure);
-            return new TcpConnection(manager, endpoint, this, connector, connectionId, adapter);
-        }
-
         public Socket? Fd() => _delegate.Fd();
 
         public int Initialize(ref ArraySegment<byte> readBuffer, IList<ArraySegment<byte>> writeBuffer)

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -110,8 +110,20 @@ namespace ZeroC.Ice
         public override Endpoint NewTimeout(TimeSpan timeout) =>
             timeout == Timeout ? this : CreateIPEndpoint(Host, Port, HasCompressionFlag, timeout);
 
-        public override IAcceptor GetAcceptor(string adapterName) =>
-            new TcpAcceptor(this, Communicator, Host, Port, adapterName);
+       public override Connection CreateConnection(
+            IConnectionManager manager,
+            ITransceiver? transceiver,
+            IConnector? connector,
+            string connectionId,
+            ObjectAdapter? adapter) =>
+            new TcpConnection(manager,
+                              this,
+                              Protocol == Protocol.Ice1 ? (IBinaryConnection)
+                                new Ice1BinaryConnection(transceiver!, this, adapter) :
+                                new SlicBinaryConnection(transceiver!, this, adapter),
+                              connector,
+                              connectionId,
+                              adapter);
         public override ITransceiver? GetTransceiver() => null;
 
         internal TcpEndpoint(

--- a/csharp/src/Ice/TcpTransceiver.cs
+++ b/csharp/src/Ice/TcpTransceiver.cs
@@ -11,12 +11,6 @@ namespace ZeroC.Ice
 {
     internal sealed class TcpTransceiver : ITransceiver
     {
-        public Connection CreateConnection(
-            IConnectionManager manager,
-            Endpoint endpoint,
-            IConnector? connector,
-            string connectionId,
-            ObjectAdapter? adapter) => new TcpConnection(manager, endpoint, this, connector, connectionId, adapter);
         public Socket? Fd() => _stream.Fd();
 
         public int Initialize(ref ArraySegment<byte> readBuffer, IList<ArraySegment<byte>> writeBuffer) =>

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -131,7 +131,17 @@ namespace ZeroC.Ice
 
         public override Endpoint NewTimeout(TimeSpan timeout) => this;
 
-        public override IAcceptor? GetAcceptor(string adapterName) => null;
+        public override Connection CreateConnection(
+             IConnectionManager manager,
+             ITransceiver? transceiver,
+             IConnector? connector,
+             string connectionId,
+             ObjectAdapter? adapter) => new UdpConnection(manager,
+                                                          this,
+                                                          new Ice1BinaryConnection(transceiver!, this, adapter),
+                                                          connector,
+                                                          connectionId,
+                                                          adapter);
 
         public override ITransceiver GetTransceiver() =>
             new UdpTransceiver(this, Communicator, Host, Port, McastInterface, _connect);

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -14,12 +14,6 @@ namespace ZeroC.Ice
     {
         internal System.Net.IPEndPoint? McastAddress { get; private set; }
 
-        public Connection CreateConnection(
-            IConnectionManager manager,
-            Endpoint endpoint,
-            IConnector? connector,
-            string connectionId,
-            ObjectAdapter? adapter) => new UdpConnection(manager, endpoint, this, connector, connectionId, adapter);
         public Socket? Fd() => _fd;
 
         public int Initialize(ref ArraySegment<byte> readBuffer, IList<ArraySegment<byte>> writeBuffer)

--- a/csharp/src/Ice/UniversalEndpoint.cs
+++ b/csharp/src/Ice/UniversalEndpoint.cs
@@ -86,6 +86,13 @@ namespace ZeroC.Ice
         public override ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType _) =>
             new ValueTask<IEnumerable<IConnector>>(new List<IConnector>());
 
+        public override Connection CreateConnection(
+            IConnectionManager manager,
+            ITransceiver? transceiver,
+            IConnector? connector,
+            string connectionId,
+            ObjectAdapter? adapter) => null!;
+
         public override IEnumerable<Endpoint> ExpandHost(out Endpoint? publishedEndpoint)
         {
             publishedEndpoint = null;
@@ -94,7 +101,6 @@ namespace ZeroC.Ice
 
         public override IEnumerable<Endpoint> ExpandIfWildcard() => new Endpoint[] { this };
 
-        public override IAcceptor? GetAcceptor(string adapterName) => null;
         public override ITransceiver? GetTransceiver() => null;
 
         protected internal override void AppendOptions(StringBuilder sb, char optionSeparator)

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -90,6 +90,21 @@ namespace ZeroC.Ice
             }
         }
 
+        public override Connection CreateConnection(
+            IConnectionManager manager,
+            ITransceiver? transceiver,
+            IConnector? connector,
+            string connectionId,
+            ObjectAdapter? adapter) =>
+            new WSConnection(manager,
+                this,
+                Protocol == Protocol.Ice1? (IBinaryConnection)
+                new Ice1BinaryConnection(transceiver!, this, adapter) :
+                new SlicBinaryConnection(transceiver!, this, adapter),
+                connector,
+                connectionId,
+                adapter);
+
         internal WSEndpoint(
             Communicator communicator,
             Protocol protocol,

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -33,14 +33,6 @@ namespace ZeroC.Ice
     {
         internal SslStream? SslStream => (_delegate as SslTransceiver)?.SslStream;
 
-        public Connection CreateConnection(
-            IConnectionManager manager,
-            Endpoint endpoint,
-            IConnector? connector,
-            string connectionId,
-            ObjectAdapter? adapter) =>
-            new WSConnection(manager, endpoint, this, connector, connectionId, adapter);
-
         public Socket? Fd() => _delegate.Fd();
 
         public int Initialize(ref ArraySegment<byte> readBuffer, IList<ArraySegment<byte>> writeBuffer)

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -37,7 +37,7 @@ namespace ZeroC.Ice.Test.Invoke
                     throw new MyException();
                 }
                 return new ValueTask<OutgoingResponseFrame>(
-                    new OutgoingResponseFrame(current, new MyException()));
+                    new OutgoingResponseFrame(request, new MyException()));
             }
             else if (current.Operation.Equals("shutdown"))
             {

--- a/csharp/test/Ice/metrics/InstrumentationI.cs
+++ b/csharp/test/Ice/metrics/InstrumentationI.cs
@@ -144,7 +144,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
         }
 
-        public IRemoteObserver GetRemoteObserver(Connection c, int a, int b)
+        public IRemoteObserver GetRemoteObserver(Connection c, long a, int b)
         {
             lock (Mutex)
             {
@@ -157,7 +157,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
         }
 
-        public ICollocatedObserver GetCollocatedObserver(ObjectAdapter adapter, int a, int b)
+        public ICollocatedObserver GetCollocatedObserver(ObjectAdapter adapter, long a, int b)
         {
             lock (Mutex)
             {
@@ -308,7 +308,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
         }
 
-        public IDispatchObserver GetDispatchObserver(Current current, int requestId, int s)
+        public IDispatchObserver GetDispatchObserver(Current current, long requestId, int s)
         {
             lock (_mutex)
             {

--- a/csharp/test/Ice/retry/Instrumentation.cs
+++ b/csharp/test/Ice/retry/Instrumentation.cs
@@ -50,9 +50,9 @@ namespace ZeroC.Ice.Test.Retry
             {
             }
 
-            public IRemoteObserver? GetRemoteObserver(Connection connection, int requestId, int size) => null;
+            public IRemoteObserver? GetRemoteObserver(Connection connection, long requestId, int size) => null;
 
-            public ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, int i, int j) => null;
+            public ICollocatedObserver? GetCollocatedObserver(ObjectAdapter adapter, long i, int j) => null;
 
         }
 
@@ -72,7 +72,7 @@ namespace ZeroC.Ice.Test.Retry
             public IInvocationObserver? GetInvocationObserver(IObjectPrx? p, string o,
                 IReadOnlyDictionary<string, string> c) => _invocationObserver;
 
-            public IDispatchObserver? GetDispatchObserver(Current c, int requestId, int i) => null;
+            public IDispatchObserver? GetDispatchObserver(Current c, long requestId, int i) => null;
 
             public void SetObserverUpdater(IObserverUpdater? u)
             {

--- a/csharp/test/IceBox/admin/config.icebox
+++ b/csharp/test/IceBox/admin/config.icebox
@@ -1,6 +1,5 @@
 Ice.Admin.InstanceName=DemoIceBox
 Ice.Admin.Endpoints=default -p 9996 -h 127.0.0.1
 Ice.ProgramName=IceBox
-Ice.Default.Protocol=ice1
 
 IceBox.Service.TestService=msbuild/testservice/netcoreapp3.1/testservice.dll:ZeroC.IceBox.Test.Admin.TestService --Ice.Config=config.service

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -99,9 +99,9 @@ namespace Test
                 {
                     sb.Append(host);
                 }
-                sb.Append(":");
+                sb.Append(':');
                 sb.Append(GetTestPort(properties, num));
-                sb.Append("/");
+                sb.Append('/');
                 sb.Append(identity);
                 return sb.ToString();
             }

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -11,6 +11,7 @@ class Ice(Component):
     # Options for all transports (ran only with Ice client/server tests defined for cross testing)
     transportOptions = {
         "transport" : ["tcp", "ssl", "wss", "ws"],
+        "protocol" : ["ice1", "ice2"],
         "compress" : [False, True],
         "ipv6" : [False, True],
         "serialize" : [False, True],
@@ -20,6 +21,7 @@ class Ice(Component):
     # Options for Ice tests, run tests with ssl and ws/ipv6/serial/mx/compress
     coreOptions = {
         "transport" : ["ssl", "ws"],
+        "protocol" : ["ice1", "ice2"],
         "compress" : [False, True],
         "ipv6" : [False, True],
         "serialize" : [False, True],
@@ -29,6 +31,7 @@ class Ice(Component):
     # Options for Ice services, run tests with ssl + mx
     serviceOptions = {
         "transport" : ["ssl"],
+        "protocol" : ["ice1"],
         "compress" : [False],
         "ipv6" : [False],
         "serialize" : [False],
@@ -130,6 +133,11 @@ class Ice(Component):
             #
             if current.config.ipv6 and testId in ["Ice/udp"]:
                 return False
+
+        # Only Ice/IceBox tests support running with the ice2 protocol for now
+        # TODO: remove once ice2 is supported with all the mappings
+        if not parent in ["Ice", "IceBox"]:
+            return current.config.protocol == "ice1"
 
         return True
 

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -551,8 +551,8 @@ class Mapping(object):
 
         @classmethod
         def getSupportedArgs(self):
-            return ("", ["config=", "platform=", "transport=", "target=", "compress", "ipv6", "no-ipv6", "serialize",
-                         "mx", "cprops=", "sprops="])
+            return ("", ["config=", "platform=", "transport=", "protocol=", "target=", "compress", "ipv6", "no-ipv6",
+                         "serialize", "mx", "cprops=", "sprops="])
 
         @classmethod
         def usage(self):
@@ -563,6 +563,7 @@ class Mapping(object):
             print("")
             print("Mapping options:")
             print("--transport=<value>   Run with the given transport.")
+            print("--protocol=<value>    Run with the given protocol.")
             print("--compress            Run the tests with protocol compression.")
             print("--ipv6                Use IPv6 addresses.")
             print("--serialize           Run with connection serialization.")
@@ -589,6 +590,7 @@ class Mapping(object):
 
             self.pathOverride = ""
             self.transport = "tcp"
+            self.protocol = "ice2"
             self.compress = False
             self.serialize = False
             self.ipv6 = False
@@ -720,7 +722,7 @@ class Mapping(object):
             # options that are set on the JS configuration.
             #
             clone = copy.copy(self)
-            for o in current.config.parsedOptions + ["transport"]:
+            for o in current.config.parsedOptions + ["transport", "protocol"]:
                 if o not in ["buildConfig", "buildPlatform"]:
                     setattr(clone, o, getattr(current.config, o))
             clone.parsedOptions = current.config.parsedOptions
@@ -735,6 +737,8 @@ class Mapping(object):
                 props["Ice.Warn.Connections"] = True
                 if self.transport:
                     props["Ice.Default.Transport"] = self.transport
+                if self.protocol:
+                    props["Ice.Default.Protocol"] = self.protocol
                 if self.compress:
                     props["Ice.Override.Compress"] = "1"
                 if self.serialize:

--- a/scripts/tests/Ice/ami.py
+++ b/scripts/tests/Ice/ami.py
@@ -5,7 +5,7 @@
 
 # Enable some tracing to allow investigating test failures
 traceProps = {
-    "Ice.Trace.Network" : 2,
+    "Ice.Trace.Network" : 3,
     "Ice.Trace.Retry" : 1,
     "Ice.Trace.Protocol" : 1
 }

--- a/scripts/tests/IceBox/admin.py
+++ b/scripts/tests/IceBox/admin.py
@@ -18,11 +18,12 @@ class IceBoxAdminTestCase(ClientServerTestCase):
         admin.run(current, args=['shutdown'])
         current.writeln("ok")
 
+# TODO: add support for running the test with ice2
 TestSuite(__name__, [
         ClientServerTestCase(server=IceBox("{testdir}/config.icebox")),
         IceBoxAdminTestCase("iceboxadmin", server=IceBox("{testdir}/config.icebox")),
     ],
     libDirs=["testservice"],
     runOnMainThread=True,
-    options={ "ipv6" : [False], "mx" : [False] },
+    options={ "ipv6" : [False], "mx" : [False], "protocol" : ["ice1"] },
     multihost=False)

--- a/scripts/tests/IceBox/configuration.py
+++ b/scripts/tests/IceBox/configuration.py
@@ -3,7 +3,13 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+# TODO: support for different protocols? For services without inheritance, we have to somehow set the
+# default protocol in the service configuration
 TestSuite(__name__, [
     ClientServerTestCase("client/server #1", server=IceBox("{testdir}/config.icebox")),
     ClientServerTestCase("client/server #2", server=IceBox("{testdir}/config.icebox2"))
-], libDirs=["testservice"], runOnMainThread=True, options={ "transport" : ["tcp"], "ipv6" : [False], "mx" : [False] }, multihost=False)
+],
+libDirs=["testservice"],
+runOnMainThread=True,
+options={ "transport" : ["tcp"], "ipv6" : [False], "mx" : [False], "protocol": ["ice2"] },
+multihost=False)


### PR DESCRIPTION
This PR changes the following:
- the endpoint compress flag is no longer used for figuring out if compression should be used for ice1 requests
- Outgoing/Incoming frames now support a compress boolean or status to tell the Ice1Connection whether not the protocol frame should be compressed
- introduction of the IBinaryConnection interface with two concrete implementations: Ice1BinaryConnection and SlicBinaryConnection, these classes handle the transport framing on top of the raw binary transport (tcp/ssl/ws). For now, the slic frames are the same as ice1 but this will evolve to implement Slic frames (INITALIZE, etc). A QuicBinaryConnection will handle the communication with Quic.
- the connection class now only only handles Incoming/Outgoing frames created/passed from/to the binary connection
- I've split the incoming connection factory into a DatagramIncomingConnection and TcpIncomingConnectionFactory. We'll eventually have a QuicIncomingConnectionFactory. And depending on what we decide for port sharing the TcpIncomingConnectionFactory might be split into an Ice1IncomingFactory (no port sharing, creates Ice1BinaryConnection) and SlicIncomingConnectionFactory which would support listening on the same port for several ice2 endpoints (tcp,ws).
- Fixed the test suite driver to support testing ice1 and ice2 with --all and --protocol=ice1|ice2
