### PR TITLE
Add StringUtil.JoinString helper method

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -295,8 +295,7 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        // TODO: this join is not sufficient to create a string compatible with GetPropertyAsList
-                        combinedProperties[key] = string.Join(",", values);
+                        combinedProperties[key] = StringUtil.JoinString(values, ", \t\r\n");
                     }
                 }
             }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -295,7 +295,7 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        combinedProperties[key] = StringUtil.JoinString(values, ", \t\r\n");
+                        combinedProperties[key] = StringUtil.JoinStringProperty(values);
                     }
                 }
             }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -295,7 +295,7 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        combinedProperties[key] = StringUtil.JoinStringProperty(values);
+                        combinedProperties[key] = StringUtil.ToPropertyValue(values);
                     }
                 }
             }

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -9,21 +9,21 @@ using System.Text;
 
 namespace ZeroC.Ice
 {
-    internal static class StringUtil
+    public static class StringUtil
     {
         //
         // Return the index of the first character in str to
         // appear in match, starting from 0. Returns -1 if none is
         // found.
         //
-        public static int FindFirstOf(string str, string match) => FindFirstOf(str, match, 0);
+        internal static int FindFirstOf(string str, string match) => FindFirstOf(str, match, 0);
 
         //
         // Return the index of the first character in str to
         // appear in match, starting from start. Returns -1 if none is
         // found.
         //
-        public static int FindFirstOf(string str, string match, int start)
+        internal static int FindFirstOf(string str, string match, int start)
         {
             int len = str.Length;
             for (int i = start; i < len; i++)
@@ -43,7 +43,7 @@ namespace ZeroC.Ice
         // not appear in match, starting from start. Returns -1 if none is
         // found.
         //
-        public static int FindFirstNotOf(string str, string match, int start)
+        internal static int FindFirstNotOf(string str, string match, int start)
         {
             int len = str.Length;
             for (int i = start; i < len; i++)
@@ -602,13 +602,64 @@ namespace ZeroC.Ice
             return l.ToArray();
         }
 
+        public static string JoinString(string[] values, string delimiters)
+        {
+            if (delimiters.Length == 0)
+            {
+                throw new ArgumentException("delimiters cannot be empty", nameof(delimiters));
+            }
+
+            char quote = '"';
+            var result = new StringBuilder();
+            char delimiter = delimiters[0];
+
+            foreach (string value in values)
+            {
+                if (result.Length != 0)
+                {
+                    result.Append(delimiter);
+                }
+
+                bool addQuote = false;
+                for (int i = 0; i < delimiters.Length; ++i)
+                {
+                    if (value.Contains(delimiters[i]))
+                    {
+                        addQuote = true;
+                        break;
+                    }
+                }
+
+                if (addQuote)
+                {
+                    result.Append(quote);
+                }
+
+                for (int i = 0; i < value.Length; ++i)
+                {
+                    char c = value[i];
+                    if (c == quote)
+                    {
+                        result.Append('\\');
+                    }
+                    result.Append(c);
+                }
+
+                if (addQuote)
+                {
+                    result.Append(quote);
+                }
+            }
+            return result.ToString();
+        }
+
         //
         // If a single or double quotation mark is found at the start position,
         // then the position of the matching closing quote is returned. If no
         // quotation mark is found at the start position, then 0 is returned.
         // If no matching closing quote is found, then -1 is returned.
         //
-        public static int CheckQuote(string s, int start)
+        internal static int CheckQuote(string s, int start)
         {
             char quoteChar = s[start];
             if (quoteChar == '"' || quoteChar == '\'')
@@ -629,7 +680,7 @@ namespace ZeroC.Ice
             return 0; // Not quoted
         }
 
-        public static bool Match(string s, string pat, bool emptyMatch)
+        internal static bool Match(string s, string pat, bool emptyMatch)
         {
             Debug.Assert(s.Length > 0);
             Debug.Assert(pat.Length > 0);

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -602,9 +602,14 @@ namespace ZeroC.Ice
             return l.ToArray();
         }
 
+        /// <summary>Concatenates a list of strings in a format that is compatible with
+        /// <see cref="Communicator.GetPropertyAsList(string)"/>.</summary>
+        /// <param name="values">The list of strings to concatenate.</param>
+        /// <returns>The values concatenated in a string that is compatible with
+        /// <see cref="Communicator.GetPropertyAsList(string)"/>.</returns>
         public static string JoinStringProperty(IReadOnlyList<string> values)
         {
-            string delimiters = ", \n\r\t";
+            char[] delimiters = new char[] { ',', ' ', '\n', '\r', '\t' };
             char quote = '"';
             var result = new StringBuilder();
             char delimiter = ' ';
@@ -616,24 +621,14 @@ namespace ZeroC.Ice
                     result.Append(delimiter);
                 }
 
-                bool addQuote = false;
-                for (int i = 0; i < delimiters.Length; ++i)
-                {
-                    if (value.Contains(delimiters[i]))
-                    {
-                        addQuote = true;
-                        break;
-                    }
-                }
-
+                bool addQuote = value.IndexOfAny(delimiters) != -1;
                 if (addQuote)
                 {
                     result.Append(quote);
                 }
 
-                for (int i = 0; i < value.Length; ++i)
+                foreach (char c in value)
                 {
-                    char c = value[i];
                     if (c == quote)
                     {
                         result.Append('\\');

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -604,15 +604,15 @@ namespace ZeroC.Ice
 
         /// <summary>Concatenates a collection of strings in a format that is compatible with
         /// <see cref="Communicator.GetPropertyAsList(string)"/>.</summary>
-        /// <param name="values">The collection that contains of strings to concatenate.</param>
+        /// <param name="values">The collection of strings to concatenate.</param>
         /// <returns>The values concatenated in a string that is compatible with
         /// <see cref="Communicator.GetPropertyAsList(string)"/>.</returns>
         public static string ToPropertyValue(IEnumerable<string> values)
         {
             char[] delimiters = new char[] { ',', ' ', '\n', '\r', '\t' };
             char quote = '"';
+            char delimiter = ',';
             var result = new StringBuilder();
-            char delimiter = ' ';
 
             foreach (string value in values)
             {

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -602,12 +602,12 @@ namespace ZeroC.Ice
             return l.ToArray();
         }
 
-        /// <summary>Concatenates a list of strings in a format that is compatible with
+        /// <summary>Concatenates a collection of strings in a format that is compatible with
         /// <see cref="Communicator.GetPropertyAsList(string)"/>.</summary>
-        /// <param name="values">The list of strings to concatenate.</param>
+        /// <param name="values">The collection that contains of strings to concatenate.</param>
         /// <returns>The values concatenated in a string that is compatible with
         /// <see cref="Communicator.GetPropertyAsList(string)"/>.</returns>
-        public static string JoinStringProperty(IReadOnlyList<string> values)
+        public static string ToPropertyValue(IEnumerable<string> values)
         {
             char[] delimiters = new char[] { ',', ' ', '\n', '\r', '\t' };
             char quote = '"';

--- a/csharp/src/Ice/StringUtil.cs
+++ b/csharp/src/Ice/StringUtil.cs
@@ -602,16 +602,12 @@ namespace ZeroC.Ice
             return l.ToArray();
         }
 
-        public static string JoinString(string[] values, string delimiters)
+        public static string JoinStringProperty(IReadOnlyList<string> values)
         {
-            if (delimiters.Length == 0)
-            {
-                throw new ArgumentException("delimiters cannot be empty", nameof(delimiters));
-            }
-
+            string delimiters = ", \n\r\t";
             char quote = '"';
             var result = new StringBuilder();
-            char delimiter = delimiters[0];
+            char delimiter = ' ';
 
             foreach (string value in values)
             {

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -679,7 +679,7 @@ namespace ZeroC.IceBox
 
                     if (facetNames.Count > 0)
                     {
-                        properties["Ice.Admin.Facets"] = StringUtil.JoinStringProperty(facetNames);
+                        properties["Ice.Admin.Facets"] = StringUtil.ToPropertyValue(facetNames);
                     }
                     return true;
                 }

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -679,7 +679,7 @@ namespace ZeroC.IceBox
 
                     if (facetNames.Count > 0)
                     {
-                        properties["Ice.Admin.Facets"] = StringUtil.JoinString(facetNames.ToArray(), ", \t\n\r");
+                        properties["Ice.Admin.Facets"] = StringUtil.JoinStringProperty(facetNames);
                     }
                     return true;
                 }

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -679,8 +679,7 @@ namespace ZeroC.IceBox
 
                     if (facetNames.Count > 0)
                     {
-                        // TODO: need String.Join with escape!
-                        properties["Ice.Admin.Facets"] = string.Join(" ", facetNames.ToArray());
+                        properties["Ice.Admin.Facets"] = StringUtil.JoinString(facetNames.ToArray(), ", \t\n\r");
                     }
                     return true;
                 }

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -302,8 +302,8 @@ namespace ZeroC.Ice.Test.Properties
 
                 var properties = new Dictionary<string, string>
                 {
-                    { "Services", StringUtil.JoinStringProperty(services) },
-                    { "LoggerProperties", StringUtil.JoinStringProperty(loggerProperties) }
+                    { "Services", StringUtil.ToPropertyValue(services) },
+                    { "LoggerProperties", StringUtil.ToPropertyValue(loggerProperties) }
                 };
 
                 Console.Out.Write("testing properties as list... ");

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Test;
 
@@ -287,6 +288,28 @@ namespace ZeroC.Ice.Test.Properties
                     }
                 }
 
+                Console.Out.WriteLine("ok");
+            }
+
+            {
+                var services = new string[] {"Logging Service", "Authentication Service", "Printing Service"};
+                var loggerProperties = new string[] { "IceSSL.Protocols=tls12,tls13",
+                                                      "Ice.ProgramName=My Service",
+                                                      "Test=Foo's Bar's Demo\"",
+                                                      "Foo\"",
+                                                      "x,y,z",
+                                                      "b"};
+
+                var properties = new Dictionary<string, string>
+                {
+                    { "Services", StringUtil.JoinString(services, ", \t\r\n") },
+                    { "LoggerProperties", StringUtil.JoinString(loggerProperties, ", \t\r\n") }
+                };
+
+                Console.Out.Write("testing properties as list... ");
+                await using var communicator = new Communicator(properties);
+                Assert(communicator.GetPropertyAsList("Services").SequenceEqual(services));
+                Assert(communicator.GetPropertyAsList("LoggerProperties").SequenceEqual(loggerProperties));
                 Console.Out.WriteLine("ok");
             }
         }

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -302,8 +302,8 @@ namespace ZeroC.Ice.Test.Properties
 
                 var properties = new Dictionary<string, string>
                 {
-                    { "Services", StringUtil.JoinString(services, ", \t\r\n") },
-                    { "LoggerProperties", StringUtil.JoinString(loggerProperties, ", \t\r\n") }
+                    { "Services", StringUtil.JoinStringProperty(services) },
+                    { "LoggerProperties", StringUtil.JoinStringProperty(loggerProperties) }
                 };
 
                 Console.Out.Write("testing properties as list... ");


### PR DESCRIPTION
This small PR adds `StringUtil.JoinString` helper method to join a string an escape it to be compatible with `GetPropertyAsList`