### PR TITLE
URI parsing for OA Endpoints in C#

### DIFF
--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1042,8 +1042,8 @@ namespace ZeroC.Ice
                 "-t" => InvocationMode.Twoway,
                 "-o" => InvocationMode.Oneway,
                 "-d" => InvocationMode.Datagram,
-                "-O" => throw new NotSupportedException("batch oneway is not supported in ProxyOptions"),
-                "-D" => throw new NotSupportedException("batch datagram is not supported in ProxyOptions"),
+                "-O" => throw new NotSupportedException($"batch oneway is not supported in {Name}.ProxyOptions"),
+                "-D" => throw new NotSupportedException($"batch datagram is not supported in {Name}.ProxyOptions"),
                 _ => throw new InvalidConfigurationException($"cannot parse ProxyOptions {proxyOptions}")
             };
 

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -29,7 +29,7 @@ namespace ZeroC.Ice
                 Protocol.Ice1 => Encoding.V1_1,
                 Protocol.Ice2 => Encoding.V2_0,
                 _ => throw new NotSupportedException(@$"Ice protocol `{protocol.GetName()
-                }' is not supported by this Ice runtime ({Runtime.StringVersion})")
+                    }' is not supported by this Ice runtime ({Runtime.StringVersion})")
             };
 
         /// <summary>Returns the name of this protocol in lowercase, e.g. "ice1" or "ice2".</summary>

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -29,7 +29,7 @@ namespace ZeroC.Ice
                 Protocol.Ice1 => Encoding.V1_1,
                 Protocol.Ice2 => Encoding.V2_0,
                 _ => throw new NotSupportedException(@$"Ice protocol `{protocol.GetName()
-                    }' is not supported by this Ice runtime ({Runtime.StringVersion})")
+                }' is not supported by this Ice runtime ({Runtime.StringVersion})")
             };
 
         /// <summary>Returns the name of this protocol in lowercase, e.g. "ice1" or "ice2".</summary>

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -70,7 +70,7 @@ namespace ZeroC.Ice
                 throw new FormatException("empty string is invalid");
             }
 
-            return UriParser.IsUri(proxyString) ? ParseUri(proxyString, communicator, propertyPrefix) :
+            return UriParser.IsProxyUri(proxyString) ? ParseUri(proxyString, communicator, propertyPrefix) :
                 ParseIce1Format(proxyString, communicator, propertyPrefix);
         }
 
@@ -734,11 +734,8 @@ namespace ZeroC.Ice
 
         private static Reference ParseUri(string uriString, Communicator communicator, string? propertyPrefix)
         {
-            var proxyOptions = new UriParser.ProxyOptions();
-            (Uri uri, IReadOnlyList<Endpoint> endpoints) = UriParser.Parse(uriString, communicator, proxyOptions);
-
-            string facet = uri.Fragment.Length >= 2 ? Uri.UnescapeDataString(uri.Fragment.TrimStart('#')) : "";
-            var path = uri.AbsolutePath.TrimStart('/').Split('/').Select(s => Uri.UnescapeDataString(s)).ToList();
+            (IReadOnlyList<Endpoint> endpoints, List<string> path, UriParser.ProxyOptions proxyOptions, string facet) =
+                UriParser.ParseProxy(uriString, communicator);
 
             string adapterId = "";
             Identity identity;

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -31,7 +31,7 @@ namespace ZeroC.Ice
             GenericUriParserOptions.IriParsing |
             GenericUriParserOptions.NoUserInfo;
 
-        /// <summary>Checks if a string is an ice+transport URI, and not a endpoint string using the ice1 string
+        /// <summary>Checks if a string is an ice+transport URI, and not an endpoint string using the ice1 string
         /// format.</summary>
         /// <param name="s">The string to check.</param>
         /// <returns>True when the string is most likely an ice+transport URI; otherwise, false.</returns>

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -176,6 +176,13 @@ namespace ZeroC.Ice
             return endpoint;
         }
 
+        /// <summary>Creates a Uri and parses its query.</summary>
+        /// <param name="uriString">The string to parse.</param>
+        /// <param name="pureEndpoints">When true, the string represents one or more endpoints, and proxy options are
+        /// not allowed in the query.</param>
+        /// <param name="endpointOptions">A dictionary that accepts the parsed endpoint options. Set to null when
+        /// parsing an ice URI (and in this case pureEndpoints must be false).</param>
+        /// <returns>The parsed URI, the alt-endpoint option (if set) and the ProxyOptions struct.</returns>
         private static (Uri Uri, string? AltEndpoint, ProxyOptions ProxyOptions) InitialParse(
             string uriString,
             bool pureEndpoints,

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -16,11 +16,11 @@ namespace ZeroC.Ice
     internal static class UriParser
     {
         /// <summary>Provides the proxy options parsed by the UriParser.</summary>
-        internal class ProxyOptions
+        internal struct ProxyOptions
         {
             // TODO: add more proxy options
-            internal Encoding? Encoding { get; set; }
-            internal Protocol? Protocol { get; set; }
+            internal Encoding? Encoding;
+            internal Protocol? Protocol;
         }
 
         // Common options for the ice and ice[+transport] parsers we register for each transport.
@@ -31,101 +31,27 @@ namespace ZeroC.Ice
             GenericUriParserOptions.IriParsing |
             GenericUriParserOptions.NoUserInfo;
 
-        /// <summary>Checks if a string is an ice or ice+transport URI, and not a proxy or endpoint string using the
-        /// ice1 string format.</summary>
+        /// <summary>Checks if a string is an ice+transport URI, and not a endpoint string using the ice1 string
+        /// format.</summary>
+        /// <param name="s">The string to check.</param>
+        /// <returns>True when the string is most likely an ice+transport URI; otherwise, false.</returns>
+        internal static bool IsEndpointUri(string s) => s.StartsWith("ice+") && s.Contains("://");
+
+        /// <summary>Checks if a string is an ice or ice+transport URI, and not a proxy string using the ice1 string
+        /// format.</summary>
         /// <param name="s">The string to check.</param>
         /// <returns>True when the string is most likely an ice or ice+transport URI; otherwise, false.</returns>
-        internal static bool IsUri(string s) => s.StartsWith("ice:") || (s.StartsWith("ice+") && s.Contains("://"));
+        internal static bool IsProxyUri(string s) => s.StartsWith("ice:") || IsEndpointUri(s);
 
-        /// <summary>Parses an ice or ice+transport URI string.</summary>
+        /// <summary>Parses an ice+transport URI string that represents one or more object adapter endpoints.</summary>
         /// <param name="uriString">The URI string to parse.</param>
         /// <param name="communicator">The communicator.</param>
-        /// <param name="proxyOptions">When not null, the uriString represents a proxy and this method parses proxy
-        /// options into this parameter.</param>
-        /// <returns>The Uri and endpoints of the ice or ice+transport URI.</returns>
-        internal static (Uri Uri, IReadOnlyList<Endpoint> Endpoints) Parse(
-            string uriString,
-            Communicator communicator,
-            ProxyOptions? proxyOptions = null)
-        {
-            Debug.Assert(IsUri(uriString));
-
-            try
-            {
-                bool iceScheme = uriString.StartsWith("ice:");
-                if (iceScheme && proxyOptions == null)
-                {
-                    throw new FormatException("an object adapter endpoint supports only ice+transport URIs");
-                }
-
-                Dictionary<string, string>? endpointOptions = iceScheme ? null : new Dictionary<string, string>();
-
-                (Uri uri, string? altEndpoint) = InitialParse(uriString, proxyOptions, endpointOptions);
-
-                List<Endpoint>? endpoints = null;
-
-                if (endpointOptions != null) // i.e. not ice scheme
-                {
-                    endpoints = new List<Endpoint>
-                    {
-                        CreateEndpoint(communicator, proxyOptions, endpointOptions, uri, uriString)
-                    };
-
-                    if (altEndpoint != null)
-                    {
-                        foreach (string endpointStr in altEndpoint.Split(','))
-                        {
-                            if (endpointStr.StartsWith("ice:"))
-                            {
-                                throw new FormatException(
-                                    $"invalid URI scheme for endpoint `{endpointStr}': must be empty or ice+transport");
-                            }
-
-                            string altUriString = endpointStr;
-                            if (!altUriString.StartsWith("ice+"))
-                            {
-                                altUriString = $"{uri.Scheme}://{altUriString}";
-                            }
-
-                            // The separator for endpoint options in alt-endpoint is $, and we replace these $ by &
-                            // before sending the string the main parser (InitialParse), which uses & as separator.
-                            altUriString = altUriString.Replace('$', '&');
-
-                            // No need to clear endpointOptions before reusing it since CreateEndpoint consumes all the
-                            // endpoint options
-                            Debug.Assert(endpointOptions.Count == 0);
-
-                            (Uri endpointUri, string? endpointAltEndpoint) =
-                                InitialParse(altUriString, proxyOptions: null, endpointOptions);
-
-                            if (endpointAltEndpoint != null)
-                            {
-                                throw new FormatException(
-                                    $"invalid option `alt-endpoint' in endpoint `{endpointStr}'");
-                            }
-
-                            Debug.Assert(endpointUri.AbsolutePath[0] == '/'); // there is always a first segment
-                            if (endpointUri.AbsolutePath.Length > 1 || endpointUri.Fragment.Length > 0)
-                            {
-                                throw new FormatException(
-                                    $"endpoint `{endpointStr}' must not specify a path or fragment");
-                            }
-                            endpoints.Add(
-                                CreateEndpoint(communicator, proxyOptions, endpointOptions, endpointUri, endpointStr));
-                        }
-                    }
-                }
-                return (uri, (IReadOnlyList<Endpoint>?)endpoints ?? ImmutableArray<Endpoint>.Empty);
-            }
-            catch (Exception ex)
-            {
-                // Give context to the exception.
-                throw new FormatException($"failed to parse URI `{uriString}'", ex);
-            }
-        }
+        /// <returns>The list of endpoints.</returns>
+        internal static IReadOnlyList<Endpoint> ParseEndpoints(string uriString, Communicator communicator) =>
+            Parse(uriString, oaEndpoints: true, communicator).Endpoints;
 
         /// <summary>Parses a relative URI [category/]name[#facet] into an identity and facet.</summary>
-        internal static (Identity Identity, string Facet) Parse(string uriString)
+        internal static (Identity Identity, string Facet) ParseIdentityAndFacet(string uriString)
         {
             // First extract the facet, if any
             string facet = "";
@@ -141,6 +67,23 @@ namespace ZeroC.Ice
                 path = uriString;
             }
             return (Identity.Parse(path), facet);
+        }
+
+        /// <summary>Parses an ice or ice+transport URI string that represents a proxy.</summary>
+        /// <param name="uriString">The URI string to parse.</param>
+        /// <param name="communicator">The communicator.</param>
+        /// <returns>The components of the proxy.</returns>
+        internal static (IReadOnlyList<Endpoint> Endpoints,
+                        List<string> Path,
+                        ProxyOptions ProxyOptions,
+                        string Facet) ParseProxy(string uriString, Communicator communicator)
+        {
+            (Uri uri, IReadOnlyList<Endpoint> endpoints, ProxyOptions proxyOptions) =
+                Parse(uriString, oaEndpoints: false, communicator);
+
+            string facet = uri.Fragment.Length >= 2 ? Uri.UnescapeDataString(uri.Fragment.TrimStart('#')) : "";
+            var path = uri.AbsolutePath.TrimStart('/').Split('/').Select(s => Uri.UnescapeDataString(s)).ToList();
+            return (endpoints, path, proxyOptions, facet);
         }
 
         /// <summary>Registers the ice and ice+universal schemes.</summary>
@@ -166,15 +109,14 @@ namespace ZeroC.Ice
 
         private static Endpoint CreateEndpoint(
             Communicator communicator,
-            ProxyOptions? proxyOptions,
+            bool oaEndpoint,
             Dictionary<string, string> options,
+            Protocol protocol,
             Uri uri,
             string uriString)
         {
             Debug.Assert(uri.Scheme.StartsWith("ice+"));
             string transportName = uri.Scheme.Substring(4); // i.e. chop-off "ice+"
-
-            Protocol protocol = proxyOptions?.Protocol ?? Protocol.Ice2;
 
             ushort port;
             checked
@@ -187,7 +129,7 @@ namespace ZeroC.Ice
 
             if (transportName == "universal")
             {
-                if (proxyOptions == null)
+                if (oaEndpoint)
                 {
                     throw new FormatException("ice+universal cannot specify an object adapter endpoint");
                 }
@@ -223,7 +165,7 @@ namespace ZeroC.Ice
                                                 uri.DnsSafeHost,
                                                 port,
                                                 options,
-                                                oaEndpoint: proxyOptions == null,
+                                                oaEndpoint,
                                                 uriString) ??
                 new UniversalEndpoint(communicator, transport, protocol, uri.DnsSafeHost, port, options);
 
@@ -234,15 +176,15 @@ namespace ZeroC.Ice
             return endpoint;
         }
 
-        private static (Uri Uri, string? AltEndpoint) InitialParse(
+        private static (Uri Uri, string? AltEndpoint, ProxyOptions ProxyOptions) InitialParse(
             string uriString,
-            ProxyOptions? proxyOptions,
+            bool pureEndpoints,
             Dictionary<string, string>? endpointOptions)
         {
             if (endpointOptions == null) // i.e. ice scheme
             {
                 Debug.Assert(uriString.StartsWith("ice:"));
-                Debug.Assert(proxyOptions != null);
+                Debug.Assert(!pureEndpoints);
 
                 string body = uriString.Substring(4);
                 if (body.StartsWith("//"))
@@ -262,9 +204,19 @@ namespace ZeroC.Ice
 
             var uri = new Uri(uriString);
 
+            if (pureEndpoints)
+            {
+                Debug.Assert(uri.AbsolutePath[0] == '/'); // there is always a first segment
+                if (uri.AbsolutePath.Length > 1 || uri.Fragment.Length > 0)
+                {
+                    throw new FormatException($"endpoint `{uriString}' must not specify a path or fragment");
+                }
+            }
+
             string[] nvPairs = uri.Query.Length >= 2 ? uri.Query.TrimStart('?').Split('&') : Array.Empty<string>();
 
             string? altEndpoint = null;
+            ProxyOptions proxyOptions = default;
 
             foreach (string p in nvPairs)
             {
@@ -278,7 +230,7 @@ namespace ZeroC.Ice
 
                 if (name == "encoding")
                 {
-                    if (proxyOptions == null)
+                    if (pureEndpoints)
                     {
                         throw new FormatException($"encoding is not a valid option for endpoint `{uriString}'");
                     }
@@ -290,7 +242,7 @@ namespace ZeroC.Ice
                 }
                 else if (name == "protocol")
                 {
-                    if (proxyOptions == null)
+                    if (pureEndpoints)
                     {
                         throw new FormatException($"protocol is not a valid option for endpoint `{uriString}'");
                     }
@@ -324,7 +276,95 @@ namespace ZeroC.Ice
                     }
                 }
             }
-            return (uri, altEndpoint);
+            return (uri, altEndpoint, proxyOptions);
+        }
+
+        /// <summary>Parses an ice or ice+transport URI string.</summary>
+        /// <param name="uriString">The URI string to parse.</param>
+        /// <param name="oaEndpoints">True when parsing the endpoints of an object adapter; false when parsing a proxy.
+        /// </param>
+        /// <param name="communicator">The communicator.</param>
+        /// <returns>The Uri and endpoints of the ice or ice+transport URI.</returns>
+        private static (Uri Uri, IReadOnlyList<Endpoint> Endpoints, ProxyOptions ProxyOptions) Parse(
+            string uriString,
+            bool oaEndpoints,
+            Communicator communicator)
+        {
+            Debug.Assert(IsProxyUri(uriString));
+
+            try
+            {
+                bool iceScheme = uriString.StartsWith("ice:");
+                if (iceScheme && oaEndpoints)
+                {
+                    throw new FormatException("an object adapter endpoint supports only ice+transport URIs");
+                }
+
+                Dictionary<string, string>? endpointOptions = iceScheme ? null : new Dictionary<string, string>();
+
+                (Uri uri, string? altEndpoint, ProxyOptions proxyOptions) =
+                    InitialParse(uriString, pureEndpoints: oaEndpoints, endpointOptions);
+
+                Protocol protocol = proxyOptions.Protocol ?? Protocol.Ice2;
+
+                List<Endpoint>? endpoints = null;
+
+                if (endpointOptions != null) // i.e. not ice scheme
+                {
+                    endpoints = new List<Endpoint>
+                    {
+                        CreateEndpoint(communicator, oaEndpoints, endpointOptions, protocol, uri, uriString)
+                    };
+
+                    if (altEndpoint != null)
+                    {
+                        foreach (string endpointStr in altEndpoint.Split(','))
+                        {
+                            if (endpointStr.StartsWith("ice:"))
+                            {
+                                throw new FormatException(
+                                    $"invalid URI scheme for endpoint `{endpointStr}': must be empty or ice+transport");
+                            }
+
+                            string altUriString = endpointStr;
+                            if (!altUriString.StartsWith("ice+"))
+                            {
+                                altUriString = $"{uri.Scheme}://{altUriString}";
+                            }
+
+                            // The separator for endpoint options in alt-endpoint is $, and we replace these $ by &
+                            // before sending the string the main parser (InitialParse), which uses & as separator.
+                            altUriString = altUriString.Replace('$', '&');
+
+                            // No need to clear endpointOptions before reusing it since CreateEndpoint consumes all the
+                            // endpoint options
+                            Debug.Assert(endpointOptions.Count == 0);
+
+                            (Uri endpointUri, string? endpointAltEndpoint, _) =
+                                InitialParse(altUriString, pureEndpoints: true, endpointOptions);
+
+                            if (endpointAltEndpoint != null)
+                            {
+                                throw new FormatException(
+                                    $"invalid option `alt-endpoint' in endpoint `{endpointStr}'");
+                            }
+
+                            endpoints.Add(CreateEndpoint(communicator,
+                                                         oaEndpoints,
+                                                         endpointOptions,
+                                                         protocol,
+                                                         endpointUri,
+                                                         endpointStr));
+                        }
+                    }
+                }
+                return (uri, (IReadOnlyList<Endpoint>?)endpoints ?? ImmutableArray<Endpoint>.Empty, proxyOptions);
+            }
+            catch (Exception ex)
+            {
+                // Give context to the exception.
+                throw new FormatException($"failed to parse URI `{uriString}'", ex);
+            }
         }
     }
 }

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -124,6 +124,25 @@ namespace ZeroC.Ice
             }
         }
 
+        /// <summary>Parses a relative URI [category/]name[#facet] into an identity and facet.</summary>
+        internal static (Identity Identity, string Facet) Parse(string uriString)
+        {
+            // First extract the facet, if any
+            string facet = "";
+            string path;
+            int hashPos = uriString.IndexOf('#');
+            if (hashPos != -1 && hashPos != uriString.Length - 1)
+            {
+                facet = Uri.UnescapeDataString(uriString.Substring(hashPos + 1));
+                path = uriString[0..hashPos];
+            }
+            else
+            {
+                path = uriString;
+            }
+            return (Identity.Parse(path), facet);
+        }
+
         /// <summary>Registers the ice and ice+universal schemes.</summary>
         internal static void RegisterCommon()
         {

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -31,7 +31,14 @@ namespace ZeroC.Ice.Test.ACM
                 communicator.SetProperty($"{name}.ACM.Heartbeat", Enum.Parse<AcmHeartbeat>(heartbeatValue).ToString());
             }
 
-            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(name, $"{transport} -h \"{host}\"");
+            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            if (!ice1 && host.Contains(':'))
+            {
+                host = $"[{host}]";
+            }
+            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(name,
+                ice1 ? $"{transport} -h \"{host}\"" : $"ice+{transport}://{host}:0");
+
             return current.Adapter.AddWithUUID(new RemoteObjectAdapter(adapter), IRemoteObjectAdapterPrx.Factory);
         }
 

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -128,13 +128,15 @@ namespace ZeroC.Ice.Test.Admin
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
             TextWriter output = helper.GetWriter();
+            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+
             output.Write("testing communicator operations... ");
             output.Flush();
             {
                 // Test: Exercise AddAdminFacet, FindAdminFacet, RemoveAdminFacet with a typical configuration.
                 var properties = new Dictionary<string, string>
                 {
-                    ["Ice.Admin.Endpoints"] = "tcp -h 127.0.0.1",
+                    ["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0",
                     ["Ice.Admin.InstanceName"] = "Test"
                 };
                 using var com = new Communicator(properties);
@@ -144,7 +146,7 @@ namespace ZeroC.Ice.Test.Admin
                 // Test: Verify that the operations work correctly in the presence of facet filters.
                 var properties = new Dictionary<string, string>
                 {
-                    ["Ice.Admin.Endpoints"] = "tcp -h 127.0.0.1",
+                    ["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0",
                     ["Ice.Admin.InstanceName"] = "Test",
                     ["Ice.Admin.Facets"] = "Properties"
                 };
@@ -186,7 +188,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var properties = new Dictionary<string, string>()
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.DelayCreation", "1" }
                 };
@@ -208,7 +210,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" }
                 };
                 IRemoteCommunicatorPrx? com = factory.CreateCommunicator(props);
@@ -227,7 +229,7 @@ namespace ZeroC.Ice.Test.Admin
             {
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Prop1", "1" },
                     { "Prop2", "2" },
@@ -249,13 +251,14 @@ namespace ZeroC.Ice.Test.Admin
                 // Test: PropertiesAdmin::getProperties()
                 //
                 Dictionary<string, string> pd = pa.GetPropertiesForPrefix("");
-                TestHelper.Assert(pd.Count == 6);
+                TestHelper.Assert(pd.Count == 7);
                 TestHelper.Assert(pd["Ice.ProgramName"] == "server");
-                TestHelper.Assert(pd["Ice.Admin.Endpoints"] == "tcp -h 127.0.0.1");
+                TestHelper.Assert(pd["Ice.Admin.Endpoints"] == (ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0"));
                 TestHelper.Assert(pd["Ice.Admin.InstanceName"] == "Test");
                 TestHelper.Assert(pd["Prop1"] == "1");
                 TestHelper.Assert(pd["Prop2"] == "2");
                 TestHelper.Assert(pd["Prop3"] == "3");
+                TestHelper.Assert(pd["Ice.Default.Protocol"] == communicator.DefaultProtocol.GetName());
 
                 Dictionary<string, string> changes;
 
@@ -296,7 +299,7 @@ namespace ZeroC.Ice.Test.Admin
             {
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "NullLogger", "1" }
                 };
@@ -379,7 +382,7 @@ namespace ZeroC.Ice.Test.Admin
                 // Now, test RemoteLogger
                 //
                 ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints("RemoteLoggerAdapter",
-                    "tcp -h localhost", serializeDispatch: true);
+                    ice1 ? "tcp -h localhost" : "ice+tcp://localhost:0", serializeDispatch: true);
 
                 var remoteLogger = new RemoteLogger();
 
@@ -465,7 +468,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" }
                 };
                 IRemoteCommunicatorPrx? com = factory.CreateCommunicator(props);
@@ -487,7 +490,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.Facets", "Properties" }
                 };
@@ -521,7 +524,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.Facets", "Process" }
                 };
@@ -555,7 +558,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.Facets", "TestFacet" }
                 };
@@ -589,7 +592,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.Facets", "Properties TestFacet" }
                 };
@@ -618,7 +621,7 @@ namespace ZeroC.Ice.Test.Admin
                 //
                 var props = new Dictionary<string, string>
                 {
-                    { "Ice.Admin.Endpoints", "tcp -h 127.0.0.1" },
+                    { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.Admin.InstanceName", "Test" },
                     { "Ice.Admin.Facets", "TestFacet, Process" }
                 };

--- a/csharp/test/Ice/admin/Server.cs
+++ b/csharp/test/Ice/admin/Server.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Admin
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            communicator.SetProperty("TestAdapter.Endpoints", $"{GetTestEndpoint(0)} -t 10000");
+            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("factory", new RemoteCommunicatorFactoryI());
             await adapter.ActivateAsync();

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -59,6 +59,8 @@ namespace ZeroC.Ice.Test.Admin
                 logger = new NullLogger();
             }
 
+            props.Add("Ice.Default.Protocol", current.Communicator.DefaultProtocol.GetName());
+
             //
             // Initialize a new communicator.
             //

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -735,10 +735,10 @@ namespace ZeroC.Ice.Test.Binding
                 output.Flush();
                 {
                     var adapters = new List<IRemoteObjectAdapterPrx>
-                {
-                    com.CreateObjectAdapter("Adapter71", "default"),
-                    com.CreateObjectAdapter("Adapter72", "udp")
-                };
+                    {
+                        com.CreateObjectAdapter("Adapter71", "default"),
+                        com.CreateObjectAdapter("Adapter72", "udp")
+                    };
 
                     ITestIntfPrx obj = CreateTestIntfPrx(adapters);
                     TestHelper.Assert(obj.GetAdapterName().Equals("Adapter71"));

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -450,15 +450,15 @@ namespace ZeroC.Ice.Test.Binding
                     // Now, re-activate the adapters with the same endpoints in the opposite
                     // order.
                     //
-                    adapters.Add(com.CreateObjectAdapter("Adapter36", endpoints[2].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter36", endpoints[2].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter36"); i++) ;
                     TestHelper.Assert(i == nRetry);
                     obj.GetConnection()!.Close(ConnectionClose.GracefullyWithWait);
-                    adapters.Add(com.CreateObjectAdapter("Adapter35", endpoints[1].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter35", endpoints[1].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter35"); i++) ;
                     TestHelper.Assert(i == nRetry);
                     obj.GetConnection()!.Close(ConnectionClose.GracefullyWithWait);
-                    adapters.Add(com.CreateObjectAdapter("Adapter34", endpoints[0].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter34", endpoints[0].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter34"); i++) ;
                     TestHelper.Assert(i == nRetry);
                     deactivate(com, adapters);
@@ -627,13 +627,13 @@ namespace ZeroC.Ice.Test.Binding
                     // Now, re-activate the adapters with the same endpoints in the opposite
                     // order.
                     //
-                    adapters.Add(com.CreateObjectAdapter("Adapter66", endpoints[2].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter66", endpoints[2].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter66"); i++) ;
                     TestHelper.Assert(i == nRetry);
-                    adapters.Add(com.CreateObjectAdapter("Adapter65", endpoints[1].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter65", endpoints[1].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter65"); i++) ;
                     TestHelper.Assert(i == nRetry);
-                    adapters.Add(com.CreateObjectAdapter("Adapter64", endpoints[0].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter64", endpoints[0].ToString())!);
                     for (i = 0; i < nRetry && obj.GetAdapterName().Equals("Adapter64"); i++) ;
                     TestHelper.Assert(i == nRetry);
 
@@ -693,13 +693,13 @@ namespace ZeroC.Ice.Test.Binding
                     // Now, re-activate the adapters with the same endpoints in the opposite
                     // order.
                     //
-                    adapters.Add(com.CreateObjectAdapter("AdapterAMI66", endpoints[2].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("AdapterAMI66", endpoints[2].ToString())!);
                     for (i = 0; i < nRetry && getAdapterNameWithAMI(obj).Equals("AdapterAMI66"); i++) ;
                     TestHelper.Assert(i == nRetry);
-                    adapters.Add(com.CreateObjectAdapter("AdapterAMI65", endpoints[1].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("AdapterAMI65", endpoints[1].ToString())!);
                     for (i = 0; i < nRetry && getAdapterNameWithAMI(obj).Equals("AdapterAMI65"); i++) ;
                     TestHelper.Assert(i == nRetry);
-                    adapters.Add(com.CreateObjectAdapter("AdapterAMI64", endpoints[0].ToString())!);
+                    adapters.Add(com.CreateObjectAdapterWithEndpoints("AdapterAMI64", endpoints[0].ToString())!);
                     for (i = 0; i < nRetry && getAdapterNameWithAMI(obj).Equals("AdapterAMI64"); i++) ;
                     TestHelper.Assert(i == nRetry);
 
@@ -708,31 +708,34 @@ namespace ZeroC.Ice.Test.Binding
             }
             output.WriteLine("ok");
 
-            output.Write("testing endpoint mode filtering... ");
-            output.Flush();
+            if (communicator.DefaultProtocol == Protocol.Ice1)
             {
-                var adapters = new List<IRemoteObjectAdapterPrx>
+                output.Write("testing endpoint mode filtering... ");
+                output.Flush();
                 {
-                    com.CreateObjectAdapter("Adapter71", "default")!,
-                    com.CreateObjectAdapter("Adapter72", "udp")!
+                    var adapters = new List<IRemoteObjectAdapterPrx>
+                {
+                    com.CreateObjectAdapter("Adapter71", "default"),
+                    com.CreateObjectAdapter("Adapter72", "udp")
                 };
 
-                var obj = createTestIntfPrx(adapters);
-                TestHelper.Assert(obj.GetAdapterName().Equals("Adapter71"));
+                    var obj = createTestIntfPrx(adapters);
+                    TestHelper.Assert(obj.GetAdapterName().Equals("Adapter71"));
 
-                var testUDP = obj.Clone(invocationMode: InvocationMode.Datagram);
-                TestHelper.Assert(obj.GetConnection() != testUDP.GetConnection());
-                try
-                {
-                    testUDP.GetAdapterName();
-                    TestHelper.Assert(false);
+                    var testUDP = obj.Clone(invocationMode: InvocationMode.Datagram);
+                    TestHelper.Assert(obj.GetConnection() != testUDP.GetConnection());
+                    try
+                    {
+                        testUDP.GetAdapterName();
+                        TestHelper.Assert(false);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // expected
+                    }
                 }
-                catch (InvalidOperationException)
-                {
-                    // expected
-                }
+                output.WriteLine("ok");
             }
-            output.WriteLine("ok");
             if (communicator.GetProperty("Ice.Plugin.IceSSL") != null)
             {
                 output.Write("testing secure and non-secure endpoints... ");
@@ -769,7 +772,7 @@ namespace ZeroC.Ice.Test.Binding
                     // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
                     if (communicator.DefaultProtocol == Protocol.Ice1)
                     {
-                        com.CreateObjectAdapter("Adapter83", (obj.Endpoints[1]).ToString()); // Recreate a tcp OA.
+                        com.CreateObjectAdapterWithEndpoints("Adapter83", (obj.Endpoints[1]).ToString()); // Recreate a tcp OA.
 
                         for (i = 0; i < 5; i++)
                         {

--- a/csharp/test/Ice/binding/RemoteCommunicatorI.cs
+++ b/csharp/test/Ice/binding/RemoteCommunicatorI.cs
@@ -8,21 +8,17 @@ namespace ZeroC.Ice.Test.Binding
 {
     public class RemoteCommunicator : IRemoteCommunicator
     {
-        public IRemoteObjectAdapterPrx CreateObjectAdapter(string name, string endpts, Current current)
+        public IRemoteObjectAdapterPrx CreateObjectAdapter(string name, string transport, Current current)
         {
             int retry = 5;
             while (true)
             {
                 try
                 {
-                    Communicator communicator = current.Adapter.Communicator;
-                    string endpoints = endpts;
-                    if (endpoints.IndexOf("-p") < 0)
-                    {
-                        endpoints = TestHelper.GetTestEndpoint(communicator.GetProperties(), _nextPort++, endpoints);
-                    }
+                    string endpoints =
+                        TestHelper.GetTestEndpoint(current.Communicator.GetProperties(), _nextPort++, transport);
 
-                    ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(name, endpoints);
+                    ObjectAdapter adapter = current.Communicator.CreateObjectAdapterWithEndpoints(name, endpoints);
                     return current.Adapter.AddWithUUID(
                         new RemoteObjectAdapter(adapter), IRemoteObjectAdapterPrx.Factory);
                 }
@@ -34,6 +30,12 @@ namespace ZeroC.Ice.Test.Binding
                     }
                 }
             }
+        }
+
+        public IRemoteObjectAdapterPrx CreateObjectAdapterWithEndpoints(string name, string endpoints, Current current)
+        {
+            ObjectAdapter adapter = current.Communicator.CreateObjectAdapterWithEndpoints(name, endpoints);
+            return current.Adapter.AddWithUUID(new RemoteObjectAdapter(adapter), IRemoteObjectAdapterPrx.Factory);
         }
 
         // Collocated call.

--- a/csharp/test/Ice/binding/Test.ice
+++ b/csharp/test/Ice/binding/Test.ice
@@ -23,7 +23,8 @@ interface RemoteObjectAdapter
 
 interface RemoteCommunicator
 {
-    RemoteObjectAdapter* createObjectAdapter(string name, string endpoints);
+    RemoteObjectAdapter createObjectAdapter(string name, string transport);
+    RemoteObjectAdapter createObjectAdapterWithEndpoints(string name, string endpoints);
 
     void deactivateObjectAdapter(RemoteObjectAdapter* adapter);
 

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -43,17 +43,17 @@ namespace ZeroC.Ice.Test.Facets
             var obj = new Empty();
 
             adapter.Add("d", obj);
-            adapter.Add("d", "facetABCD", obj);
+            adapter.Add("d#facetABCD", obj);
             try
             {
-                adapter.Add("d", "facetABCD", obj);
+                adapter.Add("d#facetABCD", obj);
                 TestHelper.Assert(false);
             }
             catch (System.ArgumentException)
             {
             }
-            adapter.Remove("d", "facetABCD");
-            adapter.Remove("d", "facetABCD"); // multiple Remove are fine as of Ice 4.0
+            adapter.Remove("d#facetABCD");
+            adapter.Remove("d#facetABCD"); // multiple Remove are fine as of Ice 4.0
             output.WriteLine("ok");
 
             adapter.Dispose();

--- a/csharp/test/Ice/facets/Collocated.cs
+++ b/csharp/test/Ice/facets/Collocated.cs
@@ -16,11 +16,11 @@ namespace ZeroC.Ice.Test.Facets
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             var d = new D();
             adapter.Add("d", d);
-            adapter.Add("d", "facetABCD", d);
+            adapter.Add("d#facetABCD", d);
             var f = new F();
-            adapter.Add("d", "facetEF", f);
+            adapter.Add("d#facetEF", f);
             var h = new H(communicator);
-            adapter.Add("d", "facetGH", h);
+            adapter.Add("d#facetGH", h);
             AllTests.allTests(this);
         }
 

--- a/csharp/test/Ice/facets/Server.cs
+++ b/csharp/test/Ice/facets/Server.cs
@@ -16,11 +16,11 @@ namespace ZeroC.Ice.Test.Facets
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             var d = new D();
             adapter.Add("d", d);
-            adapter.Add("d", "facetABCD", d);
+            adapter.Add("d#facetABCD", d);
             var f = new F();
-            adapter.Add("d", "facetEF", f);
+            adapter.Add("d#facetEF", f);
             var h = new H(communicator);
-            adapter.Add("d", "facetGH", h);
+            adapter.Add("d#facetGH", h);
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/info/Server.cs
+++ b/csharp/test/Ice/info/Server.cs
@@ -12,7 +12,14 @@ namespace ZeroC.Ice.Test.Info
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + ":" + GetTestEndpoint(0, "udp"));
+            if (communicator.DefaultProtocol == Protocol.Ice1)
+            {
+                communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + ":" + GetTestEndpoint(0, "udp"));
+            }
+            else
+            {
+                communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            }
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());
             await adapter.ActivateAsync();

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Location
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool oldProtocol = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
             var manager = IServerManagerPrx.Parse(helper.GetTestProxy("ServerManager", 0), communicator);
             var locator = ITestLocatorPrx.UncheckedCast(communicator.DefaultLocator!);
             Console.WriteLine("registry checkedcast");
@@ -27,11 +27,11 @@ namespace ZeroC.Ice.Test.Location
             output.Write("testing stringToProxy... ");
             output.Flush();
             IObjectPrx base1, base2, base3, base4, base5, base6;
-            if (oldProtocol)
+            if (ice1)
             {
                 base1 = IObjectPrx.Parse("test @ TestAdapter", communicator);
                 base2 = IObjectPrx.Parse("test @ TestAdapter", communicator);
-                base3 = IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator);
+                base3 = IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator);
                 base4 = IObjectPrx.Parse("ServerManager", communicator);
                 base5 = IObjectPrx.Parse("test2", communicator);
                 base6 = IObjectPrx.Parse("test @ ReplicatedAdapter", communicator);
@@ -50,16 +50,16 @@ namespace ZeroC.Ice.Test.Location
             output.Write("testing ice_locator and ice_getLocator... ");
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Locator!, communicator.DefaultLocator!));
             ILocatorPrx anotherLocator =
-                ILocatorPrx.Parse(oldProtocol ? "anotherLocator" : "ice:anotherLocator", communicator);
+                ILocatorPrx.Parse(ice1 ? "anotherLocator" : "ice:anotherLocator", communicator);
             base1 = base1.Clone(locator: anotherLocator);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Locator!, anotherLocator));
             communicator.DefaultLocator = null;
-            base1 = IObjectPrx.Parse(oldProtocol ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
+            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
             TestHelper.Assert(base1.Locator == null);
             base1 = base1.Clone(locator: anotherLocator);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Locator!, anotherLocator));
             communicator.DefaultLocator = locator;
-            base1 = IObjectPrx.Parse(oldProtocol ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
+            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Locator!, communicator.DefaultLocator!));
 
             //
@@ -67,15 +67,15 @@ namespace ZeroC.Ice.Test.Location
             // test/Ice/router test?)
             //
             TestHelper.Assert(base1.Router == null);
-            var anotherRouter = IRouterPrx.Parse(oldProtocol ? "anotherRouter" : "ice:anotherRouter", communicator);
+            var anotherRouter = IRouterPrx.Parse(ice1 ? "anotherRouter" : "ice:anotherRouter", communicator);
             base1 = base1.Clone(router: anotherRouter);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, anotherRouter));
-            var router = IRouterPrx.Parse(oldProtocol ? "dummyrouter" : "ice:dummyrouter", communicator);
+            var router = IRouterPrx.Parse(ice1 ? "dummyrouter" : "ice:dummyrouter", communicator);
             communicator.DefaultRouter = router;
-            base1 = IObjectPrx.Parse(oldProtocol ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
+            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, communicator.DefaultRouter!));
             communicator.DefaultRouter = null;
-            base1 = IObjectPrx.Parse(oldProtocol ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
+            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
             TestHelper.Assert(base1.Router == null);
             output.WriteLine("ok");
 
@@ -204,7 +204,7 @@ namespace ZeroC.Ice.Test.Location
             output.Flush();
             try
             {
-                base1 = IObjectPrx.Parse(oldProtocol ? "unknown/unknown" : "ice:unknown/unknown", communicator);
+                base1 = IObjectPrx.Parse(ice1 ? "unknown/unknown" : "ice:unknown/unknown", communicator);
                 base1.IcePing();
                 TestHelper.Assert(false);
             }
@@ -218,7 +218,7 @@ namespace ZeroC.Ice.Test.Location
             try
             {
                 base1 = IObjectPrx.Parse(
-                    oldProtocol ? "test @ TestAdapterUnknown" : "ice:TestAdapterUnknown//test", communicator);
+                    ice1 ? "test @ TestAdapterUnknown" : "ice:TestAdapterUnknown//test", communicator);
                 base1.IcePing();
                 TestHelper.Assert(false);
             }
@@ -231,7 +231,7 @@ namespace ZeroC.Ice.Test.Location
             output.Flush();
 
             IObjectPrx basencc = IObjectPrx.Parse(
-                oldProtocol ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(cacheConnection: false);
+                ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(cacheConnection: false);
             int count = locator.GetRequestCount();
             basencc.Clone(locatorCacheTimeout: TimeSpan.Zero).IcePing(); // No locator cache.
             TestHelper.Assert(++count == locator.GetRequestCount());
@@ -243,37 +243,37 @@ namespace ZeroC.Ice.Test.Location
             basencc.Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout.
             TestHelper.Assert(++count == locator.GetRequestCount());
 
-            IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator)
+            IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.Zero).IcePing(); // No locator cache.
             count += 2;
             TestHelper.Assert(count == locator.GetRequestCount());
-            IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator)
+            IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(2)).IcePing(); // 2s timeout
             TestHelper.Assert(count == locator.GetRequestCount());
             System.Threading.Thread.Sleep(1300); // 1300ms
-            IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator)
+            IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout
             count += 2;
             TestHelper.Assert(count == locator.GetRequestCount());
 
-            IObjectPrx.Parse(oldProtocol ? "test@TestAdapter" : "ice:TestAdapter//test", communicator)
+            IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator)
                 .Clone(locatorCacheTimeout: Timeout.InfiniteTimeSpan).IcePing();
             TestHelper.Assert(count == locator.GetRequestCount());
-            IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator).Clone(locatorCacheTimeout: Timeout.InfiniteTimeSpan).IcePing();
+            IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator).Clone(locatorCacheTimeout: Timeout.InfiniteTimeSpan).IcePing();
             TestHelper.Assert(count == locator.GetRequestCount());
-            IObjectPrx.Parse(oldProtocol ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).IcePing();
+            IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).IcePing();
             TestHelper.Assert(count == locator.GetRequestCount());
-            IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator).IcePing();
+            IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator).IcePing();
             TestHelper.Assert(count == locator.GetRequestCount());
 
-            TestHelper.Assert(IObjectPrx.Parse(oldProtocol ? "test" : "ice:test", communicator)
+            TestHelper.Assert(IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(99)).LocatorCacheTimeout == TimeSpan.FromSeconds(99));
 
             output.WriteLine("ok");
 
             output.Write("testing proxy from server... ");
             output.Flush();
-            obj1 = ITestIntfPrx.Parse(oldProtocol ? "test@TestAdapter" : "ice:TestAdapter//test", communicator);
+            obj1 = ITestIntfPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator);
             IHelloPrx? hello = obj1.GetHello();
             TestHelper.Assert(hello != null);
             TestHelper.Assert(hello.AdapterId.Equals("TestAdapter"));
@@ -335,7 +335,7 @@ namespace ZeroC.Ice.Test.Location
             output.Flush();
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (AdapterNotFoundException)
@@ -344,11 +344,11 @@ namespace ZeroC.Ice.Test.Location
             registry.SetAdapterDirectProxy("TestAdapter3", locator.FindAdapterById("TestAdapter"));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
                 registry.SetAdapterDirectProxy(
                     "TestAdapter3",
                     IObjectPrx.Parse(helper.GetTestProxy("dummy", 99), communicator));
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
             }
             catch (System.Exception)
             {
@@ -357,7 +357,7 @@ namespace ZeroC.Ice.Test.Location
 
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).Clone(
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).Clone(
                         locatorCacheTimeout: TimeSpan.Zero).IcePing();
                 TestHelper.Assert(false);
             }
@@ -367,7 +367,7 @@ namespace ZeroC.Ice.Test.Location
 
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
             }
             catch (ConnectionRefusedException)
             {
@@ -376,7 +376,7 @@ namespace ZeroC.Ice.Test.Location
             registry.SetAdapterDirectProxy("TestAdapter3", locator.FindAdapterById("TestAdapter"));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter3" : "ice:TestAdapter3//test", communicator).IcePing();
             }
             catch (System.Exception)
             {
@@ -387,22 +387,22 @@ namespace ZeroC.Ice.Test.Location
             output.Write("testing well-known object locator cache... ");
             output.Flush();
             registry.AddObject(IObjectPrx.Parse(
-                oldProtocol ? "test3@TestUnknown" : "ice:TestUnknown//test3", communicator));
+                ice1 ? "test3@TestUnknown" : "ice:TestUnknown//test3", communicator));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (AdapterNotFoundException)
             {
             }
             registry.AddObject(IObjectPrx.Parse(
-                oldProtocol ? "test3@TestAdapter4" : "ice:TestAdapter4//test3", communicator)); // Update
+                ice1 ? "test3@TestAdapter4" : "ice:TestAdapter4//test3", communicator)); // Update
             registry.SetAdapterDirectProxy("TestAdapter4",
                                            IObjectPrx.Parse(helper.GetTestProxy("dummy", 99), communicator));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (ConnectionRefusedException)
@@ -411,7 +411,7 @@ namespace ZeroC.Ice.Test.Location
             registry.SetAdapterDirectProxy("TestAdapter4", locator.FindAdapterById("TestAdapter"));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
             }
             catch
             {
@@ -422,7 +422,7 @@ namespace ZeroC.Ice.Test.Location
                                            IObjectPrx.Parse(helper.GetTestProxy("dummy", 99), communicator));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
             }
             catch
             {
@@ -431,7 +431,7 @@ namespace ZeroC.Ice.Test.Location
 
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter4" : "ice:TestAdapter4//test", communicator).Clone(
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter4" : "ice:TestAdapter4//test", communicator).Clone(
                     locatorCacheTimeout: TimeSpan.Zero).IcePing();
                 TestHelper.Assert(false);
             }
@@ -440,7 +440,7 @@ namespace ZeroC.Ice.Test.Location
             }
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter4" : "ice:TestAdapter4//test", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter4" : "ice:TestAdapter4//test", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (ConnectionRefusedException)
@@ -448,27 +448,27 @@ namespace ZeroC.Ice.Test.Location
             }
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (ConnectionRefusedException)
             {
             }
             registry.AddObject(IObjectPrx.Parse(
-                oldProtocol ? "test3@TestAdapter" : "ice:TestAdapter//test3", communicator));
+                ice1 ? "test3@TestAdapter" : "ice:TestAdapter//test3", communicator));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", communicator).IcePing();
             }
             catch (Exception)
             {
                 TestHelper.Assert(false);
             }
 
-            registry.AddObject(IObjectPrx.Parse(oldProtocol ? "test4" : "ice:test4", communicator));
+            registry.AddObject(IObjectPrx.Parse(ice1 ? "test4" : "ice:test4", communicator));
             try
             {
-                IObjectPrx.Parse(oldProtocol ? "test4" : "ice:test4", communicator).IcePing();
+                IObjectPrx.Parse(ice1 ? "test4" : "ice:test4", communicator).IcePing();
                 TestHelper.Assert(false);
             }
             catch (NoEndpointException)
@@ -485,19 +485,19 @@ namespace ZeroC.Ice.Test.Location
 
                 registry.SetAdapterDirectProxy("TestAdapter5", locator.FindAdapterById("TestAdapter"));
                 registry.AddObject(IObjectPrx.Parse(
-                    oldProtocol ? "test3@TestAdapter" : "ice:TestAdapter//test3", communicator));
+                    ice1 ? "test3@TestAdapter" : "ice:TestAdapter//test3", communicator));
 
                 count = locator.GetRequestCount();
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
                     .Clone(locatorCacheTimeout: TimeSpan.Zero).IcePing(); // No locator cache.
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", ic).Clone(locatorCacheTimeout: TimeSpan.Zero).IcePing(); // No locator cache.
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", ic).Clone(locatorCacheTimeout: TimeSpan.Zero).IcePing(); // No locator cache.
                 count += 3;
                 TestHelper.Assert(count == locator.GetRequestCount());
                 registry.SetAdapterDirectProxy("TestAdapter5", null);
                 registry.AddObject(IObjectPrx.Parse(helper.GetTestProxy("test3", 99), communicator));
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
                     .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(10)).IcePing(); // 10s timeout.
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", ic)
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", ic)
                     .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(10)).IcePing(); // 10s timeout.
                 TestHelper.Assert(count == locator.GetRequestCount());
                 Thread.Sleep(1200);
@@ -505,16 +505,16 @@ namespace ZeroC.Ice.Test.Location
                 // The following request should trigger the background
                 // updates but still use the cached endpoints and
                 // therefore succeed.
-                IObjectPrx.Parse(oldProtocol ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
+                IObjectPrx.Parse(ice1 ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
                     .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout.
-                IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", ic)
+                IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", ic)
                     .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout.
 
                 try
                 {
                     while (true)
                     {
-                        IObjectPrx.Parse(oldProtocol ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
+                        IObjectPrx.Parse(ice1 ? "test@TestAdapter5" : "ice:TestAdapter5//test", ic)
                             .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout.
                         Thread.Sleep(10);
                     }
@@ -527,7 +527,7 @@ namespace ZeroC.Ice.Test.Location
                 {
                     while (true)
                     {
-                        IObjectPrx.Parse(oldProtocol ? "test3" : "ice:test3", ic)
+                        IObjectPrx.Parse(ice1 ? "test3" : "ice:test3", ic)
                             .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout.
                         Thread.Sleep(10);
                     }
@@ -550,7 +550,7 @@ namespace ZeroC.Ice.Test.Location
 
             output.Write("testing object migration... ");
             output.Flush();
-            hello = IHelloPrx.Parse(oldProtocol ? "hello" : "ice:hello", communicator);
+            hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
             obj1.MigrateHello();
             hello.GetConnection()!.Close(ConnectionClose.GracefullyWithWait);
             hello.SayHello();
@@ -562,9 +562,9 @@ namespace ZeroC.Ice.Test.Location
 
             output.Write("testing locator encoding resolution... ");
             output.Flush();
-            hello = IHelloPrx.Parse(oldProtocol ? "hello" : "ice:hello", communicator);
+            hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
             count = locator.GetRequestCount();
-            IObjectPrx.Parse(oldProtocol ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(encoding: Encoding.V1_1).IcePing();
+            IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(encoding: Encoding.V1_1).IcePing();
             TestHelper.Assert(count == locator.GetRequestCount());
             output.WriteLine("ok");
 
@@ -606,7 +606,8 @@ namespace ZeroC.Ice.Test.Location
             output.Flush();
 
             communicator.SetProperty("Hello.AdapterId", Guid.NewGuid().ToString());
-            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints("Hello", "default");
+            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
+                "Hello", ice1 ? "tcp" : "ice+tcp://localhost:0");
 
             var id = new Identity(Guid.NewGuid().ToString(), "");
             adapter.Add(id, new Hello());
@@ -614,7 +615,7 @@ namespace ZeroC.Ice.Test.Location
 
             // Ensure that calls on the well-known proxy is collocated.
             IHelloPrx? helloPrx;
-            if (oldProtocol)
+            if (ice1)
             {
                 helloPrx = IHelloPrx.Parse($"{id}", communicator);
             }

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -14,7 +14,12 @@ namespace ZeroC.Ice.Test.Metrics
             var observer = new CommunicatorObserver();
 
             var properties = CreateTestProperties(ref args);
-            properties["Ice.Admin.Endpoints"] = "tcp";
+            bool ice1 = false;
+            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
+            {
+                ice1 = value == "ice1";
+            }
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "client";
             properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -13,7 +13,13 @@ namespace ZeroC.Ice.Test.Metrics
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.Admin.Endpoints"] = "tcp";
+            bool ice1 = false;
+            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
+            {
+                ice1 = value == "ice1";
+            }
+
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -13,7 +13,13 @@ namespace ZeroC.Ice.Test.Metrics
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.Admin.Endpoints"] = "tcp";
+             bool ice1 = false;
+            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
+            {
+                ice1 = value == "ice1";
+            }
+
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";

--- a/csharp/test/Ice/slicing/exceptions/Server.cs
+++ b/csharp/test/Ice/slicing/exceptions/Server.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + " -t 2000");
+            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());
             await adapter.ActivateAsync();

--- a/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
-            communicator.SetProperty("TestAdapter.Endpoints", $"{GetTestEndpoint(0)} -t 2000");
+            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntfAsync());
             await adapter.ActivateAsync();

--- a/csharp/test/Ice/slicing/objects/Server.cs
+++ b/csharp/test/Ice/slicing/objects/Server.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
-            communicator.SetProperty("TestAdapter.Endpoints", $"{GetTestEndpoint(0)} -t 2000");
+            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());
             adapter.Add("Test2", new TestIntf2());

--- a/csharp/test/Ice/slicing/objects/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/objects/ServerAMD.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + " -t 2000");
+            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntfAsync());
             adapter.Add("Test2", new TestIntf2Async());

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -87,7 +87,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
             var factory = IServerFactoryPrx.Parse(factoryRef, communicator);
 
-            string defaultHost = communicator.GetProperty("Ice.Default.Host") ?? "";
+            string host = communicator.GetProperty("Ice.Default.Host") ?? "127.0.0.1";
             string defaultDir = $"{testDir}/../certs";
             Dictionary<string, string> defaultProperties = communicator.GetProperties();
             defaultProperties["IceSSL.DefaultDir"] = defaultDir;
@@ -277,7 +277,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    ObjectAdapter? adapter = serverCommunicator.CreateObjectAdapterWithEndpoints("MyAdapter", "ssl");
+                    bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
+                    ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
+                            "MyAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
                     adapter.Activate();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
@@ -321,7 +323,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    ObjectAdapter? adapter = serverCommunicator.CreateObjectAdapterWithEndpoints("MyAdapter", "ssl");
+                    bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
+                    ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
+                        "MyAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
                     adapter.Activate();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
@@ -560,7 +564,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                     // Test Hostname verification only when Ice.DefaultHost is 127.0.0.1 as that is the IP address used
                     // in the test certificates.
-                    if (defaultHost.Equals("127.0.0.1"))
+                    if (host.Equals("127.0.0.1"))
                     {
                         // Test using localhost as target host.
                         var props = new Dictionary<string, string>(defaultProperties);

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -78,7 +78,17 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     RequireClientCertificate = requireClientCertificate
                 });
-            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints("ServerAdapter", "ssl");
+
+            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            string host = "";
+            if (!ice1)
+            {
+                // TODO: does not work with [::0]!
+                host = communicator.GetProperty("Ice.Default.Host") ?? "[::0]";
+            }
+
+            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
+                "ServerAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
             var server = new SSLServer(communicator);
             var prx = adapter.AddWithUUID(server, IServerPrx.Factory);
             _servers[prx.Identity] = server;

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -57,11 +57,43 @@ namespace Test
                 }
             }
 
-            var sb = new StringBuilder();
-            sb.Append(transport);
-            sb.Append(" -p ");
-            sb.Append(GetTestPort(properties, num));
-            return sb.ToString();
+            bool uriFormat = true;
+            // TODO: switch to a different test-only property to select the protocol
+            if (properties.TryGetValue("Ice.Default.Protocol", out string? protocolValue))
+            {
+                if (protocolValue == "ice1")
+                {
+                    uriFormat = false;
+                }
+            }
+
+            if (uriFormat)
+            {
+                var sb = new StringBuilder("ice+");
+                sb.Append(transport);
+                sb.Append("://");
+                string host = GetTestHost(properties);
+                if (host.Contains(':'))
+                {
+                    sb.Append('[');
+                    sb.Append(host);
+                    sb.Append(']');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
+                sb.Append(':');
+                sb.Append(GetTestPort(properties, num));
+                return sb.ToString();
+            }
+            else
+            {
+                var sb = new StringBuilder(transport);
+                sb.Append(" -p ");
+                sb.Append(GetTestPort(properties, num));
+                return sb.ToString();
+            }
         }
 
         public string GetTestProxy(string identity, int num = 0, string? transport = null) =>

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -45,7 +45,7 @@ namespace Test
 
         public static string GetTestEndpoint(Dictionary<string, string> properties, int num = 0, string transport = "")
         {
-            if (transport.Length == 0)
+            if (transport.Length == 0 || transport == "default")
             {
                 if (properties.TryGetValue("Ice.Default.Transport", out string? value))
                 {
@@ -184,6 +184,7 @@ namespace Test
 
         public int GetTestPort(int num) => GetTestPort(_communicator!.GetProperties(), num);
 
+        // TODO: switch to ushort
         public static int GetTestPort(Dictionary<string, string> properties, int num)
         {
             int basePort = 12010;


### PR DESCRIPTION
This PR improves the parsing of object adapter `Endpoints` and `PublishedEndpoints` to support ice2 (specified through URIs) and ice1 (specified through endpoints in the ice1 string format).

It also simplifies a number of ObjectAdapter Add and CreateProxy overload: instead of taking a string identity + a string facet (+ overload without facet), they just take a string identityAndFacet that gets parsed as a relative URI [category/]name#facet.