### PR TITLE
Read connection configuration during initialization

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -160,9 +160,10 @@ namespace ZeroC.Ice
         internal Acm ServerAcm { get; }
         internal SslEngine SslEngine { get; }
         internal TraceLevels TraceLevels { get; private set; }
-
         internal bool WarnConnections { get; }
         internal bool WarnDatagrams { get; }
+        internal bool WarnDispatch { get; }
+        internal bool WarnUnknownProperties { get; }
 
         private static string[] _emptyArgs = Array.Empty<string>();
         private static readonly string[] _suffixes =
@@ -471,6 +472,9 @@ namespace ZeroC.Ice
 
                 WarnConnections = GetPropertyAsBool("Ice.Warn.Connections") ?? false;
                 WarnDatagrams = GetPropertyAsBool("Ice.Warn.Datagrams") ?? false;
+                WarnDispatch = GetPropertyAsBool("Ice.Warn.Dispatch") ?? false;
+                WarnUnknownProperties = GetPropertyAsBool("Ice.Warn.UnknownProperties") ?? true;
+
                 int compressionLevel = GetPropertyAsInt("Ice.Compression.Level") ?? 1;
                 if (compressionLevel < 1 || compressionLevel > 9)
                 {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -150,6 +150,7 @@ namespace ZeroC.Ice
         internal CancellationToken CancellationToken => _cancellationTokenSource.Token;
         internal int ClassGraphDepthMax { get; }
         internal Acm ClientAcm { get; }
+        internal int CompressionLevel { get; }
         internal int FrameSizeMax { get; }
         internal int IPVersion { get; }
         internal bool IsDisposed => _disposeTask != null;
@@ -159,6 +160,9 @@ namespace ZeroC.Ice
         internal Acm ServerAcm { get; }
         internal SslEngine SslEngine { get; }
         internal TraceLevels TraceLevels { get; private set; }
+
+        internal bool WarnConnections { get; }
+        internal bool WarnDatagrams { get; }
 
         private static string[] _emptyArgs = Array.Empty<string>();
         private static readonly string[] _suffixes =
@@ -464,6 +468,15 @@ namespace ZeroC.Ice
 
                 int frameSizeMax = GetPropertyAsByteSize("Ice.MessageSizeMax") ?? 1024 * 1024;
                 FrameSizeMax = frameSizeMax == 0 ? int.MaxValue : frameSizeMax;
+
+                WarnConnections = GetPropertyAsBool("Ice.Warn.Connections") ?? false;
+                WarnDatagrams = GetPropertyAsBool("Ice.Warn.Datagrams") ?? false;
+                int compressionLevel = GetPropertyAsInt("Ice.Compression.Level") ?? 1;
+                if (compressionLevel < 1 || compressionLevel > 9)
+                {
+                    throw new InvalidConfigurationException(@$"invalid value for Ice.Compression.Level: `{
+                        compressionLevel}' it must be an integer between 1 and 9");
+                }
 
                 // TODO: switch to 0 default
                 AcceptNonSecureConnections = GetPropertyAsBool("Ice.AcceptNonSecureConnections") ?? true;

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -479,7 +479,7 @@ namespace ZeroC.Ice
                 if (compressionLevel < 1 || compressionLevel > 9)
                 {
                     throw new InvalidConfigurationException(@$"invalid value for Ice.Compression.Level: `{
-                        compressionLevel}' it must be an integer between 1 and 9");
+                        compressionLevel}', it must be an integer between 1 and 9");
                 }
 
                 // TODO: switch to 0 default

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -158,7 +158,6 @@ namespace ZeroC.Ice
             new Dictionary<long, (TaskCompletionSource<IncomingResponseFrame>, bool)>();
         private ConnectionState _state; // The current state.
         private bool _validated;
-        private readonly bool _warn;
 
         /// <summary>Manually closes the connection using the specified closure mode.</summary>
         /// <param name="mode">Determines how the connection will be closed.</param>
@@ -288,7 +287,6 @@ namespace ZeroC.Ice
             Endpoint = endpoint;
             Endpoints = new List<Endpoint>() { endpoint };
             _adapter = adapter;
-            _warn = _communicator.GetPropertyAsBool("Ice.Warn.Connections") ?? false;
             _dispatchCount = 0;
             _state = ConnectionState.Validating;
         }
@@ -915,7 +913,7 @@ namespace ZeroC.Ice
                 _exception = exception;
 
                 // We don't warn if we are not validated.
-                if (_warn && _validated)
+                if (_communicator.WarnConnections && _validated)
                 {
                     // Don't warn about certain expected exceptions.
                     if (!(_exception is ConnectionClosedException ||

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -483,7 +483,6 @@ namespace ZeroC.Ice
         private readonly HashSet<Connection> _connections = new HashSet<Connection>();
         private bool _disposed;
         private readonly object _mutex = new object();
-        private readonly bool _warn;
 
         public override async ValueTask DisposeAsync()
         {
@@ -524,7 +523,6 @@ namespace ZeroC.Ice
         {
             _communicator = adapter.Communicator;
             _adapter = adapter;
-            _warn = _communicator.GetPropertyAsBool("Ice.Warn.Connections") ?? false;
             AcmMonitor = new ConnectionFactoryAcmMonitor(_communicator, acm);
 
             // TODO: for ice2, support for multiple endpoints for the same acceptor and not one acceptor per endpoint
@@ -635,7 +633,7 @@ namespace ZeroC.Ice
                             // Ignore
                         }
 
-                        if (_warn)
+                        if (_communicator.WarnConnections)
                         {
                             _communicator.Logger.Warning($"connection exception:\n{ex}\n{_acceptor}");
                         }

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -16,7 +16,6 @@ namespace ZeroC.Ice
         public Endpoint Endpoint { get; }
         public ITransceiver Transceiver { get; }
 
-        private readonly int _compressionLevel;
         private readonly int _frameSizeMax;
         private Action? _heartbeatCallback;
         private readonly bool _incoming;
@@ -25,8 +24,6 @@ namespace ZeroC.Ice
         private Action<int>? _receivedCallback;
         private Task _sendTask = Task.CompletedTask;
         private Action<int>? _sentCallback;
-        private readonly bool _warn;
-        private readonly bool _warnUdp;
 
         private static readonly List<ArraySegment<byte>> _closeConnectionFrame =
             new List<ArraySegment<byte>> { Ice1Definitions.CloseConnectionFrame };
@@ -241,18 +238,6 @@ namespace ZeroC.Ice
 
             _incoming = adapter != null;
             _frameSizeMax = adapter?.FrameSizeMax ?? Endpoint.Communicator.FrameSizeMax;
-            _warn = Endpoint.Communicator.GetPropertyAsBool("Ice.Warn.Connections") ?? false;
-            _warnUdp = Endpoint.Communicator.GetPropertyAsBool("Ice.Warn.Datagrams") ?? false;
-            _compressionLevel = Endpoint.Communicator.GetPropertyAsInt("Ice.Compression.Level") ?? 1;
-
-            if (_compressionLevel < 1)
-            {
-                _compressionLevel = 1;
-            }
-            else if (_compressionLevel > 9)
-            {
-                _compressionLevel = 9;
-            }
         }
 
         private (int, object?) ParseFrame(ArraySegment<byte> readBuffer)
@@ -279,7 +264,7 @@ namespace ZeroC.Ice
                     ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
                     if (Endpoint.IsDatagram)
                     {
-                        if (_warn)
+                        if (Endpoint.Communicator.WarnConnections)
                         {
                             Endpoint.Communicator.Logger.Warning(
                                 $"ignoring close connection frame for datagram connection:\n{this}");
@@ -404,7 +389,7 @@ namespace ZeroC.Ice
             }
             else if (size > readBuffer.Count)
             {
-                if (_warnUdp)
+                if (Endpoint.Communicator.WarnDatagrams)
                 {
                     Endpoint.Communicator.Logger.Warning($"maximum datagram size of {readBuffer.Count} exceeded");
                 }
@@ -446,7 +431,10 @@ namespace ZeroC.Ice
                 List<ArraySegment<byte>>? compressed = null;
                 if (size >= 100)
                 {
-                    compressed = BZip2.Compress(writeBuffer, size, Ice1Definitions.HeaderSize, _compressionLevel);
+                    compressed = BZip2.Compress(writeBuffer,
+                                                size,
+                                                Ice1Definitions.HeaderSize,
+                                                Endpoint.Communicator.CompressionLevel);
                 }
 
                 if (compressed != null)

--- a/csharp/src/Ice/Incoming.cs
+++ b/csharp/src/Ice/Incoming.cs
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-using System;
 using System.Diagnostics;
 
 using ZeroC.Ice.Instrumentation;
@@ -17,7 +16,7 @@ namespace ZeroC.Ice
         {
             bool unhandledException = ex is UnhandledException;
 
-            if (unhandledException && (current.Adapter.Communicator.GetPropertyAsBool("Ice.Warn.Dispatch") ?? false))
+            if (unhandledException && current.Adapter.Communicator.WarnDispatch)
             {
                 Warning((UnhandledException)ex, current);
             }

--- a/csharp/src/Ice/MetricsAdmin.cs
+++ b/csharp/src/Ice/MetricsAdmin.cs
@@ -599,7 +599,7 @@ namespace ZeroC.Ice
                 }
             }
 
-            if (unknownProps.Count != 0 && (communicator.GetPropertyAsBool("Ice.Warn.UnknownProperties") ?? true))
+            if (unknownProps.Count != 0 && communicator.WarnUnknownProperties)
             {
                 var message = new StringBuilder("found unknown IceMX properties for `");
                 message.Append(prefix[0..^1]);

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -765,7 +765,7 @@ namespace ZeroC.Ice
             (bool noProps, List<string> unknownProps) = FilterProperties();
 
             // Warn about unknown object adapter properties.
-            if (unknownProps.Count != 0 && (Communicator.GetPropertyAsBool("Ice.Warn.UnknownProperties") ?? true))
+            if (unknownProps.Count != 0 && Communicator.WarnUnknownProperties)
             {
                 var message = new StringBuilder("found unknown properties for object adapter `");
                 message.Append(Name);

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1531,7 +1531,7 @@ namespace ZeroC.Ice
             if (propertyPrefix != null && propertyPrefix.Length > 0)
             {
                 // Warn about unknown properties.
-                if (communicator.GetPropertyAsBool("Ice.Warn.UnknownProperties") ?? true)
+                if (communicator.WarnUnknownProperties)
                 {
                     communicator.CheckForUnknownProperties(propertyPrefix);
                 }


### PR DESCRIPTION
This PR moves the reading of connection related properties, to the communicator initialization, so we can throw InvalidConfigurationException during initialization rather than detect this later when the first connection reads this properties.