### PR TITLE
Remove Communicator.DefaultFormat in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -67,24 +67,17 @@ isDefaultInitialized(const MemberPtr& member, bool considerDefaultValue)
 string
 opFormatTypeToString(const OperationPtr& op)
 {
+    // TODO: eliminate DefaultFormat in the parser (DefaultFormat means the communicator default that was removed in
+    // Ice 4.0)
     switch (op->format())
     {
         case DefaultFormat:
-        {
-            return "null";
-        }
         case CompactFormat:
-        {
-            return "ZeroC.Ice.FormatType.Compact";
-        }
+            return "default"; // same as Compact
         case SlicedFormat:
-        {
             return "ZeroC.Ice.FormatType.Sliced";
-        }
         default:
-        {
             assert(false);
-        }
     }
 
     return "???";
@@ -2577,8 +2570,8 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
     if(inParams.size() > 0)
     {
         _out << ",";
-        _out << nl << "format: " << opFormatTypeToString(operation) << ",";
         _out << nl << "compress: " << (opCompressParams(operation) ? "true" : "false") << ",";
+        _out << nl << "format: " << opFormatTypeToString(operation) << ",";
         _out << nl << "writer: ";
         writeOutgoingRequestWriter(operation);
     }
@@ -2808,7 +2801,7 @@ Slice::Gen::DispatcherVisitor::writeReturnValueStruct(const OperationPtr& operat
         _out.inc();
         _out << nl << "current, "
              << "compress: " << (opCompressReturn(operation) ? "true" : "false") << ", "
-             << opFormatTypeToString(operation) << ", "
+             << "format: " << opFormatTypeToString(operation) << ", "
              << toTuple(outParams, "iceP_") << ",";
         if(outParams.size() > 1)
         {
@@ -2978,7 +2971,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
             _out << nl << "var response = ZeroC.Ice.OutgoingResponseFrame.WithReturnValue("
                  << "current, "
                  << "compress: " << (opCompressReturn(operation) ? "true" : "false") << ", "
-                 << opFormatTypeToString(operation) << ", "
+                 << "format: " << opFormatTypeToString(operation) << ", "
                  << "result, "
                  << writer << ");";
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -105,7 +105,6 @@ namespace ZeroC.Ice
 
         public Encoding DefaultEncoding { get; }
         public EndpointSelectionType DefaultEndpointSelection { get; }
-        public FormatType DefaultFormat { get; }
 
         /// <summary>The default locator for this communicator. To disable the default locator, null can be used.
         /// All newly created proxies and object adapters will use this default locator. Note that setting this property
@@ -412,9 +411,6 @@ namespace ZeroC.Ice
                     _ => throw new InvalidConfigurationException(
                              $"illegal value `{endpointSelection}'; expected `Random' or `Ordered'")
                 };
-
-                DefaultFormat = (GetPropertyAsBool("Ice.Default.SlicedFormat") ?? false) ?
-                    FormatType.Sliced : FormatType.Compact;
 
                 // TODO: switch to 0/false default
                 DefaultPreferNonSecure = GetPropertyAsBool("Ice.Default.PreferNonSecure") ?? true;

--- a/csharp/src/Ice/FormatType.cs
+++ b/csharp/src/Ice/FormatType.cs
@@ -12,12 +12,12 @@ namespace ZeroC.Ice
         /// <summary>The Compact format assumes the sender and receiver have the same Slice definitions for classes
         /// and exceptions. If an application receives a derived class or exception it does not know, it is
         /// not capable to unmarshal it into a known base class or exception because there is not enough information
-        /// in the encoded payload.</summary>
+        /// in the encoded payload. The Compact format is the default for classes.</summary>
         Compact,
 
         /// <summary>The Sliced format allows slicing of unknown slices by the receiver. If an application receives
         /// a derived class or exception it does not know, it can slice off the derived bits and create a base class
-        /// or exception.</summary>
+        /// or exception. Exceptions are always marshaled using the Sliced format.</summary>
         Sliced
     }
 }

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -85,7 +85,7 @@ namespace ZeroC.Ice
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current,
                                                       compress: false,
-                                                      format: null,
+                                                      format: default,
                                                       ret,
                                                       OutputStream.IceWriterFromBool));
         }
@@ -97,7 +97,7 @@ namespace ZeroC.Ice
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current,
                                                       compress: false,
-                                                      format: null,
+                                                      format: default,
                                                       ret,
                                                       OutputStream.IceWriterFromString));
         }
@@ -109,9 +109,10 @@ namespace ZeroC.Ice
             return new ValueTask<OutgoingResponseFrame>(
                 OutgoingResponseFrame.WithReturnValue(current,
                                                       compress: false,
-                                                      format: null,
+                                                      format: default,
                                                       ret,
-                                            (ostr, ret) => ostr.WriteSequence(ret, OutputStream.IceWriterFromString)));
+                                                      (ostr, ret) =>
+                                                          ostr.WriteSequence(ret, OutputStream.IceWriterFromString)));
         }
     }
 }

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -238,8 +238,8 @@ namespace ZeroC.Ice
         private static OutgoingRequestWithParam<string, bool> IceI_IsARequest =>
             _iceI_IsARequest ??= new OutgoingRequestWithParam<string, bool>("ice_isA",
                                                                             idempotent: true,
-                                                                            format: null,
                                                                             compress: false,
+                                                                            format: default,
                                                                             writer: OutputStream.IceWriterFromString,
                                                                             reader: InputStream.IceReaderIntoBool);
 

--- a/csharp/src/Ice/OutgoingRequest.cs
+++ b/csharp/src/Ice/OutgoingRequest.cs
@@ -79,14 +79,14 @@ namespace ZeroC.Ice
     {
         private readonly bool _idempotent;
         private readonly string _operationName;
-        private readonly FormatType? _format;
+        private readonly FormatType _format;
         private readonly OutputStreamWriter<TParamList> _writer;
 
         public OutgoingRequestWithParam(
             string operationName,
             bool idempotent,
-            FormatType? format,
             bool compress,
+            FormatType format,
             OutputStreamWriter<TParamList> writer,
             InputStreamReader<TReturnValue> reader)
             : base(reader, compress)
@@ -135,14 +135,14 @@ namespace ZeroC.Ice
     {
         private readonly string _operationName;
         private readonly bool _idempotent;
-        private readonly FormatType? _format;
+        private readonly FormatType _format;
         private readonly OutputStreamValueWriter<TParamList> _writer;
 
         public OutgoingRequestWithStructParam(
             string operationName,
             bool idempotent,
-            FormatType? format,
             bool compress,
+            FormatType format,
             OutputStreamValueWriter<TParamList> writer,
             InputStreamReader<TReturnValue> reader)
             : base(reader, compress)
@@ -261,15 +261,15 @@ namespace ZeroC.Ice
     {
         private readonly string _operationName;
         private readonly bool _idempotent;
-        private readonly FormatType? _format;
+        private readonly FormatType _format;
         private readonly OutputStreamWriter<TParamList> _writer;
 
         public OutgoingRequestWithParam(
             string operationName,
             bool idempotent,
             bool oneway,
-            FormatType? format,
             bool compress,
+            FormatType format,
             OutputStreamWriter<TParamList> writer)
         : base(oneway, compress)
         {
@@ -320,15 +320,15 @@ namespace ZeroC.Ice
     {
         private readonly string _operationName;
         private readonly bool _idempotent;
-        private readonly FormatType? _format;
+        private readonly FormatType _format;
         private readonly OutputStreamValueWriter<TParamList> _writer;
 
         public OutgoingRequestWithStructParam(
             string operationName,
             bool idempotent,
             bool oneway,
-            FormatType? format,
             bool compress,
+            FormatType format,
             OutputStreamValueWriter<TParamList> writer)
         : base(oneway, compress)
         {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -31,8 +31,7 @@ namespace ZeroC.Ice
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="compress">True if the request should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes and exceptions, when this parameter is null
-        /// the communicator's default format is used.</param>
+        /// <param name="format">The format used to marshal classes.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="value">The parameter to marshal in the frame.</param>
@@ -43,14 +42,17 @@ namespace ZeroC.Ice
             string operation,
             bool idempotent,
             bool compress,
-            FormatType? format,
+            FormatType format,
             IReadOnlyDictionary<string, string>? context,
             T value,
             OutputStreamWriter<T> writer)
         {
             var request = new OutgoingRequestFrame(proxy, operation, idempotent, compress, context);
-            var ostr = new OutputStream(proxy.Protocol.GetEncoding(), request.Payload, request._encapsulationStart,
-                request.Encoding, format ?? proxy.Communicator.DefaultFormat);
+            var ostr = new OutputStream(proxy.Protocol.GetEncoding(),
+                                        request.Payload,
+                                        request._encapsulationStart,
+                                        request.Encoding,
+                                        format);
             writer(ostr, value);
             request.Finish(ostr.Save());
             if (compress && proxy.Encoding == Encoding.V2_0)
@@ -66,8 +68,7 @@ namespace ZeroC.Ice
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="compress">True if the request should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes and exceptions, when this parameter is null
-        /// the communicator's default format is used.</param>
+        /// <param name="format">The format used to marshal classes.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="value">The parameter to marshal in the frame, when the request frame contain multiple
@@ -79,14 +80,17 @@ namespace ZeroC.Ice
             string operation,
             bool idempotent,
             bool compress,
-            FormatType? format,
+            FormatType format,
             IReadOnlyDictionary<string, string>? context,
             in T value,
             OutputStreamValueWriter<T> writer) where T : struct
         {
             var request = new OutgoingRequestFrame(proxy, operation, idempotent, compress, context);
-            var ostr = new OutputStream(proxy.Protocol.GetEncoding(), request.Payload, request._encapsulationStart,
-                request.Encoding, format ?? proxy.Communicator.DefaultFormat);
+            var ostr = new OutputStream(proxy.Protocol.GetEncoding(),
+                                        request.Payload,
+                                        request._encapsulationStart,
+                                        request.Encoding,
+                                        format);
             writer(ostr, value);
             request.Finish(ostr.Save());
             if (compress && proxy.Encoding == Encoding.V2_0)

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -43,7 +43,7 @@ namespace ZeroC.Ice
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,
             bool compress,
-            FormatType? format,
+            FormatType format,
             T value,
             OutputStreamWriter<T> writer)
         {
@@ -69,7 +69,7 @@ namespace ZeroC.Ice
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,
             bool compress,
-            FormatType? format,
+            FormatType format,
             in T value,
             OutputStreamValueWriter<T> writer)
             where T : struct
@@ -224,7 +224,7 @@ namespace ZeroC.Ice
         private static (OutgoingResponseFrame ResponseFrame, OutputStream Ostr) PrepareReturnValue(
             Current current,
             bool compress,
-            FormatType? format)
+            FormatType format = default)
         {
             var response = new OutgoingResponseFrame(current.Protocol,
                                                      current.Encoding,
@@ -241,7 +241,7 @@ namespace ZeroC.Ice
                                         response.Payload,
                                         response._encapsulationStart,
                                         response.Encoding,
-                                        format ?? current.Communicator.DefaultFormat);
+                                        format);
             return (response, ostr);
         }
 

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -224,7 +224,7 @@ namespace ZeroC.Ice
         private static (OutgoingResponseFrame ResponseFrame, OutputStream Ostr) PrepareReturnValue(
             Current current,
             bool compress,
-            FormatType format = default)
+            FormatType format)
         {
             var response = new OutgoingResponseFrame(current.Protocol,
                                                      current.Encoding,

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -56,7 +56,7 @@ namespace ZeroC.Ice.Test.Invoke
                                                              "opString",
                                                              idempotent: false,
                                                              compress: false,
-                                                             format: null,
+                                                             format: default,
                                                              context: null,
                                                              TestString,
                                                              OutputStream.IceWriterFromString);
@@ -118,7 +118,7 @@ namespace ZeroC.Ice.Test.Invoke
                                                              "opString",
                                                              idempotent: false,
                                                              compress: false,
-                                                             format: null,
+                                                             format: default,
                                                              context: null,
                                                              TestString,
                                                              OutputStream.IceWriterFromString);

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Invoke
                 string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current,
                                                                           compress: false,
-                                                                          format: null,
+                                                                          format: default,
                                                                           (s, s),
                     (OutputStream ostr, (string ReturnValue, string s2) value) =>
                     {
@@ -52,7 +52,7 @@ namespace ZeroC.Ice.Test.Invoke
                 string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current,
                                                                           compress: false,
-                                                                          format: null,
+                                                                          format: default,
                                                                           s == "::ZeroC::Ice::Test::Invoke::MyClass",
                                                                           OutputStream.IceWriterFromBool);
                 return new ValueTask<OutgoingResponseFrame >(responseFrame);

--- a/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
+++ b/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
@@ -11,11 +11,12 @@ namespace ZeroC.Ice.Test.Objects
         public ValueTask<OutgoingResponseFrame> DispatchAsync(IncomingRequestFrame request, Current current)
         {
             var ae = new AlsoEmpty();
-            var responseFrame = OutgoingResponseFrame.WithReturnValue(current,
-                                                                      compress: false,
-                                                                      format: null,
-                                                                      ae,
-                                                    (OutputStream ostr, AlsoEmpty ae) => ostr.WriteClass(ae, null));
+            var responseFrame =
+                OutgoingResponseFrame.WithReturnValue(current,
+                                                      compress: false,
+                                                      FormatType.Compact,
+                                                      ae,
+                                                      (OutputStream ostr, AlsoEmpty ae) => ostr.WriteClass(ae, null));
             return new ValueTask<OutgoingResponseFrame>(responseFrame);
         }
     }

--- a/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
+++ b/csharp/test/Ice/objects/UnexpectedObjectExceptionTestI.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Objects
             var responseFrame =
                 OutgoingResponseFrame.WithReturnValue(current,
                                                       compress: false,
-                                                      FormatType.Compact,
+                                                      format: default,
                                                       ae,
                                                       (OutputStream ostr, AlsoEmpty ae) => ostr.WriteClass(ae, null));
             return new ValueTask<OutgoingResponseFrame>(responseFrame);

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -31,21 +31,14 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             output.Write("testing stringToProxy... ");
             output.Flush();
             var testPrx = ITestIntfPrx.Parse(helper.GetTestProxy("Test", 0), communicator);
-            var test2Prx = ITestIntf2Prx.Parse(helper.GetTestProxy("Test2", 0), communicator);
             output.WriteLine("ok");
 
-            output.Write("testing Ice.Default.SlicedFormat... ");
-            // server to client. Note that client and server has the same Ice.Default.SlicedFormat setting.
+            output.Write("testing basic slicing... ");
+            // server to client
             try
             {
-                SBase? sb = test2Prx.SBSUnknownDerivedAsSBase();
+                SBase? sb = testPrx.SBSUnknownDerivedAsSBase();
                 TestHelper.Assert(sb != null && sb.Sb.Equals("SBSUnknownDerived.sb"));
-                TestHelper.Assert(communicator.DefaultFormat == FormatType.Sliced);
-            }
-            catch (InvalidDataException)
-            {
-                // Expected when format is Compact
-                TestHelper.Assert(communicator.DefaultFormat == FormatType.Compact);
             }
             catch (Exception ex)
             {
@@ -56,13 +49,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             // client to server
             try
             {
-                test2Prx.CUnknownAsSBase(new CUnknown("CUnknown.sb", "CUnknown.cu"));
-                TestHelper.Assert(communicator.DefaultFormat == FormatType.Sliced);
-            }
-            catch (UnhandledException)
-            {
-                // Expected when format is Compact
-                TestHelper.Assert(communicator.DefaultFormat == FormatType.Compact);
+                testPrx.CUnknownAsSBase(new CUnknown("CUnknown.sb", "CUnknown.cu"));
             }
             catch (Exception ex)
             {
@@ -202,10 +189,8 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             }
             try
             {
-                //
                 // This test fails when using the compact format because the instance cannot
                 // be sliced to a known type.
-                //
                 testPrx.SBSUnknownDerivedAsSBaseCompact();
                 TestHelper.Assert(false);
             }
@@ -227,10 +212,8 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 TestHelper.Assert(sb != null && sb.Sb.Equals("SBSUnknownDerived.sb"));
             }
 
-            //
             // This test fails when using the compact format because the instance cannot
             // be sliced to a known type.
-            //
             try
             {
                 SBase? sb = testPrx.SBSUnknownDerivedAsSBaseCompactAsync().Result;

--- a/csharp/test/Ice/slicing/objects/Server.cs
+++ b/csharp/test/Ice/slicing/objects/Server.cs
@@ -18,7 +18,6 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());
-            adapter.Add("Test2", new TestIntf2());
             await adapter.ActivateAsync();
             await communicator.WaitForShutdownAsync();
         }

--- a/csharp/test/Ice/slicing/objects/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/objects/ServerAMD.cs
@@ -18,7 +18,6 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntfAsync());
-            adapter.Add("Test2", new TestIntf2Async());
             await adapter.ActivateAsync();
             await communicator.WaitForShutdownAsync();
         }

--- a/csharp/test/Ice/slicing/objects/Test.ice
+++ b/csharp/test/Ice/slicing/objects/Test.ice
@@ -108,6 +108,7 @@ interface TestIntf
     SBSKnownDerived SBSKnownDerivedAsSBSKnownDerived();
 
     SBase SBSUnknownDerivedAsSBase();
+    void CUnknownAsSBase(SBase cUnknown);
 
     [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
 
@@ -155,13 +156,6 @@ interface TestIntf
     void useForward(out Forward f); /* Use of forward-declared class to verify that code is generated correctly. */
 
     void shutdown();
-}
-
-// Used to test Ice.Default.SlicedFormat property
-interface TestIntf2
-{
-    SBase SBSUnknownDerivedAsSBase();
-    void CUnknownAsSBase(SBase cUnknown);
 }
 
 class Hidden

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -32,6 +32,15 @@ namespace ZeroC.Ice.Test.Slicing.Objects
         public ValueTask<SBase?> SBSUnknownDerivedAsSBaseAsync(Current current) =>
             new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
 
+        public ValueTask CUnknownAsSBaseAsync(SBase? cUnknown, Current current)
+        {
+            if (cUnknown!.Sb != "CUnknown.sb")
+            {
+                throw new Exception();
+            }
+            return new ValueTask();
+        }
+
         public ValueTask<SBase?> SBSUnknownDerivedAsSBaseCompactAsync(Current current) =>
             new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
 
@@ -371,20 +380,5 @@ namespace ZeroC.Ice.Test.Slicing.Objects
 
         // Type-inference helper method
         private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
-    }
-
-    public sealed class TestIntf2Async : ITestIntf2Async
-    {
-        public ValueTask<SBase?> SBSUnknownDerivedAsSBaseAsync(Current current) =>
-            new ValueTask<SBase?>(new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud"));
-
-        public ValueTask CUnknownAsSBaseAsync(SBase? cUnknown, Current current)
-        {
-            if (cUnknown!.Sb != "CUnknown.sb")
-            {
-                throw new Exception();
-            }
-            return new ValueTask();
-        }
     }
 }

--- a/csharp/test/Ice/slicing/objects/TestI.cs
+++ b/csharp/test/Ice/slicing/objects/TestI.cs
@@ -35,6 +35,14 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             return sbskd;
         }
 
+        public void CUnknownAsSBase(SBase? cUnknown, Current current)
+        {
+            if (cUnknown!.Sb != "CUnknown.sb")
+            {
+                throw new Exception();
+            }
+        }
+
         public SBSKnownDerived SBSKnownDerivedAsSBSKnownDerived(Current current)
         {
             var sbskd = new SBSKnownDerived();
@@ -357,20 +365,6 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             f.H = new Hidden();
             f.H.F = f;
             return f;
-        }
-    }
-
-    public sealed class TestIntf2 : ITestIntf2
-    {
-        public SBase SBSUnknownDerivedAsSBase(Current current) =>
-            new SBSUnknownDerived("SBSUnknownDerived.sb", "SBSUnknownDerived.sbsud");
-
-        public void CUnknownAsSBase(SBase? cUnknown, Current current)
-        {
-            if (cUnknown!.Sb != "CUnknown.sb")
-            {
-                throw new Exception();
-            }
         }
     }
 }

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -401,7 +401,7 @@ namespace ZeroC.Ice.Test.Tagged
             initial.OpVoid();
 
             var requestFrame = OutgoingRequestFrame.WithParamList(
-                initial, "opVoid", idempotent: false, compress: false, format: null, context: null, (15, "test"),
+                initial, "opVoid", idempotent: false, compress: false, format: default, context: null, (15, "test"),
                 (OutputStream ostr, (int n, string s) value) =>
                 {
                     ostr.WriteTaggedInt(1, value.n);
@@ -542,7 +542,7 @@ namespace ZeroC.Ice.Test.Tagged
                     initial, "opByte",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null, p1,
                     (OutputStream ostr, byte? p1) => ostr.WriteTaggedByte(2, p1));
 
@@ -582,7 +582,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opBool",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null, p1,
                     (OutputStream ostr, bool? p1) => ostr.WriteTaggedBool(2, p1));
 
@@ -622,7 +622,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opShort",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null, p1,
                     (OutputStream ostr, short? p1) => ostr.WriteTaggedShort(2, p1));
 
@@ -662,7 +662,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opInt",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, int? p1) => ostr.WriteTaggedInt(2, p1));
@@ -702,7 +702,7 @@ namespace ZeroC.Ice.Test.Tagged
                     initial, "opLong",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, long? p1) => ostr.WriteTaggedLong(1, p1));
@@ -742,7 +742,7 @@ namespace ZeroC.Ice.Test.Tagged
                     initial, "opFloat",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, float? p1) => ostr.WriteTaggedFloat(2, p1));
@@ -783,7 +783,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opDouble",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, double? p1) => ostr.WriteTaggedDouble(2, p1));
@@ -826,7 +826,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opString",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, string? p1) => ostr.WriteTaggedString(2, p1));
@@ -867,7 +867,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opMyEnum",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, MyEnum? p1) => ostr.WriteTaggedSize(2, (int?) p1));
@@ -904,7 +904,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opSmallStruct",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, SmallStruct? p1) => ostr.WriteTaggedStruct(2, p1, 1));
@@ -943,7 +943,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opFixedStruct",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, FixedStruct? p1) => ostr.WriteTaggedStruct(2, p1, 4));
@@ -986,7 +986,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opVarStruct",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, VarStruct? p1) =>
@@ -1050,7 +1050,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opByteSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, byte[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1088,7 +1088,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opBoolSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, bool[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1126,7 +1126,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opShortSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, short[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1163,7 +1163,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opIntSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null, p1,
                     (OutputStream ostr, int[]? p1) => ostr.WriteTaggedArray(2, p1));
 
@@ -1199,7 +1199,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opLongSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, long[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1236,7 +1236,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opFloatSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, float[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1273,7 +1273,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opDoubleSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, double[]? p1) => ostr.WriteTaggedArray(2, p1));
@@ -1311,7 +1311,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opStringSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, string[]? p1) =>
@@ -1350,7 +1350,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opSmallStructSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, SmallStruct[]? p1) => ostr.WriteTaggedSequence(2, p1, 1,
@@ -1394,7 +1394,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opSmallStructList",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, List<SmallStruct>? p1) => ostr.WriteTaggedSequence(2, p1, 1,
@@ -1443,7 +1443,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opFixedStructSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, FixedStruct[]? p1) => ostr.WriteTaggedSequence(2, p1, 4,
@@ -1487,7 +1487,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opFixedStructList",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, LinkedList<FixedStruct>? p1) => ostr.WriteTaggedSequence(2, p1, 4,
@@ -1535,7 +1535,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opVarStructSeq",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, VarStruct[]? p1) =>
@@ -1575,7 +1575,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opSerializable",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, SerializableClass? p1) => ostr.WriteTaggedSerializable(2, p1));
@@ -1617,7 +1617,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opIntIntDict",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null, p1,
                     (OutputStream ostr, Dictionary<int, int>? p1) => ostr.WriteTaggedDictionary(2, p1, 8,
                         (ostr, k) => ostr.WriteInt(k), (ostr, v) => ostr.WriteInt(v)));
@@ -1662,7 +1662,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opStringIntDict",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, Dictionary<string, int>? p1) =>
@@ -1711,7 +1711,7 @@ namespace ZeroC.Ice.Test.Tagged
                     "opIntOneTaggedDict",
                     idempotent: false,
                     compress: false,
-                    format: null,
+                    format: default,
                     context: null,
                     p1,
                     (OutputStream ostr, Dictionary<int, OneTagged?>? p1) =>


### PR DESCRIPTION
The default format is now always `FormatType.Compact`, typically written as `default`.