### PR TITLE
Update projects to .NET 5 preview

### DIFF
--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -121,9 +121,9 @@
                  Properties="Configuration=$(Configuration);Platform=Any CPU;AppTargetFramework=netcoreapp2.1;BaseIntermediateOutputPath=obj\netcoreapp2.1\"
                  Targets="Restore;Publish"/>
 
-        <!-- Build iceboxnet with netcoreapp3.1 target framework -->
+        <!-- Build iceboxnet with net5 target framework -->
         <MSBuild Projects="$(MSBuildThisFileDirectory)..\src\IceBox\icebox.csproj"
-                 Properties="Configuration=$(Configuration);Platform=Any CPU;AppTargetFramework=netcoreapp3.1;BaseIntermediateOutputPath=obj\netcoreapp3.1\"
+                 Properties="Configuration=$(Configuration);Platform=Any CPU;AppTargetFramework=net5;BaseIntermediateOutputPath=obj\net5\"
                  Targets="Restore;Publish"
                  Condition="'$(VisualStudioVersion)' == '16.0'"/>
 
@@ -149,7 +149,7 @@
 
         <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\packages\bzip2.$(DefaultPlatformToolset).1.0.6.10\build\native\bin\x64\MT-Release\bzip2.dll;
                            $(MSBuildThisFileDirectory)..\..\cpp\msbuild\packages\bzip2.$(DefaultPlatformToolset).1.0.6.10\build\native\bin\x64\MT-Release\bzip2.pdb"
-              DestinationFolder="$(MSBuildThisFileDirectory)zeroc.ice.net\tools\netcoreapp3.1"
+              DestinationFolder="$(MSBuildThisFileDirectory)zeroc.ice.net\tools\net5"
               Condition="'$(VisualStudioVersion)' == '16.0'"/>
 
         <Copy SourceFiles="zeroc.ice.net.props"

--- a/csharp/src/Directory.Build.props
+++ b/csharp/src/Directory.Build.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="../msbuild/ice.props" />
     <PropertyGroup>
-        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">netcoreapp3.1</AppTargetFramework>
+        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net5</AppTargetFramework>
     </PropertyGroup>
 </Project>

--- a/csharp/src/Glacier2/glacier2.csproj
+++ b/csharp/src/Glacier2/glacier2.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>Glacier2</AssemblyName>
         <Title>Glacier2 .NET Client Library</Title>
         <OutputPath>../../lib</OutputPath>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice" />

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -299,16 +299,19 @@ namespace ZeroC.Ice
 
             if (appSettings != null)
             {
-                foreach (string key in appSettings.AllKeys)
+                foreach (string? key in appSettings.AllKeys)
                 {
-                    string[]? values = appSettings.GetValues(key);
-                    if (values == null)
+                    if (key != null)
                     {
-                        combinedProperties[key] = "";
-                    }
-                    else
-                    {
-                        combinedProperties[key] = StringUtil.ToPropertyValue(values);
+                        string[]? values = appSettings.GetValues(key);
+                        if (values == null)
+                        {
+                            combinedProperties[key] = "";
+                        }
+                        else
+                        {
+                            combinedProperties[key] = StringUtil.ToPropertyValue(values);
+                        }
                     }
                 }
             }
@@ -342,8 +345,9 @@ namespace ZeroC.Ice
                         string? stdErr = GetProperty("Ice.StdErr");
                         if (stdErr != null)
                         {
-                            if (stdErr.Equals(stdOut))
+                            if (stdErr == stdOut)
                             {
+                                Debug.Assert(outStream != null);
                                 Console.SetError(outStream);
                             }
                             else

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -549,7 +549,7 @@ namespace ZeroC.Ice
             CancellationTokenSource? source = null;
             try
             {
-                CancellationToken cancel;
+                CancellationToken cancel = default;
                 TimeSpan timeout = _communicator.ConnectTimeout;
                 if (timeout > TimeSpan.Zero)
                 {
@@ -811,7 +811,7 @@ namespace ZeroC.Ice
                                 // If the stream isn't terminated, we create a cancellation token source to be able
                                 // to cancel the dispatch if the client sends a stream reset (which can occur if the
                                 // invocation times out or is canceled for example).
-                                CancellationToken cancellationToken;
+                                CancellationToken cancellationToken = default;
                                 if (!fin)
                                 {
                                     var source = new CancellationTokenSource();

--- a/csharp/src/Ice/Logger.cs
+++ b/csharp/src/Ice/Logger.cs
@@ -173,11 +173,11 @@ namespace ZeroC.Ice
         private const string Time = "HH:mm:ss:fff";
 
         public override void TraceEvent(
-            TraceEventCache cache,
+            TraceEventCache? cache,
             string source,
             TraceEventType type,
             int id,
-            string message)
+            string? message)
         {
             var s = new StringBuilder(
                 type switch
@@ -195,8 +195,8 @@ namespace ZeroC.Ice
             WriteLine(s.ToString());
         }
 
-        public override void Write(string message) => Console.Error.Write(message);
+        public override void Write(string? message) => Console.Error.Write(message);
 
-        public override void WriteLine(string message) => Console.Error.WriteLine(message);
+        public override void WriteLine(string? message) => Console.Error.WriteLine(message);
     }
 }

--- a/csharp/src/Ice/MetricsObserver.cs
+++ b/csharp/src/Ice/MetricsObserver.cs
@@ -86,7 +86,7 @@ namespace ZeroC.IceMX
             }
         }
 
-        internal MetricsMap<T>.Entry? GetEntry(MetricsMap<T> map) => _entries.FirstOrDefault(entry => entry.Map == map);
+        internal MetricsMap<T>.Entry? GetEntry(MetricsMap<T> map) => _entries?.FirstOrDefault(entry => entry.Map == map);
 
         internal ObserverImpl? GetObserver<S, ObserverImpl>(string mapName, MetricsHelper<S> helper)
             where S : Metrics, new()

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -331,7 +331,7 @@ namespace ZeroC.Ice
         internal static int GetIPVersion(IPAddress addr) =>
             addr.AddressFamily == AddressFamily.InterNetwork ? EnableIPv4 : EnableIPv6;
 
-        internal static EndPoint GetLocalAddress(Socket socket)
+        internal static EndPoint? GetLocalAddress(Socket socket)
         {
             try
             {
@@ -449,7 +449,7 @@ namespace ZeroC.Ice
             addr.AddressFamily == AddressFamily.InterNetwork ?
                 (addr.Address.GetAddressBytes()[0] & 0xF0) == 0xE0 : addr.Address.IsIPv6Multicast;
 
-        internal static string LocalAddrToString(EndPoint endpoint)
+        internal static string LocalAddrToString(EndPoint? endpoint)
         {
             if (endpoint == null)
             {
@@ -475,7 +475,7 @@ namespace ZeroC.Ice
                 // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then
                 // read the size back to get the size that was actually set.
                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, rcvSize);
-                int size = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
+                int size = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer)!;
                 if (size < rcvSize)
                 {
                     // Warn if the size that was set is less than the requested size and we have not already warned.
@@ -495,7 +495,7 @@ namespace ZeroC.Ice
                 // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then
                 // read the size back to get the size that was actually set.
                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer, sndSize);
-                int size = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
+                int size = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer)!;
                 if (size < sndSize) // Warn if the size that was set is less than the requested size.
                 {
                     // Warn if the size that was set is less than the requested size and we have not already warned.

--- a/csharp/src/Ice/SslTransceiver.cs
+++ b/csharp/src/Ice/SslTransceiver.cs
@@ -209,16 +209,16 @@ namespace ZeroC.Ice
             }
         }
 
-        private X509Certificate? CertificateSelectionCallback(
+        private X509Certificate CertificateSelectionCallback(
             object sender,
             string targetHost,
             X509CertificateCollection? certs,
-            X509Certificate remoteCertificate,
+            X509Certificate? remoteCertificate,
             string[]? acceptableIssuers)
         {
             if (certs == null || certs.Count == 0)
             {
-                return null;
+                throw new ArgumentException("X509Certificate not available", nameof(certs));
             }
 
             // Use the first certificate that match the acceptable issuers.
@@ -237,8 +237,8 @@ namespace ZeroC.Ice
 
         private bool RemoteCertificateValidationCallback(
             object sender,
-            X509Certificate certificate,
-            X509Chain chain,
+            X509Certificate? certificate,
+            X509Chain? chain,
             SslPolicyErrors errors)
         {
             var message = new StringBuilder();
@@ -302,7 +302,7 @@ namespace ZeroC.Ice
                             chain.ChainPolicy.ExtraStore.Add(cert);
                         }
                     }
-                    chain.Build(certificate as X509Certificate2);
+                    chain.Build((X509Certificate2)certificate!);
                 }
 
                 if (chain != null && chain.ChainStatus != null)
@@ -344,7 +344,7 @@ namespace ZeroC.Ice
             {
                 if (buildCustomChain)
                 {
-                    chain.Dispose();
+                    chain!.Dispose();
                 }
             }
 

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -61,7 +61,7 @@ namespace ZeroC.Ice
             try
             {
                 _socket.Bind(_addr);
-                _addr = (IPEndPoint)_socket.LocalEndPoint;
+                _addr = (IPEndPoint)_socket.LocalEndPoint!;
                 _socket.Listen(endpoint.Communicator.GetPropertyAsInt("Ice.TCP.Backlog") ?? 511);
             }
             catch (SocketException ex)

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -58,7 +58,7 @@ namespace ZeroC.Ice
                     }
 
                     Socket.Bind(_addr);
-                    _addr = (IPEndPoint)Socket.LocalEndPoint;
+                    _addr = (IPEndPoint)Socket.LocalEndPoint!;
 
                     if (endpoint.Port == 0)
                     {
@@ -71,7 +71,7 @@ namespace ZeroC.Ice
                 else
                 {
                     Socket.Bind(_addr);
-                    _addr = (IPEndPoint)Socket.LocalEndPoint;
+                    _addr = (IPEndPoint)Socket.LocalEndPoint!;
                 }
             }
             catch (SocketException ex)
@@ -230,6 +230,7 @@ namespace ZeroC.Ice
                 }
                 else
                 {
+                    Debug.Assert(_peerAddr != null);
                     // TODO: Fix to use the cancellable API with 5.0
                     return await Socket.SendToAsync(buffer.GetSegment(0, count),
                                                     SocketFlags.None,
@@ -291,10 +292,10 @@ namespace ZeroC.Ice
             try
             {
                 Network.SetBufSize(Socket, _communicator, Transport.UDP);
-                _rcvSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
-                _sndSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
+                _rcvSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer)!;
+                _sndSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer)!;
 
-                if (Network.IsMulticast((IPEndPoint)_addr))
+                if (Network.IsMulticast(_addr))
                 {
                     if (_multicastInterface.Length > 0)
                     {
@@ -329,8 +330,8 @@ namespace ZeroC.Ice
             try
             {
                 Network.SetBufSize(Socket, _communicator, Transport.UDP);
-                _rcvSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
-                _sndSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
+                _rcvSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer)!;
+                _sndSize = (int)Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer)!;
             }
             catch (SocketException ex)
             {

--- a/csharp/src/Ice/ice.csproj
+++ b/csharp/src/Ice/ice.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>Ice</AssemblyName>
         <Title>Ice .NET library</Title>
         <OutputPath>../../lib</OutputPath>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice" />

--- a/csharp/src/IceBox/icebox.csproj
+++ b/csharp/src/IceBox/icebox.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>IceBox</AssemblyName>
         <Title>IceBox .NET library</Title>
         <OutputPath>../../lib</OutputPath>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice" />

--- a/csharp/src/IceGrid/icegrid.csproj
+++ b/csharp/src/IceGrid/icegrid.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>IceGrid</AssemblyName>
         <Title>IceGrid .NET Client Library</Title>
         <OutputPath>../../lib</OutputPath>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice" />

--- a/csharp/src/IceStorm/icestorm.csproj
+++ b/csharp/src/IceStorm/icestorm.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>IceStorm</AssemblyName>
         <Title>IceStorm .NET Client Library</Title>
         <OutputPath>../../lib</OutputPath>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice" />

--- a/csharp/test/Directory.Build.props
+++ b/csharp/test/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)../msbuild/ice.test.props" />
     <PropertyGroup>
-        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">netcoreapp3.1</AppTargetFramework>
+        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net5</AppTargetFramework>
     </PropertyGroup>
     <Choose>
         <When Condition="'$(ICE_BIN_DIST)' == 'all'">
@@ -12,11 +12,11 @@
         </When>
         <Otherwise>
             <ItemGroup>
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/Glacier2.dll" />
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/Ice.dll" />
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceBox.dll" />
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceGrid.dll" />
-                <Reference Include="$(MSBuildThisFileDirectory)../lib/netcoreapp3.1/IceStorm.dll" />
+                <Reference Include="$(MSBuildThisFileDirectory)../lib/net5/Glacier2.dll" />
+                <Reference Include="$(MSBuildThisFileDirectory)../lib/net5/Ice.dll" />
+                <Reference Include="$(MSBuildThisFileDirectory)../lib/net5/IceBox.dll" />
+                <Reference Include="$(MSBuildThisFileDirectory)../lib/net5/IceGrid.dll" />
+                <Reference Include="$(MSBuildThisFileDirectory)../lib/net5/IceStorm.dll" />
             </ItemGroup>
         </Otherwise>
       </Choose>

--- a/csharp/test/Ice/assemblies/msbuild/core/core.csproj
+++ b/csharp/test/Ice/assemblies/msbuild/core/core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>core</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <SliceCompile>

--- a/csharp/test/Ice/assemblies/msbuild/user/user.csproj
+++ b/csharp/test/Ice/assemblies/msbuild/user/user.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>user</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <SliceCompile>

--- a/csharp/test/Ice/faultTolerance/TestI.cs
+++ b/csharp/test/Ice/faultTolerance/TestI.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
 
         public void IdempotentAbort(Current current) => Process.GetCurrentProcess().Kill();
 
-        public int Pid(Current current) => Process.GetCurrentProcess().Id;
+        public int Pid(Current current) => System.Environment.ProcessId;
 
         public void Shutdown(Current current) => _ = current.Adapter.Communicator.ShutdownAsync();
     }

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -184,12 +184,12 @@ namespace ZeroC.Ice.Test.Optional
             TestHelper.Assert(myStruct != myStructResult); // the proxies and arrays can't be identical
             TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
                 myStructResult.X == myStruct.X &&
-                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq));
+                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));
 
             myStructResult = test.OpOptMyStruct(myStruct)!.Value;
             TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
                 myStructResult.X == myStruct.X &&
-                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq));
+                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));
 
             TestHelper.Assert(test.OpOptMyStruct(null) == null);
             output.WriteLine("ok");
@@ -199,7 +199,7 @@ namespace ZeroC.Ice.Test.Optional
             Derived derivedResult = test.OpDerived(derived);
             TestHelper.Assert(derivedResult.Proxy!.Equals(derived.Proxy) &&
                 derivedResult.X == derived.X &&
-                derivedResult.StringSeq!.SequenceEqual(derived.StringSeq) &&
+                derivedResult.StringSeq!.SequenceEqual(derived.StringSeq!) &&
                 derivedResult.SomeClass == null &&
                 derivedResult.S == derived.S);
 

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -308,8 +308,8 @@ namespace ZeroC.Ice.Test.Properties
 
                 Console.Out.Write("testing properties as list... ");
                 await using var communicator = new Communicator(properties);
-                Assert(communicator.GetPropertyAsList("Services").SequenceEqual(services));
-                Assert(communicator.GetPropertyAsList("LoggerProperties").SequenceEqual(loggerProperties));
+                Assert(communicator.GetPropertyAsList("Services")!.SequenceEqual(services));
+                Assert(communicator.GetPropertyAsList("LoggerProperties")!.SequenceEqual(loggerProperties));
                 Console.Out.WriteLine("ok");
             }
         }

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -198,13 +198,13 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo5.G == mo1.G);
             TestHelper.Assert(mo5.H!.Equals(mo1.H));
             TestHelper.Assert(mo5.I == mo1.I);
-            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Bs, mo1.Bs));
-            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Ss, mo1.Ss));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Bs!, mo1.Bs));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Ss!, mo1.Ss));
             TestHelper.Assert(mo5.Iid != null && mo5.Iid[4] == 3);
             TestHelper.Assert(mo5.Sid != null && mo5.Sid["test"] == 10);
             TestHelper.Assert(mo5.Fs.Equals(mo1.Fs));
             TestHelper.Assert(mo5.Vs.Equals(mo1.Vs));
-            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Shs, mo1.Shs));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Shs!, mo1.Shs));
             TestHelper.Assert(mo5.Es != null && mo5.Es[0] == MyEnum.MyEnumMember && mo1.Es[1] == MyEnum.MyEnumMember);
             TestHelper.Assert(mo5.Fss != null && mo5.Fss[0].Equals(new FixedStruct(78)));
             TestHelper.Assert(mo5.Vss != null && mo5.Vss[0].Equals(new VarStruct("hello")));
@@ -215,7 +215,7 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo5.Ivsd != null && mo5.Ivsd[5].Equals(new VarStruct("hello")));
             TestHelper.Assert(mo5.Iood != null && mo5.Iood[5]!.A == 15);
 
-            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Bos, new bool[] { false, true, false }));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo5.Bos!, new bool[] { false, true, false }));
             if (supportsCsharpSerializable)
             {
                 TestHelper.Assert(mo5.Ser!.Equals(new SerializableClass(56)));
@@ -260,14 +260,14 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo7.G == null);
             TestHelper.Assert(mo7.H != null && mo7.H.Equals(mo1.H));
             TestHelper.Assert(mo7.I == null);
-            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Bs, mo1.Bs));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Bs!, mo1.Bs));
             TestHelper.Assert(mo7.Ss == null);
             TestHelper.Assert(mo7.Iid != null && mo7.Iid[4] == 3);
             TestHelper.Assert(mo7.Sid == null);
             TestHelper.Assert(mo7.Fs.Equals(mo1.Fs));
             TestHelper.Assert(mo7.Vs == null);
 
-            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Shs, mo1.Shs));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Shs!, mo1.Shs));
             TestHelper.Assert(mo7.Es == null);
             TestHelper.Assert(mo7.Fss != null && mo7.Fss[0].Equals(new FixedStruct(78)));
             TestHelper.Assert(mo7.Vss == null);
@@ -278,7 +278,7 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo7.Ivsd == null);
             TestHelper.Assert(mo7.Iood != null && mo7.Iood[5]!.A == 15);
 
-            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Bos, new bool[] { false, true, false }));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo7.Bos!, new bool[] { false, true, false }));
             TestHelper.Assert(mo7.Ser == null);
 
             // Clear the second half of the tagged members
@@ -314,7 +314,7 @@ namespace ZeroC.Ice.Test.Tagged
             TestHelper.Assert(mo9.H == null);
             TestHelper.Assert(mo9.I.Equals(mo1.I));
             TestHelper.Assert(mo9.Bs == null);
-            TestHelper.Assert(Enumerable.SequenceEqual(mo9.Ss, mo1.Ss));
+            TestHelper.Assert(Enumerable.SequenceEqual(mo9.Ss!, mo1.Ss));
             TestHelper.Assert(mo9.Iid == null);
             TestHelper.Assert(mo9.Sid != null && mo9.Sid["test"] == 10);
             TestHelper.Assert(mo9.Fs == null);
@@ -1034,13 +1034,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(x => (byte)56).ToArray();
                 (p2, p3) = initial.OpByteSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpByteSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpByteSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpByteSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpByteSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1059,8 +1059,8 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<byte>(1), istr.ReadTaggedArray<byte>(3)));
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1072,13 +1072,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => true).ToArray();
                 (p2, p3) = initial.OpBoolSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpBoolSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpBoolSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpBoolSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpBoolSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1096,8 +1096,8 @@ namespace ZeroC.Ice.Test.Tagged
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<bool>(1), istr.ReadTaggedArray<bool>(3)));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1109,14 +1109,14 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => (short)56).ToArray();
                 (p2, p3) = initial.OpShortSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpShortSeqAsync(p1).Result;
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpShortSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpShortSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpShortSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1134,8 +1134,8 @@ namespace ZeroC.Ice.Test.Tagged
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<short>(1), istr.ReadTaggedArray<short>(3)));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1147,13 +1147,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => 56).ToArray();
                 (p2, p3) = initial.OpIntSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpIntSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1170,8 +1170,8 @@ namespace ZeroC.Ice.Test.Tagged
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<int>(1), istr.ReadTaggedArray<int>(3)));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1183,13 +1183,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => 56L).ToArray();
                 (p2, p3) = initial.OpLongSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpLongSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpLongSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpLongSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpLongSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1207,8 +1207,8 @@ namespace ZeroC.Ice.Test.Tagged
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<long>(1), istr.ReadTaggedArray<long>(3)));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1220,13 +1220,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => 1.0f).ToArray();
                 (p2, p3) = initial.OpFloatSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFloatSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFloatSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFloatSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpFloatSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1244,8 +1244,8 @@ namespace ZeroC.Ice.Test.Tagged
                 IncomingResponseFrame responseFrame = initial.Invoke(requestFrame);
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<float>(1), istr.ReadTaggedArray<float>(3)));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1257,13 +1257,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 100).Select(_ => 1.0).ToArray();
                 (p2, p3) = initial.OpDoubleSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpDoubleSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpDoubleSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpDoubleSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpDoubleSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1282,8 +1282,8 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray<double>(1), istr.ReadTaggedArray<double>(3)));
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1295,13 +1295,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 10).Select(_ => "test1").ToArray();
                 (p2, p3) = initial.OpStringSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpStringSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1321,8 +1321,8 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                     (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => istr.ReadString()),
                        istr.ReadTaggedArray(3, 1, fixedSize: false, istr => istr.ReadString())));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1334,13 +1334,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 10).Select(_ => new SmallStruct()).ToArray();
                 (p2, p3) = initial.OpSmallStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpSmallStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpSmallStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpSmallStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpSmallStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1361,8 +1361,8 @@ namespace ZeroC.Ice.Test.Tagged
                     (istr.ReadTaggedArray(1, 1, fixedSize: true, istr => new SmallStruct(istr)),
                         istr.ReadTaggedArray(3, 1, fixedSize: true, istr => new SmallStruct(istr))));
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1378,13 +1378,13 @@ namespace ZeroC.Ice.Test.Tagged
                     p1.Add(new SmallStruct());
                 }
                 (p2, p3) = initial.OpSmallStructList(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1));
                 (p2, p3) = initial.OpSmallStructListAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1));
                 (p2, p3) = initial.OpSmallStructList(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1));
                 (p2, p3) = initial.OpSmallStructListAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1));
 
                 (p2, p3) = initial.OpSmallStructList(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1413,8 +1413,8 @@ namespace ZeroC.Ice.Test.Tagged
 
                         return (list1, list2);
                     });
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
 
             }
 
@@ -1427,13 +1427,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 10).Select(_ => new FixedStruct()).ToArray();
                 (p2, p3) = initial.OpFixedStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpFixedStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1454,8 +1454,8 @@ namespace ZeroC.Ice.Test.Tagged
                     (istr.ReadTaggedArray(1, 4, fixedSize: true, istr => new FixedStruct(istr)),
                         istr.ReadTaggedArray(3, 4, fixedSize: true, istr => new FixedStruct(istr))));
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1471,13 +1471,13 @@ namespace ZeroC.Ice.Test.Tagged
                     p1.AddLast(new FixedStruct());
                 }
                 (p2, p3) = initial.OpFixedStructList(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructListAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructList(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpFixedStructListAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpFixedStructList(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1506,8 +1506,8 @@ namespace ZeroC.Ice.Test.Tagged
 
                         return (list1, list2);
                     });
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1519,13 +1519,13 @@ namespace ZeroC.Ice.Test.Tagged
 
                 p1 = Enumerable.Range(0, 10).Select(_ => new VarStruct("")).ToArray();
                 (p2, p3) = initial.OpVarStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpVarStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpVarStructSeq(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpVarStructSeqAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpVarStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1545,8 +1545,8 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = responseFrame.ReadReturnValue(communicator, istr =>
                       (istr.ReadTaggedArray(1, 1, fixedSize: false, istr => new VarStruct(istr)),
                         istr.ReadTaggedArray(3, 1, fixedSize: false, istr => new VarStruct(istr))));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             if (supportsCsharpSerializable)
@@ -1601,13 +1601,13 @@ namespace ZeroC.Ice.Test.Tagged
                     { 2, 3 }
                 };
                 (p2, p3) = initial.OpIntIntDict(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntIntDictAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntIntDict(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpIntIntDictAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpIntIntDict(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1629,8 +1629,8 @@ namespace ZeroC.Ice.Test.Tagged
                      istr.ReadTaggedDictionary(3, 4, 4, fixedSize: true,
                          istr => istr.ReadInt(), istr => istr.ReadInt())));
 
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1646,13 +1646,13 @@ namespace ZeroC.Ice.Test.Tagged
                     { "2", 2 }
                 };
                 (p2, p3) = initial.OpStringIntDict(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringIntDictAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringIntDict(p1);
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 (p2, p3) = initial.OpStringIntDictAsync(p1).Result;
-                TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
 
                 (p2, p3) = initial.OpStringIntDict(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
@@ -1678,8 +1678,8 @@ namespace ZeroC.Ice.Test.Tagged
                                                                             istr => istr.ReadInt()),
                        istr.ReadTaggedDictionary(3, 1, 4, fixedSize: false, istr => istr.ReadString(),
                                                                             istr => istr.ReadInt())));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2));
-                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p2!));
+                TestHelper.Assert(Enumerable.SequenceEqual(p1, p3!));
             }
 
             {
@@ -1836,7 +1836,7 @@ namespace ZeroC.Ice.Test.Tagged
 
                     p1 = new string[1] { "hello" };
                     (p3, p2) = initial.OpMSeq2(p1);
-                    TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                    TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 }
                 {
                     Dictionary<string, int>? p1, p2, p3;
@@ -1848,7 +1848,7 @@ namespace ZeroC.Ice.Test.Tagged
                         ["test"] = 54
                     };
                     (p3, p2) = initial.OpMDict2(p1);
-                    TestHelper.Assert(Enumerable.SequenceEqual(p2, p1) && Enumerable.SequenceEqual(p3, p1));
+                    TestHelper.Assert(Enumerable.SequenceEqual(p2!, p1) && Enumerable.SequenceEqual(p3!, p1));
                 }
             }
             output.WriteLine("ok");

--- a/csharp/test/IceBox/admin/config.icebox
+++ b/csharp/test/IceBox/admin/config.icebox
@@ -2,4 +2,4 @@ Ice.Admin.InstanceName=DemoIceBox
 Ice.Admin.Endpoints=tcp -p 9996 -h 127.0.0.1
 Ice.ProgramName=IceBox
 
-IceBox.Service.TestService=msbuild/testservice/netcoreapp3.1/testservice.dll:ZeroC.IceBox.Test.Admin.TestService --Ice.Config=config.service
+IceBox.Service.TestService=msbuild/testservice/net5/testservice.dll:ZeroC.IceBox.Test.Admin.TestService --Ice.Config=config.service

--- a/csharp/test/IceBox/admin/msbuild/testservice/testservice.csproj
+++ b/csharp/test/IceBox/admin/msbuild/testservice/testservice.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>testservice</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../TestI.cs" />

--- a/csharp/test/IceBox/configuration/config.icebox
+++ b/csharp/test/IceBox/configuration/config.icebox
@@ -2,12 +2,12 @@ Ice.Admin.InstanceName=DemoIceBox
 Ice.Admin.Endpoints=ice+tcp://127.0.0.1:9996
 Ice.ProgramName=IceBox
 
-IceBox.Service.Service1=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service1 --Service1.ArgProp=1 --Service1.Ovrd=2 --Service1.Unset= -a --Arg=2
-IceBox.Service.Service2=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service2 --Service1.ArgProp=1 --IceBox.InheritProperties
+IceBox.Service.Service1=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service1 --Service1.ArgProp=1 --Service1.Ovrd=2 --Service1.Unset= -a --Arg=2
+IceBox.Service.Service2=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service2 --Service1.ArgProp=1 --IceBox.InheritProperties
 
 IceBox.UseSharedCommunicator.Service3=1
-IceBox.Service.Service3=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service3
+IceBox.Service.Service3=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service3
 IceBox.UseSharedCommunicator.Service4=1
-IceBox.Service.Service4=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service4 --Service3.Prop=2 --Ice.Trace.Slicing=3
+IceBox.Service.Service4=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service4 --Service3.Prop=2 --Ice.Trace.Slicing=3
 
 IceBox.LoadOrder=Service1 Service2 Service3 Service4

--- a/csharp/test/IceBox/configuration/config.icebox2
+++ b/csharp/test/IceBox/configuration/config.icebox2
@@ -8,9 +8,9 @@ ServerProp=1
 OverrideMe=1
 UnsetMe=1
 
-IceBox.Service.Service1=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service1-2 --Service1.ArgProp=2
+IceBox.Service.Service1=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service1-2 --Service1.ArgProp=2
 
 IceBox.UseSharedCommunicator.Service2=1
-IceBox.Service.Service2=msbuild\testservice\netcoreapp3.1\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service2-2
+IceBox.Service.Service2=msbuild\testservice\net5\testservice.dll:ZeroC.IceBox.Test.Configuration.TestService --Ice.Config=config.service2-2
 
 IceBox.LoadOrder=Service1 Service2

--- a/csharp/test/IceBox/configuration/msbuild/testservice/testservice.csproj
+++ b/csharp/test/IceBox/configuration/msbuild/testservice/testservice.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>testservice</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../TestI.cs" />

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -301,7 +301,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
                             {
                                 serverCertificateValidationCallbackCalled = true;
-                                return certificate.GetCertHashString() == serverCertificate.GetCertHashString();
+                                return certificate!.GetCertHashString() == serverCertificate.GetCertHashString();
                             }
                         });
 
@@ -314,7 +314,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             ClientCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
                             {
                                 clientCertificateValidationCallbackCalled = true;
-                                return certificate.GetCertHashString() == clientCertificate.GetCertHashString();
+                                return certificate!.GetCertHashString() == clientCertificate.GetCertHashString();
                             }
                         });
 
@@ -779,37 +779,6 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                 Console.Out.Write("testing certificate selection callback... ");
                 Console.Out.Flush();
-                {
-                    clientProperties = CreateProperties(defaultProperties, null, "cacert1");
-                    clientProperties["IceSSL.Password"] = "";
-
-                    bool called = false;
-                    using var comm = new Communicator(ref args, clientProperties,
-                        tlsClientOptions: new TlsClientOptions()
-                        {
-                            ClientCertificateSelectionCallback =
-                                (sender, targetHost, certs, remoteCertificate, acceptableIssuers) =>
-                                {
-                                    called = true;
-                                    return null;
-                                }
-                        });
-                    var fact = IServerFactoryPrx.Parse(factoryRef, comm);
-                    serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
-                    IServerPrx? server = fact.CreateServer(serverProperties, false);
-                    TestHelper.Assert(server != null);
-                    try
-                    {
-                        server.NoCert();
-                        TestHelper.Assert(called);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine(ex.ToString());
-                        TestHelper.Assert(false);
-                    }
-                    fact.DestroyServer(server);
-                }
                 {
 
                     var myCerts = new X509Certificate2Collection();

--- a/csharp/test/xamarin/tests/Ice/Directory.Build.props
+++ b/csharp/test/xamarin/tests/Ice/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)../../../../msbuild/ice.test.props" />
     <PropertyGroup>
-        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">netcoreapp3.1</AppTargetFramework>
+        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net5</AppTargetFramework>
     </PropertyGroup>
     <Choose>
         <When Condition="'$(ICE_BIN_DIST)' == 'all'">

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -210,7 +210,7 @@ class Platform(object):
             version = run("dotnet --version").split(".")
             self.nugetPackageCache = re.search("global-packages: (.*)",
                                                run("dotnet nuget locals --list global-packages")).groups(1)[0]
-            self.defaultNetCoreFramework = "netcoreapp{}".format("3.1" if int(version[0]) >= 3 else "2.1")
+            self.defaultNetCoreFramework = "net5"
         except:
             self.nugetPackageCache = None
 
@@ -281,7 +281,7 @@ class Platform(object):
     def _getLibDir(self, component, process, mapping, current):
         installDir = component.getInstallDir(mapping, current)
         if isinstance(mapping, CSharpMapping):
-            return os.path.join(installDir, "lib", "netcoreapp3.1")
+            return os.path.join(installDir, "lib", "net5")
         return os.path.join(installDir, "lib")
 
     def getBuildSubDir(self, mapping, name, current):
@@ -3382,7 +3382,7 @@ class CSharpMapping(Mapping):
         def __init__(self, options=[]):
             Mapping.Config.__init__(self, options)
 
-            self.libTargetFramework = "netcoreapp3.1"
+            self.libTargetFramework = "net5"
             self.binTargetFramework = platform.defaultNetCoreFramework if self.framework == "" else self.framework
             self.testTargetFramework = platform.defaultNetCoreFramework if self.framework == "" else self.framework
 
@@ -3500,7 +3500,7 @@ class CSharpMapping(Mapping):
         else:
             path = os.path.join(current.testcase.getPath(current), current.getBuildDir(exe))
 
-        useDotnetExe = current.config.testTargetFramework in ["netcoreapp2.1"] or process.isFromBinDir()
+        useDotnetExe = process.isFromBinDir()
 
         command = ""
         if useDotnetExe:


### PR DESCRIPTION
This PR update C# projects to target .NET 5, it fixes some new warnings, mostly related to nullability. There is a new warning related to use of BinaryFormatter (now obsolete) that need to be resolved

https://github.com/GrabYourPitchforks/docs/blob/bf_obsoletion_docs/docs/standard/serialization/resolving-binaryformatter-obsoletion-errors.md