### PR TITLE
Cleanup C# TestHelper

### DIFF
--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -154,9 +154,6 @@ namespace ZeroC.Glacier2.Test.SessionHelper
 
             using Communicator communicator = Initialize(properties);
 
-            string transport = GetTestTransport();
-            string host = GetTestHost();
-
             var factory = new SessionFactoryHelper(new SessionCallback1(this), properties);
             Glacier2.SessionHelper? session = null;
 
@@ -168,7 +165,7 @@ namespace ZeroC.Glacier2.Test.SessionHelper
                 Console.Out.Write("testing SessionHelper connect with wrong userid/password... ");
                 Console.Out.Flush();
 
-                factory.Transport = transport;
+                factory.Transport = Transport;
                 session = factory.Connect("userid", "xxx");
                 while (true)
                 {
@@ -193,9 +190,9 @@ namespace ZeroC.Glacier2.Test.SessionHelper
             {
                 Console.Out.Write("testing SessionHelper connect interrupt... ");
                 Console.Out.Flush();
-                factory.RouterHost = host;
-                factory.Port = GetTestPort(1);
-                factory.Transport = transport;
+                factory.RouterHost = Host;
+                factory.Port = BasePort + 1;
+                factory.Transport = Transport;
                 session = factory.Connect("userid", "abc123");
 
                 Thread.Sleep(100);
@@ -223,9 +220,9 @@ namespace ZeroC.Glacier2.Test.SessionHelper
             {
                 Console.Out.Write("testing SessionHelper connect... ");
                 Console.Out.Flush();
-                factory.RouterHost = host;
-                factory.Port = GetTestPort(50);
-                factory.Transport = transport;
+                factory.RouterHost = Host;
+                factory.Port = BasePort + 50;
+                factory.Transport = Transport;
                 session = factory.Connect("userid", "abc123");
                 while (true)
                 {
@@ -359,9 +356,9 @@ namespace ZeroC.Glacier2.Test.SessionHelper
                 Console.Out.Write("testing SessionHelper connect after router shutdown... ");
                 Console.Out.Flush();
 
-                factory.RouterHost = host;
-                factory.Port = GetTestPort(50);
-                factory.Transport = transport;
+                factory.RouterHost = Host;
+                factory.Port = BasePort + 50;
+                factory.Transport = Transport;
                 session = factory.Connect("userid", "abc123");
                 while (true)
                 {

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -132,7 +132,7 @@ namespace ZeroC.Ice.Test.ACM
         {
             _name = name;
             _com = com;
-            _output = helper.Writer;
+            _output = helper.Output;
             _logger = new Logger(_name, _output);
             _helper = helper;
 
@@ -587,7 +587,7 @@ namespace ZeroC.Ice.Test.ACM
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
 
             var tests = new List<TestCase>
             {

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -132,7 +132,7 @@ namespace ZeroC.Ice.Test.ACM
         {
             _name = name;
             _com = com;
-            _output = helper.GetWriter();
+            _output = helper.Writer;
             _logger = new Logger(_name, _output);
             _helper = helper;
 
@@ -583,11 +583,11 @@ namespace ZeroC.Ice.Test.ACM
 
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
 
             var tests = new List<TestCase>
             {

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -13,10 +13,10 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
     {
         public static ITestIntfPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var obj = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var obj = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -124,10 +124,10 @@ namespace ZeroC.Ice.Test.Admin
 
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+            TextWriter output = helper.Writer;
+            bool ice1 = helper.Protocol == Protocol.Ice1;
 
             output.Write("testing communicator operations... ");
             output.Flush();
@@ -249,7 +249,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(pd["Prop1"] == "1");
                 TestHelper.Assert(pd["Prop2"] == "2");
                 TestHelper.Assert(pd["Prop3"] == "3");
-                TestHelper.Assert(pd["Test.Protocol"] == helper.GetTestProtocol().GetName());
+                TestHelper.Assert(pd["Test.Protocol"] == helper.Protocol.GetName());
 
                 Dictionary<string, string> changes;
 

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -126,7 +126,7 @@ namespace ZeroC.Ice.Test.Admin
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             bool ice1 = helper.Protocol == Protocol.Ice1;
 
             output.Write("testing communicator operations... ");

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -121,7 +121,7 @@ namespace ZeroC.Ice.Test.AMI
             var p = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             var serialized = ITestIntfPrx.Parse(helper.GetTestProxy("serialized", 1), communicator);
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
 
             output.Write("testing async invocation...");
             output.Flush();

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -115,13 +115,13 @@ namespace ZeroC.Ice.Test.AMI
 
         public static void Run(TestHelper helper, bool collocated)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
 
             var p = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             var serialized = ITestIntfPrx.Parse(helper.GetTestProxy("serialized", 1), communicator);
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
 
             output.Write("testing async invocation...");
             output.Flush();

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -53,14 +53,14 @@ namespace ZeroC.Ice.Test.Binding
 
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+            Communicator? communicator = helper.Communicator;
+            bool ice1 = helper.Protocol == Protocol.Ice1;
             TestHelper.Assert(communicator != null);
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
-            string testTransport = helper.GetTestTransport();
+            string testTransport = helper.Transport;
 
             var rand = new Random(unchecked((int)DateTime.Now.Ticks));
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
             output.Write("testing binding with single endpoint... ");
             output.Flush();
@@ -633,7 +633,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (helper.GetTestProtocol() == Protocol.Ice1)
+                if (helper.Protocol == Protocol.Ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("Adapter66", endpoints[2].ToString()));
@@ -707,7 +707,7 @@ namespace ZeroC.Ice.Test.Binding
                 adapters.Clear();
 
                 // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                if (helper.GetTestProtocol() == Protocol.Ice1)
+                if (helper.Protocol == Protocol.Ice1)
                 {
                     // Now, re-activate the adapters with the same endpoints in the opposite order.
                     adapters.Add(com.CreateObjectAdapterWithEndpoints("AdapterAMI66", endpoints[2].ToString()));
@@ -732,7 +732,7 @@ namespace ZeroC.Ice.Test.Binding
             }
             output.WriteLine("ok");
 
-            if (helper.GetTestProtocol() == Protocol.Ice1)
+            if (helper.Protocol == Protocol.Ice1)
             {
                 output.Write("testing endpoint mode filtering... ");
                 output.Flush();
@@ -794,7 +794,7 @@ namespace ZeroC.Ice.Test.Binding
                     }
 
                     // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
-                    if (helper.GetTestProtocol() == Protocol.Ice1)
+                    if (helper.Protocol == Protocol.Ice1)
                     {
                         com.CreateObjectAdapterWithEndpoints("Adapter83", obj.Endpoints[1].ToString()); // Recreate a tcp OA.
 

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -60,7 +60,7 @@ namespace ZeroC.Ice.Test.Binding
             string testTransport = helper.Transport;
 
             var rand = new Random(unchecked((int)DateTime.Now.Ticks));
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             output.Write("testing binding with single endpoint... ");
             output.Flush();

--- a/csharp/test/Ice/compress/Client.cs
+++ b/csharp/test/Ice/compress/Client.cs
@@ -13,10 +13,9 @@ namespace ZeroC.Ice.Test.Compress
     {
         public override async Task RunAsync(string[] args)
         {
-            TextWriter output = GetWriter();
             var properties = CreateTestProperties(ref args);
-            output.Write("testing operations using compression... ");
-            output.Flush();
+            Writer.Write("testing operations using compression... ");
+            Writer.Flush();
             {
                 properties["Ice.CompressionMinSize"] = "1K";
                 await using Communicator communicator = Initialize(properties);
@@ -31,7 +30,7 @@ namespace ZeroC.Ice.Test.Compress
                 await server.ShutdownAsync();
             }
 
-            output.WriteLine("ok");
+            Writer.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/compress/Client.cs
+++ b/csharp/test/Ice/compress/Client.cs
@@ -14,8 +14,8 @@ namespace ZeroC.Ice.Test.Compress
         public override async Task RunAsync(string[] args)
         {
             var properties = CreateTestProperties(ref args);
-            Writer.Write("testing operations using compression... ");
-            Writer.Flush();
+            Output.Write("testing operations using compression... ");
+            Output.Flush();
             {
                 properties["Ice.CompressionMinSize"] = "1K";
                 await using Communicator communicator = Initialize(properties);
@@ -30,7 +30,7 @@ namespace ZeroC.Ice.Test.Compress
                 await server.ShutdownAsync();
             }
 
-            Writer.WriteLine("ok");
+            Output.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -12,8 +12,8 @@ namespace ZeroC.Ice.Test.DefaultServant
     {
         public static void Run(TestHelper helper)
         {
-            TextWriter output = helper.GetWriter();
-            Communicator? communicator = helper.Communicator();
+            TextWriter output = helper.Writer;
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");
             oa.Activate();

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.DefaultServant
     {
         public static void Run(TestHelper helper)
         {
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.DefaultValue
     {
         public static void Run(TestHelper helper)
         {
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing default values... ");
             output.Flush();
 

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.DefaultValue
     {
         public static void Run(TestHelper helper)
         {
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing default values... ");
             output.Flush();
 

--- a/csharp/test/Ice/dictMapping/AllTests.cs
+++ b/csharp/test/Ice/dictMapping/AllTests.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.DictMapping
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
 
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
 

--- a/csharp/test/Ice/dictMapping/AllTests.cs
+++ b/csharp/test/Ice/dictMapping/AllTests.cs
@@ -11,9 +11,9 @@ namespace ZeroC.Ice.Test.DictMapping
     {
         public static IMyClassPrx Run(TestHelper helper, bool collocated)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
 
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
 

--- a/csharp/test/Ice/dictMapping/Client.cs
+++ b/csharp/test/Ice/dictMapping/Client.cs
@@ -12,12 +12,11 @@ namespace ZeroC.Ice.Test.DictMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            System.IO.TextWriter output = GetWriter();
             IMyClassPrx myClass = AllTests.Run(this, false);
-            output.Write("shutting down server... ");
-            output.Flush();
+            Writer.Write("shutting down server... ");
+            Writer.Flush();
             await myClass.ShutdownAsync();
-            output.WriteLine("ok");
+            Writer.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/dictMapping/Client.cs
+++ b/csharp/test/Ice/dictMapping/Client.cs
@@ -13,10 +13,10 @@ namespace ZeroC.Ice.Test.DictMapping
         {
             await using Communicator communicator = Initialize(ref args);
             IMyClassPrx myClass = AllTests.Run(this, false);
-            Writer.Write("shutting down server... ");
-            Writer.Flush();
+            Output.Write("shutting down server... ");
+            Output.Flush();
             await myClass.ShutdownAsync();
-            Writer.WriteLine("ok");
+            Output.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/enums/AllTests.cs
+++ b/csharp/test/Ice/enums/AllTests.cs
@@ -12,10 +12,10 @@ namespace ZeroC.Ice.Test.Enums
     {
         public static ITestIntfPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var proxy = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
             output.Write("testing enum values... ");
             output.Flush();

--- a/csharp/test/Ice/enums/AllTests.cs
+++ b/csharp/test/Ice/enums/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Enums
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var proxy = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             output.Write("testing enum values... ");
             output.Flush();

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Exceptions
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             bool ice1 = helper.Protocol == Protocol.Ice1;
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             {
                 output.Write("testing object adapter registration exceptions... ");
                 ObjectAdapter first;

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -12,10 +12,10 @@ namespace ZeroC.Ice.Test.Exceptions
     {
         public static IThrowerPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
-            TextWriter output = helper.GetWriter();
+            bool ice1 = helper.Protocol == Protocol.Ice1;
+            TextWriter output = helper.Writer;
             {
                 output.Write("testing object adapter registration exceptions... ");
                 ObjectAdapter first;

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Facets
 
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing Ice.Admin.Facets property... ");
             TestHelper.Assert(communicator.GetPropertyAsList("Ice.Admin.Facets") == null);
             communicator.SetProperty("Ice.Admin.Facets", "foobar");

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -13,9 +13,9 @@ namespace ZeroC.Ice.Test.Facets
         public static IGPrx Run(TestHelper helper)
         {
 
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing Ice.Admin.Facets property... ");
             TestHelper.Assert(communicator.GetPropertyAsList("Ice.Admin.Facets") == null);
             communicator.SetProperty("Ice.Admin.Facets", "foobar");

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -36,9 +36,9 @@ namespace ZeroC.Ice.Test.FaultTolerance
 
         public static void Run(TestHelper helper, List<int> ports)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
 
@@ -48,15 +48,15 @@ namespace ZeroC.Ice.Test.FaultTolerance
             if (ports.Count > 1)
             {
                 var sb = new StringBuilder(refString);
-                if (helper.GetTestProtocol() == Protocol.Ice1)
+                if (helper.Protocol == Protocol.Ice1)
                 {
-                    string transport = helper.GetTestTransport();
+                    string transport = helper.Transport;
                     for (int i = 1; i < ports.Count; ++i)
                     {
                         sb.Append($": {transport} -h ");
-                        sb.Append(helper.GetTestHost());
+                        sb.Append(helper.Host);
                         sb.Append(" -p ");
-                        sb.Append(helper.GetTestPort(ports[i]));
+                        sb.Append(helper.BasePort + ports[i]);
                     }
                 }
                 else
@@ -68,9 +68,9 @@ namespace ZeroC.Ice.Test.FaultTolerance
                         {
                             sb.Append(',');
                         }
-                        sb.Append(helper.GetTestHost());
+                        sb.Append(helper.Host);
                         sb.Append(':');
-                        sb.Append(helper.GetTestPort(ports[i]));
+                        sb.Append(helper.BasePort + ports[i]);
                     }
                 }
                 refString = sb.ToString();

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -38,7 +38,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
 

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -15,11 +15,11 @@ namespace ZeroC.Ice.Test.Info
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
-            string transport = helper.GetTestTransport();
-            TextWriter output = helper.GetWriter();
+            bool ice1 = helper.Protocol == Protocol.Ice1;
+            string transport = helper.Transport;
+            TextWriter output = helper.Writer;
             output.Write("testing proxy endpoint information... ");
             output.Flush();
             {
@@ -111,7 +111,7 @@ namespace ZeroC.Ice.Test.Info
 
                 adapter.Dispose();
 
-                int port = helper.GetTestPort(1);
+                int port = helper.BasePort + 1;
                 communicator.SetProperty("TestAdapter.Endpoints",
                     ice1 ? $"{transport} -h 0.0.0.0 -p {port}" : $"ice+{transport}://0.0.0.0:{port}");
                 communicator.SetProperty("TestAdapter.PublishedEndpoints", helper.GetTestEndpoint(1));
@@ -135,7 +135,7 @@ namespace ZeroC.Ice.Test.Info
             }
             output.WriteLine("ok");
 
-            int endpointPort = helper.GetTestPort(0);
+            int endpointPort = helper.BasePort + 0;
 
             ITestIntfPrx testIntf;
             if (ice1)
@@ -148,7 +148,7 @@ namespace ZeroC.Ice.Test.Info
                 testIntf = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             }
 
-            string defaultHost = helper.GetTestHost();
+            string defaultHost = helper.Host;
 
             output.Write("test connection endpoint information... ");
             output.Flush();

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Info
             TestHelper.Assert(communicator != null);
             bool ice1 = helper.Protocol == Protocol.Ice1;
             string transport = helper.Transport;
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing proxy endpoint information... ");
             output.Flush();
             {

--- a/csharp/test/Ice/info/Server.cs
+++ b/csharp/test/Ice/info/Server.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Info
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            if (GetTestProtocol() == Protocol.Ice1)
+            if (Protocol == Protocol.Ice1)
             {
                 communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + ":" + GetTestEndpoint(0, "udp"));
             }

--- a/csharp/test/Ice/inheritance/AllTests.cs
+++ b/csharp/test/Ice/inheritance/AllTests.cs
@@ -10,9 +10,9 @@ namespace ZeroC.Ice.Test.Inheritance
     {
         public static IInitialPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
 
             output.Write("getting proxies for interface hierarchy... ");

--- a/csharp/test/Ice/inheritance/AllTests.cs
+++ b/csharp/test/Ice/inheritance/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Inheritance
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
 
             output.Write("getting proxies for interface hierarchy... ");

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -13,9 +13,9 @@ namespace ZeroC.Ice.Test.Interceptor
     {
         public static IMyObjectPrx Run(TestHelper helper)
         {
-            bool ice2 = helper.GetTestProtocol() == Protocol.Ice2;
-            var prx = IMyObjectPrx.Parse(helper.GetTestProxy("test"), helper.Communicator()!);
-            System.IO.TextWriter output = helper.GetWriter();
+            bool ice2 = helper.Protocol == Protocol.Ice2;
+            var prx = IMyObjectPrx.Parse(helper.GetTestProxy("test"), helper.Communicator!);
+            System.IO.TextWriter output = helper.Writer;
 
             output.Write("testing retry... ");
             output.Flush();

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Interceptor
         {
             bool ice2 = helper.Protocol == Protocol.Ice2;
             var prx = IMyObjectPrx.Parse(helper.GetTestProxy("test"), helper.Communicator!);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             output.Write("testing retry... ");
             output.Flush();

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Invoke
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             IMyClassPrx oneway = cl.Clone(oneway: true);
 
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing Invoke... ");
             output.Flush();
 

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -13,13 +13,13 @@ namespace ZeroC.Ice.Test.Invoke
 
         public static IMyClassPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+            bool ice1 = helper.Protocol == Protocol.Ice1;
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             IMyClassPrx oneway = cl.Clone(oneway: true);
 
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing Invoke... ");
             output.Flush();
 

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -14,16 +14,16 @@ namespace ZeroC.Ice.Test.Location
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+            bool ice1 = helper.Protocol == Protocol.Ice1;
             var manager = IServerManagerPrx.Parse(helper.GetTestProxy("ServerManager", 0), communicator);
             var locator = communicator.DefaultLocator!.Clone(ITestLocatorPrx.Factory);
             Console.WriteLine("registry checkedcast");
             var registry = locator.GetRegistry()!.Clone(ITestLocatorRegistryPrx.Factory);
             TestHelper.Assert(registry != null);
 
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             IObjectPrx base1, base2, base3, base4, base5, base6;

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Location
             var registry = locator.GetRegistry()!.Clone(ITestLocatorRegistryPrx.Factory);
             TestHelper.Assert(registry != null);
 
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             IObjectPrx base1, base2, base3, base4, base5, base6;

--- a/csharp/test/Ice/location/ServerManagerI.cs
+++ b/csharp/test/Ice/location/ServerManagerI.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.Location
             // its endpoints with the locator and create references containing
             // the adapter id instead of the endpoints.
             //
-            Dictionary<string, string> properties = _helper.Communicator()!.GetProperties();
+            Dictionary<string, string> properties = _helper.Communicator!.GetProperties();
             properties["TestAdapter.AdapterId"] = "TestAdapter";
             properties["TestAdapter.ReplicaGroupId"] = "ReplicatedAdapter";
             properties["TestAdapter2.AdapterId"] = "TestAdapter2";

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.Metrics
         }
 
         public static string GetPort(IPropertiesAdminPrx p, int port) =>
-            TestHelper.GetTestPort(p.Communicator.GetProperties(), port).ToString();
+            $"{TestHelper.GetTestBasePort(p.Communicator.GetProperties()) + port}";
 
         private static Dictionary<string, string> GetClientProps(
             IPropertiesAdminPrx p,
@@ -364,13 +364,13 @@ namespace ZeroC.Ice.Test.Metrics
 
         public static IMetricsPrx Run(TestHelper helper, CommunicatorObserver obsv)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
-            string host = helper.GetTestHost();
-            string port = helper.GetTestPort(0).ToString();
+            bool ice1 = helper.Protocol == Protocol.Ice1;
+            string host = helper.Host;
+            string port = $"{helper.BasePort + 0}";
             string hostAndPort = host + ":" + port;
-            string transport = helper.GetTestTransport();
+            string transport = helper.Transport;
             string defaultTimeout = "60000";
             string endpoint = ice1 ?
                 $"{transport} -h {host} -p {port}" : $"ice+{transport}://{host}:{port}";
@@ -380,7 +380,7 @@ namespace ZeroC.Ice.Test.Metrics
                 IMetricsPrx.Parse($"{endpoint}/metrics", communicator);
 
             bool collocated = metrics.GetConnection() == null;
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing metrics admin facet checkedCast... ");
             output.Flush();
             IObjectPrx? admin = communicator.GetAdmin();
@@ -550,7 +550,7 @@ namespace ZeroC.Ice.Test.Metrics
                 cm2 = (ConnectionMetrics)clientMetrics.GetMetricsView("View").ReturnValue["Connection"][0]!;
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
-                int sizeLengthIncrease = helper.GetTestEncoding() == Encoding.V1_1 ? 4 : 1;
+                int sizeLengthIncrease = helper.Encoding == Encoding.V1_1 ? 4 : 1;
 
                 TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == requestSz + bs.Length + sizeLengthIncrease);
                 TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == replySz);
@@ -566,7 +566,7 @@ namespace ZeroC.Ice.Test.Metrics
                 cm2 = (ConnectionMetrics)clientMetrics.GetMetricsView("View").ReturnValue["Connection"][0]!;
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
-                sizeLengthIncrease = helper.GetTestEncoding() == Encoding.V1_1 ? 4 : 3;
+                sizeLengthIncrease = helper.Encoding == Encoding.V1_1 ? 4 : 3;
 
                 TestHelper.Assert((cm2.SentBytes - cm1.SentBytes) == (requestSz + bs.Length + sizeLengthIncrease));
                 TestHelper.Assert((cm2.ReceivedBytes - cm1.ReceivedBytes) == replySz);
@@ -1152,8 +1152,8 @@ namespace ZeroC.Ice.Test.Metrics
                 }
             }
 
-            Encoding defaultEncoding = helper.GetTestEncoding();
-            string defaultProtocolName = helper.GetTestProtocol().GetName();
+            Encoding defaultEncoding = helper.Encoding;
+            string defaultProtocolName = helper.Protocol.GetName();
 
             TestAttribute(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);
             if (ice1)

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -380,7 +380,7 @@ namespace ZeroC.Ice.Test.Metrics
                 IMetricsPrx.Parse($"{endpoint}/metrics", communicator);
 
             bool collocated = metrics.GetConnection() == null;
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing metrics admin facet checkedCast... ");
             output.Flush();
             IObjectPrx? admin = communicator.GetAdmin();

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.NamespaceMD
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);

--- a/csharp/test/Ice/namespacemd/AllTests.cs
+++ b/csharp/test/Ice/namespacemd/AllTests.cs
@@ -10,9 +10,9 @@ namespace ZeroC.Ice.Test.NamespaceMD
     {
         public static IInitialPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);

--- a/csharp/test/Ice/networkProxy/AllTests.cs
+++ b/csharp/test/Ice/networkProxy/AllTests.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
             int proxyPort = communicator.GetPropertyAsInt("Ice.HTTPProxyPort") ??
                             communicator.GetPropertyAsInt("Ice.SOCKSProxyPort") ?? 0;
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing connection... ");
             output.Flush();
             {

--- a/csharp/test/Ice/networkProxy/AllTests.cs
+++ b/csharp/test/Ice/networkProxy/AllTests.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             string sref = helper.GetTestProxy("test", 0);
             var testPrx = ITestIntfPrx.Parse(sref, communicator);
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
             int proxyPort = communicator.GetPropertyAsInt("Ice.HTTPProxyPort") ??
                             communicator.GetPropertyAsInt("Ice.SOCKSProxyPort") ?? 0;
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing connection... ");
             output.Flush();
             {

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -41,7 +41,7 @@ namespace ZeroC.Ice.Test.Objects
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.Writer;
+            TextWriter? output = helper.Output;
 
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
             TestHelper.Assert(initial != null);

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -39,9 +39,9 @@ namespace ZeroC.Ice.Test.Objects
     {
         public static IInitialPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.GetWriter();
+            TextWriter? output = helper.Writer;
 
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
             TestHelper.Assert(initial != null);

--- a/csharp/test/Ice/operations/AllTests.cs
+++ b/csharp/test/Ice/operations/AllTests.cs
@@ -10,9 +10,9 @@ namespace ZeroC.Ice.Test.Operations
     {
         public static IMyClassPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             var derivedProxy = IMyDerivedClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);

--- a/csharp/test/Ice/operations/AllTests.cs
+++ b/csharp/test/Ice/operations/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Operations
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             var derivedProxy = IMyDerivedClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);

--- a/csharp/test/Ice/operations/OnewaysAMI.cs
+++ b/csharp/test/Ice/operations/OnewaysAMI.cs
@@ -47,7 +47,7 @@ namespace ZeroC.Ice.Test.Operations
 
         internal static void Run(TestHelper helper, IMyClassPrx proxy)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             IMyClassPrx p = proxy.Clone(oneway: true);
 

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.Operations
     {
         internal static void Run(TestHelper helper, IMyClassPrx p)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             string[] literals = p.OpStringLiterals();
 

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Operations
     {
         internal static void Run(TestHelper helper, IMyClassPrx p)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
 
             {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Optional
             Communicator communicator = helper.Communicator!;
             var test = ITestPrx.Parse(helper.GetTestProxy("test", 0), communicator);
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing BitSequence and ReadOnlyBitSequence... ");
 
             Span<byte> span1 = stackalloc byte[7];

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -14,10 +14,10 @@ namespace ZeroC.Ice.Test.Optional
     {
         internal static ITestPrx Run(TestHelper helper)
         {
-            Communicator communicator = helper.Communicator()!;
+            Communicator communicator = helper.Communicator!;
             var test = ITestPrx.Parse(helper.GetTestProxy("test", 0), communicator);
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing BitSequence and ReadOnlyBitSequence... ");
 
             Span<byte> span1 = stackalloc byte[7];

--- a/csharp/test/Ice/perf/AllTests.cs
+++ b/csharp/test/Ice/perf/AllTests.cs
@@ -57,9 +57,9 @@ namespace ZeroC.Ice.Test.Perf
 
         public static IPerformancePrx Run(TestHelper helper)
         {
-            Communicator communicator = helper.Communicator()!;
+            Communicator communicator = helper.Communicator!;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
 #if DEBUG
             output.WriteLine("warning: performance test built with DEBUG");

--- a/csharp/test/Ice/perf/AllTests.cs
+++ b/csharp/test/Ice/perf/AllTests.cs
@@ -59,7 +59,7 @@ namespace ZeroC.Ice.Test.Perf
         {
             Communicator communicator = helper.Communicator!;
             TestHelper.Assert(communicator != null);
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
 #if DEBUG
             output.WriteLine("warning: performance test built with DEBUG");

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
     {
         public static ITestIntfPrx Run(TestHelper helper)
         {
-            Communicator communicator = helper.Communicator()!;
+            Communicator communicator = helper.Communicator!;
 
             var forwardSamePrx = ITestIntfPrx.Parse(helper.GetTestProxy("ForwardSame", 0), communicator);
             var forwardOtherPrx = ITestIntfPrx.Parse(helper.GetTestProxy("ForwardOther", 0), communicator);
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
             ITestIntfPrx newPrx;
 
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing forwarding with same protocol... ");
             output.Flush();
             newPrx = TestProxy(forwardSamePrx);

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
             ITestIntfPrx newPrx;
 
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing forwarding with same protocol... ");
             output.Flush();
             newPrx = TestProxy(forwardSamePrx);

--- a/csharp/test/Ice/protocolBridging/Server.cs
+++ b/csharp/test/Ice/protocolBridging/Server.cs
@@ -15,17 +15,15 @@ namespace ZeroC.Ice.Test.ProtocolBridging
             await using Communicator communicator = Initialize(ref args);
             communicator.SetProperty("TestAdapterForwarder.Endpoints", GetTestEndpoint(0));
 
-            string transport = GetTestTransport();
-
-            if (GetTestProtocol() == Protocol.Ice1)
+            if (Protocol == Protocol.Ice1)
             {
-                communicator.SetProperty("TestAdapterSame.Endpoints", $"{transport} -h localhost");
-                communicator.SetProperty("TestAdapterOther.Endpoints", $"ice+{transport}://localhost:0");
+                communicator.SetProperty("TestAdapterSame.Endpoints", $"{Transport} -h localhost");
+                communicator.SetProperty("TestAdapterOther.Endpoints", $"ice+{Transport}://localhost:0");
             }
             else
             {
-                communicator.SetProperty("TestAdapterSame.Endpoints", $"ice+{transport}://localhost:0");
-                communicator.SetProperty("TestAdapterOther.Endpoints", $"{transport} -h localhost");
+                communicator.SetProperty("TestAdapterSame.Endpoints", $"ice+{Transport}://localhost:0");
+                communicator.SetProperty("TestAdapterOther.Endpoints", $"{Transport} -h localhost");
             }
 
             ObjectAdapter adapterForwarder = communicator.CreateObjectAdapter("TestAdapterForwarder");

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -13,10 +13,10 @@ namespace ZeroC.Ice.Test.Proxy
     {
         public static IMyClassPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
-            System.IO.TextWriter output = helper.GetWriter();
+            bool ice1 = helper.Protocol == Protocol.Ice1;
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing proxy parsing... ");
             output.Flush();
 
@@ -948,14 +948,14 @@ namespace ZeroC.Ice.Test.Proxy
             }
             output.WriteLine("ok");
 
-            if (helper.GetTestProtocol() == Protocol.Ice2)
+            if (helper.Protocol == Protocol.Ice2)
             {
                 output.Write("testing protocol versioning... ");
                 output.Flush();
                 string ref3 = helper.GetTestProxy("test", 0);
                 ref3 += "?protocol=3";
 
-                string transport = helper.GetTestTransport();
+                string transport = helper.Transport;
                 ref3 = ref3.Replace($"ice+{transport}", "ice+universal");
                 ref3 += $"&transport={transport}";
                 var cl3 = IMyClassPrx.Parse(ref3, communicator);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Proxy
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             bool ice1 = helper.Protocol == Protocol.Ice1;
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing proxy parsing... ");
             output.Flush();
 

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -48,11 +48,11 @@ namespace ZeroC.Ice.Test.Retry
             Communicator communicator2,
             string rf)
         {
-           bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+           bool ice1 = helper.Protocol == Protocol.Ice1;
 
             Instrumentation.TestInvocationReset();
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var retry1 = IRetryPrx.Parse(rf, communicator);

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -52,7 +52,7 @@ namespace ZeroC.Ice.Test.Retry
 
             Instrumentation.TestInvocationReset();
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var retry1 = IRetryPrx.Parse(rf, communicator);

--- a/csharp/test/Ice/scope/AllTests.cs
+++ b/csharp/test/Ice/scope/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Scope
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             {
                 var i = IIPrx.Parse(helper.GetTestProxy("i1"), communicator);

--- a/csharp/test/Ice/scope/Client.cs
+++ b/csharp/test/Ice/scope/Client.cs
@@ -12,10 +12,10 @@ namespace ZeroC.Ice.Test.Scope
         public override async Task RunAsync(string[] args)
         {
             await using var communicator = Initialize(ref args);
-            Writer.Write("test using same type name in different Slice modules... ");
-            Writer.Flush();
+            Output.Write("test using same type name in different Slice modules... ");
+            Output.Flush();
             AllTests.Run(this);
-            Writer.WriteLine("ok");
+            Output.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/scope/Client.cs
+++ b/csharp/test/Ice/scope/Client.cs
@@ -12,11 +12,10 @@ namespace ZeroC.Ice.Test.Scope
         public override async Task RunAsync(string[] args)
         {
             await using var communicator = Initialize(ref args);
-            var output = GetWriter();
-            output.Write("test using same type name in different Slice modules... ");
-            output.Flush();
+            Writer.Write("test using same type name in different Slice modules... ");
+            Writer.Flush();
             AllTests.Run(this);
-            output.WriteLine("ok");
+            Writer.WriteLine("ok");
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/seqMapping/AllTests.cs
+++ b/csharp/test/Ice/seqMapping/AllTests.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.SeqMapping
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             output.Write("testing twoway operations... ");
             output.Flush();

--- a/csharp/test/Ice/seqMapping/AllTests.cs
+++ b/csharp/test/Ice/seqMapping/AllTests.cs
@@ -11,9 +11,9 @@ namespace ZeroC.Ice.Test.SeqMapping
     {
         public static IMyClassPrx Run(TestHelper helper, bool collocated)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             var cl = IMyClassPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             output.Write("testing twoway operations... ");
             output.Flush();

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Serialize
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             output.Write("testing serialization... ");
             output.Flush();
 

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -15,9 +15,9 @@ namespace ZeroC.Ice.Test.Serialize
     {
         public static int Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             output.Write("testing serialization... ");
             output.Flush();
 

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -36,9 +36,9 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
 
         public static ITestIntfPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.GetWriter();
+            TextWriter? output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var testPrx = ITestIntfPrx.Parse(helper.GetTestProxy("Test", 0), communicator);
@@ -767,7 +767,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(slices[0].TypeId!.Equals("::ZeroC::Ice::Test::Slicing::Exceptions::SPreserved2"));
                 }
 
-                ObjectAdapter adapter = communicator.CreateObjectAdapter(protocol: helper.GetTestProtocol());
+                ObjectAdapter adapter = communicator.CreateObjectAdapter(protocol: helper.Protocol);
                 IRelayPrx relay = adapter.AddWithUUID(new Relay(), IRelayPrx.Factory);
                 adapter.Activate();
                 testPrx.GetConnection()!.Adapter = adapter;

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -38,7 +38,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.Writer;
+            TextWriter? output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var testPrx = ITestIntfPrx.Parse(helper.GetTestProxy("Test", 0), communicator);

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -25,9 +25,9 @@ namespace ZeroC.Ice.Test.Slicing.Objects
     {
         public static ITestIntfPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.GetWriter();
+            TextWriter? output = helper.Writer;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var testPrx = ITestIntfPrx.Parse(helper.GetTestProxy("Test", 0), communicator);

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            TextWriter? output = helper.Writer;
+            TextWriter? output = helper.Output;
             output.Write("testing stringToProxy... ");
             output.Flush();
             var testPrx = ITestIntfPrx.Parse(helper.GetTestProxy("Test", 0), communicator);

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -61,9 +61,9 @@ namespace ZeroC.Ice.Test.Stream
 
         public static int Run(TestHelper helper)
         {
-            //Communicator? communicator = helper.Communicator();
+            //Communicator? communicator = helper.Communicator;
 
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing primitive types... ");
             output.Flush();
 

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -63,7 +63,7 @@ namespace ZeroC.Ice.Test.Stream
         {
             //Communicator? communicator = helper.Communicator;
 
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing primitive types... ");
             output.Flush();
 

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -13,10 +13,10 @@ namespace ZeroC.Ice.Test.Tagged
     {
         public static IInitialPrx Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
 
-            TextWriter output = helper.GetWriter();
+            TextWriter output = helper.Writer;
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
 
             output.Write("testing tagged data members... ");

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Tagged
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
 
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             var initial = IInitialPrx.Parse(helper.GetTestProxy("initial", 0), communicator);
 
             output.Write("testing tagged data members... ");

--- a/csharp/test/Ice/threading/AllTests.cs
+++ b/csharp/test/Ice/threading/AllTests.cs
@@ -36,7 +36,7 @@ namespace ZeroC.Ice.Test.Threading
         }
         public static async ValueTask AllTestsWithServer(TestHelper helper, bool collocated, int server)
         {
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             TaskScheduler? scheduler = TaskScheduler.Current;
 
@@ -105,7 +105,7 @@ namespace ZeroC.Ice.Test.Threading
 
             var schedulers = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 2);
             Dictionary<string, string> properties = communicator.GetProperties();
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
 
             // Use the Default task scheduler to run continuations tests with the 3 object adapters
             // setup by the server, each object adapter uses a different task scheduler.

--- a/csharp/test/Ice/threading/AllTests.cs
+++ b/csharp/test/Ice/threading/AllTests.cs
@@ -36,11 +36,11 @@ namespace ZeroC.Ice.Test.Threading
         }
         public static async ValueTask AllTestsWithServer(TestHelper helper, bool collocated, int server)
         {
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
             TaskScheduler? scheduler = TaskScheduler.Current;
 
-            var proxy = ITestIntfPrx.Parse(helper.GetTestProxy("test", server), helper.Communicator()!);
+            var proxy = ITestIntfPrx.Parse(helper.GetTestProxy("test", server), helper.Communicator!);
 
             if (collocated)
             {
@@ -100,12 +100,12 @@ namespace ZeroC.Ice.Test.Threading
 
         public static async Task<ITestIntfPrx> Run(TestHelper helper, bool collocated)
         {
-            Communicator communicator = helper.Communicator()!;
+            Communicator communicator = helper.Communicator!;
             TestHelper.Assert(communicator != null);
 
             var schedulers = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 2);
             Dictionary<string, string> properties = communicator.GetProperties();
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
 
             // Use the Default task scheduler to run continuations tests with the 3 object adapters
             // setup by the server, each object adapter uses a different task scheduler.

--- a/csharp/test/Ice/threading/Client.cs
+++ b/csharp/test/Ice/threading/Client.cs
@@ -20,7 +20,7 @@ namespace ZeroC.Ice.Test.Threading
             }
             catch (TestFailedException ex)
             {
-                GetWriter().WriteLine($"test failed: {ex.Reason}");
+                Writer.WriteLine($"test failed: {ex.Reason}");
                 Assert(false);
                 throw;
             }

--- a/csharp/test/Ice/threading/Client.cs
+++ b/csharp/test/Ice/threading/Client.cs
@@ -20,7 +20,7 @@ namespace ZeroC.Ice.Test.Threading
             }
             catch (TestFailedException ex)
             {
-                Writer.WriteLine($"test failed: {ex.Reason}");
+                Output.WriteLine($"test failed: {ex.Reason}");
                 Assert(false);
                 throw;
             }

--- a/csharp/test/Ice/threading/Collocated.cs
+++ b/csharp/test/Ice/threading/Collocated.cs
@@ -45,7 +45,7 @@ namespace ZeroC.Ice.Test.Threading
             }
             catch (TestFailedException ex)
             {
-                GetWriter().WriteLine($"test failed: {ex.Reason}");
+                Writer.WriteLine($"test failed: {ex.Reason}");
                 Assert(false);
                 throw;
             }

--- a/csharp/test/Ice/threading/Collocated.cs
+++ b/csharp/test/Ice/threading/Collocated.cs
@@ -45,7 +45,7 @@ namespace ZeroC.Ice.Test.Threading
             }
             catch (TestFailedException ex)
             {
-                Writer.WriteLine($"test failed: {ex.Reason}");
+                Output.WriteLine($"test failed: {ex.Reason}");
                 Assert(false);
                 throw;
             }

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Timeout
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var controller = IControllerPrx.Parse(helper.GetTestProxy("controller", 1), communicator);
             try
@@ -30,12 +30,12 @@ namespace ZeroC.Ice.Test.Timeout
 
         public static void RunWithController(TestHelper helper, IControllerPrx controller)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
 
             var timeout = ITimeoutPrx.Parse(helper.GetTestProxy("timeout", 0), communicator);
 
-            System.IO.TextWriter output = helper.GetWriter();
+            System.IO.TextWriter output = helper.Writer;
             output.Write("testing connect timeout... ");
             output.Flush();
             {

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -35,7 +35,7 @@ namespace ZeroC.Ice.Test.Timeout
 
             var timeout = ITimeoutPrx.Parse(helper.GetTestProxy("timeout", 0), communicator);
 
-            System.IO.TextWriter output = helper.Writer;
+            System.IO.TextWriter output = helper.Output;
             output.Write("testing connect timeout... ");
             output.Flush();
             {

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -57,7 +57,7 @@ namespace ZeroC.Ice.Test.UDP
 
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             communicator.SetProperty("ReplyAdapter.Endpoints", "udp -h localhost");
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ReplyAdapter");
@@ -164,7 +164,7 @@ namespace ZeroC.Ice.Test.UDP
                 sb.Append("239.255.1.1");
             }
             sb.Append(" -p ");
-            sb.Append(helper.GetTestPort(10));
+            sb.Append(helper.BasePort + 10);
             if (AssemblyUtil.IsWindows || AssemblyUtil.IsMacOS)
             {
                 if (communicator.GetPropertyAsBool("Ice.IPv6") ?? false)

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -69,7 +69,7 @@ namespace ZeroC.Ice.Test.UDP
                 }
             }
             endpoint.Append(" -p ");
-            endpoint.Append(GetTestPort(properties, 10));
+            endpoint.Append(GetTestBasePort(properties) + 10);
             communicator.SetProperty("McastTestAdapter.Endpoints", endpoint.ToString());
             ObjectAdapter mcastAdapter = communicator.CreateObjectAdapter("McastTestAdapter");
             mcastAdapter.Add("test", new TestIntf());

--- a/csharp/test/IceBox/admin/AllTests.cs
+++ b/csharp/test/IceBox/admin/AllTests.cs
@@ -14,7 +14,7 @@ namespace ZeroC.IceBox.Test.Admin
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var admin = IObjectPrx.Parse("DemoIceBox/admin:default -h localhost -p 9996 -t 10000", communicator);
 

--- a/csharp/test/IceBox/configuration/AllTests.cs
+++ b/csharp/test/IceBox/configuration/AllTests.cs
@@ -13,7 +13,7 @@ namespace ZeroC.IceBox.Test.Configuration
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var service1 = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
             var service2 = ITestIntfPrx.Parse(helper.GetTestProxy("test", 1), communicator);

--- a/csharp/test/IceBox/configuration/Client.cs
+++ b/csharp/test/IceBox/configuration/Client.cs
@@ -17,11 +17,9 @@ namespace ZeroC.IceBox.Test.Configuration
             await using Communicator communicator = Initialize(properties);
             AllTests.Run(this);
             // Shutdown the IceBox server.
-            string transport = GetTestTransport();
-
-            await IProcessPrx.Parse(GetTestProtocol() == Protocol.Ice1 ?
-                                    $"DemoIceBox/admin -f Process:{transport} -h 127.0.0.1 -p 9996" :
-                                    $"ice+{transport}://127.0.0.1:9996/DemoIceBox/admin#Process",
+            await IProcessPrx.Parse(Protocol == Protocol.Ice1 ?
+                                    $"DemoIceBox/admin -f Process:{Transport} -h 127.0.0.1 -p 9996" :
+                                    $"ice+{Transport}://127.0.0.1:9996/DemoIceBox/admin#Process",
                                     communicator).ShutdownAsync();
         }
 

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -14,7 +14,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
     {
         public static void Run(TestHelper helper, int num)
         {
-            TextWriter output = helper.Writer;
+            TextWriter output = helper.Output;
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var proxies = new List<IControllerPrx>();

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -14,12 +14,12 @@ namespace ZeroC.IceDiscovery.Test.Simple
     {
         public static void Run(TestHelper helper, int num)
         {
-            TextWriter output = helper.GetWriter();
-            Communicator? communicator = helper.Communicator();
+            TextWriter output = helper.Writer;
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var proxies = new List<IControllerPrx>();
             var indirectProxies = new List<IControllerPrx>();
-            bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+            bool ice1 = helper.Protocol == Protocol.Ice1;
 
             for (int i = 0; i < num; ++i)
             {

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -13,7 +13,7 @@ namespace ZeroC.IceGrid.Test.Simple
     {
         public static void Run(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             Console.Out.Write("testing stringToProxy... ");
             Console.Out.Flush();
@@ -51,9 +51,9 @@ namespace ZeroC.IceGrid.Test.Simple
                 Dictionary<string, string>? properties = communicator.GetProperties();
                 properties.Remove("Ice.Default.Locator");
                 properties["Ice.Plugin.IceLocatorDiscovery"] = "Ice:ZeroC.IceLocatorDiscovery.PluginFactory";
-                properties["IceLocatorDiscovery.Port"] = helper.GetTestPort(99).ToString();
+                properties["IceLocatorDiscovery.Port"] = $"{helper.BasePort + 99}";
                 properties["AdapterForDiscoveryTest.AdapterId"] = "discoveryAdapter";
-                properties["AdapterForDiscoveryTest.Endpoints"] = $"{helper.GetTestTransport()} -h 127.0.0.1";
+                properties["AdapterForDiscoveryTest.Endpoints"] = $"{helper.Transport} -h 127.0.0.1";
 
                 {
                     using var com = new Communicator(properties);
@@ -174,7 +174,7 @@ namespace ZeroC.IceGrid.Test.Simple
                         {
                             intf = $" --interface \"{intf}\"";
                         }
-                        string port = helper.GetTestPort(99).ToString();
+                        string port = $"{helper.BasePort + 99}";
                         properties["IceLocatorDiscovery.Lookup"] =
                             $"udp -h {multicast} --interface unknown:udp -h {multicast} -p {port}{intf}";
                     }
@@ -200,7 +200,7 @@ namespace ZeroC.IceGrid.Test.Simple
 
         public static void RunWithDeploy(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             Console.Out.Write("testing stringToProxy... ");
             Console.Out.Flush();

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -80,7 +80,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
         public static IServerFactoryPrx Run(TestHelper helper, string testDir)
         {
-            Communicator? communicator = helper.Communicator();
+            Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             string factoryRef = helper.GetTestProxy("factory", 0, "tcp");
 
@@ -272,7 +272,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+                    bool ice1 = helper.Protocol == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                             "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
@@ -318,7 +318,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    bool ice1 = helper.GetTestProtocol() == Protocol.Ice1;
+                    bool ice1 = helper.Protocol == Protocol.Ice1;
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                         "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -45,7 +45,7 @@ namespace Test
 
         public string Transport => GetTestTransport(Communicator!.GetProperties());
 
-        public TextWriter Writer
+        public TextWriter Output
         {
             get => _writer ?? Console.Out;
             set => _writer = value;
@@ -243,14 +243,10 @@ namespace Test
             ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
         {
             var communicator = new Communicator(properties, observer: observer);
-            if (Communicator == null)
-            {
-                Communicator = communicator;
-            }
-            if (ControllerHelper != null)
-            {
-                ControllerHelper.CommunicatorInitialized(communicator);
-            }
+
+            Communicator ??= communicator;
+            ControllerHelper?.CommunicatorInitialized(communicator);
+
             return communicator;
         }
 

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -30,6 +30,27 @@ namespace Test
 
     public abstract class TestHelper
     {
+        private TextWriter? _writer;
+
+        public ushort BasePort => GetTestBasePort(Communicator!.GetProperties());
+
+        public IControllerHelper? ControllerHelper { get; set; }
+        public Communicator? Communicator { get; private set; }
+
+        public ZeroC.Ice.Encoding Encoding => GetTestEncoding(Communicator!.GetProperties());
+
+        public string Host => GetTestHost(Communicator!.GetProperties());
+
+        public Protocol Protocol => GetTestProtocol(Communicator!.GetProperties());
+
+        public string Transport => GetTestTransport(Communicator!.GetProperties());
+
+        public TextWriter Writer
+        {
+            get => _writer ?? Console.Out;
+            set => _writer = value;
+        }
+
         public static void Assert([DoesNotReturnIf(false)] bool b)
         {
             if (!b)
@@ -41,7 +62,7 @@ namespace Test
         public abstract Task RunAsync(string[] args);
 
         public string GetTestEndpoint(int num = 0, string transport = "") =>
-            GetTestEndpoint(_communicator!.GetProperties(), num, transport);
+            GetTestEndpoint(Communicator!.GetProperties(), num, transport);
 
         public static string GetTestEndpoint(Dictionary<string, string> properties, int num = 0, string transport = "")
         {
@@ -76,7 +97,7 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(':');
-                sb.Append(GetTestPort(properties, num));
+                sb.Append(GetTestBasePort(properties) + num);
                 return sb.ToString();
             }
             else
@@ -94,13 +115,13 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(" -p ");
-                sb.Append(GetTestPort(properties, num));
+                sb.Append(GetTestBasePort(properties) + num);
                 return sb.ToString();
             }
         }
 
         public string GetTestProxy(string identity, int num = 0, string? transport = null) =>
-            GetTestProxy(identity, _communicator!.GetProperties(), num, transport);
+            GetTestProxy(identity, Communicator!.GetProperties(), num, transport);
 
         public static string GetTestProxy(
             string identity,
@@ -125,7 +146,7 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(':');
-                sb.Append(GetTestPort(properties, num));
+                sb.Append(GetTestBasePort(properties) + num);
                 sb.Append('/');
                 sb.Append(identity);
                 return sb.ToString();
@@ -148,11 +169,10 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(" -p ");
-                sb.Append(GetTestPort(properties, num));
+                sb.Append(GetTestBasePort(properties) + num);
                 return sb.ToString();
             }
         }
-        public string GetTestHost() => GetTestHost(_communicator!.GetProperties());
 
         public static string GetTestHost(Dictionary<string, string> properties)
         {
@@ -162,8 +182,6 @@ namespace Test
             }
             return host;
         }
-
-        public Protocol GetTestProtocol() => GetTestProtocol(_communicator!.GetProperties());
 
         public static Protocol GetTestProtocol(Dictionary<string, string> properties)
         {
@@ -182,12 +200,8 @@ namespace Test
             }
         }
 
-        public ZeroC.Ice.Encoding GetTestEncoding() => GetTestEncoding(_communicator!.GetProperties());
-
         public static ZeroC.Ice.Encoding GetTestEncoding(Dictionary<string, string> properties)
             => ProtocolExtensions.GetEncoding(GetTestProtocol(properties));
-
-        public string GetTestTransport() => GetTestTransport(_communicator!.GetProperties());
 
         public static string GetTestTransport(Dictionary<string, string> properties)
         {
@@ -198,32 +212,15 @@ namespace Test
             return transport;
         }
 
-        public int GetTestPort(int num) => GetTestPort(_communicator!.GetProperties(), num);
-
-        // TODO: switch to ushort
-        public static int GetTestPort(Dictionary<string, string> properties, int num)
+        public static ushort GetTestBasePort(Dictionary<string, string> properties)
         {
-            int basePort = 12010;
+            ushort basePort = 12010;
             if (properties.TryGetValue("Test.BasePort", out string? value))
             {
-                basePort = int.Parse(value);
+                basePort = ushort.Parse(value);
             }
-            return basePort + num;
+            return basePort;
         }
-
-        public TextWriter GetWriter()
-        {
-            if (_writer == null)
-            {
-                return Console.Out;
-            }
-            else
-            {
-                return _writer;
-            }
-        }
-
-        public void SetWriter(TextWriter writer) => _writer = writer;
 
         public Dictionary<string, string> CreateTestProperties(
             ref string[] args,
@@ -246,31 +243,18 @@ namespace Test
             ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
         {
             var communicator = new Communicator(properties, observer: observer);
-            if (_communicator == null)
+            if (Communicator == null)
             {
-                _communicator = communicator;
+                Communicator = communicator;
             }
-            if (_controllerHelper != null)
+            if (ControllerHelper != null)
             {
-                _controllerHelper.CommunicatorInitialized(communicator);
+                ControllerHelper.CommunicatorInitialized(communicator);
             }
             return communicator;
         }
 
-        public Communicator? Communicator() => _communicator;
-        public void SetControllerHelper(IControllerHelper controllerHelper) => _controllerHelper = controllerHelper;
-
-        public void ServerReady()
-        {
-            if (_controllerHelper != null)
-            {
-                _controllerHelper.ServerReady();
-            }
-        }
-
-        private Communicator? _communicator;
-        private IControllerHelper? _controllerHelper;
-        private TextWriter? _writer;
+        public void ServerReady() => ControllerHelper?.ServerReady();
     }
 
     public static class TestDriver

--- a/csharp/test/xamarin/controller/MainPage.xaml.cs
+++ b/csharp/test/xamarin/controller/MainPage.xaml.cs
@@ -399,7 +399,7 @@ namespace controller
 
         public string getOutput()
         {
-            return _helper.Writer.ToString();
+            return _helper.Output.ToString();
         }
 
         public void join()
@@ -428,13 +428,13 @@ namespace controller
                 {
                     _helper = TestFactory.create(_typename);
                     _helper.ControllerHelper = this;
-                    _helper.Writer = new StringWriter();
+                    _helper.Output = new StringWriter();
                     _helper.run(_args);
                     completed(0);
                 }
                 catch (System.Exception ex)
                 {
-                    _helper.Writer.WriteLine("unexpected unknown exception while running `{0}':\n", ex);
+                    _helper.Output.WriteLine("unexpected unknown exception while running `{0}':\n", ex);
                     completed(1);
                 }
             });

--- a/csharp/test/xamarin/controller/MainPage.xaml.cs
+++ b/csharp/test/xamarin/controller/MainPage.xaml.cs
@@ -399,7 +399,7 @@ namespace controller
 
         public string getOutput()
         {
-            return _helper.getWriter().ToString();
+            return _helper.Writer.ToString();
         }
 
         public void join()
@@ -427,14 +427,14 @@ namespace controller
                 try
                 {
                     _helper = TestFactory.create(_typename);
-                    _helper.setControllerHelper(this);
-                    _helper.setWriter(new StringWriter());
+                    _helper.ControllerHelper = this;
+                    _helper.Writer = new StringWriter();
                     _helper.run(_args);
                     completed(0);
                 }
                 catch (System.Exception ex)
                 {
-                    _helper.getWriter().WriteLine("unexpected unknown exception while running `{0}':\n", ex);
+                    _helper.Writer.WriteLine("unexpected unknown exception while running `{0}':\n", ex);
                     completed(1);
                 }
             });
@@ -466,7 +466,7 @@ namespace controller
 
                 if (_helper != null)
                 {
-                    var communicator = _helper.communicator();
+                    var communicator = _helper.Communicator;
                     if (communicator != null)
                     {
                         communicator.shutdown();

--- a/python/test/Ice/operations/Oneways.py
+++ b/python/test/Ice/operations/Oneways.py
@@ -9,7 +9,7 @@ def test(b):
         raise RuntimeError('test assertion failed')
 
 def oneways(helper, p):
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     p = Test.MyClassPrx.uncheckedCast(p.ice_oneway())
 
     #

--- a/python/test/Ice/operations/OnewaysAMI.py
+++ b/python/test/Ice/operations/OnewaysAMI.py
@@ -32,7 +32,7 @@ class Callback(CallbackBase):
         test(False)
 
 def onewaysAMI(helper, proxy):
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     p = Test.MyClassPrx.uncheckedCast(proxy.ice_oneway())
 
     cb = Callback()

--- a/python/test/Ice/operations/OnewaysFuture.py
+++ b/python/test/Ice/operations/OnewaysFuture.py
@@ -9,7 +9,7 @@ def test(b):
         raise RuntimeError('test assertion failed')
 
 def onewaysFuture(helper, proxy):
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     p = Test.MyClassPrx.uncheckedCast(proxy.ice_oneway())
 
     f = p.ice_pingAsync()

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -11,7 +11,7 @@ def test(b):
 
 def twoways(helper, p, bprx):
 
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     literals = p.opStringLiterals()
 
     test(Test.s0 == "\\")

--- a/python/test/Ice/operations/TwowaysAMI.py
+++ b/python/test/Ice/operations/TwowaysAMI.py
@@ -747,7 +747,7 @@ class Callback(CallbackBase):
         test(False)
 
 def twowaysAMI(helper, p):
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     cb = Callback()
     p.begin_ice_ping(cb.ping, cb.exCB)
     cb.check()

--- a/python/test/Ice/operations/TwowaysFuture.py
+++ b/python/test/Ice/operations/TwowaysFuture.py
@@ -894,7 +894,7 @@ class Callback(CallbackBase):
         self.called()
 
 def twowaysFuture(helper, p):
-    communicator = helper.communicator()
+    communicator = helper.Communicator
     f = p.ice_pingAsync()
     test(f.result() is None)
 


### PR DESCRIPTION
Cleanup of TestHelper, mostly converting functions to properties where possible. 