### PR TITLE
Codesign C# test host executables in macOS

### DIFF
--- a/csharp/Directory.Build.targets
+++ b/csharp/Directory.Build.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target AfterTargets="Build" Name="CodeSign" Condition="'$(OutputType)' == 'Exe' AND  $([MSBuild]::IsOSPlatform('OSX'))">
-        <Exec Command="codesign --force --sign - $(OutputPath)$(AssemblyName)"/>
+        <Exec Command="codesign --force --sign - $(TargetDir)$(ProjectName)"/>
     </Target>
 </Project>

--- a/csharp/src/Directory.Build.targets
+++ b/csharp/src/Directory.Build.targets
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)../msbuild/ice.sign.targets"/>
+    <Import Project="$(MSBuildThisFileDirectory)../Directory.Build.targets" />
 </Project>

--- a/csharp/test/Directory.Build.targets
+++ b/csharp/test/Directory.Build.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target AfterTargets="Build" Name="CodeSign" Condition="'$(OutputType)' == 'Exe' AND  $([MSBuild]::IsOSPlatform('OSX'))">
+        <Exec Command="codesign --force --sign - $(OutputPath)$(AssemblyName)"/>
+    </Target>
+</Project>


### PR DESCRIPTION
This avoid problems with macOS firewall that otherwise will consider all executables being the same, as the host is just a copy of the one included with .NET