### PR TITLE
Fixes to run service tests with SSL when --all is used

### DIFF
--- a/cpp/test/IceGrid/session/AllTests.cpp
+++ b/cpp/test/IceGrid/session/AllTests.cpp
@@ -1186,7 +1186,7 @@ allTests(Test::TestHelper* helper)
                                          Ice::Identity(),
                                          Ice::Identity());
 
-        Ice::ObjectAdapterPtr adpt2 = communicator->createObjectAdapterWithEndpoints("Observer2", "default");
+        Ice::ObjectAdapterPtr adpt2 = communicator->createObjectAdapterWithEndpoints("Observer2", "tcp");
         ApplicationObserverIPtr appObs2 = new ApplicationObserverI("appObs2");
         Ice::ObjectPrx app2 = adpt2->addWithUUID(appObs2);
         NodeObserverIPtr nodeObs2 = new NodeObserverI("nodeObs1");
@@ -1972,7 +1972,7 @@ allTests(Test::TestHelper* helper)
 
         session1->ice_getConnection()->setACM(registry->getACMTimeout(), IceUtil::None, Ice::HeartbeatOnIdle);
 
-        Ice::ObjectAdapterPtr adpt1 = communicator->createObjectAdapterWithEndpoints("", "default");
+        Ice::ObjectAdapterPtr adpt1 = communicator->createObjectAdapterWithEndpoints("", "tcp");
         NodeObserverIPtr nodeObs1 = new NodeObserverI("nodeObs1");
         Ice::ObjectPrx no1 = adpt1->addWithUUID(nodeObs1);
         adpt1->activate();
@@ -1989,7 +1989,7 @@ allTests(Test::TestHelper* helper)
     {
         cout << "testing observer with indirect proxy... " << flush;
         AdminSessionPrx session1 = registry->createAdminSession("admin1", "test1");
-        communicator->getProperties()->setProperty("IndirectAdpt1.Endpoints", "default");
+        communicator->getProperties()->setProperty("IndirectAdpt1.Endpoints", "tcp");
         communicator->getProperties()->setProperty("IndirectAdpt1.AdapterId", "adapter1");
         Ice::ObjectAdapterPtr adpt1 = communicator->createObjectAdapter("IndirectAdpt1");
         test(communicator->getDefaultLocator());

--- a/cpp/test/IceStorm/repgrid/test.py
+++ b/cpp/test/IceStorm/repgrid/test.py
@@ -3,7 +3,9 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+# Use the IceGridServer for the client because the client is an IceStorm subscriber and needs to be able
+# to accept connections (this is important for picking the correct server certificate for TLS).
 if isinstance(platform, Windows) or os.getuid() != 0:
     TestSuite(__file__, [ IceGridTestCase(icegridregistry=IceGridRegistryMaster(),
-                                          client=IceGridClient()) ],
+                                          client=IceGridServer()) ],
               runOnMainThread=True, multihost=False)

--- a/cpp/test/IceStorm/repstress/Publisher.cpp
+++ b/cpp/test/IceStorm/repstress/Publisher.cpp
@@ -115,7 +115,7 @@ Publisher::run(int argc, char** argv)
     //
     SinglePrx single = SinglePrx::uncheckedCast(topic->getPublisher()->ice_twoway()->ice_connectionCached(false));
 
-    ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("ControllerAdapter", "default");
+    ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("ControllerAdapter", "tcp");
     Ice::ObjectPrx controller = adapter->addWithUUID(new ControllerI);
     adapter->activate();
     cout << communicator->proxyToString(controller) << endl;

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -181,7 +181,7 @@ class Ice(Component):
         if parent not in ["Ice", "IceBox", "IceGrid", "Glacier2", "IceStorm", "IceDiscovery", "IceBridge"]:
             return None
 
-        if not isinstance(testcase, ClientServerTestCase):
+        if isinstance(testcase, CollocatedTestCase):
             return None
 
         # Define here Ice tests which are slow to execute and for which it's not useful to test different options
@@ -189,7 +189,7 @@ class Ice(Component):
             return self.serviceOptions
 
         # We only run the client/server tests defined for cross testing with all transports
-        if testcase.__class__.__name__ == 'ClientServerTestCase' and self.isCross(testcase.getTestSuite().getId()):
+        if isinstance(testcase, ClientServerTestCase) and self.isCross(testcase.getTestSuite().getId()):
             return self.transportOptions
         elif parent in ["Ice", "IceBox"]:
             return self.coreOptions


### PR DESCRIPTION
This PR brings back testing with SSL for Ice services. It also fixes few tests where SSL testing was failing due to the client certificate no longer supporting being used for server side (because of the extended key usage setting not specifying serverAuth for the client certificate). 