### PR TITLE
Cleanup endpoint timeout and compression settings

### DIFF
--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -20,12 +20,6 @@ namespace ZeroC.Ice
         /// <summary>Gets the communicator that created this endpoint.</summary>
         public Communicator Communicator { get; }
 
-        /// <summary>Indicates whether or not this endpoint's compression flag is set. When the compression flag is
-        /// set, a request sent to this endpoint using the ice1 protocol is automatically compressed using bzip2 if
-        /// the request's uncompressed size is greater than 100 bytes. Only applies to ice1.</summary>
-        /// <value>True when the compression flag is set; otherwise, false.</value>
-        public virtual bool HasCompressionFlag => false;
-
         /// <summary>The host name or address.</summary>
         public abstract string Host { get; }
 
@@ -51,11 +45,8 @@ namespace ZeroC.Ice
                 {
                     return option switch
                     {
-                        "compress" => HasCompressionFlag ? "true" : null,
                         "host" => Host.Length > 0 ? Host : null,
                         "port" => Port != DefaultPort ? Port.ToString(CultureInfo.InvariantCulture) : null,
-                        "timeout" => Timeout != DefaultTimeout ?
-                            Timeout.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) : null,
                         _ => null,
                     };
                 }
@@ -76,9 +67,6 @@ namespace ZeroC.Ice
         /// ice2, it's ice+transport (ice+tcp, ice+quic etc.) or ice+universal.</summary>
         public virtual string Scheme => Protocol == Protocol.Ice1 ? TransportName : $"ice+{TransportName}";
 
-        /// <summary>The timeout for the endpoint. This timeout is no longer used since Ice 4.0.</summary>
-        public virtual TimeSpan Timeout => DefaultTimeout;
-
         /// <summary>The <see cref="ZeroC.Ice.Transport"></see> of this endpoint.</summary>
         public abstract Transport Transport { get; }
 
@@ -91,9 +79,6 @@ namespace ZeroC.Ice
         /// <summary>Indicates whether or not this endpoint has options with non default values that ToString would
         /// print. Always true for ice1 endpoints.</summary>
         protected internal abstract bool HasOptions { get; }
-
-        /// <summary>The default timeout for ice1 endpoints.</summary>
-        protected static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
 
         public static bool operator ==(Endpoint? lhs, Endpoint? rhs)
         {
@@ -164,14 +149,6 @@ namespace ZeroC.Ice
         /// include the host and port; with ice2, the host and port are not considered options.</summary>
         /// <param name="ostr">The output stream.</param>
         protected internal abstract void WriteOptions(OutputStream ostr);
-
-        // Returns a new endpoint with a different timeout value, provided that timeouts are supported by the endpoint.
-        // Otherwise the same endpoint is returned.
-        public abstract Endpoint NewTimeout(TimeSpan t);
-
-        // Returns a new endpoint with a different compression flag, provided that compression is supported by the
-        // endpoint. Otherwise the same endpoint is returned.
-        public abstract Endpoint NewCompressionFlag(bool compressionFlag);
 
         // Returns a connector for this endpoint, or empty list if no connector is available.
         public abstract ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType endpointSelection);

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -145,8 +145,8 @@ namespace ZeroC.Ice
             }
             else
             {
-                return addresses.Select(address => CloneWithHostAndPort(Network.EndpointAddressToString(address),
-                                                                        Network.EndpointPort(address)));
+                return addresses.Select(address => Clone(Network.EndpointAddressToString(address),
+                                                         Network.EndpointPort(address)));
             }
         }
 
@@ -159,7 +159,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                return hosts.Select(host => CloneWithHostAndPort(host, Port));
+                return hosts.Select(host => Clone(host, Port));
             }
         }
 
@@ -216,7 +216,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                return CloneWithHostAndPort(Host, port);
+                return Clone(Host, port);
             }
         }
 
@@ -351,6 +351,6 @@ namespace ZeroC.Ice
 
         private protected abstract IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy);
 
-        private protected abstract IPEndpoint CloneWithHostAndPort(string host, ushort port);
+        private protected abstract IPEndpoint Clone(string host, ushort port);
     }
 }

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -84,9 +84,6 @@ namespace ZeroC.Ice
             }
         }
 
-        public override Endpoint NewCompressionFlag(bool compressionFlag) =>
-            compressionFlag == HasCompressionFlag ? this : CreateIPEndpoint(Host, Port, compressionFlag, Timeout);
-
         public override async ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType endptSelection)
         {
             Instrumentation.IObserver? observer = Communicator.Observer?.GetEndpointLookupObserver(this);
@@ -148,10 +145,8 @@ namespace ZeroC.Ice
             }
             else
             {
-                return addresses.Select(address => CreateIPEndpoint(Network.EndpointAddressToString(address),
-                                                                    Network.EndpointPort(address),
-                                                                    HasCompressionFlag,
-                                                                    Timeout));
+                return addresses.Select(address => CloneWithHostAndPort(Network.EndpointAddressToString(address),
+                                                                        Network.EndpointPort(address)));
             }
         }
 
@@ -164,7 +159,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                return hosts.Select(host => CreateIPEndpoint(host, Port, HasCompressionFlag, Timeout));
+                return hosts.Select(host => CloneWithHostAndPort(host, Port));
             }
         }
 
@@ -221,7 +216,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                return CreateIPEndpoint(Host, port, HasCompressionFlag, Timeout);
+                return CloneWithHostAndPort(Host, port);
             }
         }
 
@@ -356,11 +351,6 @@ namespace ZeroC.Ice
 
         private protected abstract IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy);
 
-        // TODO: rename to Clone and make parameters optional?
-        private protected abstract IPEndpoint CreateIPEndpoint(
-            string host,
-            ushort port,
-            bool compressionFlag,
-            TimeSpan timeout);
+        private protected abstract IPEndpoint CloneWithHostAndPort(string host, ushort port);
     }
 }

--- a/csharp/src/Ice/ITransceiver.cs
+++ b/csharp/src/Ice/ITransceiver.cs
@@ -122,7 +122,7 @@ namespace ZeroC.Ice
                     {
                         ArraySegmentAndOffset result;
                         result = await self.ReadImplAsync(readBuffer, 0, false).ConfigureAwait(false);
-                        readBuffer = result.buffer;
+                        readBuffer = result.Buffer;
                     }
                     else if (status == SocketOperation.Write)
                     {
@@ -226,13 +226,14 @@ namespace ZeroC.Ice
         // TODO: Benoit: temporary hack, it will be removed with the transport refactoring
         private class ArraySegmentAndOffset
         {
+            public ArraySegment<byte> Buffer;
+            public int Offset;
+
             public ArraySegmentAndOffset(ArraySegment<byte> buffer, int offset)
             {
-                this.buffer = buffer;
-                this.offset = offset;
+                Buffer = buffer;
+                Offset = offset;
             }
-            public ArraySegment<byte> buffer;
-            public int offset;
         };
 
         // TODO: Benoit: temporary hack, it will be removed with the transport refactoring
@@ -240,7 +241,7 @@ namespace ZeroC.Ice
         {
             ArraySegmentAndOffset received =
                 await ReadImplAsync(ArraySegment<byte>.Empty, 0, true).WaitAsync(cancel).ConfigureAwait(false);
-            return received.buffer;
+            return received.Buffer;
         }
 
         // TODO: Benoit: temporary hack, it will be removed with the transport refactoring
@@ -248,7 +249,7 @@ namespace ZeroC.Ice
         {
             ArraySegmentAndOffset received =
                 await ReadImplAsync(buffer, offset, true).WaitAsync(cancel).ConfigureAwait(false);
-            return received.offset - offset;
+            return received.Offset - offset;
         }
 
          // TODO: Benoit: temporary hack, it will be removed with the transport refactoring
@@ -270,8 +271,8 @@ namespace ZeroC.Ice
                         int status;
                         lock (transceiver)
                         {
-                            transceiver.FinishRead(ref p.buffer, ref p.offset);
-                            status = transceiver.Read(ref p.buffer, ref p.offset);
+                            transceiver.FinishRead(ref p.Buffer, ref p.Offset);
+                            status = transceiver.Read(ref p.Buffer, ref p.Offset);
                         }
                         if ((status & SocketOperation.Write) != 0)
                         {
@@ -280,7 +281,7 @@ namespace ZeroC.Ice
                         }
                         if ((status & SocketOperation.Read) != 0 && !partial)
                         {
-                            result.SetResult(await transceiver.ReadImplAsync(p.buffer, p.offset,
+                            result.SetResult(await transceiver.ReadImplAsync(p.Buffer, p.Offset,
                                 false).ConfigureAwait(false));
                         }
                         else
@@ -296,7 +297,7 @@ namespace ZeroC.Ice
 
                 lock (self)
                 {
-                    if (self.StartRead(ref p.buffer, ref p.offset, ReadCallback, self))
+                    if (self.StartRead(ref p.Buffer, ref p.Offset, ReadCallback, self))
                     {
                         ReadCallback(self);
                     }

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -279,12 +279,6 @@ namespace ZeroC.Ice
                 Add("endpointTransport", obj => (obj as ConnectionHelper)?._connection.Endpoint?.Transport);
                 Add("endpointIsDatagram", obj => (obj as ConnectionHelper)?._connection.Endpoint?.IsDatagram);
                 Add("endpointIsSecure", obj => (obj as ConnectionHelper)?._connection.Endpoint?.IsSecure);
-                Add("endpointTimeout", obj =>
-                    {
-                        Endpoint? endpoint = (obj as ConnectionHelper)?._connection.Endpoint;
-                        return endpoint != null ? (int?)endpoint.Timeout.TotalMilliseconds : null;
-                    });
-                Add("endpointCompress", obj => (obj as ConnectionHelper)?._connection.Endpoint?.HasCompressionFlag);
                 Add("endpointHost", obj => (obj as ConnectionHelper)?._connection.Endpoint.Host);
                 Add("endpointPort", obj => (obj as ConnectionHelper)?._connection.Endpoint.Port);
             }
@@ -377,12 +371,6 @@ namespace ZeroC.Ice
                 Add("endpointTransport", obj => (obj as DispatchHelper)?.Connection.Endpoint.Transport);
                 Add("endpointIsDatagram", obj => (obj as DispatchHelper)?.Connection.Endpoint.IsDatagram);
                 Add("endpointIsSecure", obj => (obj as DispatchHelper)?.Connection.Endpoint.IsSecure);
-                Add("endpointTimeout", obj =>
-                    {
-                        Endpoint? endpoint = (obj as DispatchHelper)?.Connection.Endpoint;
-                        return endpoint != null ? (int?)endpoint.Timeout.TotalMilliseconds : null;
-                    });
-                Add("endpointCompress", obj => (obj as DispatchHelper)?.Connection.Endpoint.HasCompressionFlag);
                 Add("endpointHost", obj => (obj as DispatchHelper)?.Connection.Endpoint.Host);
                 Add("endpointPort", obj => (obj as DispatchHelper)?.Connection.Endpoint.Port);
 
@@ -443,12 +431,6 @@ namespace ZeroC.Ice
                 Add("endpointTransport", obj => (obj as EndpointHelper)?._endpoint?.Transport);
                 Add("endpointIsDatagram", obj => (obj as EndpointHelper)?._endpoint?.IsDatagram);
                 Add("endpointIsSecure", obj => (obj as EndpointHelper)?._endpoint?.IsSecure);
-                Add("endpointTimeout", obj =>
-                    {
-                        Endpoint? endpoint = (obj as EndpointHelper)?._endpoint;
-                        return endpoint != null ? (int?)endpoint.Timeout.TotalMilliseconds : null;
-                    });
-                Add("endpointCompress", obj => (obj as EndpointHelper)?._endpoint?.HasCompressionFlag);
                 Add("endpointHost", obj => (obj as EndpointHelper)?._endpoint.Host);
                 Add("endpointPort", obj => (obj as EndpointHelper)?._endpoint.Port);
             }
@@ -694,12 +676,6 @@ namespace ZeroC.Ice
                 Add("endpointTransport", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.Transport);
                 Add("endpointIsDatagram", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.IsDatagram);
                 Add("endpointIsSecure", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.IsSecure);
-                Add("endpointTimeout", obj =>
-                    {
-                        Endpoint? endpoint = (obj as RemoteInvocationHelper)?._connection.Endpoint;
-                        return endpoint != null ? (int?)endpoint.Timeout.TotalMilliseconds : null;
-                    });
-                Add("endpointCompress", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.HasCompressionFlag);
                 Add("endpointHost", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.Host);
                 Add("endpointPort", obj => (obj as RemoteInvocationHelper)?._connection.Endpoint.Port);
             }

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -19,8 +19,6 @@ namespace ZeroC.Ice
     /// </summary>
     internal sealed class OpaqueEndpoint : Endpoint
     {
-        public override bool HasCompressionFlag => false;
-
         public override string Host => "";
 
         public override string? this[string option] =>
@@ -81,9 +79,6 @@ namespace ZeroC.Ice
             Debug.Assert(false);
             throw new NotImplementedException("cannot write the options of an opaque endpoint");
         }
-
-        public override Endpoint NewTimeout(TimeSpan t) => this;
-        public override Endpoint NewCompressionFlag(bool compress) => this;
 
         public override ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType _) =>
             new ValueTask<IEnumerable<IConnector>>(new List<IConnector>());

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -11,7 +11,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
 
 namespace ZeroC.Ice
 {

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -13,11 +13,12 @@ namespace ZeroC.Ice
     /// <summary>The Endpoint class for the TCP transport.</summary>
     internal class TcpEndpoint : IPEndpoint
     {
-        public override bool HasCompressionFlag { get; }
         public override bool IsDatagram => false;
         public override bool IsSecure => Transport == Transport.SSL;
-        public override TimeSpan Timeout { get; } = DefaultTimeout;
         public override Transport Transport { get; }
+
+        protected readonly bool HasCompressionFlag;
+        protected readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
 
         private int _hashCode;
 
@@ -106,9 +107,6 @@ namespace ZeroC.Ice
                 ostr.WriteSize(0); // empty sequence of options
             }
         }
-
-        public override Endpoint NewTimeout(TimeSpan timeout) =>
-            timeout == Timeout ? this : CreateIPEndpoint(Host, Port, HasCompressionFlag, timeout);
 
        public override Connection CreateConnection(
             IConnectionManager manager,
@@ -228,19 +226,15 @@ namespace ZeroC.Ice
         private protected override IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy) =>
             new TcpConnector(this, addr, proxy);
 
-        private protected override IPEndpoint CreateIPEndpoint(
-            string host,
-            ushort port,
-            bool compressionFlag,
-            TimeSpan timeout) =>
+        private protected override IPEndpoint CloneWithHostAndPort(string host, ushort port) =>
             new TcpEndpoint(Communicator,
                             Transport,
                             Protocol,
                             host,
                             port,
                             SourceAddress,
-                            timeout,
-                            compressionFlag);
+                            Timeout,
+                            HasCompressionFlag);
 
         internal virtual ITransceiver CreateTransceiver(StreamSocket socket, string? adapterName)
         {

--- a/csharp/src/Ice/UniversalEndpoint.cs
+++ b/csharp/src/Ice/UniversalEndpoint.cs
@@ -80,9 +80,6 @@ namespace ZeroC.Ice
 
         public override bool IsLocal(Endpoint endpoint) => false;
 
-        public override Endpoint NewTimeout(TimeSpan t) => this;
-        public override Endpoint NewCompressionFlag(bool compress) => this;
-
         public override ValueTask<IEnumerable<IConnector>> ConnectorsAsync(EndpointSelectionType _) =>
             new ValueTask<IEnumerable<IConnector>>(new List<IConnector>());
 

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -195,7 +195,7 @@ namespace ZeroC.Ice
             }
         }
 
-        private protected override IPEndpoint CloneWithHostAndPort(string host, ushort port) =>
+        private protected override IPEndpoint Clone(string host, ushort port) =>
             new WSEndpoint(Communicator,
                            Protocol,
                            Transport,

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -195,19 +195,15 @@ namespace ZeroC.Ice
             }
         }
 
-        private protected override IPEndpoint CreateIPEndpoint(
-            string host,
-            ushort port,
-            bool compressionFlag,
-            TimeSpan timeout) =>
+        private protected override IPEndpoint CloneWithHostAndPort(string host, ushort port) =>
             new WSEndpoint(Communicator,
                            Protocol,
                            Transport,
                            host,
                            port,
                            SourceAddress,
-                           timeout,
-                           compressionFlag,
+                           Timeout,
+                           HasCompressionFlag,
                            _resource);
 
         internal override ITransceiver CreateTransceiver(StreamSocket socket, string? adapterName)

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -39,11 +39,6 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(tcpEndpoint.Host == "tcphost");
                 TestHelper.Assert(tcpEndpoint.Port == 10000);
                 TestHelper.Assert(tcpEndpoint["source-address"] == "10.10.10.10");
-                if (ice1)
-                {
-                    TestHelper.Assert(tcpEndpoint["timeout"] == "1200");
-                    TestHelper.Assert(tcpEndpoint["compress"] == "true");
-                }
                 TestHelper.Assert(!tcpEndpoint.IsDatagram);
 
                 if (ice1)
@@ -54,8 +49,6 @@ namespace ZeroC.Ice.Test.Info
                     TestHelper.Assert(udpEndpoint["interface"] == "eth0");
                     TestHelper.Assert(udpEndpoint["ttl"] == "5");
                     TestHelper.Assert(udpEndpoint["source-address"] == "10.10.10.10");
-                    TestHelper.Assert(udpEndpoint["timeout"] == null);
-                    TestHelper.Assert(udpEndpoint["compress"] == null);
                     TestHelper.Assert(!udpEndpoint.IsSecure);
                     TestHelper.Assert(udpEndpoint.IsDatagram);
                     TestHelper.Assert(udpEndpoint.Transport == Transport.UDP);
@@ -96,7 +89,6 @@ namespace ZeroC.Ice.Test.Info
 
                 TestHelper.Assert(tcpEndpoint.Host == host);
                 TestHelper.Assert(tcpEndpoint.Port > 0);
-                TestHelper.Assert(tcpEndpoint.Timeout == TimeSpan.FromMilliseconds(15000));
 
                 Endpoint udpEndpoint = endpoints[1];
                 TestHelper.Assert(udpEndpoint.Host == host);
@@ -155,13 +147,10 @@ namespace ZeroC.Ice.Test.Info
             {
                 Endpoint tcpEndpoint = testIntf.GetConnection()!.Endpoint;
                 TestHelper.Assert(tcpEndpoint.Port == endpointPort);
-
-                TestHelper.Assert(tcpEndpoint["compress"] == null);
                 TestHelper.Assert(tcpEndpoint.Host == defaultHost);
 
                 Dictionary<string, string> ctx = testIntf.GetEndpointInfoAsContext();
                 TestHelper.Assert(ctx["host"] == tcpEndpoint.Host);
-                TestHelper.Assert(ctx["compress"] == "false");
                 int port = int.Parse(ctx["port"]);
                 TestHelper.Assert(port > 0);
 

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -39,6 +39,11 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(tcpEndpoint.Host == "tcphost");
                 TestHelper.Assert(tcpEndpoint.Port == 10000);
                 TestHelper.Assert(tcpEndpoint["source-address"] == "10.10.10.10");
+                if (ice1)
+                {
+                    TestHelper.Assert(tcpEndpoint["timeout"] == "1200");
+                    TestHelper.Assert(tcpEndpoint["compress"] == "true");
+                }
                 TestHelper.Assert(!tcpEndpoint.IsDatagram);
 
                 if (ice1)
@@ -49,6 +54,8 @@ namespace ZeroC.Ice.Test.Info
                     TestHelper.Assert(udpEndpoint["interface"] == "eth0");
                     TestHelper.Assert(udpEndpoint["ttl"] == "5");
                     TestHelper.Assert(udpEndpoint["source-address"] == "10.10.10.10");
+                    TestHelper.Assert(udpEndpoint["timeout"] == null);
+                    TestHelper.Assert(udpEndpoint["compress"] == null);
                     TestHelper.Assert(!udpEndpoint.IsSecure);
                     TestHelper.Assert(udpEndpoint.IsDatagram);
                     TestHelper.Assert(udpEndpoint.Transport == Transport.UDP);
@@ -89,6 +96,7 @@ namespace ZeroC.Ice.Test.Info
 
                 TestHelper.Assert(tcpEndpoint.Host == host);
                 TestHelper.Assert(tcpEndpoint.Port > 0);
+                TestHelper.Assert(tcpEndpoint["timeout"] is string value && int.Parse(value) == 15000);
 
                 Endpoint udpEndpoint = endpoints[1];
                 TestHelper.Assert(udpEndpoint.Host == host);
@@ -147,10 +155,13 @@ namespace ZeroC.Ice.Test.Info
             {
                 Endpoint tcpEndpoint = testIntf.GetConnection()!.Endpoint;
                 TestHelper.Assert(tcpEndpoint.Port == endpointPort);
+
+                TestHelper.Assert(tcpEndpoint["compress"] == null);
                 TestHelper.Assert(tcpEndpoint.Host == defaultHost);
 
                 Dictionary<string, string> ctx = testIntf.GetEndpointInfoAsContext();
                 TestHelper.Assert(ctx["host"] == tcpEndpoint.Host);
+                TestHelper.Assert(ctx["compress"] == "false");
                 int port = int.Parse(ctx["port"]);
                 TestHelper.Assert(port > 0);
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -641,8 +641,6 @@ namespace ZeroC.Ice.Test.Metrics
                 TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointTransport", transportName, output);
                 TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsDatagram", "False", output);
                 TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsSecure", isSecure, output);
-                TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointTimeout", "60000", output);
-                TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointCompress", "False", output);
                 TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointHost", host, output);
                 TestAttribute(clientMetrics, clientProps, update, "Connection", "endpointPort", port, output);
 
@@ -721,9 +719,6 @@ namespace ZeroC.Ice.Test.Metrics
                 TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsDatagram", "False",
                             c, output);
                 TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsSecure", isSecure,
-                            c, output);
-                TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTimeout", "60000", c, output);
-                TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointCompress", "False",
                             c, output);
                 TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointHost", host, c, output);
                 TestAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointPort", port, c, output);
@@ -808,8 +803,6 @@ namespace ZeroC.Ice.Test.Metrics
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointTransport", transportName, c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsDatagram", "False", c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsSecure", isSecure, c, output);
-                TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointTimeout", "60000", c, output);
-                TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointCompress", "False", c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointHost", "localhost", c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointPort", port, c, output);
 
@@ -924,8 +917,6 @@ namespace ZeroC.Ice.Test.Metrics
                 TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointTransport", transportName, op, output);
                 TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointIsDatagram", "False", op, output);
                 TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointIsSecure", isSecure, op, output);
-                TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointTimeout", "60000", op, output);
-                TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointCompress", "False", op, output);
                 TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointHost", host, op, output);
                 TestAttribute(serverMetrics, serverProps, update, "Dispatch", "endpointPort", port, op, output);
 


### PR DESCRIPTION
This PR cleanups the compression and timeout settings, the corresponding public properties are removed as the NewTimeout/NewCompressionFlag methods used to change the settings.

`CreateIPEndpoint` is replaced by `CloneWithHostAndPort`