### PR TITLE
Support for cancelling dispatch with Ice2/Slic

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -147,6 +147,8 @@ namespace ZeroC.Ice
         private Task? _closeTask;
         private readonly Communicator _communicator;
         private readonly IConnector? _connector;
+        private readonly Dictionary<long, CancellationTokenSource> _dispatch =
+            new Dictionary<long, CancellationTokenSource>();
         private int _dispatchCount;
         private TaskCompletionSource<bool>? _dispatchTaskCompletionSource;
         private Exception? _exception;
@@ -157,8 +159,6 @@ namespace ZeroC.Ice
         private Task _receiveTask = Task.CompletedTask;
         private readonly Dictionary<long, (TaskCompletionSource<IncomingResponseFrame>, bool)> _requests =
             new Dictionary<long, (TaskCompletionSource<IncomingResponseFrame>, bool)>();
-        private readonly Dictionary<long, CancellationTokenSource> _dispatch =
-            new Dictionary<long, CancellationTokenSource>();
         private ConnectionState _state; // The current state.
         private bool _validated;
 
@@ -463,6 +463,7 @@ namespace ZeroC.Ice
                 {
                     throw new RetryException(_exception);
                 }
+                cancel.ThrowIfCancellationRequested();
 
                 Debug.Assert(_state > ConnectionState.Validating);
                 Debug.Assert(_state < ConnectionState.Closing);
@@ -481,64 +482,65 @@ namespace ZeroC.Ice
                     childObserver?.Attach();
                 }
 
-                // If oneway, terminate the stream after sending the request.
+                // It's important to call SendAsync from the synchronization here to ensure the requests are queued
+                // for sending in the same order as the streamId are allocated.
                 writeTask = BinaryConnection.SendAsync(streamId, request, fin: oneway, cancel);
             }
 
             try
             {
+                // Wait for the sending of the request.
                 await writeTask.ConfigureAwait(false);
+
+                // The request is sent
+                progress.Report(false); // sentSynchronously: false
+
+                if (responseTask == null)
+                {
+                    // We're done if no response is expected.
+                    return IncomingResponseFrame.WithVoidReturnValue(request.Protocol, request.Encoding);
+                }
+                else
+                {
+                    // Wait for the reception of the response.
+                    IncomingResponseFrame response = await responseTask.WaitAsync(cancel).ConfigureAwait(false);
+                    childObserver?.Reply(response.Size);
+                    return response;
+                }
             }
             catch (Exception ex)
             {
-                if (ex is OperationCanceledException || ex is DatagramLimitException)
+                if (ex is OperationCanceledException)
                 {
-                    // Non fatal exception, remove the request from the request map.
+                    try
+                    {
+                        // Reset the stream
+                        await BinaryConnection.ResetAsync(streamId).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                    }
+
                     lock (_mutex)
                     {
-                        _requests.Remove(streamId);
-                        if (_requests.Count == 0)
+                        if (_requests.Remove(streamId) && _requests.Count == 0)
                         {
                             System.Threading.Monitor.PulseAll(_mutex); // Notify threads blocked in Close()
                         }
                     }
                 }
-                else
+                else if (!(ex is DatagramLimitException))
                 {
                     // If it's a fatal exception, we close the connection and rethrow the connection's exception
                     _ = CloseAsync(ex);
                     ex = _exception!;
                 }
                 childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
-                childObserver?.Detach();
                 throw ExceptionUtil.Throw(ex);
             }
-
-            // The request is sent
-            progress.Report(false); // sentSynchronously: false
-
-            if (responseTask == null)
+            finally
             {
                 childObserver?.Detach();
-                return IncomingResponseFrame.WithVoidReturnValue(request.Protocol, request.Encoding);
-            }
-            else
-            {
-                try
-                {
-                    IncomingResponseFrame response = await responseTask.WaitAsync(cancel).ConfigureAwait(false);
-                    childObserver?.Reply(response.Size);
-                    return response;
-                }
-                catch (Exception ex)
-                {
-                    childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
-                    throw;
-                }
-                finally
-                {
-                    childObserver?.Detach();
-                }
             }
         }
 
@@ -686,89 +688,79 @@ namespace ZeroC.Ice
 
         private async ValueTask InvokeAsync(IncomingRequestFrame request, Current current, long streamId)
         {
+            // Notify and set dispatch observer, if any.
             IDispatchObserver? dispatchObserver = null;
+            ICommunicatorObserver? communicatorObserver = _communicator.Observer;
+            if (communicatorObserver != null)
+            {
+                dispatchObserver = communicatorObserver.GetDispatchObserver(current, streamId, request.Size);
+                dispatchObserver?.Attach();
+            }
+
             OutgoingResponseFrame? response = null;
             try
             {
-                // Notify and set dispatch observer, if any.
-                ICommunicatorObserver? communicatorObserver = _communicator.Observer;
-                if (communicatorObserver != null)
+                ValueTask<OutgoingResponseFrame> vt = current.Adapter.DispatchAsync(request, current);
+                if (!current.IsOneway)
                 {
-                    dispatchObserver = communicatorObserver.GetDispatchObserver(current, streamId, request.Size);
-                    dispatchObserver?.Attach();
+                    response = await vt.ConfigureAwait(false);
                 }
+            }
+            catch (Exception ex)
+            {
+                if (!current.IsOneway)
+                {
+                    RemoteException actualEx;
+                    if (ex is RemoteException remoteEx && !remoteEx.ConvertToUnhandled)
+                    {
+                        actualEx = remoteEx;
+                    }
+                    else
+                    {
+                        actualEx = new UnhandledException(current.Identity, current.Facet, current.Operation, ex);
+                    }
+                    Incoming.ReportException(actualEx, dispatchObserver, current);
+                    response = new OutgoingResponseFrame(request, actualEx);
+                }
+            }
+
+            if (response != null)
+            {
+                response.Finish();
+                dispatchObserver?.Reply(response.Size);
 
                 try
                 {
-                    ValueTask<OutgoingResponseFrame> vt = current.Adapter.DispatchAsync(request, current);
-                    if (!current.IsOneway)
-                    {
-                        response = await vt.ConfigureAwait(false);
-                    }
+                    await BinaryConnection.SendAsync(streamId, response, fin: true, cancel: current.CancellationToken);
                 }
-                catch (Exception ex)
+                catch (OperationCanceledException)
                 {
-                    if (!current.IsOneway)
-                    {
-                        RemoteException actualEx;
-                        if (ex is RemoteException remoteEx && !remoteEx.ConvertToUnhandled)
-                        {
-                            actualEx = remoteEx;
-                        }
-                        else
-                        {
-                            actualEx = new UnhandledException(current.Identity, current.Facet, current.Operation, ex);
-                        }
-                        Incoming.ReportException(actualEx, dispatchObserver, current);
-                        response = new OutgoingResponseFrame(request, actualEx);
-                    }
-                }
-
-                if (response != null)
-                {
-                    response.Finish();
-                    dispatchObserver?.Reply(response.Size);
-                }
-            }
-            finally
-            {
-                lock (_mutex)
-                {
-                    // Dispose of the cancellation token source
-                    if (_dispatch.Remove(streamId, out CancellationTokenSource? cancelSource))
-                    {
-                        cancelSource.Dispose();
-                    }
-
-                    // Send the response if there's a response
-                    if (_state < ConnectionState.Closed && response != null)
-                    {
-                        _ = SendResponseAsync(streamId, response);
-                    }
-
-                    // Decrease the dispatch count
-                    Debug.Assert(_dispatchCount > 0);
-                    if (--_dispatchCount == 0 && _dispatchTaskCompletionSource != null)
-                    {
-                        Debug.Assert(_state > ConnectionState.Active);
-                        _dispatchTaskCompletionSource.SetResult(true);
-                    }
-                }
-
-                dispatchObserver?.Detach();
-            }
-
-            async Task SendResponseAsync(long requestId, OutgoingResponseFrame response)
-            {
-                try
-                {
-                    await BinaryConnection.SendAsync(requestId, response, fin: true, cancel: current.CancellationToken);
+                    // Ignore, the dispatch got canceled.
                 }
                 catch (Exception ex)
                 {
                     _ = CloseAsync(ex);
                 }
             }
+
+            lock (_mutex)
+            {
+                // Dispose of the cancellation token source
+                if (_dispatch.Remove(streamId, out CancellationTokenSource? cancelSource))
+                {
+                    cancelSource.Dispose();
+                }
+
+                // Decrease the dispatch count
+                Debug.Assert(_dispatchCount > 0);
+                if (--_dispatchCount == 0 && _dispatchTaskCompletionSource != null)
+                {
+                    Debug.Assert(_state > ConnectionState.Active);
+                    _dispatchTaskCompletionSource.SetResult(true);
+                }
+            }
+
+            dispatchObserver?.Detach();
         }
 
         private async ValueTask ReceiveAndDispatchFrameAsync()
@@ -840,11 +832,11 @@ namespace ZeroC.Ice
                         {
                             if (_requests.Remove(streamId,
                                     out (TaskCompletionSource<IncomingResponseFrame> TaskCompletionSource,
-                                        bool Synchronous) request))
+                                         bool Synchronous) request))
                             {
-                                // Unless i's a synchronous request whose continuation is safe to call from here since
+                                // Unless it's a synchronous request whose continuation is safe to call from here since
                                 // it won't call user code, we can't call SetResult directly here as if could end up
-                                // running user code with mutex locked.
+                                // running user code with the mutex locked.
                                 if (request.Synchronous)
                                 {
                                     request.TaskCompletionSource.SetResult(responseFrame);

--- a/csharp/src/Ice/Ice1BinaryConnection.cs
+++ b/csharp/src/Ice/Ice1BinaryConnection.cs
@@ -197,7 +197,7 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        throw new ConnectionClosedByPeerException();
+                        throw new ConnectionClosedByPeerException("");
                     }
                     return default;
                 }
@@ -401,19 +401,16 @@ namespace ZeroC.Ice
                 {
                     // If the send failed because the datagram was too large, ignore and continue sending.
                 }
-                catch (OperationCanceledException)
-                {
-                    // If the send was canceled, ignore and continue sending.
-                }
 
                 // If the send got cancelled, throw now. This isn't a fatal connection error, the next pending
                 // outgoing will be sent because we ignore the cancelation exception above.
-                // TODO: is it really a good idea to cancel the request here with ice1?  The stream/request ID assigned
-                // for the request won't be used.
-                cancel.ThrowIfCancellationRequested();
-
-                // Perform the write
-                await PerformSendFrameAsync(streamId, frame).ConfigureAwait(false);
+                //
+                // TODO: is it really a good idea to cancel the request here with ice1?  The request ID assigned
+                // for the request won't be used so the server might receive non-continuous request IDs with 4.0.
+                if (!cancel.IsCancellationRequested)
+                {
+                    await PerformSendFrameAsync(streamId, frame).ConfigureAwait(false);
+                }
             }
         }
 

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -225,7 +225,8 @@ namespace ZeroC.Ice
     [Serializable]
     public class ConnectionClosedByPeerException : ConnectionClosedException
     {
-        public ConnectionClosedByPeerException()
+        public ConnectionClosedByPeerException(string message)
+            : base(message)
         {
         }
 

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         {
             bool ice1 = TestHelper.GetTestProtocol(current.Communicator.GetProperties()) == Protocol.Ice1;
             var transport = TestHelper.GetTestTransport(current.Communicator.GetProperties());
-            var endpoint = ice1 ? "{transport} -h localhost" : $"ice+{transport}://localhost:0";
+            var endpoint = ice1 ? $"{transport} -h localhost" : $"ice+{transport}://localhost:0";
 
             using ObjectAdapter adapter = current.Communicator.CreateObjectAdapterWithEndpoints(
                 "TransientTestAdapter", endpoint);

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -629,9 +629,7 @@ namespace ZeroC.Ice.Test.AMI
                     source.CancelAfter(TimeSpan.FromMilliseconds(i));
                     try
                     {
-                        p.Clone(connectionId: $"cancel{i}").SleepAsync(50,
-                                                                       cancel: source.Token,
-                                                                       context: cancelCtx).Wait();
+                        p.Clone().SleepAsync(50, cancel: source.Token, context: cancelCtx).Wait();
                         TestHelper.Assert(false);
                     }
                     catch (AggregateException ae)

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -620,14 +620,18 @@ namespace ZeroC.Ice.Test.AMI
             }
             if (p.GetConnection() != null)
             {
-                // Stress test cancellation to ensure we exercise the various cancellation points.
+                // Stress test cancellation to ensure we exercise the various cancellation points. Cancellation of
+                // the sleep might fail or succeed on the server side depending how long we sleep.
+                var cancelCtx = new Dictionary<string, string> { { "cancel", "mightSucceed" } };
                 for (int i = 0; i < 20; ++i)
                 {
                     var source = new CancellationTokenSource();
                     source.CancelAfter(TimeSpan.FromMilliseconds(i));
                     try
                     {
-                        p.Clone(connectionId: $"cancel{i}").SleepAsync(50, cancel: source.Token).Wait();
+                        p.Clone(connectionId: $"cancel{i}").SleepAsync(50,
+                                                                       cancel: source.Token,
+                                                                       context: cancelCtx).Wait();
                         TestHelper.Assert(false);
                     }
                     catch (AggregateException ae)

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -33,12 +33,15 @@ namespace ZeroC.Ice.Test.AMI
             try
             {
                 Task.Delay(ms, current.CancellationToken).Wait();
-                TestHelper.Assert(!current.Context.ContainsKey("cancel") || current.Connection != null);
+                // Cancellation isn't supported with Ice1
+                TestHelper.Assert(!current.Context.ContainsKey("cancel") ||
+                                  current.Context["cancel"] == "mightSucceed" ||
+                                  current.Protocol == Protocol.Ice1);
             }
             catch (TaskCanceledException)
             {
                 // Expected if the request is canceled.
-                TestHelper.Assert(current.Context.ContainsKey("cancel") && current.Connection == null);
+                TestHelper.Assert(current.Context.ContainsKey("cancel"));
             }
         }
 


### PR DESCRIPTION
This PR adds support for cancelling dispatch when the peer invocation is canceled. The cancellation of the request on the client side triggers the reset of the stream which is then received by the server to cancel the dispatch by triggering the cancel on the Ice.Current cancellation token. 

The update also includes a change to transmit the graceful connection closure message to the peer.