### PR TITLE
Use adapter protocol in FindObjectById replies

### DIFF
--- a/csharp/src/Ice/IceDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceDiscovery/Locator.cs
@@ -43,7 +43,7 @@ namespace ZeroC.IceDiscovery
             {
                 if (proxy != null)
                 {
-                    _adapters.Add(adapterId, proxy.Clone(clearLocator: true, clearRouter: true));
+                    _adapters[adapterId] = proxy.Clone(clearLocator: true, clearRouter: true);
                 }
                 else
                 {
@@ -78,7 +78,7 @@ namespace ZeroC.IceDiscovery
                         adapterIds = new HashSet<string>();
                         _replicaGroups.Add(replicaGroupId, adapterIds);
                     }
-                    _adapters.Add(adapterId, proxy.Clone(clearLocator: true, clearRouter: true));
+                    _adapters[adapterId] = proxy.Clone(clearLocator: true, clearRouter: true);
                     adapterIds.Add(adapterId);
                 }
                 else

--- a/csharp/src/Ice/IceDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceDiscovery/Locator.cs
@@ -144,7 +144,7 @@ namespace ZeroC.IceDiscovery
                 {
                     try
                     {
-                        IObjectPrx proxy = _adapters.First().Value;
+                        IObjectPrx proxy = _adapters[ids.First()];
                         proxy = proxy.Clone(IObjectPrx.Factory, adapterId: key, identity: identity);
                         proxy.IcePing();
                         return proxy;

--- a/csharp/src/Ice/IceDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceDiscovery/Locator.cs
@@ -43,7 +43,7 @@ namespace ZeroC.IceDiscovery
             {
                 if (proxy != null)
                 {
-                    _adapters.Add(adapterId, proxy);
+                    _adapters.Add(adapterId, proxy.Clone(clearLocator: true, clearRouter: true));
                 }
                 else
                 {
@@ -70,7 +70,7 @@ namespace ZeroC.IceDiscovery
                             registeredProxy.Protocol != proxy.Protocol)
                         {
                             throw new InvalidProxyException(
-                                $"The proxy protocol {proxy.Protocol} doesnt match the replica group protocol");
+                                $"The proxy protocol {proxy.Protocol} doesn't match the replica group protocol");
                         }
                     }
                     else
@@ -78,7 +78,7 @@ namespace ZeroC.IceDiscovery
                         adapterIds = new HashSet<string>();
                         _replicaGroups.Add(replicaGroupId, adapterIds);
                     }
-                    _adapters.Add(adapterId, proxy);
+                    _adapters.Add(adapterId, proxy.Clone(clearLocator: true, clearRouter: true));
                     adapterIds.Add(adapterId);
                 }
                 else
@@ -144,15 +144,10 @@ namespace ZeroC.IceDiscovery
                 {
                     try
                     {
-
-                        IObjectPrx prx = _adapters[ids.First()];
-                        prx = prx.Clone(IObjectPrx.Factory,
-                                        adapterId: key,
-                                        clearLocator: true,
-                                        clearRouter: true,
-                                        identity: identity);
-                        prx.IcePing();
-                        return prx;
+                        IObjectPrx proxy = _adapters.First().Value;
+                        proxy = proxy.Clone(IObjectPrx.Factory, adapterId: key, identity: identity);
+                        proxy.IcePing();
+                        return proxy;
                     }
                     catch
                     {
@@ -160,17 +155,15 @@ namespace ZeroC.IceDiscovery
                     }
                 }
 
-                foreach ((string key, IObjectPrx prx) in _adapters)
+                foreach ((string key, IObjectPrx registeredProxy) in _adapters)
                 {
                     try
                     {
-                        IObjectPrx result = prx.Clone(IObjectPrx.Factory,
-                                                      adapterId: key,
-                                                      clearLocator: true,
-                                                      clearRouter: true,
-                                                      identity: identity);
-                        result.IcePing();
-                        return result;
+                        IObjectPrx proxy = registeredProxy.Clone(IObjectPrx.Factory,
+                                                                 adapterId: key,
+                                                                 identity: identity);
+                        proxy.IcePing();
+                        return proxy;
                     }
                     catch
                     {

--- a/csharp/src/Ice/IceDiscovery/Lookup.cs
+++ b/csharp/src/Ice/IceDiscovery/Lookup.cs
@@ -317,7 +317,17 @@ namespace ZeroC.IceDiscovery
                 IObjectPrx result = _proxies.First();
                 foreach (IObjectPrx prx in _proxies)
                 {
-                    endpoints.AddRange(prx.Endpoints);
+                    if (prx.Protocol != result.Protocol)
+                    {
+                        prx.Communicator.Logger.Trace(
+                            "Lookup",
+                            @$"ignoring replica group reply, the proxy protocol {prx.Protocol
+                               } doesn't match the replica group protocol");
+                    }
+                    else
+                    {
+                        endpoints.AddRange(prx.Endpoints);
+                    }
                 }
                 CompletionSource.SetResult(result.Clone(endpoints: endpoints));
             }

--- a/csharp/src/Ice/IceDiscovery/Lookup.cs
+++ b/csharp/src/Ice/IceDiscovery/Lookup.cs
@@ -54,7 +54,7 @@ namespace ZeroC.IceDiscovery
 
         public void FindObjectById(string domainId, Identity id, ILookupReplyPrx? reply, Current current)
         {
-            if (!domainId.Equals(_domainId))
+            if (domainId != _domainId)
             {
                 return; // Ignore
             }
@@ -62,7 +62,7 @@ namespace ZeroC.IceDiscovery
             IObjectPrx? proxy = _registry.FindObject(id);
             if (proxy != null)
             {
-                // Reply to the mulicast request using the given proxy.
+                // Reply to the multicast request using the given proxy.
                 try
                 {
                     Debug.Assert(reply != null);

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -102,7 +102,7 @@ namespace ZeroC.IceDiscovery
             _locatorAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Locator");
 
             // Setup locator registry.
-            var locatorRegistry = new LocatorRegistry(_communicator);
+            var locatorRegistry = new LocatorRegistry();
             ILocatorRegistryPrx locatorRegistryPrx =
                 _locatorAdapter.AddWithUUID(locatorRegistry, ILocatorRegistryPrx.Factory);
 

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -25,6 +25,11 @@ module Ice
     {
     }
 
+    /// This exception is raised if the proxy is invalid for the given replica group.
+    exception InvalidProxyException
+    {
+    }
+
     /// This exception is raised if the replica group provided by the
     /// server is invalid.
     exception InvalidReplicaGroupIdException


### PR DESCRIPTION
This small PR Fixes IceDiscovery to use the adapter protocol when a reply to FindObjectById requests, by cloning the proxy registered with the locator.

It also includes a check to ensure that members of a replica group use the same Protocol, after the first replica group member has been registered attempts to register members with a different protocol will be ignore