### PR TITLE
Ssl fixes

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -577,15 +577,15 @@ generated from the section label.
         <property name="CertStore" />
         <property name="CertStoreLocation" />
         <property name="CertFile" />
-        <property name="CertVerifier" />
-        <property name="CheckCertName" />
-        <property name="CheckCRL" />
-        <property name="Ciphers" />
+        <property name="CertVerifier" />  <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="CheckCertName" /> <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="CheckCRL" />      <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="Ciphers" />       <!-- TODO Remove this property, already removed in C# 4.0-->
         <property name="DefaultDir" />
         <property name="DH.[any]" />
         <property name="DHParams" />
         <property name="EntropyDaemon" />
-        <property name="FindCert" />
+        <property name="FindCert" />      <!-- TODO Remove this property, already removed in C# 4.0-->
         <property name="InitOpenSSL" />
         <property name="KeyFile" deprecated="true"/>
         <property name="Keychain"/>
@@ -594,8 +594,8 @@ generated from the section label.
         <property name="KeystorePassword" />
         <property name="KeystoreType" />
         <property name="Password" />
-        <property name="PasswordCallback" />
-        <property name="PasswordRetryMax" />
+        <property name="PasswordCallback" /> <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="PasswordRetryMax" /> <!-- TODO Remove this property, already removed in C# 4.0-->
         <property name="Protocols" />
         <property name="ProtocolVersionMax" />
         <property name="ProtocolVersionMin" />
@@ -609,9 +609,9 @@ generated from the section label.
         <property name="Truststore" />
         <property name="TruststorePassword" />
         <property name="TruststoreType" />
-        <property name="UsePlatformCAs" />
-        <property name="VerifyDepthMax" />
-        <property name="VerifyPeer" />
+        <property name="UsePlatformCAs" />     <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="VerifyDepthMax" />     <!-- TODO Remove this property, already removed in C# 4.0-->
+        <property name="VerifyPeer" />         <!-- TODO Remove this property, already removed in C# 4.0-->
     </section>
 
     <section name="IceStormAdmin">

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -191,8 +191,7 @@ namespace ZeroC.Ice.Test.Info
                 if (connection.Endpoint.IsSecure)
                 {
                     TestHelper.Assert(((TcpConnection)connection).IsEncrypted);
-                    // WSS tests run with IceSSL.VerifyPeer set to 0 so the connection is no mutually
-                    // authenticated for compatibility with web browser testing.
+                    // WSS tests run client authentication disabled for compatibility with web browser testing.
                     if (connection.Endpoint.Transport == Transport.SSL)
                     {
                         TestHelper.Assert(((TcpConnection)connection).IsMutuallyAuthenticated);

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -438,7 +438,6 @@ namespace ZeroC.IceSSL.Test.Configuration
                     using var comm = new Communicator(ref args, clientProperties);
                     var fact = IServerFactoryPrx.Parse(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
-                    serverProperties["IceSSL.VerifyPeer"] = "2";
                     IServerPrx? server = fact.CreateServer(serverProperties, true);
                     try
                     {

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -240,7 +240,13 @@ namespace Test
             Dictionary<string, string> properties,
             ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
         {
-            var communicator = new Communicator(properties, observer: observer);
+            var tlsServerOptions = new TlsServerOptions();
+            if (properties.TryGetValue("Test.Transport", out string? value) && value == "wss")
+            {
+                // When running test with WSS disable client authentication for browser compatibility
+                tlsServerOptions.RequireClientCertificate = false;
+            }
+            var communicator = new Communicator(properties, tlsServerOptions: tlsServerOptions, observer: observer);
 
             Communicator ??= communicator;
             ControllerHelper?.CommunicatorInitialized(communicator);


### PR DESCRIPTION
This PR marks IceSSL properties removed in C# 4.0 as candidates to be removed, it also fixes an WSS testing failure related to WSS testing depend on one of the removed properties.