### PR TITLE
New public Read API for byte buffers encoded using the Ice encoding

### DIFF
--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -216,7 +216,7 @@ namespace ZeroC.Ice
         internal static ArraySegment<byte> Decompress(ArraySegment<byte> compressed, int headerSize, int frameSizeMax)
         {
             Debug.Assert(IsLoaded);
-            int decompressedSize = InputStream.ReadInt(compressed.AsSpan(headerSize, 4));
+            int decompressedSize = compressed.AsReadOnlySpan(headerSize, 4).ReadInt();
             if (decompressedSize <= headerSize)
             {
                 throw new InvalidDataException(

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -1,0 +1,246 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+using System;
+
+namespace ZeroC.Ice
+{
+    /// <summary>Provides extension methods for byte buffers (such as <c>ReadOnlyMemory{byte}</c>) to read and write
+    /// data encoded using the Ice encoding.</summary>
+    public static class ByteBufferExtensions
+    {
+        private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
+
+        /// <summary>Reads a value from the the buffer.</summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="encoding">The encoding of the data in the buffer.</param>
+        /// <param name="communicator">The communicator, which is mandatory only when reading proxies.</param>
+        /// <param name="reader">The <see cref="InputStreamReader{T}"/> that reads the value from the buffer using an
+        /// <see cref="InputStream"/>.</param>
+        /// <returns>The value read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
+        /// unread data in the buffer.</exception>
+        public static T Read<T>(
+            this ReadOnlyMemory<byte> buffer,
+            Encoding encoding,
+            Communicator? communicator,
+            InputStreamReader<T> reader)
+        {
+            var istr = new InputStream(buffer, encoding, communicator);
+            T result = reader(istr);
+            istr.CheckEndOfBuffer(skipTaggedParams: false);
+            return result;
+        }
+
+        /// <summary>Reads a value from the the buffer that uses the Ice 2.0 encoding.</summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="communicator">The communicator, which is mandatory only when reading proxies.</param>
+        /// <param name="reader">The <see cref="InputStreamReader{T}"/> that reads the value from the buffer using an
+        /// <see cref="InputStream"/>.</param>
+        /// <returns>The value read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
+        /// unread data in the buffer.</exception>
+        public static T Read<T>(
+            this ReadOnlyMemory<byte> buffer,
+            Communicator communicator,
+            InputStreamReader<T> reader) => buffer.Read(Encoding.V2_0, communicator, reader);
+
+        /// <summary>Reads a value from the the buffer. Value cannot contain any proxy.</summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="encoding">The encoding of the data in the buffer.</param>
+        /// <param name="reader">The <see cref="InputStreamReader{T}"/> that reads the value from the buffer using an
+        /// <see cref="InputStream"/>.</param>
+        /// <returns>The value read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
+        /// unread data in the buffer.</exception>
+        public static T Read<T>(
+            this ReadOnlyMemory<byte> buffer,
+            Encoding encoding,
+            InputStreamReader<T> reader) => buffer.Read(encoding, null, reader);
+
+        /// <summary>Reads a value from the the buffer that uses the 2.0 encoding. Value cannot contain any proxy.
+        /// </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="reader">The <see cref="InputStreamReader{T}"/> that reads the value from the buffer using an
+        /// <see cref="InputStream"/>.</param>
+        /// <returns>The value read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
+        /// unread data in the buffer.</exception>
+        public static T Read<T>(this ReadOnlyMemory<byte> buffer, InputStreamReader<T> reader) =>
+            buffer.Read(Encoding.V2_0, null, reader);
+
+        /// <summary>Reads an empty encapsulation from the buffer.</summary>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="encoding">The encoding of encapsulation header.</param>
+        /// <param name="communicator">The communicator.</param>
+        /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
+        /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
+        // TODO: eliminate communicator parameter once tagged classes are gone
+        public static void ReadEmptyEncapsulation(
+            this ReadOnlyMemory<byte> buffer,
+            Encoding encoding,
+            Communicator communicator) =>
+            new InputStream(buffer,
+                            encoding,
+                            communicator,
+                            startEncapsulation: true).CheckEndOfBuffer(skipTaggedParams: true);
+
+        /// <summary>Reads an empty encapsulation from the buffer, with the encapsulation header encoded using the 2.0
+        /// encoding.</summary>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="communicator">The communicator.</param>
+        /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
+        /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
+        // TODO: eliminate communicator parameter once tagged classes are gone
+        public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer, Communicator communicator) =>
+            buffer.ReadEmptyEncapsulation(Encoding.V2_0, communicator);
+
+        /// <summary>Reads the contents of an encapsulation from the buffer.</summary>
+        /// <typeparam name="T">The type of the contents.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="encoding">The encoding of encapsulation header in the buffer.</param>
+        /// <param name="communicator">The communicator.</param>
+        /// <param name="payloadReader">The <see cref="InputStreamReader{T}"/> that reads the payload of the
+        /// encapsulation using an <see cref="InputStream"/>.</param>
+        /// <returns>The contents of the encapsulation read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>buffer</c> is not a valid encapsulation or
+        /// <c>payloadReader</c> finds invalid data.</exception>
+        public static T ReadEncapsulation<T>(
+            this ReadOnlyMemory<byte> buffer,
+            Encoding encoding,
+            Communicator communicator,
+            InputStreamReader<T> payloadReader)
+        {
+            var istr = new InputStream(buffer, encoding, communicator, startEncapsulation: true);
+            T result = payloadReader(istr);
+            istr.CheckEndOfBuffer(skipTaggedParams: true);
+            return result;
+        }
+
+        /// <summary>Reads the contents of an encapsulation from the buffer, with the encapsulation header encoded
+        /// using the 2.0 encoding.</summary>
+        /// <typeparam name="T">The type of the contents.</typeparam>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <param name="communicator">The communicator.</param>
+        /// <param name="payloadReader">The <see cref="InputStreamReader{T}"/> that reads the payload of the
+        /// encapsulation using an <see cref="InputStream"/>.</param>
+        /// <returns>The contents of the encapsulation read from the buffer.</returns>
+        /// <exception name="InvalidDataException">Thrown when <c>buffer</c> is not a valid encapsulation or
+        /// <c>payloadReader</c> finds invalid data.</exception>
+        public static T ReadEncapsulation<T>(
+            this ReadOnlyMemory<byte> buffer,
+            Communicator communicator,
+            InputStreamReader<T> payloadReader) =>
+            buffer.ReadEncapsulation(Encoding.V2_0, communicator, payloadReader);
+
+        internal static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this ArraySegment<T> segment) => segment;
+
+        internal static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this ArraySegment<T> segment, int start) =>
+            segment.AsMemory(start);
+
+        internal static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this ArraySegment<T> segment, int start, int length) =>
+            segment.AsMemory(start, length);
+
+        internal static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment) => segment;
+
+        internal static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment, int start) =>
+            segment.AsSpan(start);
+
+        internal static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment, int start, int length) =>
+            segment.AsSpan(start, length);
+
+        internal static (int Size, Encoding Encoding) ReadEncapsulationHeader(
+            this ReadOnlySpan<byte> buffer,
+            Encoding encoding)
+        {
+            int sizeLength;
+            int size;
+
+            if (encoding == Encoding.V1_1)
+            {
+                sizeLength = 4;
+                size = buffer.ReadInt() - sizeLength; // Remove the size length which is included with the 1.1 encoding.
+                if (size < 0)
+                {
+                    throw new InvalidDataException(
+                        $"the 1.1 encapsulation's size ({size + sizeLength}) is too small");
+                }
+            }
+            else
+            {
+                (size, sizeLength) = buffer.ReadSize20();
+            }
+
+            if (sizeLength + size > buffer.Length)
+            {
+                throw new InvalidDataException(
+                    $"the encapsulation's size ({size}) extends beyond the end of the buffer");
+            }
+
+            return (size, new Encoding(buffer[sizeLength], buffer[sizeLength + 1]));
+        }
+
+        internal static int ReadFixedLengthSize(this ReadOnlySpan<byte> buffer, Encoding encoding)
+        {
+            if (encoding == Encoding.V1_1)
+            {
+                return buffer.ReadInt();
+            }
+            else
+            {
+                return buffer.ReadSize20().Size;
+            }
+        }
+
+        internal static int ReadInt(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt32(buffer);
+        internal static long ReadLong(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt64(buffer);
+        internal static short ReadShort(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt16(buffer);
+
+        internal static (int Size, int SizeLength) ReadSize(this ReadOnlySpan<byte> buffer, Encoding encoding) =>
+            encoding == Encoding.V1_1 ? buffer.ReadSize11() : buffer.ReadSize20();
+
+        /// <summary>Reads a string from a UTF-8 byte buffer. The size of the byte buffer corresponds to the number of
+        /// UTF-8 code points in the string.</summary>
+        /// <param name="buffer">The byte buffer.</param>
+        /// <returns>The string read from the buffer.</returns>
+        internal static string ReadString(this ReadOnlySpan<byte> buffer) =>
+            buffer.IsEmpty ? "" : _utf8.GetString(buffer);
+
+        private static (int Size, int SizeLength) ReadSize11(this ReadOnlySpan<byte> buffer)
+        {
+            byte b = buffer[0];
+            if (b < 255)
+            {
+                return (b, 1);
+            }
+
+            int size = buffer.Slice(1, 4).ReadInt();
+            if (size < 0)
+            {
+                throw new InvalidDataException($"read invalid size: {size}");
+            }
+            return (size, 5);
+        }
+
+        private static (int Size, int SizeLength) ReadSize20(this ReadOnlySpan<byte> buffer)
+        {
+            ulong size = (buffer[0] & 0x03) switch
+            {
+                0 => (uint)buffer[0] >> 2,
+                1 => (uint)BitConverter.ToUInt16(buffer) >> 2,
+                2 => BitConverter.ToUInt32(buffer) >> 2,
+                _ => BitConverter.ToUInt64(buffer) >> 2
+            };
+
+            checked // make sure we don't overflow
+            {
+                return ((int)size, (1 << (buffer[0] & 0x03)));
+            }
+        }
+    }
+}

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice
     {
         private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
 
-        /// <summary>Reads a value from the the buffer.</summary>
+        /// <summary>Reads a value from the buffer.</summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="encoding">The encoding of the data in the buffer.</param>
@@ -34,7 +34,7 @@ namespace ZeroC.Ice
             return result;
         }
 
-        /// <summary>Reads a value from the the buffer that uses the Ice 2.0 encoding.</summary>
+        /// <summary>Reads a value from the buffer that uses the Ice 2.0 encoding.</summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="communicator">The communicator, which is mandatory only when reading proxies.</param>
@@ -48,7 +48,7 @@ namespace ZeroC.Ice
             Communicator communicator,
             InputStreamReader<T> reader) => buffer.Read(Encoding.V2_0, communicator, reader);
 
-        /// <summary>Reads a value from the the buffer. Value cannot contain any proxy.</summary>
+        /// <summary>Reads a value from the buffer. Value cannot contain any proxy.</summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="encoding">The encoding of the data in the buffer.</param>
@@ -62,7 +62,7 @@ namespace ZeroC.Ice
             Encoding encoding,
             InputStreamReader<T> reader) => buffer.Read(encoding, null, reader);
 
-        /// <summary>Reads a value from the the buffer that uses the 2.0 encoding. Value cannot contain any proxy.
+        /// <summary>Reads a value from the buffer that uses the 2.0 encoding. Value cannot contain any proxy.
         /// </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="buffer">The byte buffer.</param>
@@ -239,7 +239,7 @@ namespace ZeroC.Ice
 
             checked // make sure we don't overflow
             {
-                return ((int)size, (1 << (buffer[0] & 0x03)));
+                return ((int)size, 1 << (buffer[0] & 0x03));
             }
         }
     }

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -124,7 +124,7 @@ namespace ZeroC.Ice
                             }' before receiving the validate connection frame");
                     }
 
-                    int size = InputStream.ReadInt(readBuffer.AsSpan(10, 4));
+                    int size = readBuffer.AsReadOnlySpan(10, 4).ReadInt();
                     if (size != Ice1Definitions.HeaderSize)
                     {
                         throw new InvalidDataException(
@@ -283,13 +283,13 @@ namespace ZeroC.Ice
                                                            readBuffer.Slice(Ice1Definitions.HeaderSize + 4),
                                                            compressionStatus);
                     ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, request);
-                    return (InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4)), request);
+                    return (readBuffer.AsReadOnlySpan(Ice1Definitions.HeaderSize, 4).ReadInt(), request);
                 }
 
                 case Ice1Definitions.FrameType.RequestBatch:
                 {
                     ProtocolTrace.TraceReceived(Endpoint.Communicator, Endpoint.Protocol, readBuffer);
-                    int invokeNum = InputStream.ReadInt(readBuffer.AsSpan(Ice1Definitions.HeaderSize, 4));
+                    int invokeNum = readBuffer.AsReadOnlySpan(Ice1Definitions.HeaderSize, 4).ReadInt();
                     if (invokeNum < 0)
                     {
                         throw new InvalidDataException(
@@ -304,7 +304,7 @@ namespace ZeroC.Ice
                     var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
                                                                   readBuffer.Slice(Ice1Definitions.HeaderSize + 4));
                     ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, responseFrame);
-                    return (InputStream.ReadInt(readBuffer.AsSpan(14, 4)), responseFrame);
+                    return (readBuffer.AsReadOnlySpan(14, 4).ReadInt(), responseFrame);
                 }
 
                 case Ice1Definitions.FrameType.ValidateConnection:
@@ -349,7 +349,7 @@ namespace ZeroC.Ice
 
             // Check header
             Ice1Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-            int size = InputStream.ReadInt(readBuffer.Slice(10, 4));
+            int size = readBuffer.AsReadOnlySpan(10, 4).ReadInt();
             if (size < Ice1Definitions.HeaderSize)
             {
                 throw new InvalidDataException($"received ice1 frame with only {size} bytes");

--- a/csharp/src/Ice/Ice1Parser.cs
+++ b/csharp/src/Ice/Ice1Parser.cs
@@ -610,7 +610,7 @@ namespace ZeroC.Ice
                     Debug.Assert(bufferList.Count == 1);
                     Debug.Assert(tail.Segment == 0 && tail.Offset == 8 + opaqueEndpoint.Value.Length);
 
-                    return new InputStream(Ice1Definitions.Encoding, bufferList[0]).ReadEndpoint(Protocol.Ice1,
+                    return new InputStream(bufferList[0], Ice1Definitions.Encoding).ReadEndpoint(Protocol.Ice1,
                                                                                                  communicator);
                 }
                 else

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -46,7 +46,7 @@ namespace ZeroC.Ice
             Data = data;
             Protocol = protocol;
 
-            var istr = new InputStream(Protocol.GetEncoding(), data);
+            var istr = new InputStream(data, Protocol.GetEncoding());
             Identity = new Identity(istr);
             Facet = istr.ReadFacet();
             Operation = istr.ReadString();
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
         /// <param name="communicator">The communicator.</param>
         // TODO: we currently need the communicator only to skip (read) tagged classes.
         public void ReadEmptyParamList(Communicator communicator) =>
-            InputStream.ReadEmptyEncapsulation(communicator, Protocol.GetEncoding(), Payload);
+            Payload.AsReadOnlyMemory().ReadEmptyEncapsulation(Protocol.GetEncoding(), communicator);
 
         /// <summary>Reads the request frame parameter list.</summary>
         /// <param name="communicator">The communicator.</param>
@@ -98,6 +98,6 @@ namespace ZeroC.Ice
         /// <returns>The request parameters, when the frame parameter list contains multiple parameters
         /// they must be return as a tuple.</returns>
         public T ReadParamList<T>(Communicator communicator, InputStreamReader<T> reader) =>
-            InputStream.ReadEncapsulation(communicator, Protocol.GetEncoding(), Payload, reader);
+            Payload.AsReadOnlyMemory().ReadEncapsulation(Protocol.GetEncoding(), communicator, reader);
     }
 }

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -146,10 +146,10 @@ namespace ZeroC.Ice
             if (size + sizeLength != buffer.Length)
             {
                 throw new InvalidDataException(@$"buffer size {
-                    buffer.Length} for message does not match size length + message size {size + sizeLength}");
+                    buffer.Length} for message does not match size length plus message size of {size + sizeLength}");
             }
 
-            throw new UnhandledException(buffer.Slice(sizeLength).ReadString(), Identity.Empty, "", "");
+            return new UnhandledException(buffer.Slice(sizeLength).ReadString(), Identity.Empty, "", "");
         }
 
         internal DispatchException ReadDispatchException()

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -128,7 +128,7 @@ namespace ZeroC.Ice
             istr => istr.ReadVarULong();
 
         /// <summary>The Ice encoding used by this stream when reading its byte buffer.</summary>
-        /// <value>The current encoding.</value>
+        /// <value>The encoding.</value>
         public Encoding Encoding { get; }
 
         /// <summary>The 0-based position (index) in the underlying buffer.</summary>
@@ -151,7 +151,7 @@ namespace ZeroC.Ice
             }
         }
 
-        // The communicator must be set when reading proxies, classes or an exception.
+        // The communicator must be set when reading a proxy, class, or exception.
         private readonly Communicator? _communicator;
 
         private bool OldEncoding => Encoding == Encoding.V1_1;
@@ -162,7 +162,7 @@ namespace ZeroC.Ice
         // Data for the class or exception instance that is currently getting unmarshaled.
         private InstanceData _current;
 
-        // The current depth when reading nested class/exception instances.
+        // The current depth when reading nested class instances.
         private int _classGraphDepth;
 
         // True when reading a top-level encapsulation; otherwise, false.
@@ -1036,7 +1036,7 @@ namespace ZeroC.Ice
         /// <summary>Constructs a new InputStream over a byte buffer.</summary>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="encoding">The encoding of the buffer.</param>
-        /// <param name="communicator">The communicator (optional).</param>
+        /// <param name="communicator">The communicator.</param>
         /// <param name="startEncapsulation">When true, start reading an encapsulation in this byte buffer, and
         /// <c>encoding</c> represents the encoding of the header.</param>
         internal InputStream(
@@ -1150,7 +1150,7 @@ namespace ZeroC.Ice
                     endpoint = factory?.Read(istr, transport, protocol) ??
                         new UniversalEndpoint(istr, communicator, transport, protocol); // protocol is ice2 or greater
 
-                    if (istr == this)
+                    if (ReferenceEquals(istr, this))
                     {
                         // Make sure we read the full encaps
                         if (Pos != oldPos + size - 2)

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -129,7 +129,7 @@ namespace ZeroC.Ice
 
         /// <summary>The Ice encoding used by this stream when reading its byte buffer.</summary>
         /// <value>The current encoding.</value>
-        public Encoding Encoding { get; private set; }
+        public Encoding Encoding { get; }
 
         /// <summary>The 0-based position (index) in the underlying buffer.</summary>
         internal int Pos { get; private set; }
@@ -151,25 +151,22 @@ namespace ZeroC.Ice
             }
         }
 
-        private static readonly System.Text.UTF8Encoding _utf8 = new System.Text.UTF8Encoding(false, true);
-
-        // The communicator must be set when reading a non-empty encapsulation, as this encapsulation can contain
-        // proxies, classes or an exception.
+        // The communicator must be set when reading proxies, classes or an exception.
         private readonly Communicator? _communicator;
-
-        // True when reading a top-level encapsulation; otherwise, false.
-        private bool InEncapsulation => _communicator != null;
 
         private bool OldEncoding => Encoding == Encoding.V1_1;
 
         // The byte buffer we are reading.
-        private ReadOnlyMemory<byte> _buffer;
+        private readonly ReadOnlyMemory<byte> _buffer;
 
         // Data for the class or exception instance that is currently getting unmarshaled.
         private InstanceData _current;
 
         // The current depth when reading nested class/exception instances.
         private int _classGraphDepth;
+
+        // True when reading a top-level encapsulation; otherwise, false.
+        private readonly bool _inEncapsulation;
 
         // Map of class instance ID to class instance.
         // When reading a top-level encapsulation:
@@ -263,9 +260,12 @@ namespace ZeroC.Ice
             {
                 return "";
             }
-            string value = _utf8.GetString(_buffer.Span.Slice(Pos, size));
-            Pos += size;
-            return value;
+            else
+            {
+                string value = _buffer.Slice(Pos, size).Span.ReadString();
+                Pos += size;
+                return value;
+            }
         }
 
         /// <summary>Reads a uint from the stream.</summary>
@@ -467,8 +467,15 @@ namespace ZeroC.Ice
         /// <summary>Reads a nullable proxy from the stream.</summary>
         /// <param name="factory">The proxy factory used to create the typed proxy.</param>
         /// <returns>The proxy read from the stream, or null.</returns>
-        public T? ReadNullableProxy<T>(ProxyFactory<T> factory) where T : class, IObjectPrx =>
-            Reference.Read(this, _communicator!) is Reference reference ? factory(reference) : null;
+        public T? ReadNullableProxy<T>(ProxyFactory<T> factory) where T : class, IObjectPrx
+        {
+            if (_communicator == null)
+            {
+                throw new InvalidOperationException(
+                    "cannot read a proxy from an input stream with a null communicator");
+            }
+            return Reference.Read(this, _communicator) is Reference reference ? factory(reference) : null;
+        }
 
         /// <summary>Reads a proxy from the stream.</summary>
         /// <param name="factory">The proxy factory used to create the typed proxy.</param>
@@ -515,10 +522,17 @@ namespace ZeroC.Ice
             int sz = ReadAndCheckSeqSize(1);
             if (sz == 0)
             {
-                throw new InvalidDataException("read an empty byte sequence for non-null serializable object");
+                throw new InvalidDataException("read an empty byte sequence for a serializable object");
             }
             var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, _communicator!));
-            return f.Deserialize(new StreamWrapper(this));
+            var streamWrapper = new StreamWrapper(_buffer.Slice(Pos, sz));
+            object result = f.Deserialize(streamWrapper);
+            if (streamWrapper.Position != sz)
+            {
+                throw new InvalidDataException($"{sz - streamWrapper.Position} bytes left in object stream");
+            }
+            Pos += sz;
+            return result;
         }
 
         /// <summary>Reads a sorted dictionary from the stream.</summary>
@@ -1019,136 +1033,70 @@ namespace ZeroC.Ice
             return new ReadOnlyBitSequence(_buffer.Span.Slice(startPos, size));
         }
 
-        /// <summary>Reads an empty encapsulation from the provided byte buffer.</summary>
-        /// <param name="communicator">The communicator.</param>
-        /// <param name="encoding">The encoding of the buffer.</param>
+        /// <summary>Constructs a new InputStream over a byte buffer.</summary>
         /// <param name="buffer">The byte buffer.</param>
-        internal static void ReadEmptyEncapsulation(
-            Communicator communicator,
-            Encoding encoding,
-            ReadOnlyMemory<byte> buffer)
-        {
-            var istr = new InputStream(communicator, encoding, buffer);
-            istr.SkipTaggedParams();
-            istr.CheckEndOfBuffer();
-        }
-
-        /// <summary>Reads the contents of an encapsulation from the provided byte buffer.</summary>
-        /// <param name="communicator">The communicator.</param>
         /// <param name="encoding">The encoding of the buffer.</param>
-        /// <param name="buffer">The byte buffer.</param>
-        /// <param name="payloadReader">The reader used to read the payload of this encapsulation.</param>
-        internal static T ReadEncapsulation<T>(
-            Communicator communicator,
-            Encoding encoding,
+        /// <param name="communicator">The communicator (optional).</param>
+        /// <param name="startEncapsulation">When true, start reading an encapsulation in this byte buffer, and
+        /// <c>encoding</c> represents the encoding of the header.</param>
+        internal InputStream(
             ReadOnlyMemory<byte> buffer,
-            InputStreamReader<T> payloadReader)
-        {
-            var istr = new InputStream(communicator, encoding, buffer);
-            T result = payloadReader(istr);
-            istr.SkipTaggedParams();
-            istr.CheckEndOfBuffer();
-            return result;
-        }
-
-        internal static (int Size, Encoding Encoding) ReadEncapsulationHeader(
             Encoding encoding,
-            ReadOnlySpan<byte> buffer)
+            Communicator? communicator = null,
+            bool startEncapsulation = false)
         {
-            int sizeLength;
-            int size;
+            _communicator = communicator;
+            Pos = 0;
+            _buffer = buffer;
+            Encoding = encoding;
+            Encoding.CheckSupported();
 
-            if (encoding == Encoding.V1_1)
+            if (startEncapsulation)
             {
-                sizeLength = 4;
-                size = ReadInt(buffer) - sizeLength; // Remove the size length which is included with the 1.1 encoding.
-                if (size < 0)
+                // TODO: a null communicator should be ok for an empty encaps.
+                Debug.Assert(_communicator != null);
+
+                (int size, Encoding encapsEncoding) = ReadEncapsulationHeader();
+
+                // When startEncapsulation is true, the buffer must extend until the end of the encapsulation - it
+                // cannot include extra bytes.
+                if (Pos + size - 2 != _buffer.Length)
                 {
                     throw new InvalidDataException(
-                        $"the 1.1 encapsulation's size ({size + sizeLength}) is too small");
+                        $"the buffer has {_buffer.Length - (Pos + size - 2)} bytes after the encapsulation");
                 }
-            }
-            else
-            {
-                sizeLength = 1 << (buffer[0] & 0x03);
-                size = ReadSize20(buffer);
-            }
 
-            if (sizeLength + size > buffer.Length)
-            {
-                throw new InvalidDataException(
-                    $"the encapsulation's size ({size}) extends beyond the end of the buffer");
+                // We slice the provided buffer to the encapsulation (minus its header).
+                _buffer = buffer.Slice(Pos);
+                Pos = 0;
+                Encoding = encapsEncoding;
+                Encoding.CheckSupported();
             }
-
-            return (size, new Encoding(buffer[sizeLength], buffer[sizeLength + 1]));
+            _inEncapsulation = startEncapsulation;
         }
 
-        internal static int ReadFixedLengthSize(Encoding encoding, ReadOnlySpan<byte> buffer)
+        /// <summary>Verifies the input stream has reached the end of its underlying buffer.</summary>
+        /// <param name="skipTaggedParams">When true, first skips all remaining tagged parameters in the current
+        /// encapsulation.</param>
+        internal void CheckEndOfBuffer(bool skipTaggedParams)
         {
-            if (encoding == Encoding.V1_1)
+            if (skipTaggedParams)
             {
-                return ReadInt(buffer);
+                Debug.Assert(_inEncapsulation);
+                SkipTaggedParams();
             }
-            else
-            {
-                return ReadSize20(buffer);
-            }
-        }
 
-        internal static int ReadInt(ReadOnlySpan<byte> buffer) => BitConverter.ToInt32(buffer);
-        internal static long ReadLong(ReadOnlySpan<byte> buffer) => BitConverter.ToInt64(buffer);
-        internal static short ReadShort(ReadOnlySpan<byte> buffer) => BitConverter.ToInt16(buffer);
-
-        // TODO: this is a temporary helper for ice1-style unhandled exceptions.
-        internal static string ReadString(Encoding encoding, ReadOnlySpan<byte> span)
-        {
-            if (encoding == Encoding.V1_1)
+            if (Pos != _buffer.Length)
             {
-                return ReadString11(span);
+                throw new InvalidDataException($"{_buffer.Length - Pos} bytes remaining in the InputStream buffer");
             }
-            else
-            {
-                int size = ReadSize20(span);
-                if (size == 0)
-                {
-                    return "";
-                }
-                else
-                {
-                    int sizeLength = 1 << (span[0] & 0x03);
-                    return _utf8.GetString(span.Slice(sizeLength, size));
-                }
-            }
-        }
-
-        internal static string ReadString11(ReadOnlySpan<byte> span)
-        {
-            int size = ReadSize11(span);
-            if (size == 0)
-            {
-                return "";
-            }
-            else
-            {
-                return _utf8.GetString(span.Slice(size < 255 ? 1 : 5, size));
-            }
-        }
-
-        /// <summary>Constructs a new InputStream over a byte buffer.</summary>
-        /// <param name="encoding">The encoding of the buffer.</param>
-        /// <param name="buffer">The byte buffer.</param>
-        internal InputStream(Encoding encoding, ReadOnlyMemory<byte> buffer)
-        {
-            _buffer = buffer;
-            Pos = 0;
-            Encoding = encoding;
         }
 
         /// <summary>Reads an encapsulation header from the stream.</summary>
         /// <returns>The encapsulation header read from the stream.</returns>
         internal (int Size, Encoding Encoding) ReadEncapsulationHeader()
         {
-            (int Size, Encoding Encoding) result = ReadEncapsulationHeader(Encoding, _buffer.Span.Slice(Pos));
+            (int Size, Encoding Encoding) result = _buffer.Span.Slice(Pos).ReadEncapsulationHeader(Encoding);
             if (OldEncoding)
             {
                 Pos += 6; // 4 bytes for the encaps size + 2 bytes for the encoding
@@ -1191,26 +1139,31 @@ namespace ZeroC.Ice
                 }
                 else if (encoding.IsSupported)
                 {
-                    Encoding previousEncoding = Encoding;
-                    ReadOnlyMemory<byte> previousBuffer = _buffer;
-                    int previousPos = Pos;
-                    int previousMinTotalSeqSize = _minTotalSeqSize;
-                    Encoding = encoding;
-                    _buffer = _buffer.Slice(Pos, size - 2);
-                    Pos = 0;
-                    _minTotalSeqSize = 0;
+                    int oldPos = Pos;
 
-                    endpoint = factory?.Read(this, transport, protocol) ??
-                        new UniversalEndpoint(this, communicator, transport, protocol); // protocol is ice2 or greater
+                    // The common situation is an ice1 proxy in 1.1 encaps, with endpoints encoded with 1.1 (no need to
+                    // create a new InputStream). A less common situation is an ice1 proxy in 2.0 encaps with
+                    // 1.1-encoded endpoints (we need a new InputStream in this case).
+                    InputStream istr = encoding == Encoding ?
+                        this : new InputStream(_buffer.Slice(Pos, size - 2), encoding);
 
-                    CheckEndOfBuffer();
+                    endpoint = factory?.Read(istr, transport, protocol) ??
+                        new UniversalEndpoint(istr, communicator, transport, protocol); // protocol is ice2 or greater
 
-                    // Exceptions when reading InputStream are considered fatal to the InputStream so no need to restore
-                    // anything unless we succeed.
-                    Encoding = previousEncoding;
-                    _buffer = previousBuffer;
-                    Pos = previousPos + size - 2;
-                    _minTotalSeqSize = previousMinTotalSeqSize;
+                    if (istr == this)
+                    {
+                        // Make sure we read the full encaps
+                        if (Pos != oldPos + size - 2)
+                        {
+                            throw new InvalidDataException(
+                                $"{oldPos + size - 2 - Pos} bytes left in endpoint encapsulation");
+                        }
+                    }
+                    else
+                    {
+                        istr.CheckEndOfBuffer(skipTaggedParams: false);
+                        Pos += size - 2;
+                    }
                 }
                 else
                 {
@@ -1247,69 +1200,6 @@ namespace ZeroC.Ice
                 throw new IndexOutOfRangeException($"cannot skip {size} bytes");
             }
             Pos += size;
-        }
-
-        private static int ReadSize11(ReadOnlySpan<byte> buffer)
-        {
-            byte b = buffer[0];
-            if (b < 255)
-            {
-                return b;
-            }
-
-            int size = ReadInt(buffer.Slice(1, 4));
-            if (size < 0)
-            {
-                throw new InvalidDataException($"read invalid size: {size}");
-            }
-            return size;
-        }
-
-        private static int ReadSize20(ReadOnlySpan<byte> buffer)
-        {
-            ulong size = (buffer[0] & 0x03) switch
-            {
-                0 => (uint)buffer[0] >> 2,
-                1 => (uint)BitConverter.ToUInt16(buffer) >> 2,
-                2 => BitConverter.ToUInt32(buffer) >> 2,
-                _ => BitConverter.ToUInt64(buffer) >> 2
-            };
-
-            checked // make sure we don't overflow
-            {
-                return (int)size;
-            }
-        }
-
-        // This constructor starts a new encapsulation and as a result requires a communicator.
-        private InputStream(
-            Communicator communicator,
-            Encoding encoding,
-            ReadOnlyMemory<byte> buffer)
-        {
-            _communicator = communicator;
-            Pos = 0;
-            _buffer = buffer;
-            Encoding = encoding;
-            Encoding.CheckSupported();
-
-            (int size, Encoding encapsEncoding) = ReadEncapsulationHeader();
-
-            // We slice the provided buffer to the encapsulation (minus its header). This way, we can easily prevent
-            // reads past the end of the encapsulation.
-            _buffer = buffer.Slice(Pos, size - 2);
-            Pos = 0;
-
-            Encoding = encapsEncoding;
-            Encoding.CheckSupported();
-        }
-
-        private void CheckEndOfBuffer()
-        {
-            if (Pos != _buffer.Length)
-            {
-                throw new InvalidDataException($"{_buffer.Length - Pos} bytes remaining in the InputStream buffer");
-            }
         }
 
         /// <summary>Reads a sequence size and makes sure there is enough space in the underlying buffer to read the
@@ -1439,7 +1329,7 @@ namespace ZeroC.Ice
         private bool ReadTaggedParamHeader(int tag, EncodingDefinitions.TagFormat expectedFormat)
         {
             // Tagged members/parameters can only be in the main encapsulation.
-            Debug.Assert(InEncapsulation);
+            Debug.Assert(_inEncapsulation);
 
             // The current slice has no tagged parameter.
             if (_current.InstanceType != InstanceType.None &&
@@ -1566,20 +1456,19 @@ namespace ZeroC.Ice
             }
         }
 
-        private bool SkipTaggedParams()
+        private void SkipTaggedParams()
         {
-            // Skip remaining unread tagged parameters.
             while (true)
             {
                 if (_buffer.Length - Pos <= 0)
                 {
-                    return false; // End of encapsulation also indicates end of tagged parameters.
+                    break;
                 }
 
                 int v = ReadByte();
                 if (v == EncodingDefinitions.TaggedEndMarker)
                 {
-                    return true;
+                    break;
                 }
 
                 var format = (EncodingDefinitions.TagFormat)(v & 0x07); // Read first 3 bits.

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -169,7 +169,7 @@ namespace ZeroC.Ice
                     $"payload should contain at least 6 bytes, but it contains {payload.Count} bytes",
                     nameof(payload));
             }
-            int size = InputStream.ReadFixedLengthSize(proxy.Protocol.GetEncoding(), payload.AsSpan(0, 4));
+            int size = payload.AsReadOnlySpan(0, 4).ReadFixedLengthSize(proxy.Protocol.GetEncoding());
             if (size != payload.Count)
             {
                 throw new ArgumentException($"invalid payload size `{size}' expected `{payload.Count}'",

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -124,8 +124,8 @@ namespace ZeroC.Ice
                         nameof(payload));
                 }
 
-                (int size, Encoding encapsEncoding) = InputStream.ReadEncapsulationHeader(
-                    Protocol.GetEncoding(), payload.AsSpan(1));
+                (int size, Encoding encapsEncoding) =
+                    payload.AsReadOnlySpan(1).ReadEncapsulationHeader(Protocol.GetEncoding());
 
                 if (size + 4 + 1 != payload.Count) // 4 = size length with 1.1 encoding
                 {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -790,7 +790,7 @@ namespace ZeroC.Ice
         public void WriteSerializable(object o)
         {
             var w = new StreamWrapper(this);
-            IFormatter f = new BinaryFormatter();
+            var f = new BinaryFormatter();
             f.Serialize(w, o);
             w.Close();
         }

--- a/csharp/src/Ice/ProtocolTrace.cs
+++ b/csharp/src/Ice/ProtocolTrace.cs
@@ -20,8 +20,8 @@ namespace ZeroC.Ice
                 frame.Protocol,
                 header[8], // Frame type
                 header[9], // Compression Status
-                InputStream.ReadFixedLengthSize(frame.Protocol.GetEncoding(), header.Slice(10, 4)), // Request size
-                InputStream.ReadInt(header.Slice(14, 4)), // Request-Id
+                header.Slice(10, 4).ReadFixedLengthSize(frame.Protocol.GetEncoding()), // Request size
+                header.Slice(14, 4).ReadInt(), // Request-Id
                 frame.Identity,
                 frame.Facet,
                 frame.Operation,
@@ -39,8 +39,8 @@ namespace ZeroC.Ice
                 frame.Protocol,
                 header[8], // Frame type
                 header[9], // Compression Status
-                InputStream.ReadFixedLengthSize(frame.Protocol.GetEncoding(), header.Slice(10, 4)), // Request size
-                InputStream.ReadInt(header.Slice(14, 4)), // Request-Id,
+                header.Slice(10, 4).ReadFixedLengthSize(frame.Protocol.GetEncoding()), // Request size
+                header.Slice(14, 4).ReadInt(), // Request-Id,
                 frame.ReplyStatus,
                 frame.Encoding);
 
@@ -54,8 +54,8 @@ namespace ZeroC.Ice
                 frame.Protocol,
                 header[8], // Frame type
                 header[9], // Compression Status
-                InputStream.ReadFixedLengthSize(frame.Protocol.GetEncoding(), header.Slice(10, 4)), // Request size
-                InputStream.ReadInt(header.Slice(14, 4)), // Request-Id,
+                header.Slice(10, 4).ReadFixedLengthSize(frame.Protocol.GetEncoding()), // Request size
+                header.Slice(14, 4).ReadInt(), // Request-Id,
                 frame.Identity,
                 frame.Facet,
                 frame.Operation,
@@ -73,8 +73,8 @@ namespace ZeroC.Ice
                 frame.Protocol,
                 header[8], // Frame type
                 header[9], // Compression Status
-                InputStream.ReadFixedLengthSize(frame.Protocol.GetEncoding(), header.Slice(10, 4)), // Request size
-                InputStream.ReadInt(header.Slice(14, 4)), // Request-Id,
+                header.Slice(10, 4).ReadFixedLengthSize(frame.Protocol.GetEncoding()), // Request size
+                header.Slice(14, 4).ReadInt(), // Request-Id,
                 frame.ReplyStatus,
                 frame.Encoding);
 
@@ -221,7 +221,7 @@ namespace ZeroC.Ice
                 PrintHeader(protocol,
                             header[8],
                             header[9],
-                            InputStream.ReadFixedLengthSize(protocol.GetEncoding(), header.Slice(10, 4)),
+                            header.Slice(10, 4).ReadFixedLengthSize(protocol.GetEncoding()),
                             s);
                 communicator.Logger.Trace(communicator.TraceLevels.ProtocolCategory, s.ToString());
             }

--- a/csharp/src/Ice/SlicBinaryConnection.cs
+++ b/csharp/src/Ice/SlicBinaryConnection.cs
@@ -124,8 +124,8 @@ namespace ZeroC.Ice
                 // TODO: this is temporary code. With the 2.0 encoding, sizes are always variable-length
                 // with the length encoded on the first 2 bits of the size. Assuming the size is encoded
                 // on 4 bytes (like we do below) is not correct.
-                int size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(),
-                                                           readBuffer.AsSpan(10, 4));
+                int size =
+                    readBuffer.AsReadOnlySpan(10, 4).ReadFixedLengthSize(Endpoint.Protocol.GetEncoding());
                 if (size != Ice2Definitions.HeaderSize)
                 {
                     throw new InvalidDataException(
@@ -228,7 +228,7 @@ namespace ZeroC.Ice
                     var request = new IncomingRequestFrame(Endpoint.Protocol,
                                                            readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
                     ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, request);
-                    return (InputStream.ReadInt(readBuffer.AsSpan(Ice2Definitions.HeaderSize, 4)), request);
+                    return (readBuffer.AsReadOnlySpan(Ice2Definitions.HeaderSize, 4).ReadInt(), request);
                 }
 
                 case Ice2Definitions.FrameType.Reply:
@@ -236,7 +236,7 @@ namespace ZeroC.Ice
                     var responseFrame = new IncomingResponseFrame(Endpoint.Protocol,
                                                                   readBuffer.Slice(Ice2Definitions.HeaderSize + 4));
                     ProtocolTrace.TraceFrame(Endpoint.Communicator, readBuffer, responseFrame);
-                    return (InputStream.ReadInt(readBuffer.AsSpan(14, 4)), responseFrame);
+                    return (readBuffer.AsReadOnlySpan(14, 4).ReadInt(), responseFrame);
                 }
 
                 case Ice2Definitions.FrameType.ValidateConnection:
@@ -273,7 +273,7 @@ namespace ZeroC.Ice
 
             // Check header
             Ice2Definitions.CheckHeader(readBuffer.AsSpan(0, 8));
-            int size = InputStream.ReadFixedLengthSize(Endpoint.Protocol.GetEncoding(), readBuffer.Slice(10, 4));
+            int size = readBuffer.AsReadOnlySpan(10, 4).ReadFixedLengthSize(Endpoint.Protocol.GetEncoding());
             if (size < Ice2Definitions.HeaderSize)
             {
                 throw new InvalidDataException($"received ice2 frame with only {size} bytes");

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -1044,7 +1044,7 @@ namespace ZeroC.Ice
                     {
                         // Uses network byte order
                         _readPayloadLength = System.Net.IPAddress.NetworkToHostOrder(
-                            InputStream.ReadShort(_readBuffer.Slice(_readBufferPos, 2)));
+                            _readBuffer.AsReadOnlySpan(_readBufferPos, 2).ReadShort());
                         if (_readPayloadLength < 0)
                         {
                             _readPayloadLength += 65536;
@@ -1055,7 +1055,7 @@ namespace ZeroC.Ice
                     {
                         // Uses network byte order.
                         long length = System.Net.IPAddress.NetworkToHostOrder(
-                            InputStream.ReadLong(_readBuffer.Slice(_readBufferPos, 8)));
+                            _readBuffer.AsReadOnlySpan(_readBufferPos, 8).ReadLong());
                         _readBufferPos += 8;
                         if (length < 0 || length > int.MaxValue)
                         {

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -434,7 +434,7 @@ namespace ZeroC.Ice.Test.Exceptions
             }
             catch (UnhandledException ex)
             {
-                 TestHelper.Assert(ex.Message.Contains("unhandled exception")); // verify we get custom message
+                TestHelper.Assert(ex.Message.Contains("unhandled exception")); // verify we get custom message
             }
             catch
             {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -875,6 +875,17 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(c.DictionaryEquals(c2));
             output.WriteLine("ok");
 
+            if (communicator.DefaultProtocol == Protocol.Ice2)
+            {
+                output.Write("testing ice1 proxy in 2.0 encapsulation... ");
+                output.Flush();
+                var ice1Prx = IObjectPrx.Parse(
+                    "foo:tcp -h localhost -p 10000:udp -h localhost -p 10000", communicator);
+                var prx = IMyDerivedClassPrx.UncheckedCast(baseProxy).Echo(ice1Prx);
+                TestHelper.Assert(ice1Prx.Equals(prx));
+                output.WriteLine("ok");
+            }
+
             output.Write("testing ice_fixed... ");
             output.Flush();
             {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -875,7 +875,17 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(c.DictionaryEquals(c2));
             output.WriteLine("ok");
 
-            if (communicator.DefaultProtocol == Protocol.Ice2)
+            if (communicator.DefaultProtocol == Protocol.Ice1)
+            {
+                output.Write("testing ice2 proxy in 1.1 encapsulation... ");
+                output.Flush();
+                var ice2Prx = IObjectPrx.Parse(
+                    "ice+tcp://localhost:10000/foo?alt-endpoint=ice+ws://localhost:10000", communicator);
+                var prx = IMyDerivedClassPrx.UncheckedCast(baseProxy).Echo(ice2Prx);
+                TestHelper.Assert(ice2Prx.Equals(prx));
+                output.WriteLine("ok");
+            }
+            else
             {
                 output.Write("testing ice1 proxy in 2.0 encapsulation... ");
                 output.Flush();


### PR DESCRIPTION
This PR introduces a new public API for reading Ice-encoded buffers: extension methods for `ReadOnlyMemory<byte>`.

This PR also includes a number of _internal_ `AsReadOnlyMemory`/`AsReadOnlySpan` extension methods that are convenient to convert an `ArraySegment<byte>` into a `ReadOnlyMemory<byte>` (or `ReadOnlySpan<byte>`) for use with these extensions. Should I make the `AsReadOnlyMemory` methods public? (The span methods are only for internal extensions).
