### PR TITLE
Avoid copy data when coverting a single item list of ArraySegment

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -94,7 +94,7 @@ namespace ZeroC.Ice
 
                 var incomingResponseFrame = new IncomingResponseFrame(
                     outgoingRequest.Protocol,
-                    VectoredBufferExtensions.ToArray(outgoingResponseFrame.Data),
+                    outgoingResponseFrame.Data.AsArraySegment(),
                     _adapter.IncomingFrameSizeMax);
 
                 if (_adapter.Communicator.TraceLevels.Protocol >= 1)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -65,10 +65,8 @@ namespace ZeroC.Ice
             HasCompressedPayload = Encoding == Encoding.V2_0 && Encapsulation[sizeLength + 2] != 0;
         }
 
-        // TODO avoid copy payload (ToArray) creates a copy, that should be possible when
-        // the frame has a single segment.
         internal IncomingRequestFrame(OutgoingRequestFrame frame, int sizeMax)
-            : this(frame.Protocol, VectoredBufferExtensions.ToArray(frame.Data), sizeMax)
+            : this(frame.Protocol, frame.Data.AsArraySegment(), sizeMax)
         {
         }
 

--- a/csharp/src/Ice/VectoredBufferExtensions.cs
+++ b/csharp/src/Ice/VectoredBufferExtensions.cs
@@ -134,17 +134,24 @@ namespace ZeroC.Ice
             return data;
         }
 
-        public static byte[] ToArray(this IList<ArraySegment<byte>> src)
+        internal static ArraySegment<byte> AsArraySegment(this IList<ArraySegment<byte>> src)
         {
-            byte[] data = new byte[src.GetByteCount()];
-            int offset = 0;
-            foreach (ArraySegment<byte> segment in src)
+            if (src.Count == 1)
             {
-                Debug.Assert(segment.Array != null);
-                Buffer.BlockCopy(segment.Array, segment.Offset, data, offset, segment.Count);
-                offset += segment.Count;
+                return src[0];
             }
-            return data;
+            else
+            {
+                byte[] data = new byte[src.GetByteCount()];
+                int offset = 0;
+                foreach (ArraySegment<byte> segment in src)
+                {
+                    Debug.Assert(segment.Array != null);
+                    Buffer.BlockCopy(segment.Array, segment.Offset, data, offset, segment.Count);
+                    offset += segment.Count;
+                }
+                return data;
+            }
         }
 
         internal static List<ArraySegment<byte>> Slice(


### PR DESCRIPTION
This small PR avoids copy the data when converting a  single item `List<ArraySegment<byte>>` to an `ArraySegment<byte>>` 