### PR TITLE
Refactor proxy generated code in C#

### DIFF
--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -46,39 +46,55 @@ namespace ZeroC.Ice
     /// <summary>Base interface of all object proxies.</summary>
     public interface IObjectPrx : IEquatable<IObjectPrx>
     {
-        /// <summary>Holds an <see cref="OutgoingRequestFrame"/> factory for each remote operation defined in the
-        /// pseudo-interface Object.</summary>
+        /// <summary>Provides an <see cref="OutgoingRequestFrame"/> factory method for each remote operation defined in
+        /// the pseudo-interface Object.</summary>
         public static class Request
         {
-            /// <summary>The <see cref="OutgoingRequestFrame"/> factory for operation ice_id.</summary>
-            public static OutgoingRequestFrame.Factory IceId =>
-                _ice_id ??= OutgoingRequestFrame.CreateFactory("ice_id", idempotent: true);
+            /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_id.</summary>
+            /// <param name="proxy">Proxy to the target Ice Object.</param>
+            /// <param name="context">The context to write into the request.</param>
+            /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
+            public static OutgoingRequestFrame IceId(IObjectPrx proxy, IReadOnlyDictionary<string, string>? context) =>
+                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_id", idempotent: true, context);
 
-            /// <summary>The <see cref="OutgoingRequestFrame"/> factory for operation ice_ids.</summary>
-            public static OutgoingRequestFrame.Factory IceIds =>
-                _ice_ids ??= OutgoingRequestFrame.CreateFactory("ice_ids", idempotent: true);
+            /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_ids.</summary>
+            /// <param name="proxy">Proxy to the target Ice Object.</param>
+            /// <param name="context">The context to write into the request.</param>
+            /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
+            public static OutgoingRequestFrame IceIds(IObjectPrx proxy, IReadOnlyDictionary<string, string>? context) =>
+                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_ids", idempotent: true, context);
 
-            /// <summary>The <see cref="OutgoingRequestFrame"/> factory for operation ice_isA.</summary>
-            public static OutgoingRequestFrame.SingleParamFactory<string> IceIsA =>
-                _ice_isA ??= OutgoingRequestFrame.CreateSingleParamFactory<string>(
+            /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_isA.</summary>
+            /// <param name="proxy">Proxy to the target Ice Object.</param>
+            /// <param name="id">The type ID argument to write into the request.</param>
+            /// <param name="context">The context to write into the request.</param>
+            /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
+            public static OutgoingRequestFrame IceIsA(
+                IObjectPrx proxy,
+                string id,
+                IReadOnlyDictionary<string, string>? context) =>
+                OutgoingRequestFrame.WithSingleParam(
+                    proxy,
                     "ice_isA",
                     idempotent: true,
                     compress: false,
                     format: default,
-                    writer: OutputStream.IceWriterFromString);
+                    context,
+                    id,
+                    OutputStream.IceWriterFromString);
 
-            /// <summary>The <see cref="OutgoingRequestFrame"/> factory for operation ice_ping.</summary>
-            public static OutgoingRequestFrame.Factory IcePing =>
-                _ice_ping ??= OutgoingRequestFrame.CreateFactory("ice_ping", idempotent: true);
-
-            private static OutgoingRequestFrame.Factory? _ice_id;
-            private static OutgoingRequestFrame.Factory? _ice_ids;
-            private static OutgoingRequestFrame.SingleParamFactory<string>? _ice_isA;
-            private static OutgoingRequestFrame.Factory? _ice_ping;
+            /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_ping.</summary>
+            /// <param name="proxy">Proxy to the target Ice Object.</param>
+            /// <param name="context">The context to write into the request.</param>
+            /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
+            public static OutgoingRequestFrame IcePing(
+                IObjectPrx proxy,
+                IReadOnlyDictionary<string, string>? context) =>
+                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_ping", idempotent: true, context);
         }
 
-        /// <summary>Holds an <see cref="InputStreamReader{T}"/> for each non-void remote operation defined in
-        /// the pseudo-interface Object.</summary>
+        /// <summary>Holds an <see cref="InputStreamReader{T}"/> for each non-void remote operation defined in the
+        /// pseudo-interface Object.</summary>
         public static class Response
         {
             /// <summary>The <see cref="InputStreamReader{T}"/> reader for operation ice_id.</summary>
@@ -141,7 +157,7 @@ namespace ZeroC.Ice
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>The Slice type ID of the most-derived interface.</returns>
         public string IceId(IReadOnlyDictionary<string, string>? context = null, CancellationToken cancel = default) =>
-            this.Invoke(Request.IceId(this, context), Response.IceId, cancel);
+            IceInvoke(Request.IceId(this, context), Response.IceId, cancel);
 
         /// <summary>Returns the Slice type ID of the most-derived interface supported by the target object of this
         /// proxy.</summary>
@@ -153,7 +169,7 @@ namespace ZeroC.Ice
             IReadOnlyDictionary<string, string>? context = null,
             IProgress<bool>? progress = null,
             CancellationToken cancel = default) =>
-            this.InvokeAsync(Request.IceId(this, context), Response.IceId, progress, cancel);
+            IceInvokeAsync(Request.IceId(this, context), Response.IceId, progress, cancel);
 
         /// <summary>Returns the Slice type IDs of the interfaces supported by the target object of this proxy.</summary>
         /// <param name="context">The context dictionary for the invocation.</param>
@@ -163,7 +179,7 @@ namespace ZeroC.Ice
         public string[] IceIds(
             IReadOnlyDictionary<string, string>? context = null,
             CancellationToken cancel = default) =>
-            this.Invoke(Request.IceIds(this, context), Response.IceIds, cancel);
+            IceInvoke(Request.IceIds(this, context), Response.IceIds, cancel);
 
         /// <summary>Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
         /// </summary>
@@ -175,7 +191,7 @@ namespace ZeroC.Ice
             IReadOnlyDictionary<string, string>? context = null,
             IProgress<bool>? progress = null,
             CancellationToken cancel = default) =>
-            this.InvokeAsync(Request.IceIds(this, context), Response.IceIds, progress, cancel);
+            IceInvokeAsync(Request.IceIds(this, context), Response.IceIds, progress, cancel);
 
         /// <summary>Tests whether the target object implements a specific Slice interface.</summary>
         /// <param name="id">The type ID of the Slice interface to test against.</param>
@@ -186,7 +202,7 @@ namespace ZeroC.Ice
             string id,
             IReadOnlyDictionary<string, string>? context = null,
             CancellationToken cancel = default) =>
-            this.Invoke(Request.IceIsA(this, id, context), Response.IceIsA, cancel);
+            IceInvoke(Request.IceIsA(this, id, context), Response.IceIsA, cancel);
 
         /// <summary>Tests whether this object supports a specific Slice interface.</summary>
         /// <param name="id">The type ID of the Slice interface to test against.</param>
@@ -199,13 +215,13 @@ namespace ZeroC.Ice
             IReadOnlyDictionary<string, string>? context = null,
             IProgress<bool>? progress = null,
             CancellationToken cancel = default) =>
-            this.InvokeAsync(Request.IceIsA(this, id, context), Response.IceIsA, progress, cancel);
+            IceInvokeAsync(Request.IceIsA(this, id, context), Response.IceIsA, progress, cancel);
 
         /// <summary>Tests whether the target object of this proxy can be reached.</summary>
         /// <param name="context">The context dictionary for the invocation.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         public void IcePing(IReadOnlyDictionary<string, string>? context = null, CancellationToken cancel = default) =>
-            this.InvokeVoid(Request.IcePing(this, context), IsOneway, cancel);
+            IceInvoke(Request.IcePing(this, context), IsOneway, cancel);
 
         /// <summary>Tests whether the target object of this proxy can be reached.</summary>
         /// <param name="context">The context dictionary for the invocation.</param>
@@ -216,7 +232,7 @@ namespace ZeroC.Ice
             IReadOnlyDictionary<string, string>? context = null,
             IProgress<bool>? progress = null,
             CancellationToken cancel = default) =>
-            this.InvokeVoidAsync(Request.IcePing(this, context), IsOneway, progress, cancel);
+            IceInvokeAsync(Request.IcePing(this, context), IsOneway, progress, cancel);
 
         /// <summary>The identity of the target Ice object.</summary>
         public Identity Identity => IceReference.Identity;
@@ -336,6 +352,74 @@ namespace ZeroC.Ice
                 return false;
             }
             return true;
+        }
+
+        /// <summary>Sends a request that returns a value and returns the result synchronously.</summary>
+        /// <typeparam name="T">The operation's return type.</typeparam>
+        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation.</param>
+        /// <param name="reader">An <see cref="InputStreamReader{T}"/> for the operation's return value. Typically
+        /// {IInterfaceNamePrx}.Response.{OperationName}.</param>
+        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+        /// <returns>The operation's return value.</returns>
+        protected T IceInvoke<T>(OutgoingRequestFrame request, InputStreamReader<T> reader, CancellationToken cancel) =>
+            this.Invoke(request, oneway: false, cancel).ReadReturnValue(Communicator, reader);
+
+        /// <summary>Sends a request that returns void and waits synchronously for the result.</summary>
+        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation.</param>
+        /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
+        /// twoway request.</param>
+        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+        protected void IceInvoke(OutgoingRequestFrame request, bool oneway, CancellationToken cancel)
+        {
+            IncomingResponseFrame response = this.Invoke(request, oneway, cancel);
+            if (!oneway)
+            {
+                response.ReadVoidReturnValue(Communicator);
+            }
+        }
+
+        /// <summary>Sends a request that returns a value and returns the result asynchronously.</summary>
+        /// <typeparam name="T">The operation's return type.</typeparam>
+        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation.</param>
+        /// <param name="reader">An <see cref="InputStreamReader{T}"/> for the operation's return value. Typically
+        /// {IInterfaceNamePrx}.Response.{OperationName}.</param>
+        /// <param name="progress">Sent progress provider.</param>
+        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+        /// <returns>A task that provides the return value asynchronously.</returns>
+        protected Task<T> IceInvokeAsync<T>(
+            OutgoingRequestFrame request,
+            InputStreamReader<T> reader,
+            IProgress<bool>? progress,
+            CancellationToken cancel)
+        {
+            return ReadResponseAsync(this.InvokeAsync(request, oneway: false, progress, cancel), reader, Communicator);
+
+            static async Task<T> ReadResponseAsync(
+                ValueTask<IncomingResponseFrame> task,
+                InputStreamReader<T> reader,
+                Communicator communicator) =>
+                (await task.ConfigureAwait(false)).ReadReturnValue(communicator, reader);
+        }
+
+        /// <summary>Sends a request that returns void and returns the result asynchronously.</summary>
+        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation.</param>
+        /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
+        /// twoway request.</param>
+        /// <param name="progress">Sent progress provider.</param>
+        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+        /// <returns>A task that completes when the request completes.</returns>
+        protected Task IceInvokeAsync(
+            OutgoingRequestFrame request,
+            bool oneway,
+            IProgress<bool>? progress,
+            CancellationToken cancel)
+        {
+            ValueTask<IncomingResponseFrame> response = this.InvokeAsync(request, oneway, progress, cancel);
+            return oneway ? Task.CompletedTask : ReadResponseAsync(response, Communicator);
+
+            static async Task ReadResponseAsync(
+                ValueTask<IncomingResponseFrame> response,
+                Communicator communicator) => (await response.ConfigureAwait(false)).ReadVoidReturnValue(communicator);
         }
     }
 

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -10,34 +10,6 @@ namespace ZeroC.Ice
     /// <summary>Represents an ice1 or ice2 request frame sent by the application.</summary>
     public sealed class OutgoingRequestFrame : OutgoingFrame
     {
-        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/>.</summary>
-        /// <param name="prx">The proxy used to send the new request frame.</param>
-        /// <param name="context">The Ice request context.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/>.</returns>
-        public delegate OutgoingRequestFrame Factory(IObjectPrx prx, IReadOnlyDictionary<string, string>? context);
-
-        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/>. This factory is used for operations with multiple
-        /// parameters or with a single non-optional struct parameter.</summary>
-        /// <param name="prx">The proxy used to send the new request frame.</param>
-        /// <param name="paramList">The request parameters.</param>
-        /// <param name="context">The Ice request context.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/>.</returns>
-        public delegate OutgoingRequestFrame Factory<T>(
-            IObjectPrx prx,
-            in T paramList,
-            IReadOnlyDictionary<string, string>? context) where T : struct;
-
-        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/>. This factory is used for operations with a single
-        /// parameter that is not a non-optional struct.</summary>
-        /// <param name="prx">The proxy used to send the new request frame.</param>
-        /// <param name="param">The parameter.</param>
-        /// <param name="context">The Ice request context.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/>.</returns>
-        public delegate OutgoingRequestFrame SingleParamFactory<T>(
-            IObjectPrx prx,
-            T param,
-            IReadOnlyDictionary<string, string>? context);
-
         /// <summary>The context of this request frame.</summary>
         public IReadOnlyDictionary<string, string> Context => _contextOverride ?? _initialContext;
 
@@ -83,50 +55,6 @@ namespace ZeroC.Ice
         // When true, we always write Context in slot 0 of the binary context. This field is always false when
         // _defaultBinaryContext is empty.
         private readonly bool _writeSlot0;
-
-        /// <summary>Creates an <see cref="OutgoingRequestFrame"/> factory for the given parameterless operation.
-        /// </summary>
-        /// <param name="operationName">The operation name.</param>
-        /// <param name="idempotent"><c>True</c> if the requests are idempotent, <c>False</c> otherwise.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/> factory.</returns>
-        public static Factory CreateFactory(string operationName, bool idempotent) =>
-            (prx, context) => WithEmptyParamList(prx, operationName, idempotent, context);
-
-        /// <summary>Creates an <see cref="OutgoingRequestFrame"/> factory for the given operation.</summary>
-        /// <param name="operationName">The operation name.</param>
-        /// <param name="idempotent"><c>True</c> if the requests are idempotent, <c>False</c> otherwise.</param>
-        /// <param name="compress"><c>True</c> if the request's parameters are compressed during frame creation with
-        /// ice2, or if entire request frame is compressed during sending with ice1; otherwise, <c>False</c>.</param>
-        /// <param name="format">The format for class instances.</param>
-        /// <param name="writer">The <see cref="OutputStream"/> writer used to write the request parameters.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/> factory.</returns>
-        public static Factory<T> CreateFactory<T>(
-            string operationName,
-            bool idempotent,
-            bool compress,
-            FormatType format,
-            OutputStreamValueWriter<T> writer)
-            where T : struct =>
-            (IObjectPrx prx, in T paramList, IReadOnlyDictionary<string, string>? context) =>
-            WithParamList(prx, operationName, idempotent, compress, format, context, in paramList, writer);
-
-        /// <summary>Creates an <see cref="OutgoingRequestFrame"/> factory for the given single-parameter operation.
-        /// </summary>
-        /// <param name="operationName">The operation name.</param>
-        /// <param name="idempotent"><c>True</c> if the requests are idempotent, <c>False</c> otherwise.</param>
-        /// <param name="compress"><c>True</c> if the request's parameter is compressed during frame creation with
-        /// ice2, or if entire request frame is compressed during sending with ice1; otherwise, <c>False</c>.</param>
-        /// <param name="format">The format for class instances.</param>
-        /// <param name="writer">The <see cref="OutputStream"/> writer used to write the request parameter.</param>
-        /// <returns>The new <see cref="OutgoingRequestFrame"/> factory.</returns>
-        public static SingleParamFactory<T> CreateSingleParamFactory<T>(
-            string operationName,
-            bool idempotent,
-            bool compress,
-            FormatType format,
-            OutputStreamWriter<T> writer) =>
-            (prx, param, context) =>
-            WithSingleParam(prx, operationName, idempotent, compress, format, context, param, writer);
 
         /// <summary>Create a new OutgoingRequestFrame for an operation with a single parameter.</summary>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -234,23 +234,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Sends a request that returns a value and waits synchronously for the result.</summary>
-        /// <typeparam name="T">The operation's return type.</typeparam>
-        /// <param name="proxy">The proxy for the target Ice object.</param>
-        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation. Usually this request
-        /// frame should have been created using the same proxy, however some differences are acceptable, for example
-        /// proxy can have different endpoints.</param>
-        /// <param name="reader">An <see cref="InputStreamReader{T}"/> for the operation's return value. Typically
-        /// {IInterfaceNamePrx}.Response.{OperationName}.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        /// <returns>The return value.</returns>
-        public static T Invoke<T>(
-            this IObjectPrx proxy,
-            OutgoingRequestFrame request,
-            InputStreamReader<T> reader,
-            CancellationToken cancel = default) =>
-            proxy.Invoke(request, oneway: false, cancel).ReadReturnValue(proxy.Communicator, reader);
-
         /// <summary>Sends a request asynchronously.</summary>
         /// <param name="proxy">The proxy for the target Ice object.</param>
         /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation. Usually this request
@@ -268,80 +251,6 @@ namespace ZeroC.Ice
             IProgress<bool>? progress = null,
             CancellationToken cancel = default) =>
             InvokeWithInterceptorsAsync(proxy, request, oneway, synchronous: false, progress, cancel);
-
-        /// <summary>Sends a request that returns a value and returns the result asynchronously.</summary>
-        /// <typeparam name="T">The operation's return type.</typeparam>
-        /// <param name="proxy">The proxy for the target Ice object.</param>
-        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation. Usually this request
-        /// frame should have been created using the same proxy, however some differences are acceptable, for example
-        /// proxy can have different endpoints.</param>
-        /// <param name="reader">An <see cref="InputStreamReader{T}"/> for the operation's return value. Typically
-        /// {IInterfaceNamePrx}.Response.{OperationName}.</param>
-        /// <param name="progress">Sent progress provider.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        /// <returns>The return value.</returns>
-        public static Task<T> InvokeAsync<T>(
-            this IObjectPrx proxy,
-            OutgoingRequestFrame request,
-            InputStreamReader<T> reader,
-            IProgress<bool>? progress = null,
-            CancellationToken cancel = default)
-        {
-            return ReadResponseAsync(proxy.InvokeAsync(request, oneway: false, progress, cancel),
-                                     reader,
-                                     proxy.Communicator);
-
-            static async Task<T> ReadResponseAsync(
-                ValueTask<IncomingResponseFrame> task,
-                InputStreamReader<T> reader,
-                Communicator communicator) =>
-                (await task.ConfigureAwait(false)).ReadReturnValue(communicator, reader);
-        }
-
-        /// <summary>Sends a request that returns void and waits synchronously for the result.</summary>
-        /// <param name="proxy">The proxy for the target Ice object.</param>
-        /// <param name="request">The outgoing request frame for this invocation. Usually this request frame should have
-        /// been created using the same proxy, however some differences are acceptable, for example proxy can have
-        /// different endpoints.</param>
-        /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
-        /// twoway request.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        public static void InvokeVoid(
-            this IObjectPrx proxy,
-            OutgoingRequestFrame request,
-            bool oneway,
-            CancellationToken cancel = default)
-        {
-            IncomingResponseFrame response = proxy.Invoke(request, oneway, cancel);
-            if (!oneway)
-            {
-                response.ReadVoidReturnValue(proxy.Communicator);
-            }
-        }
-
-        /// <summary>Sends a request that returns void and returns the result asynchronously.</summary>
-        /// <param name="proxy">The proxy for the target Ice object.</param>
-        /// <param name="request">The <see cref="OutgoingRequestFrame"/> for this invocation. Usually this request
-        /// frame should have been created using the same proxy, however some differences are acceptable, for example
-        /// proxy can have different endpoints.</param>
-        /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
-        /// twoway request.</param>
-        /// <param name="progress">Sent progress provider.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        public static Task InvokeVoidAsync(
-            this IObjectPrx proxy,
-            OutgoingRequestFrame request,
-            bool oneway,
-            IProgress<bool>? progress = null,
-            CancellationToken cancel = default)
-        {
-            ValueTask<IncomingResponseFrame> response = proxy.InvokeAsync(request, oneway, progress, cancel);
-            return oneway ? Task.CompletedTask : ReadResponseAsync(response, proxy.Communicator);
-
-            static async Task ReadResponseAsync(
-                ValueTask<IncomingResponseFrame> response,
-                Communicator communicator) => (await response.ConfigureAwait(false)).ReadVoidReturnValue(communicator);
-        }
 
         /// <summary>Forwards an incoming request to another Ice object represented by the <paramref name="proxy"/>
         /// parameter.</summary>


### PR DESCRIPTION
This PR simplifies the proxy generated code and brings it in sync with the servant generated code.

It also removes all the OutgoingRequestFrame factory delegates (and related methods) introduced by #1038.