### PR TITLE
Removed support for tagged classes

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2902,11 +2902,11 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
          _out << nl << "IceCheckNonIdempotent(current);";
     }
 
-    // Even when the parameters are empty, we verify we could read the data. Note that EndEncapsulation
-    // skips tagged members, and needs to understand them.
-    if(inParams.empty())
+    // Even when the parameters are empty, we verify the encapsulation is indeed empty (can contain tagged params
+    // that we skip).
+    if (inParams.empty())
     {
-        _out << nl << "request.ReadEmptyParamList(current.Communicator);";
+        _out << nl << "request.ReadEmptyParamList();";
     }
     else if(inParams.size() == 1)
     {

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -77,28 +77,21 @@ namespace ZeroC.Ice
         /// <summary>Reads an empty encapsulation from the buffer.</summary>
         /// <param name="buffer">The byte buffer.</param>
         /// <param name="encoding">The encoding of encapsulation header.</param>
-        /// <param name="communicator">The communicator.</param>
         /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
         /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
-        // TODO: eliminate communicator parameter once tagged classes are gone
-        public static void ReadEmptyEncapsulation(
-            this ReadOnlyMemory<byte> buffer,
-            Encoding encoding,
-            Communicator communicator) =>
+        public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer, Encoding encoding) =>
             new InputStream(buffer,
                             encoding,
-                            communicator,
+                            communicator: null,
                             startEncapsulation: true).CheckEndOfBuffer(skipTaggedParams: true);
 
         /// <summary>Reads an empty encapsulation from the buffer, with the encapsulation header encoded using the 2.0
         /// encoding.</summary>
         /// <param name="buffer">The byte buffer.</param>
-        /// <param name="communicator">The communicator.</param>
         /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
         /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
-        // TODO: eliminate communicator parameter once tagged classes are gone
-        public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer, Communicator communicator) =>
-            buffer.ReadEmptyEncapsulation(Encoding.V2_0, communicator);
+        public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer) =>
+            buffer.ReadEmptyEncapsulation(Encoding.V2_0);
 
         /// <summary>Reads the contents of an encapsulation from the buffer.</summary>
         /// <typeparam name="T">The type of the contents.</typeparam>

--- a/csharp/src/Ice/EncodingDefinitions.cs
+++ b/csharp/src/Ice/EncodingDefinitions.cs
@@ -52,7 +52,7 @@ namespace ZeroC.Ice
             Size = 4,
             VSize = 5,
             FSize = 6,
-            Class = 7,
+            Class = 7, // no longer written or accepted as of Ice 4.0
 
             /// <summary>VInt is a special value that is never marshaled and that means "one of F1, F2, F4 or F8".
             /// </summary>

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -73,7 +73,7 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_pingAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList(current.Communicator);
+            request.ReadEmptyParamList();
             IcePing(current);
             return new ValueTask<OutgoingResponseFrame>(OutgoingResponseFrame.WithVoidReturnValue(current));
         }
@@ -88,7 +88,7 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList(current.Communicator);
+            request.ReadEmptyParamList();
             string ret = IceId(current);
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current, format: null, ret, OutputStream.IceWriterFromString));
@@ -96,7 +96,7 @@ namespace ZeroC.Ice
 
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idsAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList(current.Communicator);
+            request.ReadEmptyParamList();
             IEnumerable<string> ret = IceIds(current);
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current, format: null, ret,

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -294,7 +294,7 @@ namespace ZeroC.Ice
         {
             if (!(context.Context is Communicator communicator))
             {
-                throw new ArgumentException("cannot deserialize proxy: Ice.Communicator not found in StreamingContext",
+                throw new ArgumentException("cannot deserialize proxy: communicator not found in StreamingContext",
                     nameof(context));
             }
             string? str = info.GetString("proxy");

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -84,10 +84,7 @@ namespace ZeroC.Ice
 
         /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload
         /// correspond to the empty parameter list.</summary>
-        /// <param name="communicator">The communicator.</param>
-        // TODO: we currently need the communicator only to skip (read) tagged classes.
-        public void ReadEmptyParamList(Communicator communicator) =>
-            Payload.AsReadOnlyMemory().ReadEmptyEncapsulation(Protocol.GetEncoding(), communicator);
+        public void ReadEmptyParamList() => Payload.AsReadOnlyMemory().ReadEmptyEncapsulation(Protocol.GetEncoding());
 
         /// <summary>Reads the request frame parameter list.</summary>
         /// <param name="communicator">The communicator.</param>

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -65,7 +65,7 @@ namespace ZeroC.Ice
         {
             if (ResultType == ResultType.Success)
             {
-                Payload.AsReadOnlyMemory(1).ReadEmptyEncapsulation(Protocol.GetEncoding(), communicator);
+                Payload.AsReadOnlyMemory(1).ReadEmptyEncapsulation(Protocol.GetEncoding());
             }
             else
             {

--- a/csharp/src/Ice/InputStream-Class.cs
+++ b/csharp/src/Ice/InputStream-Class.cs
@@ -65,8 +65,12 @@ namespace ZeroC.Ice
             {
                 throw new InvalidOperationException("cannot read an exception outside an encapsulation");
             }
+            if (_communicator == null)
+            {
+                throw new InvalidOperationException(
+                    "cannot read an exception from an InputStream with a null communicator");
+            }
 
-            Debug.Assert(_communicator != null);
             Debug.Assert(_current.InstanceType == InstanceType.None);
             _current.InstanceType = InstanceType.Exception;
 
@@ -164,13 +168,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Reads a tagged class instance from the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <returns>The class instance, or null.</returns>
-        public T? ReadTaggedClass<T>(int tag) where T : AnyClass =>
-            ReadTaggedParamHeader(tag, EncodingDefinitions.TagFormat.Class) ?
-                ReadNullableClass<T>(formalTypeId: null) : null;
-
         /// <summary>Reads a class instance from the stream.</summary>
         /// <param name="formalTypeId">The type ID of the formal type of the parameter or data member being read.
         /// </param>
@@ -180,6 +177,11 @@ namespace ZeroC.Ice
             if (!_inEncapsulation)
             {
                 throw new InvalidOperationException("cannot read a class outside an encapsulation");
+            }
+            if (_communicator == null)
+            {
+                throw new InvalidOperationException(
+                    "cannot read a class from an InputStream with a null communicator");
             }
 
             int index = ReadSize();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -472,7 +472,7 @@ namespace ZeroC.Ice
             if (_communicator == null)
             {
                 throw new InvalidOperationException(
-                    "cannot read a proxy from an input stream with a null communicator");
+                    "cannot read a proxy from an InputStream with a null communicator");
             }
             return Reference.Read(this, _communicator) is Reference reference ? factory(reference) : null;
         }
@@ -524,7 +524,7 @@ namespace ZeroC.Ice
             {
                 throw new InvalidDataException("read an empty byte sequence for a serializable object");
             }
-            var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, _communicator!));
+            var f = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, _communicator));
             var streamWrapper = new StreamWrapper(_buffer.Slice(Pos, sz));
             object result = f.Deserialize(streamWrapper);
             if (streamWrapper.Position != sz)
@@ -1053,9 +1053,6 @@ namespace ZeroC.Ice
 
             if (startEncapsulation)
             {
-                // TODO: a null communicator should be ok for an empty encaps.
-                Debug.Assert(_communicator != null);
-
                 (int size, Encoding encapsEncoding) = ReadEncapsulationHeader();
 
                 // When startEncapsulation is true, the buffer must extend until the end of the encapsulation - it
@@ -1475,9 +1472,9 @@ namespace ZeroC.Ice
                         Skip(ReadSize20());
                     }
                     break;
-                case EncodingDefinitions.TagFormat.Class:
-                    ReadAnyClass(formalTypeId: null);
-                    break;
+                default:
+                    throw new InvalidDataException(
+                        $"cannot skip tagged parameter or data member with tag format `{format}'");
             }
         }
 

--- a/csharp/src/Ice/OutputStream-Class.cs
+++ b/csharp/src/Ice/OutputStream-Class.cs
@@ -223,21 +223,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged class instance to the stream.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The class instance to write.</param>
-        public void WriteTaggedClass(int tag, AnyClass? v)
-        {
-            if (v != null)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.Class);
-
-                // Since the recipient may not know the tag, we cannot use formal type optimization and set formalTypeId
-                // to null.
-                WriteClass(v, formalTypeId: null);
-            }
-        }
-
         /// <summary>Writes sliced-off slices to the stream.</summary>
         /// <param name="slicedData">The sliced-off slices to write.</param>
         /// <param name="baseTypeIds">The type IDs of less derived slices.</param>

--- a/csharp/test/Ice/seqMapping/Serializable.cs
+++ b/csharp/test/Ice/seqMapping/Serializable.cs
@@ -27,6 +27,8 @@ namespace ZeroC.Ice.Test.SeqMapping.Serialize
         public double d10;
         public double d11;
 
+        public IMyClassPrx? proxy;
+
         public string s1 = "";
 
         // Use as data member of Large to ensure that the class serialization will take more than 254 bytes

--- a/csharp/test/Ice/seqMapping/Twoways.cs
+++ b/csharp/test/Ice/seqMapping/Twoways.cs
@@ -703,6 +703,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                 i.d9 = 9.0;
                 i.d10 = 10.0;
                 i.d11 = 11.0;
+                i.proxy = p;
                 i.s1 = Serialize.Large.LargeString;
                 Serialize.Large o;
                 Serialize.Large r;
@@ -721,6 +722,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                     TestHelper.Assert(o.d9 == 9.0);
                     TestHelper.Assert(o.d10 == 10.0);
                     TestHelper.Assert(o.d11 == 11.0);
+                    TestHelper.Assert(o.proxy!.Equals(p));
                     TestHelper.Assert(o.s1 == Serialize.Large.LargeString);
                     TestHelper.Assert(r.d1 == 1.0);
                     TestHelper.Assert(r.d2 == 2.0);
@@ -733,6 +735,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                     TestHelper.Assert(r.d9 == 9.0);
                     TestHelper.Assert(r.d10 == 10.0);
                     TestHelper.Assert(r.d11 == 11.0);
+                    TestHelper.Assert(r.proxy!.Equals(p));
                     TestHelper.Assert(r.s1 == Serialize.Large.LargeString);
                 }
                 catch (OperationNotExistException)

--- a/csharp/test/Ice/seqMapping/TwowaysAMI.cs
+++ b/csharp/test/Ice/seqMapping/TwowaysAMI.cs
@@ -652,6 +652,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                 i.d9 = 9.0;
                 i.d10 = 10.0;
                 i.d11 = 11.0;
+                i.proxy = p;
                 i.s1 = Serialize.Large.LargeString;
 
                 (Serialize.Large ReturnValue, Serialize.Large o) = p.OpSerialLargeCSharpAsync(i).Result;
@@ -666,6 +667,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                 TestHelper.Assert(o.d9 == 9.0);
                 TestHelper.Assert(o.d10 == 10.0);
                 TestHelper.Assert(o.d11 == 11.0);
+                TestHelper.Assert(o.proxy!.Equals(p));
                 TestHelper.Assert(o.s1 == Serialize.Large.LargeString);
 
                 TestHelper.Assert(ReturnValue.d1 == 1.0);
@@ -679,6 +681,7 @@ namespace ZeroC.Ice.Test.SeqMapping
                 TestHelper.Assert(ReturnValue.d9 == 9.0);
                 TestHelper.Assert(ReturnValue.d10 == 10.0);
                 TestHelper.Assert(ReturnValue.d11 == 11.0);
+                TestHelper.Assert(ReturnValue.proxy!.Equals(p));
                 TestHelper.Assert(ReturnValue.s1 == Serialize.Large.LargeString);
             }
 

--- a/csharp/test/Ice/seqMapping/msbuild/client/client.csproj
+++ b/csharp/test/Ice/seqMapping/msbuild/client/client.csproj
@@ -10,13 +10,8 @@
     <Compile Include="../../../../TestCommon/TestHelper.cs" />
     <Compile Include="../../AllTests.cs" />
     <Compile Include="../../Client.cs" />
-    <Compile Include="../../Custom.cs" />
     <Compile Include="../../Twoways.cs" />
     <Compile Include="../../TwowaysAMI.cs" />
-    <Compile Include="generated/Test.cs">
-      <SliceCompileSource>../../Test.ice</SliceCompileSource>
-    </Compile>
-    <SliceCompile Include="../../Test.ice" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../serializable/serializable.csproj" />

--- a/csharp/test/Ice/seqMapping/msbuild/collocated/collocated.csproj
+++ b/csharp/test/Ice/seqMapping/msbuild/collocated/collocated.csproj
@@ -13,11 +13,6 @@
     <Compile Include="../../Twoways.cs" />
     <Compile Include="../../TwowaysAMI.cs" />
     <Compile Include="../../Collocated.cs" />
-    <Compile Include="../../Custom.cs" />
-    <Compile Include="generated/Test.cs">
-      <SliceCompileSource>../../Test.ice</SliceCompileSource>
-    </Compile>
-    <SliceCompile Include="../../Test.ice" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../serializable/serializable.csproj" />

--- a/csharp/test/Ice/seqMapping/msbuild/serializable/serializable.csproj
+++ b/csharp/test/Ice/seqMapping/msbuild/serializable/serializable.csproj
@@ -6,5 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../Serializable.cs" />
+    <Compile Include="../../Custom.cs" />
+    <Compile Include="generated/Test.cs">
+      <SliceCompileSource>../../Test.ice</SliceCompileSource>
+    </Compile>
+    <SliceCompile Include="../../Test.ice" />
   </ItemGroup>
 </Project>

--- a/csharp/test/Ice/seqMapping/msbuild/server/server.csproj
+++ b/csharp/test/Ice/seqMapping/msbuild/server/server.csproj
@@ -8,13 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../../../TestCommon/TestHelper.cs" />
-    <Compile Include="../../Custom.cs" />
     <Compile Include="../../MyClassI.cs" />
     <Compile Include="../../Server.cs" />
-    <Compile Include="generated/Test.cs">
-      <SliceCompileSource>../../Test.ice</SliceCompileSource>
-    </Compile>
-    <SliceCompile Include="../../Test.ice" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../serializable/serializable.csproj" />

--- a/csharp/test/Ice/seqMapping/msbuild/serveramd/serveramd.csproj
+++ b/csharp/test/Ice/seqMapping/msbuild/serveramd/serveramd.csproj
@@ -8,13 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../../../TestCommon/TestHelper.cs" />
-    <Compile Include="../../Custom.cs" />
     <Compile Include="../../MyClassAMDI.cs" />
     <Compile Include="../../ServerAMD.cs" />
-    <Compile Include="generated/Test.cs">
-      <SliceCompileSource>../../Test.ice</SliceCompileSource>
-    </Compile>
-    <SliceCompile Include="../../Test.ice" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../serializable/serializable.csproj" />

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -47,10 +47,9 @@ namespace ZeroC.Ice.Test.Serialize
                                       optValStruct: null,
                                       optRefStruct: null,
                                       optEnum: null,
-                                      optClass: null,
                                       optProxy: null);
 
-            ex2 = inOut(ex, communicator);
+            ex2 = InOut(ex, communicator);
 
             TestHelper.Assert(ex2.Name.Length == 0);
             TestHelper.Assert(ex2.Vss!.Length == 0);
@@ -66,7 +65,7 @@ namespace ZeroC.Ice.Test.Serialize
             TestHelper.Assert(ex2.OptValStruct == null);
             TestHelper.Assert(ex2.OptRefStruct == null);
             TestHelper.Assert(ex2.OptEnum == null);
-            TestHelper.Assert(ex2.OptClass == null);
+
             TestHelper.Assert(ex2.OptProxy == null);
 
             ex.Name = "MyException";
@@ -98,9 +97,8 @@ namespace ZeroC.Ice.Test.Serialize
             ex.OptValStruct = ex.Vs;
             ex.OptRefStruct = ex.Rs;
             ex.OptEnum = MyEnum.enum3;
-            ex.OptClass = null;
             ex.OptProxy = proxy;
-            ex2 = inOut(ex, communicator);
+            ex2 = InOut(ex, communicator);
 
             TestHelper.Assert(ex2.Name.Equals(ex.Name));
             TestHelper.Assert(ex2.B == ex.B);
@@ -122,7 +120,6 @@ namespace ZeroC.Ice.Test.Serialize
             TestHelper.Assert(ex2.OptValStruct.HasValue && ex2.OptValStruct.Value.Equals(ex.Vs));
             TestHelper.Assert(ex2.OptRefStruct != null && ex2.OptRefStruct.Value.P!.Equals(ex.Rs.P));
             TestHelper.Assert(ex2.OptEnum.HasValue && ex2.OptEnum.Value == MyEnum.enum3);
-            TestHelper.Assert(ex2.OptClass == null);
             TestHelper.Assert(ex2.OptProxy!.Equals(proxy));
 
             RefStruct rs, rs2;
@@ -132,7 +129,7 @@ namespace ZeroC.Ice.Test.Serialize
             rs.C = null;
             rs.P = IMyInterfacePrx.Parse("test", communicator);
             rs.Seq = new IMyInterfacePrx[] { rs.P };
-            rs2 = inOut(rs, communicator);
+            rs2 = InOut(rs, communicator);
             TestHelper.Assert(rs2.S == "RefStruct");
             TestHelper.Assert(rs2.Sp == "prop");
             TestHelper.Assert(rs2.C == null);
@@ -141,26 +138,29 @@ namespace ZeroC.Ice.Test.Serialize
             TestHelper.Assert(rs2.Seq[0]!.Equals(rs.Seq[0]));
 
             Base b, b2;
-            b = new Base(true, 1, 2, 3, 4, MyEnum.enum2);
-            b2 = inOut(b, communicator);
+            IMyInterfacePrx prx = IMyInterfacePrx.Parse("ice+tcp://localhost:1000/foo", communicator);
+            b = new Base(true, 1, 2, 3, 4, MyEnum.enum2, prx);
+            b2 = InOut(b, communicator);
             TestHelper.Assert(b2.Bo == b.Bo);
             TestHelper.Assert(b2.By == b.By);
             TestHelper.Assert(b2.Sh == b.Sh);
             TestHelper.Assert(b2.I == b.I);
             TestHelper.Assert(b2.L == b.L);
             TestHelper.Assert(b2.E == b.E);
+            TestHelper.Assert(b2.Prx!.Equals(b.Prx));
 
             MyClass c, c2;
-            c = new MyClass(true, 1, 2, 3, 4, MyEnum.enum1, null, null, new ValStruct(true, 1, 2, 3, 4, MyEnum.enum2));
+            c = new MyClass(true, 1, 2, 3, 4, MyEnum.enum1, prx, null, null, new ValStruct(true, 1, 2, 3, 4, MyEnum.enum2));
             c.C = c;
             c.O = c;
-            c2 = inOut(c, communicator);
+            c2 = InOut(c, communicator);
             TestHelper.Assert(c2.Bo == c.Bo);
             TestHelper.Assert(c2.By == c.By);
             TestHelper.Assert(c2.Sh == c.Sh);
             TestHelper.Assert(c2.I == c.I);
             TestHelper.Assert(c2.L == c.L);
             TestHelper.Assert(c2.E == c.E);
+            TestHelper.Assert(c2.Prx!.Equals(c.Prx));
             TestHelper.Assert(c2.C == c2);
             TestHelper.Assert(c2.O == c2);
             TestHelper.Assert(c2.S.Equals(c.S));
@@ -169,7 +169,7 @@ namespace ZeroC.Ice.Test.Serialize
             return 0;
         }
 
-        private static T inOut<T>(T o, Communicator communicator)
+        private static T InOut<T>(T o, Communicator communicator)
         {
             var bin = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.All, communicator));
             using MemoryStream mem = new MemoryStream();

--- a/csharp/test/Ice/serialize/Test.ice
+++ b/csharp/test/Ice/serialize/Test.ice
@@ -72,6 +72,7 @@ class Base
     int i;
     long l;
     MyEnum e;
+    MyInterface* prx;
 }
 
 class MyClass : Base
@@ -109,8 +110,7 @@ exception MyException
     tag(3) ValStruct? optValStruct;
     tag(4) RefStruct? optRefStruct;
     tag(5) MyEnum? optEnum;
-    tag(6) MyClass? optClass;
-    tag(7) MyInterface* optProxy;
+    tag(6) MyInterface* optProxy;
 }
 
 }

--- a/csharp/test/Ice/stream/Test.ice
+++ b/csharp/test/Ice/stream/Test.ice
@@ -64,35 +64,35 @@ dictionary<long, float> LongFloatD;
 dictionary<string, string> StringStringD;
 dictionary<string, MyClass> StringMyClassD;
 
-[clr:generic:List]
+[cs:generic:List]
 sequence<bool> BoolList;
-[clr:generic:List]
+[cs:generic:List]
 sequence<byte> ByteList;
-[clr:generic:List]
+[cs:generic:List]
 sequence<MyEnum> MyEnumList;
-[clr:generic:List]
+[cs:generic:List]
 sequence<SmallStruct> SmallStructList;
-[clr:generic:List]
+[cs:generic:List]
 sequence<MyClass> MyClassList;
-[clr:generic:List]
+[cs:generic:List]
 sequence<MyInterface*> MyInterfaceProxyList;
 
-[clr:generic:LinkedList]
+[cs:generic:LinkedList]
 sequence<short> ShortLinkedList;
-[clr:generic:LinkedList]
+[cs:generic:LinkedList]
 sequence<int> IntLinkedList;
-[clr:generic:LinkedList]
+[cs:generic:LinkedList]
 sequence<MyEnum> MyEnumLinkedList;
-[clr:generic:LinkedList]
+[cs:generic:LinkedList]
 sequence<SmallStruct> SmallStructLinkedList;
 
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<long> LongStack;
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<float> FloatStack;
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<SmallStruct> SmallStructStack;
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<MyInterface*> MyInterfaceProxyStack;
 
 //
@@ -100,7 +100,7 @@ sequence<MyInterface*> MyInterfaceProxyStack;
 // sequence mapping. The generic:Stack metadata cannot be use
 // with object sequences.
 //
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<Object> ObjectStack;
 
 //
@@ -108,25 +108,25 @@ sequence<Object> ObjectStack;
 // sequence mapping. The generic:Stack metadata cannot be use
 // with object sequences.
 //
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<MyClass> MyClassStack;
 
-[clr:generic:Queue]
+[cs:generic:Queue]
 sequence<double> DoubleQueue;
-[clr:generic:Queue]
+[cs:generic:Queue]
 sequence<string> StringQueue;
-[clr:generic:Queue]
+[cs:generic:Queue]
 sequence<SmallStruct> SmallStructQueue;
 
-[clr:generic:List]
+[cs:generic:List]
 sequence<Ice::StringSeq> StringSList;
-[clr:generic:Stack]
+[cs:generic:Stack]
 sequence<Ice::StringSeq> StringSStack;
 
-[clr:generic:SortedDictionary]
+[cs:generic:SortedDictionary]
 dictionary<string, string> SortedStringStringD;
 
-[clr:serializable:ZeroC.Ice.Test.Stream.Serialize.Small] sequence<byte> SerialSmall;
+[cs:serializable:ZeroC.Ice.Test.Stream.Serialize.Small] sequence<byte> SerialSmall;
 
 class MyClass
 {

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -40,7 +40,6 @@ namespace ZeroC.Ice.Test.Tagged
             mo1.G = 1.0;
             mo1.H = "test";
             mo1.I = MyEnum.MyEnumMember;
-            mo1.K = mo1;
             mo1.Bs = new byte[] { 5 };
             mo1.Ss = new string[] { "test", "test2" };
             mo1.Iid = new Dictionary<int, int>
@@ -105,7 +104,6 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo1.G == 1.0);
             TestHelper.Assert(mo1.H.Equals("test"));
             TestHelper.Assert(mo1.I == MyEnum.MyEnumMember);
-            TestHelper.Assert(mo1.K == mo1);
             TestHelper.Assert(Enumerable.SequenceEqual(mo1.Bs, new byte[] { 5 }));
             TestHelper.Assert(Enumerable.SequenceEqual(mo1.Ss, new string[] { "test", "test2" }));
             TestHelper.Assert(mo1.Iid[4] == 3);
@@ -149,7 +147,6 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo4.G == null);
             TestHelper.Assert(mo4.H == null);
             TestHelper.Assert(mo4.I == null);
-            TestHelper.Assert(mo4.K == null);
             TestHelper.Assert(mo4.Bs == null);
             TestHelper.Assert(mo4.Ss == null);
             TestHelper.Assert(mo4.Iid == null);
@@ -201,7 +198,6 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo5.G == mo1.G);
             TestHelper.Assert(mo5.H!.Equals(mo1.H));
             TestHelper.Assert(mo5.I == mo1.I);
-            TestHelper.Assert(mo5.K == mo5);
             TestHelper.Assert(Enumerable.SequenceEqual(mo5.Bs, mo1.Bs));
             TestHelper.Assert(Enumerable.SequenceEqual(mo5.Ss, mo1.Ss));
             TestHelper.Assert(mo5.Iid != null && mo5.Iid[4] == 3);
@@ -264,7 +260,6 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo7.G == null);
             TestHelper.Assert(mo7.H != null && mo7.H.Equals(mo1.H));
             TestHelper.Assert(mo7.I == null);
-            TestHelper.Assert(mo7.K == null);
             TestHelper.Assert(Enumerable.SequenceEqual(mo7.Bs, mo1.Bs));
             TestHelper.Assert(mo7.Ss == null);
             TestHelper.Assert(mo7.Iid != null && mo7.Iid[4] == 3);
@@ -293,7 +288,6 @@ namespace ZeroC.Ice.Test.Tagged
             mo8.E = mo5.E;
             mo8.G = mo5.G;
             mo8.I = mo5.I;
-            mo8.K = mo8;
             mo8.Ss = mo5.Ss;
             mo8.Sid = mo5.Sid;
             mo8.Vs = mo5.Vs;
@@ -319,7 +313,6 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo9.G.Equals(mo1.G));
             TestHelper.Assert(mo9.H == null);
             TestHelper.Assert(mo9.I.Equals(mo1.I));
-            TestHelper.Assert(mo9.K == mo9);
             TestHelper.Assert(mo9.Bs == null);
             TestHelper.Assert(Enumerable.SequenceEqual(mo9.Ss, mo1.Ss));
             TestHelper.Assert(mo9.Iid == null);
@@ -396,16 +389,6 @@ namespace ZeroC.Ice.Test.Tagged
             factory.setEnabled(false);
             */
 
-            //
-            // TODO: simplify  It was using the 1.0 encoding with operations whose
-            // only class parameters were tagged.
-            //
-            var oo = new OneTagged(53);
-            initial.SendTaggedClass(true, oo);
-
-            oo = initial.ReturnTaggedClass(true);
-            TestHelper.Assert(oo != null);
-
             var recursive1 = new Recursive[1];
             recursive1[0] = new Recursive();
             var recursive2 = new Recursive[1];
@@ -414,18 +397,6 @@ namespace ZeroC.Ice.Test.Tagged
             var outer = new Recursive();
             outer.Value = recursive1;
             initial.PingPong(outer);
-
-            var g = new G();
-            g.Gg1Opt = new G1("gg1Opt");
-            g.Gg2 = new G2(10);
-            g.Gg2Opt = new G2(20);
-            g.Gg1 = new G1("gg1");
-            g = initial.OpG(g);
-            TestHelper.Assert(g != null);
-            TestHelper.Assert("gg1Opt".Equals(g.Gg1Opt!.A));
-            TestHelper.Assert(10 == g.Gg2!.A);
-            TestHelper.Assert(20 == g.Gg2Opt!.A);
-            TestHelper.Assert("gg1".Equals(g.Gg1!.A));
 
             initial.OpVoid();
 
@@ -523,37 +494,6 @@ namespace ZeroC.Ice.Test.Tagged
                 factory.setEnabled(false);
                 */
 
-            }
-            output.WriteLine("ok");
-
-            output.Write("testing marshalling of objects with tagged objects...");
-            output.Flush();
-            {
-                var f = new F();
-
-                f.Af = new A();
-                f.Ae = f.Af;
-
-                var rf = (F?)initial.PingPong(f);
-                TestHelper.Assert(rf != null);
-                TestHelper.Assert(rf.Ae == rf.Af);
-
-                /*
-                factory.setEnabled(true);
-                os = new OutputStream(communicator);
-                os.StartEncapsulation();
-                os.WriteNullableClass(f);
-                os.EndEncapsulation();
-                inEncaps = os.Finished();
-                responseFrame.InputStream = new InputStream(communicator, inEncaps);
-                responseFrame.InputStream.StartEncapsulation();
-                ReadNullableClassCallbackI rocb = new ReadNullableClassCallbackI();
-                responseFrame.InputStream.ReadNullableClass(rocb.invoke);
-                responseFrame.InputStream.EndEncapsulation();
-                factory.setEnabled(false);
-                rf = ((FClassReader)rocb.obj).getF();
-                test(rf.ae != null && !rf.af.HasValue);
-                */
             }
             output.WriteLine("ok");
 
@@ -1017,37 +957,6 @@ namespace ZeroC.Ice.Test.Tagged
                 var a = istr.ReadNullableClass<A>();
                 istr.EndEncapsulation();
                 test(a != null && a.requiredA == 56);*/
-            }
-
-            {
-                OneTagged? p1 = null;
-                (OneTagged? p2, OneTagged? p3) = initial.OpOneTagged(p1);
-                TestHelper.Assert(p2 == null && p3 == null);
-                (p2, p3) = initial.OpOneTagged(null);
-                TestHelper.Assert(p2 == null && p3 == null);
-
-                p1 = new OneTagged(58);
-                (p2, p3) = initial.OpOneTagged(p1);
-                TestHelper.Assert(p2!.A == 58 && p3!.A == 58);
-                (p2, p3) = initial.OpOneTaggedAsync(p1).Result;
-                TestHelper.Assert(p2!.A == 58 && p3!.A == 58);
-                (p2, p3) = initial.OpOneTagged(p1);
-                TestHelper.Assert(p2!.A == 58 && p3!.A == 58);
-                (p2, p3) = initial.OpOneTaggedAsync(p1).Result;
-                TestHelper.Assert(p2!.A == 58 && p3!.A == 58);
-
-                (p2, p3) = initial.OpOneTagged(null);
-                TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
-
-                requestFrame = OutgoingRequestFrame.WithParamList(initial, "opOneTagged", idempotent: false,
-                    format: null, context: null, p1,
-                    (OutputStream ostr, OneTagged? p1) => ostr.WriteTaggedClass(2, p1));
-
-                IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
-                (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
-                    (istr.ReadTaggedClass<OneTagged>(1),
-                    istr.ReadTaggedClass<OneTagged>(3)));
-                TestHelper.Assert(p2!.A == 58 && p3!.A == 58);
             }
 
             {
@@ -1666,94 +1575,78 @@ namespace ZeroC.Ice.Test.Tagged
                 {
                     int? a = null;
                     string? b = null;
-                    OneTagged? o = null;
-                    initial.OpTaggedException(a, b, o);
+                    initial.OpTaggedException(a, b);
                 }
                 catch (TaggedException ex)
                 {
                     TestHelper.Assert(ex.A == null); // don't use default value for 'a' data member since set explicitly
                                                      // to null by server
                     TestHelper.Assert(ex.B == null);
-                    TestHelper.Assert(ex.O == null);
                 }
 
                 try
                 {
                     int? a = 30;
                     string? b = "test";
-                    var o = new OneTagged(53);
-                    initial.OpTaggedException(a, b, o);
+                    initial.OpTaggedException(a, b);
                 }
                 catch (TaggedException ex)
                 {
                     TestHelper.Assert(ex.A == 30);
                     TestHelper.Assert(ex.B == "test");
-                    TestHelper.Assert(ex.O!.A == 53);
                 }
 
                 try
                 {
                     int? a = null;
                     string? b = null;
-                    OneTagged? o = null;
-                    initial.OpDerivedException(a, b, o);
+                    initial.OpDerivedException(a, b);
                 }
                 catch (DerivedException ex)
                 {
                     TestHelper.Assert(ex.A == null); // don't use default value for 'a' data member since set explicitly
                                                      // to null by server
                     TestHelper.Assert(ex.B == null);
-                    TestHelper.Assert(ex.O == null);
                     TestHelper.Assert(ex.Ss == null);
-                    TestHelper.Assert(ex.O2 == null);
                 }
 
                 try
                 {
                     int? a = 30;
                     string? b = "test2";
-                    var o = new OneTagged(53);
-                    initial.OpDerivedException(a, b, o);
+                    initial.OpDerivedException(a, b);
                 }
                 catch (DerivedException ex)
                 {
                     TestHelper.Assert(ex.A == 30);
                     TestHelper.Assert(ex.B == "test2");
-                    TestHelper.Assert(ex.O!.A == 53);
                     TestHelper.Assert(ex.Ss == "test2");
-                    TestHelper.Assert(ex.O2!.A == 53);
                 }
 
                 try
                 {
                     int? a = null;
                     string? b = null;
-                    OneTagged? o = null;
-                    initial.OpRequiredException(a, b, o);
+                    initial.OpRequiredException(a, b);
                 }
                 catch (RequiredException ex)
                 {
                     TestHelper.Assert(ex.A == null);
                     TestHelper.Assert(ex.B == null);
-                    TestHelper.Assert(ex.O == null);
                     TestHelper.Assert(ex.Ss == "test");
-                    TestHelper.Assert(ex.O2 == null);
                 }
 
                 try
                 {
                     int? a = 30;
                     string? b = "test2";
-                    var o = new OneTagged(53);
-                    initial.OpRequiredException(a, b, o);
+                    initial.OpRequiredException(a, b);
                 }
                 catch (RequiredException ex)
                 {
                     TestHelper.Assert(ex.A == 30);
                     TestHelper.Assert(ex.B == "test2");
-                    TestHelper.Assert(ex.O!.A == 53);
                     TestHelper.Assert(ex.Ss == "test2");
-                    TestHelper.Assert(ex.O2!.A == 53);
                 }
             }
             output.WriteLine("ok");
@@ -1764,7 +1657,6 @@ namespace ZeroC.Ice.Test.Tagged
                 TestHelper.Assert(initial.OpMStruct1() != null);
                 TestHelper.Assert(initial.OpMDict1() != null);
                 TestHelper.Assert(initial.OpMSeq1() != null);
-                TestHelper.Assert(initial.OpMG1() != null);
 
                 {
                     SmallStruct? p1, p2, p3;
@@ -1795,15 +1687,6 @@ namespace ZeroC.Ice.Test.Tagged
                     };
                     (p3, p2) = initial.OpMDict2(p1);
                     TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
-                }
-                {
-                    G? p1, p2, p3;
-                    (p3, p2) = initial.OpMG2(null);
-                    TestHelper.Assert(p2 == null && p3 == null);
-
-                    p1 = new G();
-                    (p3, p2) = initial.OpMG2(p1);
-                    TestHelper.Assert(p2 != null && p3 != null && p3 == p2);
                 }
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/tagged/Test.ice
+++ b/csharp/test/Ice/tagged/Test.ice
@@ -52,25 +52,25 @@ sequence<string> StringSeq;
 sequence<ushort> UShortSeq;
 sequence<varulong> VarULongSeq;
 
-[clr:generic:List] sequence<byte> ByteList;
-[clr:generic:List] sequence<bool> BoolList;
-[clr:generic:List] sequence<short> ShortList;
-[clr:generic:List] sequence<int> IntList;
-[clr:generic:List] sequence<long> LongList;
-[clr:generic:List] sequence<float> FloatList;
-[clr:generic:List] sequence<double> DoubleList;
-[clr:generic:List] sequence<string> StringList;
-[clr:generic:List] sequence<varint> VarIntList;
+[cs:generic:List] sequence<byte> ByteList;
+[cs:generic:List] sequence<bool> BoolList;
+[cs:generic:List] sequence<short> ShortList;
+[cs:generic:List] sequence<int> IntList;
+[cs:generic:List] sequence<long> LongList;
+[cs:generic:List] sequence<float> FloatList;
+[cs:generic:List] sequence<double> DoubleList;
+[cs:generic:List] sequence<string> StringList;
+[cs:generic:List] sequence<varint> VarIntList;
 
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[clr:generic:List] sequence<SmallStruct> SmallStructList;
+[cs:generic:List] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[clr:generic:LinkedList] sequence<FixedStruct> FixedStructList;
+[cs:generic:LinkedList] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 sequence<OneTagged> OneTaggedSeq;
 
-[clr:serializable:ZeroC.Ice.Test.Tagged.SerializableClass]
+[cs:serializable:ZeroC.Ice.Test.Tagged.SerializableClass]
 sequence<byte> Serializable;
 
 dictionary<int, int> IntIntDict;
@@ -91,7 +91,6 @@ class MultiTagged
     tag(7) double? g;
     tag(8) string? h;
     tag(9) MyEnum? i;
-    tag(11) MultiTagged? k;
     tag(12) ByteSeq? bs;
     tag(13) StringSeq? ss;
     tag(14) IntIntDict? iid;
@@ -159,55 +158,24 @@ exception TaggedException
     bool req = false;
     tag(1) int? a = 5;
     tag(2) string? b;
-    tag(50) OneTagged? o;
 }
 
 exception DerivedException : TaggedException
 {
     tag(600) string? ss = "test";
-    tag(601) OneTagged? o2;
 }
 
 exception RequiredException : TaggedException
 {
     string ss = "test";
-    OneTagged? o2;
 }
 
-[clr:property]
+[cs:property]
 class TaggedWithCustom
 {
     tag(1) SmallStructList? l;
     tag(2) SmallStructList? lp;
     tag(3) ClassVarStruct? s;
-}
-
-class E
-{
-    A ae;
-}
-
-class F : E
-{
-    tag(1) A? af;
-}
-
-class G1
-{
-    string a;
-}
-
-class G2
-{
-    long a;
-}
-
-class G
-{
-    tag(1) G1? gg1Opt;
-    G2 gg2;
-    tag(0) G2? gg2Opt;
-    G1 gg1;
 }
 
 class Recursive;
@@ -224,14 +192,11 @@ interface Initial
 
     Object pingPong(Object o);
 
-    void opTaggedException(tag(1) int? a, tag(2) string? b, tag(3) OneTagged? o)
-        throws TaggedException;
+    void opTaggedException(tag(1) int? a, tag(2) string? b);
 
-    void opDerivedException(tag(1) int? a, tag(2) string? b, tag(3) OneTagged? o)
-        throws TaggedException;
+    void opDerivedException(tag(1) int? a, tag(2) string? b);
 
-    void opRequiredException(tag(1) int? a, tag(2) string? b, tag(3) OneTagged? o)
-        throws TaggedException;
+    void opRequiredException(tag(1) int? a, tag(2) string? b);
 
     tag(1) byte? opByte(tag(2) byte? p1, out tag(3) byte? p3);
 
@@ -256,8 +221,6 @@ interface Initial
     tag(1) FixedStruct? opFixedStruct(tag(2) FixedStruct? p1, out tag(3) FixedStruct? p3);
 
     tag(1) VarStruct? opVarStruct(tag(2) VarStruct? p1, out tag(3) VarStruct? p3);
-
-    tag(1) OneTagged? opOneTagged(tag(2) OneTagged? p1, out tag(3) OneTagged? p3);
 
     tag(1) ByteSeq? opByteSeq(tag(2) ByteSeq? p1, out tag(3) ByteSeq? p3);
     tag(1) ByteList? opByteList(tag(2) ByteList? p1, out tag(3) ByteList? p3);
@@ -304,12 +267,6 @@ interface Initial
 
     void opClassAndUnknownTagged(A p);
 
-    void sendTaggedClass(bool req, tag(1) OneTagged? o);
-
-    void returnTaggedClass(bool req, out tag(1) OneTagged? o);
-
-    G opG(G g);
-
     void opVoid();
 
     [marshaled-result] tag(1) SmallStruct? opMStruct1();
@@ -320,9 +277,6 @@ interface Initial
 
     [marshaled-result] tag(1) StringIntDict? opMDict1();
     [marshaled-result] tag(1) StringIntDict? opMDict2(tag(2) StringIntDict? p1, out tag(3) StringIntDict? p2);
-
-    [marshaled-result] tag(1) G? opMG1();
-    [marshaled-result] tag(1) G? opMG2(tag(2) G? p1, out tag(3) G? p2);
 
     bool supportsRequiredParams();
 

--- a/csharp/test/Ice/tagged/TestAMDI.cs
+++ b/csharp/test/Ice/tagged/TestAMDI.cs
@@ -16,36 +16,23 @@ namespace ZeroC.Ice.Test.Tagged
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<AnyClass?>
-        PingPongAsync(AnyClass? obj, Current current) => MakeValueTask(obj);
+        public ValueTask<AnyClass?> PingPongAsync(AnyClass? obj, Current current) => MakeValueTask(obj);
 
-        public ValueTask
-        OpTaggedExceptionAsync(int? a, string? b, OneTagged? o, Current c) =>
-            throw new TaggedException(false, a, b, o);
+        public ValueTask OpTaggedExceptionAsync(int? a, string? b, Current c) =>
+            throw new TaggedException(false, a, b);
 
-        public ValueTask
-        OpDerivedExceptionAsync(int? a, string? b, OneTagged? o, Current c) =>
-            throw new DerivedException(false, a, b, o, b, o);
+        public ValueTask OpDerivedExceptionAsync(int? a, string? b, Current c) =>
+            throw new DerivedException(false, a, b, b);
 
-        public ValueTask
-        OpRequiredExceptionAsync(int? a,
-                                    string? b,
-                                    OneTagged? o,
-                                    Current c)
+        public ValueTask OpRequiredExceptionAsync(int? a, string? b, Current c)
         {
             var e = new RequiredException();
             e.A = a;
             e.B = b;
-            e.O = o;
             if (b != null)
             {
                 e.Ss = b;
             }
-            if (o != null)
-            {
-                e.O2 = o;
-            }
-
             throw e;
         }
 
@@ -76,9 +63,6 @@ namespace ZeroC.Ice.Test.Tagged
 
         public ValueTask<(VarStruct?, VarStruct?)>
         OpVarStructAsync(VarStruct? p1, Current current) => MakeValueTask((p1, p1));
-
-        public ValueTask<(OneTagged?, OneTagged?)> OpOneTaggedAsync(OneTagged? p1, Current current) =>
-            MakeValueTask((p1, p1));
 
         public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> OpByteSeqAsync(byte[]? p1, Current current) =>
             ToReturnValue(p1);
@@ -151,14 +135,6 @@ namespace ZeroC.Ice.Test.Tagged
 
         public ValueTask OpClassAndUnknownTaggedAsync(A? p, Current current) => new ValueTask(Task.CompletedTask);
 
-        public ValueTask SendTaggedClassAsync(bool req, OneTagged? o, Current current) =>
-            new ValueTask(Task.CompletedTask);
-
-        public ValueTask<OneTagged?> ReturnTaggedClassAsync(bool req, Current current) =>
-            new ValueTask<OneTagged?>(new OneTagged(53));
-
-        public ValueTask<G?> OpGAsync(G? g, Current current) => MakeValueTask(g);
-
         public ValueTask OpVoidAsync(Current current) => new ValueTask(Task.CompletedTask);
 
         public async ValueTask<IInitial.OpMStruct1MarshaledReturnValue>
@@ -201,20 +177,6 @@ namespace ZeroC.Ice.Test.Tagged
         {
             await Task.Delay(0);
             return new IInitial.OpMDict2MarshaledReturnValue(p1, p1, current);
-        }
-
-        public async ValueTask<IInitial.OpMG1MarshaledReturnValue>
-        OpMG1Async(Current current)
-        {
-            await Task.Delay(0);
-            return new IInitial.OpMG1MarshaledReturnValue(new G(), current);
-        }
-
-        public async ValueTask<IInitial.OpMG2MarshaledReturnValue>
-        OpMG2Async(G? p1, Current current)
-        {
-            await Task.Delay(0);
-            return new IInitial.OpMG2MarshaledReturnValue(p1, p1, current);
         }
 
         public ValueTask<bool>

--- a/csharp/test/Ice/tagged/TestI.cs
+++ b/csharp/test/Ice/tagged/TestI.cs
@@ -13,29 +13,20 @@ namespace ZeroC.Ice.Test.Tagged
 
         public AnyClass? PingPong(AnyClass? obj, Current current) => obj;
 
-        public void OpTaggedException(int? a, string? b, OneTagged? o, Current current) =>
-            throw new TaggedException(false, a, b, o);
+        public void OpTaggedException(int? a, string? b, Current current) =>
+            throw new TaggedException(false, a, b);
 
-        public void OpDerivedException(int? a, string? b, OneTagged? o, Current current) =>
-            throw new DerivedException(false, a, b, o, b, o);
+        public void OpDerivedException(int? a, string? b, Current current) =>
+            throw new DerivedException(false, a, b, b);
 
-        public void OpRequiredException(int? a,
-                                        string? b,
-                                        OneTagged? o,
-                                        Current current)
+        public void OpRequiredException(int? a, string? b, Current current)
         {
             var e = new RequiredException();
             e.A = a;
             e.B = b;
-            e.O = o;
             if (b != null)
             {
                 e.Ss = b;
-            }
-
-            if (o != null)
-            {
-                e.O2 = o;
             }
             throw e;
         }
@@ -63,8 +54,6 @@ namespace ZeroC.Ice.Test.Tagged
         public (FixedStruct?, FixedStruct?) OpFixedStruct(FixedStruct? p1, Current current) => (p1, p1);
 
         public (VarStruct?, VarStruct?) OpVarStruct(VarStruct? p1, Current current) => (p1, p1);
-
-        public (OneTagged?, OneTagged?) OpOneTagged(OneTagged? p1, Current current) => (p1, p1);
 
         public (ReadOnlyMemory<byte>, ReadOnlyMemory<byte>) OpByteSeq(byte[]? p1, Current current) => (p1, p1);
         public (IEnumerable<byte>?, IEnumerable<byte>?) OpByteList(List<byte>? p1, Current current) => (p1, p1);
@@ -120,14 +109,6 @@ namespace ZeroC.Ice.Test.Tagged
         {
         }
 
-        public void SendTaggedClass(bool req, OneTagged? o, Current current)
-        {
-        }
-
-        public OneTagged? ReturnTaggedClass(bool req, Current current) => new OneTagged(53);
-
-        public G? OpG(G? g, Current current) => g;
-
         public void OpVoid(Current current)
         {
         }
@@ -152,12 +133,6 @@ namespace ZeroC.Ice.Test.Tagged
         public IInitial.OpMDict2MarshaledReturnValue
         OpMDict2(Dictionary<string, int>? p1, Current current) =>
             new IInitial.OpMDict2MarshaledReturnValue(p1, p1, current);
-
-        public IInitial.OpMG1MarshaledReturnValue
-        OpMG1(Current current) => new IInitial.OpMG1MarshaledReturnValue(new G(), current);
-
-        public IInitial.OpMG2MarshaledReturnValue
-        OpMG2(G? p1, Current current) => new IInitial.OpMG2MarshaledReturnValue(p1, p1, current);
 
         public bool SupportsRequiredParams(Current current) => false;
 


### PR DESCRIPTION
This PR removes support for tagged classes, which also allows the remove the communicator parameter of ReadEmptyEncapsulation/ReadEmptyParamList.

Also adds a test for proxy fields in serialized classes.