### PR TITLE
Remove Ice.IPv4 and Ice.IPv6 in C#

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -362,7 +362,9 @@ generated from the section label.
         <property name="ImplicitContext" />
         <property name="IncomingFrameSizeMax" />
         <property name="InitPlugins" />
+        <!-- TODO: Remove IPv4 -->
         <property name="IPv4" />
+        <!-- TODO: Remove IPv6 -->
         <property name="IPv6" />
         <property name="LogFile" />
         <property name="LogFile.SizeMax" />

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -160,7 +160,6 @@ namespace ZeroC.Ice
         internal IReadOnlyList<DispatchInterceptor> DispatchInterceptors => _dispatchInterceptors;
         internal int IncomingFrameSizeMax { get; }
         internal IReadOnlyList<InvocationInterceptor> InvocationInterceptors => _invocationInterceptors;
-        internal int IPVersion { get; }
         internal bool IsDisposed => _disposeTask != null;
         internal INetworkProxy? NetworkProxy { get; }
         internal bool PreferIPv6 { get; }
@@ -533,10 +532,9 @@ namespace ZeroC.Ice
                     }
                 }
 
-                IPVersion = Network.EnableBoth;
                 PreferIPv6 = GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
 
-                NetworkProxy = CreateNetworkProxy(IPVersion);
+                NetworkProxy = CreateNetworkProxy(Network.EnableBoth);
 
                 SslEngine = new SslEngine(this, tlsClientOptions, tlsServerOptions);
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -533,25 +533,7 @@ namespace ZeroC.Ice
                     }
                 }
 
-                bool isIPv6Supported = Network.IsIPv6Supported();
-                bool ipv4 = GetPropertyAsBool("Ice.IPv4") ?? true;
-                bool ipv6 = GetPropertyAsBool("Ice.IPv6") ?? isIPv6Supported;
-                if (!ipv4 && !ipv6)
-                {
-                    throw new InvalidConfigurationException("Both IPV4 and IPv6 support cannot be disabled.");
-                }
-                else if (ipv4 && ipv6)
-                {
-                    IPVersion = Network.EnableBoth;
-                }
-                else if (ipv4)
-                {
-                    IPVersion = Network.EnableIPv4;
-                }
-                else
-                {
-                    IPVersion = Network.EnableIPv6;
-                }
+                IPVersion = Network.EnableBoth;
                 PreferIPv6 = GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
 
                 NetworkProxy = CreateNetworkProxy(IPVersion);

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -92,7 +92,7 @@ namespace ZeroC.Ice
             try
             {
                 INetworkProxy? networkProxy = Communicator.NetworkProxy;
-                int ipVersion = networkProxy?.IPVersion ?? Communicator.IPVersion;
+                int ipVersion = networkProxy?.IPVersion ?? Network.EnableBoth;
                 if (networkProxy != null)
                 {
                     networkProxy = await networkProxy.ResolveHostAsync(ipVersion, cancel).ConfigureAwait(false);
@@ -128,7 +128,7 @@ namespace ZeroC.Ice
 
             IEnumerable<IPEndPoint> addresses = Network.GetAddresses(Host,
                                                                      Port,
-                                                                     Communicator.IPVersion,
+                                                                     Network.EnableBoth,
                                                                      EndpointSelectionType.Ordered,
                                                                      Communicator.PreferIPv6);
 
@@ -144,7 +144,7 @@ namespace ZeroC.Ice
 
         public override IEnumerable<Endpoint> ExpandIfWildcard()
         {
-            List<string> hosts = Network.GetHostsForEndpointExpand(Host, Communicator.IPVersion, false);
+            List<string> hosts = Network.GetHostsForEndpointExpand(Host, Network.EnableBoth, false);
             if (hosts.Count == 0)
             {
                 return new Endpoint[] { this };
@@ -272,7 +272,7 @@ namespace ZeroC.Ice
 
                 if (Host == "*")
                 {
-                    Host = oaEndpoint ? (communicator.IPVersion == Network.EnableIPv4 ? "0.0.0.0" : "::0") :
+                    Host = oaEndpoint ? "::0" :
                         throw new FormatException($"`-h *' not valid for proxy endpoint `{endpointString}'");
                 }
                 options.Remove("-h");

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -272,6 +272,8 @@ namespace ZeroC.Ice
 
                 if (Host == "*")
                 {
+                    // TODO: Should we check that IPv6 is enabled first and use 0.0.0.0 otherwise, or will
+                    // ::0 just bind to the IPv4 addresses in this case?
                     Host = oaEndpoint ? "::0" :
                         throw new FormatException($"`-h *' not valid for proxy endpoint `{endpointString}'");
                 }

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -42,16 +42,9 @@ namespace ZeroC.IceDiscovery
 
         public void Initialize(PluginInitializationContext context)
         {
-            bool preferIPv6 = _communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
-            string address;
-            if (preferIPv6)
-            {
-                address = _communicator.GetProperty("IceDiscovery.Address") ?? "ff15::1";
-            }
-            else
-            {
-                address = _communicator.GetProperty("IceDiscovery.Address") ?? "239.255.0.1";
-            }
+            string address = _communicator.GetProperty("IceDiscovery.Address") ??
+                (_communicator.PreferIPv6 ? "ff15::1" : "239.255.0.1");
+
             int port = _communicator.GetPropertyAsInt("IceDiscovery.Port") ?? 4061;
             string intf = _communicator.GetProperty("IceDiscovery.Interface") ?? "";
 
@@ -71,7 +64,7 @@ namespace ZeroC.IceDiscovery
             string lookupEndpoints = _communicator.GetProperty("IceDiscovery.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = preferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
+                int ipVersion = _communicator.PreferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
                 List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 foreach (string p in interfaces)
                 {

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -42,16 +42,15 @@ namespace ZeroC.IceDiscovery
 
         public void Initialize(PluginInitializationContext context)
         {
-            bool ipv4 = _communicator.GetPropertyAsBool("Ice.IPv4") ?? true;
             bool preferIPv6 = _communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
             string address;
-            if (ipv4 && !preferIPv6)
+            if (preferIPv6)
             {
-                address = _communicator.GetProperty("IceDiscovery.Address") ?? "239.255.0.1";
+                address = _communicator.GetProperty("IceDiscovery.Address") ?? "ff15::1";
             }
             else
             {
-                address = _communicator.GetProperty("IceDiscovery.Address") ?? "ff15::1";
+                address = _communicator.GetProperty("IceDiscovery.Address") ?? "239.255.0.1";
             }
             int port = _communicator.GetPropertyAsInt("IceDiscovery.Port") ?? 4061;
             string intf = _communicator.GetProperty("IceDiscovery.Interface") ?? "";
@@ -72,7 +71,7 @@ namespace ZeroC.IceDiscovery
             string lookupEndpoints = _communicator.GetProperty("IceDiscovery.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = ipv4 && !preferIPv6 ? Network.EnableIPv4 : Network.EnableIPv6;
+                int ipVersion = preferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
                 List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 foreach (string p in interfaces)
                 {

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -385,24 +385,16 @@ namespace ZeroC.IceLocatorDiscovery
 
         public void Initialize(PluginInitializationContext context)
         {
-            bool preferIPv6 = _communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
+            string address = _communicator.GetProperty($"{_name}.Address") ??
+                (_communicator.PreferIPv6 ? "ff15::1" : "239.255.0.1");
 
-            string address;
-            if (preferIPv6)
-            {
-                address = _communicator.GetProperty($"{_name}.Address") ?? "ff15::1";
-            }
-            else
-            {
-                address = _communicator.GetProperty($"{_name}.Address") ?? "239.255.0.1";
-            }
             int port = _communicator.GetPropertyAsInt($"{_name}.Port") ?? 4061;
             string intf = _communicator.GetProperty($"{_name}.Interface") ?? "";
 
             string lookupEndpoints = _communicator.GetProperty($"{_name}.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = preferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
+                int ipVersion = _communicator.PreferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
                 List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 lookupEndpoints = string.Join(":", interfaces.Select(
                     intf => $"udp -h \"{address}\" -p {port} --interface \"{intf}\""));

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -385,17 +385,16 @@ namespace ZeroC.IceLocatorDiscovery
 
         public void Initialize(PluginInitializationContext context)
         {
-            bool ipv4 = _communicator.GetPropertyAsBool("Ice.IPv4") ?? true;
             bool preferIPv6 = _communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
 
             string address;
-            if (ipv4 && !preferIPv6)
+            if (preferIPv6)
             {
-                address = _communicator.GetProperty($"{_name}.Address") ?? "239.255.0.1";
+                address = _communicator.GetProperty($"{_name}.Address") ?? "ff15::1";
             }
             else
             {
-                address = _communicator.GetProperty($"{_name}.Address") ?? "ff15::1";
+                address = _communicator.GetProperty($"{_name}.Address") ?? "239.255.0.1";
             }
             int port = _communicator.GetPropertyAsInt($"{_name}.Port") ?? 4061;
             string intf = _communicator.GetProperty($"{_name}.Interface") ?? "";
@@ -403,7 +402,7 @@ namespace ZeroC.IceLocatorDiscovery
             string lookupEndpoints = _communicator.GetProperty($"{_name}.Lookup") ?? "";
             if (lookupEndpoints.Length == 0)
             {
-                int ipVersion = ipv4 && !preferIPv6 ? Network.EnableIPv4 : Network.EnableIPv6;
+                int ipVersion = preferIPv6 ? Network.EnableIPv6 : Network.EnableIPv4;
                 List<string> interfaces = Network.GetInterfacesForMulticast(intf, ipVersion);
                 lookupEndpoints = string.Join(":", interfaces.Select(
                     intf => $"udp -h \"{address}\" -p {port} --interface \"{intf}\""));

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -20,15 +20,15 @@ namespace ZeroC.Ice
         internal const int EnableIPv6 = 1;
         internal const int EnableBoth = 2;
 
-        internal static Socket CreateServerSocket(bool udp, AddressFamily family, int ipVersion)
+        internal static Socket CreateServerSocket(bool udp, AddressFamily family)
         {
             Socket socket = CreateSocket(udp, family);
-            if (family == AddressFamily.InterNetworkV6 && ipVersion != EnableIPv4)
+            if (family == AddressFamily.InterNetworkV6)
             {
                 try
                 {
-                    int flag = ipVersion == EnableIPv6 ? 1 : 0;
-                    socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, flag);
+                    // TODO: this should configured by an "ipv6only" option on the OA's endpoint
+                    socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, 0);
                 }
                 catch (SocketException ex)
                 {
@@ -367,20 +367,6 @@ namespace ZeroC.Ice
                 addresses.Add(IPAddress.Loopback);
             }
             return addresses;
-        }
-
-        internal static bool IsIPv6Supported()
-        {
-            try
-            {
-                using var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-                socket.CloseNoThrow();
-                return true;
-            }
-            catch (SocketException)
-            {
-                return false;
-            }
         }
 
         internal static bool IsLinklocal(IPAddress addr)

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -34,7 +34,7 @@ namespace ZeroC.Ice
             s.Append(ToString());
 
             List<string> interfaces =
-                Network.GetHostsForEndpointExpand(_addr.Address.ToString(), Endpoint.Communicator.IPVersion, true);
+                Network.GetHostsForEndpointExpand(_addr.Address.ToString(), Network.EnableBoth, true);
             if (interfaces.Count != 0)
             {
                 s.Append("\nlocal interfaces = ");
@@ -51,10 +51,10 @@ namespace ZeroC.Ice
 
             _addr = Network.GetAddressForServerEndpoint(endpoint.Host,
                                                         endpoint.Port,
-                                                        endpoint.Communicator.IPVersion,
+                                                        Network.EnableBoth,
                                                         endpoint.Communicator.PreferIPv6);
 
-            _socket = Network.CreateServerSocket(false, _addr.AddressFamily, endpoint.Communicator.IPVersion);
+            _socket = Network.CreateServerSocket(false, _addr.AddressFamily, Network.EnableBoth);
 
             try
             {

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
                                                         Network.EnableBoth,
                                                         endpoint.Communicator.PreferIPv6);
 
-            _socket = Network.CreateServerSocket(false, _addr.AddressFamily, Network.EnableBoth);
+            _socket = Network.CreateServerSocket(false, _addr.AddressFamily);
 
             try
             {

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -206,7 +206,7 @@ namespace ZeroC.Ice
                 List<string> interfaces;
                 if (MulticastAddress == null)
                 {
-                    interfaces = Network.GetHostsForEndpointExpand(_addr.ToString(), _communicator.IPVersion, true);
+                    interfaces = Network.GetHostsForEndpointExpand(_addr.ToString(), Network.EnableBoth, true);
                 }
                 else
                 {
@@ -316,11 +316,11 @@ namespace ZeroC.Ice
             string multicastInterface)
         {
             _communicator = communicator;
-            _addr = Network.GetAddressForServerEndpoint(host, port, communicator.IPVersion, communicator.PreferIPv6);
+            _addr = Network.GetAddressForServerEndpoint(host, port, Network.EnableBoth, communicator.PreferIPv6);
             _multicastInterface = multicastInterface;
             _incoming = true;
 
-            Socket = Network.CreateServerSocket(true, _addr.AddressFamily, communicator.IPVersion);
+            Socket = Network.CreateServerSocket(true, _addr.AddressFamily, Network.EnableBoth);
             try
             {
                 Network.SetBufSize(Socket, _communicator, Transport.UDP);

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -320,7 +320,7 @@ namespace ZeroC.Ice
             _multicastInterface = multicastInterface;
             _incoming = true;
 
-            Socket = Network.CreateServerSocket(true, _addr.AddressFamily, Network.EnableBoth);
+            Socket = Network.CreateServerSocket(true, _addr.AddressFamily);
             try
             {
                 Network.SetBufSize(Socket, _communicator, Transport.UDP);

--- a/csharp/test/Ice/faultTolerance/AllTests.cs
+++ b/csharp/test/Ice/faultTolerance/AllTests.cs
@@ -52,7 +52,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
                     for (int i = 1; i < ports.Count; ++i)
                     {
                         sb.Append($": {transport} -h ");
-                        sb.Append(helper.Host);
+                        sb.Append(helper.Host.Contains(":") ? $"\"{helper.Host}\"" : helper.Host);
                         sb.Append(" -p ");
                         sb.Append(helper.BasePort + ports[i]);
                     }
@@ -66,7 +66,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
                         {
                             sb.Append(',');
                         }
-                        sb.Append(helper.Host);
+                        sb.Append(helper.Host.Contains(":") ? $"[{helper.Host}]" : helper.Host);
                         sb.Append(':');
                         sb.Append(helper.BasePort + ports[i]);
                     }

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -75,7 +75,7 @@ namespace ZeroC.Ice.Test.Info
             output.Write("test object adapter endpoint information... ");
             output.Flush();
             {
-                string host = (communicator.GetPropertyAsBool("Ice.IPv6") ?? false) ? "::1" : "127.0.0.1";
+                string host = (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false) ? "::1" : "127.0.0.1";
                 communicator.SetProperty("TestAdapter.Endpoints", "tcp -h \"" + host +
                     "\" -t 15000:udp -h \"" + host + "\"");
                 adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -62,7 +62,7 @@ namespace ZeroC.Ice.Test.UDP
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
-            communicator.SetProperty("ReplyAdapter.Endpoints", "udp -h localhost");
+            communicator.SetProperty("ReplyAdapter.Endpoints", helper.GetTestEndpoint(0, "udp", true));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ReplyAdapter");
             var replyI = new PingReplyI();
             IPingReplyPrx reply = adapter.AddWithUUID(replyI, IPingReplyPrx.Factory)
@@ -154,7 +154,7 @@ namespace ZeroC.Ice.Test.UDP
             var sb = new StringBuilder("test -d:udp -h ");
 
             // Use loopback to prevent other machines to answer.
-            if (communicator.GetPropertyAsBool("Ice.IPv6") ?? false)
+            if (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false)
             {
                 sb.Append("\"ff15::1:1\"");
             }
@@ -166,7 +166,7 @@ namespace ZeroC.Ice.Test.UDP
             sb.Append(helper.BasePort + 10);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (communicator.GetPropertyAsBool("Ice.IPv6") ?? false)
+                if (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false)
                 {
                     sb.Append(" --interface \"::1\"");
                 }
@@ -200,27 +200,31 @@ namespace ZeroC.Ice.Test.UDP
                 Console.Out.WriteLine("ok");
             }
 
-            Console.Out.Write("testing udp bi-dir connection... ");
-            Console.Out.Flush();
-            obj.GetConnection()!.Adapter = adapter;
-            nRetry = 5;
-            while (nRetry-- > 0)
+            // Disable dual mode sockets on macOS, see https://github.com/dotnet/corefx/issues/31182
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                replyI.Reset();
-                obj.PingBiDir(reply.Identity);
-                obj.PingBiDir(reply.Identity);
-                obj.PingBiDir(reply.Identity);
-                ret = replyI.WaitReply(3, TimeSpan.FromSeconds(2));
-                if (ret)
+                Console.Out.Write("testing udp bi-dir connection... ");
+                Console.Out.Flush();
+                obj.GetConnection()!.Adapter = adapter;
+                nRetry = 5;
+                while (nRetry-- > 0)
                 {
-                    break; // Success
+                    replyI.Reset();
+                    obj.PingBiDir(reply.Identity);
+                    obj.PingBiDir(reply.Identity);
+                    obj.PingBiDir(reply.Identity);
+                    ret = replyI.WaitReply(3, TimeSpan.FromSeconds(2));
+                    if (ret)
+                    {
+                        break; // Success
+                    }
+                    replyI = new PingReplyI();
+                    reply = adapter.AddWithUUID(
+                        replyI, IPingReplyPrx.Factory).Clone(invocationMode: InvocationMode.Datagram);
                 }
-                replyI = new PingReplyI();
-                reply = adapter.AddWithUUID(
-                    replyI, IPingReplyPrx.Factory).Clone(invocationMode: InvocationMode.Datagram);
+                TestHelper.Assert(ret);
+                Console.Out.WriteLine("ok");
             }
-            TestHelper.Assert(ret);
-            Console.Out.WriteLine("ok");
         }
     }
 }

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -17,14 +17,6 @@ namespace ZeroC.Ice.Test.UDP
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.UDP.RcvSize"] = "16K";
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                properties.TryGetValue("Ice.IPv6", out string? value) &&
-                int.TryParse(value, out int ipv6) && ipv6 > 0)
-            {
-                // Disable dual mode sockets on macOS, see https://github.com/dotnet/corefx/issues/31182
-                properties["Ice.IPv4"] = "0";
-            }
-
             await using Communicator communicator = Initialize(properties);
             int num = 0;
             try
@@ -51,7 +43,7 @@ namespace ZeroC.Ice.Test.UDP
             var endpoint = new StringBuilder();
 
             // Use loopback to prevent other machines to answer.
-            if (communicator.GetProperty("Ice.IPv6") == "1")
+            if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
             {
                 endpoint.Append("udp -h \"ff15::1:1\"");
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -208,7 +208,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
             output.Flush();
             {
                 string multicast;
-                if (communicator.GetProperty("Ice.IPv6") == "1")
+                if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
                 {
                     multicast = "\"ff15::1\"";
                 }

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -109,7 +109,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 }
 
                 string multicast;
-                if (communicator.GetProperty("Ice.IPv6") == "1")
+                if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
                 {
                     multicast = "\"ff15::1\"";
                 }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -563,10 +563,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn1", "cacert1");
                             IServerPrx server = fact.CreateServer(serverProperties, true)!;
 
-                            foreach (var endpoint in server.Endpoints)
-                            {
-                                TestHelper.Assert(endpoint.Host == "localhost");
-                            }
+                            TestHelper.Assert(server.Endpoints.All(endpoint => endpoint.Host == "localhost"));
 
                             try
                             {

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -50,9 +50,9 @@ namespace ZeroC.IceSSL.Test.Configuration
                 properties["Test.Host"] = value;
             }
 
-            if (defaultProperties.TryGetValue("Ice.IPv6", out value))
+            if (defaultProperties.TryGetValue("Ice.PreferIPv6Address", out value))
             {
-                properties["Ice.IPv6"] = value;
+                properties["Ice.PreferIPv6Address"] = value;
             }
 
             properties["Ice.RetryIntervals"] = "-1";

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -544,7 +544,6 @@ namespace ZeroC.IceSSL.Test.Configuration
                 }
 
                 {
-
                     // Test Hostname verification only when Test.Host is 127.0.0.1 as that is the IP address used
                     // in the test certificates.
                     if (host.Equals("127.0.0.1"))
@@ -562,10 +561,16 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                             var fact = IServerFactoryPrx.Parse(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn1", "cacert1");
-                            IServerPrx? server = fact.CreateServer(serverProperties, true);
+                            IServerPrx server = fact.CreateServer(serverProperties, true)!;
+
+                            foreach (var endpoint in server.Endpoints)
+                            {
+                                TestHelper.Assert(endpoint.Host == "localhost");
+                            }
+
                             try
                             {
-                                server!.IcePing();
+                                server.IcePing();
                             }
                             catch (Exception ex)
                             {

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -80,7 +80,7 @@ namespace ZeroC.IceSSL.Test.Configuration
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             string host = TestHelper.GetTestHost(communicator.GetProperties());
 
-            string serverEndpoint = serverEndpoint = TestHelper.GetTestEndpoint(
+            string serverEndpoint = TestHelper.GetTestEndpoint(
                 properties: communicator.GetProperties(),
                 num: 1,
                 transport: "ssl",

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -80,8 +80,13 @@ namespace ZeroC.IceSSL.Test.Configuration
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             string host = TestHelper.GetTestHost(communicator.GetProperties());
 
-            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints(
-                "ServerAdapter", ice1 ? $"ssl -h {host}" : $"ice+ssl://{host}:0");
+            string serverEndpoint = serverEndpoint = TestHelper.GetTestEndpoint(
+                properties: communicator.GetProperties(),
+                num: 1,
+                transport: "ssl",
+                ephemeral: host != "localhost");
+
+            ObjectAdapter adapter = communicator.CreateObjectAdapterWithEndpoints("ServerAdapter", serverEndpoint);
             var server = new SSLServer(communicator);
             IServerPrx prx = adapter.AddWithUUID(server, IServerPrx.Factory);
             _servers[prx.Identity] = server;

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -62,7 +62,8 @@ namespace Test
         public string GetTestEndpoint(int num = 0, string transport = "") =>
             GetTestEndpoint(Communicator!.GetProperties(), num, transport);
 
-        public static string GetTestEndpoint(Dictionary<string, string> properties, int num = 0, string transport = "")
+        public static string GetTestEndpoint(
+            Dictionary<string, string> properties, int num = 0, string transport = "", bool ephemeral = false)
         {
             if (transport.Length == 0 || transport == "default")
             {
@@ -77,6 +78,7 @@ namespace Test
             }
 
             string host = GetTestHost(properties);
+            string port = ephemeral ? "0" : $"{GetTestBasePort(properties) + num}";
 
             if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
             {
@@ -95,7 +97,7 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(':');
-                sb.Append(GetTestBasePort(properties) + num);
+                sb.Append(port);
                 return sb.ToString();
             }
             else
@@ -113,7 +115,7 @@ namespace Test
                     sb.Append(host);
                 }
                 sb.Append(" -p ");
-                sb.Append(GetTestBasePort(properties) + num);
+                sb.Append(port);
                 return sb.ToString();
             }
         }

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -59,8 +59,8 @@ namespace Test
         }
         public abstract Task RunAsync(string[] args);
 
-        public string GetTestEndpoint(int num = 0, string transport = "") =>
-            GetTestEndpoint(Communicator!.GetProperties(), num, transport);
+        public string GetTestEndpoint(int num = 0, string transport = "", bool ephemeral = false) =>
+            GetTestEndpoint(Communicator!.GetProperties(), num, transport, ephemeral);
 
         public static string GetTestEndpoint(
             Dictionary<string, string> properties, int num = 0, string transport = "", bool ephemeral = false)


### PR DESCRIPTION
This PR removes the usage of Ice.IPv4 and Ice.IPv6 in C#. More work still needs to be done in a follow-up PR.

- Remove Ice.PreferIPv6Address property
- Add ipv6only OA endpoint option
- Verify everything works right when IPv6 is disabled (https://docs.microsoft.com/en-us/dotnet/framework/network-programming/enabling-and-disabling-ipv6)
- Look into IPv6 usage with network proxies

For now I've left the EnableIPv4, EnableIPv6 and EnableBoth properties are they're still used by some APIs such has the network proxies (SOCKS), the IceDiscovery plugin, etc. for IP filtering.