### PR TITLE
Small cleanup in C#

### DIFF
--- a/csharp/src/Ice/Acm.cs
+++ b/csharp/src/Ice/Acm.cs
@@ -95,7 +95,7 @@ namespace ZeroC.Ice
             Timeout = communicator.GetPropertyAsTimeSpan($"{prefix}.Timeout") ?? defaults.Timeout;
             if (Timeout == TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException($"0 is not a valid value for invalid `{prefix}.Timeout'");
+                throw new ArgumentOutOfRangeException($"0 is not a valid value for `{prefix}.Timeout'");
             }
 
             Heartbeat = communicator.GetPropertyAsEnum<AcmHeartbeat>($"{prefix}.Heartbeat") ?? defaults.Heartbeat;

--- a/csharp/src/Ice/Acm.cs
+++ b/csharp/src/Ice/Acm.cs
@@ -53,7 +53,8 @@ namespace ZeroC.Ice
         public AcmHeartbeat Heartbeat { get; }
         /// <summary>Returns true if ACM is disabled, false otherwise.</summary>
         public bool IsDisabled => (Close == AcmClose.Off && Heartbeat == AcmHeartbeat.Off) ||
-            Timeout == System.Threading.Timeout.InfiniteTimeSpan || Timeout == TimeSpan.Zero;
+            Timeout == System.Threading.Timeout.InfiniteTimeSpan;
+
         /// <summary>Gets the timeout setting for the Acm configuration.</summary>
         public TimeSpan Timeout { get; }
 
@@ -68,7 +69,7 @@ namespace ZeroC.Ice
         /// <param name="heartbeat">The heartbeat setting.</param>
         public Acm(TimeSpan timeout, AcmClose close, AcmHeartbeat heartbeat)
         {
-            if (timeout != System.Threading.Timeout.InfiniteTimeSpan && timeout < TimeSpan.Zero)
+            if (timeout != System.Threading.Timeout.InfiniteTimeSpan && timeout <= TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException($"invalid {nameof(timeout)} argument");
             }
@@ -92,9 +93,9 @@ namespace ZeroC.Ice
         internal Acm(Communicator communicator, string prefix, Acm defaults)
         {
             Timeout = communicator.GetPropertyAsTimeSpan($"{prefix}.Timeout") ?? defaults.Timeout;
-            if (Timeout != System.Threading.Timeout.InfiniteTimeSpan && Timeout < TimeSpan.Zero)
+            if (Timeout == TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException($"invalid `{prefix}.Timeout' property value");
+                throw new ArgumentOutOfRangeException($"0 is not a valid value for invalid `{prefix}.Timeout'");
             }
 
             Heartbeat = communicator.GetPropertyAsEnum<AcmHeartbeat>($"{prefix}.Heartbeat") ?? defaults.Heartbeat;

--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -60,7 +60,10 @@ namespace ZeroC.Ice
             }
 
             Task<OutgoingResponseFrame> task;
-            if (_adapter.TaskScheduler != null || !synchronous || oneway || _reference.InvocationTimeout > 0)
+            if (_adapter.TaskScheduler != null ||
+                !synchronous ||
+                oneway ||
+                _reference.InvocationTimeout != Timeout.InfiniteTimeSpan)
             {
                 // Don't invoke from the user thread if async or invocation timeout is set. We also don't dispatch
                 // oneway from the user thread to match the non-collocated behavior where the oneway synchronous

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -123,7 +123,7 @@ namespace ZeroC.Ice
 
         public IPAddress? DefaultSourceAddress { get; }
         public string DefaultTransport { get; }
-        public int DefaultInvocationTimeout { get; }
+        public TimeSpan DefaultInvocationTimeout { get; }
         public TimeSpan DefaultLocatorCacheTimeout { get; }
 
         /// <summary>The default router for this communicator. To disable the default router, null can be used.
@@ -430,8 +430,10 @@ namespace ZeroC.Ice
 
                 DefaultTransport = GetProperty("Ice.Default.Transport") ?? "tcp";
 
-                DefaultInvocationTimeout = GetPropertyAsInt("Ice.Default.InvocationTimeout") ?? -1;
-                if (DefaultInvocationTimeout < 1 && DefaultInvocationTimeout != -1)
+                DefaultInvocationTimeout =
+                    GetPropertyAsTimeSpan("Ice.Default.InvocationTimeout") ?? Timeout.InfiniteTimeSpan;;
+
+                if (DefaultInvocationTimeout != Timeout.InfiniteTimeSpan && DefaultInvocationTimeout <= TimeSpan.Zero)
                 {
                     throw new InvalidConfigurationException(
                         $"invalid value for Ice.Default.InvocationTimeout: `{DefaultInvocationTimeout}'");

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -433,31 +433,25 @@ namespace ZeroC.Ice
                 DefaultInvocationTimeout =
                     GetPropertyAsTimeSpan("Ice.Default.InvocationTimeout") ?? Timeout.InfiniteTimeSpan;;
 
-                if (DefaultInvocationTimeout != Timeout.InfiniteTimeSpan && DefaultInvocationTimeout <= TimeSpan.Zero)
+                if (DefaultInvocationTimeout == TimeSpan.Zero)
                 {
-                    throw new InvalidConfigurationException(
-                        $"invalid value for Ice.Default.InvocationTimeout: `{DefaultInvocationTimeout}'");
+                    throw new InvalidConfigurationException("0 is not a valid value for Ice.Default.InvocationTimeout");
                 }
 
+                // For locator cache timeout, 0 means disable locator cache.
                 DefaultLocatorCacheTimeout =
                     GetPropertyAsTimeSpan("Ice.Default.LocatorCacheTimeout") ?? Timeout.InfiniteTimeSpan;
-                if (DefaultLocatorCacheTimeout != Timeout.InfiniteTimeSpan &&
-                    DefaultLocatorCacheTimeout < TimeSpan.Zero)
-                {
-                    throw new InvalidConfigurationException(
-                        $"invalid value for Ice.Default.LocatorCacheTimeout: `{DefaultLocatorCacheTimeout}'");
-                }
 
                 CloseTimeout = GetPropertyAsTimeSpan("Ice.CloseTimeout") ?? TimeSpan.FromSeconds(10);
-                if (CloseTimeout < TimeSpan.Zero)
+                if (CloseTimeout == TimeSpan.Zero)
                 {
-                    throw new InvalidConfigurationException($"invalid value for Ice.CloseTimeout: `{CloseTimeout}'");
+                    throw new InvalidConfigurationException("0 is not a valid value for Ice.CloseTimeout");
                 }
 
                 ConnectTimeout = GetPropertyAsTimeSpan("Ice.ConnectTimeout") ?? TimeSpan.FromSeconds(10);
-                if (ConnectTimeout < TimeSpan.Zero)
+                if (ConnectTimeout == TimeSpan.Zero)
                 {
-                    throw new InvalidConfigurationException($"invalid value for Ice.ConnectTimeout: `{ConnectTimeout}'");
+                    throw new InvalidConfigurationException("0 is not a valid value for Ice.ConnectTimeout");
                 }
 
                 ClientAcm = new Acm(this, "Ice.ACM.Client", new Acm(this, "Ice.ACM", Acm.ClientDefault));

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -145,11 +145,8 @@ namespace ZeroC.Ice
         /// <summary>The endpoints of this proxy. A proxy with a non-empty endpoint list is a direct proxy.</summary>
         public IReadOnlyList<Endpoint> Endpoints => IceReference.Endpoints;
 
-        /// <summary>The locator cache timeout of this proxy.</summary>
-        public TimeSpan LocatorCacheTimeout => IceReference.LocatorCacheTimeout;
-
-        /// <summary>The invocation timeout of this proxy, in seconds.</summary>
-        public int InvocationTimeout => IceReference.InvocationTimeout;
+        /// <summary>The invocation timeout of this proxy.</summary>
+        public TimeSpan InvocationTimeout => IceReference.InvocationTimeout;
 
         /// <summary>Indicates whether or not this proxy caches its connection.</summary>
         /// <value>True when the proxy caches its connection; otherwise, false.</value>
@@ -160,6 +157,9 @@ namespace ZeroC.Ice
 
         /// <summary>The encoding used to marshal request parameters.</summary>
         public Encoding Encoding => IceReference.Encoding;
+
+        /// <summary>The locator cache timeout of this proxy.</summary>
+        public TimeSpan LocatorCacheTimeout => IceReference.LocatorCacheTimeout;
 
         /// <summary>Indicates whether or not this proxy prefers non-secure connections.</summary>
         /// <value>When true, the proxy attempts to establish a non-secure connection if such a connection is available;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -42,7 +42,6 @@ namespace ZeroC.Ice
         /// version of the invocationMode parameter.</param>
         /// <param name="preferNonSecure">Determines whether the clone prefers non-secure connections over secure
         /// connections (optional).</param>
-        /// <param name="protocol">The Ice protocol of the clone (optional).</param>
         /// <param name="router">The router proxy of the clone (optional).</param>
         /// <returns>A new proxy manufactured by the proxy factory (see factory parameter).</returns>
         public static T Clone<T>(this IObjectPrx prx,
@@ -65,7 +64,6 @@ namespace ZeroC.Ice
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
                                  bool? preferNonSecure = null,
-                                 Protocol? protocol = null,
                                  IRouterPrx? router = null) where T : class, IObjectPrx
         {
             return factory(prx.IceReference.Clone(adapterId,
@@ -86,7 +84,6 @@ namespace ZeroC.Ice
                                                   locatorCacheTimeout,
                                                   oneway,
                                                   preferNonSecure,
-                                                  protocol,
                                                   router));
         }
 
@@ -116,7 +113,6 @@ namespace ZeroC.Ice
         /// version of the invocationMode parameter.</param>
         /// <param name="preferNonSecure">Determines whether the clone prefers non-secure connections over secure
         /// connections (optional).</param>
-        /// <param name="protocol">The Ice protocol of the clone (optional).</param>
         /// <param name="router">The router proxy of the clone (optional).</param>
         /// <returns>A new proxy manufactured by the proxy factory (see factory parameter).</returns>
         public static T Clone<T>(this IObjectPrx prx,
@@ -138,7 +134,6 @@ namespace ZeroC.Ice
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
                                  bool? preferNonSecure = null,
-                                 Protocol? protocol = null,
                                  IRouterPrx? router = null) where T : class, IObjectPrx
         {
             return factory(prx.IceReference.Clone(adapterId,
@@ -159,7 +154,6 @@ namespace ZeroC.Ice
                                                   locatorCacheTimeout,
                                                   oneway,
                                                   preferNonSecure,
-                                                  protocol,
                                                   router));
         }
 
@@ -188,7 +182,6 @@ namespace ZeroC.Ice
         /// version of the invocationMode parameter.</param>
         /// <param name="preferNonSecure">Determines whether the clone prefers non-secure connections over secure
         /// connections (optional).</param>
-        /// <param name="protocol">The Ice protocol of the clone (optional).</param>
         /// <param name="router">The router proxy of the clone (optional).</param>
         /// <returns>A new proxy with the same type as this proxy.</returns>
         public static T Clone<T>(this T prx,
@@ -208,7 +201,6 @@ namespace ZeroC.Ice
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
                                  bool? preferNonSecure = null,
-                                 Protocol? protocol = null,
                                  IRouterPrx? router = null) where T : IObjectPrx
         {
             Reference clone = prx.IceReference.Clone(adapterId,
@@ -229,7 +221,6 @@ namespace ZeroC.Ice
                                                      locatorCacheTimeout,
                                                      oneway,
                                                      preferNonSecure,
-                                                     protocol,
                                                      router);
 
             // Reference.Clone never returns a new reference == to itself.
@@ -316,11 +307,15 @@ namespace ZeroC.Ice
                                                                    CancellationToken cancel = default) =>
             InvokeAsync(proxy, request, oneway, synchronous: false, progress, cancel);
 
-        /// <summary>Forwards an incoming request to another Ice object.</summary>
+        /// <summary>Forwards an incoming request to another Ice object represented by the <paramref name="proxy"/>
+        /// parameter.</summary>
+        /// <remarks>When the incoming request frame's protocol and proxy's protocol are different, this method
+        /// automatically bridges between these two protocols. When proxy's protocol is ice1, the resulting outgoing
+        /// request frame is never compressed.</remarks>
         /// <param name="proxy">The proxy for the target Ice object.</param>
         /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
         /// two-way request.</param>
-        /// <param name="request">The incoming request frame.</param>
+        /// <param name="request">The incoming request frame to forward to proxy's target.</param>
         /// <param name="progress">Sent progress provider.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>A task holding the response frame.</returns>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -59,7 +59,7 @@ namespace ZeroC.Ice
                                  string? facet = null,
                                  Connection? fixedConnection = null,
                                  InvocationMode? invocationMode = null,
-                                 int? invocationTimeout = null,
+                                 TimeSpan? invocationTimeout = null,
                                  ILocatorPrx? locator = null,
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
@@ -129,7 +129,7 @@ namespace ZeroC.Ice
                                  IEnumerable<Endpoint>? endpoints = null,
                                  Connection? fixedConnection = null,
                                  InvocationMode? invocationMode = null,
-                                 int? invocationTimeout = null,
+                                 TimeSpan? invocationTimeout = null,
                                  ILocatorPrx? locator = null,
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
@@ -196,7 +196,7 @@ namespace ZeroC.Ice
                                  IEnumerable<Endpoint>? endpoints = null,
                                  Connection? fixedConnection = null,
                                  InvocationMode? invocationMode = null,
-                                 int? invocationTimeout = null,
+                                 TimeSpan? invocationTimeout = null,
                                  ILocatorPrx? locator = null,
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
@@ -369,7 +369,7 @@ namespace ZeroC.Ice
                                                                                      request.Context);
                 int retryCount = 0;
                 CancellationTokenSource? invocationTimeout = null;
-                if (reference.InvocationTimeout > 0)
+                if (reference.InvocationTimeout != Timeout.InfiniteTimeSpan)
                 {
                     invocationTimeout = new CancellationTokenSource();
                     invocationTimeout.CancelAfter(reference.InvocationTimeout);

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -811,7 +811,6 @@ namespace ZeroC.Ice
                                  TimeSpan? locatorCacheTimeout = null,
                                  bool? oneway = null,
                                  bool? preferNonSecure = null,
-                                 Protocol? protocol = null,
                                  IRouterPrx? router = null)
         {
             // Check for incompatible arguments
@@ -890,10 +889,6 @@ namespace ZeroC.Ice
                 {
                     throw new ArgumentException("cannot change the prefer non-secure configuration of a fixed proxy",
                         nameof(preferNonSecure));
-                }
-                if (protocol != null)
-                {
-                    throw new ArgumentException("cannot change the protocol of a fixed proxy", nameof(protocol));
                 }
                 if (router != null)
                 {
@@ -985,7 +980,7 @@ namespace ZeroC.Ice
                                       locatorCacheTimeout ?? LocatorCacheTimeout,
                                       locatorInfo, // no fallback otherwise breaks clearLocator
                                       preferNonSecure ?? PreferNonSecure,
-                                      protocol ?? Protocol,
+                                      Protocol,
                                       routerInfo); // no fallback otherwise breaks clearRouter
 
                 return clone == this ? this : clone;

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1322,6 +1322,12 @@ namespace ZeroC.Ice
             PreferNonSecure = preferNonSecure;
             Protocol = protocol;
             RouterInfo = routerInfo;
+
+            if (Protocol == Protocol.Ice2 && (byte)InvocationMode > (byte)InvocationMode.Oneway)
+            {
+                throw new ArgumentException(
+                    $"invocation mode `{InvocationMode}' is not compatible with the ice2 protocol");
+            }
         }
 
         // Constructor for fixed references.
@@ -1353,6 +1359,14 @@ namespace ZeroC.Ice
             RouterInfo = null;
 
             _fixedConnection = fixedConnection;
+            _fixedConnection.ThrowException(); // Throw in case our connection is already destroyed.
+            _requestHandler = new ConnectionRequestHandler(_fixedConnection);
+
+            if (Protocol == Protocol.Ice2 && (byte)InvocationMode > (byte)InvocationMode.Oneway)
+            {
+                throw new ArgumentException(
+                    $"invocation mode `{InvocationMode}' is not compatible with the ice2 protocol");
+            }
 
             if (InvocationMode == InvocationMode.Datagram)
             {
@@ -1366,9 +1380,6 @@ namespace ZeroC.Ice
             {
                 throw new NotSupportedException("batch invocation modes are not supported for fixed proxies");
             }
-
-            _fixedConnection.ThrowException(); // Throw in case our connection is already destroyed.
-            _requestHandler = new ConnectionRequestHandler(_fixedConnection);
         }
     }
 }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -169,27 +169,15 @@ namespace ZeroC.Ice
 
                 property = $"{propertyPrefix}.InvocationTimeout";
                 invocationTimeout = communicator.GetPropertyAsTimeSpan(property);
-                if (invocationTimeout != null &&
-                    invocationTimeout <= TimeSpan.Zero &&
-                    invocationTimeout != Timeout.InfiniteTimeSpan)
+                if (invocationTimeout == TimeSpan.Zero)
                 {
-                    throw new InvalidConfigurationException(
-                        $"invalid value for property `{property}': `{invocationTimeout}'");
+                    throw new InvalidConfigurationException($"0 is not a value value for property `{property}'");
                 }
 
                 locatorInfo = communicator.GetLocatorInfo(
                     communicator.GetPropertyAsProxy($"{propertyPrefix}.Locator", ILocatorPrx.Factory), encoding);
 
-                property = $"{propertyPrefix}.LocatorCacheTimeout";
-                locatorCacheTimeout = communicator.GetPropertyAsTimeSpan(property);
-                if (locatorCacheTimeout != null &&
-                    locatorCacheTimeout < TimeSpan.Zero &&
-                    locatorCacheTimeout != Timeout.InfiniteTimeSpan)
-                {
-                    throw new InvalidConfigurationException(
-                        $"invalid value for property `{property}': `{locatorCacheTimeout}'");
-                }
-
+                locatorCacheTimeout = communicator.GetPropertyAsTimeSpan($"{propertyPrefix}.LocatorCacheTimeout");
                 preferNonSecure = communicator.GetPropertyAsBool($"{propertyPrefix}.PreferNonSecure");
 
                 property = $"{propertyPrefix}.Router";
@@ -837,12 +825,10 @@ namespace ZeroC.Ice
                 throw new ArgumentException($"cannot set both {nameof(endpoints)} and {nameof(adapterId)}");
             }
 
-            if (invocationTimeout != null &&
-                invocationTimeout <= TimeSpan.Zero &&
-                invocationTimeout != Timeout.InfiniteTimeSpan)
+            if (invocationTimeout != Timeout.InfiniteTimeSpan && invocationTimeout <= TimeSpan.Zero)
             {
-                throw new ArgumentException(
-                    $"invalid {nameof(invocationTimeout)}: {invocationTimeout}", nameof(invocationTimeout));
+                throw new ArgumentException($"{invocationTimeout} is not a valid value for {nameof(invocationTimeout)}",
+                                            nameof(invocationTimeout));
             }
 
             if (IsFixed || fixedConnection != null)

--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.ACM
             properties["Ice.ACM.Timeout"] = "1s";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            communicator.SetProperty("TestAdapter.ACM.Timeout", "0s");
+            communicator.SetProperty("TestAdapter.ACM.Timeout", "infinite");
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());
             await adapter.ActivateAsync();

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -15,6 +15,7 @@ namespace ZeroC.Ice.Test.Proxy
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
+            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
             System.IO.TextWriter output = helper.GetWriter();
             output.Write("testing proxy parsing... ");
             output.Flush();
@@ -670,13 +671,16 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(baseProxy.Clone(adapterId: "id").AdapterId.Equals("id"));
             TestHelper.Assert(!baseProxy.Clone(invocationMode: InvocationMode.Twoway).IsOneway);
             TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.Oneway).IsOneway);
-            TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.Datagram).IsOneway);
-            TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.BatchOneway).InvocationMode ==
-                InvocationMode.BatchOneway);
-            TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.Datagram).InvocationMode ==
-                InvocationMode.Datagram);
-            TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.BatchDatagram).InvocationMode ==
-                InvocationMode.BatchDatagram);
+            if (ice1)
+            {
+                TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.Datagram).IsOneway);
+                TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.BatchOneway).InvocationMode ==
+                    InvocationMode.BatchOneway);
+                TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.Datagram).InvocationMode ==
+                    InvocationMode.Datagram);
+                TestHelper.Assert(baseProxy.Clone(invocationMode: InvocationMode.BatchDatagram).InvocationMode ==
+                    InvocationMode.BatchDatagram);
+            }
             TestHelper.Assert(baseProxy.Clone(preferNonSecure: true).PreferNonSecure);
             TestHelper.Assert(!baseProxy.Clone(preferNonSecure: false).PreferNonSecure);
 
@@ -868,7 +872,7 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(c.DictionaryEquals(c2));
             output.WriteLine("ok");
 
-            if (communicator.DefaultProtocol == Protocol.Ice1)
+            if (ice1)
             {
                 output.Write("testing ice2 proxy in 1.1 encapsulation... ");
                 output.Flush();

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -574,10 +574,10 @@ namespace ZeroC.Ice.Test.Proxy
             communicator.RemoveProperty(property);
 
             property = propertyPrefix + ".InvocationTimeout";
-            TestHelper.Assert(b1.InvocationTimeout == -1);
-            communicator.SetProperty(property, "1000");
+            TestHelper.Assert(b1.InvocationTimeout == Timeout.InfiniteTimeSpan);
+            communicator.SetProperty(property, "1000ms");
             b1 = communicator.GetPropertyAsProxy(propertyPrefix, IObjectPrx.Factory)!;
-            TestHelper.Assert(b1.InvocationTimeout == 1000);
+            TestHelper.Assert(b1.InvocationTimeout == TimeSpan.FromMilliseconds(1000));
             communicator.RemoveProperty(property);
 
             property = propertyPrefix + ".EndpointSelection";
@@ -615,14 +615,14 @@ namespace ZeroC.Ice.Test.Proxy
                 preferNonSecure: true,
                 endpointSelection: EndpointSelectionType.Random,
                 locatorCacheTimeout: TimeSpan.FromSeconds(200),
-                invocationTimeout: 1500);
+                invocationTimeout: TimeSpan.FromMilliseconds(1500));
 
             ILocatorPrx? locator = ILocatorPrx.Parse("ice:locator", communicator).Clone(
                 cacheConnection: false,
                 preferNonSecure: true,
                 endpointSelection: EndpointSelectionType.Random,
                 locatorCacheTimeout: TimeSpan.FromSeconds(300),
-                invocationTimeout: 1500,
+                invocationTimeout: TimeSpan.FromMilliseconds(1500),
                 router: router);
 
             b1 = IObjectPrx.Parse("ice:test", communicator).Clone(
@@ -630,7 +630,7 @@ namespace ZeroC.Ice.Test.Proxy
                 preferNonSecure: false,
                 endpointSelection: EndpointSelectionType.Ordered,
                 locatorCacheTimeout: TimeSpan.FromSeconds(100),
-                invocationTimeout: 1234,
+                invocationTimeout: TimeSpan.FromMilliseconds(1234),
                 locator: locator);
 
             Dictionary<string, string> proxyProps = b1.ToProperty("Test");
@@ -641,21 +641,21 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(proxyProps["Test.PreferNonSecure"] == "0");
             TestHelper.Assert(proxyProps["Test.EndpointSelection"] == "Ordered");
             TestHelper.Assert(proxyProps["Test.LocatorCacheTimeout"] == "100s");
-            TestHelper.Assert(proxyProps["Test.InvocationTimeout"] == "1234");
+            TestHelper.Assert(proxyProps["Test.InvocationTimeout"] == "1234ms");
 
             TestHelper.Assert(proxyProps["Test.Locator"] == "ice:locator"); // strange test with an indirect locator!
             TestHelper.Assert(proxyProps["Test.Locator.ConnectionCached"] == "0");
             TestHelper.Assert(proxyProps["Test.Locator.PreferNonSecure"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.EndpointSelection"] == "Random");
             TestHelper.Assert(proxyProps["Test.Locator.LocatorCacheTimeout"] == "5m");
-            TestHelper.Assert(proxyProps["Test.Locator.InvocationTimeout"] == "1500");
+            TestHelper.Assert(proxyProps["Test.Locator.InvocationTimeout"] == "1500ms");
 
             TestHelper.Assert(proxyProps["Test.Locator.Router"] == "ice:router?encoding=1.1"); // also very strange
             TestHelper.Assert(proxyProps["Test.Locator.Router.ConnectionCached"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.Router.PreferNonSecure"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.Router.EndpointSelection"] == "Random");
             TestHelper.Assert(proxyProps["Test.Locator.Router.LocatorCacheTimeout"] == "200s");
-            TestHelper.Assert(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500");
+            TestHelper.Assert(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500ms");
 
             output.WriteLine("ok");
 
@@ -682,7 +682,7 @@ namespace ZeroC.Ice.Test.Proxy
 
             try
             {
-                baseProxy.Clone(invocationTimeout: 0);
+                baseProxy.Clone(invocationTimeout: TimeSpan.Zero);
                 TestHelper.Assert(false);
             }
             catch (ArgumentException)
@@ -691,16 +691,7 @@ namespace ZeroC.Ice.Test.Proxy
 
             try
             {
-                baseProxy.Clone(invocationTimeout: -1);
-            }
-            catch (ArgumentException)
-            {
-                TestHelper.Assert(false);
-            }
-
-            try
-            {
-                baseProxy.Clone(invocationTimeout: -2);
+                baseProxy.Clone(invocationTimeout: TimeSpan.FromSeconds(-2));
                 TestHelper.Assert(false);
             }
             catch (ArgumentException)
@@ -816,8 +807,10 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(!compObj1.Clone(locatorCacheTimeout: TimeSpan.FromSeconds(10))
                 .Equals(compObj1.Clone(locatorCacheTimeout: TimeSpan.FromSeconds(20))));
 
-            TestHelper.Assert(compObj1.Clone(invocationTimeout: 20).Equals(compObj1.Clone(invocationTimeout: 20)));
-            TestHelper.Assert(!compObj1.Clone(invocationTimeout: 10).Equals(compObj1.Clone(invocationTimeout: 20)));
+            TestHelper.Assert(compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20)).Equals(
+                compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20))));
+            TestHelper.Assert(!compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(10)).Equals(
+                compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20))));
 
             compObj1 = IObjectPrx.Parse("ice+tcp://127.0.0.1:10000/foo", communicator);
             compObj2 = IObjectPrx.Parse("ice:MyAdapter1//foo", communicator);
@@ -914,8 +907,10 @@ namespace ZeroC.Ice.Test.Proxy
                     };
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).Context.Count == 0);
                     TestHelper.Assert(cl.Clone(context: ctx, fixedConnection: connection2).Context.Count == 2);
-                    TestHelper.Assert(cl.Clone(fixedConnection: connection2).InvocationTimeout == -1);
-                    TestHelper.Assert(cl.Clone(invocationTimeout: 10, fixedConnection: connection2).InvocationTimeout == 10);
+                    TestHelper.Assert(
+                        cl.Clone(fixedConnection: connection2).InvocationTimeout == Timeout.InfiniteTimeSpan);
+                    TestHelper.Assert(cl.Clone(invocationTimeout: TimeSpan.FromMilliseconds(10),
+                        fixedConnection: connection2).InvocationTimeout == TimeSpan.FromMilliseconds(10));
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).GetConnection() == connection2);
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).Clone(fixedConnection: connection2).GetConnection() == connection2);
                     Connection? fixedConnection = cl.Clone(connectionId: "ice_fixed").GetConnection();

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -243,7 +243,7 @@ namespace ZeroC.Ice.Test.Retry
                 try
                 {
                     // No more than 2 retries before timeout kicks-in
-                    retry2.Clone(invocationTimeout: 500).OpIdempotent(4);
+                    retry2.Clone(invocationTimeout: TimeSpan.FromMilliseconds(500)).OpIdempotent(4);
                     TestHelper.Assert(false);
                 }
                 catch (TimeoutException)
@@ -255,7 +255,7 @@ namespace ZeroC.Ice.Test.Retry
                 try
                 {
                     // No more than 2 retries before timeout kicks-in
-                    IRetryPrx prx = retry2.Clone(invocationTimeout: 500);
+                    IRetryPrx prx = retry2.Clone(invocationTimeout: TimeSpan.FromMilliseconds(500));
                     prx.OpIdempotentAsync(4).Wait();
                     TestHelper.Assert(false);
                 }

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -114,7 +114,7 @@ namespace ZeroC.Ice.Test.Timeout
             {
                 timeout.IcePing(); // Makes sure a working connection is associated with the proxy
                 Connection? connection = timeout.GetConnection();
-                ITimeoutPrx? to = timeout.Clone(invocationTimeout: 100);
+                ITimeoutPrx? to = timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(100));
                 TestHelper.Assert(connection == to.GetConnection());
                 try
                 {
@@ -125,7 +125,7 @@ namespace ZeroC.Ice.Test.Timeout
                 {
                 }
                 timeout.IcePing();
-                to = timeout.Clone(invocationTimeout: 1000);
+                to = timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(1000));
                 TestHelper.Assert(connection == to.GetConnection());
                 try
                 {
@@ -141,7 +141,7 @@ namespace ZeroC.Ice.Test.Timeout
                 //
                 // Expect TimeoutException.
                 //
-                ITimeoutPrx to = timeout.Clone(invocationTimeout: 100);
+                ITimeoutPrx to = timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(100));
                 try
                 {
                     to.SleepAsync(1000).Wait();
@@ -153,7 +153,7 @@ namespace ZeroC.Ice.Test.Timeout
             }
             {
                 // Expect success.
-                ITimeoutPrx to = timeout.Clone(invocationTimeout: 1000);
+                ITimeoutPrx to = timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(1000));
                 to.SleepAsync(100).Wait();
             }
 
@@ -201,8 +201,8 @@ namespace ZeroC.Ice.Test.Timeout
                 ObjectAdapter adapter = communicator.CreateObjectAdapter("TimeoutCollocated");
                 adapter.Activate();
 
-                ITimeoutPrx proxy =
-                    adapter.AddWithUUID(new Timeout(), ITimeoutPrx.Factory).Clone(invocationTimeout: 100);
+                ITimeoutPrx proxy = adapter.AddWithUUID(new Timeout(), ITimeoutPrx.Factory).Clone(
+                    invocationTimeout: TimeSpan.FromMilliseconds(100));
                 try
                 {
                     proxy.Sleep(500);


### PR DESCRIPTION
This small clean-up PR converts invocation timeout from int to TimeSpan, removes protocol from Clone and limits the invocation modes accepted by ice2 proxies.