### PR TITLE
Add binary context for Ice2

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -94,7 +94,7 @@ namespace ZeroC.Ice
 
                 var incomingResponseFrame = new IncomingResponseFrame(
                     outgoingRequest.Protocol,
-                    VectoredBufferExtensions.ToArray(outgoingResponseFrame.Payload),
+                    VectoredBufferExtensions.ToArray(outgoingResponseFrame.Data),
                     _adapter.IncomingFrameSizeMax);
 
                 if (_adapter.Communicator.TraceLevels.Protocol >= 1)
@@ -168,7 +168,7 @@ namespace ZeroC.Ice
                         // not completed yet and we want to make sure the observer is detached only when the dispatch
                         // completes, not when the caller cancels the request.
                         outgoingResponseFrame = await vt.ConfigureAwait(false);
-                        outgoingResponseFrame.FinishPayload(context: null);
+                        outgoingResponseFrame.FinishBinaryContext();
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
@@ -189,7 +189,7 @@ namespace ZeroC.Ice
                     if (requestId != 0)
                     {
                         outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
-                        outgoingResponseFrame.FinishPayload(context: null);
+                        outgoingResponseFrame.FinishBinaryContext();
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
@@ -197,7 +197,7 @@ namespace ZeroC.Ice
                 if (outgoingResponseFrame == null)
                 {
                     outgoingResponseFrame = OutgoingResponseFrame.WithVoidReturnValue(current);
-                    outgoingResponseFrame.FinishPayload(context: null);
+                    outgoingResponseFrame.FinishBinaryContext();
                 }
                 return outgoingResponseFrame;
             }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -188,6 +188,7 @@ namespace ZeroC.Ice
                     if (requestId != 0)
                     {
                         outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
+                        outgoingResponseFrame.FinishPayload(context: null);
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -134,7 +134,6 @@ namespace ZeroC.Ice
             // Increase the direct count to prevent the object adapter from being destroyed while the dispatch is in
             // progress. This will also throw if the object adapter has been deactivated.
             _adapter.IncDirectCount();
-            outgoingRequest.Finish();
 
             IDispatchObserver? dispatchObserver = null;
             try

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -168,6 +168,7 @@ namespace ZeroC.Ice
                         // not completed yet and we want to make sure the observer is detached only when the dispatch
                         // completes, not when the caller cancels the request.
                         outgoingResponseFrame = await vt.ConfigureAwait(false);
+                        outgoingResponseFrame.FinishPayload(context: null);
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
@@ -188,13 +189,14 @@ namespace ZeroC.Ice
                     if (requestId != 0)
                     {
                         outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
+                        outgoingResponseFrame.FinishPayload(context: null);
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
 
-                outgoingResponseFrame ??= OutgoingResponseFrame.WithVoidReturnValue(current);
-                if (!outgoingResponseFrame.IsSealed)
+                if (outgoingResponseFrame == null)
                 {
+                    outgoingResponseFrame = OutgoingResponseFrame.WithVoidReturnValue(current);
                     outgoingResponseFrame.FinishPayload(context: null);
                 }
                 return outgoingResponseFrame;

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -134,6 +134,7 @@ namespace ZeroC.Ice
             // Increase the direct count to prevent the object adapter from being destroyed while the dispatch is in
             // progress. This will also throw if the object adapter has been deactivated.
             _adapter.IncDirectCount();
+            outgoingRequest.Finish();
 
             IDispatchObserver? dispatchObserver = null;
             try
@@ -168,7 +169,7 @@ namespace ZeroC.Ice
                         // not completed yet and we want to make sure the observer is detached only when the dispatch
                         // completes, not when the caller cancels the request.
                         outgoingResponseFrame = await vt.ConfigureAwait(false);
-                        outgoingResponseFrame.FinishBinaryContext();
+                        outgoingResponseFrame.Finish();
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
@@ -189,7 +190,7 @@ namespace ZeroC.Ice
                     if (requestId != 0)
                     {
                         outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
-                        outgoingResponseFrame.FinishBinaryContext();
+                        outgoingResponseFrame.Finish();
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
@@ -197,7 +198,7 @@ namespace ZeroC.Ice
                 if (outgoingResponseFrame == null)
                 {
                     outgoingResponseFrame = OutgoingResponseFrame.WithVoidReturnValue(current);
-                    outgoingResponseFrame.FinishBinaryContext();
+                    outgoingResponseFrame.Finish();
                 }
                 return outgoingResponseFrame;
             }

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -193,7 +193,9 @@ namespace ZeroC.Ice
                     }
                 }
 
-                return outgoingResponseFrame ?? OutgoingResponseFrame.WithVoidReturnValue(current);
+                outgoingResponseFrame ??= OutgoingResponseFrame.WithVoidReturnValue(current);
+                outgoingResponseFrame.FinishPayload(context: null);
+                return outgoingResponseFrame;
             }
             finally
             {

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -188,13 +188,15 @@ namespace ZeroC.Ice
                     if (requestId != 0)
                     {
                         outgoingResponseFrame = new OutgoingResponseFrame(incomingRequest, actualEx);
-                        outgoingResponseFrame.FinishPayload(context: null);
                         dispatchObserver?.Reply(outgoingResponseFrame.Size);
                     }
                 }
 
                 outgoingResponseFrame ??= OutgoingResponseFrame.WithVoidReturnValue(current);
-                outgoingResponseFrame.FinishPayload(context: null);
+                if (!outgoingResponseFrame.IsSealed)
+                {
+                    outgoingResponseFrame.FinishPayload(context: null);
+                }
                 return outgoingResponseFrame;
             }
             finally

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -702,6 +702,7 @@ namespace ZeroC.Ice
                     if (!current.IsOneway)
                     {
                         response = await vt.ConfigureAwait(false);
+                        response.FinishPayload(context: null);
                     }
                 }
                 catch (Exception ex)
@@ -719,6 +720,7 @@ namespace ZeroC.Ice
                         }
                         Incoming.ReportException(actualEx, dispatchObserver, current);
                         response = new OutgoingResponseFrame(request, actualEx);
+                        response.FinishPayload(context: null);
                     }
                 }
 

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -724,7 +724,10 @@ namespace ZeroC.Ice
 
                 if (response != null)
                 {
-                    response.FinishPayload(context: null);
+                    if (!response.IsSealed)
+                    {
+                        response.FinishPayload(context: null);
+                    }
                     dispatchObserver?.Reply(response.Size);
                 }
             }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -702,7 +702,6 @@ namespace ZeroC.Ice
                     if (!current.IsOneway)
                     {
                         response = await vt.ConfigureAwait(false);
-                        response.FinishPayload(context: null);
                     }
                 }
                 catch (Exception ex)
@@ -720,12 +719,12 @@ namespace ZeroC.Ice
                         }
                         Incoming.ReportException(actualEx, dispatchObserver, current);
                         response = new OutgoingResponseFrame(request, actualEx);
-                        response.FinishPayload(context: null);
                     }
                 }
 
                 if (response != null)
                 {
+                    response.FinishPayload(context: null);
                     dispatchObserver?.Reply(response.Size);
                 }
             }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -726,7 +726,7 @@ namespace ZeroC.Ice
                 {
                     if (!response.IsSealed)
                     {
-                        response.FinishPayload(context: null);
+                        response.FinishBinaryContext();
                     }
                     dispatchObserver?.Reply(response.Size);
                 }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -724,10 +724,7 @@ namespace ZeroC.Ice
 
                 if (response != null)
                 {
-                    if (!response.IsSealed)
-                    {
-                        response.FinishBinaryContext();
-                    }
+                    response.Finish();
                     dispatchObserver?.Reply(response.Size);
                 }
             }

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -121,7 +121,7 @@ namespace ZeroC.Ice
             OutputStream.WriteInt(requestId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
-            data.AddRange(frame.Payload);
+            data.AddRange(frame.Data);
             return data;
         }
 
@@ -134,7 +134,7 @@ namespace ZeroC.Ice
             OutputStream.WriteInt(requestId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
-            data.AddRange(frame.Payload);
+            data.AddRange(frame.Data);
             return data;
         }
 

--- a/csharp/src/Ice/Ice1Parser.cs
+++ b/csharp/src/Ice/Ice1Parser.cs
@@ -606,12 +606,12 @@ namespace ZeroC.Ice
 
                     var ostr = new OutputStream(Ice1Definitions.Encoding, bufferList);
                     ostr.WriteEndpoint(opaqueEndpoint);
-                    OutputStream.Position tail = ostr.Save();
+                    OutputStream.Position tail = ostr.Finish();
                     Debug.Assert(bufferList.Count == 1);
                     Debug.Assert(tail.Segment == 0 && tail.Offset == 8 + opaqueEndpoint.Value.Length);
 
-                    return new InputStream(bufferList[0], Ice1Definitions.Encoding).ReadEndpoint(Protocol.Ice1,
-                                                                                                 communicator);
+                    return new InputStream(bufferList[0].Slice(0, tail.Offset),
+                                           Ice1Definitions.Encoding).ReadEndpoint(Protocol.Ice1, communicator);
                 }
                 else
                 {

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -112,7 +112,7 @@ namespace ZeroC.Ice
             OutputStream.WriteInt((int)streamId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
-            data.AddRange(frame.Payload);
+            data.AddRange(frame.Data);
             return data;
         }
 
@@ -126,7 +126,7 @@ namespace ZeroC.Ice
             OutputStream.WriteInt((int)streamId, headerData.AsSpan(HeaderSize, 4));
 
             var data = new List<ArraySegment<byte>>() { headerData };
-            data.AddRange(frame.Payload);
+            data.AddRange(frame.Data);
             return data;
         }
 

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -88,11 +88,9 @@ namespace ZeroC.Ice
             {
                 ReadOnlySpan<byte> buffer = Encapsulation.AsReadOnlySpan();
                 (int size, int sizeLength, Encoding _) = buffer.ReadEncapsulationHeader(Protocol.GetEncoding());
-                // Offset of the start of the GZip decompressed data +3 corresponds to (Encoding 2 bytes, Compression
-                // status 1 byte)
 
                 // Read the decompressed size that is written after the compression status byte when the payload is
-                // compressed.
+                // compressed +3 corresponds to (Encoding 2 bytes, Compression status 1 byte)
                 (int decompressedSize, int decompressedSizeLength) = buffer.Slice(sizeLength + 3).ReadSize20();
                 if (decompressedSize > _sizeMax)
                 {

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -28,14 +28,15 @@ namespace ZeroC.Ice
                     int binaryContextSize = Payload.Count - Encapsulation.Count - (Encapsulation.Offset - Payload.Offset);
                     if (binaryContextSize > 0)
                     {
-                        var istr = new InputStream(Payload.Slice(Payload.Count - binaryContextSize), Encoding.V2_0);
+                        int offset = Payload.Count - binaryContextSize;
+                        var istr = new InputStream(Payload.Slice(offset), Encoding.V2_0);
                         int entriesSize = istr.ReadSize();
                         var binaryContext = new Dictionary<int, ReadOnlyMemory<byte>>();
                         for (int i = 0; i < entriesSize; ++i)
                         {
                             int key = istr.ReadInt();
                             int entrySize = istr.ReadSize();
-                            binaryContext[key] = new ReadOnlyMemory<byte>(Payload.Array, istr.Pos, entrySize);
+                            binaryContext[key] = Payload.AsReadOnlyMemory(offset + istr.Pos, entrySize);
                         }
                         _binaryContext = binaryContext.ToImmutableDictionary();
                     }

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -37,6 +37,7 @@ namespace ZeroC.Ice
                             int key = istr.ReadInt();
                             int entrySize = istr.ReadSize();
                             binaryContext[key] = Payload.AsReadOnlyMemory(offset + istr.Pos, entrySize);
+                            istr.Skip(entrySize);
                         }
                         _binaryContext = binaryContext.ToImmutableDictionary();
                     }

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -70,7 +70,7 @@ namespace ZeroC.Ice
 
         // If the frame payload contains an encapsulation, this segment corresponds to the frame encapsulation
         // otherwise is an empty segment. This is always an Slice of the Payload, both must use the same array.
-        private protected ArraySegment<byte> Encapsulation { get; set; }
+        internal ArraySegment<byte> Encapsulation { get; private protected set; }
 
         private IReadOnlyDictionary<int, ReadOnlyMemory<byte>>? _binaryContext;
 

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -43,9 +43,9 @@ namespace ZeroC.Ice
                 payload.Slice(istr.Pos).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
             Encapsulation = payload.Slice(istr.Pos, size + sizeLength);
 
-            if (Protocol == Protocol.Ice2)
+            if (Protocol == Protocol.Ice2 && BinaryContext.TryGetValue(0, out ReadOnlyMemory<byte> value))
             {
-                Context = BinaryContext[0].Read(ContextHelper.IceReader);
+                Context = value.Read(ContextHelper.IceReader);
             }
 
             if (protocol == Protocol.Ice1 && size + 4 + istr.Pos != payload.Count)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -40,6 +40,10 @@ namespace ZeroC.Ice
             {
                 Context = istr.ReadContext();
             }
+            else
+            {
+                Context = ImmutableDictionary<string, string>.Empty;
+            }
 
             (int size, int sizeLength, Encoding encoding) =
                 Data.Slice(istr.Pos).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
@@ -48,10 +52,6 @@ namespace ZeroC.Ice
             if (Protocol == Protocol.Ice2 && BinaryContext.TryGetValue(0, out ReadOnlyMemory<byte> value))
             {
                 Context = value.Read(ContextHelper.IceReader);
-            }
-            else
-            {
-                Context = ImmutableDictionary<string, string>.Empty;
             }
 
             if (protocol == Protocol.Ice1 && size + 4 + istr.Pos != data.Count)

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -91,7 +91,7 @@ namespace ZeroC.Ice
 
             if (Protocol == Protocol.Ice1)
             {
-                byte b = data[0];
+                byte b = Data[0];
                 if (b > 7)
                 {
                     throw new InvalidDataException($"received response frame with unknown reply status `{b}'");
@@ -108,7 +108,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                byte b = data[0];
+                byte b = Data[0];
                 if (b > 1)
                 {
                     throw new InvalidDataException($"invalid result type `{b}' in ice2 response frame");
@@ -123,9 +123,9 @@ namespace ZeroC.Ice
                 int sizeLength;
 
                 (size, sizeLength, Encoding) =
-                    data.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
-                Encapsulation = data.Slice(1, size + sizeLength);
-                Payload = data.Slice(0, 1 + size + sizeLength);
+                    Data.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+                Encapsulation = Data.Slice(1, size + sizeLength);
+                Payload = Data.Slice(0, 1 + size + sizeLength);
                 if (sizeLength + size != Encapsulation.Count)
                 {
                     throw new InvalidDataException(
@@ -136,7 +136,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                Payload = data;
+                Payload = Data;
             }
         }
 

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -82,16 +82,16 @@ namespace ZeroC.Ice
 
         /// <summary>Creates a new IncomingResponse Frame</summary>
         /// <param name="protocol">The Ice protocol of this frame.</param>
-        /// <param name="payload">The frame data as an array segment.</param>
+        /// <param name="data">The frame data as an array segment.</param>
         /// <param name="sizeMax">The maximum payload size, checked during decompress.</param>
-        public IncomingResponseFrame(Protocol protocol, ArraySegment<byte> payload, int sizeMax)
-            : base(protocol, payload, sizeMax)
+        public IncomingResponseFrame(Protocol protocol, ArraySegment<byte> data, int sizeMax)
+            : base(data, protocol, sizeMax)
         {
             bool hasEncapsulation = false;
 
             if (Protocol == Protocol.Ice1)
             {
-                byte b = Payload[0];
+                byte b = data[0];
                 if (b > 7)
                 {
                     throw new InvalidDataException($"received response frame with unknown reply status `{b}'");
@@ -108,7 +108,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                byte b = Payload[0];
+                byte b = data[0];
                 if (b > 1)
                 {
                     throw new InvalidDataException($"invalid result type `{b}' in ice2 response frame");
@@ -123,9 +123,9 @@ namespace ZeroC.Ice
                 int sizeLength;
 
                 (size, sizeLength, Encoding) =
-                    Payload.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
-                Encapsulation = Payload.Slice(1, size + sizeLength);
-
+                    data.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+                Encapsulation = data.Slice(1, size + sizeLength);
+                Payload = data.Slice(0, 1 + size + sizeLength);
                 if (sizeLength + size != Encapsulation.Count)
                 {
                     throw new InvalidDataException(
@@ -133,6 +133,10 @@ namespace ZeroC.Ice
                 }
 
                 HasCompressedPayload = Encoding == Encoding.V2_0 && Encapsulation[sizeLength + 2] != 0;
+            }
+            else
+            {
+                Payload = data;
             }
         }
 

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -122,9 +122,9 @@ namespace ZeroC.Ice
                 int size;
                 int sizeLength;
 
-                Encapsulation = Payload.Slice(1);
                 (size, sizeLength, Encoding) =
-                    Encapsulation.AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+                    Payload.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+                Encapsulation = Payload.Slice(1, size + sizeLength);
 
                 if (sizeLength + size != Encapsulation.Count)
                 {

--- a/csharp/src/Ice/InputStream-Class.cs
+++ b/csharp/src/Ice/InputStream-Class.cs
@@ -551,7 +551,7 @@ namespace ZeroC.Ice
         {
             _current.SliceFlags = (EncodingDefinitions.SliceFlags)ReadByte();
 
-            string? typeId = null;
+            string? typeId;
             int? compactId = null;
 
             // Read the type ID. For class slices, the type ID is encoded as a string or as an index or as a compact ID,

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -284,7 +284,7 @@ namespace ZeroC.Ice
 
             if (_binaryContextKeys.Contains(key))
             {
-                throw new ArgumentException($"key `{key}' is already in use");
+                throw new ArgumentException($"key `{key}' is already in use", nameof(key));
             }
 
             var ostr = new OutputStream(Encoding, Payload, _binaryContextEnd ?? encapsulationEnd);

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -148,6 +148,11 @@ namespace ZeroC.Ice
         /// </returns>
         public CompressionResult CompressPayload()
         {
+            if (IsSealed)
+            {
+                throw new InvalidOperationException("cannot modify a sealed frame");
+            }
+
             OutputStream.Position encapsulationEnd = _encapsulationEnd ??
                 throw new InvalidOperationException("payload has not been written");
 
@@ -268,6 +273,11 @@ namespace ZeroC.Ice
                 throw new NotSupportedException("binary context is not supported with Ice1 protocol");
             }
 
+            if (IsSealed)
+            {
+                throw new InvalidOperationException("cannot modify a sealed frame");
+            }
+
             OutputStream.Position encapsulationEnd = _encapsulationEnd ??
                 throw new InvalidOperationException(
                     "binary context cannot be written before finishing the encapsulation");
@@ -296,7 +306,7 @@ namespace ZeroC.Ice
             {
                 if (Protocol == Protocol.Ice2)
                 {
-                    if (context != null)
+                    if (context != null && context.Count > 0)
                     {
                         AddBinaryContextEntry(0, context, ContextHelper.IceWriter);
                     }

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 
@@ -312,6 +311,7 @@ namespace ZeroC.Ice
                 }
                 Payload[^1] = Payload[^1].Slice(0, _binaryContextEnd?.Offset ?? encapsulationEnd.Offset);
                 Size = Payload.GetByteCount();
+                IsSealed = true;
             }
         }
     }

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -181,7 +181,7 @@ namespace ZeroC.Ice
 
             if (Encoding != Encoding.V2_0)
             {
-                throw new NotSupportedException("compressed payload are only supported with 2.0 encoding");
+                throw new NotSupportedException("payload compression is only supported with 2.0 encoding");
             }
             else
             {
@@ -325,9 +325,8 @@ namespace ZeroC.Ice
                 throw new InvalidOperationException("cannot modify a sealed frame");
             }
 
-            OutputStream.Position encapsulationEnd = _encapsulationEnd ??
-                throw new InvalidOperationException(
-                    "binary context cannot be written before finishing the encapsulation");
+            Debug.Assert(_encapsulationEnd != null);
+            OutputStream.Position encapsulationEnd = _encapsulationEnd.Value;
 
             if (_binaryContextOstr == null)
             {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
             var ostr = new OutputStream(proxy.Protocol.GetEncoding(), request.Data, request._encapsulationStart,
                 request.Encoding, format ?? proxy.Communicator.DefaultFormat);
             writer(ostr, value);
-            request.FinishEncapsulation(ostr.Save());
+            request.FinishEncapsulation(ostr.Finish());
             if (compress && proxy.Encoding == Encoding.V2_0)
             {
                 request.CompressPayload();
@@ -90,7 +90,7 @@ namespace ZeroC.Ice
             var ostr = new OutputStream(proxy.Protocol.GetEncoding(), request.Data, request._encapsulationStart,
                 request.Encoding, format ?? proxy.Communicator.DefaultFormat);
             writer(ostr, value);
-            request.FinishEncapsulation(ostr.Save());
+            request.FinishEncapsulation(ostr.Finish());
             if (compress && proxy.Encoding == Encoding.V2_0)
             {
                 request.CompressPayload();
@@ -156,15 +156,15 @@ namespace ZeroC.Ice
             IsSealed = true;
         }
 
-        internal override void FinishBinaryContext()
+        internal override void Finish()
         {
-            if (Protocol == Protocol.Ice2 && !IsSealed)
+            if (!IsSealed)
             {
-                if (Context.Count > 0)
+                if (Protocol == Protocol.Ice2 && Context.Count > 0)
                 {
                     AddBinaryContextEntry(0, Context, ContextHelper.IceWriter);
                 }
-                base.FinishBinaryContext();
+                base.Finish();
             }
         }
 

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace ZeroC.Ice
 {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -165,6 +165,7 @@ namespace ZeroC.Ice
             IsSealed = true;
         }
 
+        // Finish prepare the frame for sending, write the frame Context into the slot 0 of the binary context.
         internal override void Finish()
         {
             if (!IsSealed)

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -49,7 +49,7 @@ namespace ZeroC.Ice
         {
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, value);
-            response.Finish(ostr.Save());
+            response.FinishEncapsulation(ostr.Save());
             if (compress && current.Encoding == Encoding.V2_0)
             {
                 response.CompressPayload();
@@ -76,7 +76,7 @@ namespace ZeroC.Ice
         {
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, value);
-            response.Finish(ostr.Save());
+            response.FinishEncapsulation(ostr.Save());
             if (compress && current.Encoding == Encoding.V2_0)
             {
                 response.CompressPayload();
@@ -143,7 +143,7 @@ namespace ZeroC.Ice
             if (hasEncapsulation)
             {
                 _encapsulationStart = new OutputStream.Position(Payload.Count - 1, 1);
-                Finish(new OutputStream.Position(Payload.Count - 1, data.Count));
+                _encapsulationEnd = new OutputStream.Position(Payload.Count - 1, data.Count);
             }
         }
 
@@ -218,7 +218,7 @@ namespace ZeroC.Ice
             {
                 ostr.WriteException(exception);
             }
-            Finish(ostr.Save());
+            FinishEncapsulation(ostr.Save());
         }
 
         private static (OutgoingResponseFrame ResponseFrame, OutputStream Ostr) PrepareReturnValue(

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -239,6 +239,7 @@ namespace ZeroC.Ice
             {
                 ostr.WriteException(exception);
             }
+
             OutputStream.Position end = ostr.Finish();
             if (hasEncapsulation)
             {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1631,10 +1631,8 @@ namespace ZeroC.Ice
         /// </summary>
         /// <returns>The tail position that marks the end of the stream.</returns>
         /// TODO: The stream should not longer be used, how can we enforce it.
-        internal Position Save()
+        internal Position Finish()
         {
-            _segmentList[_tail.Segment] = _segmentList[_tail.Segment].Slice(0, _tail.Offset);
-
             if (_startPos is Position startPos)
             {
                 Encoding = _mainEncoding;
@@ -1653,7 +1651,7 @@ namespace ZeroC.Ice
             {
                 WriteByte(0); // The compression status, 0 not-compressed
             }
-            return Save();
+            return _tail;
         }
 
         internal void WriteEndpoint(Endpoint endpoint)

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1730,7 +1730,7 @@ namespace ZeroC.Ice
             EndFixedLengthSize(pos, 2);
         }
 
-        internal void WriteBinaryContextEntry<T>(int key, T value, OutputStreamValueWriter<T> writer) where T : struct
+        internal void WriteBinaryContextEntry<T>(int key, in T value, OutputStreamValueWriter<T> writer) where T : struct
         {
             WriteVarInt(key);
             Position pos = StartFixedLengthSize(2); // 2-bytes size place holder

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1788,7 +1788,7 @@ namespace ZeroC.Ice
         /// <summary>Writes a size into a span of bytes using a fixed number of bytes.</summary>
         /// <param name="size">The size to write.</param>
         /// <param name="data">The destination byte buffer, which must be 1, 2 or 4 bytes long.</param>
-        private static void WriteFixedLengthSize20(int size, Span<byte> data)
+        internal static void WriteFixedLengthSize20(int size, Span<byte> data)
         {
             int sizeLength = data.Length;
             Debug.Assert(sizeLength == 1 || sizeLength == 2 || sizeLength == 4);

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -348,10 +348,7 @@ namespace ZeroC.Ice
                                                                     IProgress<bool>? progress = null,
                                                                     CancellationToken cancel = default)
         {
-            if (!request.IsSealed)
-            {
-                request.FinishBinaryContext();
-            }
+            request.Finish();
             InvocationMode mode = proxy.IceReference.InvocationMode;
             if (mode == InvocationMode.BatchOneway || mode == InvocationMode.BatchDatagram)
             {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -348,7 +348,10 @@ namespace ZeroC.Ice
                                                                     IProgress<bool>? progress = null,
                                                                     CancellationToken cancel = default)
         {
-            request.FinishPayload(request.Context);
+            if (!request.IsSealed)
+            {
+                request.FinishPayload(request.Context);
+            }
             InvocationMode mode = proxy.IceReference.InvocationMode;
             if (mode == InvocationMode.BatchOneway || mode == InvocationMode.BatchDatagram)
             {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -348,6 +348,7 @@ namespace ZeroC.Ice
                                                                     IProgress<bool>? progress = null,
                                                                     CancellationToken cancel = default)
         {
+            request.FinishPayload(request.Context);
             InvocationMode mode = proxy.IceReference.InvocationMode;
             if (mode == InvocationMode.BatchOneway || mode == InvocationMode.BatchDatagram)
             {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -338,7 +338,7 @@ namespace ZeroC.Ice
                                                                      progress,
                                                                      cancel).ConfigureAwait(false);
             // TODO: need protocol bridging when the protocols are not the same.
-            return new OutgoingResponseFrame(request, response.Payload);
+            return new OutgoingResponseFrame(request, response);
         }
 
         private static ValueTask<IncomingResponseFrame> InvokeAsync(this IObjectPrx proxy,
@@ -350,7 +350,7 @@ namespace ZeroC.Ice
         {
             if (!request.IsSealed)
             {
-                request.FinishPayload(request.Context);
+                request.FinishBinaryContext();
             }
             InvocationMode mode = proxy.IceReference.InvocationMode;
             if (mode == InvocationMode.BatchOneway || mode == InvocationMode.BatchDatagram)

--- a/csharp/src/Ice/VectoredBufferExtensions.cs
+++ b/csharp/src/Ice/VectoredBufferExtensions.cs
@@ -146,5 +146,36 @@ namespace ZeroC.Ice
             }
             return data;
         }
+
+        internal static List<ArraySegment<byte>> Slice(
+            this List<ArraySegment<byte>> src,
+            OutputStream.Position from,
+            OutputStream.Position to)
+        {
+            var dst = new List<ArraySegment<byte>>();
+            if (from.Segment == to.Segment)
+            {
+                dst.Add(src[from.Segment].Slice(from.Offset, to.Offset - from.Offset));
+            }
+            else
+            {
+                ArraySegment<byte> segment = src[from.Segment].Slice(from.Offset);
+                if (segment.Count > 0)
+                {
+                    dst.Add(segment);
+                }
+                for (int i = from.Segment + 1; i < to.Segment; i++)
+                {
+                    dst.Add(src[i]);
+                }
+
+                segment = src[to.Segment].Slice(0, to.Offset);
+                if (segment.Count > 0)
+                {
+                    dst.Add(segment);
+                }
+            }
+            return dst;
+        }
     }
 }

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -75,6 +75,19 @@ namespace ZeroC.Ice.Test.Interceptor
             output.Flush();
             TestInterceptorExceptions(prx);
             output.WriteLine("ok");
+
+            bool ice2 = Communicator()!.DefaultProtocol != Protocol.Ice1;
+            if (ice2)
+            {
+                output.Write("testing binary context... ");
+                output.Flush();
+                var request = OutgoingRequestFrame.WithEmptyParamList(prx,
+                                                                      "opWithBinaryContext",
+                                                                      idempotent: false);
+                request.AddBinaryContextEntry(1, new Token(1, "mytoken"), Token.IceWriter);
+                prx.Invoke(request);
+                output.WriteLine("ok");
+            }
         }
 
         private void RunAmd(IMyObjectPrx prx, Interceptor interceptor)
@@ -154,7 +167,7 @@ namespace ZeroC.Ice.Test.Interceptor
             //
             communicator.SetProperty("MyOA.AdapterId", "myOA");
 
-            ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA2", "tcp -h localhost");
+            ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA2", GetTestEndpoint(0));
 
             var myObject = new MyObject();
             var interceptor = new Interceptor(myObject);

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Test;
+using ZeroC.IceGrid;
 
 namespace ZeroC.Ice.Test.Interceptor
 {
@@ -85,6 +87,10 @@ namespace ZeroC.Ice.Test.Interceptor
                                                                       "opWithBinaryContext",
                                                                       idempotent: false);
                 request.AddBinaryContextEntry(1, new Token(1, "mytoken"), Token.IceWriter);
+                request.AddBinaryContextEntry(3, (short)1024, (ostr, value) => ostr.WriteShort(value));
+                request.AddBinaryContextEntry(2,
+                                              Enumerable.Range(0, 10).Select(i => $"string-{i}").ToArray(),
+                                              Ice.StringSeqHelper.IceWriter);
                 prx.Invoke(request);
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Test;
-using ZeroC.IceGrid;
 
 namespace ZeroC.Ice.Test.Interceptor
 {
@@ -137,7 +136,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 Assert(request.CompressPayload() == CompressionResult.Success);
                 prx.Invoke(request);
 
-                // repeat compressed the frame before writting the context
+                // repeat compressed the frame before writing the context
                 request = OutgoingRequestFrame.WithParamList(prx,
                                                              "opWithBinaryContext",
                                                              idempotent: false,

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -37,7 +37,9 @@ namespace ZeroC.Ice.Test.Interceptor
             {
                 if (request.Protocol == Protocol.Ice2)
                 {
-                    var t2 = new Token(1, "mytoken", Enumerable.Range(0, 1024).Select(i => (byte)i).ToArray());
+                    Debug.Assert(request.BinaryContext.ContainsKey(3));
+                    short size = request.BinaryContext[3].Read(istr => istr.ReadShort());
+                    var t2 = new Token(1, "mytoken", Enumerable.Range(0, size).Select(i => (byte)2).ToArray());
                     Debug.Assert(request.BinaryContext.ContainsKey(1));
                     Token t1 = request.BinaryContext[1].Read(Token.IceReader);
                     TestHelper.Assert(t1.Hash == t2.Hash);
@@ -46,12 +48,13 @@ namespace ZeroC.Ice.Test.Interceptor
                     Debug.Assert(request.BinaryContext.ContainsKey(2));
                     string[] s2 = request.BinaryContext[2].Read(Ice.StringSeqHelper.IceReader);
                     Enumerable.Range(0, 10).Select(i => $"string-{i}").SequenceEqual(s2);
-                    Debug.Assert(request.BinaryContext.ContainsKey(3));
-                    TestHelper.Assert(1024 == request.BinaryContext[3].Read(istr => istr.ReadShort()));
 
                     if (request.HasCompressedPayload)
                     {
                         request.DecompressPayload();
+
+                        Debug.Assert(request.BinaryContext.ContainsKey(3));
+                        size = request.BinaryContext[3].Read(istr => istr.ReadShort());
 
                         Debug.Assert(request.BinaryContext.ContainsKey(1));
                         t1 = request.BinaryContext[1].Read(Token.IceReader);
@@ -62,8 +65,6 @@ namespace ZeroC.Ice.Test.Interceptor
                         Debug.Assert(request.BinaryContext.ContainsKey(2));
                         s2 = request.BinaryContext[2].Read(Ice.StringSeqHelper.IceReader);
                         Enumerable.Range(0, 10).Select(i => $"string-{i}").SequenceEqual(s2);
-                        Debug.Assert(request.BinaryContext.ContainsKey(3));
-                        TestHelper.Assert(1024 == request.BinaryContext[3].Read(istr => istr.ReadShort()));
                     }
                 }
                 else

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,15 +35,29 @@ namespace ZeroC.Ice.Test.Interceptor
 
             if (_lastOperation == "OpWithBinaryContext")
             {
-                Debug.Assert(request.BinaryContext.ContainsKey(1));
-                Token t1 = request.BinaryContext[1].Read(Token.IceReader);
-                Token t2 = request.ReadParamList(current.Communicator, Token.IceReader);
-                TestHelper.Assert(t1 == t2);
-                Debug.Assert(request.BinaryContext.ContainsKey(2));
-                string[] s2 = request.BinaryContext[2].Read(Ice.StringSeqHelper.IceReader);
-                Enumerable.Range(0, 10).Select(i => $"string-{i}").SequenceEqual(s2);
-                Debug.Assert(request.BinaryContext.ContainsKey(3));
-                TestHelper.Assert(1024 == request.BinaryContext[3].Read(istr => istr.ReadShort()));
+                if (request.Protocol == Protocol.Ice2)
+                {
+                    Debug.Assert(request.BinaryContext.ContainsKey(1));
+                    Token t1 = request.BinaryContext[1].Read(Token.IceReader);
+                    Token t2 = request.ReadParamList(current.Communicator, Token.IceReader);
+                    TestHelper.Assert(t1 == t2);
+                    Debug.Assert(request.BinaryContext.ContainsKey(2));
+                    string[] s2 = request.BinaryContext[2].Read(Ice.StringSeqHelper.IceReader);
+                    Enumerable.Range(0, 10).Select(i => $"string-{i}").SequenceEqual(s2);
+                    Debug.Assert(request.BinaryContext.ContainsKey(3));
+                    TestHelper.Assert(1024 == request.BinaryContext[3].Read(istr => istr.ReadShort()));
+                }
+                else
+                {
+                    try
+                    {
+                        _ = request.BinaryContext;
+                        TestHelper.Assert(false);
+                    }
+                    catch (NotSupportedException)
+                    {
+                    }
+                }
             }
             else if (_lastOperation.Equals("addWithRetry") || _lastOperation.Equals("amdAddWithRetry"))
             {

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Test;
 
@@ -30,7 +31,14 @@ namespace ZeroC.Ice.Test.Interceptor
 
             _lastOperation = current.Operation;
 
-            if (_lastOperation.Equals("addWithRetry") || _lastOperation.Equals("amdAddWithRetry"))
+            if (_lastOperation == "OpWithBinaryContext")
+            {
+                Debug.Assert(request.BinaryContext.ContainsKey(1));
+                Token t1 = request.BinaryContext[1].Read(Token.IceReader);
+                Token t2 = request.ReadParamList(current.Communicator, Token.IceReader);
+                TestHelper.Assert(t1 == t2);
+            }
+            else if (_lastOperation.Equals("addWithRetry") || _lastOperation.Equals("amdAddWithRetry"))
             {
                 for (int i = 0; i < 10; ++i)
                 {

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -3,6 +3,7 @@
 //
 
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Test;
 
@@ -37,6 +38,11 @@ namespace ZeroC.Ice.Test.Interceptor
                 Token t1 = request.BinaryContext[1].Read(Token.IceReader);
                 Token t2 = request.ReadParamList(current.Communicator, Token.IceReader);
                 TestHelper.Assert(t1 == t2);
+                Debug.Assert(request.BinaryContext.ContainsKey(2));
+                string[] s2 = request.BinaryContext[2].Read(Ice.StringSeqHelper.IceReader);
+                Enumerable.Range(0, 10).Select(i => $"string-{i}").SequenceEqual(s2);
+                Debug.Assert(request.BinaryContext.ContainsKey(3));
+                TestHelper.Assert(1024 == request.BinaryContext[3].Read(istr => istr.ReadShort()));
             }
             else if (_lastOperation.Equals("addWithRetry") || _lastOperation.Equals("amdAddWithRetry"))
             {

--- a/csharp/test/Ice/interceptor/MyObjectI.cs
+++ b/csharp/test/Ice/interceptor/MyObjectI.cs
@@ -23,6 +23,10 @@ namespace ZeroC.Ice.Test.Interceptor
 
         public int NotExistAdd(int x, int y, Current current) => throw new ObjectNotExistException(current);
 
+        public void OpWithBinaryContext(Token token, Current current)
+        {
+        }
+
         //
         // AMD
         //

--- a/csharp/test/Ice/interceptor/Test.ice
+++ b/csharp/test/Ice/interceptor/Test.ice
@@ -9,10 +9,13 @@
 module ZeroC::Ice::Test::Interceptor
 {
 
+sequence<byte> ByteSeq;
+
 struct Token
 {
     long expiration;
     string hash;
+    ByteSeq payload;
 }
 
 exception InvalidInputException

--- a/csharp/test/Ice/interceptor/Test.ice
+++ b/csharp/test/Ice/interceptor/Test.ice
@@ -9,6 +9,12 @@
 module ZeroC::Ice::Test::Interceptor
 {
 
+struct Token
+{
+    long expiration;
+    string hash;
+}
+
 exception InvalidInputException
 {
     string message;
@@ -16,48 +22,30 @@ exception InvalidInputException
 
 interface MyObject
 {
-    //
     // A simple addition
-    //
     int add(int x, int y);
 
-    //
     // Will throw RetryException until current.Context["retry"] is "no"
-    //
     int addWithRetry(int x, int y);
 
-    //
     // Throws remote exception
-    //
     int badAdd(int x, int y);
-
-    //
     // Throws ONE
-    //
     int notExistAdd(int x, int y);
+    void opWithBinaryContext(Token token);
 
-    //
     // AMD version of the above:
-    //
 
-    //
     // Simple add
-    //
     [amd] int amdAdd(int x, int y);
 
-    //
     // Will throw RetryException until current.Context["retry"] is "no"
-    //
     [amd] int amdAddWithRetry(int x, int y);
 
-    //
     // Throws remote exception
-    //
     [amd] int amdBadAdd(int x, int y);
 
-    //
     // Throws ONE
-    //
     [amd] int amdNotExistAdd(int x, int y);
 }
 }

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -523,7 +523,7 @@ namespace ZeroC.Ice.Test.Metrics
                 }
                 else
                 {
-                    // Currently we're saving 2 bytes with the 2.0 encoding
+                    // Currently we're saving 3 bytes with the 2.0 encoding
                     TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == 42); // ice_ping request
                     TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == 23); // ice_ping response
                     TestHelper.Assert(sm2.ReceivedBytes - sm1.ReceivedBytes == 42);

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -880,6 +880,7 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 1);
 
             // We assume the error message is encoded in ASCII (each character uses 1-byte when encoded in UTF-8).
+            Console.WriteLine($"dm1.Size: {dm1.Size} dm1.ReplySize: {dm1.ReplySize}");
             TestHelper.Assert(dm1.Size == (38 + protocolRequestSizeAdjustment) &&
                 dm1.ReplySize == (metrics.Encoding == Encoding.V1_1 ? 48 : 51 + userExErrorMessageSize));
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -524,9 +524,9 @@ namespace ZeroC.Ice.Test.Metrics
                 else
                 {
                     // Currently we're saving 2 bytes with the 2.0 encoding
-                    TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == 43); // ice_ping request
+                    TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == 42); // ice_ping request
                     TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == 23); // ice_ping response
-                    TestHelper.Assert(sm2.ReceivedBytes - sm1.ReceivedBytes == 43);
+                    TestHelper.Assert(sm2.ReceivedBytes - sm1.ReceivedBytes == 42);
                     TestHelper.Assert(sm2.SentBytes - sm1.SentBytes == 23);
                 }
 
@@ -867,18 +867,20 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(collocated ? map.Count == 5 : map.Count == 6);
 
             // TODO: temporary, currently we often save 2 bytes with the ice2 protocol
-            int protocolSizeAdjustment = communicator.DefaultProtocol == Protocol.Ice1 ? 0 : -2;
+            int protocolRequestSizeAdjustment = communicator.DefaultProtocol == Protocol.Ice1 ? 0 : -3;
+            int protocolReplySizeAdjustment = communicator.DefaultProtocol == Protocol.Ice1 ? 0 : -2;
 
             DispatchMetrics dm1;
             dm1 = (DispatchMetrics)map["op"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 0);
-            TestHelper.Assert(dm1.Size == (21 + protocolSizeAdjustment) && dm1.ReplySize == 7 + protocolSizeAdjustment);
+            TestHelper.Assert(dm1.Size == (21 + protocolRequestSizeAdjustment) &&
+                              dm1.ReplySize == 7 + protocolReplySizeAdjustment);
 
             dm1 = (DispatchMetrics)map["opWithUserException"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 1);
 
             // We assume the error message is encoded in ASCII (each character uses 1-byte when encoded in UTF-8).
-            TestHelper.Assert(dm1.Size == (38 + protocolSizeAdjustment) &&
+            TestHelper.Assert(dm1.Size == (38 + protocolRequestSizeAdjustment) &&
                 dm1.ReplySize == (metrics.Encoding == Encoding.V1_1 ? 48 : 51 + userExErrorMessageSize));
 
             dm1 = (DispatchMetrics)map["opWithLocalException"];
@@ -886,23 +888,24 @@ namespace ZeroC.Ice.Test.Metrics
             CheckFailure(serverMetrics, "Dispatch", dm1.Id, "ZeroC.Ice.InvalidConfigurationException", 1, output);
 
             // Reply contains the exception stack depending on the OS.
-            TestHelper.Assert(dm1.Size == (39 + protocolSizeAdjustment) && dm1.ReplySize > 7);
+            TestHelper.Assert(dm1.Size == (39 + protocolRequestSizeAdjustment) && dm1.ReplySize > 7);
             dm1 = (DispatchMetrics)map["opWithRequestFailedException"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 0 && dm1.UserException == 1);
             if (ice1)
             {
-                TestHelper.Assert(dm1.Size == (47 + protocolSizeAdjustment) && dm1.ReplySize == 40);
+                TestHelper.Assert(dm1.Size == (47 + protocolRequestSizeAdjustment) && dm1.ReplySize == 40);
             }
             else
             {
                 // We marshal the full ONE.
-                TestHelper.Assert(dm1.Size == (47 + protocolSizeAdjustment) && dm1.ReplySize == 233);
+                TestHelper.Assert(dm1.Size == (47 + protocolRequestSizeAdjustment) && dm1.ReplySize == 233);
             }
 
             dm1 = (DispatchMetrics)map["opWithUnknownException"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);
             CheckFailure(serverMetrics, "Dispatch", dm1.Id, "System.ArgumentOutOfRangeException", 1, output);
-            TestHelper.Assert(dm1.Size == (41 + protocolSizeAdjustment) && dm1.ReplySize > 7); // Reply contains the exception stack depending on the OS.
+            TestHelper.Assert(dm1.Size == (41 + protocolRequestSizeAdjustment) &&
+                              dm1.ReplySize > 7); // Reply contains the exception stack depending on the OS.
 
             Action op = () => InvokeOp(metrics);
             TestAttribute(serverMetrics, serverProps, update, "Dispatch", "parent", "TestAdapter", op, output);
@@ -1078,7 +1081,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
             else
             {
-                TestHelper.Assert(rim1.Size == 38 && rim1.ReplySize == 10);
+                TestHelper.Assert(rim1.Size == 36 && rim1.ReplySize == 10);
             }
 
             if (ice1) // TODO: enable ice2
@@ -1209,7 +1212,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
             else
             {
-                TestHelper.Assert(rim1.Size == 38 && rim1.ReplySize == 0);
+                TestHelper.Assert(rim1.Size == 36 && rim1.ReplySize == 0);
             }
 
             TestAttribute(clientMetrics, clientProps, update, "Invocation", "mode", "oneway",

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -704,10 +704,7 @@ namespace ZeroC.Ice.Test.Operations
             }
         }
 
-        public IReadOnlyDictionary<string, string> OpContext(Current current) =>
-            current.Context == null ?
-                new Dictionary<string, string>() :
-                new Dictionary<string, string>(current.Context);
+        public IReadOnlyDictionary<string, string> OpContext(Current current) => current.Context;
 
         public void OpDoubleMarshaling(double p1, double[] p2, Current current)
         {


### PR DESCRIPTION
This PR adds binary context to incoming and outgoing frames, this is only available with Ice2 protocol, the old Context is marshall as entry with key 0 in the binary context.

There is some optimization that can be do in CompressPayload to avoid copy the binary context in case the frame is compressed after the context was written but that shouldn't hold the review.