### PR TITLE
Replace empty host checks with Debug.Assert in C#

### DIFF
--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -271,7 +271,7 @@ namespace ZeroC.Ice
 
                 if (Host == "*")
                 {
-                    Host = oaEndpoint ? "" :
+                    Host = oaEndpoint ? (communicator.IPVersion == Network.EnableIPv4 ? "0.0.0.0" : "::0") :
                         throw new FormatException($"`-h *' not valid for proxy endpoint `{endpointString}'");
                 }
                 options.Remove("-h");

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -121,11 +121,6 @@ namespace ZeroC.Ice
         public override IEnumerable<Endpoint> ExpandHost(out Endpoint? publish)
         {
             publish = null;
-            // If this endpoint has an empty host (wildcard address), don't expand, just return this endpoint.
-            if (Host.Length == 0)
-            {
-                return new Endpoint[] { this };
-            }
 
             // If using a fixed port, this endpoint can be used as the published endpoint to access the returned
             // endpoints. Otherwise, we'll publish each individual expanded endpoint.
@@ -164,7 +159,8 @@ namespace ZeroC.Ice
         {
             if (Protocol == Protocol.Ice1)
             {
-                if (Host.Length > 0)
+                Debug.Assert(Host.Length > 0);
+
                 {
                     sb.Append(" -h ");
                     bool addQuote = Host.IndexOf(':') != -1;
@@ -241,6 +237,11 @@ namespace ZeroC.Ice
         {
             Debug.Assert(protocol == Protocol.Ice1 || protocol == Protocol.Ice2);
             Host = istr.ReadString();
+
+            if (Host.Length == 0)
+            {
+                throw new InvalidDataException("endpoint host is empty");
+            }
 
             if (protocol == Protocol.Ice1)
             {

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -217,28 +217,7 @@ namespace ZeroC.Ice
             bool preferIPv6,
             CancellationToken cancel)
         {
-            // For client endpoints, an empty host is the same as the loopback address
-            if (host.Length == 0)
-            {
-                var addresses = new List<IPEndPoint>();
-                foreach (IPAddress a in GetLoopbackAddresses(ipVersion))
-                {
-                    addresses.Add(new IPEndPoint(a, port));
-                }
-
-                if (ipVersion == EnableBoth)
-                {
-                    if (preferIPv6)
-                    {
-                        return addresses.OrderByDescending(addr => addr.AddressFamily);
-                    }
-                    else
-                    {
-                        return addresses.OrderBy(addr => addr.AddressFamily);
-                    }
-                }
-                return addresses;
-            }
+            Debug.Assert(host.Length > 0);
 
             return await GetAddressesAsync(host, port, ipVersion, selType, preferIPv6, cancel).ConfigureAwait(false);
         }
@@ -247,18 +226,7 @@ namespace ZeroC.Ice
         {
             // TODO: Fix this method to be asynchronous.
 
-            // For server endpoints, an empty host is the same as the "any" address
-            if (host.Length == 0)
-            {
-                if (ipVersion != EnableIPv4)
-                {
-                    return new IPEndPoint(IPAddress.IPv6Any, port);
-                }
-                else
-                {
-                    return new IPEndPoint(IPAddress.Any, port);
-                }
-            }
+            Debug.Assert(host.Length > 0);
 
             try
             {
@@ -753,10 +721,7 @@ namespace ZeroC.Ice
 
         private static bool IsWildcard(string address, int ipVersion)
         {
-            if (address.Length == 0)
-            {
-                return true;
-            }
+            Debug.Assert(address.Length > 0);
 
             try
             {


### PR DESCRIPTION
This PR removes checks for empty host and replaces them with an assert. The host should never be empty.