### PR TITLE
Improvements to GetPropertyAsBool

### DIFF
--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -47,7 +47,7 @@ namespace ZeroC.Ice
 
         /// <summary>Gets the value of a property as a bool. If the property is not set, returns null.</summary>
         /// <param name="name">The property name.</param>
-        /// <returns>True if the property value is the "1" or "True"; false if "0" or "False". Strings are
+        /// <returns>True if the property value is the "1" or "True", false if "0" or "False", or null. Values are
         /// case-insensitive.</returns>
         public bool? GetPropertyAsBool(string name)
         {

--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -47,10 +47,34 @@ namespace ZeroC.Ice
 
         /// <summary>Gets the value of a property as a bool. If the property is not set, returns null.</summary>
         /// <param name="name">The property name.</param>
-        /// <returns>True if the property value is parsed into an integer greater than 0; false of the property value
-        /// is parsed into an integer smaller or equal to 0.</returns>
-        public bool? GetPropertyAsBool(string name) =>
-            GetPropertyAsInt(name) is int intValue ? intValue > 0 : (bool?)null;
+        /// <returns>True if the property value is the "1" or "True"; false if "0" or "False". Strings are
+        /// case-insensitive.</returns>
+        public bool? GetPropertyAsBool(string name)
+        {
+            lock (_properties)
+            {
+                if (_properties.TryGetValue(name, out PropertyValue? pv))
+                {
+                    pv.Used = true;
+
+                    try
+                    {
+                        return pv.Val switch
+                        {
+                            "0" => false,
+                            "1" => true,
+                            _ => bool.Parse(pv.Val)
+                        };
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidConfigurationException(
+                            $"the value `{pv.Val}' of property `{name}' is not a bool", ex);
+                    }
+                }
+                return null;
+            }
+        }
 
         /// <summary>Gets the value of a property as a size in bytes. If the property is not set, returns null.
         /// The value must be an integer followed immediately by an optional size unit of 'K', 'M' or 'G'.

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -78,6 +78,63 @@ namespace ZeroC.Ice.Test.Properties
             }
 
             {
+                Console.Out.Write("testing configuration properties as bool... ");
+                var boolProperties = new Dictionary<string, string>
+                {
+                    { "Bool.True.Integer", "1" },
+                    { "Bool.True.LowerCase", "true" },
+                    { "Bool.True.UpperCase", "TRUE" },
+                    { "Bool.True.InitialUpperCase", "True" },
+
+                    { "Bool.False.Integer", "0" },
+                    { "Bool.False.LowerCase", "false" },
+                    { "Bool.False.UpperCase", "FALSE" },
+                    { "Bool.False.InitialLowerCase", "False" },
+
+                    {"Bool.Bad.Integer", "2"},
+                    {"Bool.Bad.Empty", ""},
+                    {"Bool.Bad.NonTrueFalseWord", "hello"},
+                    {"Bool.Bad.Yes", "yes"}
+                };
+
+                await using var communicator = new Communicator(boolProperties);
+
+                {
+                    var value = communicator.GetPropertyAsBool("Bool.True.Integer");
+                    Assert(value == true);
+                    value = communicator.GetPropertyAsBool("Bool.True.LowerCase");
+                    Assert(value == true);
+                    value = communicator.GetPropertyAsBool("Bool.True.UpperCase");
+                    Assert(value == true);
+                    value = communicator.GetPropertyAsBool("Bool.True.InitialUpperCase");
+                    Assert(value == true);
+
+                    value = communicator.GetPropertyAsBool("Bool.False.Integer");
+                    Assert(value == false);
+                    value = communicator.GetPropertyAsBool("Bool.False.LowerCase");
+                    Assert(value == false);
+                    value = communicator.GetPropertyAsBool("Bool.False.UpperCase");
+                    Assert(value == false);
+                    value = communicator.GetPropertyAsBool("Bool.False.InitialLowerCase");
+                    Assert(value == false);
+                }
+
+                foreach (string property in communicator.GetProperties("Bool.Bad").Keys)
+                {
+                    try
+                    {
+                        _ = communicator.GetPropertyAsBool(property);
+                        Assert(false);
+                    }
+                    catch (InvalidConfigurationException)
+                    {
+                    }
+                }
+
+                Console.Out.WriteLine("ok");
+            }
+
+            {
                 Console.Out.Write("testing configuration properties as TimeSpan... ");
                 var timeSpanProperties = new Dictionary<string, string>
                 {


### PR DESCRIPTION
GetPropertyAsBool now supports the following values:
- 0 or 1
- True or False (case-insensitive)