### PR TITLE
Use DefaultSourceAddress with IPEndpoint

### DIFF
--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -231,6 +231,10 @@ namespace ZeroC.Ice
                     SourceAddress = IPAddress.Parse(value);
                     options.Remove("source-address");
                 }
+                else
+                {
+                    SourceAddress = Communicator.DefaultSourceAddress;
+                }
             }
         }
 
@@ -252,6 +256,7 @@ namespace ZeroC.Ice
             {
                 Port = istr.ReadUShort();
             }
+            SourceAddress = communicator.DefaultSourceAddress;
         }
 
         // Constructor for ice1 endpoint parsing.
@@ -320,6 +325,10 @@ namespace ZeroC.Ice
                         $"invalid IP address provided for --sourceAddress option in endpoint `{endpointString}'", ex);
                 }
                 options.Remove("--sourceAddress");
+            }
+            else if (!oaEndpoint)
+            {
+                SourceAddress = Communicator.DefaultSourceAddress;
             }
             // else SourceAddress remains null
         }

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -1031,6 +1031,7 @@ namespace ZeroC.Ice.Test.Proxy
 
             output.WriteLine("ok");
 
+            // TODO test communicator destroy in its own test
             output.Write("testing communicator shutdown/destroy... ");
             output.Flush();
             {
@@ -1041,6 +1042,32 @@ namespace ZeroC.Ice.Test.Proxy
                 com.ShutdownAsync();
                 com.WaitForShutdownAsync();
                 com.Dispose();
+            }
+            output.WriteLine("ok");
+
+            output.Write("testing communicator default source address... ");
+            output.Flush();
+            {
+                using var comm1 = new Communicator(new Dictionary<string, string>()
+                    {
+                        { "Ice.Default.SourceAddress", "192.168.1.40" }
+                    });
+
+                using var comm2 = new Communicator();
+
+                string[] proxyArray =
+                    {
+                        "ice+tcp://host.zeroc.com/identity#facet",
+                        "ice -t:tcp -h localhost -p 10000",
+                    };
+
+                foreach (string s in proxyArray)
+                {
+                    var prx = IObjectPrx.Parse(s, comm1);
+                    TestHelper.Assert(prx.Endpoints[0]["source-address"] == "192.168.1.40");
+                    prx = IObjectPrx.Parse(s, comm2);
+                    TestHelper.Assert(prx.Endpoints[0]["source-address"] == null);
+                }
             }
             output.WriteLine("ok");
 


### PR DESCRIPTION
This small PR fixes IPEndpoint to use Communicator.DefaultSourceAddress as the default source address