### PR TITLE
Enums with underlying types can be empty.

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -3578,7 +3578,7 @@ yyreduce:
     if(en)
     {
         EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast(yyvsp[-1]);
-        if(enumerators->v.empty())
+        if(enumerators->v.empty() && !en->underlying())
         {
             unit->error("enum `" + en->name() + "' must have at least one enumerator");
         }

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -3578,7 +3578,7 @@ yyreduce:
     if(en)
     {
         EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast(yyvsp[-1]);
-        if(enumerators->v.empty() && !en->underlying())
+        if(enumerators->v.empty() && !en->underlying() && en->isUnchecked())
         {
             unit->error("enum `" + en->name() + "' must have at least one enumerator");
         }

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1410,7 +1410,7 @@ operation_list
         // metadata only relevant to the return type would only be set on the return type.
         if (operation->hasSingleReturnType())
         {
-            operation->returnValues().front()->setMetaData(metaData->v);
+            operation->returnType().front()->setMetaData(metaData->v);
         }
     }
 }
@@ -1739,7 +1739,7 @@ enum_def
     if(en)
     {
         EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast($5);
-        if(enumerators->v.empty())
+        if(enumerators->v.empty() && !en->underlying())
         {
             unit->error("enum `" + en->name() + "' must have at least one enumerator");
         }

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1739,7 +1739,7 @@ enum_def
     if(en)
     {
         EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast($5);
-        if(enumerators->v.empty() && !en->underlying())
+        if(enumerators->v.empty() && !en->underlying() && en->isUnchecked())
         {
             unit->error("enum `" + en->name() + "' must have at least one enumerator");
         }

--- a/cpp/test/Slice/errorDetection/EnumEmpty.err
+++ b/cpp/test/Slice/errorDetection/EnumEmpty.err
@@ -1,1 +1,3 @@
 EnumEmpty.ice:8: enum `foo' must have at least one enumerator
+EnumEmpty.ice:10: enum `bar' must have at least one enumerator
+EnumEmpty.ice:12: enum `baz' must have at least one enumerator

--- a/cpp/test/Slice/errorDetection/EnumEmpty.ice
+++ b/cpp/test/Slice/errorDetection/EnumEmpty.ice
@@ -7,6 +7,10 @@ module Test
 
 enum foo {}
 
-enum bar : byte {} // Enums with underlying types can be empty.
+enum bar : ushort {}
+
+unchecked enum baz {}
+
+unchecked enum ok : byte {}
 
 }

--- a/cpp/test/Slice/errorDetection/EnumEmpty.ice
+++ b/cpp/test/Slice/errorDetection/EnumEmpty.ice
@@ -7,4 +7,6 @@ module Test
 
 enum foo {}
 
+enum bar : byte {} // Enums with underlying types can be empty.
+
 }


### PR DESCRIPTION
This incredibly tiny PR allows enums with backing types to be empty.