### PR TITLE
Reduce global:: qualifications generated C# code

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -238,13 +238,13 @@ Slice::getNamespace(const ContainedPtr& cont)
 string
 Slice::getUnqualified(const string& type, const string& scope, bool builtin)
 {
-    if(type.find(".") != string::npos && type.find(scope) == 0 && type.find(".", scope.size() + 1) == string::npos)
+    if (type.find(".") != string::npos && type.find(scope) == 0 && type.find(".", scope.size() + 1) == string::npos)
     {
         return type.substr(scope.size() + 1);
     }
-    else if(builtin)
+    else if (builtin || type.rfind("ZeroC", 0) == 0)
     {
-        return type.find(".") == string::npos ? type : "global::" + type;
+        return type;
     }
     else
     {
@@ -257,9 +257,13 @@ Slice::getUnqualified(const ContainedPtr& p, const string& package, const string
 {
     string name = fixId(prefix + p->name() + suffix);
     string contPkg = getNamespace(p);
-    if(contPkg == package || contPkg.empty())
+    if (contPkg == package || contPkg.empty())
     {
         return name;
+    }
+    else if (contPkg.rfind("ZeroC", 0) == 0)
+    {
+        return contPkg + "." + name;
     }
     else
     {
@@ -390,10 +394,9 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
         else
         {
             ostringstream out;
-            out << "global::";
             if (customType == "List" || customType == "LinkedList" || customType == "Queue" || customType == "Stack")
             {
-                out << "System.Collections.Generic.";
+                out << "global::System.Collections.Generic.";
             }
             out << customType << "<" << typeToString(seq->type(), package) << ">";
             return out.str();

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1660,7 +1660,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         _out << nl << "[global::System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Performance\", "
             << "\"CA1801:ReviewUnusedParameters\", Justification=\"Special constructor used for Ice unmarshaling\")]";
     }
-    _out << nl << "protected internal " << name << "(global::ZeroC.Ice.InputStream? istr, string? message)";
+    _out << nl << "protected internal " << name << "(ZeroC.Ice.InputStream? istr, string? message)";
     // We call the base class constructor to initialize the base class fields.
     _out.inc();
     if (p->base())
@@ -3038,9 +3038,14 @@ Slice::Gen::ClassFactoryVisitor::visitClassDefStart(const ClassDefPtr& p)
     emitEditorBrowsableNeverAttribute();
     _out << nl << "public static class " << name;
     _out << sb;
-    _out << nl << "public static global::ZeroC.Ice.AnyClass Create() =>";
+
+    // If the enclosing namespace starts with ::ZeroC::, add global:: prefix to ZeroC type references.
+    string ns = getNamespace(p);
+    string prefix = ns.rfind("ZeroC.", 0) == 0 ? "global::" : "";
+
+    _out << nl << "public static " << prefix << "ZeroC.Ice.AnyClass Create() =>";
     _out.inc();
-    _out << nl << "new global::" << getNamespace(p) << "." << name << "((global::ZeroC.Ice.InputStream?)null);";
+    _out << nl << "new global::" << ns << "." << name << "((" << prefix << "ZeroC.Ice.InputStream?)null);";
     _out.dec();
     _out << eb;
 
@@ -3079,12 +3084,17 @@ Slice::Gen::CompactIdVisitor::visitClassDefStart(const ClassDefPtr& p)
         _out << sp;
         emitCommonAttributes();
         emitEditorBrowsableNeverAttribute();
+
+        // If the enclosing namespace starts with ::ZeroC::, add global:: prefix to ZeroC type references.
+        string ns = getNamespace(p);
+        string prefix = ns.rfind("ZeroC.", 0) == 0 ? "global::" : "";
+
         _out << nl << "public static class CompactId_" << p->compactId();
         _out << sb;
-        _out << nl << "public static global::ZeroC.Ice.AnyClass Create() =>";
+        _out << nl << "public static " << prefix << "ZeroC.Ice.AnyClass Create() =>";
         _out.inc();
-        _out << nl << "new global::" << getNamespace(p) << "." << fixId(p->name())
-             << "((global::ZeroC.Ice.InputStream?)null);";
+        _out << nl << "new global::" << ns << "." << fixId(p->name()) << "((" << prefix
+            << "ZeroC.Ice.InputStream?)null);";
         _out.dec();
         _out << eb;
     }
@@ -3129,12 +3139,16 @@ Slice::Gen::RemoteExceptionFactoryVisitor::visitExceptionStart(const ExceptionPt
     _out << sp;
     emitCommonAttributes();
     emitEditorBrowsableNeverAttribute();
+
+    // If the enclosing namespace starts with ::ZeroC::, add global:: prefix to ZeroC type references.
+    string ns = getNamespace(p);
+    string prefix = ns.rfind("ZeroC.", 0) == 0 ? "global::" : "";
+
     _out << nl << "public static class " << name;
     _out << sb;
-    _out << nl << "public static global::ZeroC.Ice.RemoteException Create(string? message) =>";
+    _out << nl << "public static " << prefix << "ZeroC.Ice.RemoteException Create(string? message) =>";
     _out.inc();
-    _out << nl << "new global::" << getNamespace(p) << "." << name
-         << "((global::ZeroC.Ice.InputStream?)null, message);";
+    _out << nl << "new global::" << ns << "." << name << "((" << prefix << "ZeroC.Ice.InputStream?)null, message);";
     _out.dec();
     _out << eb;
     return false;


### PR DESCRIPTION
This PR reduces the global:: qualifications for namespace ZeroC in the generated C# code.
This qualification is needed only for generated class and exception factories with a namespace that starts with "ZeroC". 

The global:: qualification is used/generated mostly for the System namespace to deal properly with applications that define a Slice module named `System`. This PR doe not change this qualification.