### PR TITLE
Remove Ice.Default.Transport

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -117,7 +117,6 @@ namespace ZeroC.Ice
         public bool DefaultPreferNonSecure { get; }
 
         public IPAddress? DefaultSourceAddress { get; }
-        public string DefaultTransport { get; }
         public TimeSpan DefaultInvocationTimeout { get; }
         public TimeSpan DefaultLocatorCacheTimeout { get; }
 
@@ -404,8 +403,6 @@ namespace ZeroC.Ice
                             $"invalid IP address set for Ice.Default.SourceAddress: `{address}'", ex);
                     }
                 }
-
-                DefaultTransport = GetProperty("Ice.Default.Transport") ?? "tcp";
 
                 DefaultInvocationTimeout =
                     GetPropertyAsTimeSpan("Ice.Default.InvocationTimeout") ?? Timeout.InfiniteTimeSpan;;

--- a/csharp/src/Ice/Ice1Parser.cs
+++ b/csharp/src/Ice/Ice1Parser.cs
@@ -539,7 +539,7 @@ namespace ZeroC.Ice
             string transportName = args[0];
             if (transportName == "default")
             {
-                transportName = communicator.DefaultTransport;
+                transportName = "tcp";
             }
 
             var options = new Dictionary<string, string?>();

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.ACM
         public IRemoteObjectAdapterPrx CreateObjectAdapter(int timeout, string? close, string? heartbeat, Current current)
         {
             Communicator communicator = current.Adapter.Communicator;
-            string transport = communicator.GetProperty("Ice.Default.Transport") ?? "tcp";
+            string transport = communicator.GetProperty("Test.Transport")!;
             string host = communicator.GetProperty("Test.Host")!;
 
             string name = Guid.NewGuid().ToString();

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -11,11 +11,11 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
     {
         public void Transient(Current current)
         {
-            bool ice1 = TestHelper.GetTestProtocol(current.Adapter.Communicator.GetProperties()) == Protocol.Ice1;
-            var transport = TestHelper.GetTestTransport(current.Adapter.Communicator.GetProperties());
+            bool ice1 = TestHelper.GetTestProtocol(current.Communicator.GetProperties()) == Protocol.Ice1;
+            var transport = TestHelper.GetTestTransport(current.Communicator.GetProperties());
             var endpoint = ice1 ? "{transport} -h localhost" : $"ice+{transport}://localhost:0";
 
-            using ObjectAdapter adapter = current.Adapter.Communicator.CreateObjectAdapterWithEndpoints(
+            using ObjectAdapter adapter = current.Communicator.CreateObjectAdapterWithEndpoints(
                 "TransientTestAdapter", endpoint);
             adapter.Activate();
         }

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -3,6 +3,7 @@
 //
 
 using System.Threading.Tasks;
+using Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {
@@ -10,8 +11,12 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
     {
         public void Transient(Current current)
         {
+            bool ice1 = TestHelper.GetTestProtocol(current.Adapter.Communicator.GetProperties()) == Protocol.Ice1;
+            var transport = TestHelper.GetTestTransport(current.Adapter.Communicator.GetProperties());
+            var endpoint = ice1 ? "{transport} -h localhost" : $"ice+{transport}://localhost:0";
+
             using ObjectAdapter adapter = current.Adapter.Communicator.CreateObjectAdapterWithEndpoints(
-                "TransientTestAdapter", "default -h localhost");
+                "TransientTestAdapter", endpoint);
             adapter.Activate();
         }
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -57,6 +57,7 @@ namespace ZeroC.Ice.Test.Binding
             bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
+            var testTransport = helper.GetTestTransport();
 
             var rand = new Random(unchecked((int)DateTime.Now.Ticks));
             System.IO.TextWriter output = helper.GetWriter();
@@ -64,6 +65,7 @@ namespace ZeroC.Ice.Test.Binding
             output.Write("testing binding with single endpoint... ");
             output.Flush();
             {
+                // Use "default" here to ensure that it still works
                 IRemoteObjectAdapterPrx? adapter = com.CreateObjectAdapter("Adapter", "default");
                 TestHelper.Assert(adapter != null);
                 ITestIntfPrx? test1 = adapter.GetTestIntf();
@@ -96,9 +98,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("Adapter11", "default")!,
-                    com.CreateObjectAdapter("Adapter12", "default")!,
-                    com.CreateObjectAdapter("Adapter13", "default")!
+                    com.CreateObjectAdapter("Adapter11", testTransport)!,
+                    com.CreateObjectAdapter("Adapter12", testTransport)!,
+                    com.CreateObjectAdapter("Adapter13", testTransport)!
                 };
 
                 // Ensure that when a connection is opened it's reused for new proxies and that all endpoints are
@@ -186,11 +188,11 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new IRemoteObjectAdapterPrx[5]
                 {
-                    com.CreateObjectAdapter("AdapterRandom11", "default")!,
-                    com.CreateObjectAdapter("AdapterRandom12", "default")!,
-                    com.CreateObjectAdapter("AdapterRandom13", "default")!,
-                    com.CreateObjectAdapter("AdapterRandom14", "default")!,
-                    com.CreateObjectAdapter("AdapterRandom15", "default")!
+                    com.CreateObjectAdapter("AdapterRandom11", testTransport)!,
+                    com.CreateObjectAdapter("AdapterRandom12", testTransport)!,
+                    com.CreateObjectAdapter("AdapterRandom13", testTransport)!,
+                    com.CreateObjectAdapter("AdapterRandom14", testTransport)!,
+                    com.CreateObjectAdapter("AdapterRandom15", testTransport)!
                 };
 
                 int count = 20;
@@ -268,9 +270,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("AdapterAMI11", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI12", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI13", "default")!
+                    com.CreateObjectAdapter("AdapterAMI11", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI12", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI13", testTransport)!
                 };
 
                 //
@@ -362,9 +364,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("Adapter21", "default")!,
-                    com.CreateObjectAdapter("Adapter22", "default")!,
-                    com.CreateObjectAdapter("Adapter23", "default")!
+                    com.CreateObjectAdapter("Adapter21", testTransport)!,
+                    com.CreateObjectAdapter("Adapter22", testTransport)!,
+                    com.CreateObjectAdapter("Adapter23", testTransport)!
                 };
 
                 ITestIntfPrx obj = CreateTestIntfPrx(adapters);
@@ -404,9 +406,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("Adapter31", "default")!,
-                    com.CreateObjectAdapter("Adapter32", "default")!,
-                    com.CreateObjectAdapter("Adapter33", "default")!
+                    com.CreateObjectAdapter("Adapter31", testTransport)!,
+                    com.CreateObjectAdapter("Adapter32", testTransport)!,
+                    com.CreateObjectAdapter("Adapter33", testTransport)!
                 };
 
                 ITestIntfPrx obj = CreateTestIntfPrx(adapters);
@@ -476,7 +478,7 @@ namespace ZeroC.Ice.Test.Binding
             output.Write("testing per request binding with single endpoint... ");
             output.Flush();
             {
-                IRemoteObjectAdapterPrx? adapter = com.CreateObjectAdapter("Adapter41", "default");
+                IRemoteObjectAdapterPrx? adapter = com.CreateObjectAdapter("Adapter41", testTransport);
                 TestHelper.Assert(adapter != null);
                 ITestIntfPrx test1 = adapter.GetTestIntf()!.Clone(cacheConnection: false);
                 ITestIntfPrx test2 = adapter.GetTestIntf()!.Clone(cacheConnection: false);
@@ -506,9 +508,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("Adapter51", "default")!,
-                    com.CreateObjectAdapter("Adapter52", "default")!,
-                    com.CreateObjectAdapter("Adapter53", "default")!
+                    com.CreateObjectAdapter("Adapter51", testTransport)!,
+                    com.CreateObjectAdapter("Adapter52", testTransport)!,
+                    com.CreateObjectAdapter("Adapter53", testTransport)!
                 };
 
                 ITestIntfPrx obj = CreateTestIntfPrx(adapters).Clone(cacheConnection: false);
@@ -547,9 +549,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("AdapterAMI51", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI52", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI53", "default")!
+                    com.CreateObjectAdapter("AdapterAMI51", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI52", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI53", testTransport)!
                 };
 
                 ITestIntfPrx obj = CreateTestIntfPrx(adapters).Clone(cacheConnection: false);
@@ -588,9 +590,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("Adapter61", "default")!,
-                    com.CreateObjectAdapter("Adapter62", "default")!,
-                    com.CreateObjectAdapter("Adapter63", "default")!
+                    com.CreateObjectAdapter("Adapter61", testTransport)!,
+                    com.CreateObjectAdapter("Adapter62", testTransport)!,
+                    com.CreateObjectAdapter("Adapter63", testTransport)!
                 };
 
                 ITestIntfPrx obj = CreateTestIntfPrx(adapters);
@@ -662,9 +664,9 @@ namespace ZeroC.Ice.Test.Binding
             {
                 var adapters = new List<IRemoteObjectAdapterPrx>
                 {
-                    com.CreateObjectAdapter("AdapterAMI61", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI62", "default")!,
-                    com.CreateObjectAdapter("AdapterAMI63", "default")!
+                    com.CreateObjectAdapter("AdapterAMI61", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI62", testTransport)!,
+                    com.CreateObjectAdapter("AdapterAMI63", testTransport)!
                 };
 
                 ITestIntfPrx? obj = CreateTestIntfPrx(adapters);
@@ -737,7 +739,7 @@ namespace ZeroC.Ice.Test.Binding
                 {
                     var adapters = new List<IRemoteObjectAdapterPrx>
                     {
-                        com.CreateObjectAdapter("Adapter71", "default"),
+                        com.CreateObjectAdapter("Adapter71", testTransport),
                         com.CreateObjectAdapter("Adapter72", "udp")
                     };
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -57,7 +57,7 @@ namespace ZeroC.Ice.Test.Binding
             bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
-            var testTransport = helper.GetTestTransport();
+            string testTransport = helper.GetTestTransport();
 
             var rand = new Random(unchecked((int)DateTime.Now.Ticks));
             System.IO.TextWriter output = helper.GetWriter();

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Info
             Communicator? communicator = helper.Communicator();
             TestHelper.Assert(communicator != null);
             bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
-            string transport = communicator.DefaultTransport;
+            string transport = helper.GetTestTransport();
             TextWriter output = helper.GetWriter();
             output.Write("testing proxy endpoint information... ");
             output.Flush();
@@ -113,7 +113,7 @@ namespace ZeroC.Ice.Test.Info
 
                 int port = helper.GetTestPort(1);
                 communicator.SetProperty("TestAdapter.Endpoints",
-                    ice1 ? $"default -h 0.0.0.0 -p {port}" : $"ice+{transport}://0.0.0.0:{port}");
+                    ice1 ? $"{transport} -h 0.0.0.0 -p {port}" : $"ice+{transport}://0.0.0.0:{port}");
                 communicator.SetProperty("TestAdapter.PublishedEndpoints", helper.GetTestEndpoint(1));
                 adapter = communicator.CreateObjectAdapter("TestAdapter");
 

--- a/csharp/test/IceBox/configuration/Client.cs
+++ b/csharp/test/IceBox/configuration/Client.cs
@@ -17,7 +17,7 @@ namespace ZeroC.IceBox.Test.Configuration
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
             // Shutdown the IceBox server.
-            string transport = communicator.DefaultTransport.ToString().ToLowerInvariant();
+            string transport = GetTestTransport();
 
             await IProcessPrx.Parse(GetTestProtocol() == Protocol.Ice1 ?
                                     $"DemoIceBox/admin -f Process:{transport} -h 127.0.0.1 -p 9996" :

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -53,7 +53,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 properties["Ice.Plugin.IceLocatorDiscovery"] = "Ice:ZeroC.IceLocatorDiscovery.PluginFactory";
                 properties["IceLocatorDiscovery.Port"] = helper.GetTestPort(99).ToString();
                 properties["AdapterForDiscoveryTest.AdapterId"] = "discoveryAdapter";
-                properties["AdapterForDiscoveryTest.Endpoints"] = "default -h 127.0.0.1";
+                properties["AdapterForDiscoveryTest.Endpoints"] = $"{helper.GetTestTransport()} -h 127.0.0.1";
 
                 {
                     using var com = new Communicator(properties);

--- a/csharp/test/IceGrid/simple/application.netcoreapp.xml
+++ b/csharp/test/IceGrid/simple/application.netcoreapp.xml
@@ -3,7 +3,7 @@
     <node name="localnode">
       <server id="server" exe="${dotnet.exe}" pwd="." activation="on-demand">
         <option>${test.dir}/${server.dir}/server.dll</option>
-        <adapter name="TestAdapter" id="TestAdapter" endpoints="default -h ${test.host}">
+        <adapter name="TestAdapter" id="TestAdapter" endpoints="${test.transport} -h ${test.host}">
           <object identity="test" type="Test"/>
         </adapter>
       </server>

--- a/csharp/test/IceGrid/simple/application.xml
+++ b/csharp/test/IceGrid/simple/application.xml
@@ -2,7 +2,7 @@
   <application name="Test">
     <node name="localnode">
       <server id="server" exe="${test.dir}/${server.dir}/server.exe" pwd="." activation="on-demand">
-        <adapter name="TestAdapter" id="TestAdapter" endpoints="default -h ${test.host}">
+        <adapter name="TestAdapter" id="TestAdapter" endpoints="${test.transport} -h ${test.host}">
           <object identity="test" type="Test"/>
         </adapter>
       </server>

--- a/csharp/test/Slice/escape/Client.cs
+++ b/csharp/test/Slice/escape/Client.cs
@@ -99,7 +99,7 @@ public class Client : TestHelper
     public override async Task RunAsync(string[] args)
     {
         await using ZeroC.Ice.Communicator communicator = Initialize(ref args);
-        communicator.SetProperty("TestAdapter.Endpoints", "default -h localhost");
+        communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
         ZeroC.Ice.ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
         adapter.Add("test", new Decimal());
         adapter.Add("test1", new Test1I());

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -47,7 +47,7 @@ namespace Test
         {
             if (transport.Length == 0 || transport == "default")
             {
-                if (properties.TryGetValue("Ice.Default.Transport", out string? value))
+                if (properties.TryGetValue("Test.Transport", out string? value))
                 {
                     transport = value;
                 }
@@ -191,8 +191,7 @@ namespace Test
 
         public static string GetTestTransport(Dictionary<string, string> properties)
         {
-            // TODO: switch to a different test-only property to select the transport
-            if (!properties.TryGetValue("Ice.Default.Transport", out string? transport))
+            if (!properties.TryGetValue("Test.Transport", out string? transport))
             {
                 transport = "tcp";
             }

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -246,6 +246,7 @@ class IceGridTestCase(TestCase):
             variables = {
                 "test.dir" : self.getPath(current),
                 "test.host": current.driver.getHost(current.config.transport, current.config.ipv6),
+                "test.transport": current.config.transport,
                 "java.exe" : os.path.join(javaHome, "bin", "java") if javaHome else "java",
                 "icebox.exe" : IceBox().getCommandLine(current),
                 "icegridnode.exe" : IceGridNode().getCommandLine(current),

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -91,7 +91,7 @@ class Component(object):
     or the mapping directory if using a source distribution.
     """
     def getInstallDir(self, mapping, current):
-        raise Error("must be overriden")
+        raise Error("must be overridden")
 
     def getSourceDir(self):
         return toplevel
@@ -736,12 +736,15 @@ class Mapping(object):
             if isinstance(process, IceProcess):
                 props["Ice.Warn.Connections"] = True
                 if self.transport:
-                    props["Ice.Default.Transport"] = self.transport
+                    useTestTransport = isinstance(process.getMapping(current), CSharpMapping) \
+                                      and not process.isFromBinDir()
+                    transportProperty = "Test.Transport" if useTestTransport else "Ice.Default.Transport"
+                    props[transportProperty] = self.transport
                 if self.protocol:
                     useTestProtocol = isinstance(process.getMapping(current), CSharpMapping) \
                                       and not process.isFromBinDir()
-                    hostProperty = "Test.Protocol" if useTestProtocol else "Ice.Default.Protocol"
-                    props[hostProperty] = self.protocol
+                    protocolProperty = "Test.Protocol" if useTestProtocol else "Ice.Default.Protocol"
+                    props[protocolProperty] = self.protocol
                 if self.compress:
                     props["Ice.Override.Compress"] = "1"
                 if self.serialize:

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -741,10 +741,8 @@ class Mapping(object):
                     transportProperty = "Test.Transport" if useTestTransport else "Ice.Default.Transport"
                     props[transportProperty] = self.transport
                 if self.protocol:
-                    useTestProtocol = isinstance(process.getMapping(current), CSharpMapping) \
-                                      and not process.isFromBinDir()
-                    protocolProperty = "Test.Protocol" if useTestProtocol else "Ice.Default.Protocol"
-                    props[protocolProperty] = self.protocol
+                    if isinstance(process.getMapping(current), CSharpMapping) and not process.isFromBinDir():
+                        props["Test.Protocol"] = self.protocol
                 if self.compress:
                     props["Ice.Override.Compress"] = "1"
                 if self.serialize:


### PR DESCRIPTION
This PR removes `Ice.Default.Transport` property from C#

*  `default` is now an alias for `tcp`.  
* Added a new property for the tests - `Test.Transport`