### PR TITLE
Remove underscores

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -176,7 +176,7 @@ Slice::CsVisitor::writeMarshal(const OperationPtr& operation, bool returnType)
         requiredMembers.size() > 1;
     if (write11ReturnLast)
     {
-        _out << nl << "if (ostr.Encoding != ZeroC.Ice.Encoding.Version11)";
+        _out << nl << "if (ostr.Encoding != ZeroC.Ice.Encoding.V11)";
         _out << sb;
     }
 
@@ -251,7 +251,7 @@ Slice::CsVisitor::writeUnmarshal(const OperationPtr& operation, bool returnType)
 
     if (read11ReturnLast)
     {
-        _out << nl << "if (istr.Encoding != ZeroC.Ice.Encoding.Version11)";
+        _out << nl << "if (istr.Encoding != ZeroC.Ice.Encoding.V11)";
         _out << sb;
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -176,7 +176,7 @@ Slice::CsVisitor::writeMarshal(const OperationPtr& operation, bool returnType)
         requiredMembers.size() > 1;
     if (write11ReturnLast)
     {
-        _out << nl << "if (ostr.Encoding != ZeroC.Ice.Encoding.V1_1)";
+        _out << nl << "if (ostr.Encoding != ZeroC.Ice.Encoding.Version11)";
         _out << sb;
     }
 
@@ -251,7 +251,7 @@ Slice::CsVisitor::writeUnmarshal(const OperationPtr& operation, bool returnType)
 
     if (read11ReturnLast)
     {
-        _out << nl << "if (istr.Encoding != ZeroC.Ice.Encoding.V1_1)";
+        _out << nl << "if (istr.Encoding != ZeroC.Ice.Encoding.Version11)";
         _out << sb;
     }
 
@@ -1080,6 +1080,7 @@ Slice::Gen::Gen(const string& base, const vector<string>& includePaths, const st
     _out << nl << "#pragma warning disable SA1309 // Field names must not begin with underscore";
     _out << nl << "#pragma warning disable SA1312 // Variable names must begin with lower case letter";
     _out << nl << "#pragma warning disable SA1313 // Parameter names must begin with lower case letter";
+    _out << nl << "#pragma warning disable CA1707 // Remove the underscores from member name";
 
     _out << sp << nl << "#pragma warning disable 1591"; // See bug 3654
     if(impl)
@@ -2593,19 +2594,19 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out.inc();
     _out << nl << "current.Operation switch";
     _out << sb;
-    StringList allOpNames;
+    vector<pair<string, string>> allOpNames;
     for(const auto& op : p->allOperations())
     {
-        allOpNames.push_back(op->name());
+        allOpNames.push_back(make_pair(op->name(), operationName(op)));
     }
-    allOpNames.push_back("ice_id");
-    allOpNames.push_back("ice_ids");
-    allOpNames.push_back("ice_isA");
-    allOpNames.push_back("ice_ping");
+    allOpNames.push_back(make_pair("ice_id", "IceId"));
+    allOpNames.push_back(make_pair("ice_ids", "IceIds"));
+    allOpNames.push_back(make_pair("ice_isA", "IceIsA"));
+    allOpNames.push_back(make_pair("ice_ping", "IcePing"));
 
     for(const auto& opName : allOpNames)
     {
-        _out << nl << "\"" << opName << "\" => " << "servant.IceD_" << opName << "Async(request, current),";
+        _out << nl << "\"" << opName.first << "\" => " << "servant.IceD" << opName.second << "Async(request, current),";
     }
 
     _out << nl << "_ => throw new ZeroC.Ice.OperationNotExistException(current.Identity, current.Facet, "
@@ -2707,7 +2708,7 @@ Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
     string ns = getNamespace(interface);
     string opName = operationName(operation);
     string name = fixId(opName + (amd ? "Async" : ""));
-    string internalName = "IceD_" + operation->name() + "Async";
+    string internalName = "IceD" + opName + "Async";
 
     auto params = operation->params();
     auto returnType = operation->returnType();

--- a/csharp/msbuild/CodeAnalysis.ruleset
+++ b/csharp/msbuild/CodeAnalysis.ruleset
@@ -11,7 +11,6 @@
       <Rule Id="CA1305" Action="None" /> <!-- TODO enable - The behavior of 'string.Format(string, object)' could vary based on the current user's locale settings. -->
       <Rule Id="CA1307" Action="None" /> <!-- TODO enable - Specify StringComparison -->
       <Rule Id="CA1308" Action="None" /> <!-- Normalize strings to uppercase -->
-      <Rule Id="CA1707" Action="None" /> <!-- TODO enable - Remove the underscores from member name -->
       <Rule Id="CA1710" Action="None" /> <!-- TODO disable on generated code - Identifiers should have correct suffix -->
       <Rule Id="CA1712" Action="None" /> <!-- TODO disable on generated code -  Do not prefix enum values with the name of the enum type 'ThreadState'. -->
       <Rule Id="CA1715" Action="None" /> <!-- TODO enable - Prefix generic type parameter with 'T' -->

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -44,7 +44,7 @@ namespace ZeroC.Ice
         public static T Read<T>(
             this ReadOnlyMemory<byte> buffer,
             Communicator communicator,
-            InputStreamReader<T> reader) => buffer.Read(Encoding.Version20, communicator, reader);
+            InputStreamReader<T> reader) => buffer.Read(Encoding.V20, communicator, reader);
 
         /// <summary>Reads a value from the buffer. Value cannot contain any proxy.</summary>
         /// <typeparam name="T">The type of the value.</typeparam>
@@ -70,7 +70,7 @@ namespace ZeroC.Ice
         /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
         /// unread data in the buffer.</exception>
         public static T Read<T>(this ReadOnlyMemory<byte> buffer, InputStreamReader<T> reader) =>
-            buffer.Read(Encoding.Version20, null, reader);
+            buffer.Read(Encoding.V20, null, reader);
 
         /// <summary>Reads an empty encapsulation from the buffer.</summary>
         /// <param name="buffer">The byte buffer.</param>
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
         /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
         /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
         public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer) =>
-            buffer.ReadEmptyEncapsulation(Encoding.Version20);
+            buffer.ReadEmptyEncapsulation(Encoding.V20);
 
         /// <summary>Reads the contents of an encapsulation from the buffer.</summary>
         /// <typeparam name="T">The type of the contents.</typeparam>
@@ -127,7 +127,7 @@ namespace ZeroC.Ice
             this ReadOnlyMemory<byte> buffer,
             Communicator communicator,
             InputStreamReader<T> payloadReader) =>
-            buffer.ReadEncapsulation(Encoding.Version20, communicator, payloadReader);
+            buffer.ReadEncapsulation(Encoding.V20, communicator, payloadReader);
 
         internal static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this ArraySegment<T> segment) => segment;
 
@@ -152,7 +152,7 @@ namespace ZeroC.Ice
             int sizeLength;
             int size;
 
-            if (encoding == Encoding.Version11)
+            if (encoding == Encoding.V11)
             {
                 sizeLength = 4;
                 size = buffer.ReadInt() - sizeLength; // Remove the size length which is included with the 1.1 encoding.
@@ -178,7 +178,7 @@ namespace ZeroC.Ice
 
         internal static int ReadFixedLengthSize(this ReadOnlySpan<byte> buffer, Encoding encoding)
         {
-            if (encoding == Encoding.Version11)
+            if (encoding == Encoding.V11)
             {
                 return buffer.ReadInt();
             }
@@ -194,7 +194,7 @@ namespace ZeroC.Ice
         internal static ushort ReadUShort(this ReadOnlySpan<byte> buffer) => BitConverter.ToUInt16(buffer);
 
         internal static (int Size, int SizeLength) ReadSize(this ReadOnlySpan<byte> buffer, Encoding encoding) =>
-            encoding == Encoding.Version11 ? buffer.ReadSize11() : buffer.ReadSize20();
+            encoding == Encoding.V11 ? buffer.ReadSize11() : buffer.ReadSize20();
 
         /// <summary>Reads a string from a UTF-8 byte buffer. The size of the byte buffer corresponds to the number of
         /// UTF-8 code points in the string.</summary>

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -44,7 +44,7 @@ namespace ZeroC.Ice
         public static T Read<T>(
             this ReadOnlyMemory<byte> buffer,
             Communicator communicator,
-            InputStreamReader<T> reader) => buffer.Read(Encoding.V2_0, communicator, reader);
+            InputStreamReader<T> reader) => buffer.Read(Encoding.Version20, communicator, reader);
 
         /// <summary>Reads a value from the buffer. Value cannot contain any proxy.</summary>
         /// <typeparam name="T">The type of the value.</typeparam>
@@ -70,7 +70,7 @@ namespace ZeroC.Ice
         /// <exception name="InvalidDataException">Thrown when <c>reader</c> finds invalid data or <c>reader</c> leaves
         /// unread data in the buffer.</exception>
         public static T Read<T>(this ReadOnlyMemory<byte> buffer, InputStreamReader<T> reader) =>
-            buffer.Read(Encoding.V2_0, null, reader);
+            buffer.Read(Encoding.Version20, null, reader);
 
         /// <summary>Reads an empty encapsulation from the buffer.</summary>
         /// <param name="buffer">The byte buffer.</param>
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
         /// <exception name="InvalidDataException">Thrown when the buffer is not an empty encapsulation, for example
         /// when buffer contains an encapsulation that does not have only tagged parameters.</exception>
         public static void ReadEmptyEncapsulation(this ReadOnlyMemory<byte> buffer) =>
-            buffer.ReadEmptyEncapsulation(Encoding.V2_0);
+            buffer.ReadEmptyEncapsulation(Encoding.Version20);
 
         /// <summary>Reads the contents of an encapsulation from the buffer.</summary>
         /// <typeparam name="T">The type of the contents.</typeparam>
@@ -127,7 +127,7 @@ namespace ZeroC.Ice
             this ReadOnlyMemory<byte> buffer,
             Communicator communicator,
             InputStreamReader<T> payloadReader) =>
-            buffer.ReadEncapsulation(Encoding.V2_0, communicator, payloadReader);
+            buffer.ReadEncapsulation(Encoding.Version20, communicator, payloadReader);
 
         internal static ReadOnlyMemory<T> AsReadOnlyMemory<T>(this ArraySegment<T> segment) => segment;
 
@@ -152,7 +152,7 @@ namespace ZeroC.Ice
             int sizeLength;
             int size;
 
-            if (encoding == Encoding.V1_1)
+            if (encoding == Encoding.Version11)
             {
                 sizeLength = 4;
                 size = buffer.ReadInt() - sizeLength; // Remove the size length which is included with the 1.1 encoding.
@@ -178,7 +178,7 @@ namespace ZeroC.Ice
 
         internal static int ReadFixedLengthSize(this ReadOnlySpan<byte> buffer, Encoding encoding)
         {
-            if (encoding == Encoding.V1_1)
+            if (encoding == Encoding.Version11)
             {
                 return buffer.ReadInt();
             }
@@ -194,7 +194,7 @@ namespace ZeroC.Ice
         internal static ushort ReadUShort(this ReadOnlySpan<byte> buffer) => BitConverter.ToUInt16(buffer);
 
         internal static (int Size, int SizeLength) ReadSize(this ReadOnlySpan<byte> buffer, Encoding encoding) =>
-            encoding == Encoding.V1_1 ? buffer.ReadSize11() : buffer.ReadSize20();
+            encoding == Encoding.Version11 ? buffer.ReadSize11() : buffer.ReadSize20();
 
         /// <summary>Reads a string from a UTF-8 byte buffer. The size of the byte buffer corresponds to the number of
         /// UTF-8 code points in the string.</summary>

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -12,16 +12,13 @@ namespace ZeroC.Ice
         // The encodings known to the Ice runtime.
 
         /// <summary>Version 1.0 of the Ice encoding, supported by Ice 1.0 to Ice 3.7.</summary>
-        public static readonly Encoding V1_0 = new Encoding(1, 0);
+        public static readonly Encoding Version10 = new Encoding(1, 0);
 
         /// <summary>Version 1.1 of the Ice encoding, supported since Ice 3.5.</summary>
-        public static readonly Encoding V1_1 = new Encoding(1, 1);
+        public static readonly Encoding Version11 = new Encoding(1, 1);
 
         /// <summary>Version 2.0 of the Ice encoding, supported since Ice 4.0.</summary>
-        public static readonly Encoding V2_0 = new Encoding(2, 0);
-
-        /// <summary>The most recent version of the Ice encoding.</summary>
-        public static readonly Encoding Latest = V2_0;
+        public static readonly Encoding Version20 = new Encoding(2, 0);
 
         /// <summary>The major version number of this version of the Ice encoding.</summary>
         public readonly byte Major;
@@ -29,7 +26,7 @@ namespace ZeroC.Ice
         /// <summary>The minor version number of this version of the Ice encoding.</summary>
         public readonly byte Minor;
 
-        internal bool IsSupported => this == V1_1 || this == V2_0;
+        internal bool IsSupported => this == Version11 || this == Version20;
 
         /// <summary>Parses a string into an Encoding.</summary>
         /// <param name="str">The string to parse.</param>

--- a/csharp/src/Ice/Encoding.cs
+++ b/csharp/src/Ice/Encoding.cs
@@ -12,13 +12,13 @@ namespace ZeroC.Ice
         // The encodings known to the Ice runtime.
 
         /// <summary>Version 1.0 of the Ice encoding, supported by Ice 1.0 to Ice 3.7.</summary>
-        public static readonly Encoding Version10 = new Encoding(1, 0);
+        public static readonly Encoding V10 = new Encoding(1, 0);
 
         /// <summary>Version 1.1 of the Ice encoding, supported since Ice 3.5.</summary>
-        public static readonly Encoding Version11 = new Encoding(1, 1);
+        public static readonly Encoding V11 = new Encoding(1, 1);
 
         /// <summary>Version 2.0 of the Ice encoding, supported since Ice 4.0.</summary>
-        public static readonly Encoding Version20 = new Encoding(2, 0);
+        public static readonly Encoding V20 = new Encoding(2, 0);
 
         /// <summary>The major version number of this version of the Ice encoding.</summary>
         public readonly byte Major;
@@ -26,7 +26,7 @@ namespace ZeroC.Ice
         /// <summary>The minor version number of this version of the Ice encoding.</summary>
         public readonly byte Minor;
 
-        internal bool IsSupported => this == Version11 || this == Version20;
+        internal bool IsSupported => this == V11 || this == V20;
 
         /// <summary>Parses a string into an Encoding.</summary>
         /// <param name="str">The string to parse.</param>

--- a/csharp/src/Ice/IObject.cs
+++ b/csharp/src/Ice/IObject.cs
@@ -116,7 +116,7 @@ namespace ZeroC.Ice
         /// <param name="request">The request frame.</param>
         /// <param name="current">The current object for the dispatch.</param>
         /// <returns>The response frame</returns>
-        protected ValueTask<OutgoingResponseFrame> IceD_ice_idAsync(IncomingRequestFrame request, Current current)
+        protected ValueTask<OutgoingResponseFrame> IceDIceIdAsync(IncomingRequestFrame request, Current current)
         {
             request.ReadEmptyArgs();
             string returnValue = IceId(current);
@@ -127,7 +127,7 @@ namespace ZeroC.Ice
         /// <param name="request">The request frame.</param>
         /// <param name="current">The current object for the dispatch.</param>
         /// <returns>The response frame</returns>
-        protected ValueTask<OutgoingResponseFrame> IceD_ice_idsAsync(IncomingRequestFrame request, Current current)
+        protected ValueTask<OutgoingResponseFrame> IceDIceIdsAsync(IncomingRequestFrame request, Current current)
         {
             request.ReadEmptyArgs();
             IEnumerable<string> returnValue = IceIds(current);
@@ -138,7 +138,7 @@ namespace ZeroC.Ice
         /// <param name="request">The request frame.</param>
         /// <param name="current">The current object for the dispatch.</param>
         /// <returns>The response frame</returns>
-        protected ValueTask<OutgoingResponseFrame> IceD_ice_isAAsync(IncomingRequestFrame request, Current current)
+        protected ValueTask<OutgoingResponseFrame> IceDIceIsAAsync(IncomingRequestFrame request, Current current)
         {
             string id = request.ReadArgs(current.Communicator, Request.IceIsA);
             bool returnValue = IceIsA(id, current);
@@ -149,7 +149,7 @@ namespace ZeroC.Ice
         /// <param name="request">The request frame.</param>
         /// <param name="current">The current object for the dispatch.</param>
         /// <returns>The response frame</returns>
-        protected ValueTask<OutgoingResponseFrame> IceD_ice_pingAsync(IncomingRequestFrame request, Current current)
+        protected ValueTask<OutgoingResponseFrame> IceDIcePingAsync(IncomingRequestFrame request, Current current)
         {
             request.ReadEmptyArgs();
             IcePing(current);

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice
     {
         // The encoding of the header for ice1 frames. It is nominally 1.0, but in practice it is identical to 1.1
         // for the subset of the encoding used by the ice1 headers.
-        internal static readonly Encoding Encoding = Encoding.Version11;
+        internal static readonly Encoding Encoding = Encoding.V11;
 
         // Size of an ice1 frame header:
         // Magic number (4 bytes)

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice
     {
         // The encoding of the header for ice1 frames. It is nominally 1.0, but in practice it is identical to 1.1
         // for the subset of the encoding used by the ice1 headers.
-        internal static readonly Encoding Encoding = Encoding.V1_1;
+        internal static readonly Encoding Encoding = Encoding.Version11;
 
         // Size of an ice1 frame header:
         // Magic number (4 bytes)

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -6,7 +6,7 @@ namespace ZeroC.Ice
 
     internal static class Ice2Definitions
     {
-        internal static readonly Encoding Encoding = Encoding.Version20;
+        internal static readonly Encoding Encoding = Encoding.V20;
 
         // ice2 frame types:
         internal enum FrameType : byte

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -6,7 +6,7 @@ namespace ZeroC.Ice
 
     internal static class Ice2Definitions
     {
-        internal static readonly Encoding Encoding = Encoding.V2_0;
+        internal static readonly Encoding Encoding = Encoding.Version20;
 
         // ice2 frame types:
         internal enum FrameType : byte

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -28,7 +28,7 @@ namespace ZeroC.Ice
                     ArraySegment<byte> buffer = Data.Slice(Payload.Offset + Payload.Count - Data.Offset);
                     if (buffer.Count > 0)
                     {
-                        var istr = new InputStream(buffer, Encoding.V2_0);
+                        var istr = new InputStream(buffer, Encoding.Version20);
                         int dictionarySize = istr.ReadSize();
                         var binaryContext = new Dictionary<int, ReadOnlyMemory<byte>>(dictionarySize);
                         for (int i = 0; i < dictionarySize; ++i)

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -28,7 +28,7 @@ namespace ZeroC.Ice
                     ArraySegment<byte> buffer = Data.Slice(Payload.Offset + Payload.Count - Data.Offset);
                     if (buffer.Count > 0)
                     {
-                        var istr = new InputStream(buffer, Encoding.Version20);
+                        var istr = new InputStream(buffer, Encoding.V20);
                         int dictionarySize = istr.ReadSize();
                         var binaryContext = new Dictionary<int, ReadOnlyMemory<byte>>(dictionarySize);
                         for (int i = 0; i < dictionarySize; ++i)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -71,7 +71,7 @@ namespace ZeroC.Ice
             }
 
             Encoding = encoding;
-            HasCompressedPayload = Encoding == Encoding.Version20 && Payload[sizeLength + 2] != 0;
+            HasCompressedPayload = Encoding == Encoding.V20 && Payload[sizeLength + 2] != 0;
         }
 
         internal IncomingRequestFrame(OutgoingRequestFrame frame, int sizeMax)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -71,7 +71,7 @@ namespace ZeroC.Ice
             }
 
             Encoding = encoding;
-            HasCompressedPayload = Encoding == Encoding.V2_0 && Payload[sizeLength + 2] != 0;
+            HasCompressedPayload = Encoding == Encoding.Version20 && Payload[sizeLength + 2] != 0;
         }
 
         internal IncomingRequestFrame(OutgoingRequestFrame frame, int sizeMax)

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -99,7 +99,7 @@ namespace ZeroC.Ice
                 }
                 else
                 {
-                    Encoding = Encoding.V1_1;
+                    Encoding = Encoding.Version11;
                 }
             }
             else
@@ -122,7 +122,7 @@ namespace ZeroC.Ice
                     Data.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
 
                 Payload = Data.Slice(0, 1 + size + sizeLength);
-                HasCompressedPayload = Encoding == Encoding.V2_0 && Payload[1 + sizeLength + 2] != 0;
+                HasCompressedPayload = Encoding == Encoding.Version20 && Payload[1 + sizeLength + 2] != 0;
             }
             else
             {
@@ -133,7 +133,7 @@ namespace ZeroC.Ice
         /// <summary>If this response holds a 1.1-encoded system exception, reads and throws this exception.</summary>
         internal void ThrowIfSystemException(Communicator communicator)
         {
-            if (ResultType == ResultType.Failure && Encoding == Encoding.V1_1)
+            if (ResultType == ResultType.Failure && Encoding == Encoding.Version11)
             {
                 var replyStatus = (ReplyStatus)Payload[0]; // can be reassigned below
 
@@ -142,7 +142,7 @@ namespace ZeroC.Ice
                 {
                     if (replyStatus != ReplyStatus.UserException)
                     {
-                        istr = new InputStream(Payload.Slice(1), Encoding.V1_1);
+                        istr = new InputStream(Payload.Slice(1), Encoding.Version11);
                     }
                 }
                 else
@@ -191,7 +191,7 @@ namespace ZeroC.Ice
                                        communicator,
                                        startEncapsulation: true);
 
-                if (Protocol == Protocol.Ice2 && Encoding == Encoding.V1_1)
+                if (Protocol == Protocol.Ice2 && Encoding == Encoding.Version11)
                 {
                     byte b = istr.ReadByte();
                     replyStatus = b >= 1 && b <= 7 ? (ReplyStatus)b :
@@ -200,12 +200,12 @@ namespace ZeroC.Ice
             }
             else
             {
-                Debug.Assert(Protocol == Protocol.Ice1 && Encoding == Encoding.V1_1);
-                istr = new InputStream(Payload.Slice(1), Encoding.V1_1);
+                Debug.Assert(Protocol == Protocol.Ice1 && Encoding == Encoding.Version11);
+                istr = new InputStream(Payload.Slice(1), Encoding.Version11);
             }
 
             Exception exception;
-            if (Encoding == Encoding.V1_1 && replyStatus != ReplyStatus.UserException)
+            if (Encoding == Encoding.Version11 && replyStatus != ReplyStatus.UserException)
             {
                 exception = istr.ReadSystemException11(replyStatus);
                 istr.CheckEndOfBuffer(skipTaggedParams: false);

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -99,7 +99,7 @@ namespace ZeroC.Ice
                 }
                 else
                 {
-                    Encoding = Encoding.Version11;
+                    Encoding = Encoding.V11;
                 }
             }
             else
@@ -122,7 +122,7 @@ namespace ZeroC.Ice
                     Data.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
 
                 Payload = Data.Slice(0, 1 + size + sizeLength);
-                HasCompressedPayload = Encoding == Encoding.Version20 && Payload[1 + sizeLength + 2] != 0;
+                HasCompressedPayload = Encoding == Encoding.V20 && Payload[1 + sizeLength + 2] != 0;
             }
             else
             {
@@ -133,7 +133,7 @@ namespace ZeroC.Ice
         /// <summary>If this response holds a 1.1-encoded system exception, reads and throws this exception.</summary>
         internal void ThrowIfSystemException(Communicator communicator)
         {
-            if (ResultType == ResultType.Failure && Encoding == Encoding.Version11)
+            if (ResultType == ResultType.Failure && Encoding == Encoding.V11)
             {
                 var replyStatus = (ReplyStatus)Payload[0]; // can be reassigned below
 
@@ -142,7 +142,7 @@ namespace ZeroC.Ice
                 {
                     if (replyStatus != ReplyStatus.UserException)
                     {
-                        istr = new InputStream(Payload.Slice(1), Encoding.Version11);
+                        istr = new InputStream(Payload.Slice(1), Encoding.V11);
                     }
                 }
                 else
@@ -191,7 +191,7 @@ namespace ZeroC.Ice
                                        communicator,
                                        startEncapsulation: true);
 
-                if (Protocol == Protocol.Ice2 && Encoding == Encoding.Version11)
+                if (Protocol == Protocol.Ice2 && Encoding == Encoding.V11)
                 {
                     byte b = istr.ReadByte();
                     replyStatus = b >= 1 && b <= 7 ? (ReplyStatus)b :
@@ -200,12 +200,12 @@ namespace ZeroC.Ice
             }
             else
             {
-                Debug.Assert(Protocol == Protocol.Ice1 && Encoding == Encoding.Version11);
-                istr = new InputStream(Payload.Slice(1), Encoding.Version11);
+                Debug.Assert(Protocol == Protocol.Ice1 && Encoding == Encoding.V11);
+                istr = new InputStream(Payload.Slice(1), Encoding.V11);
             }
 
             Exception exception;
-            if (Encoding == Encoding.Version11 && replyStatus != ReplyStatus.UserException)
+            if (Encoding == Encoding.V11 && replyStatus != ReplyStatus.UserException)
             {
                 exception = istr.ReadSystemException11(replyStatus);
                 istr.CheckEndOfBuffer(skipTaggedParams: false);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -123,7 +123,7 @@ namespace ZeroC.Ice
         // The communicator must be set when reading a proxy, class, or exception.
         private readonly Communicator? _communicator;
 
-        private bool OldEncoding => Encoding == Encoding.V1_1;
+        private bool OldEncoding => Encoding == Encoding.Version11;
 
         // The byte buffer we are reading.
         private readonly ReadOnlyMemory<byte> _buffer;
@@ -1002,7 +1002,7 @@ namespace ZeroC.Ice
                 Encoding = encapsEncoding;
                 Encoding.CheckSupported();
 
-                if (encapsEncoding == Encoding.V2_0)
+                if (encapsEncoding == Encoding.Version20)
                 {
                     byte compressionStatus = ReadByte();
                     if (compressionStatus != 0)

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -123,7 +123,7 @@ namespace ZeroC.Ice
         // The communicator must be set when reading a proxy, class, or exception.
         private readonly Communicator? _communicator;
 
-        private bool OldEncoding => Encoding == Encoding.Version11;
+        private bool OldEncoding => Encoding == Encoding.V11;
 
         // The byte buffer we are reading.
         private readonly ReadOnlyMemory<byte> _buffer;
@@ -1002,7 +1002,7 @@ namespace ZeroC.Ice
                 Encoding = encapsEncoding;
                 Encoding.CheckSupported();
 
-                if (encapsEncoding == Encoding.Version20)
+                if (encapsEncoding == Encoding.V20)
                 {
                     byte compressionStatus = ReadByte();
                     if (compressionStatus != 0)

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -169,7 +169,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                ValueEncoding = Encoding.V1_1;
+                ValueEncoding = Encoding.Version11;
             }
 
             if (options.TryGetValue("-v", out argument))

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -169,7 +169,7 @@ namespace ZeroC.Ice
             }
             else
             {
-                ValueEncoding = Encoding.Version11;
+                ValueEncoding = Encoding.V11;
             }
 
             if (options.TryGetValue("-v", out argument))

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -135,7 +135,7 @@ namespace ZeroC.Ice
                 throw new InvalidOperationException("cannot modify a sealed frame");
             }
 
-            if (Encoding != Encoding.Version20)
+            if (Encoding != Encoding.V20)
             {
                 throw new NotSupportedException("payload compression is only supported with 2.0 encoding");
             }
@@ -295,7 +295,7 @@ namespace ZeroC.Ice
 
             if (_binaryContextOstr == null)
             {
-                _binaryContextOstr = new OutputStream(Encoding.Version20, Data, PayloadEnd);
+                _binaryContextOstr = new OutputStream(Encoding.V20, Data, PayloadEnd);
                 _binaryContextOstr.WriteByteSpan(stackalloc byte[2]); // 2-bytes size place holder
             }
             return _binaryContextOstr;
@@ -317,7 +317,7 @@ namespace ZeroC.Ice
                     if (defaultBinaryContext.Count > 0)
                     {
                         // Add segment for each slot that was not written yet.
-                        var istr = new InputStream(defaultBinaryContext, Encoding.Version20);
+                        var istr = new InputStream(defaultBinaryContext, Encoding.V20);
                         int dictionarySize = istr.ReadSize();
                         for (int i = 0; i < dictionarySize; ++i)
                         {

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -135,7 +135,7 @@ namespace ZeroC.Ice
                 throw new InvalidOperationException("cannot modify a sealed frame");
             }
 
-            if (Encoding != Encoding.V2_0)
+            if (Encoding != Encoding.Version20)
             {
                 throw new NotSupportedException("payload compression is only supported with 2.0 encoding");
             }
@@ -295,7 +295,7 @@ namespace ZeroC.Ice
 
             if (_binaryContextOstr == null)
             {
-                _binaryContextOstr = new OutputStream(Encoding.V2_0, Data, PayloadEnd);
+                _binaryContextOstr = new OutputStream(Encoding.Version20, Data, PayloadEnd);
                 _binaryContextOstr.WriteByteSpan(stackalloc byte[2]); // 2-bytes size place holder
             }
             return _binaryContextOstr;
@@ -317,7 +317,7 @@ namespace ZeroC.Ice
                     if (defaultBinaryContext.Count > 0)
                     {
                         // Add segment for each slot that was not written yet.
-                        var istr = new InputStream(defaultBinaryContext, Encoding.V2_0);
+                        var istr = new InputStream(defaultBinaryContext, Encoding.Version20);
                         int dictionarySize = istr.ReadSize();
                         for (int i = 0; i < dictionarySize; ++i)
                         {

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -88,7 +88,7 @@ namespace ZeroC.Ice
                                         format);
             writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
-            if (compress && proxy.Encoding == Encoding.Version20)
+            if (compress && proxy.Encoding == Encoding.V20)
             {
                 request.CompressPayload();
             }
@@ -130,7 +130,7 @@ namespace ZeroC.Ice
                                         format);
             writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
-            if (compress && proxy.Encoding == Encoding.Version20)
+            if (compress && proxy.Encoding == Encoding.V20)
             {
                 request.CompressPayload();
             }

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -88,7 +88,7 @@ namespace ZeroC.Ice
                                         format);
             writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
-            if (compress && proxy.Encoding == Encoding.V2_0)
+            if (compress && proxy.Encoding == Encoding.Version20)
             {
                 request.CompressPayload();
             }
@@ -130,7 +130,7 @@ namespace ZeroC.Ice
                                         format);
             writer(ostr, args);
             request.PayloadEnd = ostr.Finish();
-            if (compress && proxy.Encoding == Encoding.V2_0)
+            if (compress && proxy.Encoding == Encoding.Version20)
             {
                 request.CompressPayload();
             }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
-            if (compress && current.Encoding == Encoding.Version20)
+            if (compress && current.Encoding == Encoding.V20)
             {
                 response.CompressPayload();
             }
@@ -83,7 +83,7 @@ namespace ZeroC.Ice
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
-            if (compress && current.Encoding == Encoding.Version20)
+            if (compress && current.Encoding == Encoding.V20)
             {
                 response.CompressPayload();
             }
@@ -130,7 +130,7 @@ namespace ZeroC.Ice
                 byte[] buffer = new byte[8];
                 Data.Add(buffer);
 
-                if (response.ResultType == ResultType.Failure && Encoding == Encoding.Version11)
+                if (response.ResultType == ResultType.Failure && Encoding == Encoding.V11)
                 {
                     // When the response carries a failure encoded with 1.1, we need to perform a small adjustment
                     // between ice1 and ice2 response frames.
@@ -237,7 +237,7 @@ namespace ZeroC.Ice
             : this(request.Protocol, request.Encoding)
         {
             ReplyStatus replyStatus = ReplyStatus.UserException;
-            if (Encoding == Encoding.Version11)
+            if (Encoding == Encoding.V11)
             {
                 replyStatus = exception switch
                 {
@@ -264,7 +264,7 @@ namespace ZeroC.Ice
                                         Encoding,
                                         FormatType.Sliced);
 
-                if (Protocol == Protocol.Ice2 && Encoding == Encoding.Version11)
+                if (Protocol == Protocol.Ice2 && Encoding == Encoding.V11)
                 {
                     // The first byte of the encapsulation data is the actual ReplyStatus
                     ostr.WriteByte((byte)replyStatus);
@@ -279,7 +279,7 @@ namespace ZeroC.Ice
                 hasEncapsulation = false;
             }
 
-            if (Encoding == Encoding.Version11)
+            if (Encoding == Encoding.V11)
             {
                 switch (replyStatus)
                 {

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
-            if (compress && current.Encoding == Encoding.V2_0)
+            if (compress && current.Encoding == Encoding.Version20)
             {
                 response.CompressPayload();
             }
@@ -83,7 +83,7 @@ namespace ZeroC.Ice
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
             writer(ostr, returnValue);
             response.PayloadEnd = ostr.Finish();
-            if (compress && current.Encoding == Encoding.V2_0)
+            if (compress && current.Encoding == Encoding.Version20)
             {
                 response.CompressPayload();
             }
@@ -130,7 +130,7 @@ namespace ZeroC.Ice
                 byte[] buffer = new byte[8];
                 Data.Add(buffer);
 
-                if (response.ResultType == ResultType.Failure && Encoding == Encoding.V1_1)
+                if (response.ResultType == ResultType.Failure && Encoding == Encoding.Version11)
                 {
                     // When the response carries a failure encoded with 1.1, we need to perform a small adjustment
                     // between ice1 and ice2 response frames.
@@ -237,7 +237,7 @@ namespace ZeroC.Ice
             : this(request.Protocol, request.Encoding)
         {
             ReplyStatus replyStatus = ReplyStatus.UserException;
-            if (Encoding == Encoding.V1_1)
+            if (Encoding == Encoding.Version11)
             {
                 replyStatus = exception switch
                 {
@@ -264,7 +264,7 @@ namespace ZeroC.Ice
                                         Encoding,
                                         FormatType.Sliced);
 
-                if (Protocol == Protocol.Ice2 && Encoding == Encoding.V1_1)
+                if (Protocol == Protocol.Ice2 && Encoding == Encoding.Version11)
                 {
                     // The first byte of the encapsulation data is the actual ReplyStatus
                     ostr.WriteByte((byte)replyStatus);
@@ -279,7 +279,7 @@ namespace ZeroC.Ice
                 hasEncapsulation = false;
             }
 
-            if (Encoding == Encoding.V1_1)
+            if (Encoding == Encoding.Version11)
             {
                 switch (replyStatus)
                 {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -151,7 +151,7 @@ namespace ZeroC.Ice
 
         private bool InEncapsulation => _startPos != null;
 
-        private bool OldEncoding => Encoding == Encoding.Version11;
+        private bool OldEncoding => Encoding == Encoding.V11;
 
         // The number of bytes that the stream can hold.
         private int _capacity;
@@ -1472,7 +1472,7 @@ namespace ZeroC.Ice
 
         internal static void WriteEncapsulationSize(int size, Span<byte> data, Encoding encoding)
         {
-            if (encoding == Encoding.Version20)
+            if (encoding == Encoding.V20)
             {
                 WriteFixedLengthSize20(size, data);
             }
@@ -1528,7 +1528,7 @@ namespace ZeroC.Ice
             _format = format;
             _startPos = _tail;
             WriteEncapsulationHeader(payloadEncoding); // with placeholder for size
-            if (payloadEncoding == Encoding.Version20)
+            if (payloadEncoding == Encoding.V20)
             {
                 WriteByte(0); // Placeholder for the compression status
             }
@@ -1554,8 +1554,8 @@ namespace ZeroC.Ice
         internal Position WriteEmptyEncapsulation(Encoding encoding)
         {
             encoding.CheckSupported();
-            WriteEncapsulationHeader(size: encoding == Encoding.Version20 ? 3 : 2, encoding);
-            if (encoding == Encoding.Version20)
+            WriteEncapsulationHeader(size: encoding == Encoding.V20 ? 3 : 2, encoding);
+            if (encoding == Encoding.V20)
             {
                 WriteByte(0); // The compression status, 0 not-compressed
             }
@@ -1579,7 +1579,7 @@ namespace ZeroC.Ice
                 {
                     // For ice1 and ice2, this corresponds to the protocol's encoding.
                     Encoding payloadEncoding = endpoint.Protocol == Protocol.Ice1 ?
-                        Ice1Definitions.Encoding : Encoding.Version20;
+                        Ice1Definitions.Encoding : Encoding.V20;
 
                     WriteEncapsulationHeader(payloadEncoding, sizeLength); // with placeholder for size
                     Encoding previousEncoding = Encoding;

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -151,7 +151,7 @@ namespace ZeroC.Ice
 
         private bool InEncapsulation => _startPos != null;
 
-        private bool OldEncoding => Encoding == Encoding.V1_1;
+        private bool OldEncoding => Encoding == Encoding.Version11;
 
         // The number of bytes that the stream can hold.
         private int _capacity;
@@ -1472,7 +1472,7 @@ namespace ZeroC.Ice
 
         internal static void WriteEncapsulationSize(int size, Span<byte> data, Encoding encoding)
         {
-            if (encoding == Encoding.V2_0)
+            if (encoding == Encoding.Version20)
             {
                 WriteFixedLengthSize20(size, data);
             }
@@ -1528,7 +1528,7 @@ namespace ZeroC.Ice
             _format = format;
             _startPos = _tail;
             WriteEncapsulationHeader(payloadEncoding); // with placeholder for size
-            if (payloadEncoding == Encoding.V2_0)
+            if (payloadEncoding == Encoding.Version20)
             {
                 WriteByte(0); // Placeholder for the compression status
             }
@@ -1554,8 +1554,8 @@ namespace ZeroC.Ice
         internal Position WriteEmptyEncapsulation(Encoding encoding)
         {
             encoding.CheckSupported();
-            WriteEncapsulationHeader(size: encoding == Encoding.V2_0 ? 3 : 2, encoding);
-            if (encoding == Encoding.V2_0)
+            WriteEncapsulationHeader(size: encoding == Encoding.Version20 ? 3 : 2, encoding);
+            if (encoding == Encoding.Version20)
             {
                 WriteByte(0); // The compression status, 0 not-compressed
             }
@@ -1579,7 +1579,7 @@ namespace ZeroC.Ice
                 {
                     // For ice1 and ice2, this corresponds to the protocol's encoding.
                     Encoding payloadEncoding = endpoint.Protocol == Protocol.Ice1 ?
-                        Ice1Definitions.Encoding : Encoding.V2_0;
+                        Ice1Definitions.Encoding : Encoding.Version20;
 
                     WriteEncapsulationHeader(payloadEncoding, sizeLength); // with placeholder for size
                     Encoding previousEncoding = Encoding;

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -24,8 +24,8 @@ namespace ZeroC.Ice
         public static Encoding GetEncoding(this Protocol protocol) =>
             protocol switch
             {
-                Protocol.Ice1 => Encoding.V1_1,
-                Protocol.Ice2 => Encoding.V2_0,
+                Protocol.Ice1 => Encoding.Version11,
+                Protocol.Ice2 => Encoding.Version20,
                 _ => throw new NotSupportedException(@$"Ice protocol `{protocol.GetName()
                     }' is not supported by this Ice runtime ({Runtime.StringVersion})")
             };

--- a/csharp/src/Ice/Protocol.cs
+++ b/csharp/src/Ice/Protocol.cs
@@ -24,8 +24,8 @@ namespace ZeroC.Ice
         public static Encoding GetEncoding(this Protocol protocol) =>
             protocol switch
             {
-                Protocol.Ice1 => Encoding.Version11,
-                Protocol.Ice2 => Encoding.Version20,
+                Protocol.Ice1 => Encoding.V11,
+                Protocol.Ice2 => Encoding.V20,
                 _ => throw new NotSupportedException(@$"Ice protocol `{protocol.GetName()
                     }' is not supported by this Ice runtime ({Runtime.StringVersion})")
             };

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
                 (endpoints, path, proxyOptions, facet) = UriParser.ParseProxy(proxyString, communicator);
 
                 protocol = proxyOptions.Protocol ?? Protocol.Ice2;
-                encoding = proxyOptions.Encoding ?? Encoding.Version20;
+                encoding = proxyOptions.Encoding ?? Encoding.V20;
 
                 adapterId = "";
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -89,7 +89,7 @@ namespace ZeroC.Ice
                 (endpoints, path, proxyOptions, facet) = UriParser.ParseProxy(proxyString, communicator);
 
                 protocol = proxyOptions.Protocol ?? Protocol.Ice2;
-                encoding = proxyOptions.Encoding ?? Encoding.V2_0;
+                encoding = proxyOptions.Encoding ?? Encoding.Version20;
 
                 adapterId = "";
 

--- a/csharp/src/Ice/SlicBinaryConnection.cs
+++ b/csharp/src/Ice/SlicBinaryConnection.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice
             Close = 0x09
         }
 
-        internal static readonly Encoding Encoding = Encoding.Version20;
+        internal static readonly Encoding Encoding = Encoding.V20;
 
         // The mutex provides thread-safety for the _sendTask data member.
         private readonly object _mutex = new object();

--- a/csharp/src/Ice/SlicBinaryConnection.cs
+++ b/csharp/src/Ice/SlicBinaryConnection.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice
             Close = 0x09
         }
 
-        internal static readonly Encoding Encoding = Encoding.V2_0;
+        internal static readonly Encoding Encoding = Encoding.Version20;
 
         // The mutex provides thread-safety for the _sendTask data member.
         private readonly object _mutex = new object();

--- a/csharp/test/Ice/compress/TestI.cs
+++ b/csharp/test/Ice/compress/TestI.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Compress
         {
             if (current.Operation == "opCompressParams" || current.Operation == "opCompressParamsAndReturn")
             {
-                if (request.Encoding == Encoding.V2_0)
+                if (request.Encoding == Encoding.Version20)
                 {
                     TestHelper.Assert(request.HasCompressedPayload == _compressed);
                     if (!_compressed)
@@ -36,7 +36,7 @@ namespace ZeroC.Ice.Test.Compress
             OutgoingResponseFrame response = await _servant.DispatchAsync(request, current);
             if (current.Operation == "opCompressReturn" || current.Operation == "opCompressParamsAndReturn")
             {
-                if (response.Encoding == Encoding.V2_0)
+                if (response.Encoding == Encoding.Version20)
                 {
                     if (_compressed)
                     {
@@ -58,7 +58,7 @@ namespace ZeroC.Ice.Test.Compress
                 }
             }
 
-            if (response.Encoding == Encoding.V2_0 && current.Operation == "opWithUserException")
+            if (response.Encoding == Encoding.Version20 && current.Operation == "opWithUserException")
             {
                 response.CompressPayload();
             }

--- a/csharp/test/Ice/compress/TestI.cs
+++ b/csharp/test/Ice/compress/TestI.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Compress
         {
             if (current.Operation == "opCompressParams" || current.Operation == "opCompressParamsAndReturn")
             {
-                if (request.Encoding == Encoding.Version20)
+                if (request.Encoding == Encoding.V20)
                 {
                     TestHelper.Assert(request.HasCompressedPayload == _compressed);
                     if (!_compressed)
@@ -36,7 +36,7 @@ namespace ZeroC.Ice.Test.Compress
             OutgoingResponseFrame response = await _servant.DispatchAsync(request, current);
             if (current.Operation == "opCompressReturn" || current.Operation == "opCompressParamsAndReturn")
             {
-                if (response.Encoding == Encoding.Version20)
+                if (response.Encoding == Encoding.V20)
                 {
                     if (_compressed)
                     {
@@ -58,7 +58,7 @@ namespace ZeroC.Ice.Test.Compress
                 }
             }
 
-            if (response.Encoding == Encoding.Version20 && current.Operation == "opWithUserException")
+            if (response.Encoding == Encoding.V20 && current.Operation == "opWithUserException")
             {
                 response.CompressPayload();
             }

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -565,7 +565,7 @@ namespace ZeroC.Ice.Test.Location
             hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
             count = locator.GetRequestCount();
             IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(
-                encoding: Encoding.Version11).IcePing();
+                encoding: Encoding.V11).IcePing();
 
             // TODO: the count is apparently tied to whether or not we skip the if (ice1) block above. Would be nice to
             // add a comment.

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -564,7 +564,8 @@ namespace ZeroC.Ice.Test.Location
             output.Flush();
             hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
             count = locator.GetRequestCount();
-            IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(encoding: Encoding.V1_1).IcePing();
+            IObjectPrx.Parse(ice1 ? "test@TestAdapter" : "ice:TestAdapter//test", communicator).Clone(
+                encoding: Encoding.Version11).IcePing();
 
             // TODO: the count is apparently tied to whether or not we skip the if (ice1) block above. Would be nice to
             // add a comment.

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -548,7 +548,7 @@ namespace ZeroC.Ice.Test.Metrics
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
                 // 2 additional bytes with ice2 and Encoding2: one for the sequence size and one for the frame size
-                int sizeLengthIncrease = helper.Encoding == Encoding.V1_1 ? 4 : 2;
+                int sizeLengthIncrease = helper.Encoding == Encoding.Version11 ? 4 : 2;
 
                 TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == requestSz + bs.Length + sizeLengthIncrease);
                 TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == replySz);
@@ -565,7 +565,7 @@ namespace ZeroC.Ice.Test.Metrics
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
                 // 6 additional bytes with ice2 and Encoding2: 3 for the sequence size and 3 for the frame size
-                sizeLengthIncrease = helper.Encoding == Encoding.V1_1 ? 4 : 6;
+                sizeLengthIncrease = helper.Encoding == Encoding.Version11 ? 4 : 6;
 
                 TestHelper.Assert((cm2.SentBytes - cm1.SentBytes) == (requestSz + bs.Length + sizeLengthIncrease));
                 TestHelper.Assert((cm2.ReceivedBytes - cm1.ReceivedBytes) == replySz);
@@ -881,7 +881,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             // We assume the error message is encoded in ASCII (each character uses 1-byte when encoded in UTF-8).
             TestHelper.Assert(dm1.Size == (38 + protocolRequestSizeAdjustment) &&
-                dm1.ReplySize == (metrics.Encoding == Encoding.V1_1 ? 48 : 51 + userExErrorMessageSize));
+                dm1.ReplySize == (metrics.Encoding == Encoding.Version11 ? 48 : 51 + userExErrorMessageSize));
 
             dm1 = (DispatchMetrics)map["opWithLocalException"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -548,7 +548,7 @@ namespace ZeroC.Ice.Test.Metrics
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
                 // 2 additional bytes with ice2 and Encoding2: one for the sequence size and one for the frame size
-                int sizeLengthIncrease = helper.Encoding == Encoding.Version11 ? 4 : 2;
+                int sizeLengthIncrease = helper.Encoding == Encoding.V11 ? 4 : 2;
 
                 TestHelper.Assert(cm2.SentBytes - cm1.SentBytes == requestSz + bs.Length + sizeLengthIncrease);
                 TestHelper.Assert(cm2.ReceivedBytes - cm1.ReceivedBytes == replySz);
@@ -565,7 +565,7 @@ namespace ZeroC.Ice.Test.Metrics
                 sm2 = GetServerConnectionMetrics(serverMetrics, sm1.SentBytes + replySz)!;
 
                 // 6 additional bytes with ice2 and Encoding2: 3 for the sequence size and 3 for the frame size
-                sizeLengthIncrease = helper.Encoding == Encoding.Version11 ? 4 : 6;
+                sizeLengthIncrease = helper.Encoding == Encoding.V11 ? 4 : 6;
 
                 TestHelper.Assert((cm2.SentBytes - cm1.SentBytes) == (requestSz + bs.Length + sizeLengthIncrease));
                 TestHelper.Assert((cm2.ReceivedBytes - cm1.ReceivedBytes) == replySz);
@@ -881,7 +881,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             // We assume the error message is encoded in ASCII (each character uses 1-byte when encoded in UTF-8).
             TestHelper.Assert(dm1.Size == (38 + protocolRequestSizeAdjustment) &&
-                dm1.ReplySize == (metrics.Encoding == Encoding.Version11 ? 48 : 51 + userExErrorMessageSize));
+                dm1.ReplySize == (metrics.Encoding == Encoding.V11 ? 48 : 51 + userExErrorMessageSize));
 
             dm1 = (DispatchMetrics)map["opWithLocalException"];
             TestHelper.Assert(dm1.Current <= 1 && dm1.Total == 1 && dm1.Failures == 1 && dm1.UserException == 0);

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
             output.Write("testing forwarding with other protocol and other encoding... ");
             output.Flush();
             Encoding encoding =
-                forwardOtherPrx.Encoding == Encoding.Version11 ? Encoding.Version20 : Encoding.Version11;
+                forwardOtherPrx.Encoding == Encoding.V11 ? Encoding.V20 : Encoding.V11;
             newPrx = TestProxy(forwardOtherPrx.Clone(encoding: encoding));
             TestHelper.Assert(newPrx.Protocol != forwardOtherPrx.Protocol);
             TestHelper.Assert(newPrx.Encoding == encoding);

--- a/csharp/test/Ice/protocolBridging/AllTests.cs
+++ b/csharp/test/Ice/protocolBridging/AllTests.cs
@@ -41,7 +41,8 @@ namespace ZeroC.Ice.Test.ProtocolBridging
 
             output.Write("testing forwarding with other protocol and other encoding... ");
             output.Flush();
-            Encoding encoding = forwardOtherPrx.Encoding == Encoding.V1_1 ? Encoding.V2_0 : Encoding.V1_1;
+            Encoding encoding =
+                forwardOtherPrx.Encoding == Encoding.Version11 ? Encoding.Version20 : Encoding.Version11;
             newPrx = TestProxy(forwardOtherPrx.Clone(encoding: encoding));
             TestHelper.Assert(newPrx.Protocol != forwardOtherPrx.Protocol);
             TestHelper.Assert(newPrx.Encoding == encoding);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -372,9 +372,9 @@ namespace ZeroC.Ice.Test.Proxy
 #pragma warning restore CS0618 // Type or member is obsolete
 
             b1 = IObjectPrx.Parse("ice:test", communicator);
-            TestHelper.Assert(b1.Protocol == Protocol.Ice2 && b1.Encoding == Encoding.Version20);
+            TestHelper.Assert(b1.Protocol == Protocol.Ice2 && b1.Encoding == Encoding.V20);
             b1 = IObjectPrx.Parse("test", communicator);
-            TestHelper.Assert(b1.Protocol == Protocol.Ice1 && b1.Encoding == Encoding.Version11);
+            TestHelper.Assert(b1.Protocol == Protocol.Ice1 && b1.Encoding == Encoding.V11);
 
             b1 = IObjectPrx.Parse("ice:test?encoding=6.5", communicator);
             TestHelper.Assert(b1.Encoding.Major == 6 && b1.Encoding.Minor == 5);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -372,9 +372,9 @@ namespace ZeroC.Ice.Test.Proxy
 #pragma warning restore CS0618 // Type or member is obsolete
 
             b1 = IObjectPrx.Parse("ice:test", communicator);
-            TestHelper.Assert(b1.Protocol == Protocol.Ice2 && b1.Encoding == Encoding.V2_0);
+            TestHelper.Assert(b1.Protocol == Protocol.Ice2 && b1.Encoding == Encoding.Version20);
             b1 = IObjectPrx.Parse("test", communicator);
-            TestHelper.Assert(b1.Protocol == Protocol.Ice1 && b1.Encoding == Encoding.V1_1);
+            TestHelper.Assert(b1.Protocol == Protocol.Ice1 && b1.Encoding == Encoding.Version11);
 
             b1 = IObjectPrx.Parse("ice:test?encoding=6.5", communicator);
             TestHelper.Assert(b1.Encoding.Major == 6 && b1.Encoding.Minor == 5);

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -61,7 +61,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     // 2.0-encoded requests to IceGrid until IceGrid supports such requests.
 
                     ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(ILocatorPrx.Factory,
-                                                                           encoding: Encoding.Version11);
+                                                                           encoding: Encoding.V11);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() != null);
                     TestHelper.Assert(defaultLocator.GetLocalRegistry() != null);
@@ -92,7 +92,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     {
                     }
 
-                    Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.Version11);
+                    Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.V11);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() == null);
                     TestHelper.Assert(defaultLocator.CheckedCast(ILocatorPrx.Factory) == null);

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -61,7 +61,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     // 2.0-encoded requests to IceGrid until IceGrid supports such requests.
 
                     ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(ILocatorPrx.Factory,
-                                                                           encoding: Encoding.V1_1);
+                                                                           encoding: Encoding.Version11);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() != null);
                     TestHelper.Assert(defaultLocator.GetLocalRegistry() != null);
@@ -92,7 +92,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     {
                     }
 
-                    Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.V1_1);
+                    Ice.ILocatorPrx defaultLocator = com.DefaultLocator!.Clone(encoding: Encoding.Version11);
 
                     TestHelper.Assert(defaultLocator.GetRegistry() == null);
                     TestHelper.Assert(defaultLocator.CheckedCast(ILocatorPrx.Factory) == null);


### PR DESCRIPTION
This PR remove a few remaining underscores 

* Rename encoding fields, Encoding.V1_1 -> Encoding.Version11 
* Replace dispatch methods such iceD_ice_isA -> IceDIceIsA
* Enable `CA1707` for source builds, and disable it for the generated code with a pragma
