### PR TITLE
Refactor handling of parameters and return values in slice2cs

### DIFF
--- a/cpp/include/IceUtil/Handle.h
+++ b/cpp/include/IceUtil/Handle.h
@@ -38,7 +38,6 @@ public:
             // than just a function call). This maximises the chances
             // of inlining by compiler optimization.
             //
-            assert(0);
             throwNullHandleException(__FILE__, __LINE__);
         }
 

--- a/cpp/include/IceUtil/Handle.h
+++ b/cpp/include/IceUtil/Handle.h
@@ -38,6 +38,7 @@ public:
             // than just a function call). This maximises the chances
             // of inlining by compiler optimization.
             //
+            assert(0);
             throwNullHandleException(__FILE__, __LINE__);
         }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4408,24 +4408,6 @@ Slice::Operation::hasReturnAndOut() const
     return _hasReturnType && _usesOutParameters;
 }
 
-bool
-Slice::Operation::hasOutParameters() const
-{
-    return _usesOutParameters;
-}
-
-bool
-Slice::Operation::hasTupleReturnType() const
-{
-    return !_usesOutParameters && _returnValues.size() > 1;
-}
-
-bool
-Slice::Operation::hasSingleReturnType() const
-{
-    return _hasReturnType && (_usesOutParameters || _returnValues.size() == 1);
-}
-
 FormatType
 Slice::Operation::format() const
 {
@@ -4525,6 +4507,12 @@ Slice::Member::visit(ParserVisitor* visitor, bool)
 {
     assert(!OperationPtr::dynamicCast(this->container())); // Ensure this isn't being called for a parameter.
     visitor->visitDataMember(this);
+}
+
+OperationPtr
+Slice::Member::operation() const
+{
+    return OperationPtr::dynamicCast(container());
 }
 
 Slice::Member::Member(const ContainerPtr& container, const string& name, const TypePtr& type,

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -722,10 +722,6 @@ public:
     bool returnsData() const;
     bool returnsMultipleValues() const;
     bool hasReturnAndOut() const;
-    bool hasOutParameters() const;
-    bool hasTupleReturnType() const;
-    bool hasSingleReturnType() const;
-    int attributes() const;
     FormatType format() const;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
@@ -1064,6 +1060,9 @@ public:
     bool uses(const ContainedPtr&) const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
+
+    // Returns the enclosing operation when this member is a parameter or return value member. Otherwise, returns null.
+    OperationPtr operation() const;
 
 protected:
 

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -77,9 +77,11 @@ std::string snakeCase(const std::string&);
 // - non-tagged members listed first but kept in the same order
 // - tagged members listed last and sorted in tag order
 void sortMembers(MemberList& members);
+
 // Returns a pair of lists respectively containing the required members, and tagged members of the provided list.
 // Untagged members are kept in their original ordering, and tagged members are sorted by tag.
 std::pair<MemberList, MemberList> getSortedMembers(const MemberList& members);
+
 // Returns a new list containing all the members of the provided list that use classes, in their original order.
 MemberList getClassTypeMembers(const MemberList& members);
 

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -13,7 +13,7 @@
 namespace Slice
 {
 
-enum CSharpBaseType { ObjectType=1, ExceptionType=2 };
+enum CSharpBaseType { ObjectType = 1, ExceptionType = 2 };
 
 std::string fixId(const std::string&, unsigned int = 0);
 //
@@ -31,34 +31,19 @@ std::string getUnqualified(const ContainedPtr&,
                            const std::string& prefix = "",
                            const std::string& suffix = "");
 
-struct ParamInfo
-{
-    std::string name;
-    TypePtr type;
-    std::string typeStr;
-    bool tagged;
-    int tag;
-    MemberPtr param; // 0 == return value
-    OperationPtr operation;
-
-    ParamInfo(const OperationPtr& operation, const std::string& name, const TypePtr& type, bool readOnly,
-              bool tagged, int tag, const std::string& prefix = "");
-    ParamInfo(const MemberPtr& param, bool readOnly, const std::string& prefix = "");
-};
-
 bool normalizeCase(const ContainedPtr&);
 std::string operationName(const OperationPtr&);
-std::string paramName(const ParamInfo&);
+std::string paramName(const MemberPtr& param, const std::string& prefix = "");
+std::string paramTypeStr(const MemberPtr& param, bool readOnly = false);
+
+std::string fieldName(const MemberPtr&);
 std::string interfaceName(const InterfaceDeclPtr&);
 std::string interfaceName(const InterfaceDefPtr&);
-std::string dataMemberName(const ParamInfo&);
-std::string dataMemberName(const MemberPtr&);
 
 std::string helperName(const TypePtr&, const std::string&);
 
 std::string builtinSuffix(const BuiltinPtr&);
 
-std::string returnValueName(const MemberList&);
 std::string resultType(const OperationPtr&, const std::string&, bool);
 std::string resultTask(const OperationPtr&, const std::string&, bool);
 
@@ -67,20 +52,11 @@ bool isValueType(const TypePtr&); // value with C# "struct" meaning
 bool isReferenceType(const TypePtr&); // opposite of value
 bool isMappedToReadOnlyMemory(const SequencePtr& seq);
 
-std::list<ParamInfo> getAllInParams(const OperationPtr&, bool readOnly, const std::string& prefix = "");
-void getInParams(const OperationPtr&, bool, std::list<ParamInfo>&, std::list<ParamInfo>&,
-    const std::string& prefix = "");
+std::vector<std::string> getNames(const MemberList& params, const std::string& prefix = "");
+std::vector<std::string> getNames(const MemberList&, std::function<std::string (const MemberPtr&)>);
 
-std::list<ParamInfo> getAllOutParams(const OperationPtr&, bool readOnly, const std::string& prefix = "",
-                                     bool returnTypeIsFirst = false);
-void getOutParams(const OperationPtr&, bool readOnly, std::list<ParamInfo>&, std::list<ParamInfo>&,
-    const std::string& prefix = "");
-
-std::vector<std::string> getNames(const std::list<ParamInfo>& params, std::string prefix = "");
-std::vector<std::string> getNames(const std::list<ParamInfo>& params, std::function<std::string (const ParamInfo&)>);
-
-std::string toTuple(const std::list<ParamInfo>& params, const std::string& = "");
-std::string toTupleType(const std::list<ParamInfo>& params, const std::string& = "");
+std::string toTuple(const MemberList& params, const std::string& prefix = "");
+std::string toTupleType(const MemberList& params, bool readOnly);
 
 template<typename T> inline std::vector<std::string>
 mapfn(const std::list<T>& items, std::function<std::string (const T&)> fn)

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -27,10 +27,20 @@ public:
 
 protected:
 
-    void writeMarshalParams(const OperationPtr&, const std::list<ParamInfo>&, const std::list<ParamInfo>&,
-                            bool, const std::string& stream = "ostr", const std::string& obj = "");
-    void writeUnmarshalParams(const OperationPtr&, const std::list<ParamInfo>&, const std::list<ParamInfo>&,
-                              bool, const std::string& stream = "istr");
+    void writeMarshalParams(
+        const OperationPtr& op,
+        const MemberList& requiredParams,
+        const MemberList& taggedParams,
+        bool isReturnValue,
+        const std::string& stream = "ostr",
+        const std::string& obj = "");
+
+    void writeUnmarshalParams(
+        const OperationPtr& op,
+        const MemberList& requiredParams,
+        const MemberList& taggedParams,
+        bool isReturnValue,
+        const std::string& stream = "istr");
 
     void writeMarshalDataMembers(const MemberList&, const std::string&, unsigned int);
     void writeUnmarshalDataMembers(const MemberList&, const std::string&, unsigned int);

--- a/csharp/test/Ice/enums/TestI.cs
+++ b/csharp/test/Ice/enums/TestI.cs
@@ -28,68 +28,68 @@ namespace ZeroC.Ice.Test.Enums
         public (IEnumerable<SimpleEnum>, IEnumerable<SimpleEnum>) OpSimpleSeq(SimpleEnum[] s1, Current current) =>
             (s1, s1);
 
-        public (FLByteEnum ReturnValue, FLByteEnum b2) OpFLByte(FLByteEnum b1, Current current) => (b1, b1);
+        public (FLByteEnum ReturnValue, FLByteEnum B2) OpFLByte(FLByteEnum b1, Current current) => (b1, b1);
 
-        public (FLShortEnum ReturnValue, FLShortEnum s2) OpFLShort(FLShortEnum s1, Current current) => (s1, s1);
+        public (FLShortEnum ReturnValue, FLShortEnum S2) OpFLShort(FLShortEnum s1, Current current) => (s1, s1);
 
-        public (FLUShortEnum ReturnValue, FLUShortEnum s2) OpFLUShort(FLUShortEnum s1, Current current) => (s1, s1);
+        public (FLUShortEnum ReturnValue, FLUShortEnum S2) OpFLUShort(FLUShortEnum s1, Current current) => (s1, s1);
 
-        public (FLIntEnum ReturnValue, FLIntEnum i2) OpFLInt(FLIntEnum i1, Current current) => (i1, i1);
+        public (FLIntEnum ReturnValue, FLIntEnum I2) OpFLInt(FLIntEnum i1, Current current) => (i1, i1);
 
-        public (FLUIntEnum ReturnValue, FLUIntEnum i2) OpFLUInt(FLUIntEnum i1, Current current) => (i1, i1);
+        public (FLUIntEnum ReturnValue, FLUIntEnum I2) OpFLUInt(FLUIntEnum i1, Current current) => (i1, i1);
 
-        public (FLSimpleEnum ReturnValue, FLSimpleEnum s2) OpFLSimple(FLSimpleEnum s1, Current current) => (s1, s1);
+        public (FLSimpleEnum ReturnValue, FLSimpleEnum S2) OpFLSimple(FLSimpleEnum s1, Current current) => (s1, s1);
 
-        public (ReadOnlyMemory<FLByteEnum> ReturnValue, ReadOnlyMemory<FLByteEnum> b2) OpFLByteSeq(
+        public (ReadOnlyMemory<FLByteEnum> ReturnValue, ReadOnlyMemory<FLByteEnum> B2) OpFLByteSeq(
             FLByteEnum[] b1,
             Current current) => (b1, b1);
 
-        public (ReadOnlyMemory<FLShortEnum> ReturnValue, ReadOnlyMemory<FLShortEnum> s2) OpFLShortSeq(
+        public (ReadOnlyMemory<FLShortEnum> ReturnValue, ReadOnlyMemory<FLShortEnum> S2) OpFLShortSeq(
             FLShortEnum[] s1,
             Current current) => (s1, s1);
 
-        public (ReadOnlyMemory<FLUShortEnum> ReturnValue, ReadOnlyMemory<FLUShortEnum> s2) OpFLUShortSeq(
+        public (ReadOnlyMemory<FLUShortEnum> ReturnValue, ReadOnlyMemory<FLUShortEnum> S2) OpFLUShortSeq(
             FLUShortEnum[] s1,
             Current current) => (s1, s1);
 
-        public (ReadOnlyMemory<FLIntEnum> ReturnValue, ReadOnlyMemory<FLIntEnum> i2) OpFLIntSeq(
+        public (ReadOnlyMemory<FLIntEnum> ReturnValue, ReadOnlyMemory<FLIntEnum> I2) OpFLIntSeq(
             FLIntEnum[] i1,
             Current current) => (i1, i1);
 
-        public (ReadOnlyMemory<FLUIntEnum> ReturnValue, ReadOnlyMemory<FLUIntEnum> i2) OpFLUIntSeq(
+        public (ReadOnlyMemory<FLUIntEnum> ReturnValue, ReadOnlyMemory<FLUIntEnum> I2) OpFLUIntSeq(
             FLUIntEnum[] i1,
             Current current) => (i1, i1);
 
-        public (ReadOnlyMemory<FLSimpleEnum> ReturnValue, ReadOnlyMemory<FLSimpleEnum> s2) OpFLSimpleSeq(
+        public (ReadOnlyMemory<FLSimpleEnum> ReturnValue, ReadOnlyMemory<FLSimpleEnum> S2) OpFLSimpleSeq(
             FLSimpleEnum[] s1,
             Current current) => (s1, s1);
 
-        public (ByteEnum? ReturnValue, ByteEnum? b2) OpTaggedByte(ByteEnum? b1, Current current) => (b1, b1);
+        public (ByteEnum? ReturnValue, ByteEnum? B2) OpTaggedByte(ByteEnum? b1, Current current) => (b1, b1);
 
-        public (FLByteEnum? ReturnValue, FLByteEnum? b2) OpTaggedFLByte(FLByteEnum? b1, Current current) => (b1, b1);
+        public (FLByteEnum? ReturnValue, FLByteEnum? B2) OpTaggedFLByte(FLByteEnum? b1, Current current) => (b1, b1);
 
-        public (IEnumerable<ByteEnum>? ReturnValue, IEnumerable<ByteEnum>? b2) OpTaggedByteSeq(
+        public (IEnumerable<ByteEnum>? ReturnValue, IEnumerable<ByteEnum>? B2) OpTaggedByteSeq(
             ByteEnum[]? b1,
             Current current) => (b1, b1);
 
-        public (ReadOnlyMemory<FLByteEnum> ReturnValue, ReadOnlyMemory<FLByteEnum> b2) OpTaggedFLByteSeq(
+        public (ReadOnlyMemory<FLByteEnum> ReturnValue, ReadOnlyMemory<FLByteEnum> B2) OpTaggedFLByteSeq(
             FLByteEnum[]? b1,
             Current current) => (b1, b1);
 
-        public (ReadOnlyMemory<FLIntEnum> ReturnValue, ReadOnlyMemory<FLIntEnum> i2) OpTaggedFLIntSeq(
+        public (ReadOnlyMemory<FLIntEnum> ReturnValue, ReadOnlyMemory<FLIntEnum> I2) OpTaggedFLIntSeq(
             FLIntEnum[]? i1,
             Current current) => (i1, i1);
 
-        public (MyFlags ReturnValue, MyFlags f2) OpMyFlags(MyFlags f1, Current current) =>
+        public (MyFlags ReturnValue, MyFlags F2) OpMyFlags(MyFlags f1, Current current) =>
             (f1, f1);
 
-        public (ReadOnlyMemory<MyFlags> ReturnValue, ReadOnlyMemory<MyFlags> f2) OpMyFlagsSeq(
+        public (ReadOnlyMemory<MyFlags> ReturnValue, ReadOnlyMemory<MyFlags> F2) OpMyFlagsSeq(
             MyFlags[] f1,
             Current current) => (f1, f1);
 
-        public (MyFlags? ReturnValue, MyFlags? f2) OpTaggedMyFlags(MyFlags? f1, Current current) => (f1, f1);
+        public (MyFlags? ReturnValue, MyFlags? F2) OpTaggedMyFlags(MyFlags? f1, Current current) => (f1, f1);
 
-        public (ReadOnlyMemory<MyFlags> ReturnValue, ReadOnlyMemory<MyFlags> f2) OpTaggedMyFlagsSeq(
+        public (ReadOnlyMemory<MyFlags> ReturnValue, ReadOnlyMemory<MyFlags> F2) OpTaggedMyFlagsSeq(
             MyFlags[]? f1,
             Current current) => (f1, f1);
 

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -28,7 +28,7 @@ namespace ZeroC.Ice.Test.Optional
             TestHelper.Assert(i3 == null || i3 == i4);
         }
 
-        public (int? ReturnValue, int o1, int? o2, string? o3) OpBasicInOut(int i1, int? i2, string? i3,
+        public (int? ReturnValue, int O1, int? O2, string? O3) OpBasicInOut(int i1, int? i2, string? i3,
             Current current) => (i2, i1, i2, i3);
 
         public IObjectPrx? OpObject(IObjectPrx i1, IObjectPrx? i2, Current current)

--- a/csharp/test/Ice/scope/AllTests.cs
+++ b/csharp/test/Ice/scope/AllTests.cs
@@ -67,36 +67,36 @@ namespace ZeroC.Ice.Test.Scope
                         var s1 = new S(0);
                         var opSResult = await i.OpSAsync(s1);
                         TestHelper.Assert(s1.Equals(opSResult.ReturnValue));
-                        TestHelper.Assert(s1.Equals(opSResult.s2));
+                        TestHelper.Assert(s1.Equals(opSResult.S2));
 
                         var sseq1 = new S[] { s1 };
                         var opSSeqResult = await i.OpSSeqAsync(sseq1);
                         TestHelper.Assert(opSSeqResult.ReturnValue[0].Equals(s1));
-                        TestHelper.Assert(opSSeqResult.s2[0].Equals(s1));
+                        TestHelper.Assert(opSSeqResult.S2[0].Equals(s1));
 
                         var smap1 = new Dictionary<string, S>();
                         smap1["a"] = s1;
                         var opSMapResult = await i.OpSMapAsync(smap1);
                         TestHelper.Assert(opSMapResult.ReturnValue["a"].Equals(s1));
-                        TestHelper.Assert(opSMapResult.s2["a"].Equals(s1));
+                        TestHelper.Assert(opSMapResult.S2["a"].Equals(s1));
 
                         var c1 = new C(s1);
-                        (C? ReturnValue, C? c2) opCResult = await i.OpCAsync(c1);
+                        (C? ReturnValue, C? C2) opCResult = await i.OpCAsync(c1);
                         TestHelper.Assert(opCResult.ReturnValue != null && c1.S.Equals(opCResult.ReturnValue.S));
-                        TestHelper.Assert(opCResult.c2 != null && c1.S.Equals(opCResult.c2.S));
+                        TestHelper.Assert(opCResult.C2 != null && c1.S.Equals(opCResult.C2.S));
 
                         var cseq1 = new C[] { c1 };
-                        (C?[] ReturnValue, C?[] c2) opCSeqResult = await i.OpCSeqAsync(cseq1);
+                        (C?[] ReturnValue, C?[] C2) opCSeqResult = await i.OpCSeqAsync(cseq1);
                         TestHelper.Assert(opCSeqResult.ReturnValue[0]!.S.Equals(s1));
-                        TestHelper.Assert(opCSeqResult.c2[0]!.S.Equals(s1));
+                        TestHelper.Assert(opCSeqResult.C2[0]!.S.Equals(s1));
 
                         var cmap1 = new Dictionary<string, C?>
                         {
                             ["a"] = c1
                         };
-                        (Dictionary<string, C?> ReturnValue, Dictionary<string, C?> c2) =
+                        (Dictionary<string, C?> returnValue, Dictionary<string, C?> c2) =
                             await i.OpCMapAsync(cmap1);
-                        TestHelper.Assert(ReturnValue["a"]!.S.Equals(s1));
+                        TestHelper.Assert(returnValue["a"]!.S.Equals(s1));
                         TestHelper.Assert(c2["a"]!.S.Equals(s1));
 
                         E1 e = await i.OpE1Async(E1.v1);
@@ -152,34 +152,34 @@ namespace ZeroC.Ice.Test.Scope
                         Inner.Inner2.S s1 = new Inner.Inner2.S(0);
                         var opSResult = await i.OpSAsync(s1);
                         TestHelper.Assert(s1.Equals(opSResult.ReturnValue));
-                        TestHelper.Assert(s1.Equals(opSResult.s2));
+                        TestHelper.Assert(s1.Equals(opSResult.S2));
 
                         var sseq1 = new Inner.Inner2.S[] { s1 };
-                        (Inner.Inner2.S[] ReturnValue, Inner.Inner2.S[] s2) opSSeqResult = await i.OpSSeqAsync(sseq1);
+                        (Inner.Inner2.S[] ReturnValue, Inner.Inner2.S[] S2) opSSeqResult = await i.OpSSeqAsync(sseq1);
                         TestHelper.Assert(opSSeqResult.ReturnValue[0].Equals(s1));
-                        TestHelper.Assert(opSSeqResult.s2[0].Equals(s1));
+                        TestHelper.Assert(opSSeqResult.S2[0].Equals(s1));
 
                         var smap1 = new Dictionary<string, Inner.Inner2.S> { ["a"] = s1 };
-                        (Dictionary<string, Inner.Inner2.S> ReturnValue,
+                        (Dictionary<string, Inner.Inner2.S> returnValue,
                          Dictionary<string, Inner.Inner2.S> s2) = await i.OpSMapAsync(smap1);
-                        TestHelper.Assert(ReturnValue["a"].Equals(s1));
+                        TestHelper.Assert(returnValue["a"].Equals(s1));
                         TestHelper.Assert(s2["a"].Equals(s1));
 
                         var c1 = new Inner.Inner2.C(s1);
-                        (Inner.Inner2.C? ReturnValue, Inner.Inner2.C? c2) opCResult = await i.OpCAsync(c1);
+                        (Inner.Inner2.C? ReturnValue, Inner.Inner2.C? C2) opCResult = await i.OpCAsync(c1);
                         TestHelper.Assert(c1.S.Equals(opCResult.ReturnValue!.S));
-                        TestHelper.Assert(c1.S.Equals(opCResult.c2!.S));
+                        TestHelper.Assert(c1.S.Equals(opCResult.C2!.S));
 
                         Inner.Inner2.C[] cseq1 = new Inner.Inner2.C[] { c1 };
-                        (Inner.Inner2.C?[] ReturnValue, Inner.Inner2.C?[] c2) opCSeqResult = await i.OpCSeqAsync(cseq1);
+                        (Inner.Inner2.C?[] ReturnValue, Inner.Inner2.C?[] C2) opCSeqResult = await i.OpCSeqAsync(cseq1);
                         TestHelper.Assert(opCSeqResult.ReturnValue[0]!.S.Equals(s1));
-                        TestHelper.Assert(opCSeqResult.c2[0]!.S.Equals(s1));
+                        TestHelper.Assert(opCSeqResult.C2[0]!.S.Equals(s1));
 
                         var cmap1 = new Dictionary<string, Inner.Inner2.C?> { ["a"] = c1 };
                         (Dictionary<string, Inner.Inner2.C?> ReturnValue,
-                         Dictionary<string, Inner.Inner2.C?> c2) opCMapResult = await i.OpCMapAsync(cmap1);
+                         Dictionary<string, Inner.Inner2.C?> C2) opCMapResult = await i.OpCMapAsync(cmap1);
                         TestHelper.Assert(opCMapResult.ReturnValue["a"]!.S.Equals(s1));
-                        TestHelper.Assert(opCMapResult.c2["a"]!.S.Equals(s1));
+                        TestHelper.Assert(opCMapResult.C2["a"]!.S.Equals(s1));
                     }).Wait();
             }
 
@@ -237,22 +237,22 @@ namespace ZeroC.Ice.Test.Scope
                         var smap1 = new Dictionary<string, Inner.Inner2.S> { ["a"] = s1 };
                         var opSMapResult = await i.OpSMapAsync(smap1);
                         TestHelper.Assert(opSMapResult.ReturnValue["a"].Equals(s1));
-                        TestHelper.Assert(opSMapResult.s2["a"].Equals(s1));
+                        TestHelper.Assert(opSMapResult.S2["a"].Equals(s1));
 
                         Inner.Inner2.C c1 = new Inner.Inner2.C(s1);
                         var opCResult = await i.OpCAsync(c1);
                         TestHelper.Assert(c1.S.Equals(opCResult.ReturnValue!.S));
-                        TestHelper.Assert(c1.S.Equals(opCResult.c2!.S));
+                        TestHelper.Assert(c1.S.Equals(opCResult.C2!.S));
 
                         Inner.Inner2.C[] cseq1 = new Inner.Inner2.C[] { c1 };
                         var opCSeqResult = await i.OpCSeqAsync(cseq1);
                         TestHelper.Assert(opCSeqResult.ReturnValue[0]!.S.Equals(s1));
-                        TestHelper.Assert(opCSeqResult.c2[0]!.S.Equals(s1));
+                        TestHelper.Assert(opCSeqResult.C2[0]!.S.Equals(s1));
 
                         var cmap1 = new Dictionary<string, Inner.Inner2.C?> { ["a"] = c1 };
                         var opCMapResult = await i.OpCMapAsync(cmap1);
                         TestHelper.Assert(opCMapResult.ReturnValue["a"]!.S.Equals(s1));
-                        TestHelper.Assert(opCMapResult.c2["a"]!.S.Equals(s1));
+                        TestHelper.Assert(opCMapResult.C2["a"]!.S.Equals(s1));
                     }).Wait();
             }
 


### PR DESCRIPTION
This is a clean-up PR: slice2cs now uses directly Operation::parameters() and returnValues() instead of ParamInfo.

The logic and generated code are the same as before, except for a few fixes with capitalization and iceP prefixes.