### PR TITLE
Removed per-proxy invocation timeouts

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -58,9 +58,9 @@ namespace ZeroC.Ice
             if (_adapter.TaskScheduler != null ||
                 !synchronous ||
                 oneway ||
-                _reference.InvocationTimeout != Timeout.InfiniteTimeSpan)
+                cancel != CancellationToken.None)
             {
-                // Don't invoke from the user thread if async or invocation timeout is set. We also don't dispatch
+                // Don't invoke from the user thread if async or cancellation token is set. We also don't dispatch
                 // oneway from the user thread to match the non-collocated behavior where the oneway synchronous
                 // request returns as soon as it's sent over the transport.
                 task = Task.Factory.StartNew(() =>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -117,7 +117,6 @@ namespace ZeroC.Ice
         public bool DefaultPreferNonSecure { get; }
 
         public IPAddress? DefaultSourceAddress { get; }
-        public TimeSpan DefaultInvocationTimeout { get; }
         public TimeSpan DefaultLocatorCacheTimeout { get; }
 
         /// <summary>The default router for this communicator. To disable the default router, null can be used.
@@ -168,7 +167,6 @@ namespace ZeroC.Ice
             "ConnectionCached",
             "PreferNonSecure",
             "LocatorCacheTimeout",
-            "InvocationTimeout",
             "Locator",
             "Router",
             "Context\\..*"
@@ -402,14 +400,6 @@ namespace ZeroC.Ice
                         throw new InvalidConfigurationException(
                             $"invalid IP address set for Ice.Default.SourceAddress: `{address}'", ex);
                     }
-                }
-
-                DefaultInvocationTimeout =
-                    GetPropertyAsTimeSpan("Ice.Default.InvocationTimeout") ?? Timeout.InfiniteTimeSpan;
-
-                if (DefaultInvocationTimeout == TimeSpan.Zero)
-                {
-                    throw new InvalidConfigurationException("0 is not a valid value for Ice.Default.InvocationTimeout");
                 }
 
                 // For locator cache timeout, 0 means disable locator cache.

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -145,9 +145,6 @@ namespace ZeroC.Ice
         /// <summary>The endpoints of this proxy. A proxy with a non-empty endpoint list is a direct proxy.</summary>
         public IReadOnlyList<Endpoint> Endpoints => IceReference.Endpoints;
 
-        /// <summary>The invocation timeout of this proxy.</summary>
-        public TimeSpan InvocationTimeout => IceReference.InvocationTimeout;
-
         /// <summary>Indicates whether or not this proxy caches its connection.</summary>
         /// <value>True when the proxy caches its connection; otherwise, false.</value>
         public bool IsConnectionCached => IceReference.IsConnectionCached;

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -574,13 +574,6 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(!b1.IsConnectionCached);
             communicator.RemoveProperty(property);
 
-            property = propertyPrefix + ".InvocationTimeout";
-            TestHelper.Assert(b1.InvocationTimeout == Timeout.InfiniteTimeSpan);
-            communicator.SetProperty(property, "1000ms");
-            b1 = communicator.GetPropertyAsProxy(propertyPrefix, IObjectPrx.Factory)!;
-            TestHelper.Assert(b1.InvocationTimeout == TimeSpan.FromMilliseconds(1000));
-            communicator.RemoveProperty(property);
-
             property = propertyPrefix + ".EndpointSelection";
             TestHelper.Assert(b1.EndpointSelection == EndpointSelectionType.Random);
             communicator.SetProperty(property, "Random");
@@ -615,15 +608,13 @@ namespace ZeroC.Ice.Test.Proxy
                 cacheConnection: true,
                 preferNonSecure: true,
                 endpointSelection: EndpointSelectionType.Random,
-                locatorCacheTimeout: TimeSpan.FromSeconds(200),
-                invocationTimeout: TimeSpan.FromMilliseconds(1500));
+                locatorCacheTimeout: TimeSpan.FromSeconds(200));
 
             ILocatorPrx? locator = ILocatorPrx.Parse("ice:locator", communicator).Clone(
                 cacheConnection: false,
                 preferNonSecure: true,
                 endpointSelection: EndpointSelectionType.Random,
                 locatorCacheTimeout: TimeSpan.FromSeconds(300),
-                invocationTimeout: TimeSpan.FromMilliseconds(1500),
                 router: router);
 
             b1 = IObjectPrx.Parse("ice:test", communicator).Clone(
@@ -631,32 +622,28 @@ namespace ZeroC.Ice.Test.Proxy
                 preferNonSecure: false,
                 endpointSelection: EndpointSelectionType.Ordered,
                 locatorCacheTimeout: TimeSpan.FromSeconds(100),
-                invocationTimeout: TimeSpan.FromMilliseconds(1234),
                 locator: locator);
 
             Dictionary<string, string> proxyProps = b1.ToProperty("Test");
-            TestHelper.Assert(proxyProps.Count == 18);
+            TestHelper.Assert(proxyProps.Count == 15);
 
             TestHelper.Assert(proxyProps["Test"] == "ice:test");
             TestHelper.Assert(proxyProps["Test.ConnectionCached"] == "1");
             TestHelper.Assert(proxyProps["Test.PreferNonSecure"] == "0");
             TestHelper.Assert(proxyProps["Test.EndpointSelection"] == "Ordered");
             TestHelper.Assert(proxyProps["Test.LocatorCacheTimeout"] == "100s");
-            TestHelper.Assert(proxyProps["Test.InvocationTimeout"] == "1234ms");
 
             TestHelper.Assert(proxyProps["Test.Locator"] == "ice:locator"); // strange test with an indirect locator!
             TestHelper.Assert(proxyProps["Test.Locator.ConnectionCached"] == "0");
             TestHelper.Assert(proxyProps["Test.Locator.PreferNonSecure"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.EndpointSelection"] == "Random");
             TestHelper.Assert(proxyProps["Test.Locator.LocatorCacheTimeout"] == "5m");
-            TestHelper.Assert(proxyProps["Test.Locator.InvocationTimeout"] == "1500ms");
 
             TestHelper.Assert(proxyProps["Test.Locator.Router"] == "ice:router?encoding=1.1"); // also very strange
             TestHelper.Assert(proxyProps["Test.Locator.Router.ConnectionCached"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.Router.PreferNonSecure"] == "1");
             TestHelper.Assert(proxyProps["Test.Locator.Router.EndpointSelection"] == "Random");
             TestHelper.Assert(proxyProps["Test.Locator.Router.LocatorCacheTimeout"] == "200s");
-            TestHelper.Assert(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500ms");
 
             output.WriteLine("ok");
 
@@ -699,24 +686,6 @@ namespace ZeroC.Ice.Test.Proxy
             }
             TestHelper.Assert(baseProxy.Clone(preferNonSecure: true).PreferNonSecure);
             TestHelper.Assert(!baseProxy.Clone(preferNonSecure: false).PreferNonSecure);
-
-            try
-            {
-                baseProxy.Clone(invocationTimeout: TimeSpan.Zero);
-                TestHelper.Assert(false);
-            }
-            catch (ArgumentException)
-            {
-            }
-
-            try
-            {
-                baseProxy.Clone(invocationTimeout: TimeSpan.FromSeconds(-2));
-                TestHelper.Assert(false);
-            }
-            catch (ArgumentException)
-            {
-            }
 
             try
             {
@@ -827,11 +796,6 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(!compObj1.Clone(locatorCacheTimeout: TimeSpan.FromSeconds(10))
                 .Equals(compObj1.Clone(locatorCacheTimeout: TimeSpan.FromSeconds(20))));
 
-            TestHelper.Assert(compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20)).Equals(
-                compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20))));
-            TestHelper.Assert(!compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(10)).Equals(
-                compObj1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(20))));
-
             compObj1 = IObjectPrx.Parse("ice+tcp://127.0.0.1:10000/foo", communicator);
             compObj2 = IObjectPrx.Parse("ice:MyAdapter1//foo", communicator);
             TestHelper.Assert(!compObj1.Equals(compObj2));
@@ -930,10 +894,6 @@ namespace ZeroC.Ice.Test.Proxy
                     };
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).Context.Count == 0);
                     TestHelper.Assert(cl.Clone(context: ctx, fixedConnection: connection2).Context.Count == 2);
-                    TestHelper.Assert(
-                        cl.Clone(fixedConnection: connection2).InvocationTimeout == Timeout.InfiniteTimeSpan);
-                    TestHelper.Assert(cl.Clone(invocationTimeout: TimeSpan.FromMilliseconds(10),
-                        fixedConnection: connection2).InvocationTimeout == TimeSpan.FromMilliseconds(10));
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).GetConnection() == connection2);
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).Clone(fixedConnection: connection2).GetConnection() == connection2);
                     Connection? fixedConnection = cl.Clone(connectionId: "ice_fixed").GetConnection();


### PR DESCRIPTION
This PR removes explicit per-proxy invocation timeout support. Instead, cancellation tokens can be used to setup per invocation timeouts. I did not add support for cancellation token on synchronous call. I'm on the fence for this one... not sure it's really a must have since async invocations are quite easy to use. One other idea we could consider is to allow specifying invocation timeouts on the operation in the Slice with some metadata.