### PR TITLE
Remove Ice.Default.Host from C#

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -335,6 +335,7 @@ generated from the section label.
         <!-- TODO deprecate Default.EncodingVersion, replaced by Default.Encoding -->
         <property name="Default.EncodingVersion" />
         <property name="Default.EndpointSelection" />
+        <!-- TODO remove Default.Host -->
         <property name="Default.Host" />
         <property name="Default.Locator" class="proxy" />
         <property name="Default.LocatorCacheTimeout" />

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -106,7 +106,6 @@ namespace ZeroC.Ice
         public Encoding DefaultEncoding { get; }
         public EndpointSelectionType DefaultEndpointSelection { get; }
         public FormatType DefaultFormat { get; }
-        public string? DefaultHost { get; }
 
         /// <summary>The default locator for this communicator. To disable the default locator, null can be used.
         /// All newly created proxies and object adapters will use this default locator. Note that setting this property
@@ -415,8 +414,6 @@ namespace ZeroC.Ice
 
                 DefaultFormat = (GetPropertyAsBool("Ice.Default.SlicedFormat") ?? false) ?
                     FormatType.Sliced : FormatType.Compact;
-
-                DefaultHost = GetProperty("Ice.Default.Host");
 
                 // TODO: switch to 0/false default
                 DefaultPreferNonSecure = GetPropertyAsBool("Ice.Default.PreferNonSecure") ?? true;

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -276,7 +276,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                Host = Communicator.DefaultHost ?? "";
+                throw new FormatException($"no -h option in endpoint `{endpointString}'");
             }
 
             if (options.TryGetValue("-p", out argument))

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.ACM
         {
             Communicator communicator = current.Adapter.Communicator;
             string transport = communicator.GetProperty("Ice.Default.Transport") ?? "tcp";
-            string host = communicator.GetProperty("Ice.Default.Host") ?? "127.0.0.1";
+            string host = communicator.GetProperty("Test.Host")!;
 
             string name = Guid.NewGuid().ToString();
             if (timeout >= 0)

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -34,10 +34,10 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 output.Write("creating/destroying/recreating object adapter... ");
                 output.Flush();
                 ObjectAdapter adapter =
-                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
+                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", helper.GetTestEndpoint(1));
                 try
                 {
-                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
+                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", helper.GetTestEndpoint(2));
                     TestHelper.Assert(false);
                 }
                 catch (ArgumentException)
@@ -48,7 +48,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 //
                 // Use a different port than the first adapter to avoid an "address already in use" error.
                 //
-                adapter = communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
+                adapter = communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", helper.GetTestEndpoint(2));
                 adapter.Dispose();
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -34,10 +34,10 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 output.Write("creating/destroying/recreating object adapter... ");
                 output.Flush();
                 ObjectAdapter adapter =
-                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "default");
+                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
                 try
                 {
-                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "default");
+                    communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
                     TestHelper.Assert(false);
                 }
                 catch (ArgumentException)
@@ -48,7 +48,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 //
                 // Use a different port than the first adapter to avoid an "address already in use" error.
                 //
-                adapter = communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "default");
+                adapter = communicator.CreateObjectAdapterWithEndpoints("TransientTestAdapter", "tcp -h localhost");
                 adapter.Dispose();
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         public void Transient(Current current)
         {
             using ObjectAdapter adapter = current.Adapter.Communicator.CreateObjectAdapterWithEndpoints(
-                "TransientTestAdapter", "default");
+                "TransientTestAdapter", "default -h localhost");
             adapter.Activate();
         }
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -825,31 +825,27 @@ namespace ZeroC.Ice.Test.Binding
                 var ipv4 = new Dictionary<string, string>()
                 {
                     { "IPv4", "1" },
-                    { "IPv6", "0" },
-                    { "Adapter.Endpoints", "tcp -h localhost" }
+                    { "IPv6", "0" }
                     };
 
                 var ipv6 = new Dictionary<string, string>()
                 {
                     { "IPv4", "0" },
-                    { "IPv6", "1" },
-                    { "Adapter.Endpoints", "tcp -h localhost" }
+                    { "IPv6", "1" }
                 };
 
                 var bothPreferIPv4 = new Dictionary<string, string>()
                 {
                     { "IPv4", "1" },
                     { "IPv6", "1" },
-                    { "PreferIPv6Address", "0" },
-                    { "Adapter.Endpoints", "tcp -h localhost" }
+                    { "PreferIPv6Address", "0" }
                 };
 
                 var bothPreferIPv6 = new Dictionary<string, string>()
                 {
                     { "IPv4", "1" },
                     { "IPv6", "1" },
-                    { "PreferIPv6Address", "1" },
-                    { "Adapter.Endpoints", "tcp -h localhost" }
+                    { "PreferIPv6Address", "1" }
                 };
 
                 Dictionary<string, string>[] clientProps =
@@ -857,36 +853,42 @@ namespace ZeroC.Ice.Test.Binding
                     ipv4, ipv6, bothPreferIPv4, bothPreferIPv6
                 };
 
-                string endpoint = "tcp -p " + helper.GetTestPort(2).ToString();
+                Func<string, string> getEndpoint = host =>
+                    TestHelper.GetTestEndpoint(new Dictionary<string, string>(communicator.GetProperties(""))
+                    {
+                        ["Test.Host"] = host
+                    },
+                    2,
+                    "tcp");
 
                 var anyipv4 = new Dictionary<string, string>(ipv4)
                 {
-                    ["Adapter.Endpoints"] = $"{endpoint} -h 0.0.0.0",
-                    ["Adapter.PublishedEndpoints"] = $"{endpoint} -h 127.0.0.1"
+                    ["Adapter.Endpoints"] = getEndpoint("0.0.0.0"),
+                    ["Adapter.PublishedEndpoints"] = getEndpoint("127.0.0.1")
                 };
 
                 var anyipv6 = new Dictionary<string, string>(ipv6)
                 {
-                    ["Adapter.Endpoints"] = $"{endpoint} -h \"::0\"",
-                    ["Adapter.PublishedEndpoints"] = $"{endpoint} -h \".1\""
+                    ["Adapter.Endpoints"] = getEndpoint("::0"),
+                    ["Adapter.PublishedEndpoints"] = getEndpoint("::1")
                 };
 
                 var anyboth = new Dictionary<string, string>()
                 {
                     { "IPv4", "1" },
                     { "IPv6", "1"},
-                    { "Adapter.Endpoints", $"{endpoint} -h \"::0\"" },
-                    { "Adapter.PublishedEndpoints", $"{endpoint} -h \"::1\":{endpoint} -h 127.0.0.1" }
+                    { "Adapter.Endpoints", getEndpoint("::0")},
+                    { "Adapter.PublishedEndpoints", getEndpoint("localhost") }
                 };
 
                 var localipv4 = new Dictionary<string, string>(ipv4)
                 {
-                    ["Adapter.Endpoints"] = "tcp -h 127.0.0.1"
+                    ["Adapter.Endpoints"] = getEndpoint("127.0.0.1")
                 };
 
                 var localipv6 = new Dictionary<string, string>(ipv6)
                 {
-                    ["Adapter.Endpoints"] = "tcp -h \"::1\""
+                    ["Adapter.Endpoints"] = getEndpoint("::1")
                 };
 
                 Dictionary<string, string>[] serverProps =

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -861,13 +861,13 @@ namespace ZeroC.Ice.Test.Binding
 
                 var anyipv4 = new Dictionary<string, string>(ipv4)
                 {
-                    ["Adapter.Endpoints"] = endpoint,
+                    ["Adapter.Endpoints"] = $"{endpoint} -h 0.0.0.0",
                     ["Adapter.PublishedEndpoints"] = $"{endpoint} -h 127.0.0.1"
                 };
 
                 var anyipv6 = new Dictionary<string, string>(ipv6)
                 {
-                    ["Adapter.Endpoints"] = endpoint,
+                    ["Adapter.Endpoints"] = $"{endpoint} -h \"::0\"",
                     ["Adapter.PublishedEndpoints"] = $"{endpoint} -h \".1\""
                 };
 
@@ -875,7 +875,7 @@ namespace ZeroC.Ice.Test.Binding
                 {
                     { "IPv4", "1" },
                     { "IPv6", "1"},
-                    { "Adapter.Endpoints", endpoint },
+                    { "Adapter.Endpoints", $"{endpoint} -h \"::0\"" },
                     { "Adapter.PublishedEndpoints", $"{endpoint} -h \"::1\":{endpoint} -h 127.0.0.1" }
                 };
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -854,7 +854,7 @@ namespace ZeroC.Ice.Test.Binding
                 };
 
                 Func<string, string> getEndpoint = host =>
-                    TestHelper.GetTestEndpoint(new Dictionary<string, string>(communicator.GetProperties(""))
+                    TestHelper.GetTestEndpoint(new Dictionary<string, string>(communicator.GetProperties())
                     {
                         ["Test.Host"] = host
                     },

--- a/csharp/test/Ice/hash/Client.cs
+++ b/csharp/test/Ice/hash/Client.cs
@@ -119,13 +119,13 @@ namespace ZeroC.Ice.Test.Hash
                 Assert(proxyCollisions < maxCollisions);
             }
 
-            var prx1 = IObjectPrx.Parse("Glacier2/router:tcp -p 10010", communicator);
+            var prx1 = IObjectPrx.Parse("Glacier2/router:tcp -h localhost -p 10010", communicator);
             //Ice.ObjectPrx prx2 = communicator.stringToProxy("Glacier2/router:ssl -p 10011");
-            var prx3 = IObjectPrx.Parse("Glacier2/router:udp -p 10012", communicator);
+            var prx3 = IObjectPrx.Parse("Glacier2/router:udp -h localhost -p 10012", communicator);
             var prx4 = IObjectPrx.Parse("Glacier2/router:tcp -h zeroc.com -p 10010", communicator);
             //Ice.ObjectPrx prx5 = communicator.stringToProxy("Glacier2/router:ssl -h zeroc.com -p 10011");
             var prx6 = IObjectPrx.Parse("Glacier2/router:udp -h zeroc.com -p 10012", communicator);
-            var prx7 = IObjectPrx.Parse("Glacier2/router:tcp -p 10010 -t 10000", communicator);
+            var prx7 = IObjectPrx.Parse("Glacier2/router:tcp -h localhost -p 10010 -t 10000", communicator);
             //Ice.ObjectPrx prx8 = communicator.stringToProxy("Glacier2/router:ssl -p 10011 -t 10000");
             var prx9 = IObjectPrx.Parse("Glacier2/router:tcp -h zeroc.com -p 10010 -t 10000", communicator);
             //Ice.ObjectPrx prx10 = communicator.stringToProxy("Glacier2/router:ssl -h zeroc.com -p 10011 -t 10000");
@@ -144,15 +144,15 @@ namespace ZeroC.Ice.Test.Hash
             };
             //proxyMap["prx10"] = prx10.GetHashCode();
 
-            Assert(IObjectPrx.Parse("Glacier2/router:tcp -p 10010", communicator).GetHashCode() == proxyMap["prx1"]);
+            Assert(IObjectPrx.Parse("Glacier2/router:tcp -h localhost -p 10010", communicator).GetHashCode() == proxyMap["prx1"]);
             //Assert(communicator.stringToProxy("Glacier2/router:ssl -p 10011").GetHashCode() == proxyMap["prx2"]);
-            Assert(IObjectPrx.Parse("Glacier2/router:udp -p 10012", communicator).GetHashCode() == proxyMap["prx3"]);
+            Assert(IObjectPrx.Parse("Glacier2/router:udp -h localhost -p 10012", communicator).GetHashCode() == proxyMap["prx3"]);
             Assert(IObjectPrx.Parse("Glacier2/router:tcp -h zeroc.com -p 10010", communicator).GetHashCode() ==
                    proxyMap["prx4"]);
             //Assert(communicator.stringToProxy("Glacier2/router:ssl -h zeroc.com -p 10011").GetHashCode() == proxyMap["prx5"]);
             Assert(IObjectPrx.Parse("Glacier2/router:udp -h zeroc.com -p 10012", communicator).GetHashCode() ==
                    proxyMap["prx6"]);
-            Assert(IObjectPrx.Parse("Glacier2/router:tcp -p 10010 -t 10000", communicator).GetHashCode() ==
+            Assert(IObjectPrx.Parse("Glacier2/router:tcp -h localhost -p 10010 -t 10000", communicator).GetHashCode() ==
                    proxyMap["prx7"]);
             //Assert(communicator.stringToProxy("Glacier2/router:ssl -p 10011 -t 10000").GetHashCode() == proxyMap["prx8"]);
             Assert(

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -148,7 +148,7 @@ namespace ZeroC.Ice.Test.Info
                 testIntf = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             }
 
-            string defaultHost = communicator.GetProperty("Test.Host")!;
+            string defaultHost = helper.GetTestHost();
 
             output.Write("test connection endpoint information... ");
             output.Flush();

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -148,7 +148,7 @@ namespace ZeroC.Ice.Test.Info
                 testIntf = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             }
 
-            string defaultHost = communicator.GetProperty("Ice.Default.Host") ?? "";
+            string defaultHost = communicator.GetProperty("Test.Host")!;
 
             output.Write("test connection endpoint information... ");
             output.Flush();

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -607,7 +607,7 @@ namespace ZeroC.Ice.Test.Location
 
             communicator.SetProperty("Hello.AdapterId", Guid.NewGuid().ToString());
             ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
-                "Hello", ice1 ? "tcp" : "ice+tcp://localhost:0");
+                "Hello", ice1 ? "tcp -h localhost" : "ice+tcp://localhost:0");
 
             var id = new Identity(Guid.NewGuid().ToString(), "");
             adapter.Add(id, new Hello());

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -15,11 +15,10 @@ namespace ZeroC.Ice.Test.Metrics
             var observer = new CommunicatorObserver();
 
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            properties["Ice.Admin.Endpoints"] = "tcp";
+            properties["Ice.Admin.Endpoints"] = "tcp -h 127.0.0.1";
             properties["Ice.Admin.InstanceName"] = "client";
             properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.Default.Host"] = "127.0.0.1";
             properties["Ice.ConnectTimeout"] = "500ms";
 
             await using Communicator? communicator = Initialize(properties, observer: observer);

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -20,12 +20,11 @@ namespace ZeroC.Ice.Test.Metrics
             {
                 ice1 = value == "ice1";
             }
-            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "client";
             properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties, observer: observer);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -19,12 +19,11 @@ namespace ZeroC.Ice.Test.Metrics
                 ice1 = value == "ice1";
             }
 
-            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.IncomingFrameSizeMax"] = "50M";
-            properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -19,12 +19,11 @@ namespace ZeroC.Ice.Test.Metrics
                 ice1 = value == "ice1";
             }
 
-            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp" : "ice+tcp://127.0.0.1:0";
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.IncomingFrameSizeMax"] = "50M";
-            properties["Ice.Default.Host"] = "127.0.0.1";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -22,8 +22,8 @@ namespace ZeroC.Ice.Test.Proxy
             // ice1 proxies
             string[] ice1ProxyArray =
             {
-                "ice -t:tcp -p 10000",
-                "ice+tcp:ssl -p 10000",
+                "ice -t:tcp -h localhost -p 10000",
+                "ice+tcp:ssl -h localhost -p 10000",
             };
 
             // ice2 proxies
@@ -308,7 +308,7 @@ namespace ZeroC.Ice.Test.Proxy
             // The following tests are only for the ice1 format:
             b1 = IObjectPrx.Parse("id -f \"facet x\"", communicator);
             TestHelper.Assert(b1.Identity.Name == "id" && b1.Identity.Category.Length == 0 && b1.Facet == "facet x");
-            b1 = IObjectPrx.Parse("test -f facet:tcp", communicator);
+            b1 = IObjectPrx.Parse("test -f facet:tcp -h localhost", communicator);
             TestHelper.Assert(b1.Identity.Name == "test" && b1.Identity.Category.Length == 0 &&
                     b1.Facet == "facet" && b1.AdapterId.Length == 0);
             b1 = IObjectPrx.Parse("test -f \"facet:tcp\"", communicator);

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -59,7 +59,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            communicator.SetProperty("ReplyAdapter.Endpoints", "udp");
+            communicator.SetProperty("ReplyAdapter.Endpoints", "udp -h localhost");
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ReplyAdapter");
             var replyI = new PingReplyI();
             IPingReplyPrx reply = adapter.AddWithUUID(replyI, IPingReplyPrx.Factory)

--- a/csharp/test/IceBox/admin/AllTests.cs
+++ b/csharp/test/IceBox/admin/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.IceBox.Test.Admin
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            var admin = IObjectPrx.Parse("DemoIceBox/admin:default -p 9996 -t 10000", communicator);
+            var admin = IObjectPrx.Parse("DemoIceBox/admin:default -h localhost -p 9996 -t 10000", communicator);
 
             ITestFacetPrx? facet;
 

--- a/csharp/test/IceBox/admin/Client.cs
+++ b/csharp/test/IceBox/admin/Client.cs
@@ -14,12 +14,11 @@ namespace ZeroC.IceBox.Test.Admin
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            properties["Ice.Default.Host"] = "127.0.0.1";
             properties["Ice.Default.Protocol"] = "ice1";
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
             // Shutdown the IceBox server.
-            await IProcessPrx.Parse("DemoIceBox/admin -f Process:default -p 9996", communicator).ShutdownAsync();
+            await IProcessPrx.Parse("DemoIceBox/admin -f Process:default -h localhost -p 9996", communicator).ShutdownAsync();
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/IceBox/configuration/Client.cs
+++ b/csharp/test/IceBox/configuration/Client.cs
@@ -14,7 +14,6 @@ namespace ZeroC.IceBox.Test.Configuration
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            properties["Ice.Default.Host"] = "127.0.0.1";
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
             // Shutdown the IceBox server.

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -15,7 +15,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
             Communicator communicator = current.Adapter.Communicator;
             communicator.SetProperty($"{name}.AdapterId", adapterId);
             communicator.SetProperty($"{name}.ReplicaGroupId", replicaGroupId);
-            communicator.SetProperty($"{name}.Endpoints", "default");
+            communicator.SetProperty($"{name}.Endpoints", "default -h 127.0.0.1");
             ObjectAdapter oa = communicator.CreateObjectAdapter(name);
             _adapters[name] = oa;
             oa.Activate();

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -53,7 +53,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 properties["Ice.Plugin.IceLocatorDiscovery"] = "Ice:ZeroC.IceLocatorDiscovery.PluginFactory";
                 properties["IceLocatorDiscovery.Port"] = helper.GetTestPort(99).ToString();
                 properties["AdapterForDiscoveryTest.AdapterId"] = "discoveryAdapter";
-                properties["AdapterForDiscoveryTest.Endpoints"] = "default";
+                properties["AdapterForDiscoveryTest.Endpoints"] = "default -h 127.0.0.1";
 
                 {
                     using var com = new Communicator(properties);

--- a/csharp/test/IceGrid/simple/application.netcoreapp.xml
+++ b/csharp/test/IceGrid/simple/application.netcoreapp.xml
@@ -3,7 +3,7 @@
     <node name="localnode">
       <server id="server" exe="${dotnet.exe}" pwd="." activation="on-demand">
         <option>${test.dir}/${server.dir}/server.dll</option>
-        <adapter name="TestAdapter" id="TestAdapter" endpoints="default">
+        <adapter name="TestAdapter" id="TestAdapter" endpoints="default -h ${test.host}">
           <object identity="test" type="Test"/>
         </adapter>
       </server>

--- a/csharp/test/IceGrid/simple/application.xml
+++ b/csharp/test/IceGrid/simple/application.xml
@@ -2,7 +2,7 @@
   <application name="Test">
     <node name="localnode">
       <server id="server" exe="${test.dir}/${server.dir}/server.exe" pwd="." activation="on-demand">
-        <adapter name="TestAdapter" id="TestAdapter" endpoints="default">
+        <adapter name="TestAdapter" id="TestAdapter" endpoints="default -h ${test.host}">
           <object identity="test" type="Test"/>
         </adapter>
       </server>

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -86,7 +86,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
             var factory = IServerFactoryPrx.Parse(factoryRef, communicator);
 
-            string host = communicator.GetProperty("Test.Host")!;
+            string host = TestHelper.GetTestHost(communicator.GetProperties());
             string defaultDir = $"{testDir}/../certs";
             Dictionary<string, string> defaultProperties = communicator.GetProperties();
             defaultProperties["IceSSL.DefaultDir"] = defaultDir;

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -51,9 +51,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                 properties["IceSSL.DefaultDir"] = value;
             }
 
-            if (defaultProperties.TryGetValue("Ice.Default.Host", out value))
+            if (defaultProperties.TryGetValue("Test.Host", out value))
             {
-                properties["Ice.Default.Host"] = value;
+                properties["Test.Host"] = value;
             }
 
             if (defaultProperties.TryGetValue("Ice.IPv6", out value))
@@ -86,7 +86,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
             var factory = IServerFactoryPrx.Parse(factoryRef, communicator);
 
-            string host = communicator.GetProperty("Ice.Default.Host") ?? "127.0.0.1";
+            string host = communicator.GetProperty("Test.Host")!;
             string defaultDir = $"{testDir}/../certs";
             Dictionary<string, string> defaultProperties = communicator.GetProperties();
             defaultProperties["IceSSL.DefaultDir"] = defaultDir;
@@ -274,7 +274,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                     bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
-                            "MyAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
+                            "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
                     adapter.Activate();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
@@ -320,7 +320,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                     bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
-                        "MyAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
+                        "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
                     adapter.Activate();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
@@ -557,14 +557,14 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                 {
 
-                    // Test Hostname verification only when Ice.DefaultHost is 127.0.0.1 as that is the IP address used
+                    // Test Hostname verification only when Test.Host is 127.0.0.1 as that is the IP address used
                     // in the test certificates.
                     if (host.Equals("127.0.0.1"))
                     {
                         // Test using localhost as target host.
                         var props = new Dictionary<string, string>(defaultProperties)
                         {
-                            ["Ice.Default.Host"] = "localhost"
+                            ["Test.Host"] = "localhost"
                         };
 
                         // This must succeed, the target host matches the certificate DNS altName.

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -80,14 +80,10 @@ namespace ZeroC.IceSSL.Test.Configuration
                 });
 
             bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
-            string host = "";
-            if (!ice1)
-            {
-                host = communicator.GetProperty("Ice.Default.Host") ?? "[::0]";
-            }
+            string host = communicator.GetProperty("Test.Host")!;
 
             ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
-                "ServerAdapter", ice1 ? "ssl" : $"ice+ssl://{host}:0");
+                "ServerAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
             var server = new SSLServer(communicator);
             IServerPrx prx = adapter.AddWithUUID(server, IServerPrx.Factory);
             _servers[prx.Identity] = server;

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -80,7 +80,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 });
 
             bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
-            string host = communicator.GetProperty("Test.Host")!;
+            string host = TestHelper.GetTestHost(communicator.GetProperties());
 
             ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
                 "ServerAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");

--- a/csharp/test/Slice/escape/Client.cs
+++ b/csharp/test/Slice/escape/Client.cs
@@ -99,7 +99,7 @@ public class Client : TestHelper
     public override async Task RunAsync(string[] args)
     {
         await using ZeroC.Ice.Communicator communicator = Initialize(ref args);
-        communicator.SetProperty("TestAdapter.Endpoints", "default");
+        communicator.SetProperty("TestAdapter.Endpoints", "default -h localhost");
         ZeroC.Ice.ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
         adapter.Add("test", new Decimal());
         adapter.Add("test1", new Test1I());

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -67,12 +67,14 @@ namespace Test
                 }
             }
 
+            string host = GetTestHost(properties);
+
             if (uriFormat)
             {
                 var sb = new StringBuilder("ice+");
                 sb.Append(transport);
                 sb.Append("://");
-                string host = GetTestHost(properties);
+
                 if (host.Contains(':'))
                 {
                     sb.Append('[');
@@ -90,6 +92,17 @@ namespace Test
             else
             {
                 var sb = new StringBuilder(transport);
+                sb.Append(" -h ");
+                if (host.Contains(':'))
+                {
+                    sb.Append('"');
+                    sb.Append(host);
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
                 sb.Append(" -p ");
                 sb.Append(GetTestPort(properties, num));
                 return sb.ToString();
@@ -163,7 +176,7 @@ namespace Test
 
         public static string GetTestHost(Dictionary<string, string> properties)
         {
-            if (!properties.TryGetValue("Ice.Default.Host", out string? host))
+            if (!properties.TryGetValue("Test.Host", out string? host))
             {
                 host = "127.0.0.1";
             }

--- a/python/test/TestHelper.py
+++ b/python/test/TestHelper.py
@@ -24,14 +24,14 @@ class TestHelper:
 
         port = properties.getPropertyAsIntWithDefault("Test.BasePort", 12010) + num
 
-        return "{0} -p {1}".format(protocol, port)
+        return "{0} -h {1} -p {2}".format(protocol, host, port)
 
     def getTestHost(self, properties=None):
 
         if properties is None:
             properties = self._communicator.getProperties()
 
-        return properties.getPropertyWithDefaul("Ice.Default.Host", "127.0.0.1")
+        return properties.getPropertyWithDefault("Ice.Default.Host", "127.0.0.1")
 
     def getTestProtocol(self, properties=None):
 

--- a/scripts/Controller.py
+++ b/scripts/Controller.py
@@ -40,7 +40,7 @@ class ControllerDriver(Driver):
         parseOptions(self, options, { "clean" : "clean" })
 
         if not self.endpoints:
-            self.endpoints = ("tcp -h " + self.interface) if self.interface else "tcp"
+            self.endpoints = "tcp -h {}".format(self.interface)
 
     def run(self, mappings, testSuiteIds):
 

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -87,9 +87,10 @@ class IceGridNode(ProcessFromBinDir, Server):
                 pass
 
     def getProps(self, current):
+        host = current.driver.getHost(current.config.transport, current.config.ipv6)
         props = {
             'IceGrid.InstanceName' : 'TestIceGrid',
-            'IceGrid.Node.Endpoints' : 'default',
+            'IceGrid.Node.Endpoints' : f'default -h {host}',
             'IceGrid.Node.WaitTime' : 240,
             'Ice.ProgramName' : 'icegridnode',
             'IceGrid.Node.Trace.Replica' : 0,
@@ -147,18 +148,19 @@ class IceGridRegistry(ProcessFromBinDir, Server):
                 pass
 
     def getProps(self, current):
+        host = current.driver.getHost(current.config.transport, current.config.ipv6)
         props = {
             'IceGrid.InstanceName' : 'TestIceGrid',
             'IceGrid.Registry.PermissionsVerifier' : 'TestIceGrid/NullPermissionsVerifier',
             'IceGrid.Registry.AdminPermissionsVerifier' : 'TestIceGrid/NullPermissionsVerifier',
             'IceGrid.Registry.SSLPermissionsVerifier' : 'TestIceGrid/NullSSLPermissionsVerifier',
             'IceGrid.Registry.AdminSSLPermissionsVerifier' : 'TestIceGrid/NullSSLPermissionsVerifier',
-            'IceGrid.Registry.Server.Endpoints' : 'default',
-            'IceGrid.Registry.Internal.Endpoints' : 'default',
+            'IceGrid.Registry.Server.Endpoints' : f'default -h {host}',
+            'IceGrid.Registry.Internal.Endpoints' : f'default -h {host}',
             'IceGrid.Registry.Client.Endpoints' : self.getEndpoints(current),
             'IceGrid.Registry.Discovery.Port' : current.driver.getTestPort(99),
-            'IceGrid.Registry.SessionManager.Endpoints' : 'default',
-            'IceGrid.Registry.AdminSessionManager.Endpoints' : 'default',
+            'IceGrid.Registry.SessionManager.Endpoints' : f'default -h {host}',
+            'IceGrid.Registry.AdminSessionManager.Endpoints' : f'default -h {host}',
             'IceGrid.Registry.SessionTimeout' : 60,
             'IceGrid.Registry.ReplicaName' : self.name,
             'Ice.ProgramName' : self.name,
@@ -243,6 +245,7 @@ class IceGridTestCase(TestCase):
             serverProps = Server().getProps(current)
             variables = {
                 "test.dir" : self.getPath(current),
+                "test.host": current.driver.getHost(current.config.transport, current.config.ipv6),
                 "java.exe" : os.path.join(javaHome, "bin", "java") if javaHome else "java",
                 "icebox.exe" : IceBox().getCommandLine(current),
                 "icegridnode.exe" : IceGridNode().getCommandLine(current),

--- a/scripts/LocalDriver.py
+++ b/scripts/LocalDriver.py
@@ -641,8 +641,6 @@ class LocalDriver(Driver):
     def getProps(self, process, current):
         props = Driver.getProps(self, process, current)
         if isinstance(process, IceProcess):
-            if current.host:
-                props["Ice.Default.Host"] = current.host
             # Ice process from the bin directory don't support Test.BasePort
             if not process.isFromBinDir() and hasattr(self.threadlocal, "num"):
                 props["Test.BasePort"] = 14000 + self.threadlocal.num * 100

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3027,7 +3027,7 @@ class Driver:
             # TODO: remove Ice.Default.Host and only use Test.Host
             useTestHost = isinstance(process.getMapping(current), CSharpMapping) and not process.isFromBinDir()
             hostProperty = "Test.Host" if useTestHost else "Ice.Default.Host"
-            props[hostProperty] = self.host or "0:0:0:0:0:0:0:1" if current.config.ipv6 else "127.0.0.1"
+            props[hostProperty] = self.host or "::1" if current.config.ipv6 else "127.0.0.1"
 
         return props
 

--- a/scripts/tests/IceGrid/simple.py
+++ b/scripts/tests/IceGrid/simple.py
@@ -4,7 +4,7 @@
 #
 
 serverProps = {
-    "TestAdapter.Endpoints" : "default",
+    "TestAdapter.Endpoints" : "default -h 127.0.0.1",
     "TestAdapter.AdapterId" : "TestAdapter"
 }
 


### PR DESCRIPTION
This PR removes the support for `Ice.Default.Host` from C#. Endpoints must now contain a `-h` option. A new test property `Test.Host` is used as a property replacement for tests which support the test suite's various `--host` options.