### PR TITLE
Replace ValueTask<IncomingResponseFrame> by Task<IncomingResponseFrame>

### DIFF
--- a/csharp/src/Ice/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/CollocatedRequestHandler.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice
         private readonly Reference _reference;
         private int _requestId;
 
-        public async ValueTask<IncomingResponseFrame> SendRequestAsync(
+        public async Task<IncomingResponseFrame> SendRequestAsync(
             OutgoingRequestFrame outgoingRequest,
             bool oneway,
             bool synchronous,

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -431,7 +431,7 @@ namespace ZeroC.Ice
             }
         }
 
-        async ValueTask<IncomingResponseFrame> IRequestHandler.SendRequestAsync(
+        async Task<IncomingResponseFrame> IRequestHandler.SendRequestAsync(
             OutgoingRequestFrame request,
             bool oneway,
             bool synchronous,

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -397,7 +397,7 @@ namespace ZeroC.Ice
             return ReadResponseAsync(this.InvokeAsync(request, oneway: false, progress, cancel), reader, Communicator);
 
             static async Task<T> ReadResponseAsync(
-                ValueTask<IncomingResponseFrame> task,
+                Task<IncomingResponseFrame> task,
                 InputStreamReader<T> reader,
                 Communicator communicator) =>
                 (await task.ConfigureAwait(false)).ReadReturnValue(communicator, reader);
@@ -417,11 +417,11 @@ namespace ZeroC.Ice
             IProgress<bool>? progress,
             CancellationToken cancel)
         {
-            ValueTask<IncomingResponseFrame> response = this.InvokeAsync(request, oneway, progress, cancel);
+            Task<IncomingResponseFrame> response = this.InvokeAsync(request, oneway, progress, cancel);
             return oneway ? Task.CompletedTask : ReadResponseAsync(response, Communicator);
 
             static async Task ReadResponseAsync(
-                ValueTask<IncomingResponseFrame> response,
+                Task<IncomingResponseFrame> response,
                 Communicator communicator) => (await response.ConfigureAwait(false)).ReadVoidReturnValue(communicator);
         }
 

--- a/csharp/src/Ice/IRequestHandler.cs
+++ b/csharp/src/Ice/IRequestHandler.cs
@@ -31,7 +31,7 @@ namespace ZeroC.Ice
         /// <param name="cancel">The cancellation token to cancel the sending of the request</param>
         /// <returns>A task if the request is a twoway request or null if it's a oneway request. The returned task can
         /// be used to wait for the receipt of the response.</returns>
-        ValueTask<IncomingResponseFrame> SendRequestAsync(
+        Task<IncomingResponseFrame> SendRequestAsync(
             OutgoingRequestFrame frame,
             bool oneway,
             bool synchronous,

--- a/csharp/src/Ice/Invoker.cs
+++ b/csharp/src/Ice/Invoker.cs
@@ -9,7 +9,7 @@ namespace ZeroC.Ice
     /// <param name="target">The proxy for the invocation.</param>
     /// <param name="request">The outgoing request being sent.</param>
     /// <returns>The incoming response frame.</returns>
-    public delegate ValueTask<IncomingResponseFrame> Invoker(IObjectPrx target, OutgoingRequestFrame request);
+    public delegate Task<IncomingResponseFrame> Invoker(IObjectPrx target, OutgoingRequestFrame request);
 
     /// <summary>An invocation interceptor can be registered with a Communicator to intercept proxy invocations.
     /// </summary>
@@ -17,7 +17,7 @@ namespace ZeroC.Ice
     /// <param name="request">The outgoing request being sent.</param>
     /// <param name="next">The next invoker in the invocation chain.</param>
     /// <returns>The incoming response frame.</returns>
-    public delegate ValueTask<IncomingResponseFrame> InvocationInterceptor(
+    public delegate Task<IncomingResponseFrame> InvocationInterceptor(
         IObjectPrx target,
         OutgoingRequestFrame request,
         Invoker next);

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -220,12 +220,7 @@ namespace ZeroC.Ice
         {
             try
             {
-                ValueTask<IncomingResponseFrame> task = InvokeWithInterceptorsAsync(proxy,
-                                                                                    request,
-                                                                                    oneway,
-                                                                                    synchronous: true,
-                                                                                    cancel: cancel);
-                return task.IsCompleted ? task.Result : task.AsTask().Result;
+                return InvokeWithInterceptorsAsync(proxy, request, oneway, synchronous: true, cancel: cancel).Result;
             }
             catch (AggregateException ex)
             {
@@ -244,7 +239,7 @@ namespace ZeroC.Ice
         /// <param name="progress">Sent progress provider.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>A task holding the response frame.</returns>
-        public static ValueTask<IncomingResponseFrame> InvokeAsync(
+        public static Task<IncomingResponseFrame> InvokeAsync(
             this IObjectPrx proxy,
             OutgoingRequestFrame request,
             bool oneway = false,
@@ -288,7 +283,7 @@ namespace ZeroC.Ice
             return new OutgoingResponseFrame(request, response);
         }
 
-        private static ValueTask<IncomingResponseFrame> InvokeWithInterceptorsAsync(
+        private static Task<IncomingResponseFrame> InvokeWithInterceptorsAsync(
             this IObjectPrx proxy,
             OutgoingRequestFrame request,
             bool oneway,
@@ -298,7 +293,7 @@ namespace ZeroC.Ice
         {
             return InvokeWithInterceptorsAsync(proxy, request, oneway, synchronous, 0, progress, cancel);
 
-            static ValueTask<IncomingResponseFrame> InvokeWithInterceptorsAsync(
+            static Task<IncomingResponseFrame> InvokeWithInterceptorsAsync(
                 IObjectPrx proxy,
                 OutgoingRequestFrame request,
                 bool oneway,
@@ -323,7 +318,7 @@ namespace ZeroC.Ice
             }
         }
 
-        private static ValueTask<IncomingResponseFrame> InvokeAsync(
+        private static Task<IncomingResponseFrame> InvokeAsync(
             this IObjectPrx proxy,
             OutgoingRequestFrame request,
             bool oneway,
@@ -347,7 +342,7 @@ namespace ZeroC.Ice
                     return InvokeAsync(proxy, request, oneway, synchronous, progress, cancel);
             }
 
-            static async ValueTask<IncomingResponseFrame> InvokeAsync(
+            static async Task<IncomingResponseFrame> InvokeAsync(
                 IObjectPrx proxy,
                 OutgoingRequestFrame request,
                 bool oneway,

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -107,7 +107,7 @@ namespace ZeroC.Ice.Test.Invoke
                 IncomingResponseFrame response;
                 try
                 {
-                    response = oneway.InvokeAsync(request, oneway: true).AsTask().Result;
+                    response = oneway.InvokeAsync(request, oneway: true).Result;
                 }
                 catch
                 {
@@ -123,7 +123,7 @@ namespace ZeroC.Ice.Test.Invoke
                                                              TestString,
                                                              OutputStream.IceWriterFromString);
 
-                response = cl.InvokeAsync(request).AsTask().Result;
+                response = cl.InvokeAsync(request).Result;
                 (string s1, string s2) = response.ReadReturnValue(communicator, istr =>
                     {
                         string s1 = istr.ReadString();
@@ -136,7 +136,7 @@ namespace ZeroC.Ice.Test.Invoke
 
             {
                 var request = OutgoingRequestFrame.WithEmptyParamList(cl, "opException", idempotent: false);
-                IncomingResponseFrame response = cl.InvokeAsync(request).AsTask().Result;
+                IncomingResponseFrame response = cl.InvokeAsync(request).Result;
 
                 try
                 {


### PR DESCRIPTION
This tiny PR replaces ValueTask<IncomingResponseFrame> by Task<IncomingResponseFrame> in the invocation interceptor API.