### PR TITLE
Request context improvements

### DIFF
--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -80,8 +80,6 @@ namespace ZeroC.Ice
         // Position of the start of the encapsulation.
         private protected OutputStream.Position _encapsulationStart;
 
-        private protected bool _skipDefaultBinaryContextEntry0;
-
         private readonly CompressionLevel _compressionLevel;
         private readonly int _compressionMinSize;
 

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -128,8 +128,8 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Compresses the encapsulation payload using GZip compression, compressed encapsulation payload is
-        /// only supported with 2.0 encoding.</summary>
+        /// <summary>Compresses the encapsulation payload using GZip compression. Compressed encapsulation payload is
+        /// only supported with the 2.0 encoding.</summary>
         /// <returns>A <see cref="CompressionResult"/> value indicating the result of the compression operation.
         /// </returns>
         public CompressionResult CompressPayload()
@@ -298,7 +298,7 @@ namespace ZeroC.Ice
         private protected void FinishEncapsulation(OutputStream.Position encapsulationEnd) =>
             _encapsulationEnd = encapsulationEnd;
 
-        // Finish prepares the frame for sending, adjusts the last written segment to match the offset of the written
+        // Finish prepares the frame for sending and adjusts the last written segment to match the offset of the written
         // data. If the frame contains a binary context, Finish appends the entries from _defaultBinaryContext (if any)
         // and rewrites the binary context dictionary size.
         internal virtual void Finish()
@@ -316,15 +316,13 @@ namespace ZeroC.Ice
                         int dictionarySize = istr.ReadSize();
                         for (int i = 0; i < dictionarySize; ++i)
                         {
+                            int startPos = istr.Pos;
                             int key = istr.ReadVarInt();
                             int entrySize = istr.ReadSize();
-                            if (ContainsKey(key))
+                            istr.Skip(entrySize);
+                            if (!ContainsKey(key))
                             {
-                                istr.Skip(entrySize);
-                            }
-                            else
-                            {
-                                Data.Add(_defaultBinaryContext.Slice(istr.Pos, entrySize));
+                                Data.Add(_defaultBinaryContext.Slice(startPos, istr.Pos - startPos));
                                 AddKey(key);
                             }
                         }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -224,7 +224,7 @@ namespace ZeroC.Ice
             IsSealed = Protocol == Protocol.Ice1;
         }
 
-        // Finish prepares the frame for sending ad writes the frame's context into slot 0 of the binary context.
+        // Finish prepares the frame for sending and writes the frame's context into slot 0 of the binary context.
         internal override void Finish()
         {
             if (!IsSealed)

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -143,12 +143,11 @@ namespace ZeroC.Ice
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet
         /// and context of this proxy to create the request frame.</param>
         /// <param name="request">The incoming request from which to create an outgoing request.</param>
-        public OutgoingRequestFrame(
-            IObjectPrx proxy,
-            IncomingRequestFrame request,
-            bool compress = false,
-            bool forwardBinaryContext = true)
-            : this(proxy, request.Operation, request.IsIdempotent, compress, request.Context)
+        /// <param name="forwardBinaryContext">When true (the default), the new frame uses the incoming request frame's
+        /// binary context as a fallback - all the entries in this binary context are added before the frame is sent,
+        /// except for entries previously added by invocation interceptors.</param>
+        public OutgoingRequestFrame(IObjectPrx proxy, IncomingRequestFrame request, bool forwardBinaryContext = true)
+            : this(proxy, request.Operation, request.IsIdempotent, compress: false, request.Context)
         {
             if (request.Protocol == Protocol)
             {
@@ -173,7 +172,6 @@ namespace ZeroC.Ice
                 // constructor (when Protocol == Ice1) or will be written by Finish (when Protocol == Ice2).
                 // The payload encoding must remain the same since we cannot transcode the encoded bytes.
 
-                // TODO: is there a cleaner way to get this value?
                 int sizeLength = request.Protocol == Protocol.Ice1 ? 4 : (1 << (request.Encapsulation[0] & 0x03));
 
                 OutputStream.Position tail =

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -229,7 +229,7 @@ namespace ZeroC.Ice
         {
             if (!IsSealed)
             {
-                if (Protocol == Protocol.Ice2 && !_binaryContextKeys.Contains(0))
+                if (Protocol == Protocol.Ice2 && !ContainsKey(0))
                 {
                     if (Context.Count > 0 || _writeSlot0)
                     {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -210,24 +210,19 @@ namespace ZeroC.Ice
             {
                 if (Protocol == Protocol.Ice2 && !_binaryContextKeys.Contains(0))
                 {
-                    if (ContextOverride != null)
+                    if (ContextOverride != null && ContextOverride.Count == 0)
                     {
-                        if (ContextOverride.Count == 0)
-                        {
-                            // make sure the slot is used so base does not write it when forwarding the binary context
-                            _binaryContextKeys.Add(0);
-                        }
-                        else
-                        {
-                            AddBinaryContextEntry(0, ContextOverride, ContextHelper.IceWriter);
-                        }
+                       // Make sure the slot is used so base does not write anything in slot 0 when forwarding the
+                       // binary context
+                       _binaryContextKeys.Add(0);
                     }
-                    else if (_defaultBinaryContext.Count == 0 && Context.Count > 0)
+                    else if (Context.Count > 0)
                     {
-                        // _defaultBinaryContext.Count == 0 means we're not forwarding the binary context
+                        // Write the context now. This is necessary even when _defaultBinaryContext is not empty,
+                        // because _initialContext can be different from slot 0 in _defaultBinaryContext.
                         AddBinaryContextEntry(0, Context, ContextHelper.IceWriter);
                     }
-                    // else, base writes Context as part of _defaultBinaryContext (if set, i.e. forwarding)
+                    // else we don't write Context since it's empty
                 }
                 base.Finish();
             }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -85,6 +85,9 @@ namespace ZeroC.Ice
         /// </param>
         /// <param name="response">The incoming response for which this constructor creates an outgoing response frame.
         /// </param>
+        /// <param name="forwardBinaryContext">When true (the default), the new frame uses the incoming response frame's
+        /// binary context as a fallback - all the entries in this binary context are added before the frame is sent,
+        /// except for entries previously added by dispatch interceptors.</param>
         public OutgoingResponseFrame(
             IncomingRequestFrame request,
             IncomingResponseFrame response,
@@ -116,7 +119,6 @@ namespace ZeroC.Ice
             }
             else
             {
-                // TODO: is there a more elegant way to get this value?
                 int sizeLength = response.Protocol == Protocol.Ice1 ? 4 : (1 << (response.Encapsulation[0] & 0x03));
 
                 // Create a small buffer to hold the result type or reply status plus the encapsulation header.

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -114,7 +114,7 @@ namespace ZeroC.Ice
 
                 if (forwardBinaryContext && response.BinaryContext.Count > 0)
                 {
-                    _defaultBinaryContext = response.Data.Slice(1 + response.Encapsulation.Count);
+                    _defaultBinaryContext = response.Data.Slice(1 + response.Encapsulation.Count); // can be empty
                 }
             }
             else

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -977,30 +977,6 @@ namespace ZeroC.Ice
             }
         }
 
-        internal IReadOnlyDictionary<string, string> CurrentContext()
-        {
-            IReadOnlyDictionary<string, string> context;
-
-            if (Context.Count == 0)
-            {
-                context = Communicator.CurrentContext;
-            }
-            else if (Communicator.CurrentContext.Count == 0)
-            {
-                context = Context;
-            }
-            else
-            {
-                var combinedContext = new Dictionary<string, string>(Communicator.CurrentContext);
-                foreach ((string key, string value) in Context)
-                {
-                    combinedContext[key] = value;  // the proxy Context entry prevails.
-                }
-                context = combinedContext;
-            }
-            return context;
-        }
-
         internal Connection? GetCachedConnection() => _requestHandler?.GetConnection();
 
         internal async ValueTask<IRequestHandler> GetConnectionRequestHandlerAsync(CancellationToken cancel)

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -90,7 +90,6 @@ namespace ZeroC.Ice.Test.Interceptor
                         {
                             if (ice2)
                             {
-                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
                                 request.ContextOverride["interceptor-1"] = "interceptor-1";
                                 request.AddBinaryContextEntry(110, 110, (ostr, v) => ostr.WriteInt(v));
                             }
@@ -101,7 +100,6 @@ namespace ZeroC.Ice.Test.Interceptor
                             if (ice2)
                             {
                                 TestHelper.Assert(request.Context["interceptor-1"] == "interceptor-1");
-                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
                                 request.ContextOverride["interceptor-2"] = "interceptor-2";
                                 request.AddBinaryContextEntry(120, 120, (ostr, v) => ostr.WriteInt(v));
                             }
@@ -133,7 +131,6 @@ namespace ZeroC.Ice.Test.Interceptor
                         {
                             if (ice2)
                             {
-                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
                                 request.ContextOverride["interceptor-1"] = "interceptor-1";
                             }
                             return next(target, request);
@@ -169,7 +166,6 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         (target, request, next) =>
                         {
-                            request.ContextOverride ??= new Dictionary<string, string>(request.Context);
                             request.ContextOverride["interceptor-1"] = "interceptor-1";
                             return next(target, request);
                         },

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -88,19 +88,21 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         (target, request, next) =>
                         {
-                            request.Context["interceptor-1"] = "interceptor-1";
                             if (ice2)
                             {
+                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
+                                request.ContextOverride["interceptor-1"] = "interceptor-1";
                                 request.AddBinaryContextEntry(110, 110, (ostr, v) => ostr.WriteInt(v));
                             }
                             return next(target, request);
                         },
                         async (target, request, next) =>
                         {
-                            TestHelper.Assert(request.Context["interceptor-1"] == "interceptor-1");
-                            request.Context["interceptor-2"] = "interceptor-2";
                             if (ice2)
                             {
+                                TestHelper.Assert(request.Context["interceptor-1"] == "interceptor-1");
+                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
+                                request.ContextOverride["interceptor-2"] = "interceptor-2";
                                 request.AddBinaryContextEntry(120, 120, (ostr, v) => ostr.WriteInt(v));
                             }
                             IncomingResponseFrame response = await next(target, request);
@@ -129,7 +131,11 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         (target, request, next) =>
                         {
-                            request.Context["interceptor-1"] = "interceptor-1";
+                            if (ice2)
+                            {
+                                request.ContextOverride ??= new Dictionary<string, string>(request.Context);
+                                request.ContextOverride["interceptor-1"] = "interceptor-1";
+                            }
                             return next(target, request);
                         },
                         async (target, request, next) =>
@@ -163,7 +169,8 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         (target, request, next) =>
                         {
-                            request.Context["interceptor-1"] = "interceptor-1";
+                            request.ContextOverride ??= new Dictionary<string, string>(request.Context);
+                            request.ContextOverride["interceptor-1"] = "interceptor-1";
                             return next(target, request);
                         },
                         (target, request, next) =>

--- a/csharp/test/Ice/interceptor/InvocationPlugin.cs
+++ b/csharp/test/Ice/interceptor/InvocationPlugin.cs
@@ -3,7 +3,6 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Test;
 

--- a/csharp/test/Ice/interceptor/InvocationPlugin.cs
+++ b/csharp/test/Ice/interceptor/InvocationPlugin.cs
@@ -22,7 +22,6 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         if (request.Protocol == Protocol.Ice2)
                         {
-                            request.ContextOverride ??= new Dictionary<string, string>(request.Context);
                             request.ContextOverride["InvocationPlugin"] = "1";
                         }
                         IncomingResponseFrame response = await next(target, request);

--- a/csharp/test/Ice/interceptor/InvocationPlugin.cs
+++ b/csharp/test/Ice/interceptor/InvocationPlugin.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Test;
 
@@ -19,7 +20,11 @@ namespace ZeroC.Ice.Test.Interceptor
                 context.AddInvocationInterceptor(
                     async (target, request, next) =>
                     {
-                        request.Context["InvocationPlugin"] = "1";
+                        if (request.Protocol == Protocol.Ice2)
+                        {
+                            request.ContextOverride ??= new Dictionary<string, string>(request.Context);
+                            request.ContextOverride["InvocationPlugin"] = "1";
+                        }
                         IncomingResponseFrame response = await next(target, request);
                         if (response.Protocol == Protocol.Ice2 && response.ResultType == ResultType.Success)
                         {

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -48,7 +48,8 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
         private static ITestIntfPrx TestProxy(ITestIntfPrx prx)
         {
-            var ctx = new Dictionary<string, string> { { "MyCtx", "hello"} };
+            var ctx = new Dictionary<string, string>(prx.Context);
+            ctx.Add("MyCtx", "hello");
 
             TestHelper.Assert(prx.Op(13, ctx) == 13);
             prx.OpVoid(ctx);

--- a/csharp/test/Ice/protocolBridging/TestI.cs
+++ b/csharp/test/Ice/protocolBridging/TestI.cs
@@ -18,20 +18,23 @@ namespace ZeroC.Ice.Test.ProtocolBridging
         {
             if (current.Operation == "op" || current.Operation == "opVoid")
             {
-                TestHelper.Assert(current.Context.Count == 1);
-                TestHelper.Assert(current.Context["MyCtx"] == "hello");
+                TestHelper.Assert(request.Context.Count == 1);
+                TestHelper.Assert(request.Context["MyCtx"] == "hello");
+
+                if (current.Operation == "opVoid")
+                {
+                    request.Context.Clear();
+                }
             }
             else
             {
-                TestHelper.Assert(current.Context.Count == 0);
+                TestHelper.Assert(request.Context.Count == 0);
             }
 
             if (current.Operation != "opVoid" && current.Operation != "shutdown")
             {
                 request.Context["Intercepted"] = "1";
             }
-
-            // TODO: add interceptors to test binary context forwarding with ice2.
 
             return _target.ForwardAsync(current.IsOneway, request);
         }
@@ -51,14 +54,14 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
         public void OpVoid(Current current)
         {
-            TestHelper.Assert(current.Context["MyCtx"] == "hello");
             if (current.Context.Count == 2)
             {
+                TestHelper.Assert(current.Context["MyCtx"] == "hello");
                 TestHelper.Assert(current.Context.ContainsKey("Direct"));
             }
             else
             {
-                TestHelper.Assert(current.Context.Count == 1);
+                TestHelper.Assert(current.Context.Count == 0);
             }
         }
 

--- a/csharp/test/Ice/protocolBridging/TestI.cs
+++ b/csharp/test/Ice/protocolBridging/TestI.cs
@@ -26,10 +26,12 @@ namespace ZeroC.Ice.Test.ProtocolBridging
                 TestHelper.Assert(current.Context.Count == 0);
             }
 
-            if (current.Operation != "shutdown")
+            if (current.Operation != "opVoid" && current.Operation != "shutdown")
             {
                 request.Context["Intercepted"] = "1";
             }
+
+            // TODO: add interceptors to test binary context forwarding with ice2.
 
             return _target.ForwardAsync(current.IsOneway, request);
         }
@@ -42,22 +44,21 @@ namespace ZeroC.Ice.Test.ProtocolBridging
         public int Op(int x, Current current)
         {
             TestHelper.Assert(current.Context["MyCtx"] == "hello");
-            if (current.Context.Count > 1)
-            {
-                TestHelper.Assert(current.Context.Count == 2);
-                TestHelper.Assert(current.Context.ContainsKey("Intercepted"));
-            }
-
+            TestHelper.Assert(current.Context.Count == 2);
+            TestHelper.Assert(current.Context.ContainsKey("Intercepted") || current.Context.ContainsKey("Direct"));
             return x;
         }
 
         public void OpVoid(Current current)
         {
             TestHelper.Assert(current.Context["MyCtx"] == "hello");
-            if (current.Context.Count > 1)
+            if (current.Context.Count == 2)
             {
-                TestHelper.Assert(current.Context.Count == 2);
-                TestHelper.Assert(current.Context.ContainsKey("Intercepted"));
+                TestHelper.Assert(current.Context.ContainsKey("Direct"));
+            }
+            else
+            {
+                TestHelper.Assert(current.Context.Count == 1);
             }
         }
 


### PR DESCRIPTION
This PR ensures that request contexts are usually not copied when creating an OutgoingRequestFrame.

It also reworks the context forwarding logic when forwarding from ice2 to ice2. In particular, an interceptor can now override the entries in a forwarded binary context (implemented but not tested).