### PR TITLE
Frame class cleanup

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2131,21 +2131,20 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 inValue = paramCount > 1 || StructPtr::dynamicCast(params.front()->type());
                 _out << (inValue ? "in " : "") << toTupleType(params, true) << " "
-                    << (paramCount == 1 ? paramName(params.front(), "iceP_") : "paramList") << ", ";
+                    << (paramCount == 1 ? paramName(params.front(), "iceP_") : "args") << ", ";
             }
             _out << "global::System.Collections.Generic.IReadOnlyDictionary<string, string>? context) =>";
             _out.inc();
 
             if (paramCount == 0)
             {
-                _out << nl << "ZeroC.Ice.OutgoingRequestFrame.WithEmptyParamList(proxy, \"";
+                _out << nl << "ZeroC.Ice.OutgoingRequestFrame.WithEmptyArgs(proxy, \"";
                 _out << operation->name() << "\", "
                     << "idempotent: " << (operation->isIdempotent() ? "true" : "false") << ", context);";
             }
             else
             {
-                _out << nl << "ZeroC.Ice.OutgoingRequestFrame."
-                    << (inValue ? "WithParamList" : "WithSingleParam") << "(";
+                _out << nl << "ZeroC.Ice.OutgoingRequestFrame.WithArgs(";
                 _out.inc();
                 _out << nl << "proxy,"
                     << nl << "\"" << operation->name() << "\","
@@ -2154,7 +2153,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     << nl << "format: " << opFormatTypeToString(operation) << ","
                     << nl << "context,"
                     << nl << (inValue ? "in " : "")
-                    << (paramCount == 1 ? paramName(params.front(), "iceP_") : "paramList") << ","
+                    << (paramCount == 1 ? paramName(params.front(), "iceP_") : "args") << ","
                     << nl;
                 writeOutgoingRequestWriter(operation);
                 _out << ");";
@@ -2735,12 +2734,12 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     // that we skip).
     if (params.empty())
     {
-        _out << nl << "request.ReadEmptyParamList();";
+        _out << nl << "request.ReadEmptyArgs();";
     }
     else
     {
-        _out << nl << "var " << (params.size() == 1 ? paramName(params.front(), "iceP_") : "paramList")
-            << " = request.ReadParamList(current.Communicator, Request." << fixId(opName) << ");";
+        _out << nl << "var " << (params.size() == 1 ? paramName(params.front(), "iceP_") : "args")
+            << " = request.ReadArgs(current.Communicator, Request." << fixId(opName) << ");";
     }
 
     // The 'this.' is necessary only when the operation name matches one of our local variable (current, istr etc.)
@@ -2752,7 +2751,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
             _out << nl << "var returnValue = await this." << name << spar;
             if (params.size() > 1)
             {
-                _out << getNames(params, [](const MemberPtr& param) { return "paramList." + fieldName(param); });
+                _out << getNames(params, [](const MemberPtr& param) { return "args." + fieldName(param); });
             }
             else if (params.size() == 1)
             {
@@ -2767,7 +2766,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
                  << name << spar;
             if (params.size() > 1)
             {
-                _out << getNames(params, [](const MemberPtr& param) { return "paramList." + fieldName(param); });
+                _out << getNames(params, [](const MemberPtr& param) { return "args." + fieldName(param); });
             }
             else if (params.size() == 1)
             {
@@ -2792,7 +2791,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
         _out << "this." << name << spar;
         if (params.size() > 1)
         {
-            _out << getNames(params, [](const MemberPtr& param) { return "paramList." + fieldName(param); });
+            _out << getNames(params, [](const MemberPtr& param) { return "args." + fieldName(param); });
         }
         else if (params.size() == 1)
         {

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -120,7 +120,7 @@ namespace ZeroC.Ice
         /// <returns>The response frame</returns>
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyArgs();
             string returnValue = IceId(current);
             return new ValueTask<OutgoingResponseFrame>(Response.IceId(current, returnValue));
         }
@@ -131,7 +131,7 @@ namespace ZeroC.Ice
         /// <returns>The response frame</returns>
         protected ValueTask<OutgoingResponseFrame> IceD_ice_idsAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyArgs();
             IEnumerable<string> returnValue = IceIds(current);
             return new ValueTask<OutgoingResponseFrame>(Response.IceIds(current, returnValue));
         }
@@ -142,7 +142,7 @@ namespace ZeroC.Ice
         /// <returns>The response frame</returns>
         protected ValueTask<OutgoingResponseFrame> IceD_ice_isAAsync(IncomingRequestFrame request, Current current)
         {
-            string id = request.ReadParamList(current.Communicator, Request.IceIsA);
+            string id = request.ReadArgs(current.Communicator, Request.IceIsA);
             bool returnValue = IceIsA(id, current);
             return new ValueTask<OutgoingResponseFrame>(Response.IceIsA(current, returnValue));
         }
@@ -153,7 +153,7 @@ namespace ZeroC.Ice
         /// <returns>The response frame</returns>
         protected ValueTask<OutgoingResponseFrame> IceD_ice_pingAsync(IncomingRequestFrame request, Current current)
         {
-            request.ReadEmptyParamList();
+            request.ReadEmptyArgs();
             IcePing(current);
             return new ValueTask<OutgoingResponseFrame>(OutgoingResponseFrame.WithVoidReturnValue(current));
         }

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -55,14 +55,14 @@ namespace ZeroC.Ice
             /// <param name="context">The context to write into the request.</param>
             /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
             public static OutgoingRequestFrame IceId(IObjectPrx proxy, IReadOnlyDictionary<string, string>? context) =>
-                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_id", idempotent: true, context);
+                OutgoingRequestFrame.WithEmptyArgs(proxy, "ice_id", idempotent: true, context);
 
             /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_ids.</summary>
             /// <param name="proxy">Proxy to the target Ice Object.</param>
             /// <param name="context">The context to write into the request.</param>
             /// <returns>A new <see cref="OutgoingRequestFrame"/>.</returns>
             public static OutgoingRequestFrame IceIds(IObjectPrx proxy, IReadOnlyDictionary<string, string>? context) =>
-                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_ids", idempotent: true, context);
+                OutgoingRequestFrame.WithEmptyArgs(proxy, "ice_ids", idempotent: true, context);
 
             /// <summary>Creates an <see cref="OutgoingRequestFrame"/> for operation ice_isA.</summary>
             /// <param name="proxy">Proxy to the target Ice Object.</param>
@@ -73,7 +73,7 @@ namespace ZeroC.Ice
                 IObjectPrx proxy,
                 string id,
                 IReadOnlyDictionary<string, string>? context) =>
-                OutgoingRequestFrame.WithSingleParam(
+                OutgoingRequestFrame.WithArgs(
                     proxy,
                     "ice_isA",
                     idempotent: true,
@@ -90,7 +90,7 @@ namespace ZeroC.Ice
             public static OutgoingRequestFrame IcePing(
                 IObjectPrx proxy,
                 IReadOnlyDictionary<string, string>? context) =>
-                OutgoingRequestFrame.WithEmptyParamList(proxy, "ice_ping", idempotent: true, context);
+                OutgoingRequestFrame.WithEmptyArgs(proxy, "ice_ping", idempotent: true, context);
         }
 
         /// <summary>Holds an <see cref="InputStreamReader{T}"/> for each non-void remote operation defined in the

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -81,8 +81,8 @@ namespace ZeroC.Ice
         {
         }
 
-        /// <summary>Reads the arguments from the request and make sure this request carries no argument or only unknown
-        /// tagged arguments.</summary>
+        /// <summary>Reads the arguments from the request and makes sure this request carries no argument or only
+        /// unknown tagged arguments.</summary>
         public void ReadEmptyArgs()
         {
             if (HasCompressedPayload)
@@ -96,8 +96,7 @@ namespace ZeroC.Ice
         /// <paramtype name="T">The type of the arguments.</paramtype>
         /// <param name="communicator">The communicator.</param>
         /// <param name="reader">The delegate used to read the arguments.</param>
-        /// <returns>The request parameters, when the frame parameter list contains multiple parameters
-        /// they must be return as a tuple.</returns>
+        /// <returns>The request arguments.</returns>
         public T ReadArgs<T>(Communicator communicator, InputStreamReader<T> reader)
         {
             if (HasCompressedPayload)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -12,18 +12,23 @@ namespace ZeroC.Ice
     {
         /// <summary>The request context. Its initial value is computed when the request frame is created.</summary>
         public Dictionary<string, string> Context { get; }
+
         /// <summary>The encoding of the frame payload.</summary>
         public override Encoding Encoding { get; }
+
         /// <summary>The facet of the target Ice object.</summary>
         public string Facet { get; }
+
         /// <summary>The identity of the target Ice object.</summary>
         public Identity Identity { get; }
+
         /// <summary>When true, the operation is idempotent.</summary>
         public bool IsIdempotent { get; }
+
         /// <summary>The operation called on the Ice object.</summary>
         public string Operation { get; }
 
-        /// <summary>Creates a new IncomingRequestFrame.</summary>
+        /// <summary>Constructs an incoming request frame.</summary>
         /// <param name="protocol">The Ice protocol.</param>
         /// <param name="data">The frame data as an array segment.</param>
         /// <param name="sizeMax">The maximum payload size, checked during decompress.</param>
@@ -76,9 +81,9 @@ namespace ZeroC.Ice
         {
         }
 
-        /// <summary>Reads the empty parameter list, calling this methods ensure that the frame payload
-        /// correspond to the empty parameter list.</summary>
-        public void ReadEmptyParamList()
+        /// <summary>Reads the arguments from the request and make sure this request carries no argument or only unknown
+        /// tagged arguments.</summary>
+        public void ReadEmptyArgs()
         {
             if (HasCompressedPayload)
             {
@@ -87,13 +92,13 @@ namespace ZeroC.Ice
             Payload.AsReadOnlyMemory().ReadEmptyEncapsulation(Protocol.GetEncoding());
         }
 
-        /// <summary>Reads the request frame parameter list.</summary>
+        /// <summary>Reads the arguments from a request.</summary>
+        /// <paramtype name="T">The type of the arguments.</paramtype>
         /// <param name="communicator">The communicator.</param>
-        /// <param name="reader">An InputStreamReader delegate used to read the request frame
-        /// parameters.</param>
+        /// <param name="reader">The delegate used to read the arguments.</param>
         /// <returns>The request parameters, when the frame parameter list contains multiple parameters
         /// they must be return as a tuple.</returns>
-        public T ReadParamList<T>(Communicator communicator, InputStreamReader<T> reader)
+        public T ReadArgs<T>(Communicator communicator, InputStreamReader<T> reader)
         {
             if (HasCompressedPayload)
             {

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -12,20 +12,17 @@ namespace ZeroC.Ice
     /// <summary>Represents a response protocol frame received by the application.</summary>
     public sealed class IncomingResponseFrame : IncomingFrame
     {
-        /// <summary>The response context. Always null with Ice1.</summary>
-        public Dictionary<string, string>? Context { get; }
-
         /// <summary>The encoding of the frame payload.</summary>
         public override Encoding Encoding { get; }
 
-        /// <summary>The result type; see <see cref="ZeroC.Ice.ResultType"/>.</summary>
+        /// <summary>The <see cref="ZeroC.Ice.ResultType"/> of this response frame.</summary>
         public ResultType ResultType => Payload[0] == 0 ? ResultType.Success : ResultType.Failure;
 
         private static readonly ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), IncomingResponseFrame>
             _cachedVoidReturnValueFrames =
                 new ConcurrentDictionary<(Protocol Protocol, Encoding Encoding), IncomingResponseFrame>();
 
-        // Oneway pseudo-response
+        /// <summary>Returns an <see cref="IncomingResponseFrame"/> that represents a oneway pseudo response.</summary>
         internal static IncomingResponseFrame WithVoidReturnValue(Protocol protocol, Encoding encoding) =>
             _cachedVoidReturnValueFrames.GetOrAdd((protocol, encoding), key =>
             {
@@ -37,8 +34,9 @@ namespace ZeroC.Ice
                 return new IncomingResponseFrame(key.Protocol, data[0], int.MaxValue);
             });
 
-        /// <summary>Reads the return value carried by this response frame. If the response frame carries
-        /// a failure, reads and throws this exception.</summary>
+        /// <summary>Reads the return value. If this response frame carries a failure, reads and throws this exception.
+        /// </summary>
+        /// <paramtype name="T">The type of the return value.</paramtype>
         /// <param name="communicator">The communicator.</param>
         /// <param name="reader">An input stream reader used to read the frame return value, when the frame
         /// return value contain multiple values the reader must use a tuple to return the values.</param>
@@ -60,8 +58,8 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Reads an empty return value from the response frame. If the response frame carries a failure, reads
-        /// and throws this exception.</summary>
+        /// <summary>Reads the return value and makes sure this return value is empty (void) or has only unknown tagged
+        /// members. If this response frame carries a failure, reads and throws this exception.</summary>
         /// <param name="communicator">The communicator.</param>
         public void ReadVoidReturnValue(Communicator communicator)
         {
@@ -80,7 +78,7 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Creates a new IncomingResponse Frame</summary>
+        /// <summary>Constructs an incoming response frame.</summary>
         /// <param name="protocol">The Ice protocol of this frame.</param>
         /// <param name="data">The frame data as an array segment.</param>
         /// <param name="sizeMax">The maximum payload size, checked during decompress.</param>

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -64,7 +64,8 @@ namespace ZeroC.Ice
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="compress">True if the request should be compressed, false otherwise.</param>
-        /// <param name="format">The format used to marshal classes.</param>
+        /// <param name="format">The format to use when writing class instances in case <c>args</c> contains class
+        /// instances.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="args">The argument(s) to write into the frame.</param>
@@ -104,12 +105,13 @@ namespace ZeroC.Ice
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="compress">True if the request should be compressed, false otherwise.</param>
-        /// <param name="format">The format used to marshal classes.</param>
+        /// <param name="format">The format to use when writing class instances in case <c>args</c> contains class
+        /// instances.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="args">The argument(s) to write into the frame.</param>
         /// <param name="writer">The delegate that writes the arguments into the frame.</param>
-        /// <returns>A new OutgoingRequestFrame</returns>
+        /// <returns>A new OutgoingRequestFrame.</returns>
         public static OutgoingRequestFrame WithArgs<T>(
             IObjectPrx proxy,
             string operation,

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -69,7 +69,8 @@ namespace ZeroC.Ice
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="args">The argument(s) to write into the frame.</param>
-        /// <param name="writer">The delegate that writes the arguments into the frame.</param>
+        /// <param name="writer">The <see cref="OutputStreamWriter{T}"/> that writes the arguments into the frame.
+        /// </param>
         /// <returns>A new OutgoingRequestFrame</returns>
         public static OutgoingRequestFrame WithArgs<T>(
             IObjectPrx proxy,
@@ -110,7 +111,8 @@ namespace ZeroC.Ice
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
         /// <param name="args">The argument(s) to write into the frame.</param>
-        /// <param name="writer">The delegate that writes the arguments into the frame.</param>
+        /// <param name="writer">The <see cref="OutputStreamWriter{T}"/> that writes the arguments into the frame.
+        /// </param>
         /// <returns>A new OutgoingRequestFrame.</returns>
         public static OutgoingRequestFrame WithArgs<T>(
             IObjectPrx proxy,

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -56,7 +56,9 @@ namespace ZeroC.Ice
         // _defaultBinaryContext is empty.
         private readonly bool _writeSlot0;
 
-        /// <summary>Create a new OutgoingRequestFrame for an operation with a single parameter.</summary>
+        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/> for an operation with a single non-struct
+        /// parameter.</summary>
+        /// <typeparam name="T">The type of the operation's parameter.</typeparam>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
         /// encoding and context of this proxy to create the request frame.</param>
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
@@ -65,17 +67,17 @@ namespace ZeroC.Ice
         /// <param name="format">The format used to marshal classes.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
-        /// <param name="value">The parameter to marshal in the frame.</param>
-        /// <param name="writer">The delegate into marshal the parameter to the frame.</param>
+        /// <param name="args">The argument(s) to write into the frame.</param>
+        /// <param name="writer">The delegate that writes the arguments into the frame.</param>
         /// <returns>A new OutgoingRequestFrame</returns>
-        public static OutgoingRequestFrame WithSingleParam<T>(
+        public static OutgoingRequestFrame WithArgs<T>(
             IObjectPrx proxy,
             string operation,
             bool idempotent,
             bool compress,
             FormatType format,
             IReadOnlyDictionary<string, string>? context,
-            T value,
+            T args,
             OutputStreamWriter<T> writer)
         {
             var request = new OutgoingRequestFrame(proxy, operation, idempotent, compress, context);
@@ -84,7 +86,7 @@ namespace ZeroC.Ice
                                         request.PayloadStart,
                                         request.Encoding,
                                         format);
-            writer(ostr, value);
+            writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
             if (compress && proxy.Encoding == Encoding.V2_0)
             {
@@ -93,8 +95,10 @@ namespace ZeroC.Ice
             return request;
         }
 
-        /// <summary>Create a new OutgoingRequestFrame for an operation with multiple parameters or a single struct
-        /// parameter.</summary>
+        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/> for an operation with multiple parameters or a
+        /// single struct parameter.</summary>
+        /// <typeparam name="T">The type of the operation's parameters; it's a tuple type for an operation with multiple
+        /// parameters.</typeparam>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
         /// encoding and context of this proxy to create the request frame.</param>
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
@@ -103,17 +107,17 @@ namespace ZeroC.Ice
         /// <param name="format">The format used to marshal classes.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
-        /// <param name="value">The parameters to marshal in the frame.</param>
-        /// <param name="writer">The delegate to marshal the parameters into the frame.</param>
+        /// <param name="args">The argument(s) to write into the frame.</param>
+        /// <param name="writer">The delegate that writes the arguments into the frame.</param>
         /// <returns>A new OutgoingRequestFrame</returns>
-        public static OutgoingRequestFrame WithParamList<T>(
+        public static OutgoingRequestFrame WithArgs<T>(
             IObjectPrx proxy,
             string operation,
             bool idempotent,
             bool compress,
             FormatType format,
             IReadOnlyDictionary<string, string>? context,
-            in T value,
+            in T args,
             OutputStreamValueWriter<T> writer) where T : struct
         {
             var request = new OutgoingRequestFrame(proxy, operation, idempotent, compress, context);
@@ -122,7 +126,7 @@ namespace ZeroC.Ice
                                         request.PayloadStart,
                                         request.Encoding,
                                         format);
-            writer(ostr, value);
+            writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
             if (compress && proxy.Encoding == Encoding.V2_0)
             {
@@ -131,14 +135,14 @@ namespace ZeroC.Ice
             return request;
         }
 
-        /// <summary>Creates a new outgoing request frame with no parameter.</summary>
+        /// <summary>Creates a new <see cref="OutgoingRequestFrame"/> for an operation with no parameter.</summary>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet,
         /// encoding and context of this proxy to create the request frame.</param>
         /// <param name="operation">The operation to invoke on the target Ice object.</param>
         /// <param name="idempotent">True when operation is idempotent, otherwise false.</param>
         /// <param name="context">An optional explicit context. When non null, it overrides both the context of the
         /// proxy and the communicator's current context (if any).</param>
-        public static OutgoingRequestFrame WithEmptyParamList(
+        public static OutgoingRequestFrame WithEmptyArgs(
             IObjectPrx proxy,
             string operation,
             bool idempotent,
@@ -148,9 +152,9 @@ namespace ZeroC.Ice
                                      idempotent,
                                      compress: false,
                                      context,
-                                     writeEmptyParamList: true);
+                                     writeEmptyArgs: true);
 
-        /// <summary>Creates a new outgoing request frame from the given incoming request frame.</summary>
+        /// <summary>Constructs an outgoing request frame from the given incoming request frame.</summary>
         /// <param name="proxy">A proxy to the target Ice object. This method uses the communicator, identity, facet
         /// and context of this proxy to create the request frame.</param>
         /// <param name="request">The incoming request from which to create an outgoing request.</param>
@@ -252,7 +256,7 @@ namespace ZeroC.Ice
             bool idempotent,
             bool compress,
             IReadOnlyDictionary<string, string>? context,
-            bool writeEmptyParamList = false)
+            bool writeEmptyArgs = false)
             : base(proxy.Protocol,
                    compress,
                    proxy.Communicator.CompressionLevel,
@@ -304,7 +308,7 @@ namespace ZeroC.Ice
             }
             PayloadStart = ostr.Tail;
 
-            if (writeEmptyParamList)
+            if (writeEmptyArgs)
             {
                 PayloadEnd = ostr.WriteEmptyEncapsulation(Encoding);
             }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -40,7 +40,8 @@ namespace ZeroC.Ice
         /// <typeparam name="T">The type of the return value.</typeparam>
         /// <param name="current">The Current object for the corresponding incoming request.</param>
         /// <param name="compress">True if the response should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes.</param>
+        /// <param name="format">The format to use when writing class instances in case <c>returnValue</c> contains
+        /// class instances.</param>
         /// <param name="returnValue">The return value to write into the frame.</param>
         /// <param name="writer">The delegate that writes the return value into the frame.</param>
         /// <returns>A new OutgoingResponseFrame.</returns>
@@ -66,7 +67,8 @@ namespace ZeroC.Ice
         /// <typeparam name="T">The type of the return value.</typeparam>
         /// <param name="current">The Current object for the corresponding incoming request.</param>
         /// <param name="compress">True if the response should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes.</param>
+        /// <param name="format">The format to use when writing class instances in case <c>returnValue</c> contains
+        /// class instances.</param>
         /// <param name="returnValue">The return value to write into the frame.</param>
         /// <param name="writer">The delegate that writes the return value into the frame.</param>
         /// <returns>A new OutgoingResponseFrame.</returns>

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -17,13 +17,13 @@ namespace ZeroC.Ice
         /// <summary>The result type; see <see cref="Ice.ResultType"/>.</summary>
         public ResultType ResultType => Data[0][0] == 0 ? ResultType.Success : ResultType.Failure;
 
-        // When a response frame contains an encapsulation, it always start at position 1 of the first segment,
+        // When a response frame contains an encapsulation, it always starts at position 1 of the first segment,
         // and the first segment has always at least 2 bytes.
         private static readonly OutputStream.Position EncapsulationStart = new OutputStream.Position(0, 1);
 
         private readonly ArraySegment<byte> _defaultBinaryContext;
 
-        /// <summary>Creates a new outgoing response frame with a void return value.</summary>
+        /// <summary>Creates a new <see cref="OutgoingResponseFrame"/> for an operation that returns void.</summary>
         /// <param name="current">The Current object for the corresponding incoming request.</param>
         /// <returns>A new OutgoingResponseFrame.</returns>
         public static OutgoingResponseFrame WithVoidReturnValue(Current current)
@@ -35,23 +35,24 @@ namespace ZeroC.Ice
             return new OutgoingResponseFrame(current.Protocol, current.Encoding, data, ostr.Tail);
         }
 
-        /// <summary>Creates a new outgoing response frame with a return value.</summary>
+        /// <summary>Creates a new <see cref="OutgoingResponseFrame"/> for an operation with a non-tuple non-struct
+        /// return type.</summary>
+        /// <typeparam name="T">The type of the return value.</typeparam>
         /// <param name="current">The Current object for the corresponding incoming request.</param>
         /// <param name="compress">True if the response should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes and exceptions, when this parameter is null
-        /// the communicator's default format is used.</param>
-        /// <param name="value">The return value to marshal.</param>
-        /// <param name="writer">A delegate that must write the value to the frame.</param>
+        /// <param name="format">The format type used to marshal classes.</param>
+        /// <param name="returnValue">The return value to write into the frame.</param>
+        /// <param name="writer">The delegate that writes the return value into the frame.</param>
         /// <returns>A new OutgoingResponseFrame.</returns>
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,
             bool compress,
             FormatType format,
-            T value,
+            T returnValue,
             OutputStreamWriter<T> writer)
         {
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
-            writer(ostr, value);
+            writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
             if (compress && current.Encoding == Encoding.V2_0)
             {
@@ -60,25 +61,25 @@ namespace ZeroC.Ice
             return response;
         }
 
-        /// <summary>Creates a new outgoing response frame with a return value.</summary>
+        /// <summary>Creates a new <see cref="OutgoingResponseFrame"/> for an operation with a tuple or struct return
+        /// type.</summary>
+        /// <typeparam name="T">The type of the return value.</typeparam>
         /// <param name="current">The Current object for the corresponding incoming request.</param>
         /// <param name="compress">True if the response should be compressed, false otherwise.</param>
-        /// <param name="format">The format type used to marshal classes and exceptions, when this parameter is null
-        /// the communicator's default format is used.</param>
-        /// <param name="value">The return value to marshal, when the response frame contains multiple return
-        /// values they must be passed in a tuple.</param>
-        /// <param name="writer">A delegate that must write the value to the frame.</param>
+        /// <param name="format">The format type used to marshal classes.</param>
+        /// <param name="returnValue">The return value to write into the frame.</param>
+        /// <param name="writer">The delegate that writes the return value into the frame.</param>
         /// <returns>A new OutgoingResponseFrame.</returns>
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,
             bool compress,
             FormatType format,
-            in T value,
+            in T returnValue,
             OutputStreamValueWriter<T> writer)
             where T : struct
         {
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
-            writer(ostr, value);
+            writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
             if (compress && current.Encoding == Encoding.V2_0)
             {
@@ -87,11 +88,9 @@ namespace ZeroC.Ice
             return response;
         }
 
-        /// <summary>Creates a new outgoing response frame from the given incoming response frame.</summary>
-        /// <param name="request">The incoming request for which this constructor creates an outgoing response frame.
-        /// </param>
-        /// <param name="response">The incoming response for which this constructor creates an outgoing response frame.
-        /// </param>
+        /// <summary>Constructs an outgoing response frame from the given incoming response frame.</summary>
+        /// <param name="request">The request for which this constructor creates a response.</param>
+        /// <param name="response">The incoming response used to construct the new outgoing response frame.</param>
         /// <param name="forwardBinaryContext">When true (the default), the new frame uses the incoming response frame's
         /// binary context as a fallback - all the entries in this binary context are added before the frame is sent,
         /// except for entries previously added by dispatch interceptors.</param>
@@ -229,7 +228,7 @@ namespace ZeroC.Ice
             IsSealed = Protocol == Protocol.Ice1;
         }
 
-        /// <summary>Creates a response frame that represents a failure and contains an exception.</summary>
+        /// <summary>Constructs a response frame that represents a failure and contains an exception.</summary>
         /// <param name="request">The incoming request for which this constructor creates a response.</param>
         /// <param name="exception">The exception to store into the frame's payload.</param>
         public OutgoingResponseFrame(IncomingRequestFrame request, RemoteException exception)

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -43,7 +43,8 @@ namespace ZeroC.Ice
         /// <param name="format">The format to use when writing class instances in case <c>returnValue</c> contains
         /// class instances.</param>
         /// <param name="returnValue">The return value to write into the frame.</param>
-        /// <param name="writer">The delegate that writes the return value into the frame.</param>
+        /// <param name="writer">The <see cref="OutputStreamWriter{T}"/> that writes the return value into the frame.
+        /// </param>
         /// <returns>A new OutgoingResponseFrame.</returns>
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,
@@ -70,7 +71,8 @@ namespace ZeroC.Ice
         /// <param name="format">The format to use when writing class instances in case <c>returnValue</c> contains
         /// class instances.</param>
         /// <param name="returnValue">The return value to write into the frame.</param>
-        /// <param name="writer">The delegate that writes the return value into the frame.</param>
+        /// <param name="writer">The <see cref="OutputStreamWriter{T}"/> that writes the return value into the frame.
+        /// </param>
         /// <returns>A new OutgoingResponseFrame.</returns>
         public static OutgoingResponseFrame WithReturnValue<T>(
             Current current,

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -216,13 +216,13 @@ namespace ZeroC.Ice.Test.Interceptor
                 {
                     var token = new Token(1, "mytoken", Enumerable.Range(0, size).Select(i => (byte)2).ToArray());
                     var request = OutgoingRequestFrame.WithArgs(prx,
-                                                                     "opWithBinaryContext",
-                                                                     idempotent: false,
-                                                                     compress: false,
-                                                                     format: default,
-                                                                     context: null,
-                                                                     token,
-                                                                     Token.IceWriter);
+                                                                "opWithBinaryContext",
+                                                                idempotent: false,
+                                                                compress: false,
+                                                                format: default,
+                                                                context: null,
+                                                                token,
+                                                                Token.IceWriter);
                     request.AddBinaryContextEntry(1, token, Token.IceWriter);
                     request.AddBinaryContextEntry(3, (short)size, (ostr, value) => ostr.WriteShort(value));
                     request.AddBinaryContextEntry(
@@ -254,13 +254,13 @@ namespace ZeroC.Ice.Test.Interceptor
 
                     // repeat with compressed frame
                     request = OutgoingRequestFrame.WithArgs(prx,
-                                                                 "opWithBinaryContext",
-                                                                 idempotent: false,
-                                                                 compress: false,
-                                                                 format: default,
-                                                                 context: null,
-                                                                 token,
-                                                                 Token.IceWriter);
+                                                            "opWithBinaryContext",
+                                                            idempotent: false,
+                                                            compress: false,
+                                                            format: default,
+                                                            context: null,
+                                                            token,
+                                                            Token.IceWriter);
                     request.AddBinaryContextEntry(1, token, Token.IceWriter);
                     request.AddBinaryContextEntry(3, (short)size, (ostr, value) => ostr.WriteShort(value));
                     request.AddBinaryContextEntry(
@@ -272,13 +272,13 @@ namespace ZeroC.Ice.Test.Interceptor
 
                     // repeat compressed the frame before writing the context
                     request = OutgoingRequestFrame.WithArgs(prx,
-                                                                 "opWithBinaryContext",
-                                                                 idempotent: false,
-                                                                 compress: false,
-                                                                 format: default,
-                                                                 context: null,
-                                                                 token,
-                                                                 Token.IceWriter);
+                                                            "opWithBinaryContext",
+                                                            idempotent: false,
+                                                            compress: false,
+                                                            format: default,
+                                                            context: null,
+                                                            token,
+                                                            Token.IceWriter);
 
                     TestHelper.Assert(request.CompressPayload() == CompressionResult.Success);
                     request.AddBinaryContextEntry(1, token, Token.IceWriter);
@@ -294,13 +294,13 @@ namespace ZeroC.Ice.Test.Interceptor
             {
                 var token = new Token(1, "mytoken", Enumerable.Range(0, 256).Select(i => (byte)2).ToArray());
                 var request = OutgoingRequestFrame.WithArgs(prx,
-                                                                 "opWithBinaryContext",
-                                                                 idempotent: false,
-                                                                 compress: false,
-                                                                 format: default,
-                                                                 context: null,
-                                                                 token,
-                                                                 Token.IceWriter);
+                                                            "opWithBinaryContext",
+                                                            idempotent: false,
+                                                            compress: false,
+                                                            format: default,
+                                                            context: null,
+                                                            token,
+                                                            Token.IceWriter);
                 try
                 {
                     request.AddBinaryContextEntry(1, token, Token.IceWriter);

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -215,7 +215,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 for (int size = 128; size < 4096; size *= 2)
                 {
                     var token = new Token(1, "mytoken", Enumerable.Range(0, size).Select(i => (byte)2).ToArray());
-                    var request = OutgoingRequestFrame.WithParamList(prx,
+                    var request = OutgoingRequestFrame.WithArgs(prx,
                                                                      "opWithBinaryContext",
                                                                      idempotent: false,
                                                                      compress: false,
@@ -253,7 +253,7 @@ namespace ZeroC.Ice.Test.Interceptor
                     }
 
                     // repeat with compressed frame
-                    request = OutgoingRequestFrame.WithParamList(prx,
+                    request = OutgoingRequestFrame.WithArgs(prx,
                                                                  "opWithBinaryContext",
                                                                  idempotent: false,
                                                                  compress: false,
@@ -271,7 +271,7 @@ namespace ZeroC.Ice.Test.Interceptor
                     prx.Invoke(request);
 
                     // repeat compressed the frame before writing the context
-                    request = OutgoingRequestFrame.WithParamList(prx,
+                    request = OutgoingRequestFrame.WithArgs(prx,
                                                                  "opWithBinaryContext",
                                                                  idempotent: false,
                                                                  compress: false,
@@ -293,7 +293,7 @@ namespace ZeroC.Ice.Test.Interceptor
             else
             {
                 var token = new Token(1, "mytoken", Enumerable.Range(0, 256).Select(i => (byte)2).ToArray());
-                var request = OutgoingRequestFrame.WithParamList(prx,
+                var request = OutgoingRequestFrame.WithArgs(prx,
                                                                  "opWithBinaryContext",
                                                                  idempotent: false,
                                                                  compress: false,

--- a/csharp/test/Ice/interceptor/DispatchInterceptors.cs
+++ b/csharp/test/Ice/interceptor/DispatchInterceptors.cs
@@ -120,7 +120,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
                             Debug.Assert(request.BinaryContext.ContainsKey(1));
                             t1 = request.BinaryContext[1].Read(Token.IceReader);
-                            t2 = request.ReadParamList(current.Communicator, Token.IceReader);
+                            t2 = request.ReadArgs(current.Communicator, Token.IceReader);
                             TestHelper.Assert(t1.Hash == t2.Hash);
                             TestHelper.Assert(t1.Expiration == t2.Expiration);
                             TestHelper.Assert(t1.Payload.SequenceEqual(t2.Payload));

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Invoke
             output.Flush();
 
             {
-                var request = OutgoingRequestFrame.WithEmptyParamList(oneway, "opOneway", idempotent: false);
+                var request = OutgoingRequestFrame.WithEmptyArgs(oneway, "opOneway", idempotent: false);
 
                 // Whether the proxy is oneway or not does not matter for Invoke's oneway parameter.
 
@@ -52,7 +52,7 @@ namespace ZeroC.Ice.Test.Invoke
                     TestHelper.Assert(response.ResultType == ResultType.Failure);
                 }
 
-                request = OutgoingRequestFrame.WithSingleParam(cl,
+                request = OutgoingRequestFrame.WithArgs(cl,
                                                              "opString",
                                                              idempotent: false,
                                                              compress: false,
@@ -81,7 +81,7 @@ namespace ZeroC.Ice.Test.Invoke
                     };
                 }
 
-                var request = OutgoingRequestFrame.WithEmptyParamList(cl, "opException", idempotent: false, context: ctx);
+                var request = OutgoingRequestFrame.WithEmptyArgs(cl, "opException", idempotent: false, context: ctx);
                 IncomingResponseFrame response = cl.Invoke(request);
                 try
                 {
@@ -103,7 +103,7 @@ namespace ZeroC.Ice.Test.Invoke
             output.Flush();
 
             {
-                var request = OutgoingRequestFrame.WithEmptyParamList(oneway, "opOneway", idempotent: false);
+                var request = OutgoingRequestFrame.WithEmptyArgs(oneway, "opOneway", idempotent: false);
                 IncomingResponseFrame response;
                 try
                 {
@@ -114,7 +114,7 @@ namespace ZeroC.Ice.Test.Invoke
                     TestHelper.Assert(false);
                 }
 
-                request = OutgoingRequestFrame.WithSingleParam(cl,
+                request = OutgoingRequestFrame.WithArgs(cl,
                                                              "opString",
                                                              idempotent: false,
                                                              compress: false,
@@ -135,7 +135,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
 
             {
-                var request = OutgoingRequestFrame.WithEmptyParamList(cl, "opException", idempotent: false);
+                var request = OutgoingRequestFrame.WithEmptyArgs(cl, "opException", idempotent: false);
                 IncomingResponseFrame response = cl.InvokeAsync(request).AsTask().Result;
 
                 try

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -21,7 +21,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
             else if (current.Operation.Equals("opString"))
             {
-                string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
+                string s = request.ReadArgs(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current,
                                                                           compress: false,
                                                                           format: default,
@@ -49,7 +49,7 @@ namespace ZeroC.Ice.Test.Invoke
             }
             else if (current.Operation.Equals("ice_isA"))
             {
-                string s = request.ReadParamList(current.Communicator, InputStream.IceReaderIntoString);
+                string s = request.ReadArgs(current.Communicator, InputStream.IceReaderIntoString);
                 var responseFrame = OutgoingResponseFrame.WithReturnValue(current,
                                                                           compress: false,
                                                                           format: default,

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -349,7 +349,7 @@ namespace ZeroC.Ice.Test.Tagged
 
             initial.OpVoid();
 
-            var requestFrame = OutgoingRequestFrame.WithParamList(
+            var requestFrame = OutgoingRequestFrame.WithArgs(
                 initial, "opVoid", idempotent: false, compress: false, format: default, context: null, (15, "test"),
                 (OutputStream ostr, in (int n, string s) value) =>
                 {
@@ -487,7 +487,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpByte(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial, "opByte",
                     idempotent: false,
                     compress: false,
@@ -526,7 +526,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpBool(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opBool",
                     idempotent: false,
@@ -566,7 +566,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpShort(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opShort",
                     idempotent: false,
@@ -606,7 +606,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpInt(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opInt",
                     idempotent: false,
@@ -647,7 +647,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpLong(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial, "opLong",
                     idempotent: false,
                     compress: false,
@@ -687,7 +687,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpFloat(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial, "opFloat",
                     idempotent: false,
                     compress: false,
@@ -727,7 +727,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpDouble(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opDouble",
                     idempotent: false,
@@ -770,7 +770,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpString(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opString",
                     idempotent: false,
@@ -811,7 +811,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpMyEnum(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opMyEnum",
                     idempotent: false,
@@ -848,7 +848,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpSmallStruct(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opSmallStruct",
                     idempotent: false,
@@ -887,7 +887,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpFixedStruct(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opFixedStruct",
                     idempotent: false,
@@ -930,7 +930,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpVarStruct(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opVarStruct",
                     idempotent: false,
@@ -994,7 +994,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpByteSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opByteSeq",
                     idempotent: false,
@@ -1032,7 +1032,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpBoolSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opBoolSeq",
                     idempotent: false,
@@ -1070,7 +1070,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpShortSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opShortSeq",
                     idempotent: false,
@@ -1107,7 +1107,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpIntSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opIntSeq",
                     idempotent: false,
@@ -1143,7 +1143,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpLongSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opLongSeq",
                     idempotent: false,
@@ -1180,7 +1180,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpFloatSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opFloatSeq",
                     idempotent: false,
@@ -1217,7 +1217,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpDoubleSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opDoubleSeq",
                     idempotent: false,
@@ -1255,7 +1255,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpStringSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opStringSeq",
                     idempotent: false,
@@ -1294,7 +1294,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpSmallStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opSmallStructSeq",
                     idempotent: false,
@@ -1338,7 +1338,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpSmallStructList(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opSmallStructList",
                     idempotent: false,
@@ -1387,7 +1387,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpFixedStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opFixedStructSeq",
                     idempotent: false,
@@ -1431,7 +1431,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpFixedStructList(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opFixedStructList",
                     idempotent: false,
@@ -1479,7 +1479,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpVarStructSeq(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opVarStructSeq",
                     idempotent: false,
@@ -1522,7 +1522,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpIntIntDict(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opIntIntDict",
                     idempotent: false,
@@ -1567,7 +1567,7 @@ namespace ZeroC.Ice.Test.Tagged
                 (p2, p3) = initial.OpStringIntDict(null);
                 TestHelper.Assert(p2 == null && p3 == null); // Ensure out parameter is cleared.
 
-                requestFrame = OutgoingRequestFrame.WithSingleParam(
+                requestFrame = OutgoingRequestFrame.WithArgs(
                     initial,
                     "opStringIntDict",
                     idempotent: false,


### PR DESCRIPTION
This PR updates method names on the frame classes and adds / fixes some doc-comments.

Method names with this PR:
WithArgs, WithEmptyArgs, ReadArgs, ReadEmptyArgs
WithReturnValue, WithVoidReturnValue, ReadReturnValue, ReadReturnValue