### PR TITLE
Add factory parameter to all Clone overloads

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2355,37 +2355,6 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "return true;";
     _out << eb;
 
-    _out << sp;
-    _out << nl << "public static ";
-    if(!bases.empty())
-    {
-        _out << "new ";
-    }
-    _out << name << " UncheckedCast(ZeroC.Ice.IObjectPrx prx) => new _" << p->name()
-        << "Prx(prx.IceReference);";
-
-    _out << sp;
-    _out << nl << "public static ";
-    if(!bases.empty())
-    {
-        _out << "new ";
-    }
-    _out << name << "? CheckedCast(ZeroC.Ice.IObjectPrx prx, "
-         << "global::System.Collections.Generic.IReadOnlyDictionary<string, string>? context = null)";
-    _out << sb;
-
-    _out << nl << "if (prx.IceIsA(ZeroC.Ice.TypeExtensions.GetIceTypeId(typeof(" << interfaceName(p)
-         << "Prx))!, context))";
-    _out << sb;
-    _out << nl << "return new _" << p->name() << "Prx(prx.IceReference);";
-    _out << eb;
-    _out << nl << "else";
-    _out << sb;
-    _out << nl << "return null;";
-    _out << eb;
-
-    _out << eb;
-
     _out << eb;
 
     //

--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -374,9 +374,7 @@ namespace ZeroC.Glacier2
                 try
                 {
                     _callback.CreatedCommunicator(this);
-                    Ice.IRouterPrx? defaultRouter = _communicator.DefaultRouter;
-                    Debug.Assert(defaultRouter != null);
-                    var routerPrx = IRouterPrx.UncheckedCast(defaultRouter);
+                    IRouterPrx routerPrx = _communicator.DefaultRouter!.Clone(IRouterPrx.Factory);
                     ISessionPrx session = factory(routerPrx);
                     Connected(routerPrx, session);
                 }

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -207,7 +207,7 @@ namespace ZeroC.Ice
         /// <param name="preferNonSecure">Determines whether the clone prefers non-secure connections over secure
         /// connections (optional).</param>
         /// <param name="router">The router proxy of the clone (optional).</param>
-        /// <returns>A new proxy with the same type as this proxy.</returns>
+        /// <returns>A new proxy manufactured by the proxy factory (see factory parameter).</returns>
         public static T Clone<T>(
             this IObjectPrx prx,
             ProxyFactory<T> factory,

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -15,8 +15,8 @@ namespace ZeroC.Ice
     /// <summary>Proxy provides extension methods for IObjectPrx</summary>
     public static class Proxy
     {
-        /// <summary>Tests whether this proxy points to a remote object derived from T. If so it returns
-        /// a proxy of type T otherwise returns null.</summary>
+        /// <summary>Tests whether this proxy points to a remote object derived from T. If so it returns a proxy of
+        /// type T otherwise returns null.</summary>
         /// <param name="prx">The source proxy.</param>
         /// <param name="factory">The proxy factory used to manufacture the returned proxy.</param>
         /// <param name="context">The request context used for the remote
@@ -230,24 +230,24 @@ namespace ZeroC.Ice
             IRouterPrx? router = null) where T : IObjectPrx
         {
             return factory(prx.IceReference.Clone(adapterId,
-                                                     cacheConnection,
-                                                     clearLocator,
-                                                     clearRouter,
-                                                     connectionId,
-                                                     context,
-                                                     encoding,
-                                                     endpointSelection,
-                                                     endpoints,
-                                                     facet: null,
-                                                     fixedConnection,
-                                                     identity: null,
-                                                     invocationMode,
-                                                     invocationTimeout,
-                                                     locator,
-                                                     locatorCacheTimeout,
-                                                     oneway,
-                                                     preferNonSecure,
-                                                     router));
+                                                  cacheConnection,
+                                                  clearLocator,
+                                                  clearRouter,
+                                                  connectionId,
+                                                  context,
+                                                  encoding,
+                                                  endpointSelection,
+                                                  endpoints,
+                                                  facet: null,
+                                                  fixedConnection,
+                                                  identity: null,
+                                                  invocationMode,
+                                                  invocationTimeout,
+                                                  locator,
+                                                  locatorCacheTimeout,
+                                                  oneway,
+                                                  preferNonSecure,
+                                                  router));
         }
 
         /// <summary>Creates a clone of this proxy. The clone is identical to this proxy except for options set

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -15,6 +15,27 @@ namespace ZeroC.Ice
     /// <summary>Proxy provides extension methods for IObjectPrx</summary>
     public static class Proxy
     {
+        /// <summary>Tests whether this proxy points to a remote object derived from T. If so it returns
+        /// a proxy of type T otherwise returns null.</summary>
+        /// <param name="prx">The source proxy.</param>
+        /// <param name="factory">The proxy factory used to manufacture the returned proxy.</param>
+        /// <param name="context">The request context used for the remote
+        /// <see cref="IObjectPrx.IceIsA(string, IReadOnlyDictionary{string, string}?)"/> invocation.</param>
+        /// <returns>A new proxy manufactured by the proxy factory (see factory parameter).</returns>
+        public static T? CheckedCast<T>(
+            this IObjectPrx prx,
+            ProxyFactory<T> factory,
+            IReadOnlyDictionary<string, string>? context = null) where T : class, IObjectPrx
+        {
+            if (prx.IceIsA(TypeExtensions.GetIceTypeId(typeof(T))!, context))
+            {
+                return factory(prx.IceReference);
+            }
+            else
+            {
+                return null;
+            }
+        }
         /// <summary>Creates a clone of this proxy, with a new identity and optionally other options. The clone
         /// is identical to this proxy except for its identity and other options set through parameters.</summary>
         /// <param name="prx">The source proxy.</param>
@@ -157,6 +178,76 @@ namespace ZeroC.Ice
                                                   oneway,
                                                   preferNonSecure,
                                                   router));
+        }
+
+        /// <summary>Creates a clone of this proxy. The clone is identical to this proxy except for options set
+        /// through parameters. This method returns this proxy instead of a new proxy in the event none of the options
+        /// specified through the parameters change this proxy's options.</summary>
+        /// <param name="prx">The source proxy.</param>
+        /// <param name="factory">The proxy factory used to manufacture the clone.</param>
+        /// <param name="adapterId">The adapter ID of the clone (optional).</param>
+        /// <param name="cacheConnection">Determines whether or not the clone caches its connection (optional).</param>
+        /// <param name="clearLocator">When set to true, the clone does not have an associated locator proxy (optional).
+        /// </param>
+        /// <param name="clearRouter">When set to true, the clone does not have an associated router proxy (optional).
+        /// </param>
+        /// <param name="connectionId">The connection ID of the clone (optional).</param>
+        /// <param name="context">The context of the clone (optional).</param>
+        /// <param name="encoding">The encoding of the clone (optional).</param>
+        /// <param name="endpointSelection">The encoding selection policy of the clone (optional).</param>
+        /// <param name="endpoints">The endpoints of the clone (optional).</param>
+        /// <param name="fixedConnection">The connection of the clone (optional). When specified, the clone is a fixed
+        /// proxy. You can clone a non-fixed proxy into a fixed proxy but not vice-versa.</param>
+        /// <param name="invocationMode">The invocation mode of the clone (optional).</param>
+        /// <param name="invocationTimeout">The invocation timeout of the clone (optional).</param>
+        /// <param name="locator">The locator proxy of the clone (optional).</param>
+        /// <param name="locatorCacheTimeout">The locator cache timeout of the clone (optional).</param>
+        /// <param name="oneway">Determines whether the clone is oneway or twoway (optional). This is a simplified
+        /// version of the invocationMode parameter.</param>
+        /// <param name="preferNonSecure">Determines whether the clone prefers non-secure connections over secure
+        /// connections (optional).</param>
+        /// <param name="router">The router proxy of the clone (optional).</param>
+        /// <returns>A new proxy with the same type as this proxy.</returns>
+        public static T Clone<T>(
+            this IObjectPrx prx,
+            ProxyFactory<T> factory,
+            string? adapterId = null,
+            bool? cacheConnection = null,
+            bool clearLocator = false,
+            bool clearRouter = false,
+            string? connectionId = null,
+            IReadOnlyDictionary<string, string>? context = null,
+            Encoding? encoding = null,
+            EndpointSelectionType? endpointSelection = null,
+            IEnumerable<Endpoint>? endpoints = null,
+            Connection? fixedConnection = null,
+            InvocationMode? invocationMode = null,
+            TimeSpan? invocationTimeout = null,
+            ILocatorPrx? locator = null,
+            TimeSpan? locatorCacheTimeout = null,
+            bool? oneway = null,
+            bool? preferNonSecure = null,
+            IRouterPrx? router = null) where T : IObjectPrx
+        {
+            return factory(prx.IceReference.Clone(adapterId,
+                                                     cacheConnection,
+                                                     clearLocator,
+                                                     clearRouter,
+                                                     connectionId,
+                                                     context,
+                                                     encoding,
+                                                     endpointSelection,
+                                                     endpoints,
+                                                     facet: null,
+                                                     fixedConnection,
+                                                     identity: null,
+                                                     invocationMode,
+                                                     invocationTimeout,
+                                                     locator,
+                                                     locatorCacheTimeout,
+                                                     oneway,
+                                                     preferNonSecure,
+                                                     router));
         }
 
         /// <summary>Creates a clone of this proxy. The clone is identical to this proxy except for options set

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -37,7 +37,7 @@ namespace ZeroC.Glacier2.Test.Router
             {
                 Console.Out.Write("testing checked cast for router... ");
                 Console.Out.Flush();
-                router = IRouterPrx.CheckedCast(routerBase);
+                router = routerBase.CheckedCast(IRouterPrx.Factory);
                 Assert(router != null);
                 Console.Out.WriteLine("ok");
             }

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -19,15 +19,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             TextWriter output = helper.GetWriter();
             output.Write("testing stringToProxy... ");
             output.Flush();
-            var baseprx = IObjectPrx.Parse(helper.GetTestProxy("test", 0), communicator);
-            TestHelper.Assert(baseprx != null);
-            output.WriteLine("ok");
-
-            output.Write("testing checked cast... ");
-            output.Flush();
-            var obj = ITestIntfPrx.CheckedCast(baseprx);
-            TestHelper.Assert(obj != null);
-            TestHelper.Assert(obj.Equals(baseprx));
+            var obj = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             output.WriteLine("ok");
 
             {
@@ -135,7 +127,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             output.Flush();
             {
                 var routerId = new Identity("router", "");
-                IRouterPrx router = baseprx.Clone(routerId, IRouterPrx.Factory, connectionId: "rc");
+                IRouterPrx router = obj.Clone(routerId, IRouterPrx.Factory, connectionId: "rc");
                 ObjectAdapter adapter = communicator.CreateObjectAdapterWithRouter(router);
                 TestHelper.Assert(adapter.GetPublishedEndpoints().Count == 1);
                 string endpointsStr = adapter.GetPublishedEndpoints()[0].ToString();
@@ -173,7 +165,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 try
                 {
                     routerId = new Identity("test", "");
-                    router = baseprx.Clone(routerId, IRouterPrx.Factory);
+                    router = obj.Clone(routerId, IRouterPrx.Factory);
                     communicator.CreateObjectAdapterWithRouter(router);
                     TestHelper.Assert(false);
                 }

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -468,7 +468,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 try
                 {
-                    IProcessPrx.CheckedCast(obj.Clone(facet: "Process", IObjectPrx.Factory));
+                    obj.Clone(facet: "Process", IProcessPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -477,7 +477,7 @@ namespace ZeroC.Ice.Test.Admin
 
                 try
                 {
-                    ITestFacetPrx.CheckedCast(obj.Clone(facet: "TestFacet", IObjectPrx.Factory));
+                    obj.Clone(facet: "TestFacet", ITestFacetPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -499,7 +499,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 try
                 {
-                    IPropertiesAdminPrx.CheckedCast(obj.Clone(facet: "Properties", IObjectPrx.Factory));
+                    obj.Clone(facet: "Properties", IPropertiesAdminPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -508,7 +508,7 @@ namespace ZeroC.Ice.Test.Admin
 
                 try
                 {
-                    ITestFacetPrx.CheckedCast(obj.Clone(facet: "TestFacet", IObjectPrx.Factory));
+                    obj.Clone(facet: "TestFacet", ITestFacetPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -530,7 +530,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 try
                 {
-                    IPropertiesAdminPrx.CheckedCast(obj.Clone(facet: "Properties", IObjectPrx.Factory));
+                    obj.Clone(facet: "Properties", IPropertiesAdminPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -539,7 +539,7 @@ namespace ZeroC.Ice.Test.Admin
 
                 try
                 {
-                    IProcessPrx.CheckedCast(obj.Clone(facet: "Process", IObjectPrx.Factory));
+                    obj.Clone(facet: "Process", IProcessPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -561,11 +561,12 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 IPropertiesAdminPrx pa = obj.Clone("Properties", IPropertiesAdminPrx.Factory);
                 TestHelper.Assert(pa.GetProperty("Ice.Admin.InstanceName").Equals("Test"));
-                var tf = ITestFacetPrx.CheckedCast(obj.Clone(facet: "TestFacet", IObjectPrx.Factory));
+                ITestFacetPrx? tf =
+                    obj.Clone(facet: "TestFacet", IObjectPrx.Factory).CheckedCast(ITestFacetPrx.Factory);
                 tf!.Op();
                 try
                 {
-                    IProcessPrx.CheckedCast(obj.Clone(facet: "Process", IObjectPrx.Factory));
+                    obj.Clone(facet: "Process", IProcessPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
@@ -587,16 +588,18 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 try
                 {
-                    IPropertiesAdminPrx.CheckedCast(obj.Clone(facet: "Properties", IObjectPrx.Factory));
+                    obj.Clone(facet: "Properties", IPropertiesAdminPrx.Factory).IcePing();
                     TestHelper.Assert(false);
                 }
                 catch (ObjectNotExistException)
                 {
                 }
-                var tf = ITestFacetPrx.CheckedCast(obj.Clone(facet: "TestFacet", IObjectPrx.Factory));
+                ITestFacetPrx? tf =
+                    obj.Clone(facet: "TestFacet", IObjectPrx.Factory).CheckedCast(ITestFacetPrx.Factory);
                 TestHelper.Assert(tf != null);
                 tf.Op();
-                var proc = IProcessPrx.CheckedCast(obj.Clone(facet: "Process", IObjectPrx.Factory));
+                IProcessPrx? proc =
+                    obj.Clone(facet: "Process", IObjectPrx.Factory).CheckedCast(IProcessPrx.Factory);
                 TestHelper.Assert(proc != null);
                 proc.Shutdown();
                 com.WaitForShutdown();

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -76,7 +76,7 @@ namespace ZeroC.Ice.Test.Binding
 
                 com.DeactivateObjectAdapter(adapter);
 
-                var test3 = ITestIntfPrx.UncheckedCast(test1);
+                var test3 = test1.Clone(ITestIntfPrx.Factory);
                 TestHelper.Assert(test3.GetConnection() == test1.GetConnection());
                 TestHelper.Assert(test3.GetConnection() == test2.GetConnection());
 
@@ -489,7 +489,7 @@ namespace ZeroC.Ice.Test.Binding
 
                 com.DeactivateObjectAdapter(adapter);
 
-                var test3 = ITestIntfPrx.UncheckedCast(test1);
+                var test3 = test1.Clone(ITestIntfPrx.Factory);
                 try
                 {
                     TestHelper.Assert(test3.GetConnection() == test1.GetConnection());

--- a/csharp/test/Ice/enums/AllTests.cs
+++ b/csharp/test/Ice/enums/AllTests.cs
@@ -14,12 +14,7 @@ namespace ZeroC.Ice.Test.Enums
         {
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
-            string sref = helper.GetTestProxy("test", 0);
-            var obj = IObjectPrx.Parse(sref, communicator);
-            TestHelper.Assert(obj != null);
-            var proxy = ITestIntfPrx.UncheckedCast(obj);
-            TestHelper.Assert(proxy != null);
-
+            var proxy = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             System.IO.TextWriter output = helper.GetWriter();
 
             output.Write("testing enum values... ");

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -366,7 +366,7 @@ namespace ZeroC.Ice.Test.Exceptions
 
             try
             {
-                var thrower2 = IWrongOperationPrx.UncheckedCast(thrower);
+                var thrower2 = thrower.Clone(IWrongOperationPrx.Factory);
                 thrower2.NoSuchOperation();
                 TestHelper.Assert(false);
             }
@@ -772,7 +772,7 @@ namespace ZeroC.Ice.Test.Exceptions
             {
                 try
                 {
-                    var thrower4 = IWrongOperationPrx.UncheckedCast(thrower);
+                    var thrower4 = thrower.Clone(IWrongOperationPrx.Factory);
                     thrower4.NoSuchOperationAsync().Wait();
                     TestHelper.Assert(false);
                 }
@@ -959,7 +959,7 @@ namespace ZeroC.Ice.Test.Exceptions
             output.Flush();
 
             {
-                var thrower4 = IWrongOperationPrx.UncheckedCast(thrower);
+                var thrower4 = thrower.Clone(IWrongOperationPrx.Factory);
                 try
                 {
                     thrower4.NoSuchOperationAsync().Wait();

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -67,12 +67,12 @@ namespace ZeroC.Ice.Test.Facets
 
             output.Write("testing unchecked cast... ");
             output.Flush();
-            d = IDPrx.UncheckedCast(prx);
+            d = prx.Clone(IDPrx.Factory);
             TestHelper.Assert(d != null);
             TestHelper.Assert(d.Facet.Length == 0);
             IDPrx df = prx.Clone("facetABCD", IDPrx.Factory);
             TestHelper.Assert(df.Facet == "facetABCD");
-            df2 = IDPrx.UncheckedCast(df);
+            df2 = df.Clone(IDPrx.Factory);
             TestHelper.Assert(df2 != null);
             TestHelper.Assert(df2.Facet == "facetABCD");
             df3 = df.Clone(facet: "", IDPrx.Factory);
@@ -82,12 +82,12 @@ namespace ZeroC.Ice.Test.Facets
 
             output.Write("testing checked cast... ");
             output.Flush();
-            d = IDPrx.CheckedCast(prx);
+            d = prx.CheckedCast(IDPrx.Factory);
             TestHelper.Assert(d != null);
             TestHelper.Assert(d.Facet.Length == 0);
             df = prx.Clone(facet: "facetABCD", IDPrx.Factory);
             TestHelper.Assert(df.Facet == "facetABCD");
-            df2 = IDPrx.CheckedCast(df);
+            df2 = df.Clone(IDPrx.Factory);
             TestHelper.Assert(df2 != null);
             TestHelper.Assert(df2.Facet == "facetABCD");
             df3 = df.Clone(facet: "", IDPrx.Factory);
@@ -96,7 +96,7 @@ namespace ZeroC.Ice.Test.Facets
 
             output.Write("testing non-facets A, B, C, and D... ");
             output.Flush();
-            d = IDPrx.CheckedCast(prx);
+            d = prx.Clone(IDPrx.Factory);
             TestHelper.Assert(d != null);
             TestHelper.Assert(d.Equals(prx));
             TestHelper.Assert(d.CallA().Equals("A"));
@@ -130,7 +130,7 @@ namespace ZeroC.Ice.Test.Facets
 
             output.Write("testing whether casting preserves the facet... ");
             output.Flush();
-            var hf = IHPrx.CheckedCast(gf);
+            var hf = gf.Clone(IHPrx.Factory);
             TestHelper.Assert(hf != null);
             TestHelper.Assert(hf.CallG().Equals("G"));
             TestHelper.Assert(hf.CallH().Equals("H"));

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -76,14 +76,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
                 refString = sb.ToString();
             }
 
-            var basePrx = IObjectPrx.Parse(refString, communicator);
-            output.WriteLine("ok");
-
-            output.Write("testing checked cast... ");
-            output.Flush();
-            var obj = ITestIntfPrx.CheckedCast(basePrx);
-            TestHelper.Assert(obj != null);
-            TestHelper.Assert(obj.Equals(basePrx));
+            var obj = ITestIntfPrx.Parse(refString, communicator);
             output.WriteLine("ok");
 
             int oldPid = 0;

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -18,9 +18,9 @@ namespace ZeroC.Ice.Test.Location
             TestHelper.Assert(communicator != null);
             bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             var manager = IServerManagerPrx.Parse(helper.GetTestProxy("ServerManager", 0), communicator);
-            var locator = ITestLocatorPrx.UncheckedCast(communicator.DefaultLocator!);
+            var locator = communicator.DefaultLocator!.Clone(ITestLocatorPrx.Factory);
             Console.WriteLine("registry checkedcast");
-            var registry = ITestLocatorRegistryPrx.CheckedCast(locator.GetRegistry()!);
+            var registry = locator.GetRegistry()!.Clone(ITestLocatorRegistryPrx.Factory);
             TestHelper.Assert(registry != null);
 
             System.IO.TextWriter output = helper.GetWriter();
@@ -86,17 +86,17 @@ namespace ZeroC.Ice.Test.Location
 
             output.Write("testing checked cast... ");
             output.Flush();
-            var obj1 = ITestIntfPrx.CheckedCast(base1);
+            var obj1 = base1.CheckedCast(ITestIntfPrx.Factory);
             TestHelper.Assert(obj1 != null);
-            var obj2 = ITestIntfPrx.CheckedCast(base2);
+            var obj2 = base2.CheckedCast(ITestIntfPrx.Factory);
             TestHelper.Assert(obj2 != null);
-            var obj3 = ITestIntfPrx.CheckedCast(base3);
+            var obj3 = base3.CheckedCast(ITestIntfPrx.Factory);
             TestHelper.Assert(obj3 != null);
-            var obj4 = IServerManagerPrx.CheckedCast(base4);
+            var obj4 = base4.CheckedCast(IServerManagerPrx.Factory);
             TestHelper.Assert(obj4 != null);
-            var obj5 = ITestIntfPrx.CheckedCast(base5);
+            var obj5 = base5.CheckedCast(ITestIntfPrx.Factory);
             TestHelper.Assert(obj5 != null);
-            var obj6 = ITestIntfPrx.CheckedCast(base6);
+            var obj6 = base6.CheckedCast(ITestIntfPrx.Factory);
             TestHelper.Assert(obj6 != null);
             output.WriteLine("ok");
 
@@ -190,7 +190,7 @@ namespace ZeroC.Ice.Test.Location
             manager.StartServer();
             try
             {
-                obj5 = ITestIntfPrx.CheckedCast(base5);
+                obj5 = base5.CheckedCast(ITestIntfPrx.Factory);
                 TestHelper.Assert(obj5 != null);
                 obj5.IcePing();
             }
@@ -641,11 +641,11 @@ namespace ZeroC.Ice.Test.Location
             TestHelper.Assert(helloPrx.GetConnection() == null);
 
             // Ensure that calls on the indirect proxy (with adapter ID) is collocated
-            helloPrx = IHelloPrx.CheckedCast(adapter.CreateIndirectProxy(id, IObjectPrx.Factory));
+            helloPrx = adapter.CreateIndirectProxy(id, IObjectPrx.Factory).CheckedCast(IHelloPrx.Factory);
             TestHelper.Assert(helloPrx != null && helloPrx.GetConnection() == null);
 
             // Ensure that calls on the direct proxy is collocated
-            helloPrx = IHelloPrx.CheckedCast(adapter.CreateDirectProxy(id, IObjectPrx.Factory));
+            helloPrx = adapter.CreateDirectProxy(id, IObjectPrx.Factory).CheckedCast(IHelloPrx.Factory);
             TestHelper.Assert(helloPrx != null && helloPrx.GetConnection() == null);
 
             output.WriteLine("ok");

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -386,17 +386,17 @@ namespace ZeroC.Ice.Test.Metrics
             IObjectPrx? admin = communicator.GetAdmin();
             TestHelper.Assert(admin != null);
             var clientProps =
-                IPropertiesAdminPrx.CheckedCast(admin.Clone(facet: "Properties", IObjectPrx.Factory));
+                admin.Clone(facet: "Properties", IObjectPrx.Factory).CheckedCast(IPropertiesAdminPrx.Factory);
             var clientMetrics =
-                IMetricsAdminPrx.CheckedCast(admin.Clone(facet: "Metrics", IObjectPrx.Factory));
+                admin.Clone(facet: "Metrics", IObjectPrx.Factory).CheckedCast(IMetricsAdminPrx.Factory);
             TestHelper.Assert(clientProps != null && clientMetrics != null);
 
             admin = metrics.GetAdmin();
             TestHelper.Assert(admin != null);
             var serverProps =
-                IPropertiesAdminPrx.CheckedCast(admin.Clone(facet: "Properties", IObjectPrx.Factory));
+                admin.Clone(facet: "Properties", IObjectPrx.Factory).CheckedCast(IPropertiesAdminPrx.Factory);
             var serverMetrics =
-                IMetricsAdminPrx.CheckedCast(admin.Clone(facet: "Metrics", IObjectPrx.Factory));
+                admin.Clone(facet: "Metrics", IObjectPrx.Factory).CheckedCast(IMetricsAdminPrx.Factory);
             TestHelper.Assert(serverProps != null && serverMetrics != null);
 
             var update = new UpdateCallbackI(serverProps);

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -15,14 +15,7 @@ namespace ZeroC.Ice.Test.NamespaceMD
             System.IO.TextWriter output = helper.GetWriter();
             output.Write("testing stringToProxy... ");
             output.Flush();
-            var @base = IObjectPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
-            output.WriteLine("ok");
-
-            output.Write("testing checked cast... ");
-            output.Flush();
-            var initial = IInitialPrx.CheckedCast(@base);
-            TestHelper.Assert(initial != null);
-            TestHelper.Assert(initial.Equals(@base));
+            var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
             output.WriteLine("ok");
 
             {

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1856,7 +1856,7 @@ namespace ZeroC.Ice.Test.Operations
                 TestHelper.Assert(p.OpStringS2(Array.Empty<string>()).Length == 0);
                 TestHelper.Assert(p.OpByteBoolD2(new Dictionary<byte, bool>()).Count == 0);
 
-                var d = IMyDerivedClassPrx.UncheckedCast(p);
+                var d = p.Clone(IMyDerivedClassPrx.Factory);
                 var s = new MyStruct1();
                 s.TesT = "MyStruct1.s";
                 s.MyClass = null;

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -1297,7 +1297,7 @@ namespace ZeroC.Ice.Test.Operations
             p.OpOnewayMetadataAsync().Wait();
 
             {
-                var derived = IMyDerivedClassPrx.CheckedCast(p);
+                var derived = p.Clone(IMyDerivedClassPrx.Factory);
                 TestHelper.Assert(derived != null);
                 derived.OpDerivedAsync().Wait();
             }

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -14,7 +14,6 @@ namespace ZeroC.Ice.Test.ProtocolBridging
         public static ITestIntfPrx Run(TestHelper helper)
         {
             Communicator communicator = helper.Communicator()!;
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
 
             var forwardSamePrx = ITestIntfPrx.Parse(helper.GetTestProxy("ForwardSame", 0), communicator);
             var forwardOtherPrx = ITestIntfPrx.Parse(helper.GetTestProxy("ForwardOther", 0), communicator);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -839,16 +839,16 @@ namespace ZeroC.Ice.Test.Proxy
 
             output.Write("testing checked cast... ");
             output.Flush();
-            var cl = IMyClassPrx.CheckedCast(baseProxy);
+            var cl = baseProxy.CheckedCast(IMyClassPrx.Factory);
             TestHelper.Assert(cl != null);
-            var derived = IMyDerivedClassPrx.CheckedCast(cl);
+            var derived = cl.CheckedCast(IMyDerivedClassPrx.Factory);
             TestHelper.Assert(derived != null);
             TestHelper.Assert(cl.Equals(baseProxy));
             TestHelper.Assert(derived.Equals(baseProxy));
             TestHelper.Assert(cl.Equals(derived));
             try
             {
-                IMyDerivedClassPrx.CheckedCast(cl.Clone(facet: "facet", IObjectPrx.Factory));
+                cl.Clone(facet: "facet", IMyDerivedClassPrx.Factory).IcePing();
                 TestHelper.Assert(false);
             }
             catch (ObjectNotExistException)
@@ -867,7 +867,7 @@ namespace ZeroC.Ice.Test.Proxy
                 ["one"] = "hello",
                 ["two"] = "world"
             };
-            cl = IMyClassPrx.CheckedCast(baseProxy, c);
+            cl = baseProxy.CheckedCast(IMyClassPrx.Factory, c);
             Dictionary<string, string> c2 = cl!.GetContext();
             TestHelper.Assert(c.DictionaryEquals(c2));
             output.WriteLine("ok");
@@ -878,7 +878,7 @@ namespace ZeroC.Ice.Test.Proxy
                 output.Flush();
                 var ice2Prx = IObjectPrx.Parse(
                     "ice+tcp://localhost:10000/foo?alt-endpoint=ice+ws://localhost:10000", communicator);
-                var prx = IMyDerivedClassPrx.UncheckedCast(baseProxy).Echo(ice2Prx);
+                var prx = baseProxy.Clone(IMyDerivedClassPrx.Factory).Echo(ice2Prx);
                 TestHelper.Assert(ice2Prx.Equals(prx));
                 output.WriteLine("ok");
             }
@@ -888,7 +888,7 @@ namespace ZeroC.Ice.Test.Proxy
                 output.Flush();
                 var ice1Prx = IObjectPrx.Parse(
                     "foo:tcp -h localhost -p 10000:udp -h localhost -p 10000", communicator);
-                var prx = IMyDerivedClassPrx.UncheckedCast(baseProxy).Echo(ice1Prx);
+                var prx = baseProxy.Clone(IMyDerivedClassPrx.Factory).Echo(ice1Prx);
                 TestHelper.Assert(ice1Prx.Equals(prx));
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -55,16 +55,10 @@ namespace ZeroC.Ice.Test.Retry
             TextWriter output = helper.GetWriter();
             output.Write("testing stringToProxy... ");
             output.Flush();
-            var base1 = IObjectPrx.Parse(rf, communicator);
-            var base2 = IObjectPrx.Parse(rf, communicator);
-            output.WriteLine("ok");
-
-            output.Write("testing checked cast... ");
-            output.Flush();
-            var retry1 = IRetryPrx.CheckedCast(base1);
-            TestHelper.Assert(retry1 != null && retry1.Equals(base1));
-            var retry2 = IRetryPrx.CheckedCast(base2);
-            TestHelper.Assert(retry2 != null && retry2.Equals(base2));
+            var retry1 = IRetryPrx.Parse(rf, communicator);
+            retry1.IcePing();
+            var retry2 = IRetryPrx.Parse(rf, communicator);
+            retry2.IcePing();
             output.WriteLine("ok");
 
             output.Write("calling regular operation with first proxy... ");

--- a/csharp/test/IceBox/admin/AllTests.cs
+++ b/csharp/test/IceBox/admin/AllTests.cs
@@ -26,7 +26,7 @@ namespace ZeroC.IceBox.Test.Admin
                 //
                 // Test: Verify that the custom facet is present.
                 //
-                facet = ITestFacetPrx.CheckedCast(admin.Clone(facet: "TestFacet", IObjectPrx.Factory));
+                facet = admin.Clone(facet: "TestFacet", IObjectPrx.Factory).Clone(ITestFacetPrx.Factory);
                 TestHelper.Assert(facet != null);
                 facet.IcePing();
             }
@@ -35,8 +35,8 @@ namespace ZeroC.IceBox.Test.Admin
             Console.Out.Write("testing properties facet... ");
             Console.Out.Flush();
             {
-                var pa = IPropertiesAdminPrx.CheckedCast(
-                    admin.Clone(facet: "IceBox.Service.TestService.Properties", IObjectPrx.Factory));
+                IPropertiesAdminPrx pa = admin.Clone(facet: "IceBox.Service.TestService.Properties",
+                                                     IObjectPrx.Factory).Clone(IPropertiesAdminPrx.Factory);
 
                 // Test: PropertiesAdmin.GetProperty()
                 TestHelper.Assert(pa != null);
@@ -86,10 +86,12 @@ namespace ZeroC.IceBox.Test.Admin
             Console.Out.Write("testing metrics admin facet... ");
             Console.Out.Flush();
             {
-                var ma = IMetricsAdminPrx.CheckedCast(
-                    admin.Clone(facet: "IceBox.Service.TestService.Metrics", IObjectPrx.Factory));
-                var pa = IPropertiesAdminPrx.CheckedCast(
-                    admin.Clone(facet: "IceBox.Service.TestService.Properties", IObjectPrx.Factory));
+                IMetricsAdminPrx? ma =
+                    admin.Clone(facet: "IceBox.Service.TestService.Metrics",
+                                IObjectPrx.Factory).CheckedCast(IMetricsAdminPrx.Factory);
+                IPropertiesAdminPrx? pa =
+                    admin.Clone(facet: "IceBox.Service.TestService.Properties",
+                                IObjectPrx.Factory).CheckedCast(IPropertiesAdminPrx.Factory);
 
                 TestHelper.Assert(ma != null && pa != null);
                 string[] views = ma.GetMetricsViewNames().ReturnValue;

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -28,8 +28,7 @@ namespace ZeroC.IceGrid.Test.Simple
 
             Console.Out.Write("testing locator finder... ");
             var finderId = new Identity("LocatorFinder", "Ice");
-            var finder =
-                ILocatorFinderPrx.CheckedCast(communicator.DefaultLocator!.Clone(finderId, IObjectPrx.Factory));
+            ILocatorFinderPrx finder = communicator.DefaultLocator!.Clone(finderId, ILocatorFinderPrx.Factory);
             TestHelper.Assert(finder != null && finder.GetLocator() != null);
             Console.Out.WriteLine("ok");
 
@@ -65,9 +64,8 @@ namespace ZeroC.IceGrid.Test.Simple
                     // TODO: currently, com.DefaultLocator is a regular ice2/2.0 proxy and we don't want to forward
                     // 2.0-encoded requests to IceGrid until IceGrid supports such requests.
 
-                    // TODO: all Clone overloads should accept a factory parameter.
-                    ILocatorPrx defaultLocator =
-                        ILocatorPrx.UncheckedCast(com.DefaultLocator!.Clone(encoding: Encoding.V1_1));
+                    ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(ILocatorPrx.Factory,
+                                                                           encoding: Encoding.V1_1);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() != null);
                     TestHelper.Assert(defaultLocator.GetLocalRegistry() != null);
@@ -101,13 +99,13 @@ namespace ZeroC.IceGrid.Test.Simple
                     {
                     }
 
-                    ZeroC.Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.V1_1);
+                    Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.V1_1);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() == null);
-                    TestHelper.Assert(ILocatorPrx.CheckedCast(defaultLocator) == null);
+                    TestHelper.Assert(defaultLocator.CheckedCast(ILocatorPrx.Factory) == null);
                     try
                     {
-                        ILocatorPrx.UncheckedCast(com.DefaultLocator!).GetLocalRegistry();
+                        com.DefaultLocator!.Clone(ILocatorPrx.Factory).GetLocalRegistry();
                     }
                     catch (OperationNotExistException)
                     {


### PR DESCRIPTION
This PR adds factory parameter to all proxy Clone overloads, it also remove the generated CheckedCast and UncheckedCast, there is a new CheckedCast that takes a factory parameter, I didn't add an UncheckedCast with factory because that is the same that doing a Clone with just passing a new factory.

There is a Clone without factory for the case that you want to keep the same proxy type, but it is otherwise equivalent to the new version that has a factory parameter. 