### PR TITLE
Remove Ice.Default.Protocol & Ice.Default.Encoding

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -332,19 +332,21 @@ generated from the section label.
         <property name="Config" />
         <property name="ConsoleListener" />
         <property name="Default.CollocationOptimized" />
+        <!-- TODO: remove Default.Encoding -->
         <property name="Default.Encoding" />
         <!-- TODO deprecate Default.EncodingVersion, replaced by Default.Encoding -->
         <property name="Default.EncodingVersion" />
         <property name="Default.EndpointSelection" />
-        <!-- TODO remove Default.Host -->
+        <!-- TODO: remove Default.Host -->
         <property name="Default.Host" />
         <property name="Default.Locator" class="proxy" />
         <property name="Default.LocatorCacheTimeout" />
         <property name="Default.InvocationTimeout" />
         <property name="Default.Package" />
         <property name="Default.PreferNonSecure" />
-         <!-- TODO remove PreferSecure -->
+        <!-- TODO remove PreferSecure -->
         <property name="Default.PreferSecure" />
+        <!-- TODO: remove Default.Protocol -->
         <property name="Default.Protocol" />
         <property name="Default.Router" class="proxy" />
         <property name="Default.SlicedFormat" />

--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -102,11 +102,13 @@ namespace ZeroC.Ice
         /// <param name="serializeDispatch">Indicates whether or not this object adapter serializes the dispatching of
         /// of requests received over the same connection.</param>
         /// <param name="taskScheduler">The optional task scheduler to use for dispatching requests.</param>
+        /// <param name="protocol">The protocol used for this object adapter.</param>
         /// <returns>The new object adapter.</returns>
         public ObjectAdapter CreateObjectAdapter(
             bool serializeDispatch = false,
-            TaskScheduler? taskScheduler = null) =>
-            AddObjectAdapter(serializeDispatch: serializeDispatch, taskScheduler: taskScheduler);
+            TaskScheduler? taskScheduler = null,
+            Protocol protocol = Protocol.Ice2) =>
+            AddObjectAdapter(serializeDispatch: serializeDispatch, taskScheduler: taskScheduler, protocol: protocol);
 
         /// <summary>Creates a new object adapter with the specified endpoint string. Calling this method is equivalent
         /// to setting the name.Endpoints property and then calling
@@ -234,7 +236,8 @@ namespace ZeroC.Ice
             string? name = null,
             bool serializeDispatch = false,
             TaskScheduler? taskScheduler = null,
-            IRouterPrx? router = null)
+            IRouterPrx? router = null,
+            Protocol protocol = Protocol.Ice2)
         {
             if (name != null && name.Length == 0)
             {
@@ -264,7 +267,7 @@ namespace ZeroC.Ice
             ObjectAdapter adapter;
             try
             {
-                adapter = new ObjectAdapter(this, name ?? "", serializeDispatch, taskScheduler, router);
+                adapter = new ObjectAdapter(this, name ?? "", serializeDispatch, taskScheduler, router, protocol);
             }
             catch
             {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -103,7 +103,6 @@ namespace ZeroC.Ice
             set => _defaultContext = value.ToImmutableDictionary();
         }
 
-        public Encoding DefaultEncoding { get; }
         public EndpointSelectionType DefaultEndpointSelection { get; }
 
         /// <summary>The default locator for this communicator. To disable the default locator, null can be used.
@@ -116,10 +115,6 @@ namespace ZeroC.Ice
         }
 
         public bool DefaultPreferNonSecure { get; }
-
-        /// <summary>The Ice protocol used when parsing a stringified proxy that does not specify an Ice protocol.
-        /// </summary>
-        public Protocol DefaultProtocol { get; }
 
         public IPAddress? DefaultSourceAddress { get; }
         public string DefaultTransport { get; }
@@ -365,42 +360,6 @@ namespace ZeroC.Ice
                 }
 
                 TraceLevels = new TraceLevels(this);
-
-                if (GetProperty("Ice.Default.Protocol") is string protocol)
-                {
-                    try
-                    {
-                        DefaultProtocol = ProtocolExtensions.Parse(protocol);
-                        DefaultProtocol.CheckSupported();
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new InvalidConfigurationException(
-                            $"invalid value for for Ice.Default.Protocol: `{protocol}'", ex);
-                    }
-                }
-                else
-                {
-                    DefaultProtocol = Protocol.Ice2;
-                }
-
-                if (GetProperty("Ice.Default.Encoding") is string encoding)
-                {
-                    try
-                    {
-                        DefaultEncoding = Encoding.Parse(encoding);
-                        DefaultEncoding.CheckSupported();
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new InvalidConfigurationException(
-                            $"invalid value for Ice.Default.Encoding: `{encoding}'", ex);
-                    }
-                }
-                else
-                {
-                    DefaultEncoding = DefaultProtocol.GetEncoding();
-                }
 
                 string endpointSelection = GetProperty("Ice.Default.EndpointSelection") ?? "Random";
                 DefaultEndpointSelection = endpointSelection switch

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -108,7 +108,7 @@ namespace ZeroC.IceLocatorDiscovery
             {
                 // Get the locator to send the request to (this will return the void locator if no locator is found)
                 ILocatorPrx newLocator = await GetLocatorAsync().ConfigureAwait(false);
-                if (locator != newLocator)
+                if (!newLocator.Equals(locator))
                 {
                     try
                     {
@@ -139,6 +139,7 @@ namespace ZeroC.IceLocatorDiscovery
                             }
                         }
                         exception = ex;
+                        throw;
                     }
                 }
                 else

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -355,8 +355,6 @@ namespace ZeroC.Ice
         {
             var properties = communicator.GetProperties().Where(p =>
                 p.Key == "Ice.Default.Locator" ||
-                p.Key == "Ice.Default.Encoding" ||
-                p.Key == "Ice.Default.Protocol" ||
                 p.Key.StartsWith("IceSSL.")).ToDictionary(p => p.Key, p => p.Value);
 
             string[] args = communicator.GetPropertyAsList("Ice.Admin.Logger.Properties")?.Select(

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -710,13 +710,15 @@ namespace ZeroC.Ice
             }
         }
 
-        // Called by Communicator
+        // Called by Communicator. fallbackProtocol is used when the protocol can not be inferred
+        // from the endpoints
         internal ObjectAdapter(
             Communicator communicator,
             string name,
             bool serializeDispatch,
             TaskScheduler? scheduler,
-            IRouterPrx? router)
+            IRouterPrx? router,
+            Protocol fallbackProtocol)
         {
             Communicator = communicator;
             Name = name;
@@ -732,7 +734,7 @@ namespace ZeroC.Ice
                 _id = "";
                 _replicaGroupId = "";
                 _acm = Communicator.ServerAcm;
-                Protocol = Communicator.DefaultProtocol;
+                Protocol = fallbackProtocol;
                 return;
             }
 
@@ -822,9 +824,7 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        // TODO: better fallback!
-                        Protocol = Communicator.DefaultProtocol;
-                        Debug.Assert(Protocol != default);
+                        Protocol = fallbackProtocol;
                     }
 
                     if (endpoints == null || endpoints.Count == 0)
@@ -972,20 +972,10 @@ namespace ZeroC.Ice
                 {
                     if (UriParser.IsEndpointUri(value))
                     {
-                        if (Protocol == Protocol.Ice1)
-                        {
-                            throw new InvalidConfigurationException(
-                                $"{Name}.Endpoints and {Name}.PublishedEndpoints must use the same format");
-                        }
                         endpoints = UriParser.ParseEndpoints(value, Communicator);
                     }
                     else
                     {
-                        if (Protocol == Protocol.Ice2)
-                        {
-                            throw new InvalidConfigurationException(
-                                $"{Name}.Endpoints and {Name}.PublishedEndpoints must use the same format");
-                        }
                         endpoints = Ice1Parser.ParseEndpoints(value, Communicator, oaEndpoints: false);
                     }
                 }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -140,7 +140,7 @@ namespace ZeroC.Ice
                     nameof(request));
             }
             (int _, int _, Encoding encoding) =
-                encapsulation.AsReadOnlySpan().ReadEncapsulationHeader(proxy.Protocol.GetEncoding());
+                encapsulation.AsReadOnlySpan().ReadEncapsulationHeader(request.Protocol.GetEncoding());
 
             if (encoding != Encoding)
             {

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
         /// <summary>Parses a protocol string in the stringified proxy format into a Protocol.</summary>
         /// <param name="str">The string to parse.</param>
         /// <returns>The parsed protocol, or throws an exception if the string cannot be parsed.</returns>
-        internal static Protocol Parse(string str)
+        public static Protocol Parse(string str)
         {
             switch (str)
             {

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -652,7 +652,7 @@ namespace ZeroC.Ice
         internal Reference(Communicator communicator, Connection fixedConnection, Identity identity)
             : this(communicator: communicator,
                    context: communicator.DefaultContext,
-                   encoding: communicator.DefaultEncoding,
+                   encoding: fixedConnection.Endpoint.Protocol.GetEncoding(),
                    facet: "",
                    fixedConnection: fixedConnection,
                    identity: identity,

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Glacier2.Test.Router
             // ConnectionLostException.
             //
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
             await using Communicator communicator = Initialize(properties);
 
             IObjectPrx routerBase;

--- a/csharp/test/Glacier2/router/Server.cs
+++ b/csharp/test/Glacier2/router/Server.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Glacier2.Test.Router
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
 
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("CallbackAdapter.Endpoints", GetTestEndpoint(0));

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -149,8 +149,7 @@ namespace ZeroC.Glacier2.Test.SessionHelper
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.Default.Protocol"] = "ice1";
-            properties["Ice.Default.Encoding"] = "1.1";
+            properties["Test.Protocol"] = "ice1";
             properties["Ice.Default.Router"] = GetTestProxy("Glacier2/router", properties, 50);
 
             using Communicator communicator = Initialize(properties);

--- a/csharp/test/Glacier2/sessionHelper/Server.cs
+++ b/csharp/test/Glacier2/sessionHelper/Server.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Glacier2.Test.SessionHelper
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("DeactivatedAdapter.Endpoints", GetTestEndpoint(1));
             communicator.CreateObjectAdapter("DeactivatedAdapter");

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.ACM
                 communicator.SetProperty($"{name}.ACM.Heartbeat", Enum.Parse<AcmHeartbeat>(heartbeatValue).ToString());
             }
 
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             if (!ice1 && host.Contains(':'))
             {
                 host = $"[{host}]";

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             TextWriter output = helper.GetWriter();
             output.Write("testing stringToProxy... ");
             output.Flush();

--- a/csharp/test/Ice/adapterDeactivation/Servant.cs
+++ b/csharp/test/Ice/adapterDeactivation/Servant.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         public (IObjectPrx?, bool?) GetClientProxy(Current current) => (null, false);
 
         public IObjectPrx GetServerProxy(Current current) =>
-            IObjectPrx.Parse(current.Communicator.DefaultProtocol == Protocol.Ice1 ?
+            IObjectPrx.Parse(TestHelper.GetTestProtocol(current.Communicator.GetProperties()) == Protocol.Ice1 ?
                 $"dummy:tcp -h localhost -p {_nextPort++}" : $"ice+tcp://localhost:{_nextPort++}/dummy",
                 current.Communicator);
 

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -127,7 +127,7 @@ namespace ZeroC.Ice.Test.Admin
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
             TextWriter output = helper.GetWriter();
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
 
             output.Write("testing communicator operations... ");
             output.Flush();
@@ -249,7 +249,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(pd["Prop1"] == "1");
                 TestHelper.Assert(pd["Prop2"] == "2");
                 TestHelper.Assert(pd["Prop3"] == "3");
-                TestHelper.Assert(pd["Ice.Default.Protocol"] == communicator.DefaultProtocol.GetName());
+                TestHelper.Assert(pd["Test.Protocol"] == helper.GetTestProtocol().GetName());
 
                 Dictionary<string, string> changes;
 

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -3,6 +3,7 @@
 //
 
 using System.Collections.Generic;
+using Test;
 
 namespace ZeroC.Ice.Test.Admin
 {
@@ -56,7 +57,7 @@ namespace ZeroC.Ice.Test.Admin
                 logger = new NullLogger();
             }
 
-            props.Add("Ice.Default.Protocol", current.Communicator.DefaultProtocol.GetName());
+            props.Add("Test.Protocol", TestHelper.GetTestProtocol(current.Communicator.GetProperties()).GetName());
 
             //
             // Initialize a new communicator.

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -54,6 +54,7 @@ namespace ZeroC.Ice.Test.Binding
         public static void Run(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator();
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
 
@@ -445,7 +446,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (helper.GetTestProtocol() == Protocol.Ice1)
+                if (ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter36", endpoints[2].ToString()));

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -445,7 +445,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (communicator.DefaultProtocol == Protocol.Ice1)
+                if (helper.GetTestProtocol() == Protocol.Ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter36", endpoints[2].ToString()));
@@ -630,7 +630,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (communicator.DefaultProtocol == Protocol.Ice1)
+                if (helper.GetTestProtocol() == Protocol.Ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter66", endpoints[2].ToString()));
@@ -704,7 +704,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (communicator.DefaultProtocol == Protocol.Ice1)
+                if (helper.GetTestProtocol() == Protocol.Ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("AdapterAMI66", endpoints[2].ToString()));
@@ -729,7 +729,7 @@ namespace ZeroC.Ice.Test.Binding
             }
             output.WriteLine("ok");
 
-            if (communicator.DefaultProtocol == Protocol.Ice1)
+            if (helper.GetTestProtocol() == Protocol.Ice1)
             {
                 output.Write("testing endpoint mode filtering... ");
                 output.Flush();
@@ -791,7 +791,7 @@ namespace ZeroC.Ice.Test.Binding
                     }
 
                     // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                    if (communicator.DefaultProtocol == Protocol.Ice1)
+                    if (helper.GetTestProtocol() == Protocol.Ice1)
                     {
                         com.CreateObjectAdapterWithEndpoints("Adapter83", obj.Endpoints[1].ToString()); // Recreate a tcp OA.
 

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Exceptions
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             TextWriter output = helper.GetWriter();
             {
                 output.Write("testing object adapter registration exceptions... ");

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -48,7 +48,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
             if (ports.Count > 1)
             {
                 var sb = new StringBuilder(refString);
-                if (communicator.DefaultProtocol == Protocol.Ice1)
+                if (helper.GetTestProtocol() == Protocol.Ice1)
                 {
                     string transport = helper.GetTestTransport();
                     for (int i = 1; i < ports.Count; ++i)

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Info
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             string transport = communicator.DefaultTransport;
             TextWriter output = helper.GetWriter();
             output.Write("testing proxy endpoint information... ");

--- a/csharp/test/Ice/info/Server.cs
+++ b/csharp/test/Ice/info/Server.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Info
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            if (communicator.DefaultProtocol == Protocol.Ice1)
+            if (GetTestProtocol() == Protocol.Ice1)
             {
                 communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + ":" + GetTestEndpoint(0, "udp"));
             }

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -79,7 +79,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
             output.Write("testing binary context... ");
             output.Flush();
-            bool ice2 = GetTestProtocol() != Protocol.Ice1;
+            bool ice2 = GetTestProtocol() == Protocol.Ice2;
 
             if (ice2)
             {

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -79,7 +79,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
             output.Write("testing binary context... ");
             output.Flush();
-            bool ice2 = Communicator()!.DefaultProtocol != Protocol.Ice1;
+            bool ice2 = GetTestProtocol() != Protocol.Ice1;
 
             if (ice2)
             {

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -69,14 +69,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 }
                 else
                 {
-                    try
-                    {
-                        _ = request.BinaryContext;
-                        TestHelper.Assert(false);
-                    }
-                    catch (NotSupportedException)
-                    {
-                    }
+                    TestHelper.Assert(request.BinaryContext.Count == 0);
                 }
             }
             else if (_lastOperation.Equals("addWithRetry") || _lastOperation.Equals("amdAddWithRetry"))

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Invoke
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             IMyClassPrx oneway = cl.Clone(oneway: true);
 

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Location
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             var manager = IServerManagerPrx.Parse(helper.GetTestProxy("ServerManager", 0), communicator);
             var locator = ITestLocatorPrx.UncheckedCast(communicator.DefaultLocator!);
             Console.WriteLine("registry checkedcast");

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -366,7 +366,7 @@ namespace ZeroC.Ice.Test.Metrics
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             string host = helper.GetTestHost();
             string port = helper.GetTestPort(0).ToString();
             string hostAndPort = host + ":" + port;
@@ -550,7 +550,7 @@ namespace ZeroC.Ice.Test.Metrics
                 cm2 = (ConnectionMetrics)clientMetrics.GetMetricsView("View").ReturnValue["Connection"][0]!;
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
-                int sizeLengthIncrease = communicator.DefaultEncoding == Encoding.V1_1 ? 4 : 1;
+                int sizeLengthIncrease = helper.GetTestEncoding() == Encoding.V1_1 ? 4 : 1;
 
                 TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == requestSz + bs.Length + sizeLengthIncrease);
                 TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == replySz);
@@ -566,7 +566,7 @@ namespace ZeroC.Ice.Test.Metrics
                 cm2 = (ConnectionMetrics)clientMetrics.GetMetricsView("View").ReturnValue["Connection"][0]!;
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
-                sizeLengthIncrease = communicator.DefaultEncoding == Encoding.V1_1 ? 4 : 3;
+                sizeLengthIncrease = helper.GetTestEncoding() == Encoding.V1_1 ? 4 : 3;
 
                 TestHelper.Assert((cm2.SentBytes - cm1.SentBytes) == (requestSz + bs.Length + sizeLengthIncrease));
                 TestHelper.Assert((cm2.ReceivedBytes - cm1.ReceivedBytes) == replySz);
@@ -868,8 +868,8 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(collocated ? map.Count == 5 : map.Count == 6);
 
             // TODO: temporary, currently we often save 2 bytes with the ice2 protocol
-            int protocolRequestSizeAdjustment = communicator.DefaultProtocol == Protocol.Ice1 ? 0 : -3;
-            int protocolReplySizeAdjustment = communicator.DefaultProtocol == Protocol.Ice1 ? 0 : -2;
+            int protocolRequestSizeAdjustment = helper.GetTestProtocol() == Protocol.Ice1 ? 0 : -3;
+            int protocolReplySizeAdjustment = helper.GetTestProtocol() == Protocol.Ice1 ? 0 : -2;
 
             DispatchMetrics dm1;
             dm1 = (DispatchMetrics)map["op"];
@@ -1152,8 +1152,8 @@ namespace ZeroC.Ice.Test.Metrics
                 }
             }
 
-            Encoding defaultEncoding = communicator.DefaultEncoding;
-            string defaultProtocolName = communicator.DefaultProtocol.GetName();
+            Encoding defaultEncoding = helper.GetTestEncoding();
+            string defaultProtocolName = helper.GetTestProtocol().GetName();
 
             TestAttribute(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);
             if (ice1)

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -868,8 +868,8 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(collocated ? map.Count == 5 : map.Count == 6);
 
             // TODO: temporary, currently we often save 2 bytes with the ice2 protocol
-            int protocolRequestSizeAdjustment = helper.GetTestProtocol() == Protocol.Ice1 ? 0 : -3;
-            int protocolReplySizeAdjustment = helper.GetTestProtocol() == Protocol.Ice1 ? 0 : -2;
+            int protocolRequestSizeAdjustment = ice1 ? 0 : -3;
+            int protocolReplySizeAdjustment = ice1 ? 0 : -2;
 
             DispatchMetrics dm1;
             dm1 = (DispatchMetrics)map["op"];

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -14,8 +14,10 @@ namespace ZeroC.Ice.Test.Metrics
         {
             var observer = new CommunicatorObserver();
 
-            Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            properties["Ice.Admin.Endpoints"] = "tcp -h 127.0.0.1";
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
+            bool ice1 = GetTestProtocol(properties) == Protocol.Ice1;
+
+            properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "client";
             properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -15,11 +15,8 @@ namespace ZeroC.Ice.Test.Metrics
             var observer = new CommunicatorObserver();
 
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            bool ice1 = false;
-            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
-            {
-                ice1 = value == "ice1";
-            }
+            bool ice1 = GetTestProtocol(properties) == Protocol.Ice1;
+
             properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "client";
             properties["Ice.Admin.DelayCreation"] = "1";

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -13,11 +13,7 @@ namespace ZeroC.Ice.Test.Metrics
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-            bool ice1 = false;
-            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
-            {
-                ice1 = value == "ice1";
-            }
+            bool ice1 = GetTestProtocol(properties) == Protocol.Ice1;
 
             properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -13,11 +13,7 @@ namespace ZeroC.Ice.Test.Metrics
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-             bool ice1 = false;
-            if (properties.TryGetValue("Ice.Default.Protocol", out string? value))
-            {
-                ice1 = value == "ice1";
-            }
+            bool ice1 = GetTestProtocol(properties) == Protocol.Ice1;
 
             properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "server";

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -945,7 +945,7 @@ namespace ZeroC.Ice.Test.Proxy
             }
             output.WriteLine("ok");
 
-            if (communicator.DefaultProtocol == Protocol.Ice2)
+            if (helper.GetTestProtocol() == Protocol.Ice2)
             {
                 output.Write("testing protocol versioning... ");
                 output.Flush();

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Proxy
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             System.IO.TextWriter output = helper.GetWriter();
             output.Write("testing proxy parsing... ");
             output.Flush();

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -48,7 +48,7 @@ namespace ZeroC.Ice.Test.Retry
             Communicator communicator2,
             string rf)
         {
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1; // TODO should come from helper
+           bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
 
             Instrumentation.TestInvocationReset();
 

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -767,7 +767,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(slices[0].TypeId!.Equals("::ZeroC::Ice::Test::Slicing::Exceptions::SPreserved2"));
                 }
 
-                ObjectAdapter adapter = communicator.CreateObjectAdapter();
+                ObjectAdapter adapter = communicator.CreateObjectAdapter(protocol: helper.GetTestProtocol());
                 IRelayPrx relay = adapter.AddWithUUID(new Relay(), IRelayPrx.Factory);
                 adapter.Activate();
                 testPrx.GetConnection()!.Adapter = adapter;

--- a/csharp/test/Ice/udp/Client.cs
+++ b/csharp/test/Ice/udp/Client.cs
@@ -16,7 +16,6 @@ namespace ZeroC.Ice.Test.UDP
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.UDP.SndSize"] = "16K";
-            properties["Ice.Default.Protocol"] = "ice1"; // TODO: see comment in server
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
 

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -18,11 +18,6 @@ namespace ZeroC.Ice.Test.UDP
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.UDP.RcvSize"] = "16K";
 
-            // TODO: we currently force ice1 for this test because Ice.Default.Protocol is the only way to select
-            // the protocol used by object adapters. Once this is fixed, we should run this test with both ice1 and
-            // ice2, and use only ice1 for the udp object adapter.
-            properties["Ice.Default.Protocol"] = "ice1";
-
             if (AssemblyUtil.IsMacOS &&
                 properties.TryGetValue("Ice.IPv6", out string? value) &&
                 int.TryParse(value, out int ipv6) && ipv6 > 0)

--- a/csharp/test/IceBox/admin/Client.cs
+++ b/csharp/test/IceBox/admin/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.IceBox.Test.Admin
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
             // Shutdown the IceBox server.

--- a/csharp/test/IceBox/configuration/Client.cs
+++ b/csharp/test/IceBox/configuration/Client.cs
@@ -19,7 +19,7 @@ namespace ZeroC.IceBox.Test.Configuration
             // Shutdown the IceBox server.
             string transport = communicator.DefaultTransport.ToString().ToLowerInvariant();
 
-            await IProcessPrx.Parse(communicator.DefaultProtocol == Protocol.Ice1 ?
+            await IProcessPrx.Parse(GetTestProtocol() == Protocol.Ice1 ?
                                     $"DemoIceBox/admin -f Process:{transport} -h 127.0.0.1 -p 9996" :
                                     $"ice+{transport}://127.0.0.1:9996/DemoIceBox/admin#Process",
                                     communicator).ShutdownAsync();

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -19,15 +19,14 @@ namespace ZeroC.IceDiscovery.Test.Simple
             TestHelper.Assert(communicator != null);
             var proxies = new List<IControllerPrx>();
             var indirectProxies = new List<IControllerPrx>();
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
 
             for (int i = 0; i < num; ++i)
             {
-                string id = "controller" + i;
-                proxies.Add(IControllerPrx.Parse(ice1 ? $"{id}" : $"ice:{id}", communicator));
+                proxies.Add(IControllerPrx.Parse(ice1 ? $"controller{i}" : $"ice:controller{i}", communicator));
                 indirectProxies.Add(
-                    IControllerPrx.Parse(ice1 ? $"{id} @ control{i}" : $"ice:control{i}//{id}", communicator));
-
+                    IControllerPrx.Parse(ice1 ? $"controller{i} @ control{i}" : $"ice:control{i}//controller{i}",
+                                         communicator));
             }
 
             output.Write("testing indirect proxies... ");

--- a/csharp/test/IceDiscovery/simple/Client.cs
+++ b/csharp/test/IceDiscovery/simple/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
         {
             var properties = CreateTestProperties(ref args);
             // TODO: see server
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
             await using Ice.Communicator communicator = Initialize(properties);
             int num;
             try

--- a/csharp/test/IceDiscovery/simple/Server.cs
+++ b/csharp/test/IceDiscovery/simple/Server.cs
@@ -16,10 +16,10 @@ namespace ZeroC.IceDiscovery.Test.Simple
         public override async Task RunAsync(string[] args)
         {
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            // TODO: we currently force ice1 for this test because Ice.Default.Protocol is the only way to select
+            // TODO: we currently force ice1 for this test because Test.Protocol is the only way to select
             // the protocol used by object adapters. Once this is fixed, we should run this test with both ice1 and
             // ice2, and use only ice1 for the udp object adapter.
-            properties["Ice.Default.Protocol"] = "ice1";
+            properties["Test.Protocol"] = "ice1";
 
             await using Communicator communicator = Initialize(properties);
             int num = 0;

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -13,9 +13,10 @@ namespace ZeroC.IceDiscovery.Test.Simple
         public void ActivateObjectAdapter(string name, string adapterId, string replicaGroupId, Current current)
         {
             Communicator communicator = current.Adapter.Communicator;
+            bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             communicator.SetProperty($"{name}.AdapterId", adapterId);
             communicator.SetProperty($"{name}.ReplicaGroupId", replicaGroupId);
-            communicator.SetProperty($"{name}.Endpoints", "default -h 127.0.0.1");
+            communicator.SetProperty($"{name}.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1");
             ObjectAdapter oa = communicator.CreateObjectAdapter(name);
             _adapters[name] = oa;
             oa.Activate();

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -34,6 +34,7 @@ namespace ZeroC.IceGrid.Test.Simple
             Console.Out.WriteLine("ok");
 
             Console.Out.Write("testing discovery... ");
+            Console.Out.Flush();
             {
                 // Add test well-known object
                 var registry = IRegistryPrx.Parse(

--- a/csharp/test/IceGrid/simple/Client.cs
+++ b/csharp/test/IceGrid/simple/Client.cs
@@ -18,8 +18,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 ref args,
                 new Dictionary<string, string>
                 {
-                    ["Ice.Default.Protocol"] = "ice1",
-                    ["Ice.Default.Encoding"] = "1.1"
+                    ["Test.Protocol"] = "ice1",
                 });
             if (args.Any(v => v.Equals("--with-deploy")))
             {

--- a/csharp/test/IceGrid/simple/Server.cs
+++ b/csharp/test/IceGrid/simple/Server.cs
@@ -15,8 +15,7 @@ namespace ZeroC.IceGrid.Test.Simple
         {
             var properties = new Dictionary<string, string>();
             properties.ParseArgs(ref args, "TestAdapter");
-            properties.Add("Ice.Default.Encoding", "1.1");
-            properties.Add("Ice.Default.Protocol", "ice1");
+            properties.Add("Test.Protocol", "ice1");
 
             await using Communicator communicator = Initialize(ref args, properties);
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -272,7 +272,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
+                    bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                             "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
@@ -318,7 +318,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    bool ice1 = serverCommunicator.DefaultProtocol == Protocol.Ice1;
+                    bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                         "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -79,7 +79,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     RequireClientCertificate = requireClientCertificate
                 });
 
-            bool ice1 = communicator.DefaultProtocol == Protocol.Ice1;
+            bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             string host = TestHelper.GetTestHost(communicator.GetProperties());
 
             ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -57,19 +57,9 @@ namespace Test
                 }
             }
 
-            bool uriFormat = true;
-            // TODO: switch to a different test-only property to select the protocol
-            if (properties.TryGetValue("Ice.Default.Protocol", out string? protocolValue))
-            {
-                if (protocolValue == "ice1")
-                {
-                    uriFormat = false;
-                }
-            }
-
             string host = GetTestHost(properties);
 
-            if (uriFormat)
+            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
             {
                 var sb = new StringBuilder("ice+");
                 sb.Append(transport);
@@ -118,17 +108,7 @@ namespace Test
             int num = 0,
             string? transport = null)
         {
-            bool uriFormat = true;
-            // TODO: switch to a different test-only property to select the protocol
-            if (properties.TryGetValue("Ice.Default.Protocol", out string? protocolValue))
-            {
-                if (protocolValue == "ice1")
-                {
-                    uriFormat = false;
-                }
-            }
-
-            if (uriFormat) // i.e. ice2
+            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
             {
                 var sb = new StringBuilder("ice+");
                 sb.Append(transport ?? GetTestTransport(properties));
@@ -182,6 +162,30 @@ namespace Test
             }
             return host;
         }
+
+        public Protocol GetTestProtocol() => GetTestProtocol(_communicator!.GetProperties());
+
+        public static Protocol GetTestProtocol(Dictionary<string, string> properties)
+        {
+            if (!properties.TryGetValue("Test.Protocol", out string? value))
+            {
+                return Protocol.Ice2;
+            }
+            try
+            {
+                return ProtocolExtensions.Parse(value);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidConfigurationException(
+                    $"invalid value for for Test.Protocol: `{value}'", ex);
+            }
+        }
+
+        public ZeroC.Ice.Encoding GetTestEncoding() => GetTestEncoding(_communicator!.GetProperties());
+
+        public static ZeroC.Ice.Encoding GetTestEncoding(Dictionary<string, string> properties)
+            => ProtocolExtensions.GetEncoding(GetTestProtocol(properties));
 
         public string GetTestTransport() => GetTestTransport(_communicator!.GetProperties());
 

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -738,8 +738,9 @@ class Mapping(object):
                 if self.transport:
                     props["Ice.Default.Transport"] = self.transport
                 if self.protocol:
-                    useTestHost = isinstance(process.getMapping(current), CSharpMapping) and not process.isFromBinDir()
-                    hostProperty = "Test.Protocol" if useTestHost else "Ice.Default.Protocol"
+                    useTestProtocol = isinstance(process.getMapping(current), CSharpMapping) \
+                                      and not process.isFromBinDir()
+                    hostProperty = "Test.Protocol" if useTestProtocol else "Ice.Default.Protocol"
                     props[hostProperty] = self.protocol
                 if self.compress:
                     props["Ice.Override.Compress"] = "1"

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -738,7 +738,9 @@ class Mapping(object):
                 if self.transport:
                     props["Ice.Default.Transport"] = self.transport
                 if self.protocol:
-                    props["Ice.Default.Protocol"] = self.protocol
+                    useTestHost = isinstance(process.getMapping(current), CSharpMapping) and not process.isFromBinDir()
+                    hostProperty = "Test.Protocol" if useTestHost else "Ice.Default.Protocol"
+                    props[hostProperty] = self.protocol
                 if self.compress:
                     props["Ice.Override.Compress"] = "1"
                 if self.serialize:


### PR DESCRIPTION
Removed the `Ice.Default.Protocol` and `Ice.Default.Encoding` properties.  The tests now use the `Test.Protocol` property.