### PR TITLE
Rework generated code for return+out in C#

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -446,7 +446,7 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
 }
 
 string
-Slice::resultType(const OperationPtr& op, const string& scope, bool dispatch)
+Slice::returnTypeStr(const OperationPtr& op, const string& scope, bool dispatch)
 {
     InterfaceDefPtr interface = op->interface();
     auto returnValues = op->returnValues();
@@ -472,9 +472,9 @@ Slice::resultType(const OperationPtr& op, const string& scope, bool dispatch)
 }
 
 string
-Slice::resultTask(const OperationPtr& op, const string& ns, bool dispatch)
+Slice::returnTaskStr(const OperationPtr& op, const string& ns, bool dispatch)
 {
-    string t = resultType(op, ns, dispatch);
+    string t = returnTypeStr(op, ns, dispatch);
     if(t == "void")
     {
         if (dispatch)

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -44,8 +44,8 @@ std::string helperName(const TypePtr&, const std::string&);
 
 std::string builtinSuffix(const BuiltinPtr&);
 
-std::string returnTypeStr(const OperationPtr&, const std::string& ns, bool dispatch);
-std::string returnTaskStr(const OperationPtr&, const std::string& ns, bool dispatch);
+std::string returnTypeStr(const OperationPtr& operation, const std::string& ns, bool dispatch);
+std::string returnTaskStr(const OperationPtr& operation, const std::string& ns, bool dispatch);
 
 bool isCollectionType(const TypePtr&);
 bool isValueType(const TypePtr&); // value with C# "struct" meaning

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -44,8 +44,8 @@ std::string helperName(const TypePtr&, const std::string&);
 
 std::string builtinSuffix(const BuiltinPtr&);
 
-std::string resultType(const OperationPtr&, const std::string&, bool);
-std::string resultTask(const OperationPtr&, const std::string&, bool);
+std::string returnTypeStr(const OperationPtr&, const std::string& ns, bool dispatch);
+std::string returnTaskStr(const OperationPtr&, const std::string& ns, bool dispatch);
 
 bool isCollectionType(const TypePtr&);
 bool isValueType(const TypePtr&); // value with C# "struct" meaning

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -28,7 +28,7 @@ public:
 protected:
 
     // Write the marshaling code for the operation's params or return type.
-    void writeMarshal(const OperationPtr& operation, bool returnType, const std::string& obj = "");
+    void writeMarshal(const OperationPtr& operation, bool returnType);
 
     // Write the unmarshaling code for the operation's params or return type - operation's params in the skeleton and
     // return type in the proxy.

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -40,6 +40,10 @@ protected:
         const MemberList& taggedParams,
         bool isReturnValue);
 
+    // Write the unmarshaling code for the operation params or return type - operation params in the skeleton and return
+    // type in the proxy.
+    void writeUnmarshal(const OperationPtr& operation, bool returnType);
+
     void writeMarshalDataMembers(const MemberList&, const std::string&, unsigned int);
     void writeUnmarshalDataMembers(const MemberList&, const std::string&, unsigned int);
 

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -27,21 +27,11 @@ public:
 
 protected:
 
-    void writeMarshalParams(
-        const OperationPtr& op,
-        const MemberList& requiredParams,
-        const MemberList& taggedParams,
-        bool isReturnValue,
-        const std::string& obj = "");
+    // Write the marshaling code for the operation's params or return type.
+    void writeMarshal(const OperationPtr& operation, bool returnType, const std::string& obj = "");
 
-    void writeUnmarshalParams(
-        const OperationPtr& op,
-        const MemberList& requiredParams,
-        const MemberList& taggedParams,
-        bool isReturnValue);
-
-    // Write the unmarshaling code for the operation params or return type - operation params in the skeleton and return
-    // type in the proxy.
+    // Write the unmarshaling code for the operation's params or return type - operation's params in the skeleton and
+    // return type in the proxy.
     void writeUnmarshal(const OperationPtr& operation, bool returnType);
 
     void writeMarshalDataMembers(const MemberList&, const std::string&, unsigned int);

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -32,15 +32,13 @@ protected:
         const MemberList& requiredParams,
         const MemberList& taggedParams,
         bool isReturnValue,
-        const std::string& stream = "ostr",
         const std::string& obj = "");
 
     void writeUnmarshalParams(
         const OperationPtr& op,
         const MemberList& requiredParams,
         const MemberList& taggedParams,
-        bool isReturnValue,
-        const std::string& stream = "istr");
+        bool isReturnValue);
 
     void writeMarshalDataMembers(const MemberList&, const std::string&, unsigned int);
     void writeUnmarshalDataMembers(const MemberList&, const std::string&, unsigned int);

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         {
             bool ice1 = TestHelper.GetTestProtocol(current.Communicator.GetProperties()) == Protocol.Ice1;
             var transport = TestHelper.GetTestTransport(current.Communicator.GetProperties());
-            var endpoint = ice1 ? "{transport} -h localhost" : $"ice+{transport}://localhost:0";
+            var endpoint = ice1 ? $"{transport} -h localhost" : $"ice+{transport}://localhost:0";
 
             using ObjectAdapter adapter = current.Communicator.CreateObjectAdapterWithEndpoints(
                 "TransientTestAdapter", endpoint);

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -18,7 +18,7 @@
 
 [[3.7]] // TODO, temporary
 
-[cs:namespace:ZeroC.Ice]
+[cs:namespace:ZeroC]
 module Ice
 {
     /// A sequence of bools.


### PR DESCRIPTION
This PR updates the generated code for return+out (when both return and out are non-optional) to be encoding-dependent:
- with the 1.1 encoding, the return is marshaled after the out parameters
- with other encodings (typically 2.0), the return is marshaled before the out parameters