### PR TITLE
Renamed MetaData to Metadata in the compilers/parser

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -1871,10 +1871,10 @@ yyreduce:
   case 9: /* definitions: definitions file_metadata  */
 #line 237 "src/Slice/Grammar.y"
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[0]);
-    if(!metaData->v.empty())
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[0]);
+    if(!metadata->v.empty())
     {
-        unit->addFileMetaData(metaData->v);
+        unit->addFileMetadata(metadata->v);
     }
 }
 #line 1881 "src/Slice/Grammar.cpp"
@@ -1883,11 +1883,11 @@ yyreduce:
   case 10: /* definitions: definitions local_metadata definition  */
 #line 245 "src/Slice/Grammar.y"
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-1]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     ContainedPtr contained = ContainedPtr::dynamicCast(yyvsp[0]);
-    if(contained && !metaData->v.empty())
+    if(contained && !metadata->v.empty())
     {
-        contained->setMetaData(metaData->v);
+        contained->setMetadata(metadata->v);
     }
 }
 #line 1894 "src/Slice/Grammar.cpp"
@@ -2849,7 +2849,7 @@ yyreduce:
         unit->currentContainer()->checkIntroduced(def->name, dm);
         if (dm && !def->metadata.empty())
         {
-            dm->setMetaData(def->metadata);
+            dm->setMetadata(def->metadata);
         }
     }
 }
@@ -2870,7 +2870,7 @@ yyreduce:
         unit->currentContainer()->checkIntroduced(def->name, dm);
         if (dm && !def->metadata.empty())
         {
-            dm->setMetaData(def->metadata);
+            dm->setMetadata(def->metadata);
         }
     }
 }
@@ -2986,7 +2986,7 @@ yyreduce:
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -3025,7 +3025,7 @@ yyreduce:
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -3062,7 +3062,7 @@ yyreduce:
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -3100,7 +3100,7 @@ yyreduce:
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -3179,11 +3179,11 @@ yyreduce:
   case 104: /* operation_list: local_metadata operation ';' operation_list  */
 #line 1394 "src/Slice/Grammar.y"
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     OperationPtr operation = OperationPtr::dynamicCast(yyvsp[-2]);
-    if (operation && !metaData->v.empty())
+    if (operation && !metadata->v.empty())
     {
-        operation->setMetaData(metaData->v);
+        operation->setMetadata(metadata->v);
 
         // If the operation had a single return type (not a return tuple), also apply the metadata to the return type.
         // TODO: once we introduce more concrete metadata validation, we could sort the metadata out between the return
@@ -3191,7 +3191,7 @@ yyreduce:
         // metadata only relevant to the return type would only be set on the return type.
         if (operation->hasSingleReturnType())
         {
-            operation->returnType().front()->setMetaData(metaData->v);
+            operation->returnType().front()->setMetadata(metadata->v);
         }
     }
 }
@@ -3450,10 +3450,10 @@ yyreduce:
 #line 1634 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr type = TypePtr::dynamicCast(yyvsp[-2]);
     ModulePtr cont = unit->currentModule();
-    yyval = cont->createSequence(ident->v, type, metaData->v);
+    yyval = cont->createSequence(ident->v, type, metadata->v);
 }
 #line 3459 "src/Slice/Grammar.cpp"
     break;
@@ -3462,10 +3462,10 @@ yyreduce:
 #line 1642 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr type = TypePtr::dynamicCast(yyvsp[-2]);
     ModulePtr cont = unit->currentModule();
-    yyval = cont->createSequence(ident->v, type, metaData->v); // Dummy
+    yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 #line 3472 "src/Slice/Grammar.cpp"
@@ -3475,12 +3475,12 @@ yyreduce:
 #line 1656 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
-    StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast(yyvsp[-6]);
+    StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
     TypePtr keyType = TypePtr::dynamicCast(yyvsp[-5]);
-    StringListTokPtr valueMetaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr valueMetadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr valueType = TypePtr::dynamicCast(yyvsp[-2]);
     ModulePtr cont = unit->currentModule();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v);
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
 #line 3486 "src/Slice/Grammar.cpp"
     break;
@@ -3489,12 +3489,12 @@ yyreduce:
 #line 1666 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
-    StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast(yyvsp[-6]);
+    StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
     TypePtr keyType = TypePtr::dynamicCast(yyvsp[-5]);
-    StringListTokPtr valueMetaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr valueMetadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr valueType = TypePtr::dynamicCast(yyvsp[-2]);
     ModulePtr cont = unit->currentModule();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v); // Dummy
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 #line 3501 "src/Slice/Grammar.cpp"
@@ -3751,7 +3751,7 @@ yyreduce:
         unit->currentContainer()->checkIntroduced(def->name, param);
         if(param && !def->metadata.empty())
         {
-            param->setMetaData(def->metadata);
+            param->setMetadata(def->metadata);
         }
     }
 }
@@ -4291,11 +4291,11 @@ yyreduce:
   case 201: /* const_def: ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer  */
 #line 2302 "src/Slice/Grammar.y"
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-4]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-4]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-3]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-2]);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast(yyvsp[0]);
-    yyval = unit->currentModule()->createConst(ident->v, const_type, metaData->v, value->v,
+    yyval = unit->currentModule()->createConst(ident->v, const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral);
 }
 #line 4302 "src/Slice/Grammar.cpp"
@@ -4304,11 +4304,11 @@ yyreduce:
   case 202: /* const_def: ICE_CONST local_metadata type '=' const_initializer  */
 #line 2311 "src/Slice/Grammar.y"
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-2]);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast(yyvsp[0]);
     unit->error("missing constant name");
-    yyval = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metaData->v, value->v,
+    yyval = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
 }
 #line 4315 "src/Slice/Grammar.cpp"

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -241,110 +241,109 @@ enum yysymbol_kind_t
   YYSYMBOL_ICE_LOCAL_METADATA_OPEN = 46,   /* ICE_LOCAL_METADATA_OPEN  */
   YYSYMBOL_ICE_LOCAL_METADATA_CLOSE = 47,  /* ICE_LOCAL_METADATA_CLOSE  */
   YYSYMBOL_ICE_FILE_METADATA_OPEN = 48,    /* ICE_FILE_METADATA_OPEN  */
-  YYSYMBOL_ICE_FILE_METADATA_IGNORE = 49,  /* ICE_FILE_METADATA_IGNORE  */
-  YYSYMBOL_ICE_FILE_METADATA_CLOSE = 50,   /* ICE_FILE_METADATA_CLOSE  */
-  YYSYMBOL_ICE_IDENT_OPEN = 51,            /* ICE_IDENT_OPEN  */
-  YYSYMBOL_ICE_KEYWORD_OPEN = 52,          /* ICE_KEYWORD_OPEN  */
-  YYSYMBOL_ICE_TAG_OPEN = 53,              /* ICE_TAG_OPEN  */
-  YYSYMBOL_ICE_OPTIONAL_OPEN = 54,         /* ICE_OPTIONAL_OPEN  */
-  YYSYMBOL_BAD_CHAR = 55,                  /* BAD_CHAR  */
-  YYSYMBOL_56_ = 56,                       /* ';'  */
-  YYSYMBOL_57_ = 57,                       /* '{'  */
-  YYSYMBOL_58_ = 58,                       /* '}'  */
-  YYSYMBOL_59_ = 59,                       /* ')'  */
-  YYSYMBOL_60_ = 60,                       /* ':'  */
-  YYSYMBOL_61_ = 61,                       /* '='  */
-  YYSYMBOL_62_ = 62,                       /* ','  */
-  YYSYMBOL_63_ = 63,                       /* '('  */
-  YYSYMBOL_64_ = 64,                       /* '<'  */
-  YYSYMBOL_65_ = 65,                       /* '>'  */
-  YYSYMBOL_66_ = 66,                       /* '*'  */
-  YYSYMBOL_67_ = 67,                       /* '?'  */
-  YYSYMBOL_YYACCEPT = 68,                  /* $accept  */
-  YYSYMBOL_start = 69,                     /* start  */
-  YYSYMBOL_opt_semicolon = 70,             /* opt_semicolon  */
-  YYSYMBOL_file_metadata = 71,             /* file_metadata  */
-  YYSYMBOL_local_metadata = 72,            /* local_metadata  */
-  YYSYMBOL_definitions = 73,               /* definitions  */
-  YYSYMBOL_definition = 74,                /* definition  */
-  YYSYMBOL_75_1 = 75,                      /* $@1  */
-  YYSYMBOL_76_2 = 76,                      /* $@2  */
-  YYSYMBOL_77_3 = 77,                      /* $@3  */
-  YYSYMBOL_78_4 = 78,                      /* $@4  */
-  YYSYMBOL_79_5 = 79,                      /* $@5  */
-  YYSYMBOL_80_6 = 80,                      /* $@6  */
-  YYSYMBOL_81_7 = 81,                      /* $@7  */
-  YYSYMBOL_82_8 = 82,                      /* $@8  */
-  YYSYMBOL_83_9 = 83,                      /* $@9  */
-  YYSYMBOL_84_10 = 84,                     /* $@10  */
-  YYSYMBOL_85_11 = 85,                     /* $@11  */
-  YYSYMBOL_86_12 = 86,                     /* $@12  */
-  YYSYMBOL_87_13 = 87,                     /* $@13  */
-  YYSYMBOL_module_def = 88,                /* module_def  */
-  YYSYMBOL_89_14 = 89,                     /* @14  */
-  YYSYMBOL_90_15 = 90,                     /* @15  */
-  YYSYMBOL_exception_id = 91,              /* exception_id  */
-  YYSYMBOL_exception_decl = 92,            /* exception_decl  */
-  YYSYMBOL_exception_def = 93,             /* exception_def  */
-  YYSYMBOL_94_16 = 94,                     /* @16  */
-  YYSYMBOL_exception_extends = 95,         /* exception_extends  */
-  YYSYMBOL_tag = 96,                       /* tag  */
-  YYSYMBOL_optional = 97,                  /* optional  */
-  YYSYMBOL_struct_id = 98,                 /* struct_id  */
-  YYSYMBOL_struct_decl = 99,               /* struct_decl  */
-  YYSYMBOL_struct_def = 100,               /* struct_def  */
-  YYSYMBOL_101_17 = 101,                   /* @17  */
-  YYSYMBOL_class_name = 102,               /* class_name  */
-  YYSYMBOL_class_id = 103,                 /* class_id  */
-  YYSYMBOL_class_decl = 104,               /* class_decl  */
-  YYSYMBOL_class_def = 105,                /* class_def  */
-  YYSYMBOL_106_18 = 106,                   /* @18  */
-  YYSYMBOL_class_extends = 107,            /* class_extends  */
-  YYSYMBOL_extends = 108,                  /* extends  */
-  YYSYMBOL_data_member = 109,              /* data_member  */
-  YYSYMBOL_data_member_list = 110,         /* data_member_list  */
-  YYSYMBOL_data_members = 111,             /* data_members  */
-  YYSYMBOL_return_tuple = 112,             /* return_tuple  */
-  YYSYMBOL_return_type = 113,              /* return_type  */
-  YYSYMBOL_operation_preamble = 114,       /* operation_preamble  */
-  YYSYMBOL_operation = 115,                /* operation  */
-  YYSYMBOL_116_19 = 116,                   /* @19  */
-  YYSYMBOL_117_20 = 117,                   /* @20  */
-  YYSYMBOL_operation_list = 118,           /* operation_list  */
-  YYSYMBOL_interface_id = 119,             /* interface_id  */
-  YYSYMBOL_interface_decl = 120,           /* interface_decl  */
-  YYSYMBOL_interface_def = 121,            /* interface_def  */
-  YYSYMBOL_122_21 = 122,                   /* @21  */
-  YYSYMBOL_interface_list = 123,           /* interface_list  */
-  YYSYMBOL_interface_extends = 124,        /* interface_extends  */
-  YYSYMBOL_exception_list = 125,           /* exception_list  */
-  YYSYMBOL_exception = 126,                /* exception  */
-  YYSYMBOL_sequence_def = 127,             /* sequence_def  */
-  YYSYMBOL_dictionary_def = 128,           /* dictionary_def  */
-  YYSYMBOL_enum_start = 129,               /* enum_start  */
-  YYSYMBOL_enum_id = 130,                  /* enum_id  */
-  YYSYMBOL_enum_def = 131,                 /* enum_def  */
-  YYSYMBOL_132_22 = 132,                   /* @22  */
-  YYSYMBOL_133_23 = 133,                   /* @23  */
-  YYSYMBOL_enum_underlying = 134,          /* enum_underlying  */
-  YYSYMBOL_enumerator_list = 135,          /* enumerator_list  */
-  YYSYMBOL_enumerator = 136,               /* enumerator  */
-  YYSYMBOL_enumerator_initializer = 137,   /* enumerator_initializer  */
-  YYSYMBOL_out_qualifier = 138,            /* out_qualifier  */
-  YYSYMBOL_parameter = 139,                /* parameter  */
-  YYSYMBOL_parameter_list = 140,           /* parameter_list  */
-  YYSYMBOL_parameters = 141,               /* parameters  */
-  YYSYMBOL_throws = 142,                   /* throws  */
-  YYSYMBOL_scoped_name = 143,              /* scoped_name  */
-  YYSYMBOL_builtin = 144,                  /* builtin  */
-  YYSYMBOL_type = 145,                     /* type  */
-  YYSYMBOL_tagged_type = 146,              /* tagged_type  */
-  YYSYMBOL_member = 147,                   /* member  */
-  YYSYMBOL_string_literal = 148,           /* string_literal  */
-  YYSYMBOL_string_list = 149,              /* string_list  */
-  YYSYMBOL_const_initializer = 150,        /* const_initializer  */
-  YYSYMBOL_const_def = 151,                /* const_def  */
-  YYSYMBOL_keyword = 152                   /* keyword  */
+  YYSYMBOL_ICE_FILE_METADATA_CLOSE = 49,   /* ICE_FILE_METADATA_CLOSE  */
+  YYSYMBOL_ICE_IDENT_OPEN = 50,            /* ICE_IDENT_OPEN  */
+  YYSYMBOL_ICE_KEYWORD_OPEN = 51,          /* ICE_KEYWORD_OPEN  */
+  YYSYMBOL_ICE_TAG_OPEN = 52,              /* ICE_TAG_OPEN  */
+  YYSYMBOL_ICE_OPTIONAL_OPEN = 53,         /* ICE_OPTIONAL_OPEN  */
+  YYSYMBOL_BAD_CHAR = 54,                  /* BAD_CHAR  */
+  YYSYMBOL_55_ = 55,                       /* ';'  */
+  YYSYMBOL_56_ = 56,                       /* '{'  */
+  YYSYMBOL_57_ = 57,                       /* '}'  */
+  YYSYMBOL_58_ = 58,                       /* ')'  */
+  YYSYMBOL_59_ = 59,                       /* ':'  */
+  YYSYMBOL_60_ = 60,                       /* '='  */
+  YYSYMBOL_61_ = 61,                       /* ','  */
+  YYSYMBOL_62_ = 62,                       /* '('  */
+  YYSYMBOL_63_ = 63,                       /* '<'  */
+  YYSYMBOL_64_ = 64,                       /* '>'  */
+  YYSYMBOL_65_ = 65,                       /* '*'  */
+  YYSYMBOL_66_ = 66,                       /* '?'  */
+  YYSYMBOL_YYACCEPT = 67,                  /* $accept  */
+  YYSYMBOL_start = 68,                     /* start  */
+  YYSYMBOL_opt_semicolon = 69,             /* opt_semicolon  */
+  YYSYMBOL_file_metadata = 70,             /* file_metadata  */
+  YYSYMBOL_local_metadata = 71,            /* local_metadata  */
+  YYSYMBOL_definitions = 72,               /* definitions  */
+  YYSYMBOL_definition = 73,                /* definition  */
+  YYSYMBOL_74_1 = 74,                      /* $@1  */
+  YYSYMBOL_75_2 = 75,                      /* $@2  */
+  YYSYMBOL_76_3 = 76,                      /* $@3  */
+  YYSYMBOL_77_4 = 77,                      /* $@4  */
+  YYSYMBOL_78_5 = 78,                      /* $@5  */
+  YYSYMBOL_79_6 = 79,                      /* $@6  */
+  YYSYMBOL_80_7 = 80,                      /* $@7  */
+  YYSYMBOL_81_8 = 81,                      /* $@8  */
+  YYSYMBOL_82_9 = 82,                      /* $@9  */
+  YYSYMBOL_83_10 = 83,                     /* $@10  */
+  YYSYMBOL_84_11 = 84,                     /* $@11  */
+  YYSYMBOL_85_12 = 85,                     /* $@12  */
+  YYSYMBOL_86_13 = 86,                     /* $@13  */
+  YYSYMBOL_module_def = 87,                /* module_def  */
+  YYSYMBOL_88_14 = 88,                     /* @14  */
+  YYSYMBOL_89_15 = 89,                     /* @15  */
+  YYSYMBOL_exception_id = 90,              /* exception_id  */
+  YYSYMBOL_exception_decl = 91,            /* exception_decl  */
+  YYSYMBOL_exception_def = 92,             /* exception_def  */
+  YYSYMBOL_93_16 = 93,                     /* @16  */
+  YYSYMBOL_exception_extends = 94,         /* exception_extends  */
+  YYSYMBOL_tag = 95,                       /* tag  */
+  YYSYMBOL_optional = 96,                  /* optional  */
+  YYSYMBOL_struct_id = 97,                 /* struct_id  */
+  YYSYMBOL_struct_decl = 98,               /* struct_decl  */
+  YYSYMBOL_struct_def = 99,                /* struct_def  */
+  YYSYMBOL_100_17 = 100,                   /* @17  */
+  YYSYMBOL_class_name = 101,               /* class_name  */
+  YYSYMBOL_class_id = 102,                 /* class_id  */
+  YYSYMBOL_class_decl = 103,               /* class_decl  */
+  YYSYMBOL_class_def = 104,                /* class_def  */
+  YYSYMBOL_105_18 = 105,                   /* @18  */
+  YYSYMBOL_class_extends = 106,            /* class_extends  */
+  YYSYMBOL_extends = 107,                  /* extends  */
+  YYSYMBOL_data_member = 108,              /* data_member  */
+  YYSYMBOL_data_member_list = 109,         /* data_member_list  */
+  YYSYMBOL_data_members = 110,             /* data_members  */
+  YYSYMBOL_return_tuple = 111,             /* return_tuple  */
+  YYSYMBOL_return_type = 112,              /* return_type  */
+  YYSYMBOL_operation_preamble = 113,       /* operation_preamble  */
+  YYSYMBOL_operation = 114,                /* operation  */
+  YYSYMBOL_115_19 = 115,                   /* @19  */
+  YYSYMBOL_116_20 = 116,                   /* @20  */
+  YYSYMBOL_operation_list = 117,           /* operation_list  */
+  YYSYMBOL_interface_id = 118,             /* interface_id  */
+  YYSYMBOL_interface_decl = 119,           /* interface_decl  */
+  YYSYMBOL_interface_def = 120,            /* interface_def  */
+  YYSYMBOL_121_21 = 121,                   /* @21  */
+  YYSYMBOL_interface_list = 122,           /* interface_list  */
+  YYSYMBOL_interface_extends = 123,        /* interface_extends  */
+  YYSYMBOL_exception_list = 124,           /* exception_list  */
+  YYSYMBOL_exception = 125,                /* exception  */
+  YYSYMBOL_sequence_def = 126,             /* sequence_def  */
+  YYSYMBOL_dictionary_def = 127,           /* dictionary_def  */
+  YYSYMBOL_enum_start = 128,               /* enum_start  */
+  YYSYMBOL_enum_id = 129,                  /* enum_id  */
+  YYSYMBOL_enum_def = 130,                 /* enum_def  */
+  YYSYMBOL_131_22 = 131,                   /* @22  */
+  YYSYMBOL_132_23 = 132,                   /* @23  */
+  YYSYMBOL_enum_underlying = 133,          /* enum_underlying  */
+  YYSYMBOL_enumerator_list = 134,          /* enumerator_list  */
+  YYSYMBOL_enumerator = 135,               /* enumerator  */
+  YYSYMBOL_enumerator_initializer = 136,   /* enumerator_initializer  */
+  YYSYMBOL_out_qualifier = 137,            /* out_qualifier  */
+  YYSYMBOL_parameter = 138,                /* parameter  */
+  YYSYMBOL_parameter_list = 139,           /* parameter_list  */
+  YYSYMBOL_parameters = 140,               /* parameters  */
+  YYSYMBOL_throws = 141,                   /* throws  */
+  YYSYMBOL_scoped_name = 142,              /* scoped_name  */
+  YYSYMBOL_builtin = 143,                  /* builtin  */
+  YYSYMBOL_type = 144,                     /* type  */
+  YYSYMBOL_tagged_type = 145,              /* tagged_type  */
+  YYSYMBOL_member = 146,                   /* member  */
+  YYSYMBOL_string_literal = 147,           /* string_literal  */
+  YYSYMBOL_string_list = 148,              /* string_list  */
+  YYSYMBOL_const_initializer = 149,        /* const_initializer  */
+  YYSYMBOL_const_def = 150,                /* const_def  */
+  YYSYMBOL_keyword = 151                   /* keyword  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -359,7 +358,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 
 
-#line 363 "src/Slice/Grammar.cpp"
+#line 362 "src/Slice/Grammar.cpp"
 
 #ifdef short
 # undef short
@@ -667,19 +666,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  3
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   1051
+#define YYLAST   1065
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  68
+#define YYNTOKENS  67
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  85
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  240
+#define YYNRULES  239
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  340
+#define YYNSTATES  337
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   310
+#define YYMAXUTOK   309
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -697,15 +696,15 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      63,    59,    66,     2,    62,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    60,    56,
-      64,    61,    65,    67,     2,     2,     2,     2,     2,     2,
+      62,    58,    65,     2,    61,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,    59,    55,
+      63,    60,    64,    66,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    57,     2,    58,     2,     2,     2,     2,
+       2,     2,     2,    56,     2,    57,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -723,39 +722,37 @@ static const yytype_int8 yytranslate[] =
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
       25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
       35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
-      45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55
+      45,    46,    47,    48,    49,    50,    51,    52,    53,    54
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   195,   195,   201,   202,   208,   212,   222,   226,   233,
-     242,   250,   259,   266,   265,   271,   270,   275,   280,   279,
-     285,   284,   289,   294,   293,   299,   298,   303,   308,   307,
-     313,   312,   317,   322,   321,   327,   326,   331,   336,   335,
-     340,   345,   344,   350,   349,   354,   358,   368,   367,   406,
-     405,   483,   487,   498,   509,   508,   534,   542,   551,   569,
-     643,   649,   660,   682,   760,   770,   785,   789,   800,   811,
-     810,   851,   855,   866,   891,   981,   993,  1006,  1005,  1039,
-    1073,  1082,  1083,  1089,  1104,  1126,  1127,  1128,  1132,  1138,
-    1139,  1145,  1157,  1173,  1188,  1197,  1202,  1211,  1246,  1281,
-    1315,  1355,  1354,  1377,  1376,  1399,  1417,  1421,  1422,  1428,
-    1432,  1443,  1457,  1456,  1490,  1525,  1560,  1565,  1570,  1584,
-    1588,  1597,  1604,  1616,  1628,  1639,  1647,  1661,  1671,  1687,
-    1691,  1700,  1716,  1730,  1729,  1752,  1751,  1770,  1774,  1783,
-    1789,  1795,  1807,  1820,  1827,  1837,  1841,  1879,  1883,  1892,
-    1911,  1912,  1918,  1919,  1925,  1929,  1938,  1939,  1945,  1946,
-    1947,  1948,  1949,  1950,  1951,  1952,  1953,  1954,  1955,  1956,
-    1957,  1958,  1959,  1964,  1968,  1972,  1976,  1984,  1989,  2000,
-    2004,  2016,  2021,  2047,  2079,  2107,  2122,  2136,  2147,  2159,
-    2170,  2181,  2192,  2198,  2204,  2211,  2223,  2232,  2241,  2281,
-    2288,  2295,  2307,  2316,  2330,  2331,  2332,  2333,  2334,  2335,
-    2336,  2337,  2338,  2339,  2340,  2341,  2342,  2343,  2344,  2345,
-    2346,  2347,  2348,  2349,  2350,  2351,  2352,  2353,  2354,  2355,
-    2356,  2357,  2358,  2359,  2360,  2361,  2362,  2363,  2364,  2365,
-    2366
+       0,   194,   194,   200,   201,   207,   216,   220,   227,   236,
+     244,   253,   260,   259,   265,   264,   269,   274,   273,   279,
+     278,   283,   288,   287,   293,   292,   297,   302,   301,   307,
+     306,   311,   316,   315,   321,   320,   325,   330,   329,   334,
+     339,   338,   344,   343,   348,   352,   362,   361,   400,   399,
+     477,   481,   492,   503,   502,   528,   536,   545,   563,   637,
+     643,   654,   676,   754,   764,   779,   783,   794,   805,   804,
+     845,   849,   860,   885,   975,   987,  1000,   999,  1033,  1067,
+    1076,  1077,  1083,  1098,  1120,  1121,  1122,  1126,  1132,  1133,
+    1139,  1151,  1167,  1182,  1191,  1196,  1205,  1240,  1275,  1309,
+    1349,  1348,  1371,  1370,  1393,  1411,  1415,  1416,  1422,  1426,
+    1437,  1451,  1450,  1484,  1519,  1554,  1559,  1564,  1578,  1582,
+    1591,  1598,  1610,  1622,  1633,  1641,  1655,  1665,  1681,  1685,
+    1694,  1710,  1724,  1723,  1746,  1745,  1764,  1768,  1777,  1783,
+    1789,  1801,  1814,  1821,  1831,  1835,  1873,  1877,  1886,  1905,
+    1906,  1912,  1913,  1919,  1923,  1932,  1933,  1939,  1940,  1941,
+    1942,  1943,  1944,  1945,  1946,  1947,  1948,  1949,  1950,  1951,
+    1952,  1953,  1958,  1962,  1966,  1970,  1978,  1983,  1994,  1998,
+    2010,  2015,  2041,  2073,  2101,  2116,  2130,  2141,  2153,  2164,
+    2175,  2186,  2192,  2198,  2205,  2217,  2226,  2235,  2275,  2282,
+    2289,  2301,  2310,  2324,  2325,  2326,  2327,  2328,  2329,  2330,
+    2331,  2332,  2333,  2334,  2335,  2336,  2337,  2338,  2339,  2340,
+    2341,  2342,  2343,  2344,  2345,  2346,  2347,  2348,  2349,  2350,
+    2351,  2352,  2353,  2354,  2355,  2356,  2357,  2358,  2359,  2360
 };
 #endif
 
@@ -783,26 +780,26 @@ static const char *const yytname[] =
   "ICE_INTEGER_LITERAL", "ICE_FLOATING_POINT_LITERAL", "ICE_IDENTIFIER",
   "ICE_SCOPED_IDENTIFIER", "ICE_LOCAL_METADATA_OPEN",
   "ICE_LOCAL_METADATA_CLOSE", "ICE_FILE_METADATA_OPEN",
-  "ICE_FILE_METADATA_IGNORE", "ICE_FILE_METADATA_CLOSE", "ICE_IDENT_OPEN",
-  "ICE_KEYWORD_OPEN", "ICE_TAG_OPEN", "ICE_OPTIONAL_OPEN", "BAD_CHAR",
-  "';'", "'{'", "'}'", "')'", "':'", "'='", "','", "'('", "'<'", "'>'",
-  "'*'", "'?'", "$accept", "start", "opt_semicolon", "file_metadata",
-  "local_metadata", "definitions", "definition", "$@1", "$@2", "$@3",
-  "$@4", "$@5", "$@6", "$@7", "$@8", "$@9", "$@10", "$@11", "$@12", "$@13",
-  "module_def", "@14", "@15", "exception_id", "exception_decl",
-  "exception_def", "@16", "exception_extends", "tag", "optional",
-  "struct_id", "struct_decl", "struct_def", "@17", "class_name",
-  "class_id", "class_decl", "class_def", "@18", "class_extends", "extends",
-  "data_member", "data_member_list", "data_members", "return_tuple",
-  "return_type", "operation_preamble", "operation", "@19", "@20",
-  "operation_list", "interface_id", "interface_decl", "interface_def",
-  "@21", "interface_list", "interface_extends", "exception_list",
-  "exception", "sequence_def", "dictionary_def", "enum_start", "enum_id",
-  "enum_def", "@22", "@23", "enum_underlying", "enumerator_list",
-  "enumerator", "enumerator_initializer", "out_qualifier", "parameter",
-  "parameter_list", "parameters", "throws", "scoped_name", "builtin",
-  "type", "tagged_type", "member", "string_literal", "string_list",
-  "const_initializer", "const_def", "keyword", YY_NULLPTR
+  "ICE_FILE_METADATA_CLOSE", "ICE_IDENT_OPEN", "ICE_KEYWORD_OPEN",
+  "ICE_TAG_OPEN", "ICE_OPTIONAL_OPEN", "BAD_CHAR", "';'", "'{'", "'}'",
+  "')'", "':'", "'='", "','", "'('", "'<'", "'>'", "'*'", "'?'", "$accept",
+  "start", "opt_semicolon", "file_metadata", "local_metadata",
+  "definitions", "definition", "$@1", "$@2", "$@3", "$@4", "$@5", "$@6",
+  "$@7", "$@8", "$@9", "$@10", "$@11", "$@12", "$@13", "module_def", "@14",
+  "@15", "exception_id", "exception_decl", "exception_def", "@16",
+  "exception_extends", "tag", "optional", "struct_id", "struct_decl",
+  "struct_def", "@17", "class_name", "class_id", "class_decl", "class_def",
+  "@18", "class_extends", "extends", "data_member", "data_member_list",
+  "data_members", "return_tuple", "return_type", "operation_preamble",
+  "operation", "@19", "@20", "operation_list", "interface_id",
+  "interface_decl", "interface_def", "@21", "interface_list",
+  "interface_extends", "exception_list", "exception", "sequence_def",
+  "dictionary_def", "enum_start", "enum_id", "enum_def", "@22", "@23",
+  "enum_underlying", "enumerator_list", "enumerator",
+  "enumerator_initializer", "out_qualifier", "parameter", "parameter_list",
+  "parameters", "throws", "scoped_name", "builtin", "type", "tagged_type",
+  "member", "string_literal", "string_list", "const_initializer",
+  "const_def", "keyword", YY_NULLPTR
 };
 
 static const char *
@@ -822,17 +819,17 @@ static const yytype_int16 yytoknum[] =
      275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
      285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
      295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,    59,   123,   125,    41,
-      58,    61,    44,    40,    60,    62,    42,    63
+     305,   306,   307,   308,   309,    59,   123,   125,    41,    58,
+      61,    44,    40,    60,    62,    42,    63
 };
 #endif
 
-#define YYPACT_NINF (-278)
+#define YYPACT_NINF (-277)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-154)
+#define YYTABLE_NINF (-153)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -841,40 +838,40 @@ static const yytype_int16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-    -278,    10,    35,  -278,   -24,   -24,   -24,  -278,   202,   -24,
-    -278,   -32,   -31,    80,   -12,    49,   384,   574,   616,   658,
-      16,    18,  -278,    27,    77,   -24,  -278,  -278,    31,    42,
-    -278,   -34,    61,  -278,    53,     4,    93,  -278,    54,   114,
-    -278,   120,   123,   700,    55,  -278,   127,  -278,  -278,   -24,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,   106,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,    27,    27,   975,  -278,    50,   129,  -278,  -278,  -278,
-     100,   132,   129,    79,   163,   129,  -278,   100,   164,   129,
-      94,  -278,   172,   129,   173,   174,  -278,   135,  -278,  1006,
-    -278,   129,   175,  -278,   179,   181,   182,  -278,  -278,   185,
-     975,   975,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,    74,   178,   201,
-     102,   203,   -33,  -278,  -278,  -278,   183,  -278,  -278,  -278,
-     236,  -278,  -278,   189,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,   177,   190,  -278,  -278,  -278,  -278,   742,  -278,   192,
-    -278,  -278,  -278,  -278,  -278,  -278,   204,   209,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,   215,   180,   236,   221,  -278,
-    -278,    57,    84,   897,  1006,  1006,   222,   282,   226,  -278,
-     784,   218,   236,    94,    32,   225,   229,   230,  -278,   742,
-     138,   169,   826,    27,   180,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,   233,  -278,   234,  -278,   237,   257,  -278,   258,
-     -24,  -278,  -278,  -278,  -278,   328,  -278,  -278,  -278,   180,
-     265,  -278,   232,   421,   266,   149,  -278,   742,   267,  -278,
-    -278,  -278,  -278,   975,  -278,  -278,  -278,  -278,  -278,  -278,
-      59,  -278,  -278,    32,  -278,   470,    13,   146,   136,   239,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,   268,  -278,  -278,
-     148,  -278,  -278,   -41,   936,  -278,  -278,   271,   936,  -278,
-     269,   273,    32,   868,  -278,  -278,  -278,   323,  -278,  -278,
-    -278,   323,  -278,  -278,  -278,  -278,   936,   324,  -278,   324,
-    -278,   531,  -278,  -278,  -278,   275,  -278,  -278,   531,  -278
+    -277,    13,    18,  -277,   -26,   -26,  -277,   201,   -26,  -277,
+      49,    38,   -34,    -1,   403,   590,   632,   674,    41,    54,
+    -277,    -9,    55,   -26,  -277,  -277,    16,    36,  -277,    73,
+      72,  -277,    23,    14,    79,  -277,    24,    88,  -277,    95,
+     115,   716,   125,  -277,   132,  -277,  -277,   -26,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+     -25,  -277,  -277,  -277,  -277,  -277,  -277,  -277,    -9,    -9,
+     989,  -277,    61,   144,  -277,  -277,  -277,    71,   145,   144,
+     156,   146,   144,  -277,    71,   158,   144,   100,  -277,   159,
+     144,   163,   164,  -277,   165,  -277,  1020,  -277,   144,   167,
+    -277,   175,   178,   139,  -277,  -277,   162,   989,   989,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,    83,   169,   171,   103,   172,   -30,
+    -277,  -277,  -277,   184,  -277,  -277,  -277,   235,  -277,  -277,
+     186,  -277,  -277,  -277,  -277,  -277,  -277,  -277,   137,   188,
+    -277,  -277,  -277,  -277,   758,  -277,   189,  -277,  -277,  -277,
+    -277,  -277,  -277,   182,   206,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,   179,   183,   235,   194,  -277,  -277,    48,    53,
+     913,  1020,  1020,   213,   306,   212,  -277,   800,   210,   235,
+     100,    32,   215,   219,   216,  -277,   758,    84,    94,   842,
+      -9,   183,  -277,  -277,  -277,  -277,  -277,  -277,  -277,   221,
+    -277,   225,  -277,   226,   227,  -277,   228,   -26,  -277,  -277,
+    -277,  -277,   348,  -277,  -277,  -277,   183,   232,  -277,   236,
+     439,   233,   141,  -277,   758,   237,  -277,  -277,  -277,  -277,
+     989,  -277,  -277,  -277,  -277,  -277,  -277,    67,  -277,  -277,
+      32,  -277,   487,    28,   140,   136,   238,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,   231,  -277,  -277,   142,  -277,  -277,
+      75,   951,  -277,  -277,   239,   951,  -277,   240,   241,    32,
+     884,  -277,  -277,  -277,   287,  -277,  -277,  -277,   287,  -277,
+    -277,  -277,  -277,   951,   286,  -277,   286,  -277,   547,  -277,
+    -277,  -277,   242,  -277,  -277,   547,  -277
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -882,68 +879,68 @@ static const yytype_int16 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-      12,     0,     9,     1,     0,     0,     0,    10,     0,   193,
-     195,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   130,     9,     0,     0,    11,    13,    53,    27,
-      28,    68,    32,    33,    76,    80,    17,    18,   111,    22,
-      23,    37,    40,   135,   138,    41,    45,   192,     7,     0,
-       5,     6,    46,    47,    49,   204,   205,   206,   207,   208,
-     209,   210,   211,   212,   213,   214,   215,   216,   217,   218,
-     219,   220,   221,   222,   223,   224,   225,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,   237,   238,
-     239,   240,    71,     0,    72,   109,   110,    51,    52,    66,
-      67,     9,     9,     0,   129,     0,     4,    81,    82,    54,
-       0,     0,     4,     0,     0,     4,    77,     0,     0,     4,
-       0,   112,     0,     4,     0,     0,   131,     0,   132,     0,
-     133,     4,     0,   194,     0,     0,     0,   156,   157,     0,
-       0,     0,   158,   159,   160,   161,   162,   163,   164,   165,
-     166,   167,   168,   169,   170,   171,   172,   178,   179,   180,
-     182,   181,     0,     8,     3,    14,     0,    56,    26,    29,
-       0,    31,    34,     0,    79,    16,    19,   116,   117,   118,
-     119,   115,     0,    21,    24,    36,    39,   144,   137,     0,
-      42,    44,    12,    12,    73,    74,     0,     0,   173,   174,
-     175,   176,   183,   184,   177,     0,     0,     0,     0,    61,
-      65,     0,     0,     0,     0,     0,    87,     0,     0,   187,
-     190,    83,     0,     0,     0,   141,     0,   140,   143,   144,
-       9,     9,     0,     9,     0,   200,   201,   199,   196,   197,
-     198,   203,     0,    86,     0,    60,     0,     0,    64,     0,
-       0,   191,   185,   186,    85,     0,    70,   188,   189,     0,
-       0,   114,     0,     0,     0,     0,   136,   144,     0,    48,
-      50,   125,   126,     0,   202,    55,    58,    59,    62,    63,
-       0,    84,    78,     0,    96,     0,   148,     0,     0,   106,
-      93,   113,   145,   142,   146,   139,   134,     0,     7,   107,
-       0,   147,    95,     0,     0,    97,    99,     0,     0,   150,
-     152,     0,     0,     0,    98,   100,    94,   148,    91,   103,
-     149,   148,   101,   105,   127,   128,     0,   155,   151,   155,
-      92,     0,   104,   102,   154,   122,   123,   124,     0,   121
+      11,     0,     8,     1,     0,     0,     9,     0,   192,   194,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     129,     8,     0,     0,    10,    12,    52,    26,    27,    67,
+      31,    32,    75,    79,    16,    17,   110,    21,    22,    36,
+      39,   134,   137,    40,    44,   191,     6,     0,     5,    45,
+      46,    48,   203,   204,   205,   206,   207,   208,   209,   210,
+     211,   212,   213,   214,   215,   216,   217,   218,   219,   220,
+     221,   222,   223,   224,   225,   226,   227,   228,   229,   230,
+     231,   232,   233,   234,   235,   236,   237,   238,   239,    70,
+       0,    71,   108,   109,    50,    51,    65,    66,     8,     8,
+       0,   128,     0,     4,    80,    81,    53,     0,     0,     4,
+       0,     0,     4,    76,     0,     0,     4,     0,   111,     0,
+       4,     0,     0,   130,     0,   131,     0,   132,     4,     0,
+     193,     0,     0,     0,   155,   156,     0,     0,     0,   157,
+     158,   159,   160,   161,   162,   163,   164,   165,   166,   167,
+     168,   169,   170,   171,   177,   178,   179,   181,   180,     0,
+       7,     3,    13,     0,    55,    25,    28,     0,    30,    33,
+       0,    78,    15,    18,   115,   116,   117,   118,   114,     0,
+      20,    23,    35,    38,   143,   136,     0,    41,    43,    11,
+      11,    72,    73,     0,     0,   172,   173,   174,   175,   182,
+     183,   176,     0,     0,     0,     0,    60,    64,     0,     0,
+       0,     0,     0,    86,     0,     0,   186,   189,    82,     0,
+       0,     0,   140,     0,   139,   142,   143,     8,     8,     0,
+       8,     0,   199,   200,   198,   195,   196,   197,   202,     0,
+      85,     0,    59,     0,     0,    63,     0,     0,   190,   184,
+     185,    84,     0,    69,   187,   188,     0,     0,   113,     0,
+       0,     0,     0,   135,   143,     0,    47,    49,   124,   125,
+       0,   201,    54,    57,    58,    61,    62,     0,    83,    77,
+       0,    95,     0,   147,     0,     0,   105,    92,   112,   144,
+     141,   145,   138,   133,     0,     6,   106,     0,   146,    94,
+       0,     0,    96,    98,     0,     0,   149,   151,     0,     0,
+       0,    97,    99,    93,   147,    90,   102,   148,   147,   100,
+     104,   126,   127,     0,   154,   150,   154,    91,     0,   103,
+     101,   153,   121,   122,   123,     0,   120
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -278,  -278,   -23,  -278,     2,     9,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,  -278,
-      96,  -278,  -181,  -100,  -278,    56,  -278,  -278,  -278,  -278,
-    -271,  -278,  -278,  -278,  -278,   116,  -278,     5,  -278,  -278,
-    -278,  -278,  -278,  -278,  -278,  -278,  -278,  -192,  -278,  -278,
-    -277,    21,  -278,  -278,    33,   -88,  -278,   -95,  -243,  -199,
-      30,     1,  -221,  -278,   -16
+    -277,  -277,    -7,  -277,     2,     6,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,  -277,
+     143,  -277,  -140,  -194,  -277,    20,  -277,  -277,  -277,  -277,
+    -269,  -277,  -277,  -277,  -277,    85,  -277,   -31,  -277,  -277,
+    -277,  -277,  -277,  -277,  -277,  -277,  -277,  -138,  -277,  -277,
+    -276,   -12,  -277,  -277,   -18,   -85,  -277,   -92,  -251,  -198,
+      34,     1,  -215,  -277,   -14
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-      -1,     1,   165,     7,   213,     2,    26,   106,   118,   119,
-     122,   123,   111,   112,   114,   115,   124,   125,   131,   132,
-      27,   134,   135,    28,    29,    30,   166,   109,   214,   215,
-      31,    32,    33,   113,    34,    35,    36,    37,   173,   116,
-     110,   216,   217,   218,   303,   287,   288,   289,   329,   327,
-     264,    38,    39,    40,   182,   180,   121,   334,   335,    41,
-      42,    43,    44,    45,   189,   127,   130,   226,   227,   293,
-     308,   309,   310,   311,   332,   160,   161,   219,   220,   221,
-      10,    11,   241,    46,   228
+      -1,     1,   162,     6,   210,     2,    24,   103,   115,   116,
+     119,   120,   108,   109,   111,   112,   121,   122,   128,   129,
+      25,   131,   132,    26,    27,    28,   163,   106,   211,   212,
+      29,    30,    31,   110,    32,    33,    34,    35,   170,   113,
+     107,   213,   214,   215,   300,   284,   285,   286,   326,   324,
+     261,    36,    37,    38,   179,   177,   118,   331,   332,    39,
+      40,    41,    42,    43,   186,   124,   127,   223,   224,   290,
+     305,   306,   307,   308,   329,   157,   158,   216,   217,   218,
+       9,    10,   238,    44,   225
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -951,174 +948,185 @@ static const yytype_int16 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      94,    96,    98,   100,     8,   139,    12,    13,   162,   304,
-       3,   205,   299,   274,   251,    48,   107,     9,   316,    50,
-     290,   317,   167,   -69,   301,   103,   105,   128,   206,   174,
-      49,    49,   181,   262,   188,    -2,   255,   268,   281,    47,
-     326,   323,   290,   107,    52,   196,   197,    -9,    -9,    -9,
-      -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,
-      -9,    -9,    -9,    -9,   108,   -75,   107,    -9,    -9,    -9,
-      -9,    -9,   302,     4,   255,   295,    -9,    -9,     4,   133,
-     101,     4,   102,     5,     6,    -9,    -9,   104,   -57,   169,
-    -108,   108,   172,    53,    54,    -9,   176,   163,   -25,   244,
-     184,   137,   138,   140,   141,   318,   298,   242,   190,   320,
-     -75,  -120,    49,   -75,   108,   129,   245,   -30,   240,   252,
-     253,    49,   260,   246,   249,   177,   247,   330,   137,   138,
-      51,   117,   178,   179,   120,   181,   170,   307,   137,   138,
-     198,   199,    49,   248,   137,   138,   240,   301,   136,   -15,
-     137,   138,  -148,  -148,  -148,  -148,  -148,  -148,  -148,  -148,
-    -148,  -148,  -148,  -148,  -148,  -148,  -148,  -148,   202,   203,
-     -20,   240,  -148,  -148,  -148,  -148,   -35,   294,   297,   -38,
-    -148,  -148,  -148,   -43,     4,   164,     5,     6,   168,  -148,
-    -148,   292,   187,   137,   138,  -153,   269,   305,   306,   314,
-     315,   230,   231,    14,   258,    15,    16,    17,    18,    19,
-      20,    21,    22,   235,   236,     4,   272,     5,     6,   171,
-     175,   237,   238,   239,   137,   138,   263,   270,   183,   185,
-     186,   191,     8,     8,    23,   273,   192,   208,   193,   223,
-     207,   194,    24,   336,   195,   200,   222,   224,    25,   229,
-     336,   280,   142,   143,   144,   145,   146,   147,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,   201,   232,
-     204,   233,   209,   210,   158,   159,   234,   243,   254,   259,
-     137,   138,     4,   208,   256,   263,   265,   266,   283,   211,
-     212,   275,   267,   276,   -90,   312,   277,   325,   142,   143,
-     144,   145,   146,   147,   148,   149,   150,   151,   152,   153,
-     154,   155,   156,   157,   263,   337,   278,   279,   209,   210,
-     158,   159,   337,   282,   291,   296,   137,   138,     4,   208,
-     319,   321,   322,   313,   301,   211,   212,   338,   331,   261,
-     -89,   300,   328,   339,   142,   143,   144,   145,   146,   147,
-     148,   149,   150,   151,   152,   153,   154,   155,   156,   157,
-       0,     0,   333,     0,   209,   210,   158,   159,     0,     0,
-       0,     0,   137,   138,     4,     0,     0,     0,     0,     0,
-       0,   211,   212,     0,     0,     0,   -88,    55,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      68,    69,    70,    71,    72,    73,    74,    75,    76,    77,
-      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,     0,     0,     0,     0,    92,     0,
-       0,     0,     0,     0,     0,    93,   284,   142,   143,   144,
+      91,    93,    95,    97,     7,   136,    11,   301,   159,   287,
+     239,   296,   248,     3,   202,     8,   271,   133,    -2,   134,
+     135,    49,   164,   100,   102,   257,   104,   125,   104,   171,
+     203,   287,   178,   259,   185,   -74,   104,     4,   323,   298,
+     320,   278,    45,    50,    51,   193,   194,    -8,    -8,    -8,
+      -8,    -8,    -8,    -8,    -8,    -8,    -8,    -8,    -8,    -8,
+      -8,    -8,    -8,    -8,     4,   101,     5,    -8,    -8,    -8,
+      -8,    -8,   -56,   105,   252,   105,    -8,    -8,     4,   -74,
+    -119,   130,   -74,   105,    -8,    -8,   299,    48,   265,  -107,
+     241,   -24,   134,   135,    -8,   244,    46,   134,   135,    47,
+     137,   138,   166,   315,    98,   169,   242,   317,   160,   173,
+      47,   245,   252,   181,   295,   134,   135,    99,   237,   249,
+     250,   187,    47,   243,   246,   327,   292,   -29,    47,   -68,
+       4,   174,     5,   313,   -14,   178,   314,   304,   175,   176,
+       4,   266,     5,   -19,   134,   135,   237,   298,   195,   196,
+     -34,   267,  -147,  -147,  -147,  -147,  -147,  -147,  -147,  -147,
+    -147,  -147,  -147,  -147,  -147,  -147,  -147,  -147,   199,   200,
+     -37,   237,  -147,  -147,  -147,  -147,   114,   291,   294,   117,
+    -147,  -147,  -147,   289,   126,   134,   135,   -42,  -147,  -147,
+     302,   303,   311,   312,  -152,   227,   228,   191,   220,   161,
+     165,   168,    12,   255,    13,    14,    15,    16,    17,    18,
+      19,    20,   167,   172,   180,   269,   232,   233,   182,   183,
+     192,   184,   188,   260,   234,   235,   236,   134,   135,     7,
+       7,   189,   270,    21,   190,   197,   205,   198,   201,   231,
+     204,    22,   219,   333,   221,   226,   229,    23,   277,   240,
+     333,   139,   140,   141,   142,   143,   144,   145,   146,   147,
+     148,   149,   150,   151,   152,   153,   154,   230,   251,   253,
+     256,   206,   207,   155,   156,   262,   263,   264,   272,   134,
+     135,     4,   260,   273,   274,   275,   276,   208,   209,   279,
+     288,   280,   -89,   309,   293,   310,   322,   316,   298,   319,
+     328,   318,   297,   335,   336,   258,   325,   205,   330,     0,
+       0,   260,     0,     0,   334,     0,     0,     0,     0,     0,
+       0,   334,   139,   140,   141,   142,   143,   144,   145,   146,
+     147,   148,   149,   150,   151,   152,   153,   154,     0,     0,
+       0,     0,   206,   207,   155,   156,     0,     0,     0,   205,
+     134,   135,     4,     0,     0,     0,     0,     0,   208,   209,
+       0,     0,     0,   -88,   139,   140,   141,   142,   143,   144,
      145,   146,   147,   148,   149,   150,   151,   152,   153,   154,
-     155,   156,   157,     0,     0,     0,   285,   209,   210,   158,
-     159,     0,     0,     0,     0,   137,   138,    25,     0,     0,
-       0,     0,     0,     0,   211,   212,     0,     0,     0,     0,
-       0,     0,     0,     0,   286,   284,   142,   143,   144,   145,
-     146,   147,   148,   149,   150,   151,   152,   153,   154,   155,
-     156,   157,     0,     0,     0,     0,   209,   210,   158,   159,
-       0,     0,     0,     0,   137,   138,     0,     0,     0,     0,
-       0,     0,     0,   211,   212,     0,     0,     0,     0,     0,
-       0,     0,     0,   286,    55,    56,    57,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
-      71,    72,    73,    74,    75,    76,    77,    78,    79,    80,
-      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
-      91,     0,     0,     0,     0,   137,   138,    55,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      68,    69,    70,    71,    72,    73,    74,    75,    76,    77,
-      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,     0,     0,     0,     0,    95,    55,
+       0,     0,     0,     0,   206,   207,   155,   156,     0,     0,
+       0,     0,   134,   135,     4,     0,     0,     0,     0,     0,
+     208,   209,     0,     0,     0,   -87,    52,    53,    54,    55,
       56,    57,    58,    59,    60,    61,    62,    63,    64,    65,
       66,    67,    68,    69,    70,    71,    72,    73,    74,    75,
       76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
-      86,    87,    88,    89,    90,    91,     0,     0,     0,     0,
-      97,    55,    56,    57,    58,    59,    60,    61,    62,    63,
-      64,    65,    66,    67,    68,    69,    70,    71,    72,    73,
-      74,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,     0,     0,
-       0,     0,    99,    55,    56,    57,    58,    59,    60,    61,
+      86,    87,    88,     0,     0,     0,     0,    89,     0,     0,
+       0,     0,     0,    90,   281,   139,   140,   141,   142,   143,
+     144,   145,   146,   147,   148,   149,   150,   151,   152,   153,
+     154,     0,     0,     0,   282,   206,   207,   155,   156,     0,
+       0,     0,     0,   134,   135,    23,     0,     0,     0,     0,
+       0,   208,   209,     0,     0,     0,     0,     0,     0,     0,
+       0,   283,   281,   139,   140,   141,   142,   143,   144,   145,
+     146,   147,   148,   149,   150,   151,   152,   153,   154,     0,
+       0,     0,     0,   206,   207,   155,   156,     0,     0,     0,
+       0,   134,   135,     0,     0,     0,     0,     0,     0,   208,
+     209,     0,     0,     0,     0,     0,     0,     0,     0,   283,
+      52,    53,    54,    55,    56,    57,    58,    59,    60,    61,
       62,    63,    64,    65,    66,    67,    68,    69,    70,    71,
       72,    73,    74,    75,    76,    77,    78,    79,    80,    81,
-      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
-       0,     0,     0,     0,   126,    55,    56,    57,    58,    59,
-      60,    61,    62,    63,    64,    65,    66,    67,    68,    69,
-      70,    71,    72,    73,    74,    75,    76,    77,    78,    79,
-      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
-      90,    91,     0,     0,     0,     0,   225,    55,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      68,    69,    70,    71,    72,    73,    74,    75,    76,    77,
-      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,     0,     0,     0,     0,   257,    55,
-      56,    57,    58,    59,    60,    61,    62,    63,    64,    65,
-      66,    67,    68,    69,    70,    71,    72,    73,    74,    75,
-      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
-      86,    87,    88,    89,    90,    91,     0,     0,     0,     0,
-     271,    55,    56,    57,    58,    59,    60,    61,    62,    63,
-      64,    65,    66,    67,    68,    69,    70,    71,    72,    73,
-      74,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,     0,     0,
-       0,     0,   324,   142,   143,   144,   145,   146,   147,   148,
-     149,   150,   151,   152,   153,   154,   155,   156,   157,     0,
-       0,     0,     0,   209,   210,   158,   159,     0,     0,     0,
-       0,   137,   138,   250,     0,     0,     0,     0,     0,     0,
-     211,   212,   142,   143,   144,   145,   146,   147,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,     0,     0,
-       0,     0,   209,   210,   158,   159,     0,     0,     0,     0,
-     137,   138,     4,     0,     0,     0,     0,     0,     0,   211,
-     212,   142,   143,   144,   145,   146,   147,   148,   149,   150,
-     151,   152,   153,   154,   155,   156,   157,     0,     0,     0,
-       0,     0,     0,   158,   159,     0,     0,     0,     0,   137,
-     138,    25,   142,   143,   144,   145,   146,   147,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,     0,     0,
-       0,     0,     0,     0,   158,   159,     0,     0,     0,     0,
-     137,   138
+      82,    83,    84,    85,    86,    87,    88,     0,     0,     0,
+       0,   134,   135,    52,    53,    54,    55,    56,    57,    58,
+      59,    60,    61,    62,    63,    64,    65,    66,    67,    68,
+      69,    70,    71,    72,    73,    74,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+       0,     0,     0,     0,    92,    52,    53,    54,    55,    56,
+      57,    58,    59,    60,    61,    62,    63,    64,    65,    66,
+      67,    68,    69,    70,    71,    72,    73,    74,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,     0,     0,     0,     0,    94,    52,    53,    54,
+      55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    71,    72,    73,    74,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,     0,     0,     0,     0,    96,    52,
+      53,    54,    55,    56,    57,    58,    59,    60,    61,    62,
+      63,    64,    65,    66,    67,    68,    69,    70,    71,    72,
+      73,    74,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,     0,     0,     0,     0,
+     123,    52,    53,    54,    55,    56,    57,    58,    59,    60,
+      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+      71,    72,    73,    74,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    85,    86,    87,    88,     0,     0,
+       0,     0,   222,    52,    53,    54,    55,    56,    57,    58,
+      59,    60,    61,    62,    63,    64,    65,    66,    67,    68,
+      69,    70,    71,    72,    73,    74,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+       0,     0,     0,     0,   254,    52,    53,    54,    55,    56,
+      57,    58,    59,    60,    61,    62,    63,    64,    65,    66,
+      67,    68,    69,    70,    71,    72,    73,    74,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,     0,     0,     0,     0,   268,    52,    53,    54,
+      55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    71,    72,    73,    74,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,     0,     0,     0,     0,   321,   139,
+     140,   141,   142,   143,   144,   145,   146,   147,   148,   149,
+     150,   151,   152,   153,   154,     0,     0,     0,     0,   206,
+     207,   155,   156,     0,     0,     0,     0,   134,   135,   247,
+       0,     0,     0,     0,     0,   208,   209,   139,   140,   141,
+     142,   143,   144,   145,   146,   147,   148,   149,   150,   151,
+     152,   153,   154,     0,     0,     0,     0,   206,   207,   155,
+     156,     0,     0,     0,     0,   134,   135,     4,     0,     0,
+       0,     0,     0,   208,   209,   139,   140,   141,   142,   143,
+     144,   145,   146,   147,   148,   149,   150,   151,   152,   153,
+     154,     0,     0,     0,     0,     0,     0,   155,   156,     0,
+       0,     0,     0,   134,   135,    23,   139,   140,   141,   142,
+     143,   144,   145,   146,   147,   148,   149,   150,   151,   152,
+     153,   154,     0,     0,     0,     0,     0,     0,   155,   156,
+       0,     0,     0,     0,   134,   135
 };
 
 static const yytype_int16 yycheck[] =
 {
-      16,    17,    18,    19,     2,    93,     5,     6,   103,   286,
-       0,    44,   283,   234,   213,    47,    12,    41,    59,    50,
-     263,    62,   110,    57,    11,    23,    25,    43,    61,   117,
-      62,    62,   120,     1,   129,     0,   217,   229,   259,     9,
-     317,   312,   285,    12,    56,   140,   141,    15,    16,    17,
+      14,    15,    16,    17,     2,    90,     5,   283,   100,   260,
+     204,   280,   210,     0,    44,    41,   231,    42,     0,    44,
+      45,    55,   107,    21,    23,   219,    12,    41,    12,   114,
+      60,   282,   117,     1,   126,    12,    12,    46,   314,    11,
+     309,   256,     8,    44,    45,   137,   138,    15,    16,    17,
       18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
-      28,    29,    30,    31,    60,    12,    12,    35,    36,    37,
-      38,    39,    59,    46,   255,   267,    44,    45,    46,    49,
-      64,    46,    64,    48,    49,    53,    54,    10,    57,   112,
-      58,    60,   115,    44,    45,    63,   119,    47,    56,    42,
-     123,    44,    45,   101,   102,   304,    47,   207,   131,   308,
-      57,    57,    62,    60,    60,    60,    59,    56,   206,   214,
-     215,    62,   222,   211,   212,    31,    42,   326,    44,    45,
-      50,    35,    38,    39,    38,   223,    57,     1,    44,    45,
-      66,    67,    62,    59,    44,    45,   234,    11,    42,    56,
-      44,    45,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    66,    67,
-      56,   259,    36,    37,    38,    39,    56,   265,   273,    56,
-      44,    45,    46,    56,    46,    56,    48,    49,    56,    53,
-      54,    42,    57,    44,    45,    59,    58,    51,    52,    51,
-      52,   192,   193,     1,   220,     3,     4,     5,     6,     7,
-       8,     9,    10,    33,    34,    46,   232,    48,    49,    56,
-      56,    41,    42,    43,    44,    45,   224,    58,    56,    56,
-      56,    56,   230,   231,    32,   233,    57,     1,    57,    62,
-      57,    59,    40,   331,    59,    67,    57,    57,    46,    57,
-     338,   250,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    67,    65,
-      67,    62,    36,    37,    38,    39,    61,    56,    56,    61,
-      44,    45,    46,     1,    58,   283,    61,    58,    56,    53,
-      54,    58,    62,    59,    58,    56,    59,   313,    16,    17,
-      18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
-      28,    29,    30,    31,   312,   331,    59,    59,    36,    37,
-      38,    39,   338,    58,    58,    58,    44,    45,    46,     1,
-      59,    62,    59,    65,    11,    53,    54,    62,    14,   223,
-      58,   285,   321,   338,    16,    17,    18,    19,    20,    21,
+      28,    29,    30,    31,    46,    10,    48,    35,    36,    37,
+      38,    39,    56,    59,   214,    59,    44,    45,    46,    56,
+      56,    47,    59,    59,    52,    53,    58,    49,   226,    57,
+      42,    55,    44,    45,    62,    42,    47,    44,    45,    61,
+      98,    99,   109,   301,    63,   112,    58,   305,    47,   116,
+      61,    58,   252,   120,    47,    44,    45,    63,   203,   211,
+     212,   128,    61,   208,   209,   323,   264,    55,    61,    56,
+      46,    31,    48,    58,    55,   220,    61,     1,    38,    39,
+      46,    57,    48,    55,    44,    45,   231,    11,    65,    66,
+      55,    57,    16,    17,    18,    19,    20,    21,    22,    23,
+      24,    25,    26,    27,    28,    29,    30,    31,    65,    66,
+      55,   256,    36,    37,    38,    39,    33,   262,   270,    36,
+      44,    45,    46,    42,    59,    44,    45,    55,    52,    53,
+      50,    51,    50,    51,    58,   189,   190,    58,    61,    55,
+      55,    55,     1,   217,     3,     4,     5,     6,     7,     8,
+       9,    10,    56,    55,    55,   229,    33,    34,    55,    55,
+      58,    56,    55,   221,    41,    42,    43,    44,    45,   227,
+     228,    56,   230,    32,    56,    66,     1,    66,    66,    60,
+      56,    40,    56,   328,    56,    56,    64,    46,   247,    55,
+     335,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,    26,    27,    28,    29,    30,    31,    61,    55,    57,
+      60,    36,    37,    38,    39,    60,    57,    61,    57,    44,
+      45,    46,   280,    58,    58,    58,    58,    52,    53,    57,
+      57,    55,    57,    55,    57,    64,   310,    58,    11,    58,
+      14,    61,   282,    61,   335,   220,   318,     1,   326,    -1,
+      -1,   309,    -1,    -1,   328,    -1,    -1,    -1,    -1,    -1,
+      -1,   335,    16,    17,    18,    19,    20,    21,    22,    23,
+      24,    25,    26,    27,    28,    29,    30,    31,    -1,    -1,
+      -1,    -1,    36,    37,    38,    39,    -1,    -1,    -1,     1,
+      44,    45,    46,    -1,    -1,    -1,    -1,    -1,    52,    53,
+      -1,    -1,    -1,    57,    16,    17,    18,    19,    20,    21,
       22,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-      -1,    -1,   329,    -1,    36,    37,    38,    39,    -1,    -1,
+      -1,    -1,    -1,    -1,    36,    37,    38,    39,    -1,    -1,
       -1,    -1,    44,    45,    46,    -1,    -1,    -1,    -1,    -1,
-      -1,    53,    54,    -1,    -1,    -1,    58,     3,     4,     5,
-       6,     7,     8,     9,    10,    11,    12,    13,    14,    15,
-      16,    17,    18,    19,    20,    21,    22,    23,    24,    25,
-      26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    44,    -1,
-      -1,    -1,    -1,    -1,    -1,    51,    15,    16,    17,    18,
-      19,    20,    21,    22,    23,    24,    25,    26,    27,    28,
-      29,    30,    31,    -1,    -1,    -1,    35,    36,    37,    38,
-      39,    -1,    -1,    -1,    -1,    44,    45,    46,    -1,    -1,
-      -1,    -1,    -1,    -1,    53,    54,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    63,    15,    16,    17,    18,    19,
+      52,    53,    -1,    -1,    -1,    57,     3,     4,     5,     6,
+       7,     8,     9,    10,    11,    12,    13,    14,    15,    16,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
+      37,    38,    39,    -1,    -1,    -1,    -1,    44,    -1,    -1,
+      -1,    -1,    -1,    50,    15,    16,    17,    18,    19,    20,
+      21,    22,    23,    24,    25,    26,    27,    28,    29,    30,
+      31,    -1,    -1,    -1,    35,    36,    37,    38,    39,    -1,
+      -1,    -1,    -1,    44,    45,    46,    -1,    -1,    -1,    -1,
+      -1,    52,    53,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    62,    15,    16,    17,    18,    19,    20,    21,    22,
+      23,    24,    25,    26,    27,    28,    29,    30,    31,    -1,
+      -1,    -1,    -1,    36,    37,    38,    39,    -1,    -1,    -1,
+      -1,    44,    45,    -1,    -1,    -1,    -1,    -1,    -1,    52,
+      53,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    62,
+       3,     4,     5,     6,     7,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    17,    18,    19,    20,    21,    22,
+      23,    24,    25,    26,    27,    28,    29,    30,    31,    32,
+      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
+      -1,    44,    45,     3,     4,     5,     6,     7,     8,     9,
+      10,    11,    12,    13,    14,    15,    16,    17,    18,    19,
       20,    21,    22,    23,    24,    25,    26,    27,    28,    29,
-      30,    31,    -1,    -1,    -1,    -1,    36,    37,    38,    39,
-      -1,    -1,    -1,    -1,    44,    45,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    53,    54,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    63,     3,     4,     5,     6,     7,     8,
-       9,    10,    11,    12,    13,    14,    15,    16,    17,    18,
-      19,    20,    21,    22,    23,    24,    25,    26,    27,    28,
-      29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-      39,    -1,    -1,    -1,    -1,    44,    45,     3,     4,     5,
+      30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+      -1,    -1,    -1,    -1,    44,     3,     4,     5,     6,     7,
+       8,     9,    10,    11,    12,    13,    14,    15,    16,    17,
+      18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
+      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+      38,    39,    -1,    -1,    -1,    -1,    44,     3,     4,     5,
        6,     7,     8,     9,    10,    11,    12,    13,    14,    15,
       16,    17,    18,    19,    20,    21,    22,    23,    24,    25,
       26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
@@ -1143,130 +1151,119 @@ static const yytype_int16 yycheck[] =
        6,     7,     8,     9,    10,    11,    12,    13,    14,    15,
       16,    17,    18,    19,    20,    21,    22,    23,    24,    25,
       26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    44,     3,
-       4,     5,     6,     7,     8,     9,    10,    11,    12,    13,
-      14,    15,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    32,    33,
-      34,    35,    36,    37,    38,    39,    -1,    -1,    -1,    -1,
-      44,     3,     4,     5,     6,     7,     8,     9,    10,    11,
-      12,    13,    14,    15,    16,    17,    18,    19,    20,    21,
-      22,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-      32,    33,    34,    35,    36,    37,    38,    39,    -1,    -1,
-      -1,    -1,    44,    16,    17,    18,    19,    20,    21,    22,
-      23,    24,    25,    26,    27,    28,    29,    30,    31,    -1,
-      -1,    -1,    -1,    36,    37,    38,    39,    -1,    -1,    -1,
-      -1,    44,    45,    46,    -1,    -1,    -1,    -1,    -1,    -1,
-      53,    54,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    -1,    -1,
-      -1,    -1,    36,    37,    38,    39,    -1,    -1,    -1,    -1,
-      44,    45,    46,    -1,    -1,    -1,    -1,    -1,    -1,    53,
-      54,    16,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    30,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    38,    39,    -1,    -1,    -1,    -1,    44,
-      45,    46,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    -1,    -1,
-      -1,    -1,    -1,    -1,    38,    39,    -1,    -1,    -1,    -1,
-      44,    45
+      36,    37,    38,    39,    -1,    -1,    -1,    -1,    44,    16,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    -1,    -1,    -1,    -1,    36,
+      37,    38,    39,    -1,    -1,    -1,    -1,    44,    45,    46,
+      -1,    -1,    -1,    -1,    -1,    52,    53,    16,    17,    18,
+      19,    20,    21,    22,    23,    24,    25,    26,    27,    28,
+      29,    30,    31,    -1,    -1,    -1,    -1,    36,    37,    38,
+      39,    -1,    -1,    -1,    -1,    44,    45,    46,    -1,    -1,
+      -1,    -1,    -1,    52,    53,    16,    17,    18,    19,    20,
+      21,    22,    23,    24,    25,    26,    27,    28,    29,    30,
+      31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    -1,
+      -1,    -1,    -1,    44,    45,    46,    16,    17,    18,    19,
+      20,    21,    22,    23,    24,    25,    26,    27,    28,    29,
+      30,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,
+      -1,    -1,    -1,    -1,    44,    45
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    69,    73,     0,    46,    48,    49,    71,    72,    41,
-     148,   149,   149,   149,     1,     3,     4,     5,     6,     7,
-       8,     9,    10,    32,    40,    46,    74,    88,    91,    92,
-      93,    98,    99,   100,   102,   103,   104,   105,   119,   120,
-     121,   127,   128,   129,   130,   131,   151,   148,    47,    62,
-      50,    50,    56,    44,    45,     3,     4,     5,     6,     7,
-       8,     9,    10,    11,    12,    13,    14,    15,    16,    17,
-      18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
-      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
-      38,    39,    44,    51,   152,    44,   152,    44,   152,    44,
-     152,    64,    64,    72,    10,   149,    75,    12,    60,    95,
-     108,    80,    81,   101,    82,    83,   107,   108,    76,    77,
-     108,   124,    78,    79,    84,    85,    44,   133,   152,    60,
-     134,    86,    87,   148,    89,    90,    42,    44,    45,   143,
-      72,    72,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    38,    39,
-     143,   144,   145,    47,    56,    70,    94,   143,    56,    70,
-      57,    56,    70,   106,   143,    56,    70,    31,    38,    39,
-     123,   143,   122,    56,    70,    56,    56,    57,   145,   132,
-      70,    56,    57,    57,    59,    59,   145,   145,    66,    67,
-      67,    67,    66,    67,    67,    44,    61,    57,     1,    36,
-      37,    53,    54,    72,    96,    97,   109,   110,   111,   145,
-     146,   147,    57,    62,    57,    44,   135,   136,   152,    57,
-      73,    73,    65,    62,    61,    33,    34,    41,    42,    43,
-     143,   150,   111,    56,    42,    59,   143,    42,    59,   143,
-      46,   147,   145,   145,    56,   110,    58,    44,   152,    61,
-     111,   123,     1,    72,   118,    61,    58,    62,   135,    58,
-      58,    44,   152,    72,   150,    58,    59,    59,    59,    59,
-     149,   150,    58,    56,    15,    35,    63,   113,   114,   115,
-     146,    58,    42,   137,   143,   135,    58,   145,    47,   118,
-     113,    11,    59,   112,   138,    51,    52,     1,   138,   139,
-     140,   141,    56,    65,    51,    52,    59,    62,   147,    59,
-     147,    62,    59,   118,    44,   152,   138,   117,   139,   116,
-     147,    14,   142,   142,   125,   126,   143,   152,    62,   125
+       0,    68,    72,     0,    46,    48,    70,    71,    41,   147,
+     148,   148,     1,     3,     4,     5,     6,     7,     8,     9,
+      10,    32,    40,    46,    73,    87,    90,    91,    92,    97,
+      98,    99,   101,   102,   103,   104,   118,   119,   120,   126,
+     127,   128,   129,   130,   150,   147,    47,    61,    49,    55,
+      44,    45,     3,     4,     5,     6,     7,     8,     9,    10,
+      11,    12,    13,    14,    15,    16,    17,    18,    19,    20,
+      21,    22,    23,    24,    25,    26,    27,    28,    29,    30,
+      31,    32,    33,    34,    35,    36,    37,    38,    39,    44,
+      50,   151,    44,   151,    44,   151,    44,   151,    63,    63,
+      71,    10,   148,    74,    12,    59,    94,   107,    79,    80,
+     100,    81,    82,   106,   107,    75,    76,   107,   123,    77,
+      78,    83,    84,    44,   132,   151,    59,   133,    85,    86,
+     147,    88,    89,    42,    44,    45,   142,    71,    71,    16,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    38,    39,   142,   143,   144,
+      47,    55,    69,    93,   142,    55,    69,    56,    55,    69,
+     105,   142,    55,    69,    31,    38,    39,   122,   142,   121,
+      55,    69,    55,    55,    56,   144,   131,    69,    55,    56,
+      56,    58,    58,   144,   144,    65,    66,    66,    66,    65,
+      66,    66,    44,    60,    56,     1,    36,    37,    52,    53,
+      71,    95,    96,   108,   109,   110,   144,   145,   146,    56,
+      61,    56,    44,   134,   135,   151,    56,    72,    72,    64,
+      61,    60,    33,    34,    41,    42,    43,   142,   149,   110,
+      55,    42,    58,   142,    42,    58,   142,    46,   146,   144,
+     144,    55,   109,    57,    44,   151,    60,   110,   122,     1,
+      71,   117,    60,    57,    61,   134,    57,    57,    44,   151,
+      71,   149,    57,    58,    58,    58,    58,   148,   149,    57,
+      55,    15,    35,    62,   112,   113,   114,   145,    57,    42,
+     136,   142,   134,    57,   144,    47,   117,   112,    11,    58,
+     111,   137,    50,    51,     1,   137,   138,   139,   140,    55,
+      64,    50,    51,    58,    61,   146,    58,   146,    61,    58,
+     117,    44,   151,   137,   116,   138,   115,   146,    14,   141,
+     141,   124,   125,   142,   151,    61,   124
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    68,    69,    70,    70,    71,    71,    72,    72,    72,
-      73,    73,    73,    75,    74,    76,    74,    74,    77,    74,
-      78,    74,    74,    79,    74,    80,    74,    74,    81,    74,
-      82,    74,    74,    83,    74,    84,    74,    74,    85,    74,
-      74,    86,    74,    87,    74,    74,    74,    89,    88,    90,
-      88,    91,    91,    92,    94,    93,    95,    95,    96,    96,
-      96,    96,    97,    97,    97,    97,    98,    98,    99,   101,
-     100,   102,   102,   103,   103,   103,   104,   106,   105,   107,
-     107,   108,   108,   109,   109,   110,   110,   110,   110,   111,
-     111,   112,   112,   113,   113,   113,   113,   114,   114,   114,
-     114,   116,   115,   117,   115,   118,   118,   118,   118,   119,
-     119,   120,   122,   121,   123,   123,   123,   123,   123,   124,
-     124,   125,   125,   126,   126,   127,   127,   128,   128,   129,
-     129,   130,   130,   132,   131,   133,   131,   134,   134,   135,
-     135,   136,   136,   136,   136,   137,   137,   138,   138,   139,
-     140,   140,   141,   141,   142,   142,   143,   143,   144,   144,
-     144,   144,   144,   144,   144,   144,   144,   144,   144,   144,
-     144,   144,   144,   145,   145,   145,   145,   145,   145,   145,
-     145,   145,   145,   145,   145,   146,   146,   146,   147,   147,
-     147,   147,   148,   148,   149,   149,   150,   150,   150,   150,
-     150,   150,   151,   151,   152,   152,   152,   152,   152,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
-     152
+       0,    67,    68,    69,    69,    70,    71,    71,    71,    72,
+      72,    72,    74,    73,    75,    73,    73,    76,    73,    77,
+      73,    73,    78,    73,    79,    73,    73,    80,    73,    81,
+      73,    73,    82,    73,    83,    73,    73,    84,    73,    73,
+      85,    73,    86,    73,    73,    73,    88,    87,    89,    87,
+      90,    90,    91,    93,    92,    94,    94,    95,    95,    95,
+      95,    96,    96,    96,    96,    97,    97,    98,   100,    99,
+     101,   101,   102,   102,   102,   103,   105,   104,   106,   106,
+     107,   107,   108,   108,   109,   109,   109,   109,   110,   110,
+     111,   111,   112,   112,   112,   112,   113,   113,   113,   113,
+     115,   114,   116,   114,   117,   117,   117,   117,   118,   118,
+     119,   121,   120,   122,   122,   122,   122,   122,   123,   123,
+     124,   124,   125,   125,   126,   126,   127,   127,   128,   128,
+     129,   129,   131,   130,   132,   130,   133,   133,   134,   134,
+     135,   135,   135,   135,   136,   136,   137,   137,   138,   139,
+     139,   140,   140,   141,   141,   142,   142,   143,   143,   143,
+     143,   143,   143,   143,   143,   143,   143,   143,   143,   143,
+     143,   143,   144,   144,   144,   144,   144,   144,   144,   144,
+     144,   144,   144,   144,   145,   145,   145,   146,   146,   146,
+     146,   147,   147,   148,   148,   149,   149,   149,   149,   149,
+     149,   150,   150,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_int8 yyr2[] =
 {
-       0,     2,     1,     1,     0,     3,     3,     3,     4,     0,
-       2,     3,     0,     0,     3,     0,     3,     1,     0,     3,
-       0,     3,     1,     0,     3,     0,     3,     1,     0,     3,
-       0,     3,     1,     0,     3,     0,     3,     1,     0,     3,
-       1,     0,     3,     0,     3,     1,     2,     0,     6,     0,
-       6,     2,     2,     1,     0,     6,     2,     0,     3,     3,
-       2,     1,     3,     3,     2,     1,     2,     2,     1,     0,
-       5,     2,     2,     4,     4,     1,     1,     0,     6,     2,
-       0,     1,     1,     1,     3,     2,     2,     1,     2,     1,
-       0,     2,     4,     1,     3,     2,     1,     2,     3,     2,
-       3,     0,     5,     0,     5,     4,     2,     3,     0,     2,
-       2,     1,     0,     6,     3,     1,     1,     1,     1,     2,
-       0,     3,     1,     1,     1,     6,     6,     9,     9,     2,
-       1,     2,     2,     0,     6,     0,     5,     2,     0,     3,
-       1,     1,     3,     1,     0,     1,     1,     1,     0,     2,
-       1,     3,     1,     0,     2,     0,     1,     1,     1,     1,
+       0,     2,     1,     1,     0,     3,     3,     4,     0,     2,
+       3,     0,     0,     3,     0,     3,     1,     0,     3,     0,
+       3,     1,     0,     3,     0,     3,     1,     0,     3,     0,
+       3,     1,     0,     3,     0,     3,     1,     0,     3,     1,
+       0,     3,     0,     3,     1,     2,     0,     6,     0,     6,
+       2,     2,     1,     0,     6,     2,     0,     3,     3,     2,
+       1,     3,     3,     2,     1,     2,     2,     1,     0,     5,
+       2,     2,     4,     4,     1,     1,     0,     6,     2,     0,
+       1,     1,     1,     3,     2,     2,     1,     2,     1,     0,
+       2,     4,     1,     3,     2,     1,     2,     3,     2,     3,
+       0,     5,     0,     5,     4,     2,     3,     0,     2,     2,
+       1,     0,     6,     3,     1,     1,     1,     1,     2,     0,
+       3,     1,     1,     1,     6,     6,     9,     9,     2,     1,
+       2,     2,     0,     6,     0,     5,     2,     0,     3,     1,
+       1,     3,     1,     0,     1,     1,     1,     0,     2,     1,
+       3,     1,     0,     2,     0,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     2,     2,     2,     2,     1,     1,
-       1,     1,     1,     2,     2,     2,     2,     1,     2,     2,
-       1,     2,     2,     1,     3,     1,     1,     1,     1,     1,
-       1,     1,     6,     5,     1,     1,     1,     1,     1,     1,
+       1,     1,     2,     2,     2,     2,     2,     1,     1,     1,
+       1,     1,     2,     2,     2,     2,     1,     2,     2,     1,
+       2,     2,     1,     3,     1,     1,     1,     1,     1,     1,
+       1,     6,     5,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1
 };
 
 
@@ -1837,51 +1834,42 @@ yyreduce:
   switch (yyn)
     {
   case 5: /* file_metadata: ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE  */
-#line 209 "src/Slice/Grammar.y"
+#line 208 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[-1];
 }
-#line 1845 "src/Slice/Grammar.cpp"
+#line 1842 "src/Slice/Grammar.cpp"
     break;
 
-  case 6: /* file_metadata: ICE_FILE_METADATA_IGNORE string_list ICE_FILE_METADATA_CLOSE  */
-#line 213 "src/Slice/Grammar.y"
-{
-    unit->error("file metadata must appear before any definitions");
-    yyval = yyvsp[-1]; // Dummy
-}
-#line 1854 "src/Slice/Grammar.cpp"
-    break;
-
-  case 7: /* local_metadata: ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 223 "src/Slice/Grammar.y"
+  case 6: /* local_metadata: ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
+#line 217 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[-1];
 }
-#line 1862 "src/Slice/Grammar.cpp"
+#line 1850 "src/Slice/Grammar.cpp"
     break;
 
-  case 8: /* local_metadata: local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 227 "src/Slice/Grammar.y"
+  case 7: /* local_metadata: local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
+#line 221 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata1 = StringListTokPtr::dynamicCast(yyvsp[-3]);
     StringListTokPtr metadata2 = StringListTokPtr::dynamicCast(yyvsp[-1]);
     metadata1->v.splice(metadata1->v.end(), metadata2->v);
     yyval = metadata1;
 }
-#line 1873 "src/Slice/Grammar.cpp"
+#line 1861 "src/Slice/Grammar.cpp"
     break;
 
-  case 9: /* local_metadata: %empty  */
-#line 234 "src/Slice/Grammar.y"
+  case 8: /* local_metadata: %empty  */
+#line 228 "src/Slice/Grammar.y"
 {
     yyval = new StringListTok;
 }
-#line 1881 "src/Slice/Grammar.cpp"
+#line 1869 "src/Slice/Grammar.cpp"
     break;
 
-  case 10: /* definitions: definitions file_metadata  */
-#line 243 "src/Slice/Grammar.y"
+  case 9: /* definitions: definitions file_metadata  */
+#line 237 "src/Slice/Grammar.y"
 {
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[0]);
     if(!metaData->v.empty())
@@ -1889,11 +1877,11 @@ yyreduce:
         unit->addFileMetaData(metaData->v);
     }
 }
-#line 1893 "src/Slice/Grammar.cpp"
+#line 1881 "src/Slice/Grammar.cpp"
     break;
 
-  case 11: /* definitions: definitions local_metadata definition  */
-#line 251 "src/Slice/Grammar.y"
+  case 10: /* definitions: definitions local_metadata definition  */
+#line 245 "src/Slice/Grammar.y"
 {
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-1]);
     ContainedPtr contained = ContainedPtr::dynamicCast(yyvsp[0]);
@@ -1902,179 +1890,179 @@ yyreduce:
         contained->setMetaData(metaData->v);
     }
 }
-#line 1906 "src/Slice/Grammar.cpp"
+#line 1894 "src/Slice/Grammar.cpp"
     break;
 
-  case 13: /* $@1: %empty  */
-#line 266 "src/Slice/Grammar.y"
+  case 12: /* $@1: %empty  */
+#line 260 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ModulePtr::dynamicCast(yyvsp[0]));
 }
-#line 1914 "src/Slice/Grammar.cpp"
+#line 1902 "src/Slice/Grammar.cpp"
     break;
 
-  case 15: /* $@2: %empty  */
-#line 271 "src/Slice/Grammar.y"
+  case 14: /* $@2: %empty  */
+#line 265 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1922 "src/Slice/Grammar.cpp"
+#line 1910 "src/Slice/Grammar.cpp"
     break;
 
-  case 17: /* definition: class_decl  */
-#line 276 "src/Slice/Grammar.y"
+  case 16: /* definition: class_decl  */
+#line 270 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after class forward declaration");
 }
-#line 1930 "src/Slice/Grammar.cpp"
+#line 1918 "src/Slice/Grammar.cpp"
     break;
 
-  case 18: /* $@3: %empty  */
-#line 280 "src/Slice/Grammar.y"
+  case 17: /* $@3: %empty  */
+#line 274 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1938 "src/Slice/Grammar.cpp"
+#line 1926 "src/Slice/Grammar.cpp"
     break;
 
-  case 20: /* $@4: %empty  */
-#line 285 "src/Slice/Grammar.y"
+  case 19: /* $@4: %empty  */
+#line 279 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1946 "src/Slice/Grammar.cpp"
+#line 1934 "src/Slice/Grammar.cpp"
     break;
 
-  case 22: /* definition: interface_decl  */
-#line 290 "src/Slice/Grammar.y"
+  case 21: /* definition: interface_decl  */
+#line 284 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after interface forward declaration");
 }
-#line 1954 "src/Slice/Grammar.cpp"
+#line 1942 "src/Slice/Grammar.cpp"
     break;
 
-  case 23: /* $@5: %empty  */
-#line 294 "src/Slice/Grammar.y"
+  case 22: /* $@5: %empty  */
+#line 288 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1962 "src/Slice/Grammar.cpp"
+#line 1950 "src/Slice/Grammar.cpp"
     break;
 
-  case 25: /* $@6: %empty  */
-#line 299 "src/Slice/Grammar.y"
+  case 24: /* $@6: %empty  */
+#line 293 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0);
 }
-#line 1970 "src/Slice/Grammar.cpp"
+#line 1958 "src/Slice/Grammar.cpp"
     break;
 
-  case 27: /* definition: exception_decl  */
-#line 304 "src/Slice/Grammar.y"
+  case 26: /* definition: exception_decl  */
+#line 298 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after exception forward declaration");
 }
-#line 1978 "src/Slice/Grammar.cpp"
+#line 1966 "src/Slice/Grammar.cpp"
     break;
 
-  case 28: /* $@7: %empty  */
-#line 308 "src/Slice/Grammar.y"
+  case 27: /* $@7: %empty  */
+#line 302 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ExceptionPtr::dynamicCast(yyvsp[0]));
 }
-#line 1986 "src/Slice/Grammar.cpp"
+#line 1974 "src/Slice/Grammar.cpp"
     break;
 
-  case 30: /* $@8: %empty  */
-#line 313 "src/Slice/Grammar.y"
+  case 29: /* $@8: %empty  */
+#line 307 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0);
 }
-#line 1994 "src/Slice/Grammar.cpp"
+#line 1982 "src/Slice/Grammar.cpp"
     break;
 
-  case 32: /* definition: struct_decl  */
-#line 318 "src/Slice/Grammar.y"
+  case 31: /* definition: struct_decl  */
+#line 312 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after struct forward declaration");
 }
-#line 2002 "src/Slice/Grammar.cpp"
+#line 1990 "src/Slice/Grammar.cpp"
     break;
 
-  case 33: /* $@9: %empty  */
-#line 322 "src/Slice/Grammar.y"
+  case 32: /* $@9: %empty  */
+#line 316 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || StructPtr::dynamicCast(yyvsp[0]));
 }
-#line 2010 "src/Slice/Grammar.cpp"
+#line 1998 "src/Slice/Grammar.cpp"
     break;
 
-  case 35: /* $@10: %empty  */
-#line 327 "src/Slice/Grammar.y"
+  case 34: /* $@10: %empty  */
+#line 321 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || SequencePtr::dynamicCast(yyvsp[0]));
 }
-#line 2018 "src/Slice/Grammar.cpp"
+#line 2006 "src/Slice/Grammar.cpp"
     break;
 
-  case 37: /* definition: sequence_def  */
-#line 332 "src/Slice/Grammar.y"
+  case 36: /* definition: sequence_def  */
+#line 326 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after sequence definition");
 }
-#line 2026 "src/Slice/Grammar.cpp"
+#line 2014 "src/Slice/Grammar.cpp"
     break;
 
-  case 38: /* $@11: %empty  */
-#line 336 "src/Slice/Grammar.y"
+  case 37: /* $@11: %empty  */
+#line 330 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || DictionaryPtr::dynamicCast(yyvsp[0]));
 }
-#line 2034 "src/Slice/Grammar.cpp"
+#line 2022 "src/Slice/Grammar.cpp"
     break;
 
-  case 40: /* definition: dictionary_def  */
-#line 341 "src/Slice/Grammar.y"
+  case 39: /* definition: dictionary_def  */
+#line 335 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after dictionary definition");
 }
-#line 2042 "src/Slice/Grammar.cpp"
+#line 2030 "src/Slice/Grammar.cpp"
     break;
 
-  case 41: /* $@12: %empty  */
-#line 345 "src/Slice/Grammar.y"
+  case 40: /* $@12: %empty  */
+#line 339 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || EnumPtr::dynamicCast(yyvsp[0]));
 }
-#line 2050 "src/Slice/Grammar.cpp"
+#line 2038 "src/Slice/Grammar.cpp"
     break;
 
-  case 43: /* $@13: %empty  */
-#line 350 "src/Slice/Grammar.y"
+  case 42: /* $@13: %empty  */
+#line 344 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ConstPtr::dynamicCast(yyvsp[0]));
 }
-#line 2058 "src/Slice/Grammar.cpp"
+#line 2046 "src/Slice/Grammar.cpp"
     break;
 
-  case 45: /* definition: const_def  */
-#line 355 "src/Slice/Grammar.y"
+  case 44: /* definition: const_def  */
+#line 349 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after const definition");
 }
-#line 2066 "src/Slice/Grammar.cpp"
+#line 2054 "src/Slice/Grammar.cpp"
     break;
 
-  case 46: /* definition: error ';'  */
-#line 359 "src/Slice/Grammar.y"
+  case 45: /* definition: error ';'  */
+#line 353 "src/Slice/Grammar.y"
 {
     yyerrok;
 }
-#line 2074 "src/Slice/Grammar.cpp"
+#line 2062 "src/Slice/Grammar.cpp"
     break;
 
-  case 47: /* @14: %empty  */
-#line 368 "src/Slice/Grammar.y"
+  case 46: /* @14: %empty  */
+#line 362 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2100,11 +2088,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2104 "src/Slice/Grammar.cpp"
+#line 2092 "src/Slice/Grammar.cpp"
     break;
 
-  case 48: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
-#line 394 "src/Slice/Grammar.y"
+  case 47: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
+#line 388 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2116,11 +2104,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2120 "src/Slice/Grammar.cpp"
+#line 2108 "src/Slice/Grammar.cpp"
     break;
 
-  case 49: /* @15: %empty  */
-#line 406 "src/Slice/Grammar.y"
+  case 48: /* @15: %empty  */
+#line 400 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2175,11 +2163,11 @@ yyreduce:
 
     yyval = parent;
 }
-#line 2179 "src/Slice/Grammar.cpp"
+#line 2167 "src/Slice/Grammar.cpp"
     break;
 
-  case 50: /* module_def: ICE_MODULE ICE_SCOPED_IDENTIFIER @15 '{' definitions '}'  */
-#line 461 "src/Slice/Grammar.y"
+  case 49: /* module_def: ICE_MODULE ICE_SCOPED_IDENTIFIER @15 '{' definitions '}'  */
+#line 455 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2197,38 +2185,38 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2201 "src/Slice/Grammar.cpp"
+#line 2189 "src/Slice/Grammar.cpp"
     break;
 
-  case 51: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
-#line 484 "src/Slice/Grammar.y"
+  case 50: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
+#line 478 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2209 "src/Slice/Grammar.cpp"
+#line 2197 "src/Slice/Grammar.cpp"
     break;
 
-  case 52: /* exception_id: ICE_EXCEPTION keyword  */
-#line 488 "src/Slice/Grammar.y"
+  case 51: /* exception_id: ICE_EXCEPTION keyword  */
+#line 482 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2219 "src/Slice/Grammar.cpp"
+#line 2207 "src/Slice/Grammar.cpp"
     break;
 
-  case 53: /* exception_decl: exception_id  */
-#line 499 "src/Slice/Grammar.y"
+  case 52: /* exception_decl: exception_id  */
+#line 493 "src/Slice/Grammar.y"
 {
     unit->error("exceptions cannot be forward declared");
     yyval = 0;
 }
-#line 2228 "src/Slice/Grammar.cpp"
+#line 2216 "src/Slice/Grammar.cpp"
     break;
 
-  case 54: /* @16: %empty  */
-#line 509 "src/Slice/Grammar.y"
+  case 53: /* @16: %empty  */
+#line 503 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ExceptionPtr base = ExceptionPtr::dynamicCast(yyvsp[0]);
@@ -2241,11 +2229,11 @@ yyreduce:
     }
     yyval = ex;
 }
-#line 2245 "src/Slice/Grammar.cpp"
+#line 2233 "src/Slice/Grammar.cpp"
     break;
 
-  case 55: /* exception_def: exception_id exception_extends @16 '{' data_members '}'  */
-#line 522 "src/Slice/Grammar.y"
+  case 54: /* exception_def: exception_id exception_extends @16 '{' data_members '}'  */
+#line 516 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2253,11 +2241,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 2257 "src/Slice/Grammar.cpp"
+#line 2245 "src/Slice/Grammar.cpp"
     break;
 
-  case 56: /* exception_extends: extends scoped_name  */
-#line 535 "src/Slice/Grammar.y"
+  case 55: /* exception_extends: extends scoped_name  */
+#line 529 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2265,19 +2253,19 @@ yyreduce:
     cont->checkIntroduced(scoped->v);
     yyval = contained;
 }
-#line 2269 "src/Slice/Grammar.cpp"
+#line 2257 "src/Slice/Grammar.cpp"
     break;
 
-  case 57: /* exception_extends: %empty  */
-#line 543 "src/Slice/Grammar.y"
+  case 56: /* exception_extends: %empty  */
+#line 537 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2277 "src/Slice/Grammar.cpp"
+#line 2265 "src/Slice/Grammar.cpp"
     break;
 
-  case 58: /* tag: ICE_TAG_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 552 "src/Slice/Grammar.y"
+  case 57: /* tag: ICE_TAG_OPEN ICE_INTEGER_LITERAL ')'  */
+#line 546 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2295,11 +2283,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2299 "src/Slice/Grammar.cpp"
+#line 2287 "src/Slice/Grammar.cpp"
     break;
 
-  case 59: /* tag: ICE_TAG_OPEN scoped_name ')'  */
-#line 570 "src/Slice/Grammar.y"
+  case 58: /* tag: ICE_TAG_OPEN scoped_name ')'  */
+#line 564 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2373,31 +2361,31 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2377 "src/Slice/Grammar.cpp"
+#line 2365 "src/Slice/Grammar.cpp"
     break;
 
-  case 60: /* tag: ICE_TAG_OPEN ')'  */
+  case 59: /* tag: ICE_TAG_OPEN ')'  */
+#line 638 "src/Slice/Grammar.y"
+{
+    unit->error("missing tag");
+    TaggedDefTokPtr m = new TaggedDefTok; // Dummy
+    yyval = m;
+}
+#line 2375 "src/Slice/Grammar.cpp"
+    break;
+
+  case 60: /* tag: ICE_TAG  */
 #line 644 "src/Slice/Grammar.y"
 {
     unit->error("missing tag");
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2387 "src/Slice/Grammar.cpp"
+#line 2385 "src/Slice/Grammar.cpp"
     break;
 
-  case 61: /* tag: ICE_TAG  */
-#line 650 "src/Slice/Grammar.y"
-{
-    unit->error("missing tag");
-    TaggedDefTokPtr m = new TaggedDefTok; // Dummy
-    yyval = m;
-}
-#line 2397 "src/Slice/Grammar.cpp"
-    break;
-
-  case 62: /* optional: ICE_OPTIONAL_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 661 "src/Slice/Grammar.y"
+  case 61: /* optional: ICE_OPTIONAL_OPEN ICE_INTEGER_LITERAL ')'  */
+#line 655 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2419,11 +2407,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2423 "src/Slice/Grammar.cpp"
+#line 2411 "src/Slice/Grammar.cpp"
     break;
 
-  case 63: /* optional: ICE_OPTIONAL_OPEN scoped_name ')'  */
-#line 683 "src/Slice/Grammar.y"
+  case 62: /* optional: ICE_OPTIONAL_OPEN scoped_name ')'  */
+#line 677 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2501,11 +2489,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2505 "src/Slice/Grammar.cpp"
+#line 2493 "src/Slice/Grammar.cpp"
     break;
 
-  case 64: /* optional: ICE_OPTIONAL_OPEN ')'  */
-#line 761 "src/Slice/Grammar.y"
+  case 63: /* optional: ICE_OPTIONAL_OPEN ')'  */
+#line 755 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -2515,11 +2503,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2519 "src/Slice/Grammar.cpp"
+#line 2507 "src/Slice/Grammar.cpp"
     break;
 
-  case 65: /* optional: ICE_OPTIONAL  */
-#line 771 "src/Slice/Grammar.y"
+  case 64: /* optional: ICE_OPTIONAL  */
+#line 765 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -2529,38 +2517,38 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2533 "src/Slice/Grammar.cpp"
+#line 2521 "src/Slice/Grammar.cpp"
     break;
 
-  case 66: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
-#line 786 "src/Slice/Grammar.y"
+  case 65: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
+#line 780 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2541 "src/Slice/Grammar.cpp"
+#line 2529 "src/Slice/Grammar.cpp"
     break;
 
-  case 67: /* struct_id: ICE_STRUCT keyword  */
-#line 790 "src/Slice/Grammar.y"
+  case 66: /* struct_id: ICE_STRUCT keyword  */
+#line 784 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as struct name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2551 "src/Slice/Grammar.cpp"
+#line 2539 "src/Slice/Grammar.cpp"
     break;
 
-  case 68: /* struct_decl: struct_id  */
-#line 801 "src/Slice/Grammar.y"
+  case 67: /* struct_decl: struct_id  */
+#line 795 "src/Slice/Grammar.y"
 {
     unit->error("structs cannot be forward declared");
     yyval = 0; // Dummy
 }
-#line 2560 "src/Slice/Grammar.cpp"
+#line 2548 "src/Slice/Grammar.cpp"
     break;
 
-  case 69: /* @17: %empty  */
-#line 811 "src/Slice/Grammar.y"
+  case 68: /* @17: %empty  */
+#line 805 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -2578,11 +2566,11 @@ yyreduce:
     }
     yyval = st;
 }
-#line 2582 "src/Slice/Grammar.cpp"
+#line 2570 "src/Slice/Grammar.cpp"
     break;
 
-  case 70: /* struct_def: struct_id @17 '{' data_members '}'  */
-#line 829 "src/Slice/Grammar.y"
+  case 69: /* struct_def: struct_id @17 '{' data_members '}'  */
+#line 823 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2600,29 +2588,29 @@ yyreduce:
         unit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
     }
 }
-#line 2604 "src/Slice/Grammar.cpp"
+#line 2592 "src/Slice/Grammar.cpp"
     break;
 
-  case 71: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
-#line 852 "src/Slice/Grammar.y"
+  case 70: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
+#line 846 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2612 "src/Slice/Grammar.cpp"
+#line 2600 "src/Slice/Grammar.cpp"
     break;
 
-  case 72: /* class_name: ICE_CLASS keyword  */
-#line 856 "src/Slice/Grammar.y"
+  case 71: /* class_name: ICE_CLASS keyword  */
+#line 850 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as class name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2622 "src/Slice/Grammar.cpp"
+#line 2610 "src/Slice/Grammar.cpp"
     break;
 
-  case 73: /* class_id: ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 867 "src/Slice/Grammar.y"
+  case 72: /* class_id: ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'  */
+#line 861 "src/Slice/Grammar.y"
 {
     IceUtil::Int64 id = IntegerTokPtr::dynamicCast(yyvsp[-1])->v;
     if(id < 0)
@@ -2647,11 +2635,11 @@ yyreduce:
     classId->t = static_cast<int>(id);
     yyval = classId;
 }
-#line 2651 "src/Slice/Grammar.cpp"
+#line 2639 "src/Slice/Grammar.cpp"
     break;
 
-  case 74: /* class_id: ICE_CLASS ICE_IDENT_OPEN scoped_name ')'  */
-#line 892 "src/Slice/Grammar.y"
+  case 73: /* class_id: ICE_CLASS ICE_IDENT_OPEN scoped_name ')'  */
+#line 886 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2741,33 +2729,33 @@ yyreduce:
     yyval = classId;
 
 }
-#line 2745 "src/Slice/Grammar.cpp"
+#line 2733 "src/Slice/Grammar.cpp"
     break;
 
-  case 75: /* class_id: class_name  */
-#line 982 "src/Slice/Grammar.y"
+  case 74: /* class_id: class_name  */
+#line 976 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr classId = new ClassIdTok();
     classId->v = StringTokPtr::dynamicCast(yyvsp[0])->v;
     classId->t = -1;
     yyval = classId;
 }
-#line 2756 "src/Slice/Grammar.cpp"
+#line 2744 "src/Slice/Grammar.cpp"
     break;
 
-  case 76: /* class_decl: class_name  */
-#line 994 "src/Slice/Grammar.y"
+  case 75: /* class_decl: class_name  */
+#line 988 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
     ClassDeclPtr cl = cont->createClassDecl(ident->v);
     yyval = cl;
 }
-#line 2767 "src/Slice/Grammar.cpp"
+#line 2755 "src/Slice/Grammar.cpp"
     break;
 
-  case 77: /* @18: %empty  */
-#line 1006 "src/Slice/Grammar.y"
+  case 76: /* @18: %empty  */
+#line 1000 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr ident = ClassIdTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -2784,11 +2772,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2788 "src/Slice/Grammar.cpp"
+#line 2776 "src/Slice/Grammar.cpp"
     break;
 
-  case 78: /* class_def: class_id class_extends @18 '{' data_members '}'  */
-#line 1023 "src/Slice/Grammar.y"
+  case 77: /* class_def: class_id class_extends @18 '{' data_members '}'  */
+#line 1017 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2800,11 +2788,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2804 "src/Slice/Grammar.cpp"
+#line 2792 "src/Slice/Grammar.cpp"
     break;
 
-  case 79: /* class_extends: extends scoped_name  */
-#line 1040 "src/Slice/Grammar.y"
+  case 78: /* class_extends: extends scoped_name  */
+#line 1034 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2838,19 +2826,19 @@ yyreduce:
         }
     }
 }
-#line 2842 "src/Slice/Grammar.cpp"
+#line 2830 "src/Slice/Grammar.cpp"
     break;
 
-  case 80: /* class_extends: %empty  */
-#line 1074 "src/Slice/Grammar.y"
+  case 79: /* class_extends: %empty  */
+#line 1068 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2850 "src/Slice/Grammar.cpp"
+#line 2838 "src/Slice/Grammar.cpp"
     break;
 
-  case 83: /* data_member: member  */
-#line 1090 "src/Slice/Grammar.y"
+  case 82: /* data_member: member  */
+#line 1084 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2865,11 +2853,11 @@ yyreduce:
         }
     }
 }
-#line 2869 "src/Slice/Grammar.cpp"
+#line 2857 "src/Slice/Grammar.cpp"
     break;
 
-  case 84: /* data_member: member '=' const_initializer  */
-#line 1105 "src/Slice/Grammar.y"
+  case 83: /* data_member: member '=' const_initializer  */
+#line 1099 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-2]);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast(yyvsp[0]);
@@ -2886,19 +2874,19 @@ yyreduce:
         }
     }
 }
-#line 2890 "src/Slice/Grammar.cpp"
+#line 2878 "src/Slice/Grammar.cpp"
     break;
 
-  case 87: /* data_member_list: data_member  */
-#line 1129 "src/Slice/Grammar.y"
+  case 86: /* data_member_list: data_member  */
+#line 1123 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 2898 "src/Slice/Grammar.cpp"
+#line 2886 "src/Slice/Grammar.cpp"
     break;
 
-  case 91: /* return_tuple: out_qualifier member  */
-#line 1146 "src/Slice/Grammar.y"
+  case 90: /* return_tuple: out_qualifier member  */
+#line 1140 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2910,11 +2898,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2914 "src/Slice/Grammar.cpp"
+#line 2902 "src/Slice/Grammar.cpp"
     break;
 
-  case 92: /* return_tuple: return_tuple ',' out_qualifier member  */
-#line 1158 "src/Slice/Grammar.y"
+  case 91: /* return_tuple: return_tuple ',' out_qualifier member  */
+#line 1152 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2926,11 +2914,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2930 "src/Slice/Grammar.cpp"
+#line 2918 "src/Slice/Grammar.cpp"
     break;
 
-  case 93: /* return_type: tagged_type  */
-#line 1174 "src/Slice/Grammar.y"
+  case 92: /* return_type: tagged_type  */
+#line 1168 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     // For unnamed return types we infer their name to be 'returnValue'.
@@ -2945,11 +2933,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2949 "src/Slice/Grammar.cpp"
+#line 2937 "src/Slice/Grammar.cpp"
     break;
 
-  case 94: /* return_type: '(' return_tuple ')'  */
-#line 1189 "src/Slice/Grammar.y"
+  case 93: /* return_type: '(' return_tuple ')'  */
+#line 1183 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     if (returnMembers->v.size() == 1)
@@ -2958,28 +2946,28 @@ yyreduce:
     }
     yyval = yyvsp[-1];
 }
-#line 2962 "src/Slice/Grammar.cpp"
+#line 2950 "src/Slice/Grammar.cpp"
     break;
 
-  case 95: /* return_type: '(' ')'  */
-#line 1198 "src/Slice/Grammar.y"
+  case 94: /* return_type: '(' ')'  */
+#line 1192 "src/Slice/Grammar.y"
 {
     unit->error("return tuples must contain at least 2 elements");
     yyval = new TaggedDefListTok();
 }
-#line 2971 "src/Slice/Grammar.cpp"
+#line 2959 "src/Slice/Grammar.cpp"
     break;
 
-  case 96: /* return_type: ICE_VOID  */
-#line 1203 "src/Slice/Grammar.y"
+  case 95: /* return_type: ICE_VOID  */
+#line 1197 "src/Slice/Grammar.y"
 {
     yyval = new TaggedDefListTok();
 }
-#line 2979 "src/Slice/Grammar.cpp"
+#line 2967 "src/Slice/Grammar.cpp"
     break;
 
-  case 97: /* operation_preamble: return_type ICE_IDENT_OPEN  */
-#line 1212 "src/Slice/Grammar.y"
+  case 96: /* operation_preamble: return_type ICE_IDENT_OPEN  */
+#line 1206 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     string name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -3014,11 +3002,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3018 "src/Slice/Grammar.cpp"
+#line 3006 "src/Slice/Grammar.cpp"
     break;
 
-  case 98: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_IDENT_OPEN  */
-#line 1247 "src/Slice/Grammar.y"
+  case 97: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_IDENT_OPEN  */
+#line 1241 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     string name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -3053,11 +3041,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3057 "src/Slice/Grammar.cpp"
+#line 3045 "src/Slice/Grammar.cpp"
     break;
 
-  case 99: /* operation_preamble: return_type ICE_KEYWORD_OPEN  */
-#line 1282 "src/Slice/Grammar.y"
+  case 98: /* operation_preamble: return_type ICE_KEYWORD_OPEN  */
+#line 1276 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     string name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -3091,11 +3079,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3095 "src/Slice/Grammar.cpp"
+#line 3083 "src/Slice/Grammar.cpp"
     break;
 
-  case 100: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_KEYWORD_OPEN  */
-#line 1316 "src/Slice/Grammar.y"
+  case 99: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_KEYWORD_OPEN  */
+#line 1310 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     string name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -3129,11 +3117,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3133 "src/Slice/Grammar.cpp"
+#line 3121 "src/Slice/Grammar.cpp"
     break;
 
-  case 101: /* @19: %empty  */
-#line 1355 "src/Slice/Grammar.y"
+  case 100: /* @19: %empty  */
+#line 1349 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3145,11 +3133,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3149 "src/Slice/Grammar.cpp"
+#line 3137 "src/Slice/Grammar.cpp"
     break;
 
-  case 102: /* operation: operation_preamble parameters ')' @19 throws  */
-#line 1367 "src/Slice/Grammar.y"
+  case 101: /* operation: operation_preamble parameters ')' @19 throws  */
+#line 1361 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3159,11 +3147,11 @@ yyreduce:
         op->setExceptionList(el->v);
     }
 }
-#line 3163 "src/Slice/Grammar.cpp"
+#line 3151 "src/Slice/Grammar.cpp"
     break;
 
-  case 103: /* @20: %empty  */
-#line 1377 "src/Slice/Grammar.y"
+  case 102: /* @20: %empty  */
+#line 1371 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3171,11 +3159,11 @@ yyreduce:
     }
     yyerrok;
 }
-#line 3175 "src/Slice/Grammar.cpp"
+#line 3163 "src/Slice/Grammar.cpp"
     break;
 
-  case 104: /* operation: operation_preamble error ')' @20 throws  */
-#line 1385 "src/Slice/Grammar.y"
+  case 103: /* operation: operation_preamble error ')' @20 throws  */
+#line 1379 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3185,11 +3173,11 @@ yyreduce:
         op->setExceptionList(el->v); // Dummy
     }
 }
-#line 3189 "src/Slice/Grammar.cpp"
+#line 3177 "src/Slice/Grammar.cpp"
     break;
 
-  case 105: /* operation_list: local_metadata operation ';' operation_list  */
-#line 1400 "src/Slice/Grammar.y"
+  case 104: /* operation_list: local_metadata operation ';' operation_list  */
+#line 1394 "src/Slice/Grammar.y"
 {
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
     OperationPtr operation = OperationPtr::dynamicCast(yyvsp[-2]);
@@ -3207,37 +3195,37 @@ yyreduce:
         }
     }
 }
-#line 3211 "src/Slice/Grammar.cpp"
+#line 3199 "src/Slice/Grammar.cpp"
     break;
 
-  case 106: /* operation_list: local_metadata operation  */
-#line 1418 "src/Slice/Grammar.y"
+  case 105: /* operation_list: local_metadata operation  */
+#line 1412 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 3219 "src/Slice/Grammar.cpp"
+#line 3207 "src/Slice/Grammar.cpp"
     break;
 
-  case 109: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
-#line 1429 "src/Slice/Grammar.y"
+  case 108: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
+#line 1423 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3227 "src/Slice/Grammar.cpp"
+#line 3215 "src/Slice/Grammar.cpp"
     break;
 
-  case 110: /* interface_id: ICE_INTERFACE keyword  */
-#line 1433 "src/Slice/Grammar.y"
+  case 109: /* interface_id: ICE_INTERFACE keyword  */
+#line 1427 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as interface name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 3237 "src/Slice/Grammar.cpp"
+#line 3225 "src/Slice/Grammar.cpp"
     break;
 
-  case 111: /* interface_decl: interface_id  */
-#line 1444 "src/Slice/Grammar.y"
+  case 110: /* interface_decl: interface_id  */
+#line 1438 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -3245,11 +3233,11 @@ yyreduce:
     cont->checkIntroduced(ident->v, cl);
     yyval = cl;
 }
-#line 3249 "src/Slice/Grammar.cpp"
+#line 3237 "src/Slice/Grammar.cpp"
     break;
 
-  case 112: /* @21: %empty  */
-#line 1457 "src/Slice/Grammar.y"
+  case 111: /* @21: %empty  */
+#line 1451 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -3266,11 +3254,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3270 "src/Slice/Grammar.cpp"
+#line 3258 "src/Slice/Grammar.cpp"
     break;
 
-  case 113: /* interface_def: interface_id interface_extends @21 '{' operation_list '}'  */
-#line 1474 "src/Slice/Grammar.y"
+  case 112: /* interface_def: interface_id interface_extends @21 '{' operation_list '}'  */
+#line 1468 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -3282,11 +3270,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3286 "src/Slice/Grammar.cpp"
+#line 3274 "src/Slice/Grammar.cpp"
     break;
 
-  case 114: /* interface_list: scoped_name ',' interface_list  */
-#line 1491 "src/Slice/Grammar.y"
+  case 113: /* interface_list: scoped_name ',' interface_list  */
+#line 1485 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = InterfaceListTokPtr::dynamicCast(yyvsp[0]);
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-2]);
@@ -3321,11 +3309,11 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3325 "src/Slice/Grammar.cpp"
+#line 3313 "src/Slice/Grammar.cpp"
     break;
 
-  case 115: /* interface_list: scoped_name  */
-#line 1526 "src/Slice/Grammar.y"
+  case 114: /* interface_list: scoped_name  */
+#line 1520 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = new InterfaceListTok;
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3360,29 +3348,29 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3364 "src/Slice/Grammar.cpp"
+#line 3352 "src/Slice/Grammar.cpp"
     break;
 
-  case 116: /* interface_list: ICE_OBJECT  */
-#line 1561 "src/Slice/Grammar.y"
+  case 115: /* interface_list: ICE_OBJECT  */
+#line 1555 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type Object");
     yyval = new InterfaceListTok; // Dummy
 }
-#line 3373 "src/Slice/Grammar.cpp"
+#line 3361 "src/Slice/Grammar.cpp"
     break;
 
-  case 117: /* interface_list: ICE_ANYCLASS  */
-#line 1566 "src/Slice/Grammar.y"
+  case 116: /* interface_list: ICE_ANYCLASS  */
+#line 1560 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type AnyClass");
     yyval = new ClassListTok; // Dummy
 }
-#line 3382 "src/Slice/Grammar.cpp"
+#line 3370 "src/Slice/Grammar.cpp"
     break;
 
-  case 118: /* interface_list: ICE_VALUE  */
-#line 1571 "src/Slice/Grammar.y"
+  case 117: /* interface_list: ICE_VALUE  */
+#line 1565 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3391,49 +3379,49 @@ yyreduce:
     unit->error("illegal inheritance from type Value");
     yyval = new ClassListTok; // Dummy
 }
-#line 3395 "src/Slice/Grammar.cpp"
+#line 3383 "src/Slice/Grammar.cpp"
     break;
 
-  case 119: /* interface_extends: extends interface_list  */
-#line 1585 "src/Slice/Grammar.y"
+  case 118: /* interface_extends: extends interface_list  */
+#line 1579 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3403 "src/Slice/Grammar.cpp"
+#line 3391 "src/Slice/Grammar.cpp"
     break;
 
-  case 120: /* interface_extends: %empty  */
-#line 1589 "src/Slice/Grammar.y"
+  case 119: /* interface_extends: %empty  */
+#line 1583 "src/Slice/Grammar.y"
 {
     yyval = new InterfaceListTok;
 }
-#line 3411 "src/Slice/Grammar.cpp"
+#line 3399 "src/Slice/Grammar.cpp"
     break;
 
-  case 121: /* exception_list: exception ',' exception_list  */
-#line 1598 "src/Slice/Grammar.y"
+  case 120: /* exception_list: exception ',' exception_list  */
+#line 1592 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[-2]);
     ExceptionListTokPtr exceptionList = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3422 "src/Slice/Grammar.cpp"
+#line 3410 "src/Slice/Grammar.cpp"
     break;
 
-  case 122: /* exception_list: exception  */
-#line 1605 "src/Slice/Grammar.y"
+  case 121: /* exception_list: exception  */
+#line 1599 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[0]);
     ExceptionListTokPtr exceptionList = new ExceptionListTok;
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3433 "src/Slice/Grammar.cpp"
+#line 3421 "src/Slice/Grammar.cpp"
     break;
 
-  case 123: /* exception: scoped_name  */
-#line 1617 "src/Slice/Grammar.y"
+  case 122: /* exception: scoped_name  */
+#line 1611 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -3445,21 +3433,21 @@ yyreduce:
     cont->checkIntroduced(scoped->v, exception);
     yyval = exception;
 }
-#line 3449 "src/Slice/Grammar.cpp"
+#line 3437 "src/Slice/Grammar.cpp"
     break;
 
-  case 124: /* exception: keyword  */
-#line 1629 "src/Slice/Grammar.y"
+  case 123: /* exception: keyword  */
+#line 1623 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = unit->currentModule()->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
 }
-#line 3459 "src/Slice/Grammar.cpp"
+#line 3447 "src/Slice/Grammar.cpp"
     break;
 
-  case 125: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1640 "src/Slice/Grammar.y"
+  case 124: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' ICE_IDENTIFIER  */
+#line 1634 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3467,11 +3455,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createSequence(ident->v, type, metaData->v);
 }
-#line 3471 "src/Slice/Grammar.cpp"
+#line 3459 "src/Slice/Grammar.cpp"
     break;
 
-  case 126: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' keyword  */
-#line 1648 "src/Slice/Grammar.y"
+  case 125: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' keyword  */
+#line 1642 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3480,11 +3468,11 @@ yyreduce:
     yyval = cont->createSequence(ident->v, type, metaData->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
-#line 3484 "src/Slice/Grammar.cpp"
+#line 3472 "src/Slice/Grammar.cpp"
     break;
 
-  case 127: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1662 "src/Slice/Grammar.y"
+  case 126: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' ICE_IDENTIFIER  */
+#line 1656 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3494,11 +3482,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v);
 }
-#line 3498 "src/Slice/Grammar.cpp"
+#line 3486 "src/Slice/Grammar.cpp"
     break;
 
-  case 128: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' keyword  */
-#line 1672 "src/Slice/Grammar.y"
+  case 127: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' keyword  */
+#line 1666 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3509,27 +3497,27 @@ yyreduce:
     yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
-#line 3513 "src/Slice/Grammar.cpp"
+#line 3501 "src/Slice/Grammar.cpp"
     break;
 
-  case 129: /* enum_start: ICE_UNCHECKED ICE_ENUM  */
-#line 1688 "src/Slice/Grammar.y"
+  case 128: /* enum_start: ICE_UNCHECKED ICE_ENUM  */
+#line 1682 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3521 "src/Slice/Grammar.cpp"
+#line 3509 "src/Slice/Grammar.cpp"
     break;
 
-  case 130: /* enum_start: ICE_ENUM  */
-#line 1692 "src/Slice/Grammar.y"
+  case 129: /* enum_start: ICE_ENUM  */
+#line 1686 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3529 "src/Slice/Grammar.cpp"
+#line 3517 "src/Slice/Grammar.cpp"
     break;
 
-  case 131: /* enum_id: enum_start ICE_IDENTIFIER  */
-#line 1701 "src/Slice/Grammar.y"
+  case 130: /* enum_id: enum_start ICE_IDENTIFIER  */
+#line 1695 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3545,11 +3533,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3549 "src/Slice/Grammar.cpp"
+#line 3537 "src/Slice/Grammar.cpp"
     break;
 
-  case 132: /* enum_id: enum_start keyword  */
-#line 1717 "src/Slice/Grammar.y"
+  case 131: /* enum_id: enum_start keyword  */
+#line 1711 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3557,22 +3545,22 @@ yyreduce:
     unit->error("keyword `" + ident->v + "' cannot be used as enumeration name");
     yyval = cont->createEnum(IceUtil::generateUUID(), unchecked, Dummy);
 }
-#line 3561 "src/Slice/Grammar.cpp"
+#line 3549 "src/Slice/Grammar.cpp"
     break;
 
-  case 133: /* @22: %empty  */
-#line 1730 "src/Slice/Grammar.y"
+  case 132: /* @22: %empty  */
+#line 1724 "src/Slice/Grammar.y"
 {
     EnumPtr en = EnumPtr::dynamicCast(yyvsp[-1]);
     en->initUnderlying(TypePtr::dynamicCast(yyvsp[0]));
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3572 "src/Slice/Grammar.cpp"
+#line 3560 "src/Slice/Grammar.cpp"
     break;
 
-  case 134: /* enum_def: enum_id enum_underlying @22 '{' enumerator_list '}'  */
-#line 1737 "src/Slice/Grammar.y"
+  case 133: /* enum_def: enum_id enum_underlying @22 '{' enumerator_list '}'  */
+#line 1731 "src/Slice/Grammar.y"
 {
     EnumPtr en = EnumPtr::dynamicCast(yyvsp[-3]);
     if(en)
@@ -3586,11 +3574,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 3590 "src/Slice/Grammar.cpp"
+#line 3578 "src/Slice/Grammar.cpp"
     break;
 
-  case 135: /* @23: %empty  */
-#line 1752 "src/Slice/Grammar.y"
+  case 134: /* @23: %empty  */
+#line 1746 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[0])->v;
     unit->error("missing enumeration name");
@@ -3599,46 +3587,46 @@ yyreduce:
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3603 "src/Slice/Grammar.cpp"
+#line 3591 "src/Slice/Grammar.cpp"
     break;
 
-  case 136: /* enum_def: enum_start @23 '{' enumerator_list '}'  */
-#line 1761 "src/Slice/Grammar.y"
+  case 135: /* enum_def: enum_start @23 '{' enumerator_list '}'  */
+#line 1755 "src/Slice/Grammar.y"
 {
     unit->popContainer();
     yyval = yyvsp[-4];
 }
-#line 3612 "src/Slice/Grammar.cpp"
+#line 3600 "src/Slice/Grammar.cpp"
     break;
 
-  case 137: /* enum_underlying: ':' type  */
-#line 1771 "src/Slice/Grammar.y"
+  case 136: /* enum_underlying: ':' type  */
+#line 1765 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3620 "src/Slice/Grammar.cpp"
+#line 3608 "src/Slice/Grammar.cpp"
     break;
 
-  case 138: /* enum_underlying: %empty  */
-#line 1775 "src/Slice/Grammar.y"
+  case 137: /* enum_underlying: %empty  */
+#line 1769 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 3628 "src/Slice/Grammar.cpp"
+#line 3616 "src/Slice/Grammar.cpp"
     break;
 
-  case 139: /* enumerator_list: enumerator ',' enumerator_list  */
-#line 1784 "src/Slice/Grammar.y"
+  case 138: /* enumerator_list: enumerator ',' enumerator_list  */
+#line 1778 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr ens = EnumeratorListTokPtr::dynamicCast(yyvsp[-2]);
     ens->v.splice(ens->v.end(), EnumeratorListTokPtr::dynamicCast(yyvsp[0])->v);
     yyval = ens;
 }
-#line 3638 "src/Slice/Grammar.cpp"
+#line 3626 "src/Slice/Grammar.cpp"
     break;
 
-  case 141: /* enumerator: ICE_IDENTIFIER  */
-#line 1796 "src/Slice/Grammar.y"
+  case 140: /* enumerator: ICE_IDENTIFIER  */
+#line 1790 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     EnumeratorListTokPtr ens = new EnumeratorListTok;
@@ -3650,11 +3638,11 @@ yyreduce:
     }
     yyval = ens;
 }
-#line 3654 "src/Slice/Grammar.cpp"
+#line 3642 "src/Slice/Grammar.cpp"
     break;
 
-  case 142: /* enumerator: ICE_IDENTIFIER '=' enumerator_initializer  */
-#line 1808 "src/Slice/Grammar.y"
+  case 141: /* enumerator: ICE_IDENTIFIER '=' enumerator_initializer  */
+#line 1802 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-2]);
     EnumeratorListTokPtr ens = new EnumeratorListTok;
@@ -3667,39 +3655,39 @@ yyreduce:
     }
     yyval = ens;
 }
-#line 3671 "src/Slice/Grammar.cpp"
+#line 3659 "src/Slice/Grammar.cpp"
     break;
 
-  case 143: /* enumerator: keyword  */
-#line 1821 "src/Slice/Grammar.y"
+  case 142: /* enumerator: keyword  */
+#line 1815 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as enumerator");
     EnumeratorListTokPtr ens = new EnumeratorListTok; // Dummy
     yyval = ens;
 }
-#line 3682 "src/Slice/Grammar.cpp"
+#line 3670 "src/Slice/Grammar.cpp"
     break;
 
-  case 144: /* enumerator: %empty  */
-#line 1828 "src/Slice/Grammar.y"
+  case 143: /* enumerator: %empty  */
+#line 1822 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr ens = new EnumeratorListTok;
     yyval = ens; // Dummy
 }
-#line 3691 "src/Slice/Grammar.cpp"
+#line 3679 "src/Slice/Grammar.cpp"
     break;
 
-  case 145: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
-#line 1838 "src/Slice/Grammar.y"
+  case 144: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
+#line 1832 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3699 "src/Slice/Grammar.cpp"
+#line 3687 "src/Slice/Grammar.cpp"
     break;
 
-  case 146: /* enumerator_initializer: scoped_name  */
-#line 1842 "src/Slice/Grammar.y"
+  case 145: /* enumerator_initializer: scoped_name  */
+#line 1836 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainedList cl = unit->currentContainer()->lookupContained(scoped->v);
@@ -3732,27 +3720,27 @@ yyreduce:
 
     yyval = tok;
 }
-#line 3736 "src/Slice/Grammar.cpp"
+#line 3724 "src/Slice/Grammar.cpp"
     break;
 
-  case 147: /* out_qualifier: ICE_OUT  */
-#line 1880 "src/Slice/Grammar.y"
+  case 146: /* out_qualifier: ICE_OUT  */
+#line 1874 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3744 "src/Slice/Grammar.cpp"
+#line 3732 "src/Slice/Grammar.cpp"
     break;
 
-  case 148: /* out_qualifier: %empty  */
-#line 1884 "src/Slice/Grammar.y"
+  case 147: /* out_qualifier: %empty  */
+#line 1878 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3752 "src/Slice/Grammar.cpp"
+#line 3740 "src/Slice/Grammar.cpp"
     break;
 
-  case 149: /* parameter: out_qualifier member  */
-#line 1893 "src/Slice/Grammar.y"
+  case 148: /* parameter: out_qualifier member  */
+#line 1887 "src/Slice/Grammar.y"
 {
     BoolTokPtr isOutParam = BoolTokPtr::dynamicCast(yyvsp[-1]);
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
@@ -3767,141 +3755,141 @@ yyreduce:
         }
     }
 }
-#line 3771 "src/Slice/Grammar.cpp"
+#line 3759 "src/Slice/Grammar.cpp"
     break;
 
-  case 154: /* throws: ICE_THROWS exception_list  */
-#line 1926 "src/Slice/Grammar.y"
+  case 153: /* throws: ICE_THROWS exception_list  */
+#line 1920 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3779 "src/Slice/Grammar.cpp"
+#line 3767 "src/Slice/Grammar.cpp"
     break;
 
-  case 155: /* throws: %empty  */
-#line 1930 "src/Slice/Grammar.y"
+  case 154: /* throws: %empty  */
+#line 1924 "src/Slice/Grammar.y"
 {
     yyval = new ExceptionListTok;
 }
+#line 3775 "src/Slice/Grammar.cpp"
+    break;
+
+  case 157: /* builtin: ICE_BOOL  */
+#line 1939 "src/Slice/Grammar.y"
+           {}
+#line 3781 "src/Slice/Grammar.cpp"
+    break;
+
+  case 158: /* builtin: ICE_BYTE  */
+#line 1940 "src/Slice/Grammar.y"
+           {}
 #line 3787 "src/Slice/Grammar.cpp"
     break;
 
-  case 158: /* builtin: ICE_BOOL  */
-#line 1945 "src/Slice/Grammar.y"
-           {}
+  case 159: /* builtin: ICE_SHORT  */
+#line 1941 "src/Slice/Grammar.y"
+            {}
 #line 3793 "src/Slice/Grammar.cpp"
     break;
 
-  case 159: /* builtin: ICE_BYTE  */
-#line 1946 "src/Slice/Grammar.y"
-           {}
+  case 160: /* builtin: ICE_USHORT  */
+#line 1942 "src/Slice/Grammar.y"
+             {}
 #line 3799 "src/Slice/Grammar.cpp"
     break;
 
-  case 160: /* builtin: ICE_SHORT  */
-#line 1947 "src/Slice/Grammar.y"
-            {}
+  case 161: /* builtin: ICE_INT  */
+#line 1943 "src/Slice/Grammar.y"
+          {}
 #line 3805 "src/Slice/Grammar.cpp"
     break;
 
-  case 161: /* builtin: ICE_USHORT  */
-#line 1948 "src/Slice/Grammar.y"
-             {}
+  case 162: /* builtin: ICE_UINT  */
+#line 1944 "src/Slice/Grammar.y"
+           {}
 #line 3811 "src/Slice/Grammar.cpp"
     break;
 
-  case 162: /* builtin: ICE_INT  */
-#line 1949 "src/Slice/Grammar.y"
-          {}
+  case 163: /* builtin: ICE_VARINT  */
+#line 1945 "src/Slice/Grammar.y"
+             {}
 #line 3817 "src/Slice/Grammar.cpp"
     break;
 
-  case 163: /* builtin: ICE_UINT  */
-#line 1950 "src/Slice/Grammar.y"
-           {}
+  case 164: /* builtin: ICE_VARUINT  */
+#line 1946 "src/Slice/Grammar.y"
+              {}
 #line 3823 "src/Slice/Grammar.cpp"
     break;
 
-  case 164: /* builtin: ICE_VARINT  */
-#line 1951 "src/Slice/Grammar.y"
-             {}
+  case 165: /* builtin: ICE_LONG  */
+#line 1947 "src/Slice/Grammar.y"
+           {}
 #line 3829 "src/Slice/Grammar.cpp"
     break;
 
-  case 165: /* builtin: ICE_VARUINT  */
-#line 1952 "src/Slice/Grammar.y"
-              {}
+  case 166: /* builtin: ICE_ULONG  */
+#line 1948 "src/Slice/Grammar.y"
+            {}
 #line 3835 "src/Slice/Grammar.cpp"
     break;
 
-  case 166: /* builtin: ICE_LONG  */
-#line 1953 "src/Slice/Grammar.y"
-           {}
+  case 167: /* builtin: ICE_VARLONG  */
+#line 1949 "src/Slice/Grammar.y"
+              {}
 #line 3841 "src/Slice/Grammar.cpp"
     break;
 
-  case 167: /* builtin: ICE_ULONG  */
-#line 1954 "src/Slice/Grammar.y"
-            {}
+  case 168: /* builtin: ICE_VARULONG  */
+#line 1950 "src/Slice/Grammar.y"
+               {}
 #line 3847 "src/Slice/Grammar.cpp"
     break;
 
-  case 168: /* builtin: ICE_VARLONG  */
-#line 1955 "src/Slice/Grammar.y"
-              {}
+  case 169: /* builtin: ICE_FLOAT  */
+#line 1951 "src/Slice/Grammar.y"
+            {}
 #line 3853 "src/Slice/Grammar.cpp"
     break;
 
-  case 169: /* builtin: ICE_VARULONG  */
-#line 1956 "src/Slice/Grammar.y"
-               {}
+  case 170: /* builtin: ICE_DOUBLE  */
+#line 1952 "src/Slice/Grammar.y"
+             {}
 #line 3859 "src/Slice/Grammar.cpp"
     break;
 
-  case 170: /* builtin: ICE_FLOAT  */
-#line 1957 "src/Slice/Grammar.y"
-            {}
+  case 171: /* builtin: ICE_STRING  */
+#line 1953 "src/Slice/Grammar.y"
+             {}
 #line 3865 "src/Slice/Grammar.cpp"
     break;
 
-  case 171: /* builtin: ICE_DOUBLE  */
-#line 1958 "src/Slice/Grammar.y"
-             {}
-#line 3871 "src/Slice/Grammar.cpp"
-    break;
-
-  case 172: /* builtin: ICE_STRING  */
+  case 172: /* type: ICE_OBJECT '*'  */
 #line 1959 "src/Slice/Grammar.y"
-             {}
-#line 3877 "src/Slice/Grammar.cpp"
-    break;
-
-  case 173: /* type: ICE_OBJECT '*'  */
-#line 1965 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3885 "src/Slice/Grammar.cpp"
+#line 3873 "src/Slice/Grammar.cpp"
     break;
 
-  case 174: /* type: ICE_OBJECT '?'  */
-#line 1969 "src/Slice/Grammar.y"
+  case 173: /* type: ICE_OBJECT '?'  */
+#line 1963 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3893 "src/Slice/Grammar.cpp"
+#line 3881 "src/Slice/Grammar.cpp"
     break;
 
-  case 175: /* type: ICE_ANYCLASS '?'  */
-#line 1973 "src/Slice/Grammar.y"
+  case 174: /* type: ICE_ANYCLASS '?'  */
+#line 1967 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3901 "src/Slice/Grammar.cpp"
+#line 3889 "src/Slice/Grammar.cpp"
     break;
 
-  case 176: /* type: ICE_VALUE '?'  */
-#line 1977 "src/Slice/Grammar.y"
+  case 175: /* type: ICE_VALUE '?'  */
+#line 1971 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3909,20 +3897,20 @@ yyreduce:
     }
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3913 "src/Slice/Grammar.cpp"
+#line 3901 "src/Slice/Grammar.cpp"
     break;
 
-  case 177: /* type: builtin '?'  */
-#line 1985 "src/Slice/Grammar.y"
+  case 176: /* type: builtin '?'  */
+#line 1979 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[-1]);
     yyval = unit->optionalBuiltin(Builtin::kindFromString(typeName->v).value());
 }
-#line 3922 "src/Slice/Grammar.cpp"
+#line 3910 "src/Slice/Grammar.cpp"
     break;
 
-  case 178: /* type: ICE_OBJECT  */
-#line 1990 "src/Slice/Grammar.y"
+  case 177: /* type: ICE_OBJECT  */
+#line 1984 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -3933,19 +3921,19 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindObject);
     }
 }
-#line 3937 "src/Slice/Grammar.cpp"
+#line 3925 "src/Slice/Grammar.cpp"
     break;
 
-  case 179: /* type: ICE_ANYCLASS  */
-#line 2001 "src/Slice/Grammar.y"
+  case 178: /* type: ICE_ANYCLASS  */
+#line 1995 "src/Slice/Grammar.y"
 {
     yyval = unit->builtin(Builtin::KindAnyClass);
 }
-#line 3945 "src/Slice/Grammar.cpp"
+#line 3933 "src/Slice/Grammar.cpp"
     break;
 
-  case 180: /* type: ICE_VALUE  */
-#line 2005 "src/Slice/Grammar.y"
+  case 179: /* type: ICE_VALUE  */
+#line 1999 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -3957,20 +3945,20 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindAnyClass);
     }
 }
-#line 3961 "src/Slice/Grammar.cpp"
+#line 3949 "src/Slice/Grammar.cpp"
     break;
 
-  case 181: /* type: builtin  */
-#line 2017 "src/Slice/Grammar.y"
+  case 180: /* type: builtin  */
+#line 2011 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[0]);
     yyval = unit->builtin(Builtin::kindFromString(typeName->v).value());
 }
-#line 3970 "src/Slice/Grammar.cpp"
+#line 3958 "src/Slice/Grammar.cpp"
     break;
 
-  case 182: /* type: scoped_name  */
-#line 2022 "src/Slice/Grammar.y"
+  case 181: /* type: scoped_name  */
+#line 2016 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -3996,11 +3984,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4000 "src/Slice/Grammar.cpp"
+#line 3988 "src/Slice/Grammar.cpp"
     break;
 
-  case 183: /* type: scoped_name '*'  */
-#line 2048 "src/Slice/Grammar.y"
+  case 182: /* type: scoped_name '*'  */
+#line 2042 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4032,11 +4020,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4036 "src/Slice/Grammar.cpp"
+#line 4024 "src/Slice/Grammar.cpp"
     break;
 
-  case 184: /* type: scoped_name '?'  */
-#line 2080 "src/Slice/Grammar.y"
+  case 183: /* type: scoped_name '?'  */
+#line 2074 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4059,11 +4047,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4063 "src/Slice/Grammar.cpp"
+#line 4051 "src/Slice/Grammar.cpp"
     break;
 
-  case 185: /* tagged_type: tag type  */
-#line 2108 "src/Slice/Grammar.y"
+  case 184: /* tagged_type: tag type  */
+#line 2102 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4078,11 +4066,11 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4082 "src/Slice/Grammar.cpp"
+#line 4070 "src/Slice/Grammar.cpp"
     break;
 
-  case 186: /* tagged_type: optional type  */
-#line 2123 "src/Slice/Grammar.y"
+  case 185: /* tagged_type: optional type  */
+#line 2117 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4096,21 +4084,21 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4100 "src/Slice/Grammar.cpp"
+#line 4088 "src/Slice/Grammar.cpp"
     break;
 
-  case 187: /* tagged_type: type  */
-#line 2137 "src/Slice/Grammar.y"
+  case 186: /* tagged_type: type  */
+#line 2131 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = new TaggedDefTok;
     taggedDef->type = TypePtr::dynamicCast(yyvsp[0]);
     yyval = taggedDef;
 }
-#line 4110 "src/Slice/Grammar.cpp"
+#line 4098 "src/Slice/Grammar.cpp"
     break;
 
-  case 188: /* member: tagged_type ICE_IDENTIFIER  */
-#line 2148 "src/Slice/Grammar.y"
+  case 187: /* member: tagged_type ICE_IDENTIFIER  */
+#line 2142 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4122,11 +4110,11 @@ yyreduce:
 
     yyval = def;
 }
-#line 4126 "src/Slice/Grammar.cpp"
+#line 4114 "src/Slice/Grammar.cpp"
     break;
 
-  case 189: /* member: tagged_type keyword  */
-#line 2160 "src/Slice/Grammar.y"
+  case 188: /* member: tagged_type keyword  */
+#line 2154 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4137,11 +4125,11 @@ yyreduce:
     unit->error("keyword `" + def->name + "' cannot be used as an identifier");
     yyval = def;
 }
-#line 4141 "src/Slice/Grammar.cpp"
+#line 4129 "src/Slice/Grammar.cpp"
     break;
 
-  case 190: /* member: tagged_type  */
-#line 2171 "src/Slice/Grammar.y"
+  case 189: /* member: tagged_type  */
+#line 2165 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->name = IceUtil::generateUUID(); // Dummy
@@ -4152,53 +4140,53 @@ yyreduce:
     unit->error("missing identifier");
     yyval = def;
 }
-#line 4156 "src/Slice/Grammar.cpp"
+#line 4144 "src/Slice/Grammar.cpp"
     break;
 
-  case 191: /* member: local_metadata member  */
-#line 2182 "src/Slice/Grammar.y"
+  case 190: /* member: local_metadata member  */
+#line 2176 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->metadata = StringListTokPtr::dynamicCast(yyvsp[-1])->v;
     yyval = def;
 }
-#line 4166 "src/Slice/Grammar.cpp"
+#line 4154 "src/Slice/Grammar.cpp"
     break;
 
-  case 192: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2193 "src/Slice/Grammar.y"
+  case 191: /* string_literal: ICE_STRING_LITERAL string_literal  */
+#line 2187 "src/Slice/Grammar.y"
 {
     StringTokPtr str1 = StringTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr str2 = StringTokPtr::dynamicCast(yyvsp[0]);
     str1->v += str2->v;
 }
-#line 4176 "src/Slice/Grammar.cpp"
+#line 4164 "src/Slice/Grammar.cpp"
     break;
 
-  case 194: /* string_list: string_list ',' string_literal  */
-#line 2205 "src/Slice/Grammar.y"
+  case 193: /* string_list: string_list ',' string_literal  */
+#line 2199 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = StringListTokPtr::dynamicCast(yyvsp[-2]);
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4187 "src/Slice/Grammar.cpp"
+#line 4175 "src/Slice/Grammar.cpp"
     break;
 
-  case 195: /* string_list: string_literal  */
-#line 2212 "src/Slice/Grammar.y"
+  case 194: /* string_list: string_literal  */
+#line 2206 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = new StringListTok;
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4198 "src/Slice/Grammar.cpp"
+#line 4186 "src/Slice/Grammar.cpp"
     break;
 
-  case 196: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2224 "src/Slice/Grammar.y"
+  case 195: /* const_initializer: ICE_INTEGER_LITERAL  */
+#line 2218 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindLong);
     IntegerTokPtr intVal = IntegerTokPtr::dynamicCast(yyvsp[0]);
@@ -4207,11 +4195,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), intVal->literal);
     yyval = def;
 }
-#line 4211 "src/Slice/Grammar.cpp"
+#line 4199 "src/Slice/Grammar.cpp"
     break;
 
-  case 197: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2233 "src/Slice/Grammar.y"
+  case 196: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
+#line 2227 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindDouble);
     FloatingTokPtr floatVal = FloatingTokPtr::dynamicCast(yyvsp[0]);
@@ -4220,11 +4208,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), floatVal->literal);
     yyval = def;
 }
-#line 4224 "src/Slice/Grammar.cpp"
+#line 4212 "src/Slice/Grammar.cpp"
     break;
 
-  case 198: /* const_initializer: scoped_name  */
-#line 2242 "src/Slice/Grammar.y"
+  case 197: /* const_initializer: scoped_name  */
+#line 2236 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def;
@@ -4264,44 +4252,44 @@ yyreduce:
     }
     yyval = def;
 }
-#line 4268 "src/Slice/Grammar.cpp"
+#line 4256 "src/Slice/Grammar.cpp"
     break;
 
-  case 199: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2282 "src/Slice/Grammar.y"
+  case 198: /* const_initializer: ICE_STRING_LITERAL  */
+#line 2276 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindString);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, literal->v, literal->literal);
     yyval = def;
 }
-#line 4279 "src/Slice/Grammar.cpp"
+#line 4267 "src/Slice/Grammar.cpp"
     break;
 
-  case 200: /* const_initializer: ICE_FALSE  */
-#line 2289 "src/Slice/Grammar.y"
+  case 199: /* const_initializer: ICE_FALSE  */
+#line 2283 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "false", "false");
     yyval = def;
 }
-#line 4290 "src/Slice/Grammar.cpp"
+#line 4278 "src/Slice/Grammar.cpp"
     break;
 
-  case 201: /* const_initializer: ICE_TRUE  */
-#line 2296 "src/Slice/Grammar.y"
+  case 200: /* const_initializer: ICE_TRUE  */
+#line 2290 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "true", "true");
     yyval = def;
 }
-#line 4301 "src/Slice/Grammar.cpp"
+#line 4289 "src/Slice/Grammar.cpp"
     break;
 
-  case 202: /* const_def: ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer  */
-#line 2308 "src/Slice/Grammar.y"
+  case 201: /* const_def: ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer  */
+#line 2302 "src/Slice/Grammar.y"
 {
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-4]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-3]);
@@ -4310,11 +4298,11 @@ yyreduce:
     yyval = unit->currentModule()->createConst(ident->v, const_type, metaData->v, value->v,
                                                value->valueAsString, value->valueAsLiteral);
 }
-#line 4314 "src/Slice/Grammar.cpp"
+#line 4302 "src/Slice/Grammar.cpp"
     break;
 
-  case 203: /* const_def: ICE_CONST local_metadata type '=' const_initializer  */
-#line 2317 "src/Slice/Grammar.y"
+  case 202: /* const_def: ICE_CONST local_metadata type '=' const_initializer  */
+#line 2311 "src/Slice/Grammar.y"
 {
     StringListTokPtr metaData = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-2]);
@@ -4323,233 +4311,233 @@ yyreduce:
     yyval = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metaData->v, value->v,
                                                value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
 }
+#line 4315 "src/Slice/Grammar.cpp"
+    break;
+
+  case 203: /* keyword: ICE_MODULE  */
+#line 2324 "src/Slice/Grammar.y"
+             {}
+#line 4321 "src/Slice/Grammar.cpp"
+    break;
+
+  case 204: /* keyword: ICE_CLASS  */
+#line 2325 "src/Slice/Grammar.y"
+            {}
 #line 4327 "src/Slice/Grammar.cpp"
     break;
 
-  case 204: /* keyword: ICE_MODULE  */
-#line 2330 "src/Slice/Grammar.y"
-             {}
+  case 205: /* keyword: ICE_INTERFACE  */
+#line 2326 "src/Slice/Grammar.y"
+                {}
 #line 4333 "src/Slice/Grammar.cpp"
     break;
 
-  case 205: /* keyword: ICE_CLASS  */
-#line 2331 "src/Slice/Grammar.y"
-            {}
+  case 206: /* keyword: ICE_EXCEPTION  */
+#line 2327 "src/Slice/Grammar.y"
+                {}
 #line 4339 "src/Slice/Grammar.cpp"
     break;
 
-  case 206: /* keyword: ICE_INTERFACE  */
-#line 2332 "src/Slice/Grammar.y"
-                {}
+  case 207: /* keyword: ICE_STRUCT  */
+#line 2328 "src/Slice/Grammar.y"
+             {}
 #line 4345 "src/Slice/Grammar.cpp"
     break;
 
-  case 207: /* keyword: ICE_EXCEPTION  */
-#line 2333 "src/Slice/Grammar.y"
-                {}
+  case 208: /* keyword: ICE_SEQUENCE  */
+#line 2329 "src/Slice/Grammar.y"
+               {}
 #line 4351 "src/Slice/Grammar.cpp"
     break;
 
-  case 208: /* keyword: ICE_STRUCT  */
-#line 2334 "src/Slice/Grammar.y"
-             {}
+  case 209: /* keyword: ICE_DICTIONARY  */
+#line 2330 "src/Slice/Grammar.y"
+                 {}
 #line 4357 "src/Slice/Grammar.cpp"
     break;
 
-  case 209: /* keyword: ICE_SEQUENCE  */
-#line 2335 "src/Slice/Grammar.y"
-               {}
+  case 210: /* keyword: ICE_ENUM  */
+#line 2331 "src/Slice/Grammar.y"
+           {}
 #line 4363 "src/Slice/Grammar.cpp"
     break;
 
-  case 210: /* keyword: ICE_DICTIONARY  */
-#line 2336 "src/Slice/Grammar.y"
-                 {}
+  case 211: /* keyword: ICE_OUT  */
+#line 2332 "src/Slice/Grammar.y"
+          {}
 #line 4369 "src/Slice/Grammar.cpp"
     break;
 
-  case 211: /* keyword: ICE_ENUM  */
-#line 2337 "src/Slice/Grammar.y"
-           {}
+  case 212: /* keyword: ICE_EXTENDS  */
+#line 2333 "src/Slice/Grammar.y"
+              {}
 #line 4375 "src/Slice/Grammar.cpp"
     break;
 
-  case 212: /* keyword: ICE_OUT  */
-#line 2338 "src/Slice/Grammar.y"
-          {}
+  case 213: /* keyword: ICE_IMPLEMENTS  */
+#line 2334 "src/Slice/Grammar.y"
+                 {}
 #line 4381 "src/Slice/Grammar.cpp"
     break;
 
-  case 213: /* keyword: ICE_EXTENDS  */
-#line 2339 "src/Slice/Grammar.y"
-              {}
+  case 214: /* keyword: ICE_THROWS  */
+#line 2335 "src/Slice/Grammar.y"
+             {}
 #line 4387 "src/Slice/Grammar.cpp"
     break;
 
-  case 214: /* keyword: ICE_IMPLEMENTS  */
-#line 2340 "src/Slice/Grammar.y"
-                 {}
+  case 215: /* keyword: ICE_VOID  */
+#line 2336 "src/Slice/Grammar.y"
+           {}
 #line 4393 "src/Slice/Grammar.cpp"
     break;
 
-  case 215: /* keyword: ICE_THROWS  */
-#line 2341 "src/Slice/Grammar.y"
-             {}
+  case 216: /* keyword: ICE_BOOL  */
+#line 2337 "src/Slice/Grammar.y"
+           {}
 #line 4399 "src/Slice/Grammar.cpp"
     break;
 
-  case 216: /* keyword: ICE_VOID  */
-#line 2342 "src/Slice/Grammar.y"
+  case 217: /* keyword: ICE_BYTE  */
+#line 2338 "src/Slice/Grammar.y"
            {}
 #line 4405 "src/Slice/Grammar.cpp"
     break;
 
-  case 217: /* keyword: ICE_BOOL  */
-#line 2343 "src/Slice/Grammar.y"
-           {}
+  case 218: /* keyword: ICE_SHORT  */
+#line 2339 "src/Slice/Grammar.y"
+            {}
 #line 4411 "src/Slice/Grammar.cpp"
     break;
 
-  case 218: /* keyword: ICE_BYTE  */
-#line 2344 "src/Slice/Grammar.y"
-           {}
+  case 219: /* keyword: ICE_USHORT  */
+#line 2340 "src/Slice/Grammar.y"
+             {}
 #line 4417 "src/Slice/Grammar.cpp"
     break;
 
-  case 219: /* keyword: ICE_SHORT  */
-#line 2345 "src/Slice/Grammar.y"
-            {}
+  case 220: /* keyword: ICE_INT  */
+#line 2341 "src/Slice/Grammar.y"
+          {}
 #line 4423 "src/Slice/Grammar.cpp"
     break;
 
-  case 220: /* keyword: ICE_USHORT  */
-#line 2346 "src/Slice/Grammar.y"
-             {}
+  case 221: /* keyword: ICE_UINT  */
+#line 2342 "src/Slice/Grammar.y"
+           {}
 #line 4429 "src/Slice/Grammar.cpp"
     break;
 
-  case 221: /* keyword: ICE_INT  */
-#line 2347 "src/Slice/Grammar.y"
-          {}
+  case 222: /* keyword: ICE_VARINT  */
+#line 2343 "src/Slice/Grammar.y"
+             {}
 #line 4435 "src/Slice/Grammar.cpp"
     break;
 
-  case 222: /* keyword: ICE_UINT  */
-#line 2348 "src/Slice/Grammar.y"
-           {}
+  case 223: /* keyword: ICE_VARUINT  */
+#line 2344 "src/Slice/Grammar.y"
+              {}
 #line 4441 "src/Slice/Grammar.cpp"
     break;
 
-  case 223: /* keyword: ICE_VARINT  */
-#line 2349 "src/Slice/Grammar.y"
-             {}
+  case 224: /* keyword: ICE_LONG  */
+#line 2345 "src/Slice/Grammar.y"
+           {}
 #line 4447 "src/Slice/Grammar.cpp"
     break;
 
-  case 224: /* keyword: ICE_VARUINT  */
-#line 2350 "src/Slice/Grammar.y"
-              {}
+  case 225: /* keyword: ICE_ULONG  */
+#line 2346 "src/Slice/Grammar.y"
+            {}
 #line 4453 "src/Slice/Grammar.cpp"
     break;
 
-  case 225: /* keyword: ICE_LONG  */
-#line 2351 "src/Slice/Grammar.y"
-           {}
+  case 226: /* keyword: ICE_VARLONG  */
+#line 2347 "src/Slice/Grammar.y"
+              {}
 #line 4459 "src/Slice/Grammar.cpp"
     break;
 
-  case 226: /* keyword: ICE_ULONG  */
-#line 2352 "src/Slice/Grammar.y"
-            {}
+  case 227: /* keyword: ICE_VARULONG  */
+#line 2348 "src/Slice/Grammar.y"
+               {}
 #line 4465 "src/Slice/Grammar.cpp"
     break;
 
-  case 227: /* keyword: ICE_VARLONG  */
-#line 2353 "src/Slice/Grammar.y"
-              {}
+  case 228: /* keyword: ICE_FLOAT  */
+#line 2349 "src/Slice/Grammar.y"
+            {}
 #line 4471 "src/Slice/Grammar.cpp"
     break;
 
-  case 228: /* keyword: ICE_VARULONG  */
-#line 2354 "src/Slice/Grammar.y"
-               {}
+  case 229: /* keyword: ICE_DOUBLE  */
+#line 2350 "src/Slice/Grammar.y"
+             {}
 #line 4477 "src/Slice/Grammar.cpp"
     break;
 
-  case 229: /* keyword: ICE_FLOAT  */
-#line 2355 "src/Slice/Grammar.y"
-            {}
+  case 230: /* keyword: ICE_STRING  */
+#line 2351 "src/Slice/Grammar.y"
+             {}
 #line 4483 "src/Slice/Grammar.cpp"
     break;
 
-  case 230: /* keyword: ICE_DOUBLE  */
-#line 2356 "src/Slice/Grammar.y"
+  case 231: /* keyword: ICE_OBJECT  */
+#line 2352 "src/Slice/Grammar.y"
              {}
 #line 4489 "src/Slice/Grammar.cpp"
     break;
 
-  case 231: /* keyword: ICE_STRING  */
-#line 2357 "src/Slice/Grammar.y"
-             {}
+  case 232: /* keyword: ICE_CONST  */
+#line 2353 "src/Slice/Grammar.y"
+            {}
 #line 4495 "src/Slice/Grammar.cpp"
     break;
 
-  case 232: /* keyword: ICE_OBJECT  */
-#line 2358 "src/Slice/Grammar.y"
-             {}
+  case 233: /* keyword: ICE_FALSE  */
+#line 2354 "src/Slice/Grammar.y"
+            {}
 #line 4501 "src/Slice/Grammar.cpp"
     break;
 
-  case 233: /* keyword: ICE_CONST  */
-#line 2359 "src/Slice/Grammar.y"
-            {}
+  case 234: /* keyword: ICE_TRUE  */
+#line 2355 "src/Slice/Grammar.y"
+           {}
 #line 4507 "src/Slice/Grammar.cpp"
     break;
 
-  case 234: /* keyword: ICE_FALSE  */
-#line 2360 "src/Slice/Grammar.y"
-            {}
+  case 235: /* keyword: ICE_IDEMPOTENT  */
+#line 2356 "src/Slice/Grammar.y"
+                 {}
 #line 4513 "src/Slice/Grammar.cpp"
     break;
 
-  case 235: /* keyword: ICE_TRUE  */
-#line 2361 "src/Slice/Grammar.y"
-           {}
+  case 236: /* keyword: ICE_TAG  */
+#line 2357 "src/Slice/Grammar.y"
+          {}
 #line 4519 "src/Slice/Grammar.cpp"
     break;
 
-  case 236: /* keyword: ICE_IDEMPOTENT  */
-#line 2362 "src/Slice/Grammar.y"
-                 {}
+  case 237: /* keyword: ICE_OPTIONAL  */
+#line 2358 "src/Slice/Grammar.y"
+               {}
 #line 4525 "src/Slice/Grammar.cpp"
     break;
 
-  case 237: /* keyword: ICE_TAG  */
-#line 2363 "src/Slice/Grammar.y"
-          {}
+  case 238: /* keyword: ICE_ANYCLASS  */
+#line 2359 "src/Slice/Grammar.y"
+               {}
 #line 4531 "src/Slice/Grammar.cpp"
     break;
 
-  case 238: /* keyword: ICE_OPTIONAL  */
-#line 2364 "src/Slice/Grammar.y"
-               {}
+  case 239: /* keyword: ICE_VALUE  */
+#line 2360 "src/Slice/Grammar.y"
+            {}
 #line 4537 "src/Slice/Grammar.cpp"
     break;
 
-  case 239: /* keyword: ICE_ANYCLASS  */
-#line 2365 "src/Slice/Grammar.y"
-               {}
-#line 4543 "src/Slice/Grammar.cpp"
-    break;
 
-  case 240: /* keyword: ICE_VALUE  */
-#line 2366 "src/Slice/Grammar.y"
-            {}
-#line 4549 "src/Slice/Grammar.cpp"
-    break;
-
-
-#line 4553 "src/Slice/Grammar.cpp"
+#line 4541 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4748,5 +4736,5 @@ yyreturn:
   return yyresult;
 }
 
-#line 2369 "src/Slice/Grammar.y"
+#line 2363 "src/Slice/Grammar.y"
 

--- a/cpp/src/Slice/Grammar.h
+++ b/cpp/src/Slice/Grammar.h
@@ -120,13 +120,12 @@ extern int slice_debug;
     ICE_LOCAL_METADATA_OPEN = 301, /* ICE_LOCAL_METADATA_OPEN  */
     ICE_LOCAL_METADATA_CLOSE = 302, /* ICE_LOCAL_METADATA_CLOSE  */
     ICE_FILE_METADATA_OPEN = 303,  /* ICE_FILE_METADATA_OPEN  */
-    ICE_FILE_METADATA_IGNORE = 304, /* ICE_FILE_METADATA_IGNORE  */
-    ICE_FILE_METADATA_CLOSE = 305, /* ICE_FILE_METADATA_CLOSE  */
-    ICE_IDENT_OPEN = 306,          /* ICE_IDENT_OPEN  */
-    ICE_KEYWORD_OPEN = 307,        /* ICE_KEYWORD_OPEN  */
-    ICE_TAG_OPEN = 308,            /* ICE_TAG_OPEN  */
-    ICE_OPTIONAL_OPEN = 309,       /* ICE_OPTIONAL_OPEN  */
-    BAD_CHAR = 310                 /* BAD_CHAR  */
+    ICE_FILE_METADATA_CLOSE = 304, /* ICE_FILE_METADATA_CLOSE  */
+    ICE_IDENT_OPEN = 305,          /* ICE_IDENT_OPEN  */
+    ICE_KEYWORD_OPEN = 306,        /* ICE_KEYWORD_OPEN  */
+    ICE_TAG_OPEN = 307,            /* ICE_TAG_OPEN  */
+    ICE_OPTIONAL_OPEN = 308,       /* ICE_OPTIONAL_OPEN  */
+    BAD_CHAR = 309                 /* BAD_CHAR  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -235,19 +235,19 @@ definitions
 // ----------------------------------------------------------------------
 : definitions file_metadata
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($2);
-    if(!metaData->v.empty())
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
+    if(!metadata->v.empty())
     {
-        unit->addFileMetaData(metaData->v);
+        unit->addFileMetadata(metadata->v);
     }
 }
 | definitions local_metadata definition
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($2);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
     ContainedPtr contained = ContainedPtr::dynamicCast($3);
-    if(contained && !metaData->v.empty())
+    if(contained && !metadata->v.empty())
     {
-        contained->setMetaData(metaData->v);
+        contained->setMetadata(metadata->v);
     }
 }
 | %empty
@@ -1091,7 +1091,7 @@ data_member
         unit->currentContainer()->checkIntroduced(def->name, dm);
         if (dm && !def->metadata.empty())
         {
-            dm->setMetaData(def->metadata);
+            dm->setMetadata(def->metadata);
         }
     }
 }
@@ -1108,7 +1108,7 @@ data_member
         unit->currentContainer()->checkIntroduced(def->name, dm);
         if (dm && !def->metadata.empty())
         {
-            dm->setMetaData(def->metadata);
+            dm->setMetadata(def->metadata);
         }
     }
 }
@@ -1221,7 +1221,7 @@ operation_preamble
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -1256,7 +1256,7 @@ operation_preamble
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -1289,7 +1289,7 @@ operation_preamble
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -1323,7 +1323,7 @@ operation_preamble
                                                      returnMember->tag);
                 if (p && !returnMember->metadata.empty())
                 {
-                    p->setMetaData(returnMember->metadata);
+                    p->setMetadata(returnMember->metadata);
                 }
             }
 
@@ -1392,11 +1392,11 @@ operation_list
 // ----------------------------------------------------------------------
 : local_metadata operation ';' operation_list
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($1);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($1);
     OperationPtr operation = OperationPtr::dynamicCast($2);
-    if (operation && !metaData->v.empty())
+    if (operation && !metadata->v.empty())
     {
-        operation->setMetaData(metaData->v);
+        operation->setMetadata(metadata->v);
 
         // If the operation had a single return type (not a return tuple), also apply the metadata to the return type.
         // TODO: once we introduce more concrete metadata validation, we could sort the metadata out between the return
@@ -1404,7 +1404,7 @@ operation_list
         // metadata only relevant to the return type would only be set on the return type.
         if (operation->hasSingleReturnType())
         {
-            operation->returnType().front()->setMetaData(metaData->v);
+            operation->returnType().front()->setMetadata(metadata->v);
         }
     }
 }
@@ -1633,18 +1633,18 @@ sequence_def
 : ICE_SEQUENCE '<' local_metadata type '>' ICE_IDENTIFIER
 {
     StringTokPtr ident = StringTokPtr::dynamicCast($6);
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($3);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($3);
     TypePtr type = TypePtr::dynamicCast($4);
     ModulePtr cont = unit->currentModule();
-    $$ = cont->createSequence(ident->v, type, metaData->v);
+    $$ = cont->createSequence(ident->v, type, metadata->v);
 }
 | ICE_SEQUENCE '<' local_metadata type '>' keyword
 {
     StringTokPtr ident = StringTokPtr::dynamicCast($6);
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($3);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($3);
     TypePtr type = TypePtr::dynamicCast($4);
     ModulePtr cont = unit->currentModule();
-    $$ = cont->createSequence(ident->v, type, metaData->v); // Dummy
+    $$ = cont->createSequence(ident->v, type, metadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 ;
@@ -1655,22 +1655,22 @@ dictionary_def
 : ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' ICE_IDENTIFIER
 {
     StringTokPtr ident = StringTokPtr::dynamicCast($9);
-    StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast($3);
+    StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast($3);
     TypePtr keyType = TypePtr::dynamicCast($4);
-    StringListTokPtr valueMetaData = StringListTokPtr::dynamicCast($6);
+    StringListTokPtr valueMetadata = StringListTokPtr::dynamicCast($6);
     TypePtr valueType = TypePtr::dynamicCast($7);
     ModulePtr cont = unit->currentModule();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v);
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
 | ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' keyword
 {
     StringTokPtr ident = StringTokPtr::dynamicCast($9);
-    StringListTokPtr keyMetaData = StringListTokPtr::dynamicCast($3);
+    StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast($3);
     TypePtr keyType = TypePtr::dynamicCast($4);
-    StringListTokPtr valueMetaData = StringListTokPtr::dynamicCast($6);
+    StringListTokPtr valueMetadata = StringListTokPtr::dynamicCast($6);
     TypePtr valueType = TypePtr::dynamicCast($7);
     ModulePtr cont = unit->currentModule();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v); // Dummy
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 ;
@@ -1894,7 +1894,7 @@ parameter
         unit->currentContainer()->checkIntroduced(def->name, param);
         if(param && !def->metadata.empty())
         {
-            param->setMetaData(def->metadata);
+            param->setMetadata(def->metadata);
         }
     }
 }
@@ -2300,20 +2300,20 @@ const_def
 // ----------------------------------------------------------------------
 : ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($2);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
     TypePtr const_type = TypePtr::dynamicCast($3);
     StringTokPtr ident = StringTokPtr::dynamicCast($4);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast($6);
-    $$ = unit->currentModule()->createConst(ident->v, const_type, metaData->v, value->v,
+    $$ = unit->currentModule()->createConst(ident->v, const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral);
 }
 | ICE_CONST local_metadata type '=' const_initializer
 {
-    StringListTokPtr metaData = StringListTokPtr::dynamicCast($2);
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
     TypePtr const_type = TypePtr::dynamicCast($3);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast($5);
     unit->error("missing constant name");
-    $$ = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metaData->v, value->v,
+    $$ = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
 }
 ;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -176,7 +176,6 @@ slice_error(const char* s)
 %token ICE_LOCAL_METADATA_OPEN
 %token ICE_LOCAL_METADATA_CLOSE
 %token ICE_FILE_METADATA_OPEN
-%token ICE_FILE_METADATA_IGNORE
 %token ICE_FILE_METADATA_CLOSE
 
 // Here 'OPEN' means these tokens end with an open parenthesis.
@@ -208,11 +207,6 @@ file_metadata
 : ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE
 {
     $$ = $2;
-}
-| ICE_FILE_METADATA_IGNORE string_list ICE_FILE_METADATA_CLOSE
-{
-    unit->error("file metadata must appear before any definitions");
-    $$ = $2; // Dummy
 }
 ;
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -156,7 +156,7 @@ Slice::DefinitionContext::findMetadata(const string& prefix) const
 }
 
 StringList
-Slice::DefinitionContext::getMetadata() const
+Slice::DefinitionContext::getAllMetadata() const
 {
     return _metadata;
 }
@@ -937,7 +937,7 @@ Slice::Contained::findMetadataWithPrefix(const string& prefix) const
 }
 
 list<string>
-Slice::Contained::getMetadata() const
+Slice::Contained::getAllMetadata() const
 {
     return _metadata;
 }
@@ -4760,7 +4760,7 @@ Slice::Unit::addFileMetadata(const StringList& metadata)
     DefinitionContextPtr dc = currentDefinitionContext();
     assert(dc);
     // Append the file metadata to any existing metadata (e.g., default file metadata).
-    StringList l = dc->getMetadata();
+    StringList l = dc->getAllMetadata();
     copy(metadata.begin(), metadata.end(), back_inserter(l));
     dc->setMetadata(l);
 }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -111,8 +111,8 @@ namespace Slice
 // DefinitionContext
 // ----------------------------------------------------------------------
 
-Slice::DefinitionContext::DefinitionContext(int includeLevel, const StringList& metaData) :
-    _includeLevel(includeLevel), _metaData(metaData)
+Slice::DefinitionContext::DefinitionContext(int includeLevel, const StringList& metadata) :
+    _includeLevel(includeLevel), _metadata(metadata)
 {
     initSuppressedWarnings();
 }
@@ -136,16 +136,16 @@ Slice::DefinitionContext::setFilename(const string& filename)
 }
 
 void
-Slice::DefinitionContext::setMetaData(const StringList& metaData)
+Slice::DefinitionContext::setMetadata(const StringList& metadata)
 {
-    _metaData = metaData;
+    _metadata = metadata;
     initSuppressedWarnings();
 }
 
 string
-Slice::DefinitionContext::findMetaData(const string& prefix) const
+Slice::DefinitionContext::findMetadata(const string& prefix) const
 {
-    for (const auto& metadata : _metaData)
+    for (const auto& metadata : _metadata)
     {
         if (metadata.find(prefix) == 0)
         {
@@ -156,15 +156,15 @@ Slice::DefinitionContext::findMetaData(const string& prefix) const
 }
 
 StringList
-Slice::DefinitionContext::getMetaData() const
+Slice::DefinitionContext::getMetadata() const
 {
-    return _metaData;
+    return _metadata;
 }
 
 bool
 Slice::DefinitionContext::compatMode() const
 {
-    return findMetaData("3.7") == "3.7";
+    return findMetadata("3.7") == "3.7";
 }
 
 void
@@ -195,7 +195,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
 {
     _suppressedWarnings.clear();
     const string prefix = "suppress-warning";
-    string value = findMetaData(prefix);
+    string value = findMetadata(prefix);
     if (value == prefix)
     {
         _suppressedWarnings.insert(All);
@@ -221,7 +221,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 }
                 else if (s == "invalid-metadata")
                 {
-                    _suppressedWarnings.insert(InvalidMetaData);
+                    _suppressedWarnings.insert(InvalidMetadata);
                 }
                 else if (s == "reserved-identifier")
                 {
@@ -229,7 +229,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 }
                 else
                 {
-                    warning(InvalidMetaData, "", -1, string("invalid category `") + s +
+                    warning(InvalidMetadata, "", -1, string("invalid category `") + s +
                             "' in file metadata suppress-warning");
                 }
             }
@@ -753,7 +753,7 @@ Slice::Contained::parseComment(bool stripMarkup) const
 
     // First check metadata for a deprecated tag.
     string deprecateMetadata;
-    if (findMetaData("deprecate", deprecateMetadata))
+    if (findMetadata("deprecate", deprecateMetadata))
     {
         comment->_isDeprecated = true;
         if (deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
@@ -900,21 +900,21 @@ Slice::Contained::includeLevel() const
 }
 
 bool
-Slice::Contained::hasMetaData(const string& meta) const
+Slice::Contained::hasMetadata(const string& meta) const
 {
-    return find(_metaData.begin(), _metaData.end(), meta) != _metaData.end();
+    return find(_metadata.begin(), _metadata.end(), meta) != _metadata.end();
 }
 
 bool
-Slice::Contained::hasMetaDataWithPrefix(const string& prefix) const
+Slice::Contained::hasMetadataWithPrefix(const string& prefix) const
 {
-    return !findMetaDataWithPrefix(prefix).empty();
+    return !findMetadataWithPrefix(prefix).empty();
 }
 
 bool
-Slice::Contained::findMetaData(const string& prefix, string& meta) const
+Slice::Contained::findMetadata(const string& prefix, string& meta) const
 {
-    for (const auto& p : _metaData)
+    for (const auto& p : _metadata)
     {
         if (p.find(prefix) == 0)
         {
@@ -926,10 +926,10 @@ Slice::Contained::findMetaData(const string& prefix, string& meta) const
 }
 
 string
-Slice::Contained::findMetaDataWithPrefix(const string& prefix) const
+Slice::Contained::findMetadataWithPrefix(const string& prefix) const
 {
     string meta;
-    if (findMetaData(prefix, meta))
+    if (findMetadata(prefix, meta))
     {
         return meta.substr(prefix.size());
     }
@@ -937,24 +937,24 @@ Slice::Contained::findMetaDataWithPrefix(const string& prefix) const
 }
 
 list<string>
-Slice::Contained::getMetaData() const
+Slice::Contained::getMetadata() const
 {
-    return _metaData;
+    return _metadata;
 }
 
 void
-Slice::Contained::setMetaData(const list<string>& metaData)
+Slice::Contained::setMetadata(const list<string>& metadata)
 {
-    _metaData = metaData;
+    _metadata = metadata;
 }
 
 FormatType
-Slice::Contained::parseFormatMetaData() const
+Slice::Contained::parseFormatMetadata() const
 {
     FormatType result = DefaultFormat; // TODO: replace FormatType here by a std::optional<FormatType>
                                        // and eliminate DefaultFormat (replaced by not-set).
 
-    string tag = findMetaDataWithPrefix("format:");
+    string tag = findMetadataWithPrefix("format:");
     if (!tag.empty())
     {
         if (tag == "compact")
@@ -1261,17 +1261,17 @@ Slice::Container::enumerators(const string& scoped) const
 }
 
 bool
-Slice::Container::hasContentsWithMetaData(const string& meta) const
+Slice::Container::hasContentsWithMetadata(const string& meta) const
 {
     for (const auto& content : contents())
     {
-        if (content->hasMetaData(meta))
+        if (content->hasMetadata(meta))
         {
             return true;
         }
 
         ContainerPtr container = ContainerPtr::dynamicCast(content);
-        if (container && container->hasContentsWithMetaData(meta))
+        if (container && container->hasContentsWithMetadata(meta))
         {
             return true;
         }
@@ -1385,7 +1385,7 @@ Slice::Container::Container(const UnitPtr& ut) :
 }
 
 bool
-Slice::Container::checkFileMetaData(const StringList& m1, const StringList& m2)
+Slice::Container::checkFileMetadata(const StringList& m1, const StringList& m2)
 {
     // Not all file metadata mismatches represent actual problems. We are only concerned about
     // the prefixes listed below (also see bug 2766).
@@ -2101,7 +2101,7 @@ Slice::Module::createStruct(const string& name, NodeType nt)
 }
 
 SequencePtr
-Slice::Module::createSequence(const string& name, const TypePtr& type, const StringList& metaData, NodeType nt)
+Slice::Module::createSequence(const string& name, const TypePtr& type, const StringList& metadata, NodeType nt)
 {
     _unit->checkType(type);
     if (!checkForRedefinition(this, name, "sequence"))
@@ -2115,14 +2115,14 @@ Slice::Module::createSequence(const string& name, const TypePtr& type, const Str
         _unit->error("`" + name + "': a sequence can only be defined at module scope");
     }
 
-    SequencePtr p = new Sequence(this, name, type, metaData);
+    SequencePtr p = new Sequence(this, name, type, metadata);
     _contents.push_back(p);
     return p;
 }
 
 DictionaryPtr
-Slice::Module::createDictionary(const string& name, const TypePtr& keyType, const StringList& keyMetaData,
-                                const TypePtr& valueType, const StringList& valueMetaData, NodeType nt)
+Slice::Module::createDictionary(const string& name, const TypePtr& keyType, const StringList& keyMetadata,
+                                const TypePtr& valueType, const StringList& valueMetadata, NodeType nt)
 {
     _unit->checkType(keyType);
     _unit->checkType(valueType);
@@ -2151,7 +2151,7 @@ Slice::Module::createDictionary(const string& name, const TypePtr& keyType, cons
         }
     }
 
-    DictionaryPtr p = new Dictionary(this, name, keyType, keyMetaData, valueType, valueMetaData);
+    DictionaryPtr p = new Dictionary(this, name, keyType, keyMetadata, valueType, valueMetadata);
     _contents.push_back(p);
     return p;
 }
@@ -2176,7 +2176,7 @@ Slice::Module::createEnum(const string& name, bool unchecked, NodeType nt)
 }
 
 ConstPtr
-Slice::Module::createConst(const string name, const TypePtr& constType, const StringList& metaData,
+Slice::Module::createConst(const string name, const TypePtr& constType, const StringList& metadata,
                            const SyntaxTreeBasePtr& valueType, const string& value, const string& literal,
                            NodeType nt)
 {
@@ -2198,7 +2198,7 @@ Slice::Module::createConst(const string name, const TypePtr& constType, const St
         return nullptr;
     }
 
-    ConstPtr p = new Const(this, name, constType, metaData, resolvedValueType, value, literal);
+    ConstPtr p = new Const(this, name, constType, metadata, resolvedValueType, value, literal);
     _contents.push_back(p);
     return p;
 }
@@ -2668,9 +2668,9 @@ Slice::ClassDef::isA(const string& id) const
 }
 
 bool
-Slice::ClassDef::inheritsMetaData(const string& meta) const
+Slice::ClassDef::inheritsMetadata(const string& meta) const
 {
-    return _base && (_base->hasMetaData(meta) || _base->inheritsMetaData(meta));
+    return _base && (_base->hasMetadata(meta) || _base->inheritsMetadata(meta));
 }
 
 bool
@@ -3097,11 +3097,11 @@ Slice::InterfaceDef::isA(const string& id) const
 }
 
 bool
-Slice::InterfaceDef::inheritsMetaData(const string& meta) const
+Slice::InterfaceDef::inheritsMetadata(const string& meta) const
 {
     for (const auto& base : _bases)
     {
-        if (base->hasMetaData(meta) || base->inheritsMetaData(meta))
+        if (base->hasMetadata(meta) || base->inheritsMetadata(meta))
         {
             return true;
         }
@@ -3342,9 +3342,9 @@ Slice::Exception::usesClasses(bool includeTagged) const
 }
 
 bool
-Slice::Exception::inheritsMetaData(const string& meta) const
+Slice::Exception::inheritsMetadata(const string& meta) const
 {
-    return (_base && (_base->hasMetaData(meta) || _base->inheritsMetaData(meta)));
+    return (_base && (_base->hasMetadata(meta) || _base->inheritsMetadata(meta)));
 }
 
 bool
@@ -3502,9 +3502,9 @@ Slice::Sequence::type() const
 }
 
 StringList
-Slice::Sequence::typeMetaData() const
+Slice::Sequence::typeMetadata() const
 {
-    return _typeMetaData;
+    return _typeMetadata;
 }
 
 bool
@@ -3562,13 +3562,13 @@ Slice::Sequence::recDependencies(set<ConstructedPtr>& dependencies)
 }
 
 Slice::Sequence::Sequence(const ContainerPtr& container, const string& name, const TypePtr& type,
-                          const StringList& typeMetaData) :
+                          const StringList& typeMetadata) :
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
     Contained(container, name),
     Constructed(container, name),
     _type(type),
-    _typeMetaData(typeMetaData)
+    _typeMetadata(typeMetadata)
 {
 }
 
@@ -3589,15 +3589,15 @@ Slice::Dictionary::valueType() const
 }
 
 StringList
-Slice::Dictionary::keyMetaData() const
+Slice::Dictionary::keyMetadata() const
 {
-    return _keyMetaData;
+    return _keyMetadata;
 }
 
 StringList
-Slice::Dictionary::valueMetaData() const
+Slice::Dictionary::valueMetadata() const
 {
-    return _valueMetaData;
+    return _valueMetadata;
 }
 
 bool
@@ -3744,16 +3744,16 @@ Slice::Dictionary::legalKeyType(const TypePtr& type, bool& containsSequence)
 }
 
 Slice::Dictionary::Dictionary(const ContainerPtr& container, const string& name, const TypePtr& keyType,
-                              const StringList& keyMetaData, const TypePtr& valueType,
-                              const StringList& valueMetaData) :
+                              const StringList& keyMetadata, const TypePtr& valueType,
+                              const StringList& valueMetadata) :
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
     Contained(container, name),
     Constructed(container, name),
     _keyType(keyType),
     _valueType(valueType),
-    _keyMetaData(keyMetaData),
-    _valueMetaData(valueMetaData)
+    _keyMetadata(keyMetadata),
+    _valueMetadata(valueMetadata)
 {
 }
 
@@ -4032,9 +4032,9 @@ Slice::Const::type() const
 }
 
 StringList
-Slice::Const::typeMetaData() const
+Slice::Const::typeMetadata() const
 {
-    return _typeMetaData;
+    return _typeMetadata;
 }
 
 SyntaxTreeBasePtr
@@ -4075,12 +4075,12 @@ Slice::Const::visit(ParserVisitor* visitor, bool)
 }
 
 Slice::Const::Const(const ContainerPtr& container, const string& name, const TypePtr& type,
-                    const StringList& typeMetaData, const SyntaxTreeBasePtr& valueType, const string& value,
+                    const StringList& typeMetadata, const SyntaxTreeBasePtr& valueType, const string& value,
                     const string& literal) :
     SyntaxTreeBase(container->unit()),
     Contained(container, name),
     _type(type),
-    _typeMetaData(typeMetaData),
+    _typeMetadata(typeMetadata),
     _valueType(valueType),
     _value(value),
     _literal(literal)
@@ -4162,7 +4162,7 @@ Slice::Operation::mode() const
 Operation::Mode
 Slice::Operation::sendMode() const
 {
-    if (_mode == Operation::Idempotent && hasMetaData("nonmutating"))
+    if (_mode == Operation::Idempotent && hasMetadata("nonmutating"))
     {
         return Operation::Nonmutating;
     }
@@ -4177,7 +4177,7 @@ Slice::Operation::hasMarshaledResult() const
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(container());
     assert(interface);
-    if (interface->hasMetaData("marshaled-result") || hasMetaData("marshaled-result"))
+    if (interface->hasMetadata("marshaled-result") || hasMetadata("marshaled-result"))
     {
         for (const auto& returnValue : _returnType)
         {
@@ -4450,12 +4450,12 @@ Slice::Operation::hasSingleReturnType() const
 FormatType
 Slice::Operation::format() const
 {
-    FormatType format = parseFormatMetaData();
+    FormatType format = parseFormatMetadata();
     if (format == DefaultFormat)
     {
         ContainedPtr cont = ContainedPtr::dynamicCast(container());
         assert(cont);
-        format = cont->parseFormatMetaData();
+        format = cont->parseFormatMetadata();
     }
     return format;
 }
@@ -4755,14 +4755,14 @@ Slice::Unit::currentIncludeLevel() const
 }
 
 void
-Slice::Unit::addFileMetaData(const StringList& metaData)
+Slice::Unit::addFileMetadata(const StringList& metadata)
 {
     DefinitionContextPtr dc = currentDefinitionContext();
     assert(dc);
     // Append the file metadata to any existing metadata (e.g., default file metadata).
-    StringList l = dc->getMetaData();
-    copy(metaData.begin(), metaData.end(), back_inserter(l));
-    dc->setMetaData(l);
+    StringList l = dc->getMetadata();
+    copy(metadata.begin(), metadata.end(), back_inserter(l));
+    dc->setMetadata(l);
 }
 
 void
@@ -4846,7 +4846,7 @@ Slice::Unit::currentDefinitionContext() const
 void
 Slice::Unit::pushDefinitionContext()
 {
-    _definitionContextStack.push(new DefinitionContext(_currentIncludeLevel, _defaultFileMetaData));
+    _definitionContextStack.push(new DefinitionContext(_currentIncludeLevel, _defaultFileMetadata));
 }
 
 void
@@ -5154,7 +5154,7 @@ Slice::Unit::Unit(bool all, const StringList& defaultFileMetadata) :
     SyntaxTreeBase(nullptr),
     Container(nullptr),
     _all(all),
-    _defaultFileMetaData(defaultFileMetadata),
+    _defaultFileMetadata(defaultFileMetadata),
     _errors(0),
     _currentIncludeLevel(0)
 {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -58,7 +58,7 @@ enum WarningCategory
 {
     All,
     Deprecated,
-    InvalidMetaData,
+    InvalidMetadata,
     ReservedIdentifier
 };
 
@@ -203,9 +203,9 @@ public:
 
     void setFilename(const std::string&);
 
-    void setMetaData(const StringList&);
-    std::string findMetaData(const std::string&) const;
-    StringList getMetaData() const;
+    void setMetadata(const StringList&);
+    std::string findMetadata(const std::string&) const;
+    StringList getMetadata() const;
 
     // When parsing Slice definitions, apply 3.7 or 4.0 semantics for class parameters, Object etc.
     bool compatMode() const;
@@ -221,7 +221,7 @@ private:
     void initSuppressedWarnings();
 
     int _includeLevel;
-    StringList _metaData;
+    StringList _metadata;
     std::string _filename;
     std::set<WarningCategory> _suppressedWarnings;
 };
@@ -411,14 +411,14 @@ public:
 
     int includeLevel() const;
 
-    bool hasMetaData(const std::string&) const;
-    bool hasMetaDataWithPrefix(const std::string&) const;
-    bool findMetaData(const std::string&, std::string&) const;
-    std::string findMetaDataWithPrefix(const std::string&) const;
-    std::list<std::string> getMetaData() const;
-    void setMetaData(const std::list<std::string>&);
+    bool hasMetadata(const std::string&) const;
+    bool hasMetadataWithPrefix(const std::string&) const;
+    bool findMetadata(const std::string&, std::string&) const;
+    std::string findMetadataWithPrefix(const std::string&) const;
+    std::list<std::string> getMetadata() const;
+    void setMetadata(const std::list<std::string>&);
 
-    FormatType parseFormatMetaData() const;
+    FormatType parseFormatMetadata() const;
 
     virtual bool uses(const ContainedPtr&) const = 0;
     virtual std::string kindOf() const = 0;
@@ -437,7 +437,7 @@ protected:
     int _line;
     std::string _comment;
     int _includeLevel;
-    std::list<std::string> _metaData;
+    std::list<std::string> _metadata;
 };
 
 // ----------------------------------------------------------------------
@@ -456,7 +456,7 @@ public:
     // Finds enumerators using the deprecated unscoped enumerators lookup
     EnumeratorList enumerators(const std::string&) const;
     virtual ContainedList contents() const = 0;
-    bool hasContentsWithMetaData(const std::string&) const;
+    bool hasContentsWithMetadata(const std::string&) const;
     std::string thisScope() const;
     void containerRecDependencies(std::set<ConstructedPtr>&); // Internal operation, don't use directly.
 
@@ -466,7 +466,7 @@ protected:
 
     Container(const UnitPtr&);
 
-    bool checkFileMetaData(const StringList&, const StringList&);
+    bool checkFileMetadata(const StringList&, const StringList&);
     bool validateConstant(const std::string&, const TypePtr&, SyntaxTreeBasePtr&, const std::string&, bool);
 
     std::map<std::string, ContainedPtr> _introducedMap;
@@ -615,7 +615,7 @@ public:
     ClassList allBases() const;
     MemberList allDataMembers() const;
     bool isA(const std::string&) const;
-    bool inheritsMetaData(const std::string&) const;
+    bool inheritsMetadata(const std::string&) const;
     bool hasBaseDataMembers() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
@@ -766,7 +766,7 @@ public:
     OperationList operations() const;
     OperationList allOperations() const;
     bool isA(const std::string&) const;
-    bool inheritsMetaData(const std::string&) const;
+    bool inheritsMetadata(const std::string&) const;
     ContainedList contents() const override;
     bool uses(const ContainedPtr&) const override;
     std::string kindOf() const override;
@@ -826,7 +826,7 @@ public:
     ExceptionList allBases() const;
     bool isBaseOf(const ExceptionPtr&) const;
     bool usesClasses(bool) const;
-    bool inheritsMetaData(const std::string&) const;
+    bool inheritsMetadata(const std::string&) const;
     bool hasBaseDataMembers() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
@@ -875,7 +875,7 @@ class Sequence : public virtual Constructed
 public:
 
     TypePtr type() const;
-    StringList typeMetaData() const;
+    StringList typeMetadata() const;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;
@@ -893,7 +893,7 @@ protected:
     friend class Module;
 
     TypePtr _type;
-    StringList _typeMetaData;
+    StringList _typeMetadata;
 };
 
 // ----------------------------------------------------------------------
@@ -906,8 +906,8 @@ public:
 
     TypePtr keyType() const;
     TypePtr valueType() const;
-    StringList keyMetaData() const;
-    StringList valueMetaData() const;
+    StringList keyMetadata() const;
+    StringList valueMetadata() const;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;
@@ -929,8 +929,8 @@ protected:
 
     TypePtr _keyType;
     TypePtr _valueType;
-    StringList _keyMetaData;
-    StringList _valueMetaData;
+    StringList _keyMetadata;
+    StringList _valueMetadata;
 };
 
 // ----------------------------------------------------------------------
@@ -1024,7 +1024,7 @@ class Const : public virtual Contained
 public:
 
     TypePtr type() const;
-    StringList typeMetaData() const;
+    StringList typeMetadata() const;
     SyntaxTreeBasePtr valueType() const;
     std::string value() const;
     std::string literal() const;
@@ -1041,7 +1041,7 @@ protected:
     friend class Module;
 
     TypePtr _type;
-    StringList _typeMetaData;
+    StringList _typeMetadata;
     SyntaxTreeBasePtr _valueType;
     std::string _value;
     std::string _literal;
@@ -1108,7 +1108,7 @@ public:
     int setCurrentFile(const std::string&, int);
     int currentIncludeLevel() const;
 
-    void addFileMetaData(const StringList&);
+    void addFileMetadata(const StringList&);
 
     void error(const std::string&); // Not const because error count is increased
     void warning(WarningCategory, const std::string&) const;
@@ -1161,7 +1161,7 @@ private:
     Unit(bool, const StringList&);
 
     bool _all;
-    StringList _defaultFileMetaData;
+    StringList _defaultFileMetadata;
     int _errors;
     std::string _currentComment;
     int _currentIncludeLevel;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -205,7 +205,7 @@ public:
 
     void setMetadata(const StringList&);
     std::string findMetadata(const std::string&) const;
-    StringList getMetadata() const;
+    StringList getAllMetadata() const;
 
     // When parsing Slice definitions, apply 3.7 or 4.0 semantics for class parameters, Object etc.
     bool compatMode() const;
@@ -415,7 +415,7 @@ public:
     bool hasMetadataWithPrefix(const std::string&) const;
     bool findMetadata(const std::string&, std::string&) const;
     std::string findMetadataWithPrefix(const std::string&) const;
-    std::list<std::string> getMetadata() const;
+    std::list<std::string> getAllMetadata() const;
     void setMetadata(const std::list<std::string>&);
 
     FormatType parseFormatMetadata() const;

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -1195,9 +1195,9 @@ static const flex_int32_t yy_rule_linenum[52] =
       135,  149,  150,  157,  158,  159,  166,  185,  198,  208,
       215,  216,  228,  229,  237,  248,  258,  266,  284,  298,
       326,  331,  334,  340,  341,  346,  352,  371,  376,  382,
-      383,  398,  403,  411,  416,  432,  443,  447,  452,  458,
-      469,  476,  483,  488,  494,  531,  541,  544,  551,  555,
-      569
+      383,  398,  403,  411,  416,  429,  440,  444,  449,  455,
+      466,  473,  480,  485,  491,  528,  538,  541,  548,  552,
+      566
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -2055,21 +2055,18 @@ YY_RULE_SETUP
     yy_push_state(METADATA);
 
     // We use a different token to indicate metadata that should be ignored (if it came after a slice definition).
-    if(yy_top_state() == PRE_SLICE)
+    if(yy_top_state() != PRE_SLICE)
     {
-        return ICE_FILE_METADATA_OPEN;
+        unit->error("file metadata must appear before any definitions");
     }
-    else
-    {
-        return ICE_FILE_METADATA_IGNORE;
-    }
+    return ICE_FILE_METADATA_OPEN;
 }
 	YY_BREAK
 /* Matches the start of a metadata string, ensures the scanner is in QUOTED_METADATA mode,
    * then starts scanning a string literal. */
 case 36:
 YY_RULE_SETUP
-#line 432 "src/Slice/Scanner.l"
+#line 429 "src/Slice/Scanner.l"
 {
     BEGIN(QUOTED_METADATA);
     yy_push_state(STRING_LITERAL);
@@ -2083,14 +2080,14 @@ YY_RULE_SETUP
 /* Matches commas between string literals in quoted metadata and forwards them to the parser. */
 case 37:
 YY_RULE_SETUP
-#line 443 "src/Slice/Scanner.l"
+#line 440 "src/Slice/Scanner.l"
 {
     return yytext[0];
 }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 447 "src/Slice/Scanner.l"
+#line 444 "src/Slice/Scanner.l"
 {
     yy_pop_state();
     return ICE_LOCAL_METADATA_CLOSE;
@@ -2098,7 +2095,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 452 "src/Slice/Scanner.l"
+#line 449 "src/Slice/Scanner.l"
 {
     yy_pop_state();
     return ICE_FILE_METADATA_CLOSE;
@@ -2107,7 +2104,7 @@ YY_RULE_SETUP
 /* Matches the start of unquoted metadata and switches the scanner into UNQUOTED_METADATA mode. */
 case 40:
 YY_RULE_SETUP
-#line 458 "src/Slice/Scanner.l"
+#line 455 "src/Slice/Scanner.l"
 {
     BEGIN(UNQUOTED_METADATA);
     startLocation(yylloc);
@@ -2121,7 +2118,7 @@ YY_RULE_SETUP
 /* Matches unquoted text in UNQUOTED_METADATA mode. */
 case 41:
 YY_RULE_SETUP
-#line 469 "src/Slice/Scanner.l"
+#line 466 "src/Slice/Scanner.l"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(*yylval);
     str->literal += yytext;
@@ -2131,7 +2128,7 @@ YY_RULE_SETUP
 /* Matches the end of unquoted metadata, and places the ']' back into the stream. */
 case 42:
 YY_RULE_SETUP
-#line 476 "src/Slice/Scanner.l"
+#line 473 "src/Slice/Scanner.l"
 {
     BEGIN(METADATA);
     yyless(0);
@@ -2142,7 +2139,7 @@ YY_RULE_SETUP
 case 43:
 /* rule 43 can match eol */
 YY_RULE_SETUP
-#line 483 "src/Slice/Scanner.l"
+#line 480 "src/Slice/Scanner.l"
 {
     nextLine(yyleng);
 }
@@ -2150,7 +2147,7 @@ YY_RULE_SETUP
 /* Matches any characters not matched by another metadata rule (except whitespace), and reports an error. */
 case 44:
 YY_RULE_SETUP
-#line 488 "src/Slice/Scanner.l"
+#line 485 "src/Slice/Scanner.l"
 {
     unit->error("invalid character between metadata");
 }
@@ -2159,7 +2156,7 @@ YY_RULE_SETUP
 case 45:
 /* rule 45 can match eol */
 YY_RULE_SETUP
-#line 494 "src/Slice/Scanner.l"
+#line 491 "src/Slice/Scanner.l"
 {
     StringTokPtr ident = new StringTok;
     ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -2199,7 +2196,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 531 "src/Slice/Scanner.l"
+#line 528 "src/Slice/Scanner.l"
 {
     StringTokPtr ident = new StringTok;
     ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -2211,14 +2208,14 @@ YY_RULE_SETUP
 /* Matches and consumes any whitespace, except for newlines. */
 case 47:
 YY_RULE_SETUP
-#line 541 "src/Slice/Scanner.l"
+#line 538 "src/Slice/Scanner.l"
 {}
 	YY_BREAK
 /* Matches and consumes newlines, but only when the scanner isn't in a sub-scanner. */
 case 48:
 /* rule 48 can match eol */
 YY_RULE_SETUP
-#line 544 "src/Slice/Scanner.l"
+#line 541 "src/Slice/Scanner.l"
 {
     nextLine(yyleng);
 }
@@ -2227,7 +2224,7 @@ YY_RULE_SETUP
 /* Matches and consumes a BOM, but only when the scanner has just started scanning a new file. */
 case 49:
 YY_RULE_SETUP
-#line 551 "src/Slice/Scanner.l"
+#line 548 "src/Slice/Scanner.l"
 {}
 	YY_BREAK
 /* Matches invalid characters, one at a time to make this the 2nd lowest priority rule. All printable ASCII
@@ -2235,7 +2232,7 @@ YY_RULE_SETUP
 case 50:
 /* rule 50 can match eol */
 YY_RULE_SETUP
-#line 555 "src/Slice/Scanner.l"
+#line 552 "src/Slice/Scanner.l"
 {
     stringstream s;
     s << "illegal input character: '\\";
@@ -2252,7 +2249,7 @@ YY_RULE_SETUP
    * This is the lowest priority rule in the scanner, and is only active while not in a sub-scanner. */
 case 51:
 YY_RULE_SETUP
-#line 569 "src/Slice/Scanner.l"
+#line 566 "src/Slice/Scanner.l"
 {
     setLocation(yylloc);
     return yytext[0];
@@ -2260,10 +2257,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 574 "src/Slice/Scanner.l"
+#line 571 "src/Slice/Scanner.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 2266 "src/Slice/Scanner.cpp"
+#line 2263 "src/Slice/Scanner.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(PRE_SLICE):
 case YY_STATE_EOF(SLICE):
@@ -3269,7 +3266,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 574 "src/Slice/Scanner.l"
+#line 571 "src/Slice/Scanner.l"
 
 
 namespace Slice

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -416,14 +416,11 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     yy_push_state(METADATA);
 
     // We use a different token to indicate metadata that should be ignored (if it came after a slice definition).
-    if(yy_top_state() == PRE_SLICE)
+    if(yy_top_state() != PRE_SLICE)
     {
-        return ICE_FILE_METADATA_OPEN;
+        unit->error("file metadata must appear before any definitions");
     }
-    else
-    {
-        return ICE_FILE_METADATA_IGNORE;
-    }
+    return ICE_FILE_METADATA_OPEN;
 }
 
   /* Matches the start of a metadata string, ensures the scanner is in QUOTED_METADATA mode,

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -766,7 +766,7 @@ bool opCompress(const OperationPtr& op, bool params)
 {
     string direction = params ? "params" : "return";
     string prefix = "compress:";
-    string compress = op->findMetaDataWithPrefix(prefix);
+    string compress = op->findMetadataWithPrefix(prefix);
 
     if (compress.empty())
     {

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -63,9 +63,9 @@ isOptionalProxyOrClass(const TypePtr& type)
 }
 
 string
-stringTypeToString(const TypePtr&, const StringList& metaData, int typeCtx)
+stringTypeToString(const TypePtr&, const StringList& metadata, int typeCtx)
 {
-    string strType = findMetaData(metaData, typeCtx);
+    string strType = findMetadata(metadata, typeCtx);
     if(strType == "wstring" || (typeCtx & TypeContextUseWstring && strType == ""))
     {
         return "::std::wstring";
@@ -81,9 +81,9 @@ stringTypeToString(const TypePtr&, const StringList& metaData, int typeCtx)
 }
 
 string
-sequenceTypeToString(const SequencePtr& seq, const string& scope, const StringList& metaData, int typeCtx)
+sequenceTypeToString(const SequencePtr& seq, const string& scope, const StringList& metadata, int typeCtx)
 {
-    string seqType = findMetaData(metaData, typeCtx);
+    string seqType = findMetadata(metadata, typeCtx);
     if(!seqType.empty())
     {
         if(seqType == "%array")
@@ -106,12 +106,12 @@ sequenceTypeToString(const SequencePtr& seq, const string& scope, const StringLi
                 }
                 else
                 {
-                    string s = toTemplateArg(typeToString(seq->type(), scope, seq->typeMetaData(),
+                    string s = toTemplateArg(typeToString(seq->type(), scope, seq->typeMetadata(),
                                                           inWstringModule(seq) ? TypeContextUseWstring : 0));
                     return "::std::vector<" + s + '>';
                 }
             }
-            string s = typeToString(seq->type(), scope, seq->typeMetaData(),
+            string s = typeToString(seq->type(), scope, seq->typeMetadata(),
                                     typeCtx | (inWstringModule(seq) ? TypeContextUseWstring : 0));
             return "::std::pair<const " + s + "*, const " + s + "*>";
         }
@@ -127,9 +127,9 @@ sequenceTypeToString(const SequencePtr& seq, const string& scope, const StringLi
 }
 
 string
-dictionaryTypeToString(const DictionaryPtr& dict, const string& scope, const StringList& metaData, int typeCtx)
+dictionaryTypeToString(const DictionaryPtr& dict, const string& scope, const StringList& metadata, int typeCtx)
 {
-    const string dictType = findMetaData(metaData, typeCtx);
+    const string dictType = findMetadata(metadata, typeCtx);
     if(dictType.empty())
     {
         return getUnqualified(fixKwd(dict->scoped()), scope);
@@ -142,9 +142,9 @@ dictionaryTypeToString(const DictionaryPtr& dict, const string& scope, const Str
 
 void
 writeParamAllocateCode(Output& out, const TypePtr& type, bool isTagged, const string& scope, const string& fixedName,
-                       const StringList& metaData, int typeCtx)
+                       const StringList& metadata, int typeCtx)
 {
-    string s = typeToString(unwrapIfOptional(type), scope, metaData, typeCtx);
+    string s = typeToString(unwrapIfOptional(type), scope, metadata, typeCtx);
     if(isTagged)
     {
         s = toOptional(s);
@@ -377,7 +377,7 @@ Slice::getUnqualified(const std::string& type, const std::string& scope)
 }
 
 string
-Slice::typeToString(const TypePtr& type, const string& scope, const StringList& metaData, int typeCtx)
+Slice::typeToString(const TypePtr& type, const string& scope, const StringList& metadata, int typeCtx)
 {
     static const std::array<std::string, 17> builtinTable =
     {
@@ -402,7 +402,7 @@ Slice::typeToString(const TypePtr& type, const string& scope, const StringList& 
 
     if (isOptionalProxyOrClass(type))
     {
-        return typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metaData, typeCtx);
+        return typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metadata, typeCtx);
     }
 
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
@@ -410,7 +410,7 @@ Slice::typeToString(const TypePtr& type, const string& scope, const StringList& 
     {
         if(builtin->kind() == Builtin::KindString)
         {
-            return stringTypeToString(type, metaData, typeCtx);
+            return stringTypeToString(type, metadata, typeCtx);
         }
         else
         {
@@ -445,13 +445,13 @@ Slice::typeToString(const TypePtr& type, const string& scope, const StringList& 
     SequencePtr seq = SequencePtr::dynamicCast(type);
     if(seq)
     {
-        return sequenceTypeToString(seq, scope, metaData, typeCtx);
+        return sequenceTypeToString(seq, scope, metadata, typeCtx);
     }
 
     DictionaryPtr dict = DictionaryPtr::dynamicCast(type);
     if(dict)
     {
-        return dictionaryTypeToString(dict, scope, metaData, typeCtx);
+        return dictionaryTypeToString(dict, scope, metadata, typeCtx);
     }
 
     assert(0);
@@ -459,20 +459,20 @@ Slice::typeToString(const TypePtr& type, const string& scope, const StringList& 
 }
 
 string
-Slice::typeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metaData, int typeCtx)
+Slice::typeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metadata, int typeCtx)
 {
     if(tagged) // meaning tagged
     {
-        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metaData, typeCtx));
+        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metadata, typeCtx));
     }
     else
     {
-        return typeToString(type, scope, metaData, typeCtx);
+        return typeToString(type, scope, metadata, typeCtx);
     }
 }
 
 string
-Slice::returnTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metaData,
+Slice::returnTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metadata,
                           int typeCtx)
 {
     if(!type)
@@ -482,14 +482,14 @@ Slice::returnTypeToString(const TypePtr& type, bool tagged, const string& scope,
 
     if(tagged)
     {
-        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metaData, typeCtx));
+        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metadata, typeCtx));
     }
 
-    return typeToString(type, scope, metaData, typeCtx);
+    return typeToString(type, scope, metadata, typeCtx);
 }
 
 string
-Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metaData,
+Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metadata,
                          int typeCtx)
 {
     static const std::array<std::string, 17> inputBuiltinTable =
@@ -517,13 +517,13 @@ Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, 
 
     if(tagged)
     {
-        return "const " + toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metaData,
+        return "const " + toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metadata,
             typeCtx)) + '&';
     }
 
     if (isOptionalProxyOrClass(type))
     {
-        return inputTypeToString(OptionalPtr::dynamicCast(type)->underlying(), tagged, scope, metaData, typeCtx);
+        return inputTypeToString(OptionalPtr::dynamicCast(type)->underlying(), tagged, scope, metadata, typeCtx);
     }
 
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
@@ -531,7 +531,7 @@ Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, 
     {
         if(builtin->kind() == Builtin::KindString)
         {
-            return string("const ") + stringTypeToString(type, metaData, typeCtx) + '&';
+            return string("const ") + stringTypeToString(type, metadata, typeCtx) + '&';
         }
         else
         {
@@ -566,13 +566,13 @@ Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, 
     SequencePtr seq = SequencePtr::dynamicCast(type);
     if(seq)
     {
-        return "const " + sequenceTypeToString(seq, scope, metaData, typeCtx) + "&";
+        return "const " + sequenceTypeToString(seq, scope, metadata, typeCtx) + "&";
     }
 
     DictionaryPtr dict = DictionaryPtr::dynamicCast(type);
     if(dict)
     {
-        return "const " + dictionaryTypeToString(dict, scope, metaData, typeCtx) + "&";
+        return "const " + dictionaryTypeToString(dict, scope, metadata, typeCtx) + "&";
     }
 
     assert(0);
@@ -580,7 +580,7 @@ Slice::inputTypeToString(const TypePtr& type, bool tagged, const string& scope, 
 }
 
 string
-Slice::outputTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metaData,
+Slice::outputTypeToString(const TypePtr& type, bool tagged, const string& scope, const StringList& metadata,
                           int typeCtx)
 {
     static const std::array<std::string, 17> outputBuiltinTable =
@@ -606,12 +606,12 @@ Slice::outputTypeToString(const TypePtr& type, bool tagged, const string& scope,
 
     if(tagged)
     {
-        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metaData, typeCtx)) + '&';
+        return toOptional(typeToString(OptionalPtr::dynamicCast(type)->underlying(), scope, metadata, typeCtx)) + '&';
     }
 
     if (isOptionalProxyOrClass(type))
     {
-        return outputTypeToString(OptionalPtr::dynamicCast(type)->underlying(), tagged, scope, metaData, typeCtx);
+        return outputTypeToString(OptionalPtr::dynamicCast(type)->underlying(), tagged, scope, metadata, typeCtx);
     }
 
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
@@ -619,7 +619,7 @@ Slice::outputTypeToString(const TypePtr& type, bool tagged, const string& scope,
     {
         if(builtin->kind() == Builtin::KindString)
         {
-            return stringTypeToString(type, metaData, typeCtx) + "&";
+            return stringTypeToString(type, metadata, typeCtx) + "&";
         }
         else
         {
@@ -654,13 +654,13 @@ Slice::outputTypeToString(const TypePtr& type, bool tagged, const string& scope,
     SequencePtr seq = SequencePtr::dynamicCast(type);
     if(seq)
     {
-        return sequenceTypeToString(seq, scope, metaData, typeCtx) + "&";
+        return sequenceTypeToString(seq, scope, metadata, typeCtx) + "&";
     }
 
     DictionaryPtr dict = DictionaryPtr::dynamicCast(type);
     if(dict)
     {
-        return dictionaryTypeToString(dict, scope, metaData, typeCtx) + "&";
+        return dictionaryTypeToString(dict, scope, metadata, typeCtx) + "&";
     }
 
     assert(0);
@@ -783,12 +783,12 @@ Slice::writeAllocateCode(Output& out, const MemberList& params, const OperationP
     for (const auto& param : params)
     {
         writeParamAllocateCode(out, param->type(), param->tagged(), clScope, fixKwd(prefix + param->name()),
-                               param->getMetaData(), typeCtx);
+                               param->getMetadata(), typeCtx);
     }
 
     if(op && op->deprecatedReturnType())
     {
-        writeParamAllocateCode(out, op->deprecatedReturnType(), op->returnIsTagged(), clScope, returnValueS, op->getMetaData(),
+        writeParamAllocateCode(out, op->deprecatedReturnType(), op->returnIsTagged(), clScope, returnValueS, op->getMetadata(),
                                typeCtx);
     }
 }
@@ -922,7 +922,7 @@ Slice::writeIceTuple(::IceUtilInternal::Output& out, MemberList dataMembers, int
             out << ", ";
         }
         out << "const ";
-        out << typeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetaData(), typeCtx)
+        out << typeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetadata(), typeCtx)
             << "&";
     }
     out << "> ice_tuple() const";
@@ -941,21 +941,21 @@ Slice::writeIceTuple(::IceUtilInternal::Output& out, MemberList dataMembers, int
 }
 
 bool
-Slice::findMetaData(const string& prefix, const ClassDeclPtr& cl, string& value)
+Slice::findMetadata(const string& prefix, const ClassDeclPtr& cl, string& value)
 {
-    if(findMetaData(prefix, cl->getMetaData(), value))
+    if(findMetadata(prefix, cl->getMetadata(), value))
     {
         return true;
     }
 
     ClassDefPtr def = cl->definition();
-    return def ? findMetaData(prefix, def->getMetaData(), value) : false;
+    return def ? findMetadata(prefix, def->getMetadata(), value) : false;
 }
 
 bool
-Slice::findMetaData(const string& prefix, const StringList& metaData, string& value)
+Slice::findMetadata(const string& prefix, const StringList& metadata, string& value)
 {
-    for(StringList::const_iterator i = metaData.begin(); i != metaData.end(); i++)
+    for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); i++)
     {
         string s = *i;
         if(s.find(prefix) == 0)
@@ -968,11 +968,11 @@ Slice::findMetaData(const string& prefix, const StringList& metaData, string& va
 }
 
 string
-Slice::findMetaData(const StringList& metaData, int typeCtx)
+Slice::findMetadata(const StringList& metadata, int typeCtx)
 {
     static const string prefix = "cpp:";
 
-    for(StringList::const_iterator q = metaData.begin(); q != metaData.end(); ++q)
+    for(StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
     {
         string str = *q;
         if(str.find(prefix) == 0)
@@ -1043,12 +1043,12 @@ Slice::inWstringModule(const SequencePtr& seq)
         {
             break;
         }
-        StringList metaData = mod->getMetaData();
-        if(find(metaData.begin(), metaData.end(), "cpp:type:wstring") != metaData.end())
+        StringList metadata = mod->getMetadata();
+        if(find(metadata.begin(), metadata.end(), "cpp:type:wstring") != metadata.end())
         {
             return true;
         }
-        else if(find(metaData.begin(), metaData.end(), "cpp:type:string") != metaData.end())
+        else if(find(metadata.begin(), metadata.end(), "cpp:type:string") != metadata.end())
         {
             return false;
         }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -783,13 +783,13 @@ Slice::writeAllocateCode(Output& out, const MemberList& params, const OperationP
     for (const auto& param : params)
     {
         writeParamAllocateCode(out, param->type(), param->tagged(), clScope, fixKwd(prefix + param->name()),
-                               param->getMetadata(), typeCtx);
+                               param->getAllMetadata(), typeCtx);
     }
 
     if(op && op->deprecatedReturnType())
     {
-        writeParamAllocateCode(out, op->deprecatedReturnType(), op->returnIsTagged(), clScope, returnValueS, op->getMetadata(),
-                               typeCtx);
+        writeParamAllocateCode(out, op->deprecatedReturnType(), op->returnIsTagged(), clScope, returnValueS,
+                                    op->getAllMetadata(), typeCtx);
     }
 }
 
@@ -922,7 +922,7 @@ Slice::writeIceTuple(::IceUtilInternal::Output& out, MemberList dataMembers, int
             out << ", ";
         }
         out << "const ";
-        out << typeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetadata(), typeCtx)
+        out << typeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getAllMetadata(), typeCtx)
             << "&";
     }
     out << "> ice_tuple() const";
@@ -943,13 +943,13 @@ Slice::writeIceTuple(::IceUtilInternal::Output& out, MemberList dataMembers, int
 bool
 Slice::findMetadata(const string& prefix, const ClassDeclPtr& cl, string& value)
 {
-    if(findMetadata(prefix, cl->getMetadata(), value))
+    if (findMetadata(prefix, cl->getAllMetadata(), value))
     {
         return true;
     }
 
     ClassDefPtr def = cl->definition();
-    return def ? findMetadata(prefix, def->getMetadata(), value) : false;
+    return def ? findMetadata(prefix, def->getAllMetadata(), value) : false;
 }
 
 bool
@@ -1043,7 +1043,7 @@ Slice::inWstringModule(const SequencePtr& seq)
         {
             break;
         }
-        StringList metadata = mod->getMetadata();
+        StringList metadata = mod->getAllMetadata();
         if(find(metadata.begin(), metadata.end(), "cpp:type:wstring") != metadata.end())
         {
             return true;

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -53,9 +53,9 @@ void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::strin
 void writeStreamHelpers(::IceUtilInternal::Output&, const DataMemberContainerPtr&);
 void writeIceTuple(::IceUtilInternal::Output&, MemberList, int);
 
-bool findMetaData(const std::string&, const ClassDeclPtr&, std::string&);
-bool findMetaData(const std::string&, const StringList&, std::string&);
-std::string findMetaData(const StringList&, int = 0);
+bool findMetadata(const std::string&, const ClassDeclPtr&, std::string&);
+bool findMetadata(const std::string&, const StringList&, std::string&);
+std::string findMetadata(const StringList&, int = 0);
 bool inWstringModule(const SequencePtr&);
 
 std::string getDataMemberRef(const MemberPtr&);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -169,7 +169,7 @@ writeConstantValue(IceUtilInternal::Output& out, const TypePtr& constType, const
                 EnumeratorPtr enumerator = EnumeratorPtr::dynamicCast(valueType);
                 assert(enumerator);
 
-                bool unscoped = (findMetadata(ep->getMetadata()) == "%unscoped");
+                bool unscoped = (findMetadata(ep->getAllMetadata()) == "%unscoped");
 
                 if(unscoped)
                 {
@@ -580,7 +580,7 @@ emitOpNameResult(IceUtilInternal::Output& H, const OperationPtr& p, int useWstri
     string clScope = fixKwd(interface->scope());
 
     TypePtr ret = p->deprecatedReturnType();
-    string retS = returnTypeToString(ret, p->returnIsTagged(), clScope, p->getMetadata(), useWstring);
+    string retS = returnTypeToString(ret, p->returnIsTagged(), clScope, p->getAllMetadata(), useWstring);
 
     MemberList outParams = p->outParameters();
 
@@ -621,7 +621,8 @@ emitOpNameResult(IceUtilInternal::Output& H, const OperationPtr& p, int useWstri
         }
         for (const auto& param : outParams)
         {
-            string typeString = typeToString(param->type(), param->tagged(), clScope, param->getMetadata(), useWstring);
+            string typeString = typeToString(param->type(), param->tagged(), clScope, param->getAllMetadata(),
+                                             useWstring);
 
             map<string, StringList>::iterator r = paramComments.find(param->name());
             if(r != paramComments.end())
@@ -903,7 +904,7 @@ Slice::Gen::generate(const UnitPtr& p)
     {
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetadata = dc->getMetadata();
+        StringList globalMetadata = dc->getAllMetadata();
         for(StringList::const_iterator q = globalMetadata.begin(); q != globalMetadata.end();)
         {
             string md = *q++;
@@ -1070,7 +1071,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& p)
         string file = *q;
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetadata = dc->getMetadata();
+        StringList globalMetadata = dc->getAllMetadata();
         int headerExtension = 0;
         int sourceExtension = 0;
         int dllExport = 0;
@@ -1155,7 +1156,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& p)
 bool
 Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1168,14 +1169,14 @@ Slice::Gen::MetadataVisitor::visitModuleEnd(const ModulePtr&)
 void
 Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1188,14 +1189,14 @@ Slice::Gen::MetadataVisitor::visitClassDefEnd(const ClassDefPtr&)
 void
 Slice::Gen::MetadataVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1208,7 +1209,7 @@ Slice::Gen::MetadataVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 bool
 Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1221,7 +1222,7 @@ Slice::Gen::MetadataVisitor::visitExceptionEnd(const ExceptionPtr&)
 bool
 Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1236,7 +1237,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(p->container());
 
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
 
     const UnitPtr ut = p->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(p->file());
@@ -1273,7 +1274,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 
     for (auto& param : p->allMembers())
     {
-        metadata = validate(param->type(), param->getMetadata(), p->file(), param->line(), true);
+        metadata = validate(param->type(), param->getAllMetadata(), p->file(), param->line(), true);
         param->setMetadata(metadata);
     }
 }
@@ -1281,35 +1282,35 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::Gen::MetadataVisitor::visitDataMember(const MemberPtr& p)
 {
-    StringList metadata = validate(p->type(), p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p->type(), p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    StringList metadata = validate(p, p->getAllMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
@@ -1393,7 +1394,7 @@ int
 Slice::Gen::setUseWstring(ContainedPtr p, list<int>& hist, int use)
 {
     hist.push_back(use);
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
     if(find(metadata.begin(), metadata.end(), "cpp:type:wstring") != metadata.end())
     {
         use = TypeContextUseWstring;
@@ -1632,7 +1633,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     for (const auto& member : allDataMembers)
     {
-        string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetadata(), _useWstring);
+        string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getAllMetadata(),
+                                            _useWstring);
         allParameters.push_back(typeName + " " + fixKwd(member->name()));
 
         if (CommentPtr comment = member->parseComment(false))
@@ -1765,7 +1767,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     C << nl << "return typeId;";
     C << eb;
 
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
     if(find(metadata.begin(), metadata.end(), "cpp:ice_print") != metadata.end())
     {
         H << nl << "/**";
@@ -1915,7 +1917,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     const string scope = "";
     string name = fixKwd(p->name());
     writeDocSummary(H, p);
-    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetadata(), _useWstring)
+    H << nl << typeToString(p->type(), p->tagged(), scope, p->getAllMetadata(), _useWstring)
       << ' ' << name;
 
     string defaultValue = p->defaultValue();
@@ -1929,14 +1931,14 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
             //
             H << '{';
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetadata(), scope);
+                               p->getAllMetadata(), scope);
             H << '}';
         }
         else
         {
             H << " = ";
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetadata(), scope);
+                               p->getAllMetadata(), scope);
         }
     }
 
@@ -1951,7 +1953,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     TypePtr type = p->type();
     int typeCtx = _useWstring;
     string s = typeToString(type, scope, p->typeMetadata(), typeCtx);
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
 
     string seqType = findMetadata(metadata, _useWstring);
     H << sp;
@@ -1972,7 +1974,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     string name = fixKwd(p->name());
     string scope = fixKwd(p->scope());
-    string dictType = findMetadata(p->getMetadata());
+    string dictType = findMetadata(p->getAllMetadata());
     int typeCtx = _useWstring;
 
     H << sp;
@@ -2136,7 +2138,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     TypePtr ret = p->deprecatedReturnType();
 
     bool retIsTagged = p->returnIsTagged();
-    string retS = returnTypeToString(ret, retIsTagged, clScope, p->getMetadata(), _useWstring);
+    string retS = returnTypeToString(ret, retIsTagged, clScope, p->getAllMetadata(), _useWstring);
 
     vector<string> params;
     vector<string> paramsDecl;
@@ -2160,9 +2162,9 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         //
         // Use empty scope to get full qualified names in types used with future declarations.
         //
-        futureOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetadata(), _useWstring));
+        futureOutParams.push_back(typeToString(ret, retIsTagged, "", p->getAllMetadata(), _useWstring));
 
-        lambdaOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetadata(), _useWstring |
+        lambdaOutParams.push_back(typeToString(ret, retIsTagged, "", p->getAllMetadata(), _useWstring |
                                                TypeContextInParam));
 
         hasTaggedOutParams |= p->returnIsTagged();
@@ -2171,7 +2173,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     for (const auto& inParam : inParams)
     {
         string paramName = fixKwd(inParam->name());
-        string typeString = inputTypeToString(inParam->type(), inParam->tagged(), clScope, inParam->getMetadata(),
+        string typeString = inputTypeToString(inParam->type(), inParam->tagged(), clScope, inParam->getAllMetadata(),
                                               _useWstring);
 
         params.push_back(typeString);
@@ -2184,7 +2186,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     for (const auto& outParam : outParams)
     {
-        StringList metadata = outParam->getMetadata();
+        StringList metadata = outParam->getAllMetadata();
 
         // Use empty scope to get full qualified names in types used with future declarations.
         futureOutParams.push_back(typeToString(outParam->type(), outParam->tagged(), "", metadata, _useWstring));
@@ -2569,7 +2571,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
-    bool unscoped = findMetadata(p->getMetadata()) == "%unscoped";
+    bool unscoped = findMetadata(p->getAllMetadata()) == "%unscoped";
     H << sp;
     writeDocSummary(H, p);
     H << nl << "enum ";
@@ -2663,7 +2665,7 @@ Slice::Gen::ObjectVisitor::emitDataMember(const MemberPtr& p)
     string scope = "";
 
     writeDocSummary(H, p);
-    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetadata(), typeContext) << ' ' << name;
+    H << nl << typeToString(p->type(), p->tagged(), scope, p->getAllMetadata(), typeContext) << ' ' << name;
 
     string defaultValue = p->defaultValue();
     if(!defaultValue.empty())
@@ -2676,14 +2678,14 @@ Slice::Gen::ObjectVisitor::emitDataMember(const MemberPtr& p)
             //
             H << '{';
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetadata(), scope);
+                               p->getAllMetadata(), scope);
             H << '}';
         }
         else
         {
             H << " = ";
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetadata(), scope);
+                               p->getAllMetadata(), scope);
         }
     }
     H << ";";
@@ -2981,7 +2983,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 
     if(ret)
     {
-        string typeS = inputTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetadata(), _useWstring);
+        string typeS = inputTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getAllMetadata(), _useWstring);
         responseParams.push_back(typeS + " " + returnValueParam);
         responseParamsDecl.push_back(typeS + " ret");
         responseParamsImplDecl.push_back(typeS + " ret");
@@ -2998,14 +3000,14 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     }
     else
     {
-        retS = returnTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetadata(), _useWstring);
+        retS = returnTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getAllMetadata(), _useWstring);
     }
 
     for (const auto& inParam : inParams)
     {
         TypePtr type = inParam->type();
         string paramName = fixKwd(inParam->name());
-        params.push_back(typeToString(type, inParam->tagged(), interfaceScope, inParam->getMetadata(),
+        params.push_back(typeToString(type, inParam->tagged(), interfaceScope, inParam->getAllMetadata(),
                                       _useWstring | TypeContextInParam) + " " + paramName);
         args.push_back(condMove(isMovable(type), paramPrefix + inParam->name()));
     }
@@ -3017,13 +3019,13 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 
         if(!p->hasMarshaledResult() && !amd)
         {
-            params.push_back(outputTypeToString(type, outParam->tagged(), interfaceScope, outParam->getMetadata(),
+            params.push_back(outputTypeToString(type, outParam->tagged(), interfaceScope, outParam->getAllMetadata(),
                                                 _useWstring) + " " + paramName);
             args.push_back(paramPrefix + outParam->name());
         }
 
         string responseTypeS = inputTypeToString(outParam->type(), outParam->tagged(), interfaceScope,
-                                                    outParam->getMetadata(), _useWstring);
+                                                    outParam->getAllMetadata(), _useWstring);
         responseParams.push_back(responseTypeS + " " + paramName);
         responseParamsDecl.push_back(responseTypeS + " " + paramPrefix + outParam->name());
         responseParamsImplDecl.push_back(responseTypeS + " " + paramPrefix + outParam->name());
@@ -3533,7 +3535,7 @@ Slice::Gen::ObjectVisitor::emitOneShotConstructor(const ClassDefPtr& p)
 
         for (const auto& member : allDataMembers)
         {
-            string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetadata(),
+            string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getAllMetadata(),
                                                 typeContext);
             allParamDecls.push_back(typeName + " " + fixKwd(member->name()));
             CommentPtr comment = member->parseComment(false);
@@ -3895,7 +3897,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         TypePtr ret = op->deprecatedReturnType();
         string retS = op->hasMarshaledResult() ?
             scoped + "::" + resultStructName(opName, "", true) :
-            returnTypeToString(ret, op->returnIsTagged(), "", op->getMetadata(), _useWstring);
+            returnTypeToString(ret, op->returnIsTagged(), "", op->getAllMetadata(), _useWstring);
 
         MemberList inParams = op->params();
         MemberList outParams = op->outParameters();
@@ -3909,7 +3911,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             for (const auto& param : inParams)
             {
                 H << typeToString(param->type(), param->tagged(), scope,
-                                  param->getMetadata(), _useWstring | TypeContextInParam)
+                                  param->getAllMetadata(), _useWstring | TypeContextInParam)
                   << "," << nl;
             }
 
@@ -3921,7 +3923,8 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 if(ret)
                 {
-                    responseParams = inputTypeToString(ret, op->returnIsTagged(), scope, op->getMetadata(), _useWstring);
+                    responseParams = inputTypeToString(ret, op->returnIsTagged(), scope, op->getAllMetadata(),
+                                                       _useWstring);
                     if(!outParams.empty())
                     {
                         responseParams += ", ";
@@ -3934,7 +3937,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     {
                         responseParams += ", ";
                     }
-                    responseParams += inputTypeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetadata(),
+                    responseParams += inputTypeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getAllMetadata(),
                                                         _useWstring);
                 }
             }
@@ -3950,7 +3953,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             C.useCurrentPosAsIndent();
             for (const auto& param : inParams)
             {
-                C << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
+                C << typeToString(param->type(), param->tagged(), scope, param->getAllMetadata(),
                                   _useWstring | TypeContextInParam);
                 C << ' ' << fixKwd(param->name()) << "," << nl;
             }
@@ -3969,11 +3972,11 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             C << spar;
             if(ret)
             {
-                C << defaultValue(ret, scope, op->getMetadata());
+                C << defaultValue(ret, scope, op->getAllMetadata());
             }
             for (const auto& param : outParams)
             {
-                C << defaultValue(param->type(), scope, op->getMetadata());
+                C << defaultValue(param->type(), scope, op->getAllMetadata());
             }
 
             if(op->hasMarshaledResult())
@@ -3994,7 +3997,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (const auto& param : inParams)
             {
-                H << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
+                H << typeToString(param->type(), param->tagged(), scope, param->getAllMetadata(),
                                   _useWstring | TypeContextInParam)
                 << ',' << nl;
             }
@@ -4002,7 +4005,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    H << outputTypeToString(param->type(), param->tagged(), scope, param->getMetadata(), _useWstring)
+                    H << outputTypeToString(param->type(), param->tagged(), scope, param->getAllMetadata(), _useWstring)
                     << ',' << nl;
                 }
             }
@@ -4020,7 +4023,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (const auto& param : inParams)
             {
-                C << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
+                C << typeToString(param->type(), param->tagged(), scope, param->getAllMetadata(),
                                   _useWstring | TypeContextInParam)
                   << " /*" << fixKwd(param->name()) << "*/" << ',' << nl;
             }
@@ -4028,7 +4031,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    C << outputTypeToString(param->type(), param->tagged(), scope, param->getMetadata(), _useWstring)
+                    C << outputTypeToString(param->type(), param->tagged(), scope, param->getAllMetadata(), _useWstring)
                       << " " << fixKwd(param->name()) << ',' << nl;
                 }
             }
@@ -4046,7 +4049,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     C << nl << "return " << scoped << "::" << resultStructName(opName, "", true) << "(";
                     if(ret)
                     {
-                        C << defaultValue(ret, scope, op->getMetadata());
+                        C << defaultValue(ret, scope, op->getAllMetadata());
                         if(!outParams.empty())
                         {
                             C << ", ";
@@ -4055,7 +4058,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
                     for(auto q = outParams.begin(); q != outParams.end();)
                     {
-                        C << defaultValue((*q)->type(), scope, op->getMetadata());
+                        C << defaultValue((*q)->type(), scope, op->getAllMetadata());
                         if(++q != outParams.end())
                         {
                             C << ", ";
@@ -4068,13 +4071,14 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    C << nl << fixKwd(param->name()) << " = " << defaultValue(param->type(), scope, op->getMetadata())
+                    C << nl << fixKwd(param->name()) << " = " << defaultValue(param->type(), scope,
+                                                                              op->getAllMetadata())
                       << ";";
                 }
 
                 if(ret)
                 {
-                    C << nl << "return " << defaultValue(ret, scope, op->getMetadata()) << ";";
+                    C << nl << "return " << defaultValue(ret, scope, op->getAllMetadata()) << ";";
                 }
             }
             C << eb;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -83,8 +83,8 @@ string
 getDeprecateSymbol(const ContainedPtr& p1, const ContainedPtr& p2)
 {
     string deprecateMetadata, deprecateSymbol;
-    if(p1->findMetaData("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata)))
+    if(p1->findMetadata("deprecate", deprecateMetadata) ||
+       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
     {
         string msg = "is deprecated";
         if(deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
@@ -98,7 +98,7 @@ getDeprecateSymbol(const ContainedPtr& p1, const ContainedPtr& p2)
 
 void
 writeConstantValue(IceUtilInternal::Output& out, const TypePtr& constType, const SyntaxTreeBasePtr& valueType,
-                   const string& value, int typeContext, const StringList& metaData, const string& scope)
+                   const string& value, int typeContext, const StringList& metadata, const string& scope)
 {
     TypePtr type = unwrapIfOptional(constType);
     ConstPtr constant = ConstPtr::dynamicCast(valueType);
@@ -115,7 +115,7 @@ writeConstantValue(IceUtilInternal::Output& out, const TypePtr& constType, const
             {
                 case Builtin::KindString:
                 {
-                    bool wide = (typeContext & TypeContextUseWstring) || findMetaData(metaData) == "wstring";
+                    bool wide = (typeContext & TypeContextUseWstring) || findMetadata(metadata) == "wstring";
                     out << (wide ? "L\"" : "u8\"");
                     out << toStringLiteral(value, "\a\b\f\n\r\t\v", "?", UCN, 0);
                     out << "\"";
@@ -169,7 +169,7 @@ writeConstantValue(IceUtilInternal::Output& out, const TypePtr& constType, const
                 EnumeratorPtr enumerator = EnumeratorPtr::dynamicCast(valueType);
                 assert(enumerator);
 
-                bool unscoped = (findMetaData(ep->getMetaData()) == "%unscoped");
+                bool unscoped = (findMetadata(ep->getMetadata()) == "%unscoped");
 
                 if(unscoped)
                 {
@@ -448,7 +448,7 @@ writeDocSummary(Output& out, const ContainedPtr& p)
         static const string prefix = "cpp:doxygen:include:";
         DefinitionContextPtr dc = unt->findDefinitionContext(file);
         assert(dc);
-        string q = dc->findMetaData(prefix);
+        string q = dc->findMetadata(prefix);
         if(!q.empty())
         {
             out << nl << " * \\headerfile " << q.substr(prefix.size());
@@ -580,7 +580,7 @@ emitOpNameResult(IceUtilInternal::Output& H, const OperationPtr& p, int useWstri
     string clScope = fixKwd(interface->scope());
 
     TypePtr ret = p->deprecatedReturnType();
-    string retS = returnTypeToString(ret, p->returnIsTagged(), clScope, p->getMetaData(), useWstring);
+    string retS = returnTypeToString(ret, p->returnIsTagged(), clScope, p->getMetadata(), useWstring);
 
     MemberList outParams = p->outParameters();
 
@@ -621,7 +621,7 @@ emitOpNameResult(IceUtilInternal::Output& H, const OperationPtr& p, int useWstri
         }
         for (const auto& param : outParams)
         {
-            string typeString = typeToString(param->type(), param->tagged(), clScope, param->getMetaData(), useWstring);
+            string typeString = typeToString(param->type(), param->tagged(), clScope, param->getMetadata(), useWstring);
 
             map<string, StringList>::iterator r = paramComments.find(param->name());
             if(r != paramComments.end())
@@ -704,7 +704,7 @@ Slice::Gen::generate(const UnitPtr& p)
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
         static const string dllExportPrefix = "cpp:dll-export:";
-        string meta = dc->findMetaData(dllExportPrefix);
+        string meta = dc->findMetadata(dllExportPrefix);
         if(meta.size() > dllExportPrefix.size())
         {
             _dllExport = meta.substr(dllExportPrefix.size());
@@ -805,7 +805,7 @@ Slice::Gen::generate(const UnitPtr& p)
     H << "\n#define __" << s << "__";
     H << '\n';
 
-    validateMetaData(p);
+    validateMetadata(p);
 
     writeExtraHeaders(C);
 
@@ -840,7 +840,7 @@ Slice::Gen::generate(const UnitPtr& p)
         H << "\n#include <Ice/GCObject.h>";
         H << "\n#include <Ice/Value.h>";
         H << "\n#include <Ice/Incoming.h>";
-        if(p->hasContentsWithMetaData("amd"))
+        if(p->hasContentsWithMetadata("amd"))
         {
             H << "\n#include <Ice/IncomingAsync.h>";
         }
@@ -874,7 +874,7 @@ Slice::Gen::generate(const UnitPtr& p)
         C << "\n#include <Ice/LocalException.h>";
     }
 
-    if(p->hasContentsWithMetaData("preserve-slice"))
+    if(p->hasContentsWithMetadata("preserve-slice"))
     {
         H << "\n#include <Ice/SlicedDataF.h>";
         C << "\n#include <Ice/SlicedData.h>";
@@ -903,8 +903,8 @@ Slice::Gen::generate(const UnitPtr& p)
     {
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetaData = dc->getMetaData();
-        for(StringList::const_iterator q = globalMetaData.begin(); q != globalMetaData.end();)
+        StringList globalMetadata = dc->getMetadata();
+        for(StringList::const_iterator q = globalMetadata.begin(); q != globalMetadata.end();)
         {
             string md = *q++;
             static const string includePrefix = "cpp:include:";
@@ -919,8 +919,8 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid global metadata `" << md << "'";
-                    dc->warning(InvalidMetaData, file, -1, ostr.str());
-                    globalMetaData.remove(md);
+                    dc->warning(InvalidMetadata, file, -1, ostr.str());
+                    globalMetadata.remove(md);
                 }
             }
             else if(md.find(sourceIncludePrefix) == 0)
@@ -933,12 +933,12 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid global metadata `" << md << "'";
-                    dc->warning(InvalidMetaData, file, -1, ostr.str());
-                    globalMetaData.remove(md);
+                    dc->warning(InvalidMetadata, file, -1, ostr.str());
+                    globalMetadata.remove(md);
                 }
             }
         }
-        dc->setMetaData(globalMetaData);
+        dc->setMetadata(globalMetadata);
     }
 
     //
@@ -1049,14 +1049,14 @@ Slice::Gen::writeExtraHeaders(IceUtilInternal::Output& out)
 }
 
 void
-Slice::Gen::validateMetaData(const UnitPtr& u)
+Slice::Gen::validateMetadata(const UnitPtr& u)
 {
-    MetaDataVisitor visitor;
+    MetadataVisitor visitor;
     u->visit(&visitor, false);
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& p)
 {
     static const string prefix = "cpp:";
 
@@ -1070,11 +1070,11 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
         string file = *q;
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetaData = dc->getMetaData();
+        StringList globalMetadata = dc->getMetadata();
         int headerExtension = 0;
         int sourceExtension = 0;
         int dllExport = 0;
-        for(StringList::const_iterator r = globalMetaData.begin(); r != globalMetaData.end();)
+        for(StringList::const_iterator r = globalMetadata.begin(); r != globalMetadata.end();)
         {
             string s = *r++;
             if(s.find(prefix) == 0)
@@ -1102,8 +1102,8 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                         ostringstream ostr;
                         ostr << "ignoring invalid global metadata `" << s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetaData, file, -1, ostr.str());
-                        globalMetaData.remove(s);
+                        dc->warning(InvalidMetadata, file, -1, ostr.str());
+                        globalMetadata.remove(s);
                     }
                     continue;
                 }
@@ -1115,8 +1115,8 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                         ostringstream ostr;
                         ostr << "ignoring invalid global metadata `" << s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetaData, file, -1, ostr.str());
-                        globalMetaData.remove(s);
+                        dc->warning(InvalidMetadata, file, -1, ostr.str());
+                        globalMetadata.remove(s);
                     }
                     continue;
                 }
@@ -1128,9 +1128,9 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                         ostringstream ostr;
                         ostr << "ignoring invalid global metadata `" << s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetaData, file, -1, ostr.str());
+                        dc->warning(InvalidMetadata, file, -1, ostr.str());
 
-                        globalMetaData.remove(s);
+                        globalMetadata.remove(s);
                     }
                     continue;
                 }
@@ -1141,102 +1141,102 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
 
                 ostringstream ostr;
                 ostr << "ignoring invalid global metadata `" << s << "'";
-                dc->warning(InvalidMetaData, file, -1, ostr.str());
-                globalMetaData.remove(s);
+                dc->warning(InvalidMetadata, file, -1, ostr.str());
+                globalMetadata.remove(s);
             }
 
         }
-        dc->setMetaData(globalMetaData);
+        dc->setMetadata(globalMetadata);
     }
 
     return true;
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
+Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
     return true;
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitModuleEnd(const ModulePtr&)
+Slice::Gen::MetadataVisitor::visitModuleEnd(const ModulePtr&)
 {
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitClassDecl(const ClassDeclPtr& p)
+Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
     return true;
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitClassDefEnd(const ClassDefPtr&)
+Slice::Gen::MetadataVisitor::visitClassDefEnd(const ClassDefPtr&)
 {
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
+Slice::Gen::MetadataVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::Gen::MetadataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
     return true;
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
-{
-}
-
-bool
-Slice::Gen::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
-{
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
-    return true;
-}
-
-void
-Slice::Gen::MetaDataVisitor::visitExceptionEnd(const ExceptionPtr&)
+Slice::Gen::MetadataVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitStructStart(const StructPtr& p)
+Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
     return true;
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitStructEnd(const StructPtr&)
+Slice::Gen::MetadataVisitor::visitExceptionEnd(const ExceptionPtr&)
+{
+}
+
+bool
+Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
+{
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
+    return true;
+}
+
+void
+Slice::Gen::MetadataVisitor::visitStructEnd(const StructPtr&)
 {
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitOperation(const OperationPtr& p)
+Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(p->container());
 
-    StringList metaData = p->getMetaData();
+    StringList metadata = p->getMetadata();
 
     const UnitPtr ut = p->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(p->file());
@@ -1245,14 +1245,14 @@ Slice::Gen::MetaDataVisitor::visitOperation(const OperationPtr& p)
     TypePtr returnType = p->deprecatedReturnType();
     if(!returnType)
     {
-        for(StringList::const_iterator q = metaData.begin(); q != metaData.end();)
+        for(StringList::const_iterator q = metadata.begin(); q != metadata.end();)
         {
             string s = *q++;
             if(s.find("cpp:type:") == 0 || s.find("cpp:view-type:") == 0 || s == "cpp:array")
             {
-                dc->warning(InvalidMetaData, p->file(), p->line(),
+                dc->warning(InvalidMetadata, p->file(), p->line(),
                             "ignoring invalid metadata `" + s + "' for operation with void return type");
-                metaData.remove(s);
+                metadata.remove(s);
             }
             else if(s.find("cpp:const") == 0 || s.find("cpp:noexcept") == 0)
             {
@@ -1260,66 +1260,66 @@ Slice::Gen::MetaDataVisitor::visitOperation(const OperationPtr& p)
             }
             else if(s.find("cpp:") == 0)
             {
-                dc->warning(InvalidMetaData, p->file(), p->line(), "ignoring invalid metadata `" + s + "'");
+                dc->warning(InvalidMetadata, p->file(), p->line(), "ignoring invalid metadata `" + s + "'");
             }
         }
     }
     else
     {
-        metaData = validate(returnType, metaData, p->file(), p->line(), true);
+        metadata = validate(returnType, metadata, p->file(), p->line(), true);
     }
 
-    p->setMetaData(metaData);
+    p->setMetadata(metadata);
 
     for (auto& param : p->allMembers())
     {
-        metaData = validate(param->type(), param->getMetaData(), p->file(), param->line(), true);
-        param->setMetaData(metaData);
+        metadata = validate(param->type(), param->getMetadata(), p->file(), param->line(), true);
+        param->setMetadata(metadata);
     }
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitDataMember(const MemberPtr& p)
+Slice::Gen::MetadataVisitor::visitDataMember(const MemberPtr& p)
 {
-    StringList metaData = validate(p->type(), p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p->type(), p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitSequence(const SequencePtr& p)
+Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitEnum(const EnumPtr& p)
+Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitConst(const ConstPtr& p)
+Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
-    p->setMetaData(metaData);
+    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    p->setMetadata(metadata);
 }
 
 StringList
-Slice::Gen::MetaDataVisitor::validate(const SyntaxTreeBasePtr& cont, const StringList& metaData,
+Slice::Gen::MetadataVisitor::validate(const SyntaxTreeBasePtr& cont, const StringList& metadata,
                                       const string& file, int line, bool operation)
 {
     if (auto optional = OptionalPtr::dynamicCast(cont))
     {
-        return validate(optional->underlying(), metaData, file, line, operation);
+        return validate(optional->underlying(), metadata, file, line, operation);
     }
 
     static const string cppPrefix = "cpp:";
@@ -1327,8 +1327,8 @@ Slice::Gen::MetaDataVisitor::validate(const SyntaxTreeBasePtr& cont, const Strin
     const UnitPtr ut = cont->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    StringList newMetaData = metaData;
-    for(StringList::const_iterator p = newMetaData.begin(); p != newMetaData.end();)
+    StringList newMetadata = metadata;
+    for(StringList::const_iterator p = newMetadata.begin(); p != newMetadata.end();)
     {
         string s = *p++;
 
@@ -1381,24 +1381,24 @@ Slice::Gen::MetaDataVisitor::validate(const SyntaxTreeBasePtr& cont, const Strin
                 continue;
             }
 
-            dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + s + "'");
-            newMetaData.remove(s);
+            dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "'");
+            newMetadata.remove(s);
             continue;
         }
     }
-    return newMetaData;
+    return newMetadata;
 }
 
 int
 Slice::Gen::setUseWstring(ContainedPtr p, list<int>& hist, int use)
 {
     hist.push_back(use);
-    StringList metaData = p->getMetaData();
-    if(find(metaData.begin(), metaData.end(), "cpp:type:wstring") != metaData.end())
+    StringList metadata = p->getMetadata();
+    if(find(metadata.begin(), metadata.end(), "cpp:type:wstring") != metadata.end())
     {
         use = TypeContextUseWstring;
     }
-    else if(find(metaData.begin(), metaData.end(), "cpp:type:string") != metaData.end())
+    else if(find(metadata.begin(), metadata.end(), "cpp:type:string") != metadata.end())
     {
         use = 0;
     }
@@ -1420,7 +1420,7 @@ Slice::Gen::getHeaderExt(const string& file, const UnitPtr& ut)
     static const string headerExtPrefix = "cpp:header-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    string meta = dc->findMetaData(headerExtPrefix);
+    string meta = dc->findMetadata(headerExtPrefix);
     if(meta.size() > headerExtPrefix.size())
     {
         ext = meta.substr(headerExtPrefix.size());
@@ -1435,7 +1435,7 @@ Slice::Gen::getSourceExt(const string& file, const UnitPtr& ut)
     static const string sourceExtPrefix = "cpp:source-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    string meta = dc->findMetaData(sourceExtPrefix);
+    string meta = dc->findMetadata(sourceExtPrefix);
     if(meta.size() > sourceExtPrefix.size())
     {
         ext = meta.substr(sourceExtPrefix.size());
@@ -1632,7 +1632,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     for (const auto& member : allDataMembers)
     {
-        string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetaData(), _useWstring);
+        string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetadata(), _useWstring);
         allParameters.push_back(typeName + " " + fixKwd(member->name()));
 
         if (CommentPtr comment = member->parseComment(false))
@@ -1765,8 +1765,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     C << nl << "return typeId;";
     C << eb;
 
-    StringList metaData = p->getMetaData();
-    if(find(metaData.begin(), metaData.end(), "cpp:ice_print") != metaData.end())
+    StringList metadata = p->getMetadata();
+    if(find(metadata.begin(), metadata.end(), "cpp:ice_print") != metadata.end())
     {
         H << nl << "/**";
         H << nl << " * Prints this exception to the given stream.";
@@ -1811,8 +1811,8 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     string factoryName;
 
     ExceptionPtr base = p->base();
-    bool basePreserved = p->inheritsMetaData("preserve-slice");
-    bool preserved = p->hasMetaData("preserve-slice");
+    bool basePreserved = p->inheritsMetadata("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice");
 
     if(preserved && !basePreserved)
     {
@@ -1915,7 +1915,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     const string scope = "";
     string name = fixKwd(p->name());
     writeDocSummary(H, p);
-    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetaData(), _useWstring)
+    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetadata(), _useWstring)
       << ' ' << name;
 
     string defaultValue = p->defaultValue();
@@ -1929,14 +1929,14 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
             //
             H << '{';
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetaData(), scope);
+                               p->getMetadata(), scope);
             H << '}';
         }
         else
         {
             H << " = ";
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetaData(), scope);
+                               p->getMetadata(), scope);
         }
     }
 
@@ -1950,10 +1950,10 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     string scope = fixKwd(p->scope());
     TypePtr type = p->type();
     int typeCtx = _useWstring;
-    string s = typeToString(type, scope, p->typeMetaData(), typeCtx);
-    StringList metaData = p->getMetaData();
+    string s = typeToString(type, scope, p->typeMetadata(), typeCtx);
+    StringList metadata = p->getMetadata();
 
-    string seqType = findMetaData(metaData, _useWstring);
+    string seqType = findMetadata(metadata, _useWstring);
     H << sp;
     writeDocSummary(H, p);
 
@@ -1972,7 +1972,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     string name = fixKwd(p->name());
     string scope = fixKwd(p->scope());
-    string dictType = findMetaData(p->getMetaData());
+    string dictType = findMetadata(p->getMetadata());
     int typeCtx = _useWstring;
 
     H << sp;
@@ -1985,8 +1985,8 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
         //
         TypePtr keyType = p->keyType();
         TypePtr valueType = p->valueType();
-        string ks = typeToString(keyType, scope, p->keyMetaData(), typeCtx);
-        string vs = typeToString(valueType, scope, p->valueMetaData(), typeCtx);
+        string ks = typeToString(keyType, scope, p->keyMetadata(), typeCtx);
+        string vs = typeToString(valueType, scope, p->valueMetadata(), typeCtx);
 
         H << nl << "using " << name << " = ::std::map<" << ks << ", " << vs << ">;";
     }
@@ -2136,7 +2136,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     TypePtr ret = p->deprecatedReturnType();
 
     bool retIsTagged = p->returnIsTagged();
-    string retS = returnTypeToString(ret, retIsTagged, clScope, p->getMetaData(), _useWstring);
+    string retS = returnTypeToString(ret, retIsTagged, clScope, p->getMetadata(), _useWstring);
 
     vector<string> params;
     vector<string> paramsDecl;
@@ -2160,9 +2160,9 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         //
         // Use empty scope to get full qualified names in types used with future declarations.
         //
-        futureOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetaData(), _useWstring));
+        futureOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetadata(), _useWstring));
 
-        lambdaOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetaData(), _useWstring |
+        lambdaOutParams.push_back(typeToString(ret, retIsTagged, "", p->getMetadata(), _useWstring |
                                                TypeContextInParam));
 
         hasTaggedOutParams |= p->returnIsTagged();
@@ -2171,7 +2171,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     for (const auto& inParam : inParams)
     {
         string paramName = fixKwd(inParam->name());
-        string typeString = inputTypeToString(inParam->type(), inParam->tagged(), clScope, inParam->getMetaData(),
+        string typeString = inputTypeToString(inParam->type(), inParam->tagged(), clScope, inParam->getMetadata(),
                                               _useWstring);
 
         params.push_back(typeString);
@@ -2184,13 +2184,13 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     for (const auto& outParam : outParams)
     {
-        StringList metaData = outParam->getMetaData();
+        StringList metadata = outParam->getMetadata();
 
         // Use empty scope to get full qualified names in types used with future declarations.
-        futureOutParams.push_back(typeToString(outParam->type(), outParam->tagged(), "", metaData, _useWstring));
-        lambdaOutParams.push_back(typeToString(outParam->type(), outParam->tagged(), "", metaData,
+        futureOutParams.push_back(typeToString(outParam->type(), outParam->tagged(), "", metadata, _useWstring));
+        lambdaOutParams.push_back(typeToString(outParam->type(), outParam->tagged(), "", metadata,
                                                _useWstring | TypeContextInParam));
-        string outputTypeString = outputTypeToString(outParam->type(), outParam->tagged(), clScope, metaData,
+        string outputTypeString = outputTypeToString(outParam->type(), outParam->tagged(), clScope, metadata,
                                                      _useWstring);
 
         params.push_back(outputTypeString);
@@ -2569,7 +2569,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
-    bool unscoped = findMetaData(p->getMetaData()) == "%unscoped";
+    bool unscoped = findMetadata(p->getMetadata()) == "%unscoped";
     H << sp;
     writeDocSummary(H, p);
     H << nl << "enum ";
@@ -2616,9 +2616,9 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
     H << sp;
     writeDocSummary(H, p);
     H << nl << (isConstexprType(p->type()) ? "constexpr " : "const ")
-      << typeToString(p->type(), scope, p->typeMetaData(), _useWstring) << " " << fixKwd(p->name())
+      << typeToString(p->type(), scope, p->typeMetadata(), _useWstring) << " " << fixKwd(p->name())
       << " = ";
-    writeConstantValue(H, p->type(), p->valueType(), p->value(), _useWstring, p->typeMetaData(),
+    writeConstantValue(H, p->type(), p->valueType(), p->value(), _useWstring, p->typeMetadata(),
                        scope);
     H << ';';
 }
@@ -2663,7 +2663,7 @@ Slice::Gen::ObjectVisitor::emitDataMember(const MemberPtr& p)
     string scope = "";
 
     writeDocSummary(H, p);
-    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetaData(), typeContext) << ' ' << name;
+    H << nl << typeToString(p->type(), p->tagged(), scope, p->getMetadata(), typeContext) << ' ' << name;
 
     string defaultValue = p->defaultValue();
     if(!defaultValue.empty())
@@ -2676,14 +2676,14 @@ Slice::Gen::ObjectVisitor::emitDataMember(const MemberPtr& p)
             //
             H << '{';
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetaData(), scope);
+                               p->getMetadata(), scope);
             H << '}';
         }
         else
         {
             H << " = ";
             writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring,
-                               p->getMetaData(), scope);
+                               p->getMetadata(), scope);
         }
     }
     H << ";";
@@ -2968,7 +2968,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     MemberList outParams = p->outParameters();
     MemberList paramList = p->allMembers();
 
-    const bool amd = (interface->hasMetaData("amd") || p->hasMetaData("amd"));
+    const bool amd = (interface->hasMetadata("amd") || p->hasMetadata("amd"));
 
     const string returnValueParam = escapeParam(outParams, "returnValue");
     const string responsecbParam = escapeParam(inParams, "response");
@@ -2981,7 +2981,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 
     if(ret)
     {
-        string typeS = inputTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetaData(), _useWstring);
+        string typeS = inputTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetadata(), _useWstring);
         responseParams.push_back(typeS + " " + returnValueParam);
         responseParamsDecl.push_back(typeS + " ret");
         responseParamsImplDecl.push_back(typeS + " ret");
@@ -2998,14 +2998,14 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     }
     else
     {
-        retS = returnTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetaData(), _useWstring);
+        retS = returnTypeToString(ret, p->returnIsTagged(), interfaceScope, p->getMetadata(), _useWstring);
     }
 
     for (const auto& inParam : inParams)
     {
         TypePtr type = inParam->type();
         string paramName = fixKwd(inParam->name());
-        params.push_back(typeToString(type, inParam->tagged(), interfaceScope, inParam->getMetaData(),
+        params.push_back(typeToString(type, inParam->tagged(), interfaceScope, inParam->getMetadata(),
                                       _useWstring | TypeContextInParam) + " " + paramName);
         args.push_back(condMove(isMovable(type), paramPrefix + inParam->name()));
     }
@@ -3017,13 +3017,13 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 
         if(!p->hasMarshaledResult() && !amd)
         {
-            params.push_back(outputTypeToString(type, outParam->tagged(), interfaceScope, outParam->getMetaData(),
+            params.push_back(outputTypeToString(type, outParam->tagged(), interfaceScope, outParam->getMetadata(),
                                                 _useWstring) + " " + paramName);
             args.push_back(paramPrefix + outParam->name());
         }
 
         string responseTypeS = inputTypeToString(outParam->type(), outParam->tagged(), interfaceScope,
-                                                    outParam->getMetaData(), _useWstring);
+                                                    outParam->getMetadata(), _useWstring);
         responseParams.push_back(responseTypeS + " " + paramName);
         responseParamsDecl.push_back(responseTypeS + " " + paramPrefix + outParam->name());
         responseParamsImplDecl.push_back(responseTypeS + " " + paramPrefix + outParam->name());
@@ -3103,7 +3103,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << eb;
     }
 
-    string isConst = ((p->mode() == Operation::Nonmutating) || p->hasMetaData("cpp:const")) ? " const" : "";
+    string isConst = ((p->mode() == Operation::Nonmutating) || p->hasMetadata("cpp:const")) ? " const" : "";
 
     string opName = amd ? (name + "Async") : fixKwd(name);
     string deprecateSymbol = getDeprecateSymbol(p, interface);
@@ -3331,8 +3331,8 @@ Slice::Gen::ValueVisitor::visitClassDefEnd(const ClassDefPtr& p)
     string scope = fixKwd(p->scope());
     string name = fixKwd(p->name());
     ClassDefPtr base = p->base();
-    bool basePreserved = p->inheritsMetaData("preserve-slice");
-    bool preserved = p->hasMetaData("preserve-slice");
+    bool basePreserved = p->inheritsMetadata("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice");
 
     if(preserved && !basePreserved)
     {
@@ -3395,12 +3395,12 @@ Slice::Gen::ValueVisitor::visitClassDefEnd(const ClassDefPtr& p)
     bool inProtected = false;
     bool generateFriend = false;
     MemberList dataMembers = p->dataMembers();
-    bool prot = p->hasMetaData("protected");
+    bool prot = p->hasMetadata("protected");
     bool needSp = true;
 
     for (const auto& member : dataMembers)
     {
-        if(prot || member->hasMetaData("protected"))
+        if(prot || member->hasMetadata("protected"))
         {
             if(!inProtected)
             {
@@ -3533,7 +3533,7 @@ Slice::Gen::ObjectVisitor::emitOneShotConstructor(const ClassDefPtr& p)
 
         for (const auto& member : allDataMembers)
         {
-            string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetaData(),
+            string typeName = inputTypeToString(member->type(), member->tagged(), scope, member->getMetadata(),
                                                 typeContext);
             allParamDecls.push_back(typeName + " " + fixKwd(member->name()));
             CommentPtr comment = member->parseComment(false);
@@ -3758,7 +3758,7 @@ Slice::Gen::ImplVisitor::ImplVisitor(Output& h, Output& c, const string& dllExpo
 }
 
 string
-Slice::Gen::ImplVisitor::defaultValue(const TypePtr& type, const string& scope, const StringList& metaData) const
+Slice::Gen::ImplVisitor::defaultValue(const TypePtr& type, const string& scope, const StringList& metadata) const
 {
     if (OptionalPtr::dynamicCast(type))
     {
@@ -3822,7 +3822,7 @@ Slice::Gen::ImplVisitor::defaultValue(const TypePtr& type, const string& scope, 
         SequencePtr seq = SequencePtr::dynamicCast(type);
         if(seq)
         {
-            return typeToString(seq, scope, metaData, _useWstring) + "()";
+            return typeToString(seq, scope, metadata, _useWstring) + "()";
         }
 
         DictionaryPtr dict = DictionaryPtr::dynamicCast(type);
@@ -3895,12 +3895,12 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         TypePtr ret = op->deprecatedReturnType();
         string retS = op->hasMarshaledResult() ?
             scoped + "::" + resultStructName(opName, "", true) :
-            returnTypeToString(ret, op->returnIsTagged(), "", op->getMetaData(), _useWstring);
+            returnTypeToString(ret, op->returnIsTagged(), "", op->getMetadata(), _useWstring);
 
         MemberList inParams = op->params();
         MemberList outParams = op->outParameters();
 
-        if(p->hasMetaData("amd") || op->hasMetaData("amd"))
+        if(p->hasMetadata("amd") || op->hasMetadata("amd"))
         {
             string responseParams;
 
@@ -3909,7 +3909,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             for (const auto& param : inParams)
             {
                 H << typeToString(param->type(), param->tagged(), scope,
-                                  param->getMetaData(), _useWstring | TypeContextInParam)
+                                  param->getMetadata(), _useWstring | TypeContextInParam)
                   << "," << nl;
             }
 
@@ -3921,7 +3921,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 if(ret)
                 {
-                    responseParams = inputTypeToString(ret, op->returnIsTagged(), scope, op->getMetaData(), _useWstring);
+                    responseParams = inputTypeToString(ret, op->returnIsTagged(), scope, op->getMetadata(), _useWstring);
                     if(!outParams.empty())
                     {
                         responseParams += ", ";
@@ -3934,12 +3934,12 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     {
                         responseParams += ", ";
                     }
-                    responseParams += inputTypeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetaData(),
+                    responseParams += inputTypeToString((*q)->type(), (*q)->tagged(), scope, (*q)->getMetadata(),
                                                         _useWstring);
                 }
             }
 
-            string isConst = ((op->mode() == Operation::Nonmutating) || op->hasMetaData("cpp:const")) ? " const" : "";
+            string isConst = ((op->mode() == Operation::Nonmutating) || op->hasMetadata("cpp:const")) ? " const" : "";
 
             H << "std::function<void(" << responseParams << ")>,";
             H << nl << "std::function<void(std::exception_ptr)>,";
@@ -3950,7 +3950,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             C.useCurrentPosAsIndent();
             for (const auto& param : inParams)
             {
-                C << typeToString(param->type(), param->tagged(), scope, param->getMetaData(),
+                C << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
                                   _useWstring | TypeContextInParam);
                 C << ' ' << fixKwd(param->name()) << "," << nl;
             }
@@ -3969,11 +3969,11 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             C << spar;
             if(ret)
             {
-                C << defaultValue(ret, scope, op->getMetaData());
+                C << defaultValue(ret, scope, op->getMetadata());
             }
             for (const auto& param : outParams)
             {
-                C << defaultValue(param->type(), scope, op->getMetaData());
+                C << defaultValue(param->type(), scope, op->getMetadata());
             }
 
             if(op->hasMarshaledResult())
@@ -3994,7 +3994,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (const auto& param : inParams)
             {
-                H << typeToString(param->type(), param->tagged(), scope, param->getMetaData(),
+                H << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
                                   _useWstring | TypeContextInParam)
                 << ',' << nl;
             }
@@ -4002,7 +4002,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    H << outputTypeToString(param->type(), param->tagged(), scope, param->getMetaData(), _useWstring)
+                    H << outputTypeToString(param->type(), param->tagged(), scope, param->getMetadata(), _useWstring)
                     << ',' << nl;
                 }
             }
@@ -4010,7 +4010,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             H << "const Ice::Current&";
             H.restoreIndent();
 
-            string isConst = ((op->mode() == Operation::Nonmutating) || op->hasMetaData("cpp:const")) ? " const" : "";
+            string isConst = ((op->mode() == Operation::Nonmutating) || op->hasMetadata("cpp:const")) ? " const" : "";
 
             H << ")" << isConst << " override;";
 
@@ -4020,7 +4020,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (const auto& param : inParams)
             {
-                C << typeToString(param->type(), param->tagged(), scope, param->getMetaData(),
+                C << typeToString(param->type(), param->tagged(), scope, param->getMetadata(),
                                   _useWstring | TypeContextInParam)
                   << " /*" << fixKwd(param->name()) << "*/" << ',' << nl;
             }
@@ -4028,7 +4028,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    C << outputTypeToString(param->type(), param->tagged(), scope, param->getMetaData(), _useWstring)
+                    C << outputTypeToString(param->type(), param->tagged(), scope, param->getMetadata(), _useWstring)
                       << " " << fixKwd(param->name()) << ',' << nl;
                 }
             }
@@ -4046,7 +4046,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     C << nl << "return " << scoped << "::" << resultStructName(opName, "", true) << "(";
                     if(ret)
                     {
-                        C << defaultValue(ret, scope, op->getMetaData());
+                        C << defaultValue(ret, scope, op->getMetadata());
                         if(!outParams.empty())
                         {
                             C << ", ";
@@ -4055,7 +4055,7 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
                     for(auto q = outParams.begin(); q != outParams.end();)
                     {
-                        C << defaultValue((*q)->type(), scope, op->getMetaData());
+                        C << defaultValue((*q)->type(), scope, op->getMetadata());
                         if(++q != outParams.end())
                         {
                             C << ", ";
@@ -4068,13 +4068,13 @@ Slice::Gen::ImplVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 for (const auto& param : outParams)
                 {
-                    C << nl << fixKwd(param->name()) << " = " << defaultValue(param->type(), scope, op->getMetaData())
+                    C << nl << fixKwd(param->name()) << " = " << defaultValue(param->type(), scope, op->getMetadata())
                       << ";";
                 }
 
                 if(ret)
                 {
-                    C << nl << "return " << defaultValue(ret, scope, op->getMetaData()) << ";";
+                    C << nl << "return " << defaultValue(ret, scope, op->getMetadata()) << ";";
                 }
             }
             C << eb;

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -264,7 +264,7 @@ private:
         std::string defaultValue(const TypePtr&, const std::string&, const StringList&) const;
     };
 
-    class MetaDataVisitor : public ParserVisitor
+    class MetadataVisitor : public ParserVisitor
     {
     public:
 
@@ -293,7 +293,7 @@ private:
         StringList validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, int, bool = false);
     };
 
-    static void validateMetaData(const UnitPtr&);
+    static void validateMetadata(const UnitPtr&);
 };
 
 }

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -238,7 +238,7 @@ compile(const vector<string>& argv)
             static const string headerExtPrefix = "cpp:header-ext:";
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
             assert(dc);
-            string meta = dc->findMetaData(headerExtPrefix);
+            string meta = dc->findMetadata(headerExtPrefix);
             if(meta.size() > headerExtPrefix.size())
             {
                 ext = meta.substr(headerExtPrefix.size());

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -24,9 +24,9 @@ using namespace IceUtilInternal;
 bool
 Slice::normalizeCase(const ContainedPtr& c)
 {
-    auto fileMetaData = c->unit()->findDefinitionContext(c->file())->getMetaData();
-    if(find(begin(fileMetaData), end(fileMetaData), "preserve-case") != end(fileMetaData) ||
-       find(begin(fileMetaData), end(fileMetaData), "cs:preserve-case") != end(fileMetaData))
+    auto fileMetadata = c->unit()->findDefinitionContext(c->file())->getMetadata();
+    if(find(begin(fileMetadata), end(fileMetadata), "preserve-case") != end(fileMetadata) ||
+       find(begin(fileMetadata), end(fileMetadata), "cs:preserve-case") != end(fileMetadata))
     {
         return false;
     }
@@ -204,7 +204,7 @@ Slice::getNamespacePrefix(const ContainedPtr& cont)
     static const string prefix = "cs:namespace:";
 
     string q;
-    if(m->findMetaData(prefix, q))
+    if(m->findMetadata(prefix, q))
     {
         q = q.substr(prefix.size());
     }
@@ -373,7 +373,7 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
 
     if(seq)
     {
-        string customType = seq->findMetaDataWithPrefix("cs:generic:");
+        string customType = seq->findMetadataWithPrefix("cs:generic:");
         if (readOnly)
         {
             auto elementType = seq->type();
@@ -409,7 +409,7 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
         string prefix = "cs:generic:";
         string meta;
         string typeName;
-        if(d->findMetaData(prefix, meta))
+        if(d->findMetadata(prefix, meta))
         {
             typeName = meta.substr(prefix.size());
         }
@@ -535,7 +535,7 @@ Slice::isMappedToReadOnlyMemory(const SequencePtr& seq)
 
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
     return builtin && builtin->isNumericTypeOrBool() && !builtin->isVariableLength() &&
-        !seq->hasMetaDataWithPrefix("cs:generic");
+        !seq->hasMetadataWithPrefix("cs:generic");
 }
 
 vector<string>
@@ -1070,7 +1070,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(
                 out << "<" << typeToString(elementType, scope) << ">(" << tag << ")";
             }
         }
-        else if (seq->hasMetaDataWithPrefix("cs:generic:"))
+        else if (seq->hasMetadataWithPrefix("cs:generic:"))
         {
             const string tmpName = (dataMember ? dataMember->name() : param) + "_";
             if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
@@ -1126,7 +1126,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(
         }
 
         bool fixedSize = !keyType->isVariableLength() && !valueType->isVariableLength();
-        bool sorted = d->findMetaDataWithPrefix("cs:generic:") == "SortedDictionary";
+        bool sorted = d->findMetadataWithPrefix("cs:generic:") == "SortedDictionary";
 
         out << "istr.ReadTagged" << (sorted ? "Sorted" : "") << "Dictionary(" << tag
             << ", minKeySize: " << keyType->minWireSize();
@@ -1197,7 +1197,7 @@ Slice::CsGenerator::sequenceMarshalCode(
 string
 Slice::CsGenerator::sequenceUnmarshalCode(const SequencePtr& seq, const string& scope)
 {
-    string generic = seq->findMetaDataWithPrefix("cs:generic:");
+    string generic = seq->findMetadataWithPrefix("cs:generic:");
 
     TypePtr type = seq->type();
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
@@ -1308,7 +1308,7 @@ Slice::CsGenerator::dictionaryUnmarshalCode(const DictionaryPtr& dict, const str
 {
     TypePtr key = dict->keyType();
     TypePtr value = dict->valueType();
-    string generic = dict->findMetaDataWithPrefix("cs:generic:");
+    string generic = dict->findMetadataWithPrefix("cs:generic:");
     string dictS = typeToString(dict, scope);
 
     bool withBitSequence = false;
@@ -1391,14 +1391,14 @@ Slice::CsGenerator::writeConstantValue(Output& out, const TypePtr& type, const S
 }
 
 void
-Slice::CsGenerator::validateMetaData(const UnitPtr& u)
+Slice::CsGenerator::validateMetadata(const UnitPtr& u)
 {
-    MetaDataVisitor visitor;
+    MetadataVisitor visitor;
     u->visit(&visitor, true);
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& p)
 {
     //
     // Validate global metadata in the top-level file and all included files.
@@ -1409,12 +1409,12 @@ Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
         string file = *q;
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetaData = dc->getMetaData();
-        StringList newGlobalMetaData;
+        StringList globalMetadata = dc->getMetadata();
+        StringList newGlobalMetadata;
         static const string csPrefix = "cs:";
         static const string clrPrefix = "clr:";
 
-        for(StringList::iterator r = globalMetaData.begin(); r != globalMetaData.end(); ++r)
+        for(StringList::iterator r = globalMetadata.begin(); r != globalMetadata.end(); ++r)
         {
             string& s = *r;
             string oldS = s;
@@ -1429,74 +1429,74 @@ Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                 static const string csAttributePrefix = csPrefix + "attribute:";
                 if(!(s.find(csAttributePrefix) == 0 && s.size() > csAttributePrefix.size()))
                 {
-                    dc->warning(InvalidMetaData, file, -1, "ignoring invalid global metadata `" + oldS + "'");
+                    dc->warning(InvalidMetadata, file, -1, "ignoring invalid global metadata `" + oldS + "'");
                     continue;
                 }
             }
-            newGlobalMetaData.push_back(oldS);
+            newGlobalMetadata.push_back(oldS);
         }
 
-        dc->setMetaData(newGlobalMetaData);
+        dc->setMetadata(newGlobalMetadata);
     }
     return true;
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
+Slice::CsGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
     validate(p);
     return true;
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitModuleEnd(const ModulePtr&)
+Slice::CsGenerator::MetadataVisitor::visitModuleEnd(const ModulePtr&)
 {
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitClassDecl(const ClassDeclPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
     validate(p);
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     validate(p);
     return true;
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitClassDefEnd(const ClassDefPtr&)
+Slice::CsGenerator::MetadataVisitor::visitClassDefEnd(const ClassDefPtr&)
 {
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     validate(p);
     return true;
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitExceptionEnd(const ExceptionPtr&)
+Slice::CsGenerator::MetadataVisitor::visitExceptionEnd(const ExceptionPtr&)
 {
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitStructStart(const StructPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
     validate(p);
     return true;
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitStructEnd(const StructPtr&)
+Slice::CsGenerator::MetadataVisitor::visitStructEnd(const StructPtr&)
 {
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitOperation(const OperationPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitOperation(const OperationPtr& p)
 {
     validate(p);
     for (const auto& param : p->allMembers())
@@ -1506,54 +1506,54 @@ Slice::CsGenerator::MetaDataVisitor::visitOperation(const OperationPtr& p)
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitParameter(const MemberPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitParameter(const MemberPtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitDataMember(const MemberPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitDataMember(const MemberPtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitSequence(const SequencePtr& p)
+Slice::CsGenerator::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitEnum(const EnumPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitConst(const ConstPtr& p)
+Slice::CsGenerator::MetadataVisitor::visitConst(const ConstPtr& p)
 {
     validate(p);
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
+Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
 {
     const string msg = "ignoring invalid metadata";
 
-    StringList localMetaData = cont->getMetaData();
-    StringList newLocalMetaData;
+    StringList localMetadata = cont->getMetadata();
+    StringList newLocalMetadata;
 
     const UnitPtr ut = cont->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
     assert(dc);
 
-    for(StringList::iterator p = localMetaData.begin(); p != localMetaData.end(); ++p)
+    for(StringList::iterator p = localMetadata.begin(); p != localMetadata.end(); ++p)
     {
         string& s = *p;
         string oldS = s;
@@ -1577,7 +1577,7 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
                     string type = s.substr(csGenericPrefix.size());
                     if(!type.empty())
                     {
-                        newLocalMetaData.push_back(s);
+                        newLocalMetadata.push_back(s);
                         continue; // Custom type or List<T>
                     }
                 }
@@ -1586,12 +1586,12 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
             {
                 if(s.substr(csPrefix.size()) == "property")
                 {
-                    newLocalMetaData.push_back(s);
+                    newLocalMetadata.push_back(s);
                     continue;
                 }
                 if(s.substr(csPrefix.size()) == "readonly")
                 {
-                    newLocalMetaData.push_back(s);
+                    newLocalMetadata.push_back(s);
                     continue;
                 }
             }
@@ -1599,7 +1599,7 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
             {
                 if(s.substr(csPrefix.size()) == "property")
                 {
-                    newLocalMetaData.push_back(s);
+                    newLocalMetadata.push_back(s);
                     continue;
                 }
             }
@@ -1611,7 +1611,7 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
                     string type = s.substr(csGenericPrefix.size());
                     if(type == "SortedDictionary" ||  type == "SortedList")
                     {
-                        newLocalMetaData.push_back(s);
+                        newLocalMetadata.push_back(s);
                         continue;
                     }
                 }
@@ -1621,7 +1621,7 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
                 static const string csNamespacePrefix = csPrefix + "namespace:";
                 if(s.find(csNamespacePrefix) == 0 && s.size() > csNamespacePrefix.size())
                 {
-                    newLocalMetaData.push_back(s);
+                    newLocalMetadata.push_back(s);
                     continue;
                 }
             }
@@ -1629,15 +1629,15 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
             static const string csAttributePrefix = csPrefix + "attribute:";
             if(s.find(csAttributePrefix) == 0 && s.size() > csAttributePrefix.size())
             {
-                newLocalMetaData.push_back(s);
+                newLocalMetadata.push_back(s);
                 continue;
             }
 
-            dc->warning(InvalidMetaData, cont->file(), cont->line(), msg + " `" + oldS + "'");
+            dc->warning(InvalidMetadata, cont->file(), cont->line(), msg + " `" + oldS + "'");
             continue;
         }
-        newLocalMetaData.push_back(s);
+        newLocalMetadata.push_back(s);
     }
 
-    cont->setMetaData(newLocalMetaData);
+    cont->setMetadata(newLocalMetadata);
 }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -24,7 +24,7 @@ using namespace IceUtilInternal;
 bool
 Slice::normalizeCase(const ContainedPtr& c)
 {
-    auto fileMetadata = c->unit()->findDefinitionContext(c->file())->getMetadata();
+    auto fileMetadata = c->unit()->findDefinitionContext(c->file())->getAllMetadata();
     if(find(begin(fileMetadata), end(fileMetadata), "preserve-case") != end(fileMetadata) ||
        find(begin(fileMetadata), end(fileMetadata), "cs:preserve-case") != end(fileMetadata))
     {
@@ -1409,7 +1409,7 @@ Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& p)
         string file = *q;
         DefinitionContextPtr dc = p->findDefinitionContext(file);
         assert(dc);
-        StringList globalMetadata = dc->getMetadata();
+        StringList globalMetadata = dc->getAllMetadata();
         StringList newGlobalMetadata;
         static const string csPrefix = "cs:";
         static const string clrPrefix = "clr:";
@@ -1546,7 +1546,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
 {
     const string msg = "ignoring invalid metadata";
 
-    StringList localMetadata = cont->getMetadata();
+    StringList localMetadata = cont->getAllMetadata();
     StringList newLocalMetadata;
 
     const UnitPtr ut = cont->unit();

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -74,7 +74,7 @@ public:
     virtual ~CsGenerator() {};
 
     // Validate all metadata in the unit with a "cs:" prefix.
-    static void validateMetaData(const UnitPtr&);
+    static void validateMetadata(const UnitPtr&);
 
     static std::string typeToString(const TypePtr& type, const std::string& package, bool readOnly = false);
 
@@ -138,7 +138,7 @@ private:
         const std::string& param);
 
     std::string dictionaryUnmarshalCode(const DictionaryPtr& dict, const std::string& scope);
-    class MetaDataVisitor : public ParserVisitor
+    class MetadataVisitor : public ParserVisitor
     {
     public:
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -87,8 +87,8 @@ string
 getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
 {
     string deprecateMetadata, deprecateReason;
-    if(p1->findMetaData("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata)))
+    if(p1->findMetadata("deprecate", deprecateMetadata) ||
+       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
     {
         deprecateReason = "This " + type + " has been deprecated.";
         const string prefix = "deprecate:";
@@ -390,7 +390,7 @@ string
 getParamAttributes(const MemberPtr& p)
 {
     string result;
-    for(const auto& s : p->getMetaData())
+    for(const auto& s : p->getMetadata())
     {
         static const string prefix = "cs:attribute:";
         if(s.find(prefix) == 0)
@@ -521,8 +521,8 @@ Slice::CsVisitor::emitEqualityOperators(const string& name)
 void
 Slice::CsVisitor::emitCustomAttributes(const ContainedPtr& p)
 {
-    StringList metaData = p->getMetaData();
-    for(StringList::const_iterator i = metaData.begin(); i != metaData.end(); ++i)
+    StringList metadata = p->getMetadata();
+    for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); ++i)
     {
         static const string prefix = "cs:attribute:";
         if(i->find(prefix) == 0)
@@ -1141,7 +1141,7 @@ Slice::Gen::~Gen()
 void
 Slice::Gen::generate(const UnitPtr& p)
 {
-    CsGenerator::validateMetaData(p);
+    CsGenerator::validateMetadata(p);
 
     UnitVisitor unitVisitor(_out);
     p->visit(&unitVisitor, false);
@@ -1199,12 +1199,12 @@ Slice::Gen::UnitVisitor::visitUnitStart(const UnitPtr& p)
 {
     DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
     assert(dc);
-    StringList globalMetaData = dc->getMetaData();
+    StringList globalMetadata = dc->getMetadata();
 
     static const string attributePrefix = "cs:attribute:";
 
     bool sep = false;
-    for(StringList::const_iterator q = globalMetaData.begin(); q != globalMetaData.end(); ++q)
+    for(StringList::const_iterator q = globalMetadata.begin(); q != globalMetadata.end(); ++q)
     {
         string::size_type pos = q->find(attributePrefix);
         if(pos == 0 && q->size() > attributePrefix.size())
@@ -1497,8 +1497,8 @@ Slice::Gen::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
 
     // Marshaling support
     MemberList members = p->dataMembers();
-    const bool basePreserved = p->inheritsMetaData("preserve-slice");
-    const bool preserved = p->hasMetaData("preserve-slice");
+    const bool basePreserved = p->inheritsMetadata("preserve-slice");
+    const bool preserved = p->hasMetadata("preserve-slice");
 
     ClassDefPtr base = p->base();
 
@@ -1795,7 +1795,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     emitCommonAttributes();
     emitCustomAttributes(p);
     _out << nl << "public ";
-    if(p->hasMetaData("cs:readonly"))
+    if(p->hasMetadata("cs:readonly"))
     {
         _out << "readonly ";
     }
@@ -2089,7 +2089,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
 
     _out << sp;
 
-    bool readonly = StructPtr::dynamicCast(cont) && cont->hasMetaData("cs:readonly");
+    bool readonly = StructPtr::dynamicCast(cont) && cont->hasMetadata("cs:readonly");
 
     writeTypeDocComment(p, getDeprecateReason(p, cont, "member"));
     emitDeprecate(p, cont, _out, "member");
@@ -2101,7 +2101,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     }
     _out << typeToString(p->type(), getNamespace(cont));
     _out << " " << fixId(fieldName(p), ExceptionPtr::dynamicCast(cont) ? Slice::ExceptionType : Slice::ObjectType);
-    if(cont->hasMetaData("cs:property"))
+    if(cont->hasMetadata("cs:property"))
     {
         _out << "{ get; set; }";
     }
@@ -2372,7 +2372,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
     string opName = operationName(operation);
     string name = fixId(opName);
     string asyncName = opName + "Async";
-    bool oneway = operation->hasMetaData("oneway");
+    bool oneway = operation->hasMetadata("oneway");
 
     TypePtr ret = operation->deprecatedReturnType();
     string retS = typeToString(operation->deprecatedReturnType(), ns);
@@ -2775,7 +2775,7 @@ Slice::Gen::DispatcherVisitor::writeMethodDeclaration(const OperationPtr& operat
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(interface);
     string deprecateReason = getDeprecateReason(operation, interface, "operation");
-    bool amd = _generateAllAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAllAsync || interface->hasMetadata("amd") || operation->hasMetadata("amd");
     const string name = fixId(operationName(operation) + (amd ? "Async" : ""));
 
     _out << sp;
@@ -2805,7 +2805,7 @@ void
 Slice::Gen::DispatcherVisitor::visitOperation(const OperationPtr& operation)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
-    bool amd = _generateAllAsync || interface->hasMetaData("amd") || operation->hasMetaData("amd");
+    bool amd = _generateAllAsync || interface->hasMetadata("amd") || operation->hasMetadata("amd");
     string ns = getNamespace(interface);
     string opName = operationName(operation);
     string name = fixId(opName + (amd ? "Async" : ""));
@@ -3036,7 +3036,7 @@ Slice::Gen::ImplVisitor::visitOperation(const OperationPtr& op)
 
     _out << sp << nl;
 
-    if(interface->hasMetaData("amd") || op->hasMetaData("amd"))
+    if(interface->hasMetadata("amd") || op->hasMetadata("amd"))
     {
         _out << "public override " << returnTaskStr(op, ns, true) << " " << opName << "Async" << spar
              << getNames(op->params())

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -390,7 +390,7 @@ string
 getParamAttributes(const MemberPtr& p)
 {
     string result;
-    for(const auto& s : p->getMetadata())
+    for(const auto& s : p->getAllMetadata())
     {
         static const string prefix = "cs:attribute:";
         if(s.find(prefix) == 0)
@@ -521,7 +521,7 @@ Slice::CsVisitor::emitEqualityOperators(const string& name)
 void
 Slice::CsVisitor::emitCustomAttributes(const ContainedPtr& p)
 {
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
     for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); ++i)
     {
         static const string prefix = "cs:attribute:";
@@ -1199,7 +1199,7 @@ Slice::Gen::UnitVisitor::visitUnitStart(const UnitPtr& p)
 {
     DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
     assert(dc);
-    StringList globalMetadata = dc->getMetadata();
+    StringList globalMetadata = dc->getAllMetadata();
 
     static const string attributePrefix = "cs:attribute:";
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -156,7 +156,7 @@ Slice::JavaVisitor::getResultType(const OperationPtr& op, const string& package,
         {
             InterfaceDefPtr interface = op->interface();
             assert(interface);
-            return typeToAnnotatedString(type, TypeModeReturn, package, op->getMetadata(), returnIsTagged, object);
+            return typeToAnnotatedString(type, TypeModeReturn, package, op->getAllMetadata(), returnIsTagged, object);
         }
         else
         {
@@ -237,12 +237,12 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
 
     if(ret)
     {
-        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(), op->returnIsTagged())
+        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getAllMetadata(), op->returnIsTagged())
                 + " " + retval);
     }
     for(const auto& p : outParams)
     {
-        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(), p->tagged())
+        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getAllMetadata(), p->tagged())
                 + " " + fixKwd(p->name()));
     }
     out << epar;
@@ -271,7 +271,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
             writeDocCommentLines(out, dc->returns());
             out << nl << " **/";
         }
-        out << nl << "public " << typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(),
+        out << nl << "public " << typeToAnnotatedString(ret, TypeModeIn, package, op->getAllMetadata(),
             op->returnIsTagged()) << ' ' << retval << ';';
     }
 
@@ -290,7 +290,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
                 out << nl << " **/";
             }
         }
-        out << nl << "public " << typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(),
+        out << nl << "public " << typeToAnnotatedString(p->type(), TypeModeIn, package, p->getAllMetadata(),
             p->tagged()) << ' ' << fixKwd(name) << ';';
     }
 
@@ -304,14 +304,14 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
     {
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, "this." + paramName, true,
-                                  iter, "", pli->getMetadata());
+                                  iter, "", pli->getAllMetadata());
     }
 
     bool checkReturnType = op->returnIsTagged();
     if(ret && !checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, true, iter, "",
-                                  op->getMetadata());
+                                  op->getAllMetadata());
     }
 
     //
@@ -322,19 +322,19 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         if(checkReturnType && op->returnTag() < pli->tag())
         {
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true,
-                                      iter, "", op->getMetadata());
+                                      iter, "", op->getAllMetadata());
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(),
-                                  "this." + paramName, true, iter, "", pli->getMetadata());
+                                  "this." + paramName, true, iter, "", pli->getAllMetadata());
     }
 
     if(checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true, iter,
-                                  "", op->getMetadata());
+                                  "", op->getAllMetadata());
     }
 
     out << eb;
@@ -348,7 +348,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         const string paramName = fixKwd(pli->name());
         const string patchParams = getPatcher(pli->type(), package, "this." + paramName);
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, "this." + paramName, false,
-                                  iter, "", pli->getMetadata(), patchParams);
+                                  iter, "", pli->getAllMetadata(), patchParams);
     }
 
     checkReturnType = op->returnIsTagged();
@@ -356,7 +356,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
     {
         const string patchParams = getPatcher(ret, package, retval);
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, false, iter, "",
-                                  op->getMetadata(), patchParams);
+                                  op->getAllMetadata(), patchParams);
     }
 
     //
@@ -369,21 +369,21 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         {
             const string patchParams = getPatcher(ret, package, retval);
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, false,
-                                      iter, "", op->getMetadata(), patchParams);
+                                      iter, "", op->getAllMetadata(), patchParams);
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         const string patchParams = getPatcher(pli->type(), package, paramName);
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(),
-                                  "this." + paramName, false, iter, "", pli->getMetadata(), patchParams);
+                                  "this." + paramName, false, iter, "", pli->getAllMetadata(), patchParams);
     }
 
     if(checkReturnType)
     {
         const string patchParams = getPatcher(ret, package, retval);
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, false,
-                                  iter, "", op->getMetadata(), patchParams);
+                                  iter, "", op->getAllMetadata(), patchParams);
     }
 
     out << eb;
@@ -443,12 +443,12 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
     out << nl << "public " << opName << "MarshaledResult" << spar;
     if(ret)
     {
-        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(), op->returnIsTagged())
+        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getAllMetadata(), op->returnIsTagged())
                 + " " + retval);
     }
     for(const auto& p : outParams)
     {
-        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(), p->tagged())
+        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getAllMetadata(), p->tagged())
                 + " " + fixKwd((p->name())));
     }
     out << currentParam << epar;
@@ -464,14 +464,14 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
     {
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, true, iter,
-                                  "_ostr", pli->getMetadata());
+                                  "_ostr", pli->getAllMetadata());
     }
 
     bool checkReturnType = op->returnIsTagged();
     if(ret && !checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, true, iter, "_ostr",
-                                  op->getMetadata());
+                                  op->getAllMetadata());
     }
 
     //
@@ -483,19 +483,19 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
         if(checkReturnType && op->returnTag() < pli->tag())
         {
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true,
-                                      iter, "_ostr", op->getMetadata());
+                                      iter, "_ostr", op->getAllMetadata());
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(), paramName,
-                                  true, iter, "_ostr", pli->getMetadata());
+                                  true, iter, "_ostr", pli->getAllMetadata());
     }
 
     if(checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true, iter,
-                                  "_ostr", op->getMetadata());
+                                  "_ostr", op->getAllMetadata());
     }
 
     if(op->returnsClasses(false))
@@ -605,7 +605,7 @@ Slice::JavaVisitor::getParams(const OperationPtr& op, const string& package)
 
     for(const auto& q : op->params())
     {
-        const string type = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetadata(), q->tagged());
+        const string type = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getAllMetadata(), q->tagged());
         params.push_back(type + ' ' + fixKwd(q->name()));
     }
 
@@ -618,7 +618,8 @@ Slice::JavaVisitor::getParamsProxy(const OperationPtr& op, const string& package
     vector<string> params;
     for(const auto& q : op->params())
     {
-        const string typeString = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetadata(), q->tagged());
+        const string typeString = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getAllMetadata(),
+                                                        q->tagged());
         params.push_back(typeString + ' ' + (internal ? "iceP_" + q->name() : fixKwd(q->name())));
     }
 
@@ -660,7 +661,7 @@ Slice::JavaVisitor::writeMarshalProxyParams(Output& out, const string& package, 
     {
         string paramName = "iceP_" + pli->name();
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, true,
-                                  iter, "", pli->getMetadata());
+                                  iter, "", pli->getAllMetadata());
     }
 
     //
@@ -669,7 +670,7 @@ Slice::JavaVisitor::writeMarshalProxyParams(Output& out, const string& package, 
     for(const auto& pli : taggedParams)
     {
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedInParam, pli->tag(), "iceP_" + pli->name(), true,
-                                  iter, "", pli->getMetadata());
+                                  iter, "", pli->getAllMetadata());
     }
 
     if(op->sendsClasses(false))
@@ -709,7 +710,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
             type = ret;
             isTagged = op->returnIsTagged();
             tag = op->returnTag();
-            metadata = op->getMetadata();
+            metadata = op->getAllMetadata();
         }
         else
         {
@@ -717,7 +718,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
             isTagged = outParams.front()->tagged();
             type = unwrapIfOptional(outParams.front()->type());
             tag = outParams.front()->tag();
-            metadata = outParams.front()->getMetadata();
+            metadata = outParams.front()->getAllMetadata();
         }
 
         const bool val = isValue(type);
@@ -780,7 +781,7 @@ Slice::JavaVisitor::writeMarshalServantResults(Output& out, const string& packag
             type = unwrapIfOptional(op->deprecatedReturnType());
             mode = op->returnIsTagged() ? TaggedReturnParam : NotTagged;
             tag = op->returnTag();
-            metadata = op->getMetadata();
+            metadata = op->getAllMetadata();
         }
         else
         {
@@ -788,7 +789,7 @@ Slice::JavaVisitor::writeMarshalServantResults(Output& out, const string& packag
             mode = params.front()->tagged() ? TaggedOutParam : NotTagged;
             type = unwrapIfOptional(params.front()->type());
             tag = params.front()->tag();
-            metadata = params.front()->getMetadata();
+            metadata = params.front()->getAllMetadata();
         }
 
         int iter = 0;
@@ -842,7 +843,7 @@ Slice::JavaVisitor::writeMarshalDataMember(Output& out, const string& package, c
         out << nl << "if(_" << member->name() << ")";
         out << sb;
         writeMarshalUnmarshalCode(out, package, member->type(), TaggedInParam, member->tag(),
-                                  fixKwd(member->name()), true, iter, "ostr_", member->getMetadata());
+                                  fixKwd(member->name()), true, iter, "ostr_", member->getAllMetadata());
         out << eb;
     }
     else
@@ -855,7 +856,7 @@ Slice::JavaVisitor::writeMarshalDataMember(Output& out, const string& package, c
         }
 
         writeMarshalUnmarshalCode(out, package, member->type(), NotTagged, 0, memberName,
-                                  true, iter, stream, member->getMetadata());
+                                  true, iter, stream, member->getAllMetadata());
     }
 }
 
@@ -872,7 +873,7 @@ Slice::JavaVisitor::writeUnmarshalDataMember(Output& out, const string& package,
             << getTagFormat(member->type()) << "))";
         out << sb;
         writeMarshalUnmarshalCode(out, package, member->type(), TaggedMember, 0, fixKwd(member->name()), false,
-                                  iter, "istr_", member->getMetadata(), patchParams);
+                                  iter, "istr_", member->getAllMetadata(), patchParams);
         out << eb;
     }
     else
@@ -885,7 +886,7 @@ Slice::JavaVisitor::writeUnmarshalDataMember(Output& out, const string& package,
         }
 
         writeMarshalUnmarshalCode(out, package, member->type(), NotTagged, 0, memberName, false,
-                                  iter, stream, member->getMetadata(), patchParams);
+                                  iter, stream, member->getAllMetadata(), patchParams);
     }
 }
 
@@ -981,7 +982,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     for(OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
     {
         OperationPtr op = *r;
-        StringList opMetadata = op->getMetadata();
+        StringList opMetadata = op->getAllMetadata();
 
         CommentPtr dc = op->parseComment(false);
 
@@ -1047,7 +1048,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                 else
                 {
                     const string paramName = "iceP_" + pli->name();
-                    const string typeS = typeToAnnotatedString(paramType, TypeModeIn, package, pli->getMetadata(),
+                    const string typeS = typeToAnnotatedString(paramType, TypeModeIn, package, pli->getAllMetadata(),
                         pli->tagged());
                     out << nl << typeS << ' ' << paramName << ';';
                 }
@@ -1063,14 +1064,14 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                 const string paramName = isValue(pli->type()) ? ("icePP_" + pli->name()) : "iceP_" + pli->name();
                 const string patchParams = getPatcher(pli->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, false,
-                                          iter, "", pli->getMetadata(), patchParams);
+                                          iter, "", pli->getAllMetadata(), patchParams);
             }
             for(const auto& pli : taggedParams)
             {
                 const string paramName = isValue(pli->type()) ? ("icePP_" + pli->name()) : "iceP_" + pli->name();
                 const string patchParams = getPatcher(pli->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(out, package, pli->type(), TaggedInParam, pli->tag(),
-                                          paramName, false, iter, "", pli->getMetadata(), patchParams);
+                                          paramName, false, iter, "", pli->getAllMetadata(), patchParams);
             }
             if(op->sendsClasses(false))
             {
@@ -1080,7 +1081,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
 
             for(const auto& pli : values)
             {
-                const string typeS = typeToAnnotatedString(pli->type(), TypeModeIn, package, pli->getMetadata(),
+                const string typeS = typeToAnnotatedString(pli->type(), TypeModeIn, package, pli->getAllMetadata(),
                                                            pli->tagged());
                 out << nl << typeS << ' ' << "iceP_" << pli->name() << " = icePP_" << pli->name() << ".value;";
             }
@@ -1478,7 +1479,7 @@ Slice::JavaVisitor::writeDataMemberInitializers(Output& out, const MemberList& m
             StructPtr st = StructPtr::dynamicCast(t);
             if(st)
             {
-                string memberType = typeToString(st, TypeModeMember, package, p->getMetadata());
+                string memberType = typeToString(st, TypeModeMember, package, p->getAllMetadata());
                 out << nl << "this." << fixKwd(p->name()) << " = new " << memberType << "();";
             }
         }
@@ -2078,7 +2079,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     // Check for java:implements metadata.
     //
-    const StringList metadata = p->getMetadata();
+    const StringList metadata = p->getAllMetadata();
     static const string prefix = "java:implements:";
     StringList implements;
     for(const auto& q : metadata)
@@ -2173,7 +2174,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
                 for(const auto& d : allRequiredMembers)
                 {
                     string memberName = fixKwd(d->name());
-                    string memberType = typeToString(d->type(), TypeModeMember, package, d->getMetadata(), true);
+                    string memberType = typeToString(d->type(), TypeModeMember, package, d->getAllMetadata(), true);
                     dataMember.push_back(memberType + " " + memberName);
                 }
                 out << dataMember << epar;
@@ -2209,7 +2210,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
             for(const auto& d : allDataMembers)
             {
                 string memberName = fixKwd(d->name());
-                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetadata(),
+                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getAllMetadata(),
                     d->tagged());
                 dataMember.push_back(memberType + " " + memberName);
             }
@@ -2522,7 +2523,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
                 for(const auto& member : allRequiredMembers)
                 {
                     string memberName = fixKwd(member->name());
-                    string memberType = typeToString(member->type(), TypeModeMember, package, member->getMetadata(), true);
+                    string memberType = typeToString(member->type(), TypeModeMember, package, member->getAllMetadata(),
+                                                     true);
                     dataMember.push_back(memberType + " " + memberName);
                 }
                 out << dataMember << epar;
@@ -2591,7 +2593,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
             for(const auto& d : allDataMembers)
             {
                 string memberName = fixKwd(d->name());
-                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetadata(),
+                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getAllMetadata(),
                     d->tagged());
                 dataMember.push_back(memberType + " " + memberName);
             }
@@ -2844,7 +2846,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     //
     // Check for java:implements metadata.
     //
-    const StringList metadata = p->getMetadata();
+    const StringList metadata = p->getAllMetadata();
     static const string prefix = "java:implements:";
     StringList implements;
     for(const auto& q : metadata)
@@ -2905,7 +2907,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         for(const auto& d : members)
         {
             string memberName = fixKwd(d->name());
-            string memberType = typeToString(unwrapIfOptional(d->type()), TypeModeMember, package, d->getMetadata(),
+            string memberType = typeToString(unwrapIfOptional(d->type()), TypeModeMember, package, d->getAllMetadata(),
                 true);
             dataMember.push_back(memberType + " " + memberName);
             paramNames.push_back(memberName);
@@ -2957,7 +2959,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
             // For all other types, we can use the native equals() method.
             //
             SequencePtr seq = SequencePtr::dynamicCast(d->type());
-            if(seq && !hasTypeMetadata(seq, d->getMetadata()))
+            if(seq && !hasTypeMetadata(seq, d->getAllMetadata()))
             {
                 //
                 // Arrays.equals() handles null values.
@@ -3155,7 +3157,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     const ContainedPtr contained = ContainedPtr::dynamicCast(container);
 
     const string name = fixKwd(p->name());
-    const StringList metadata = p->getMetadata();
+    const StringList metadata = p->getAllMetadata();
     const bool getSet = p->hasMetadata(_getSetMetadata) || contained->hasMetadata(_getSetMetadata);
     const bool isTagged = p->tagged();
     const TypePtr type = unwrapIfOptional(p->type());
@@ -3755,7 +3757,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
             {
                 string metadata;
                 out << nl << "final int taggedSize = v == null ? 0 : ";
-                if(findMetadata("java:buffer", p->getMetadata(), metadata))
+                if(findMetadata("java:buffer", p->getAllMetadata(), metadata))
                 {
                     out << "v.remaining() / " << sz << ";";
                 }
@@ -3819,7 +3821,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     string absolute = getUnqualified(p);
     string helper = getUnqualified(p, "", "", "Helper");
     string package = getPackage(p);
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
     string formalType = typeToString(p, TypeModeIn, package, StringList(), true);
 
     open(helper, p->file());

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -94,8 +94,8 @@ bool
 isDeprecated(const ContainedPtr& p1, const ContainedPtr& p2)
 {
     string deprecateMetadata;
-    return p1->findMetaData("deprecate", deprecateMetadata) ||
-            (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata));
+    return p1->findMetadata("deprecate", deprecateMetadata) ||
+            (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata));
 }
 
 bool isValue(const TypePtr& constType)
@@ -156,7 +156,7 @@ Slice::JavaVisitor::getResultType(const OperationPtr& op, const string& package,
         {
             InterfaceDefPtr interface = op->interface();
             assert(interface);
-            return typeToAnnotatedString(type, TypeModeReturn, package, op->getMetaData(), returnIsTagged, object);
+            return typeToAnnotatedString(type, TypeModeReturn, package, op->getMetadata(), returnIsTagged, object);
         }
         else
         {
@@ -237,12 +237,12 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
 
     if(ret)
     {
-        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetaData(), op->returnIsTagged())
+        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(), op->returnIsTagged())
                 + " " + retval);
     }
     for(const auto& p : outParams)
     {
-        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetaData(), p->tagged())
+        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(), p->tagged())
                 + " " + fixKwd(p->name()));
     }
     out << epar;
@@ -271,7 +271,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
             writeDocCommentLines(out, dc->returns());
             out << nl << " **/";
         }
-        out << nl << "public " << typeToAnnotatedString(ret, TypeModeIn, package, op->getMetaData(),
+        out << nl << "public " << typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(),
             op->returnIsTagged()) << ' ' << retval << ';';
     }
 
@@ -290,7 +290,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
                 out << nl << " **/";
             }
         }
-        out << nl << "public " << typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetaData(),
+        out << nl << "public " << typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(),
             p->tagged()) << ' ' << fixKwd(name) << ';';
     }
 
@@ -304,14 +304,14 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
     {
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, "this." + paramName, true,
-                                  iter, "", pli->getMetaData());
+                                  iter, "", pli->getMetadata());
     }
 
     bool checkReturnType = op->returnIsTagged();
     if(ret && !checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, true, iter, "",
-                                  op->getMetaData());
+                                  op->getMetadata());
     }
 
     //
@@ -322,19 +322,19 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         if(checkReturnType && op->returnTag() < pli->tag())
         {
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true,
-                                      iter, "", op->getMetaData());
+                                      iter, "", op->getMetadata());
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(),
-                                  "this." + paramName, true, iter, "", pli->getMetaData());
+                                  "this." + paramName, true, iter, "", pli->getMetadata());
     }
 
     if(checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true, iter,
-                                  "", op->getMetaData());
+                                  "", op->getMetadata());
     }
 
     out << eb;
@@ -348,7 +348,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         const string paramName = fixKwd(pli->name());
         const string patchParams = getPatcher(pli->type(), package, "this." + paramName);
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, "this." + paramName, false,
-                                  iter, "", pli->getMetaData(), patchParams);
+                                  iter, "", pli->getMetadata(), patchParams);
     }
 
     checkReturnType = op->returnIsTagged();
@@ -356,7 +356,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
     {
         const string patchParams = getPatcher(ret, package, retval);
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, false, iter, "",
-                                  op->getMetaData(), patchParams);
+                                  op->getMetadata(), patchParams);
     }
 
     //
@@ -369,21 +369,21 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
         {
             const string patchParams = getPatcher(ret, package, retval);
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, false,
-                                      iter, "", op->getMetaData(), patchParams);
+                                      iter, "", op->getMetadata(), patchParams);
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         const string patchParams = getPatcher(pli->type(), package, paramName);
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(),
-                                  "this." + paramName, false, iter, "", pli->getMetaData(), patchParams);
+                                  "this." + paramName, false, iter, "", pli->getMetadata(), patchParams);
     }
 
     if(checkReturnType)
     {
         const string patchParams = getPatcher(ret, package, retval);
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, false,
-                                  iter, "", op->getMetaData(), patchParams);
+                                  iter, "", op->getMetadata(), patchParams);
     }
 
     out << eb;
@@ -443,12 +443,12 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
     out << nl << "public " << opName << "MarshaledResult" << spar;
     if(ret)
     {
-        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetaData(), op->returnIsTagged())
+        out << (typeToAnnotatedString(ret, TypeModeIn, package, op->getMetadata(), op->returnIsTagged())
                 + " " + retval);
     }
     for(const auto& p : outParams)
     {
-        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetaData(), p->tagged())
+        out << (typeToAnnotatedString(p->type(), TypeModeIn, package, p->getMetadata(), p->tagged())
                 + " " + fixKwd((p->name())));
     }
     out << currentParam << epar;
@@ -464,14 +464,14 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
     {
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, true, iter,
-                                  "_ostr", pli->getMetaData());
+                                  "_ostr", pli->getMetadata());
     }
 
     bool checkReturnType = op->returnIsTagged();
     if(ret && !checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, NotTagged, 0, retval, true, iter, "_ostr",
-                                  op->getMetaData());
+                                  op->getMetadata());
     }
 
     //
@@ -483,19 +483,19 @@ Slice::JavaVisitor::writeMarshaledResultType(Output& out, const OperationPtr& op
         if(checkReturnType && op->returnTag() < pli->tag())
         {
             writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true,
-                                      iter, "_ostr", op->getMetaData());
+                                      iter, "_ostr", op->getMetadata());
             checkReturnType = false;
         }
 
         const string paramName = fixKwd(pli->name());
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedOutParam, pli->tag(), paramName,
-                                  true, iter, "_ostr", pli->getMetaData());
+                                  true, iter, "_ostr", pli->getMetadata());
     }
 
     if(checkReturnType)
     {
         writeMarshalUnmarshalCode(out, package, ret, TaggedReturnParam, op->returnTag(), retval, true, iter,
-                                  "_ostr", op->getMetaData());
+                                  "_ostr", op->getMetadata());
     }
 
     if(op->returnsClasses(false))
@@ -605,7 +605,7 @@ Slice::JavaVisitor::getParams(const OperationPtr& op, const string& package)
 
     for(const auto& q : op->params())
     {
-        const string type = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetaData(), q->tagged());
+        const string type = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetadata(), q->tagged());
         params.push_back(type + ' ' + fixKwd(q->name()));
     }
 
@@ -618,7 +618,7 @@ Slice::JavaVisitor::getParamsProxy(const OperationPtr& op, const string& package
     vector<string> params;
     for(const auto& q : op->params())
     {
-        const string typeString = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetaData(), q->tagged());
+        const string typeString = typeToAnnotatedString(q->type(), TypeModeIn, package, q->getMetadata(), q->tagged());
         params.push_back(typeString + ' ' + (internal ? "iceP_" + q->name() : fixKwd(q->name())));
     }
 
@@ -660,7 +660,7 @@ Slice::JavaVisitor::writeMarshalProxyParams(Output& out, const string& package, 
     {
         string paramName = "iceP_" + pli->name();
         writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, true,
-                                  iter, "", pli->getMetaData());
+                                  iter, "", pli->getMetadata());
     }
 
     //
@@ -669,7 +669,7 @@ Slice::JavaVisitor::writeMarshalProxyParams(Output& out, const string& package, 
     for(const auto& pli : taggedParams)
     {
         writeMarshalUnmarshalCode(out, package, pli->type(), TaggedInParam, pli->tag(), "iceP_" + pli->name(), true,
-                                  iter, "", pli->getMetaData());
+                                  iter, "", pli->getMetadata());
     }
 
     if(op->sendsClasses(false))
@@ -703,13 +703,13 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
         TypePtr type;
         bool isTagged;
         int tag;
-        StringList metaData;
+        StringList metadata;
         if(ret)
         {
             type = ret;
             isTagged = op->returnIsTagged();
             tag = op->returnTag();
-            metaData = op->getMetaData();
+            metadata = op->getMetadata();
         }
         else
         {
@@ -717,7 +717,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
             isTagged = outParams.front()->tagged();
             type = unwrapIfOptional(outParams.front()->type());
             tag = outParams.front()->tag();
-            metaData = outParams.front()->getMetaData();
+            metadata = outParams.front()->getMetadata();
         }
 
         const bool val = isValue(type);
@@ -736,11 +736,11 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
         if(isTagged)
         {
             writeMarshalUnmarshalCode(out, package, type, ret ? TaggedReturnParam : TaggedOutParam,
-                                      tag, name, false, iter, "", metaData, patchParams);
+                                      tag, name, false, iter, "", metadata, patchParams);
         }
         else
         {
-            writeMarshalUnmarshalCode(out, package, type, NotTagged, 0, name, false, iter, "", metaData,
+            writeMarshalUnmarshalCode(out, package, type, NotTagged, 0, name, false, iter, "", metadata,
                                       patchParams);
         }
 
@@ -774,13 +774,13 @@ Slice::JavaVisitor::writeMarshalServantResults(Output& out, const string& packag
         TagMode mode;
         TypePtr type;
         int tag;
-        StringList metaData;
+        StringList metadata;
         if(op->deprecatedReturnType())
         {
             type = unwrapIfOptional(op->deprecatedReturnType());
             mode = op->returnIsTagged() ? TaggedReturnParam : NotTagged;
             tag = op->returnTag();
-            metaData = op->getMetaData();
+            metadata = op->getMetadata();
         }
         else
         {
@@ -788,11 +788,11 @@ Slice::JavaVisitor::writeMarshalServantResults(Output& out, const string& packag
             mode = params.front()->tagged() ? TaggedOutParam : NotTagged;
             type = unwrapIfOptional(params.front()->type());
             tag = params.front()->tag();
-            metaData = params.front()->getMetaData();
+            metadata = params.front()->getMetadata();
         }
 
         int iter = 0;
-        writeMarshalUnmarshalCode(out, package, type, mode, tag, param, true, iter, "", metaData);
+        writeMarshalUnmarshalCode(out, package, type, mode, tag, param, true, iter, "", metadata);
     }
 
     if(op->returnsClasses(false))
@@ -806,7 +806,7 @@ Slice::JavaVisitor::writeThrowsClause(const string& package, const ExceptionList
 {
     Output& out = output();
 
-    if(op && (op->hasMetaData("java:UserException") || op->hasMetaData("UserException")))
+    if(op && (op->hasMetadata("java:UserException") || op->hasMetadata("UserException")))
     {
         out.inc();
         out << nl << "throws " << getUnqualified("com.zeroc.Ice.UserException", package);
@@ -842,7 +842,7 @@ Slice::JavaVisitor::writeMarshalDataMember(Output& out, const string& package, c
         out << nl << "if(_" << member->name() << ")";
         out << sb;
         writeMarshalUnmarshalCode(out, package, member->type(), TaggedInParam, member->tag(),
-                                  fixKwd(member->name()), true, iter, "ostr_", member->getMetaData());
+                                  fixKwd(member->name()), true, iter, "ostr_", member->getMetadata());
         out << eb;
     }
     else
@@ -855,7 +855,7 @@ Slice::JavaVisitor::writeMarshalDataMember(Output& out, const string& package, c
         }
 
         writeMarshalUnmarshalCode(out, package, member->type(), NotTagged, 0, memberName,
-                                  true, iter, stream, member->getMetaData());
+                                  true, iter, stream, member->getMetadata());
     }
 }
 
@@ -872,7 +872,7 @@ Slice::JavaVisitor::writeUnmarshalDataMember(Output& out, const string& package,
             << getTagFormat(member->type()) << "))";
         out << sb;
         writeMarshalUnmarshalCode(out, package, member->type(), TaggedMember, 0, fixKwd(member->name()), false,
-                                  iter, "istr_", member->getMetaData(), patchParams);
+                                  iter, "istr_", member->getMetadata(), patchParams);
         out << eb;
     }
     else
@@ -885,7 +885,7 @@ Slice::JavaVisitor::writeUnmarshalDataMember(Output& out, const string& package,
         }
 
         writeMarshalUnmarshalCode(out, package, member->type(), NotTagged, 0, memberName, false,
-                                  iter, stream, member->getMetaData(), patchParams);
+                                  iter, stream, member->getMetadata(), patchParams);
     }
 }
 
@@ -905,7 +905,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         const string currentParam = getUnqualified("com.zeroc.Ice.Current", package) + " " +
             getEscapedParamName(op, "current");
 
-        const bool amd = p->hasMetaData("amd") || op->hasMetaData("amd");
+        const bool amd = p->hasMetadata("amd") || op->hasMetadata("amd");
 
         ExceptionList throws = op->throws();
         throws.sort();
@@ -981,7 +981,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     for(OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
     {
         OperationPtr op = *r;
-        StringList opMetaData = op->getMetaData();
+        StringList opMetadata = op->getMetadata();
 
         CommentPtr dc = op->parseComment(false);
 
@@ -994,7 +994,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         out << nl << " * @param inS -";
         out << nl << " * @param current -";
         out << nl << " * @return -";
-        if(!op->throws().empty() || op->hasMetaData("java:UserException") || op->hasMetaData("UserException"))
+        if(!op->throws().empty() || op->hasMetadata("java:UserException") || op->hasMetadata("UserException"))
         {
             out << nl << " * @throws " << getUnqualified("com.zeroc.Ice.UserException", package) << " -";
         }
@@ -1009,7 +1009,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         out << name;
         out << " obj, final " << getUnqualified("com.zeroc.IceInternal.Incoming", package) << " inS, "
             << getUnqualified("com.zeroc.Ice.Current", package) << " current)";
-        if(!op->throws().empty() || op->hasMetaData("java:UserException") || op->hasMetaData("UserException"))
+        if(!op->throws().empty() || op->hasMetadata("java:UserException") || op->hasMetadata("UserException"))
         {
             out.inc();
             out << nl << "throws " << getUnqualified("com.zeroc.Ice.UserException", package);
@@ -1017,7 +1017,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         }
         out << sb;
 
-        const bool amd = p->hasMetaData("amd") || op->hasMetaData("amd");
+        const bool amd = p->hasMetadata("amd") || op->hasMetadata("amd");
 
         const TypePtr ret = unwrapIfOptional(op->deprecatedReturnType());
 
@@ -1047,7 +1047,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                 else
                 {
                     const string paramName = "iceP_" + pli->name();
-                    const string typeS = typeToAnnotatedString(paramType, TypeModeIn, package, pli->getMetaData(),
+                    const string typeS = typeToAnnotatedString(paramType, TypeModeIn, package, pli->getMetadata(),
                         pli->tagged());
                     out << nl << typeS << ' ' << paramName << ';';
                 }
@@ -1063,14 +1063,14 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                 const string paramName = isValue(pli->type()) ? ("icePP_" + pli->name()) : "iceP_" + pli->name();
                 const string patchParams = getPatcher(pli->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(out, package, pli->type(), NotTagged, 0, paramName, false,
-                                          iter, "", pli->getMetaData(), patchParams);
+                                          iter, "", pli->getMetadata(), patchParams);
             }
             for(const auto& pli : taggedParams)
             {
                 const string paramName = isValue(pli->type()) ? ("icePP_" + pli->name()) : "iceP_" + pli->name();
                 const string patchParams = getPatcher(pli->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(out, package, pli->type(), TaggedInParam, pli->tag(),
-                                          paramName, false, iter, "", pli->getMetaData(), patchParams);
+                                          paramName, false, iter, "", pli->getMetadata(), patchParams);
             }
             if(op->sendsClasses(false))
             {
@@ -1080,7 +1080,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
 
             for(const auto& pli : values)
             {
-                const string typeS = typeToAnnotatedString(pli->type(), TypeModeIn, package, pli->getMetaData(),
+                const string typeS = typeToAnnotatedString(pli->type(), TypeModeIn, package, pli->getMetadata(),
                                                            pli->tagged());
                 out << nl << typeS << ' ' << "iceP_" << pli->name() << " = icePP_" << pli->name() << ".value;";
             }
@@ -1286,8 +1286,8 @@ Slice::JavaVisitor::writeMarshaling(Output& out, const ClassDefPtr& p)
 
     int iter;
     auto [requiredMembers, taggedMembers] = p->sortedDataMembers();
-    bool basePreserved = p->inheritsMetaData("preserve-slice");
-    bool preserved = p->hasMetaData("preserve-slice");
+    bool basePreserved = p->inheritsMetadata("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice");
 
     if(preserved && !basePreserved)
     {
@@ -1478,7 +1478,7 @@ Slice::JavaVisitor::writeDataMemberInitializers(Output& out, const MemberList& m
             StructPtr st = StructPtr::dynamicCast(t);
             if(st)
             {
-                string memberType = typeToString(st, TypeModeMember, package, p->getMetaData());
+                string memberType = typeToString(st, TypeModeMember, package, p->getMetadata());
                 out << nl << "this." << fixKwd(p->name()) << " = new " << memberType << "();";
             }
         }
@@ -1884,7 +1884,7 @@ Slice::JavaVisitor::writeServantDocComment(Output& out, const OperationPtr& p, c
         out << nl << " * @return A completion stage that the servant will complete when the invocation completes.";
     }
 
-    if(p->hasMetaData("java:UserException") || p->hasMetaData("UserException"))
+    if(p->hasMetadata("java:UserException") || p->hasMetadata("UserException"))
     {
         out << nl << " * @throws " << getUnqualified("com.zeroc.Ice.UserException", package);
     }
@@ -1987,7 +1987,7 @@ Slice::Gen::~Gen()
 void
 Slice::Gen::generate(const UnitPtr& p)
 {
-    JavaGenerator::validateMetaData(p);
+    JavaGenerator::validateMetadata(p);
 
     PackageVisitor packageVisitor(_dir);
     p->visit(&packageVisitor, false);
@@ -2078,10 +2078,10 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     // Check for java:implements metadata.
     //
-    const StringList metaData = p->getMetaData();
+    const StringList metadata = p->getMetadata();
     static const string prefix = "java:implements:";
     StringList implements;
-    for(const auto& q : metaData)
+    for(const auto& q : metadata)
     {
         if(q.find(prefix) == 0)
         {
@@ -2173,7 +2173,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
                 for(const auto& d : allRequiredMembers)
                 {
                     string memberName = fixKwd(d->name());
-                    string memberType = typeToString(d->type(), TypeModeMember, package, d->getMetaData(), true);
+                    string memberType = typeToString(d->type(), TypeModeMember, package, d->getMetadata(), true);
                     dataMember.push_back(memberType + " " + memberName);
                 }
                 out << dataMember << epar;
@@ -2209,7 +2209,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
             for(const auto& d : allDataMembers)
             {
                 string memberName = fixKwd(d->name());
-                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetaData(),
+                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetadata(),
                     d->tagged());
                 dataMember.push_back(memberType + " " + memberName);
             }
@@ -2273,7 +2273,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     writeHiddenDocComment(out);
     out << nl << "public static final long serialVersionUID = ";
     string serialVersionUID;
-    if (p->findMetaData("java:serialVersionUID", serialVersionUID))
+    if (p->findMetadata("java:serialVersionUID", serialVersionUID))
     {
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
@@ -2284,7 +2284,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
         {
             ostringstream os;
             os << "ignoring invalid serialVersionUID for class `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", -1, os.str());
+            dc->warning(InvalidMetadata, "", -1, os.str());
             out << computeSerialVersionUUID(p);
         }
         else
@@ -2298,7 +2298,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
                     ostringstream os;
                     os << "ignoring invalid serialVersionUID for class `" << p->scoped()
                        << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", -1, os.str());
+                    dc->warning(InvalidMetadata, "", -1, os.str());
                     out << computeSerialVersionUUID(p);
                 }
             }
@@ -2522,7 +2522,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
                 for(const auto& member : allRequiredMembers)
                 {
                     string memberName = fixKwd(member->name());
-                    string memberType = typeToString(member->type(), TypeModeMember, package, member->getMetaData(), true);
+                    string memberType = typeToString(member->type(), TypeModeMember, package, member->getMetadata(), true);
                     dataMember.push_back(memberType + " " + memberName);
                 }
                 out << dataMember << epar;
@@ -2591,7 +2591,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
             for(const auto& d : allDataMembers)
             {
                 string memberName = fixKwd(d->name());
-                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetaData(),
+                string memberType = typeToAnnotatedString(d->type(), TypeModeMember, package, d->getMetadata(),
                     d->tagged());
                 dataMember.push_back(memberType + " " + memberName);
             }
@@ -2687,8 +2687,8 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     string scoped = p->scoped();
     string package = getPackage(p);
     ExceptionPtr base = p->base();
-    bool basePreserved = p->inheritsMetaData("preserve-slice");
-    bool preserved = p->hasMetaData("preserve-slice");
+    bool basePreserved = p->inheritsMetadata("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice");
 
     MemberList sortedMembers = p->dataMembers();
     sortMembers(sortedMembers);
@@ -2786,7 +2786,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     writeHiddenDocComment(out);
     out << nl << "public static final long serialVersionUID = ";
     string serialVersionUID;
-    if(p->findMetaData("java:serialVersionUID", serialVersionUID))
+    if(p->findMetadata("java:serialVersionUID", serialVersionUID))
     {
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
@@ -2797,7 +2797,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         {
             ostringstream os;
             os << "ignoring invalid serialVersionUID for exception `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", -1, os.str());
+            dc->warning(InvalidMetadata, "", -1, os.str());
             out << computeSerialVersionUUID(p);
         }
         else
@@ -2811,7 +2811,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
                     ostringstream os;
                     os << "ignoring invalid serialVersionUID for exception `" << p->scoped()
                        << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", -1, os.str());
+                    dc->warning(InvalidMetadata, "", -1, os.str());
                     out << computeSerialVersionUUID(p);
                 }
             }
@@ -2844,10 +2844,10 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     //
     // Check for java:implements metadata.
     //
-    const StringList metaData = p->getMetaData();
+    const StringList metadata = p->getMetadata();
     static const string prefix = "java:implements:";
     StringList implements;
-    for(const auto& q : metaData)
+    for(const auto& q : metadata)
     {
         if(q.find(prefix) == 0)
         {
@@ -2905,7 +2905,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         for(const auto& d : members)
         {
             string memberName = fixKwd(d->name());
-            string memberType = typeToString(unwrapIfOptional(d->type()), TypeModeMember, package, d->getMetaData(),
+            string memberType = typeToString(unwrapIfOptional(d->type()), TypeModeMember, package, d->getMetadata(),
                 true);
             dataMember.push_back(memberType + " " + memberName);
             paramNames.push_back(memberName);
@@ -2957,7 +2957,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
             // For all other types, we can use the native equals() method.
             //
             SequencePtr seq = SequencePtr::dynamicCast(d->type());
-            if(seq && !hasTypeMetaData(seq, d->getMetaData()))
+            if(seq && !hasTypeMetadata(seq, d->getMetadata()))
             {
                 //
                 // Arrays.equals() handles null values.
@@ -3104,7 +3104,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     writeHiddenDocComment(out);
     out << nl << "public static final long serialVersionUID = ";
     string serialVersionUID;
-    if(p->findMetaData("java:serialVersionUID", serialVersionUID))
+    if(p->findMetadata("java:serialVersionUID", serialVersionUID))
     {
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
@@ -3114,7 +3114,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         {
             ostringstream os;
             os << "ignoring invalid serialVersionUID for struct `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", -1, os.str());
+            dc->warning(InvalidMetadata, "", -1, os.str());
             out << computeSerialVersionUUID(p);
         }
         else
@@ -3128,7 +3128,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                     ostringstream os;
                     os << "ignoring invalid serialVersionUID for struct `" << p->scoped()
                        << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", -1, os.str());
+                    dc->warning(InvalidMetadata, "", -1, os.str());
                     out << computeSerialVersionUUID(p);
                 }
             }
@@ -3155,17 +3155,17 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     const ContainedPtr contained = ContainedPtr::dynamicCast(container);
 
     const string name = fixKwd(p->name());
-    const StringList metaData = p->getMetaData();
-    const bool getSet = p->hasMetaData(_getSetMetaData) || contained->hasMetaData(_getSetMetaData);
+    const StringList metadata = p->getMetadata();
+    const bool getSet = p->hasMetadata(_getSetMetadata) || contained->hasMetadata(_getSetMetadata);
     const bool isTagged = p->tagged();
     const TypePtr type = unwrapIfOptional(p->type());
     const BuiltinPtr b = BuiltinPtr::dynamicCast(type);
 
-    const string typeS = typeToString(type, TypeModeMember, getPackage(contained), metaData);
+    const string typeS = typeToString(type, TypeModeMember, getPackage(contained), metadata);
     // Tagged data members are only allowed in classes and exceptions.
     const string typeN = (cls || ex) ?
-                             typeToAnnotatedString(type, TypeModeMember, getPackage(contained), metaData, isTagged)
-                             : typeToString(type, TypeModeMember, getPackage(contained), metaData);
+                             typeToAnnotatedString(type, TypeModeMember, getPackage(contained), metadata, isTagged)
+                             : typeToString(type, TypeModeMember, getPackage(contained), metadata);
 
     Output& out = output();
 
@@ -3182,7 +3182,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     // Access visibility for class data members can be controlled by metadata.
     // If none is specified, the default is public.
     //
-    if(cls && (p->hasMetaData("protected") || contained->hasMetaData("protected")))
+    if(cls && (p->hasMetadata("protected") || contained->hasMetadata("protected")))
     {
         out << nl << "protected " << typeN << ' ' << name << ';';
     }
@@ -3342,7 +3342,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
         SequencePtr seq = SequencePtr::dynamicCast(type);
         if(seq)
         {
-            if(!hasTypeMetaData(seq, metaData))
+            if(!hasTypeMetadata(seq, metadata))
             {
                 string elem = typeToString(seq->type(), TypeModeMember, getPackage(contained));
 
@@ -3603,11 +3603,11 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
 
     string meta;
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(elementType);
-    if(!hasTypeMetaData(p) && builtin && builtin->kind() <= Builtin::KindString)
+    if(!hasTypeMetadata(p) && builtin && builtin->kind() <= Builtin::KindString)
     {
         return; // No helpers for sequence of primitive types
     }
-    else if(hasTypeMetaData(p) && !p->findMetaData("java:type", meta))
+    else if(hasTypeMetadata(p) && !p->findMetadata("java:type", meta))
     {
         return; // No helpers for custom metadata other than java:type
     }
@@ -3656,7 +3656,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
             //
             // Stop if the inner sequence type has a custom, serializable or protobuf type.
             //
-            if(hasTypeMetaData(s))
+            if(hasTypeMetadata(s))
             {
                 break;
             }
@@ -3728,7 +3728,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
         << " ostr, int tag, " << addAnnotation(typeS, "@Nullable") << " v)";
     out << sb;
-    if(!hasTypeMetaData(p) && builtin && builtin->kind() < Builtin::KindObject)
+    if(!hasTypeMetadata(p) && builtin && builtin->kind() < Builtin::KindObject)
     {
         out << nl << "ostr.write" << builtinTable[builtin->kind()] << "Seq(tag, v);";
     }
@@ -3753,13 +3753,13 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
             const size_t sz = elementType->minWireSize();
             if(sz > 1)
             {
-                string metaData;
+                string metadata;
                 out << nl << "final int taggedSize = v == null ? 0 : ";
-                if(findMetaData("java:buffer", p->getMetaData(), metaData))
+                if(findMetadata("java:buffer", p->getMetadata(), metadata))
                 {
                     out << "v.remaining() / " << sz << ";";
                 }
-                else if(hasTypeMetaData(p))
+                else if(hasTypeMetadata(p))
                 {
                     out << "v.size();";
                 }
@@ -3781,7 +3781,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     out << nl << "public static " << addAnnotation(typeS, "@Nullable") << " read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
         << " istr, int tag)";
     out << sb;
-    if(!hasTypeMetaData(p) && builtin && builtin->kind() < Builtin::KindObject)
+    if(!hasTypeMetadata(p) && builtin && builtin->kind() < Builtin::KindObject)
     {
         out << nl << "return istr.read" << builtinTable[builtin->kind()] << "Seq(tag);";
     }
@@ -3819,7 +3819,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     string absolute = getUnqualified(p);
     string helper = getUnqualified(p, "", "", "Helper");
     string package = getPackage(p);
-    StringList metaData = p->getMetaData();
+    StringList metadata = p->getMetadata();
     string formalType = typeToString(p, TypeModeIn, package, StringList(), true);
 
     open(helper, p->file());
@@ -4716,7 +4716,7 @@ Slice::Gen::ImplVisitor::writeOperation(Output& out, const string& package, cons
     const vector<string> params = getParams(op, package);
     const string currentParam = getUnqualified("com.zeroc.Ice.Current", package) + " " + getEscapedParamName(op, "current");
 
-    const bool amd = interface->hasMetaData("amd") || op->hasMetaData("amd");
+    const bool amd = interface->hasMetadata("amd") || op->hasMetadata("amd");
 
     if(amd)
     {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -84,7 +84,7 @@ lookupKwd(const string& name)
     return found ? "_" + name : name;
 }
 
-class MetaDataVisitor : public ParserVisitor
+class MetadataVisitor : public ParserVisitor
 {
 public:
 
@@ -102,8 +102,8 @@ public:
             string file = *q;
             DefinitionContextPtr dc = p->findDefinitionContext(file);
             assert(dc);
-            StringList globalMetaData = dc->getMetaData();
-            for(StringList::const_iterator r = globalMetaData.begin(); r != globalMetaData.end();)
+            StringList globalMetadata = dc->getMetadata();
+            for(StringList::const_iterator r = globalMetadata.begin(); r != globalMetadata.end();)
             {
                 string s = *r++;
                 if(s.find(prefix) == 0)
@@ -115,82 +115,82 @@ public:
                     }
                     else
                     {
-                        dc->warning(InvalidMetaData, file, -1,  "ignoring invalid global metadata `" + s + "'");
-                        globalMetaData.remove(s);
+                        dc->warning(InvalidMetadata, file, -1,  "ignoring invalid global metadata `" + s + "'");
+                        globalMetadata.remove(s);
                         continue;
                     }
                 };
             }
-            dc->setMetaData(globalMetaData);
+            dc->setMetadata(globalMetadata);
         }
         return true;
     }
 
     bool visitModuleStart(const ModulePtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
         return true;
     }
 
     void visitClassDecl(const ClassDeclPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
     bool visitClassDefStart(const ClassDefPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
         return true;
     }
 
     void visitInterfaceDecl(const InterfaceDeclPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
     bool visitInterfaceDefStart(const InterfaceDefPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
         return true;
     }
 
     bool visitExceptionStart(const ExceptionPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
         return true;
     }
 
     bool visitStructStart(const StructPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
         return true;
     }
 
     void visitOperation(const OperationPtr& p) override
     {
         TypePtr returnType = p->deprecatedReturnType();
-        StringList metaData = getMetaData(p);
+        StringList metadata = getMetadata(p);
 
         UnitPtr unt = p->unit();
         string file = p->file();
@@ -198,40 +198,40 @@ public:
 
         if(!returnType)
         {
-            for(StringList::const_iterator q = metaData.begin(); q != metaData.end();)
+            for(StringList::const_iterator q = metadata.begin(); q != metadata.end();)
             {
                 string s = *q++;
                 if(s.find("java:type:", 0) == 0)
                 {
-                    dc->warning(InvalidMetaData, p->file(), p->line(), "ignoring invalid metadata `" + s +
+                    dc->warning(InvalidMetadata, p->file(), p->line(), "ignoring invalid metadata `" + s +
                                 "' for operation with void return type");
-                    metaData.remove(s);
+                    metadata.remove(s);
                     continue;
                 }
             }
         }
         else
         {
-            metaData = validateType(returnType, metaData, p->file(), p->line());
-            metaData = validateGetSet(p, metaData, p->file(), p->line());
+            metadata = validateType(returnType, metadata, p->file(), p->line());
+            metadata = validateGetSet(p, metadata, p->file(), p->line());
         }
-        p->setMetaData(metaData);
+        p->setMetadata(metadata);
 
         for(auto& q : p->allMembers())
         {
-            metaData = getMetaData(q);
-            metaData = validateType(q->type(), metaData, p->file(), q->line());
-            metaData = validateGetSet(q->type(), metaData, p->file(), q->line());
-            q->setMetaData(metaData);
+            metadata = getMetadata(q);
+            metadata = validateType(q->type(), metadata, p->file(), q->line());
+            metadata = validateGetSet(q->type(), metadata, p->file(), q->line());
+            q->setMetadata(metadata);
         }
     }
 
     void visitDataMember(const MemberPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p->type(), metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p->type(), metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
     void visitSequence(const SequencePtr& p) override
@@ -239,15 +239,15 @@ public:
         static const string protobuf = "java:protobuf:";
         static const string serializable = "java:serializable:";
         static const string bytebuffer = "java:buffer";
-        StringList metaData = getMetaData(p);
-        StringList newMetaData;
+        StringList metadata = getMetadata(p);
+        StringList newMetadata;
 
         const string file =  p->file();
         const int line = p->line();
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc = unt->findDefinitionContext(file);
 
-        for(StringList::const_iterator q = metaData.begin(); q != metaData.end(); )
+        for(StringList::const_iterator q = metadata.begin(); q != metadata.end(); )
         {
             string s = *q++;
 
@@ -256,19 +256,19 @@ public:
                 //
                 // Remove from list so validateType does not try to handle as well.
                 //
-                metaData.remove(s);
+                metadata.remove(s);
                 BuiltinPtr builtin = BuiltinPtr::dynamicCast(p->type());
                 if(!builtin || builtin->kind() != Builtin::KindByte)
                 {
-                    dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + s + "': " +
+                    dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "': " +
                                 "this metadata can only be used with a byte sequence");
                     continue;
                 }
-                newMetaData.push_back(s);
+                newMetadata.push_back(s);
             }
             else if(s.find(bytebuffer) == 0)
             {
-                metaData.remove(s);
+                metadata.remove(s);
 
                 BuiltinPtr builtin = BuiltinPtr::dynamicCast(p->type());
                 if(!builtin ||
@@ -276,51 +276,51 @@ public:
                     builtin->kind() != Builtin::KindInt && builtin->kind() != Builtin::KindLong &&
                     builtin->kind() != Builtin::KindFloat && builtin->kind() != Builtin::KindDouble))
                 {
-                    dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + s + "': " +
+                    dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "': " +
                                 "this metadata can not be used with this type");
                     continue;
                 }
-                newMetaData.push_back(s);
+                newMetadata.push_back(s);
             }
         }
 
-        metaData = validateType(p, metaData, file, line);
-        metaData = validateGetSet(p, metaData, file, line);
-        newMetaData.insert(newMetaData.begin(), metaData.begin(), metaData.end());
-        p->setMetaData(newMetaData);
+        metadata = validateType(p, metadata, file, line);
+        metadata = validateGetSet(p, metadata, file, line);
+        newMetadata.insert(newMetadata.begin(), metadata.begin(), metadata.end());
+        p->setMetadata(newMetadata);
     }
 
     void visitDictionary(const DictionaryPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
     void visitEnum(const EnumPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
     void visitConst(const ConstPtr& p) override
     {
-        StringList metaData = getMetaData(p);
-        metaData = validateType(p, metaData, p->file(), p->line());
-        metaData = validateGetSet(p, metaData, p->file(), p->line());
-        p->setMetaData(metaData);
+        StringList metadata = getMetadata(p);
+        metadata = validateType(p, metadata, p->file(), p->line());
+        metadata = validateGetSet(p, metadata, p->file(), p->line());
+        p->setMetadata(metadata);
     }
 
 private:
 
-    StringList getMetaData(const ContainedPtr& cont)
+    StringList getMetadata(const ContainedPtr& cont)
     {
         static const string prefix = "java:";
 
-        StringList metaData = cont->getMetaData();
+        StringList metadata = cont->getMetadata();
         StringList result;
 
         UnitPtr unt = cont->container()->unit();
@@ -328,7 +328,7 @@ private:
         DefinitionContextPtr dc = unt->findDefinitionContext(file);
         assert(dc);
 
-        for(StringList::const_iterator p = metaData.begin(); p != metaData.end(); ++p)
+        for(StringList::const_iterator p = metadata.begin(); p != metadata.end(); ++p)
         {
             string s = *p;
             if(s.find(prefix) == 0)
@@ -392,7 +392,7 @@ private:
                     continue;
                 }
 
-                dc->warning(InvalidMetaData, cont->file(), cont->line(), "ignoring invalid metadata `" + s + "'");
+                dc->warning(InvalidMetadata, cont->file(), cont->line(), "ignoring invalid metadata `" + s + "'");
             }
             else
             {
@@ -404,13 +404,13 @@ private:
         return result;
     }
 
-    StringList validateType(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
+    StringList validateType(const SyntaxTreeBasePtr& p, const StringList& metadata, const string& file, int line)
     {
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc = unt->findDefinitionContext(file);
         assert(dc);
-        StringList newMetaData;
-        for(StringList::const_iterator i = metaData.begin(); i != metaData.end(); ++i)
+        StringList newMetadata;
+        for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); ++i)
         {
             //
             // Type metadata ("java:type:Foo") is only supported by sequences and dictionaries.
@@ -429,7 +429,7 @@ private:
                     assert(b);
                     str = b->typeId();
                 }
-                dc->warning(InvalidMetaData, file, line, "invalid metadata for " + str);
+                dc->warning(InvalidMetadata, file, line, "invalid metadata for " + str);
             }
             else if(i->find("java:buffer") == 0)
             {
@@ -442,30 +442,30 @@ private:
                         builtin->kind() == Builtin::KindInt || builtin->kind() == Builtin::KindLong ||
                         builtin->kind() == Builtin::KindFloat || builtin->kind() == Builtin::KindDouble))
                     {
-                        newMetaData.push_back(*i);
+                        newMetadata.push_back(*i);
                         continue;
                     }
 
                 }
 
-                dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + *i + "'");
+                dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");
             }
             else if(i->find("java:protobuf:") == 0 || i->find("java:serializable:") == 0)
             {
                 //
                 // Only valid in sequence definition which is checked in visitSequence
                 //
-                dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + *i + "'");
+                dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");
             }
             else if(i->find("java:implements:") == 0)
             {
                 if(ClassDefPtr::dynamicCast(p) || StructPtr::dynamicCast(p))
                 {
-                    newMetaData.push_back(*i);
+                    newMetadata.push_back(*i);
                 }
                 else
                 {
-                    dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + *i + "'");
+                    dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");
                 }
             }
             else if(i->find("java:package:") == 0)
@@ -473,28 +473,28 @@ private:
                 ModulePtr m = ModulePtr::dynamicCast(p);
                 if(m && UnitPtr::dynamicCast(m->container()))
                 {
-                    newMetaData.push_back(*i);
+                    newMetadata.push_back(*i);
                 }
                 else
                 {
-                    dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + *i + "'");
+                    dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");
                 }
             }
             else
             {
-                newMetaData.push_back(*i);
+                newMetadata.push_back(*i);
             }
         }
-        return newMetaData;
+        return newMetadata;
     }
 
-    StringList validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
+    StringList validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metadata, const string& file, int line)
     {
         const UnitPtr unt = p->unit();
         const DefinitionContextPtr dc= unt->findDefinitionContext(file);
         assert(dc);
-        StringList newMetaData;
-        for(StringList::const_iterator i = metaData.begin(); i != metaData.end(); ++i)
+        StringList newMetadata;
+        for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); ++i)
         {
             //
             // The "getset" metadata can only be specified on a class, struct, exception or data member.
@@ -515,12 +515,12 @@ private:
                     assert(b);
                     str = b->typeId();
                 }
-                dc->warning(InvalidMetaData, file, line, "invalid metadata for " + str);
+                dc->warning(InvalidMetadata, file, line, "invalid metadata for " + str);
                 continue;
             }
-            newMetaData.push_back(*i);
+            newMetadata.push_back(*i);
         }
-        return newMetaData;
+        return newMetadata;
     }
 };
 
@@ -735,7 +735,7 @@ Slice::JavaOutput::printHeader()
     print("//\n");
 }
 
-const string Slice::JavaGenerator::_getSetMetaData = "java:getset";
+const string Slice::JavaGenerator::_getSetMetadata = "java:getset";
 
 Slice::JavaGenerator::JavaGenerator(const string& dir) :
     _dir(dir),
@@ -914,7 +914,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
     static const string prefix = "java:package:";
 
     string q;
-    if(!m->findMetaData(prefix, q))
+    if(!m->findMetadata(prefix, q))
     {
         UnitPtr ut = cont->unit();
         string file = cont->file();
@@ -922,7 +922,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
 
         DefinitionContextPtr dc = ut->findDefinitionContext(file);
         assert(dc);
-        q = dc->findMetaData(prefix);
+        q = dc->findMetadata(prefix);
     }
 
     if(!q.empty())
@@ -1017,7 +1017,7 @@ string
 Slice::JavaGenerator::typeToString(const TypePtr& constType,
                                    TypeMode mode,
                                    const string& package,
-                                   const StringList& metaData,
+                                   const StringList& metadata,
                                    bool formal) const
 {
     TypePtr type = unwrapIfOptional(constType);
@@ -1071,7 +1071,7 @@ Slice::JavaGenerator::typeToString(const TypePtr& constType,
     if(dict)
     {
         string instanceType, formalType;
-        getDictionaryTypes(dict, package, metaData, instanceType, formalType);
+        getDictionaryTypes(dict, package, metadata, instanceType, formalType);
         return formal ? formalType : instanceType;
     }
 
@@ -1079,7 +1079,7 @@ Slice::JavaGenerator::typeToString(const TypePtr& constType,
     if(seq)
     {
         string instanceType, formalType;
-        getSequenceTypes(seq, package, metaData, instanceType, formalType);
+        getSequenceTypes(seq, package, metadata, instanceType, formalType);
         return formal ? formalType : instanceType;
     }
 
@@ -1103,7 +1103,7 @@ string
 Slice::JavaGenerator::typeToObjectString(const TypePtr& constType,
                                          TypeMode mode,
                                          const string& package,
-                                         const StringList& metaData,
+                                         const StringList& metadata,
                                          bool formal) const
 {
     TypePtr type = unwrapIfOptional(constType);
@@ -1135,14 +1135,14 @@ Slice::JavaGenerator::typeToObjectString(const TypePtr& constType,
         return builtinTable[builtin->kind()];
     }
 
-    return typeToString(type, mode, package, metaData, formal);
+    return typeToString(type, mode, package, metadata, formal);
 }
 
 string
 Slice::JavaGenerator::typeToAnnotatedString(const TypePtr& constType,
                                             TypeMode mode,
                                             const string& package,
-                                            const StringList& metaData,
+                                            const StringList& metadata,
                                             bool tagged,
                                             bool object) const
 {
@@ -1150,15 +1150,15 @@ Slice::JavaGenerator::typeToAnnotatedString(const TypePtr& constType,
 
     if(tagged)
     {
-        return addAnnotation(typeToObjectString(type, mode, package, metaData, true), "@Nullable");
+        return addAnnotation(typeToObjectString(type, mode, package, metadata, true), "@Nullable");
     }
     else if(object)
     {
-        return typeToObjectString(type, mode, package, metaData, true);
+        return typeToObjectString(type, mode, package, metadata, true);
     }
     else
     {
-        string typeString = typeToString(type, mode, package, metaData, true);
+        string typeString = typeToString(type, mode, package, metadata, true);
 
         // TODO: Drop this logic once we stop using parameterless constructors.
         if(mode == TypeModeMember)
@@ -1238,7 +1238,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                                                 bool marshal,
                                                 int& iter,
                                                 const string& customStream,
-                                                const StringList& metaData,
+                                                const StringList& metadata,
                                                 const string& patchParams)
 {
     // TODO: for now, we handle marshaling of Optional<T> like T
@@ -1307,7 +1307,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
         return;
     }
 
-    string typeS = typeToString(type, TypeModeIn, package, metaData);
+    string typeS = typeToString(type, TypeModeIn, package, metadata);
 
     InterfaceDeclPtr interface = InterfaceDeclPtr::dynamicCast(type);
     if(interface)
@@ -1377,7 +1377,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
         if(isTaggedParam || mode == TaggedMember)
         {
             string instanceType, formalType, origInstanceType, origFormalType;
-            getDictionaryTypes(dict, "", metaData, instanceType, formalType);
+            getDictionaryTypes(dict, "", metadata, instanceType, formalType);
             getDictionaryTypes(dict, "", StringList(), origInstanceType, origFormalType);
             if(formalType == origFormalType && (marshal || instanceType == origInstanceType))
             {
@@ -1412,7 +1412,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                 if(keyType->isVariableLength() || valueType->isVariableLength())
                 {
                     out << nl << "int pos = " <<  stream << ".startSize();";
-                    writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metaData);
+                    writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metadata);
                     out << nl << stream << ".endSize(pos);";
                 }
                 else
@@ -1421,7 +1421,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     out << nl << "final int taggedSize = " << param << " == null ? 0 : " << param << ".size();";
                     out << nl << stream
                         << ".writeSize(taggedSize > 254 ? taggedSize * " << sz << " + 5 : taggedSize * " << sz << " + 1);";
-                    writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metaData);
+                    writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metadata);
                 }
 
                 if(isTaggedParam)
@@ -1446,7 +1446,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                 {
                     out << nl << stream << ".skipSize();";
                 }
-                writeDictionaryMarshalUnmarshalCode(out, package, dict, d, marshal, iter, true, customStream, metaData);
+                writeDictionaryMarshalUnmarshalCode(out, package, dict, d, marshal, iter, true, customStream, metadata);
                 if(isTaggedParam)
                 {
                     out << nl << param << " = " << d << ";";
@@ -1460,7 +1460,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
         }
         else
         {
-            writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metaData);
+            writeDictionaryMarshalUnmarshalCode(out, package, dict, param, marshal, iter, true, customStream, metadata);
         }
         return;
     }
@@ -1473,7 +1473,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
             string ignored;
             TypePtr elemType = seq->type();
             BuiltinPtr eltBltin = BuiltinPtr::dynamicCast(elemType);
-            if(!hasTypeMetaData(seq, metaData) && eltBltin && eltBltin->kind() < Builtin::KindObject)
+            if(!hasTypeMetadata(seq, metadata) && eltBltin && eltBltin->kind() < Builtin::KindObject)
             {
                 string bs = builtinSuffixTable[eltBltin->kind()];
                 if(marshal)
@@ -1487,7 +1487,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     return;
                 }
             }
-            else if(findMetaData("java:serializable", seq->getMetaData(), ignored))
+            else if(findMetadata("java:serializable", seq->getMetadata(), ignored))
             {
                 if(marshal)
                 {
@@ -1501,12 +1501,12 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     return;
                 }
             }
-            else if(!hasTypeMetaData(seq, metaData) ||
-                    findMetaData("java:type", seq->getMetaData(), ignored) ||
-                    findMetaData("java:type", metaData, ignored))
+            else if(!hasTypeMetadata(seq, metadata) ||
+                    findMetadata("java:type", seq->getMetadata(), ignored) ||
+                    findMetadata("java:type", metadata, ignored))
             {
                 string instanceType, formalType, origInstanceType, origFormalType;
-                getSequenceTypes(seq, "", metaData, instanceType, formalType);
+                getSequenceTypes(seq, "", metadata, instanceType, formalType);
                 getSequenceTypes(seq, "", StringList(), origInstanceType, origFormalType);
                 if(formalType == origFormalType && (marshal || instanceType == origInstanceType))
                 {
@@ -1537,7 +1537,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                 if(elemType->isVariableLength())
                 {
                     out << nl << "int pos = " <<  stream << ".startSize();";
-                    writeSequenceMarshalUnmarshalCode(out, package, seq, param, true, iter, true, customStream, metaData);
+                    writeSequenceMarshalUnmarshalCode(out, package, seq, param, true, iter, true, customStream, metadata);
                     out << nl << stream << ".endSize(pos);";
                 }
                 else
@@ -1547,12 +1547,12 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     {
                         string ignored2;
                         out << nl << "final int taggedSize = " << param << " == null ? 0 : ";
-                        if(findMetaData("java:buffer", seq->getMetaData(), ignored2) ||
-                           findMetaData("java:buffer", metaData, ignored2))
+                        if(findMetadata("java:buffer", seq->getMetadata(), ignored2) ||
+                           findMetadata("java:buffer", metadata, ignored2))
                         {
                             out << param << ".remaining() / " << sz << ";";
                         }
-                        else if(hasTypeMetaData(seq, metaData))
+                        else if(hasTypeMetadata(seq, metadata))
                         {
                             out << param << ".size();";
                         }
@@ -1563,7 +1563,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                         out << nl << stream << ".writeSize(taggedSize > 254 ? taggedSize * " << sz
                             << " + 5 : taggedSize * " << sz << " + 1);";
                     }
-                    writeSequenceMarshalUnmarshalCode(out, package, seq, param, true, iter, true, customStream, metaData);
+                    writeSequenceMarshalUnmarshalCode(out, package, seq, param, true, iter, true, customStream, metadata);
                 }
 
                 if(isTaggedParam)
@@ -1589,7 +1589,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                 {
                     out << nl << stream << ".skipSize();";
                 }
-                writeSequenceMarshalUnmarshalCode(out, package, seq, s, false, iter, true, customStream, metaData);
+                writeSequenceMarshalUnmarshalCode(out, package, seq, s, false, iter, true, customStream, metadata);
                 if(isTaggedParam)
                 {
                     out << nl << param << " = " << s << ";";
@@ -1603,7 +1603,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
         }
         else
         {
-            writeSequenceMarshalUnmarshalCode(out, package, seq, param, marshal, iter, true, customStream, metaData);
+            writeSequenceMarshalUnmarshalCode(out, package, seq, param, marshal, iter, true, customStream, metadata);
         }
         return;
     }
@@ -1649,7 +1649,7 @@ Slice::JavaGenerator::writeDictionaryMarshalUnmarshalCode(Output& out,
                                                           int& iter,
                                                           bool useHelper,
                                                           const string& customStream,
-                                                          const StringList& metaData)
+                                                          const StringList& metadata)
 {
     string stream = customStream;
     if(stream.empty())
@@ -1672,7 +1672,7 @@ Slice::JavaGenerator::writeDictionaryMarshalUnmarshalCode(Output& out,
     // the helper.
     //
     string instanceType, formalType, origInstanceType, origFormalType;
-    getDictionaryTypes(dict, "", metaData, instanceType, formalType);
+    getDictionaryTypes(dict, "", metadata, instanceType, formalType);
     getDictionaryTypes(dict, "", StringList(), origInstanceType, origFormalType);
     if(useHelper && formalType == origFormalType && (marshal || instanceType == origInstanceType))
     {
@@ -1768,7 +1768,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
                                                         int& iter,
                                                         bool useHelper,
                                                         const string& customStream,
-                                                        const StringList& metaData)
+                                                        const StringList& metadata)
 {
     string stream = customStream;
     if(stream.empty())
@@ -1790,7 +1790,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
         string meta;
         static const string protobuf = "java:protobuf:";
         static const string serializable = "java:serializable:";
-        if(seq->findMetaData(serializable, meta))
+        if(seq->findMetadata(serializable, meta))
         {
             if(marshal)
             {
@@ -1802,7 +1802,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
             }
             return;
         }
-        else if(seq->findMetaData(protobuf, meta))
+        else if(seq->findMetadata(protobuf, meta))
         {
             if(marshal)
             {
@@ -1834,7 +1834,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
     {
         string meta;
         static const string bytebuffer = "java:buffer";
-        if(seq->findMetaData(bytebuffer, meta) || findMetaData(bytebuffer, metaData, meta))
+        if(seq->findMetadata(bytebuffer, meta) || findMetadata(bytebuffer, metadata, meta))
         {
             if(marshal)
             {
@@ -1848,7 +1848,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
         }
     }
 
-    if(!hasTypeMetaData(seq, metaData) && builtin && builtin->kind() <= Builtin::KindString)
+    if(!hasTypeMetadata(seq, metadata) && builtin && builtin->kind() <= Builtin::KindString)
     {
         if(marshal)
         {
@@ -1876,7 +1876,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
     // the helper.
     //
     string instanceType, formalType, origInstanceType, origFormalType;
-    bool customType = getSequenceTypes(seq, "", metaData, instanceType, formalType);
+    bool customType = getSequenceTypes(seq, "", metadata, instanceType, formalType);
     getSequenceTypes(seq, "", StringList(), origInstanceType, origFormalType);
     if(useHelper && formalType == origFormalType && (marshal || instanceType == origInstanceType))
     {
@@ -1906,7 +1906,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
         //
         // Stop if the inner sequence type has a custom, serializable or protobuf type.
         //
-        if(hasTypeMetaData(s))
+        if(hasTypeMetadata(s))
         {
             break;
         }
@@ -2100,9 +2100,9 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(Output& out,
 }
 
 bool
-Slice::JavaGenerator::findMetaData(const string& prefix, const StringList& metaData, string& value)
+Slice::JavaGenerator::findMetadata(const string& prefix, const StringList& metadata, string& value)
 {
-    for(const auto& q : metaData)
+    for(const auto& q : metadata)
     {
         if(q.find(prefix) == 0)
         {
@@ -2115,7 +2115,7 @@ Slice::JavaGenerator::findMetaData(const string& prefix, const StringList& metaD
 }
 
 bool
-Slice::JavaGenerator::getTypeMetaData(const StringList& metaData, string& instanceType, string& formalType)
+Slice::JavaGenerator::getTypeMetadata(const StringList& metadata, string& instanceType, string& formalType)
 {
     //
     // Extract the instance type and an optional formal type.
@@ -2123,7 +2123,7 @@ Slice::JavaGenerator::getTypeMetaData(const StringList& metaData, string& instan
     //
     static const string prefix = "java:type:";
     string directive;
-    if(findMetaData(prefix, metaData, directive))
+    if(findMetadata(prefix, metadata, directive))
     {
         string::size_type pos = directive.find(':', prefix.size());
         if(pos != string::npos)
@@ -2143,7 +2143,7 @@ Slice::JavaGenerator::getTypeMetaData(const StringList& metaData, string& instan
 }
 
 bool
-Slice::JavaGenerator::hasTypeMetaData(const TypePtr& type, const StringList& localMetaData)
+Slice::JavaGenerator::hasTypeMetadata(const TypePtr& type, const StringList& localMetadata)
 {
     ContainedPtr cont = ContainedPtr::dynamicCast(type);
     if(cont)
@@ -2151,20 +2151,20 @@ Slice::JavaGenerator::hasTypeMetaData(const TypePtr& type, const StringList& loc
         static const string prefix = "java:type:";
         string directive;
 
-        if(findMetaData(prefix, localMetaData, directive))
+        if(findMetadata(prefix, localMetadata, directive))
         {
             return true;
         }
 
-        StringList metaData = cont->getMetaData();
+        StringList metadata = cont->getMetadata();
 
-        if(findMetaData(prefix, metaData, directive))
+        if(findMetadata(prefix, metadata, directive))
         {
             return true;
         }
 
-        if(findMetaData("java:protobuf:", metaData, directive) ||
-           findMetaData("java:serializable:", metaData, directive))
+        if(findMetadata("java:protobuf:", metadata, directive) ||
+           findMetadata("java:serializable:", metadata, directive))
         {
             SequencePtr seq = SequencePtr::dynamicCast(cont);
             if(seq)
@@ -2177,8 +2177,8 @@ Slice::JavaGenerator::hasTypeMetaData(const TypePtr& type, const StringList& loc
             }
         }
 
-        if(findMetaData("java:buffer", metaData, directive) ||
-           findMetaData("java:buffer", localMetaData, directive))
+        if(findMetadata("java:buffer", metadata, directive) ||
+           findMetadata("java:buffer", localMetadata, directive))
         {
             SequencePtr seq = SequencePtr::dynamicCast(cont);
             if(seq)
@@ -2201,7 +2201,7 @@ Slice::JavaGenerator::hasTypeMetaData(const TypePtr& type, const StringList& loc
 bool
 Slice::JavaGenerator::getDictionaryTypes(const DictionaryPtr& dict,
                                          const string& package,
-                                         const StringList& metaData,
+                                         const StringList& metadata,
                                          string& instanceType,
                                          string& formalType) const
 {
@@ -2214,8 +2214,8 @@ Slice::JavaGenerator::getDictionaryTypes(const DictionaryPtr& dict,
     //
     // Collect metadata for a custom type.
     //
-    if(getTypeMetaData(metaData, instanceType, formalType) ||
-       getTypeMetaData(dict->getMetaData(), instanceType, formalType))
+    if(getTypeMetadata(metadata, instanceType, formalType) ||
+       getTypeMetadata(dict->getMetadata(), instanceType, formalType))
     {
         assert(!instanceType.empty());
         if(formalType.empty())
@@ -2236,7 +2236,7 @@ Slice::JavaGenerator::getDictionaryTypes(const DictionaryPtr& dict,
 bool
 Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
                                        const string& package,
-                                       const StringList& metaData,
+                                       const StringList& metadata,
                                        string& instanceType,
                                        string& formalType) const
 {
@@ -2250,13 +2250,13 @@ Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
         {
             string prefix = "java:serializable:";
             string meta;
-            if(seq->findMetaData(prefix, meta))
+            if(seq->findMetadata(prefix, meta))
             {
                 instanceType = formalType = meta.substr(prefix.size());
                 return true;
             }
             prefix = "java:protobuf:";
-            if(seq->findMetaData(prefix, meta))
+            if(seq->findMetadata(prefix, meta))
             {
                 instanceType = formalType = meta.substr(prefix.size());
                 return true;
@@ -2270,7 +2270,7 @@ Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
             string prefix = "java:buffer";
             string meta;
             string ignored;
-            if(seq->findMetaData(prefix, meta) || findMetaData(prefix, metaData, ignored))
+            if(seq->findMetadata(prefix, meta) || findMetadata(prefix, metadata, ignored))
             {
                 instanceType = formalType = typeToBufferString(elementType);
                 return true;
@@ -2281,8 +2281,8 @@ Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
     //
     // Collect metadata for a custom type.
     //
-    if(getTypeMetaData(metaData, instanceType, formalType) ||
-       getTypeMetaData(seq->getMetaData(), instanceType, formalType))
+    if(getTypeMetadata(metadata, instanceType, formalType) ||
+       getTypeMetadata(seq->getMetadata(), instanceType, formalType))
     {
         assert(!instanceType.empty());
         if(formalType.empty())
@@ -2295,7 +2295,7 @@ Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
     //
     // The default mapping is a native array.
     //
-    instanceType = formalType = typeToString(elementType, TypeModeIn, package, metaData) + "[]";
+    instanceType = formalType = typeToString(elementType, TypeModeIn, package, metadata) + "[]";
     return false;
 }
 
@@ -2306,8 +2306,8 @@ Slice::JavaGenerator::createOutput()
 }
 
 void
-Slice::JavaGenerator::validateMetaData(const UnitPtr& u)
+Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
 {
-    MetaDataVisitor visitor;
+    MetadataVisitor visitor;
     u->visit(&visitor, true);
 }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -102,7 +102,7 @@ public:
             string file = *q;
             DefinitionContextPtr dc = p->findDefinitionContext(file);
             assert(dc);
-            StringList globalMetadata = dc->getMetadata();
+            StringList globalMetadata = dc->getAllMetadata();
             for(StringList::const_iterator r = globalMetadata.begin(); r != globalMetadata.end();)
             {
                 string s = *r++;
@@ -320,7 +320,7 @@ private:
     {
         static const string prefix = "java:";
 
-        StringList metadata = cont->getMetadata();
+        StringList metadata = cont->getAllMetadata();
         StringList result;
 
         UnitPtr unt = cont->container()->unit();
@@ -1487,7 +1487,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     return;
                 }
             }
-            else if(findMetadata("java:serializable", seq->getMetadata(), ignored))
+            else if(findMetadata("java:serializable", seq->getAllMetadata(), ignored))
             {
                 if(marshal)
                 {
@@ -1502,7 +1502,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                 }
             }
             else if(!hasTypeMetadata(seq, metadata) ||
-                    findMetadata("java:type", seq->getMetadata(), ignored) ||
+                    findMetadata("java:type", seq->getAllMetadata(), ignored) ||
                     findMetadata("java:type", metadata, ignored))
             {
                 string instanceType, formalType, origInstanceType, origFormalType;
@@ -1547,7 +1547,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
                     {
                         string ignored2;
                         out << nl << "final int taggedSize = " << param << " == null ? 0 : ";
-                        if(findMetadata("java:buffer", seq->getMetadata(), ignored2) ||
+                        if(findMetadata("java:buffer", seq->getAllMetadata(), ignored2) ||
                            findMetadata("java:buffer", metadata, ignored2))
                         {
                             out << param << ".remaining() / " << sz << ";";
@@ -2156,7 +2156,7 @@ Slice::JavaGenerator::hasTypeMetadata(const TypePtr& type, const StringList& loc
             return true;
         }
 
-        StringList metadata = cont->getMetadata();
+        StringList metadata = cont->getAllMetadata();
 
         if(findMetadata(prefix, metadata, directive))
         {
@@ -2215,7 +2215,7 @@ Slice::JavaGenerator::getDictionaryTypes(const DictionaryPtr& dict,
     // Collect metadata for a custom type.
     //
     if(getTypeMetadata(metadata, instanceType, formalType) ||
-       getTypeMetadata(dict->getMetadata(), instanceType, formalType))
+       getTypeMetadata(dict->getAllMetadata(), instanceType, formalType))
     {
         assert(!instanceType.empty());
         if(formalType.empty())
@@ -2282,7 +2282,7 @@ Slice::JavaGenerator::getSequenceTypes(const SequencePtr& seq,
     // Collect metadata for a custom type.
     //
     if(getTypeMetadata(metadata, instanceType, formalType) ||
-       getTypeMetadata(seq->getMetadata(), instanceType, formalType))
+       getTypeMetadata(seq->getAllMetadata(), instanceType, formalType))
     {
         assert(!instanceType.empty());
         if(formalType.empty())

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -63,7 +63,7 @@ public:
     //
     // Validate all metadata in the unit with a "java:" prefix.
     //
-    static void validateMetaData(const UnitPtr&);
+    static void validateMetadata(const UnitPtr&);
 
     void close();
 
@@ -199,21 +199,21 @@ protected:
     //
     // Search metadata for an entry with the given prefix and return the entire string.
     //
-    static bool findMetaData(const std::string&, const StringList&, std::string&);
+    static bool findMetadata(const std::string&, const StringList&, std::string&);
 
     //
     // Get custom type metadata. If metadata is found, the abstract and
     // concrete types are extracted and the function returns true. If an
     // abstract type is not specified, it is set to an empty string.
     //
-    static bool getTypeMetaData(const StringList&, std::string&, std::string&);
+    static bool getTypeMetadata(const StringList&, std::string&, std::string&);
 
     //
     // Determine whether a custom type is defined. The function checks the
     // metadata of the type's original definition, as well as any optional
     // metadata that typically represents a data member or parameter.
     //
-    static bool hasTypeMetaData(const TypePtr&, const StringList& = StringList());
+    static bool hasTypeMetadata(const TypePtr&, const StringList& = StringList());
 
     //
     // Obtain the concrete and abstract types for a dictionary or sequence type.
@@ -226,7 +226,7 @@ protected:
 
     virtual JavaOutput* createOutput();
 
-    static const std::string _getSetMetaData;
+    static const std::string _getSetMetadata;
 
 private:
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -70,8 +70,8 @@ string
 getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
 {
     string deprecateMetadata, deprecateReason;
-    if(p1->findMetaData("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata)))
+    if(p1->findMetadata("deprecate", deprecateMetadata) ||
+       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
     {
         deprecateReason = "This " + type + " has been deprecated.";
         const string prefix = "deprecate:";
@@ -695,7 +695,7 @@ Slice::Gen::generate(const UnitPtr& p)
 
     {
         const string prefix = "js:module:";
-        const string m = dc->findMetaData(prefix);
+        const string m = dc->findMetadata(prefix);
         if(!m.empty())
         {
             module = m.substr(prefix.size());
@@ -719,7 +719,7 @@ Slice::Gen::generate(const UnitPtr& p)
     //
     // Check for global "js:es6-module" metadata. If this is set we are using es6 module mapping
     //
-    bool es6module = dc->findMetaData("js:es6-module") == "js:es6-module";
+    bool es6module = dc->findMetadata("js:es6-module") == "js:es6-module";
 
     _jsout << nl << "/* eslint-disable */";
     _jsout << nl << "/* jshint ignore: start */";
@@ -1016,7 +1016,7 @@ Slice::Gen::RequireVisitor::writeRequires(const UnitPtr& p)
     {
         const string prefix = "js:module:";
         DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
-        string m1 = dc->findMetaData(prefix);
+        string m1 = dc->findMetadata(prefix);
         if(!m1.empty())
         {
             m1 = m1.substr(prefix.size());
@@ -1037,7 +1037,7 @@ Slice::Gen::RequireVisitor::writeRequires(const UnitPtr& p)
 
             dc = p->findDefinitionContext(*i);
 
-            string m2 = dc->findMetaData(prefix);
+            string m2 = dc->findMetadata(prefix);
             if(!m2.empty())
             {
                 m2 = m2.substr(prefix.size());
@@ -1393,7 +1393,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out << sp;
 
-    bool preserved = p->hasMetaData("preserve-slice") && !p->inheritsMetaData("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice") && !p->inheritsMetadata("preserve-slice");
 
     _out << nl << "Slice.defineValue(" << localScope << "." << name << ", "
          << "iceC_" << getLocalScope(scoped, "_") << "_ids[" << scopedPos << "], "
@@ -1845,8 +1845,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     _out << eb << ";";
 
-    bool basePreserved = p->inheritsMetaData("preserve-slice");
-    bool preserved = p->hasMetaData("preserve-slice");
+    bool basePreserved = p->inheritsMetadata("preserve-slice");
+    bool preserved = p->hasMetadata("preserve-slice");
 
     if(preserved && !basePreserved)
     {

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -188,7 +188,7 @@ Slice::JsGenerator::getModuleMetadata(const ContainedPtr& p)
     DefinitionContextPtr dc = p->definitionContext();
     assert(dc);
     const string prefix = "js:module:";
-    const string value = dc->findMetaData(prefix);
+    const string value = dc->findMetadata(prefix);
     return value.empty() ? value : value.substr(prefix.size());
 }
 
@@ -304,9 +304,9 @@ Slice::JsGenerator::importPrefix(const ContainedPtr& contained,
 }
 
 bool
-Slice::JsGenerator::findMetaData(const string& prefix, const StringList& metaData, string& value)
+Slice::JsGenerator::findMetadata(const string& prefix, const StringList& metadata, string& value)
 {
-    for(StringList::const_iterator i = metaData.begin(); i != metaData.end(); i++)
+    for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); i++)
     {
         string s = *i;
         if(s.find(prefix) == 0)

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -23,7 +23,7 @@ public:
     static std::string getModuleMetadata(const ContainedPtr&);
     static std::string fixId(const std::string&);
     static std::string fixId(const ContainedPtr&);
-    static bool findMetaData(const std::string&, const StringList&, std::string&);
+    static bool findMetadata(const std::string&, const StringList&, std::string&);
     static std::string importPrefix(const TypePtr&,
                                     const ContainedPtr&,
                                     const std::vector<std::pair<std::string, std::string> >&);

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -319,7 +319,7 @@ compile(const vector<string>& argv)
                     DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
                     assert(dc);
                     const string prefix = "js:module:";
-                    string m = dc->findMetaData(prefix);
+                    string m = dc->findMetadata(prefix);
                     if(!m.empty())
                     {
                         m = m.substr(prefix.size());

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -869,7 +869,7 @@ parseComment(const ContainedPtr& p)
     // First check metadata for a deprecated tag.
     //
     string deprecateMetadata;
-    if(p->findMetaData("deprecate", deprecateMetadata))
+    if(p->findMetadata("deprecate", deprecateMetadata))
     {
         doc.deprecated = true;
         if(deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
@@ -1656,7 +1656,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     const MemberList members = p->dataMembers();
     if(!members.empty())
     {
-        if(p->hasMetaData("protected"))
+        if(p->hasMetadata("protected"))
         {
             //
             // All members are protected.
@@ -1680,7 +1680,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             MemberList prot, pub;
             for (const auto& member : members)
             {
-                if (member->hasMetaData("protected"))
+                if (member->hasMetadata("protected"))
                 {
                     prot.push_back(member);
                 }
@@ -1724,8 +1724,8 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         }
     }
 
-    const bool basePreserved = p->inheritsMetaData("preserve-slice");
-    const bool preserved = p->hasMetaData("preserve-slice");
+    const bool basePreserved = p->inheritsMetadata("preserve-slice");
+    const bool preserved = p->hasMetadata("preserve-slice");
 
     MemberInfoList allMembers;
     collectClassMembers(p, allMembers, false);
@@ -2534,8 +2534,8 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     const string name = fixIdent(p->name());
     const string scoped = p->scoped();
     const string abs = getAbsolute(p);
-    const bool basePreserved = p->inheritsMetaData("preserve-slice");
-    const bool preserved = p->hasMetaData("preserve-slice");
+    const bool basePreserved = p->inheritsMetadata("preserve-slice");
+    const bool preserved = p->hasMetadata("preserve-slice");
 
     IceUtilInternal::Output out;
     openClass(abs, _dir, out);

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -418,7 +418,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetadata());
+    writeSwiftAttributes(out, p->getAllMetadata());
     out << nl << "open class " << fixIdent(name) << ": ";
     if(base)
     {
@@ -547,7 +547,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     bool isClass = p->usesClasses();
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetadata());
+    writeSwiftAttributes(out, p->getAllMetadata());
     out << nl << "public " << (isClass ? "class " : "struct ") << name;
     if(legalKeyType)
     {
@@ -669,7 +669,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << "[" << typeToString(p->type(), p, p->getMetadata()) << "]";
+        out << "[" << typeToString(p->type(), p, p->getAllMetadata()) << "]";
     }
 
     if(builtin && builtin->kind() <= Builtin::KindString)
@@ -970,7 +970,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetadata());
+    writeSwiftAttributes(out, p->getAllMetadata());
     out << nl << "public enum " << name << ": " << enumType;
     out << sb;
 
@@ -1070,7 +1070,7 @@ Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     writeDocSummary(out, p);
     out << nl << "public let " << name << ": " << typeToString(type, p) << " = ";
-    writeConstantValue(out, type, p->valueType(), p->value(), p->getMetadata(), swiftModule);
+    writeConstantValue(out, type, p->valueType(), p->value(), p->getAllMetadata(), swiftModule);
     out << nl;
 }
 
@@ -1329,7 +1329,7 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetadata());
+    writeSwiftAttributes(out, p->getAllMetadata());
     out << nl << "open class " << fixIdent(name) << ": ";
     if(base)
     {
@@ -1564,7 +1564,7 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Check for swift:inherits metadata.
     //
-    const StringList metadata = p->getMetadata();
+    const StringList metadata = p->getAllMetadata();
     static const string prefix = "swift:inherits:";
     for(StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
     {

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -27,7 +27,7 @@ getClassResolverPrefix(const UnitPtr& p)
     assert(dc);
 
     static const string classResolverPrefix = "swift:class-resolver-prefix:";
-    string result = dc->findMetaData(classResolverPrefix);
+    string result = dc->findMetadata(classResolverPrefix);
     if(!result.empty())
     {
         result = result.substr(classResolverPrefix.size());
@@ -81,7 +81,7 @@ Gen::~Gen()
 void
 Gen::generate(const UnitPtr& p)
 {
-    SwiftGenerator::validateMetaData(p);
+    SwiftGenerator::validateMetadata(p);
 
     ImportVisitor importVisitor(_out);
     p->visit(&importVisitor, false);
@@ -418,7 +418,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetaData());
+    writeSwiftAttributes(out, p->getMetadata());
     out << nl << "open class " << fixIdent(name) << ": ";
     if(base)
     {
@@ -436,8 +436,8 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     writeMembers(out, members, p);
 
-    const bool basePreserved = p->inheritsMetaData("preserve-slice");
-    const bool preserved = p->hasMetaData("preserve-slice");
+    const bool basePreserved = p->inheritsMetadata("preserve-slice");
+    const bool preserved = p->hasMetadata("preserve-slice");
 
     if(preserved && !basePreserved)
     {
@@ -547,7 +547,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     bool isClass = p->usesClasses();
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetaData());
+    writeSwiftAttributes(out, p->getMetadata());
     out << nl << "public " << (isClass ? "class " : "struct ") << name;
     if(legalKeyType)
     {
@@ -669,7 +669,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << "[" << typeToString(p->type(), p, p->getMetaData()) << "]";
+        out << "[" << typeToString(p->type(), p, p->getMetadata()) << "]";
     }
 
     if(builtin && builtin->kind() <= Builtin::KindString)
@@ -814,8 +814,8 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const string swiftModule = getSwiftModule(getTopLevelModule(ContainedPtr::dynamicCast(p)));
     const string name = getUnqualified(getAbsolute(p), swiftModule);
 
-    const string keyType = typeToString(p->keyType(), p, p->keyMetaData());
-    const string valueType = typeToString(p->valueType(), p, p->valueMetaData());
+    const string keyType = typeToString(p->keyType(), p, p->keyMetadata());
+    const string valueType = typeToString(p->valueType(), p, p->valueMetadata());
     out << sp;
     writeDocSummary(out, p);
     out << nl << "public typealias " << fixIdent(name) << " = [" << keyType << ": " << valueType << "]";
@@ -970,7 +970,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetaData());
+    writeSwiftAttributes(out, p->getMetadata());
     out << nl << "public enum " << name << ": " << enumType;
     out << sb;
 
@@ -1070,7 +1070,7 @@ Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     writeDocSummary(out, p);
     out << nl << "public let " << name << ": " << typeToString(type, p) << " = ";
-    writeConstantValue(out, type, p->valueType(), p->value(), p->getMetaData(), swiftModule);
+    writeConstantValue(out, type, p->valueType(), p->value(), p->getMetadata(), swiftModule);
     out << nl;
 }
 
@@ -1329,7 +1329,7 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out << sp;
     writeDocSummary(out, p);
-    writeSwiftAttributes(out, p->getMetaData());
+    writeSwiftAttributes(out, p->getMetadata());
     out << nl << "open class " << fixIdent(name) << ": ";
     if(base)
     {
@@ -1346,8 +1346,8 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
     const MemberList baseMembers = base ? base->allDataMembers() : MemberList();
     const MemberList allMembers = p->allDataMembers();
 
-    const bool basePreserved = p->inheritsMetaData("preserve-slice");
-    const bool preserved = p->hasMetaData("preserve-slice");
+    const bool basePreserved = p->inheritsMetadata("preserve-slice");
+    const bool preserved = p->hasMetadata("preserve-slice");
 
     writeMembers(out, members, p);
     if(preserved && !basePreserved)
@@ -1564,9 +1564,9 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Check for swift:inherits metadata.
     //
-    const StringList metaData = p->getMetaData();
+    const StringList metadata = p->getMetadata();
     static const string prefix = "swift:inherits:";
-    for(StringList::const_iterator q = metaData.begin(); q != metaData.end(); ++q)
+    for(StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
     {
         if(q->find(prefix) == 0)
         {

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1260,7 +1260,7 @@ SwiftGenerator::writeMemberwiseInitializer(IceUtilInternal::Output& out,
         out << "public init" << spar;
         for (const auto& member : allMembers)
         {
-            out << (fixIdent(member->name()) + ": " + typeToString(member->type(), p, member->getMetadata()));
+            out << (fixIdent(member->name()) + ": " + typeToString(member->type(), p, member->getAllMetadata()));
         }
 
         out << epar;
@@ -1297,7 +1297,7 @@ SwiftGenerator::writeMembers(IceUtilInternal::Output& out,
         const string defaultValue = member->defaultValue();
 
         const string memberName = fixIdent(member->name());
-        string memberType = typeToString(type, p, member->getMetadata());
+        string memberType = typeToString(type, p, member->getAllMetadata());
 
         //
         // If the member type is equal to the member name, create a local type alias
@@ -1318,7 +1318,7 @@ SwiftGenerator::writeMembers(IceUtilInternal::Output& out,
         out << " = ";
         if(alias.empty())
         {
-            writeConstantValue(out, type, member->defaultValueType(), defaultValue, p->getMetadata(), swiftModule,
+            writeConstantValue(out, type, member->defaultValueType(), defaultValue, p->getAllMetadata(), swiftModule,
                                member->tagged());
         }
         else
@@ -1643,7 +1643,7 @@ SwiftGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
             }
         }
     }
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
     return true;
 }
 
@@ -1685,7 +1685,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
         {
             os << paramLabel("returnValue", outParams) << ": ";
         }
-        os << typeToString(returnType, op, op->getMetadata());
+        os << typeToString(returnType, op, op->getAllMetadata());
     }
 
     for (auto q = outParams.begin(); q != outParams.end(); ++q)
@@ -1700,7 +1700,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
             os << (*q)->name() << ": ";
         }
 
-        os << typeToString((*q)->type(), *q, (*q)->getMetadata());
+        os << typeToString((*q)->type(), *q, (*q)->getAllMetadata());
     }
 
     if(returnIsTuple)
@@ -1788,7 +1788,7 @@ SwiftGenerator::operationInParamsDeclaration(const OperationPtr& op)
                 os << ", ";
             }
 
-            os << typeToString((*q)->type(), *q, (*q)->getMetadata());
+            os << typeToString((*q)->type(), *q, (*q)->getAllMetadata());
         }
         if(isTuple)
         {
@@ -1815,7 +1815,7 @@ SwiftGenerator::getAllInParams(const OperationPtr& op)
         ParamInfo info;
         info.name = param->name();
         info.type = param->type();
-        info.typeStr = typeToString(info.type, op, param->getMetadata());
+        info.typeStr = typeToString(info.type, op, param->getAllMetadata());
         info.isTagged = param->tagged();
         info.tag = param->tag();
         info.param = param;
@@ -1865,7 +1865,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = param->name();
         info.type = param->type();
-        info.typeStr = typeToString(info.type, op, param->getMetadata());
+        info.typeStr = typeToString(info.type, op, param->getAllMetadata());
         info.isTagged = param->tagged();
         info.tag = param->tag();
         info.param = param;
@@ -1877,7 +1877,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = paramLabel("returnValue", params);
         info.type = op->deprecatedReturnType();
-        info.typeStr = typeToString(info.type, op, op->getMetadata());
+        info.typeStr = typeToString(info.type, op, op->getAllMetadata());
         info.isTagged = op->returnIsTagged();
         info.tag = op->returnTag();
         l.push_back(info);
@@ -2493,10 +2493,10 @@ SwiftGenerator::writeDispatchAsyncOperation(::IceUtilInternal::Output& out, cons
 bool
 SwiftGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getAllMetadata(), p->file(), member->line()));
     }
     return true;
 }
@@ -2504,7 +2504,7 @@ SwiftGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 bool
 SwiftGenerator::MetadataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
     return true;
 }
 
@@ -2512,7 +2512,7 @@ void
 SwiftGenerator::MetadataVisitor::visitOperation(const OperationPtr& p)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(p->container());
-    StringList metadata = p->getMetadata();
+    StringList metadata = p->getAllMetadata();
 
     const UnitPtr ut = p->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(p->file());
@@ -2521,17 +2521,17 @@ SwiftGenerator::MetadataVisitor::visitOperation(const OperationPtr& p)
     p->setMetadata(validate(p, metadata, p->file(), p->line()));
     for (auto& param : p->allMembers())
     {
-        param->setMetadata(validate(param->type(), param->getMetadata(), p->file(), param->line()));
+        param->setMetadata(validate(param->type(), param->getAllMetadata(), p->file(), param->line()));
     }
 }
 
 bool
 SwiftGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getAllMetadata(), p->file(), member->line()));
     }
     return true;
 }
@@ -2539,10 +2539,10 @@ SwiftGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 bool
 SwiftGenerator::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getAllMetadata(), p->file(), member->line()));
     }
     return true;
 }
@@ -2550,7 +2550,7 @@ SwiftGenerator::MetadataVisitor::visitStructStart(const StructPtr& p)
 void
 SwiftGenerator::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
 }
 
 void
@@ -2584,19 +2584,19 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
         dc->error(p->file(), p->line(), "error invalid metadata `" + s + "' for dictionary value type");
     }
 
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
 }
 
 void
 SwiftGenerator::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
 }
 
 void
 SwiftGenerator::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getAllMetadata(), p->file(), p->line()));
 }
 
 StringList

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -139,7 +139,7 @@ Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
 
     string swiftModule;
 
-    if(module->findMetaData(modulePrefix, swiftModule))
+    if(module->findMetadata(modulePrefix, swiftModule))
     {
         swiftModule = swiftModule.substr(modulePrefix.size());
 
@@ -358,7 +358,7 @@ SwiftGenerator::parseComment(const ContainedPtr& p)
     // First check metadata for a deprecated tag.
     //
     string deprecateMetadata;
-    if(p->findMetaData("deprecate", deprecateMetadata))
+    if(p->findMetadata("deprecate", deprecateMetadata))
     {
         doc.deprecated = true;
         if(deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
@@ -894,9 +894,9 @@ SwiftGenerator::writeMemberDoc(IceUtilInternal::Output& out, const MemberPtr& p)
 }
 
 void
-SwiftGenerator::validateMetaData(const UnitPtr& u)
+SwiftGenerator::validateMetadata(const UnitPtr& u)
 {
-    MetaDataVisitor visitor;
+    MetadataVisitor visitor;
     u->visit(&visitor, true);
 }
 
@@ -1260,7 +1260,7 @@ SwiftGenerator::writeMemberwiseInitializer(IceUtilInternal::Output& out,
         out << "public init" << spar;
         for (const auto& member : allMembers)
         {
-            out << (fixIdent(member->name()) + ": " + typeToString(member->type(), p, member->getMetaData()));
+            out << (fixIdent(member->name()) + ": " + typeToString(member->type(), p, member->getMetadata()));
         }
 
         out << epar;
@@ -1297,7 +1297,7 @@ SwiftGenerator::writeMembers(IceUtilInternal::Output& out,
         const string defaultValue = member->defaultValue();
 
         const string memberName = fixIdent(member->name());
-        string memberType = typeToString(type, p, member->getMetaData());
+        string memberType = typeToString(type, p, member->getMetadata());
 
         //
         // If the member type is equal to the member name, create a local type alias
@@ -1318,7 +1318,7 @@ SwiftGenerator::writeMembers(IceUtilInternal::Output& out,
         out << " = ";
         if(alias.empty())
         {
-            writeConstantValue(out, type, member->defaultValueType(), defaultValue, p->getMetaData(), swiftModule,
+            writeConstantValue(out, type, member->defaultValueType(), defaultValue, p->getMetadata(), swiftModule,
                                member->tagged());
         }
         else
@@ -1568,7 +1568,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(Output& out,
 }
 
 bool
-SwiftGenerator::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
+SwiftGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
     if(UnitPtr::dynamicCast(p->container()))
     {
@@ -1582,7 +1582,7 @@ SwiftGenerator::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
         string swiftModule;
         string swiftPrefix;
 
-        if(p->findMetaData(modulePrefix, swiftModule))
+        if(p->findMetadata(modulePrefix, swiftModule))
         {
             swiftModule = swiftModule.substr(modulePrefix.size());
 
@@ -1643,7 +1643,7 @@ SwiftGenerator::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
             }
         }
     }
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
@@ -1685,7 +1685,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
         {
             os << paramLabel("returnValue", outParams) << ": ";
         }
-        os << typeToString(returnType, op, op->getMetaData());
+        os << typeToString(returnType, op, op->getMetadata());
     }
 
     for (auto q = outParams.begin(); q != outParams.end(); ++q)
@@ -1700,7 +1700,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
             os << (*q)->name() << ": ";
         }
 
-        os << typeToString((*q)->type(), *q, (*q)->getMetaData());
+        os << typeToString((*q)->type(), *q, (*q)->getMetadata());
     }
 
     if(returnIsTuple)
@@ -1788,7 +1788,7 @@ SwiftGenerator::operationInParamsDeclaration(const OperationPtr& op)
                 os << ", ";
             }
 
-            os << typeToString((*q)->type(), *q, (*q)->getMetaData());
+            os << typeToString((*q)->type(), *q, (*q)->getMetadata());
         }
         if(isTuple)
         {
@@ -1803,7 +1803,7 @@ bool
 SwiftGenerator::operationIsAmd(const OperationPtr& op)
 {
     const InterfaceDefPtr def = op->interface();
-    return def->hasMetaData("amd") || op->hasMetaData("amd");
+    return def->hasMetadata("amd") || op->hasMetadata("amd");
 }
 
 ParamInfoList
@@ -1815,7 +1815,7 @@ SwiftGenerator::getAllInParams(const OperationPtr& op)
         ParamInfo info;
         info.name = param->name();
         info.type = param->type();
-        info.typeStr = typeToString(info.type, op, param->getMetaData());
+        info.typeStr = typeToString(info.type, op, param->getMetadata());
         info.isTagged = param->tagged();
         info.tag = param->tag();
         info.param = param;
@@ -1865,7 +1865,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = param->name();
         info.type = param->type();
-        info.typeStr = typeToString(info.type, op, param->getMetaData());
+        info.typeStr = typeToString(info.type, op, param->getMetadata());
         info.isTagged = param->tagged();
         info.tag = param->tag();
         info.param = param;
@@ -1877,7 +1877,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = paramLabel("returnValue", params);
         info.type = op->deprecatedReturnType();
-        info.typeStr = typeToString(info.type, op, op->getMetaData());
+        info.typeStr = typeToString(info.type, op, op->getMetadata());
         info.isTagged = op->returnIsTagged();
         info.tag = op->returnTag();
         l.push_back(info);
@@ -2491,77 +2491,77 @@ SwiftGenerator::writeDispatchAsyncOperation(::IceUtilInternal::Output& out, cons
 }
 
 bool
-SwiftGenerator::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
+SwiftGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetaData(validate(member->type(), member->getMetaData(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
     }
     return true;
 }
 
 bool
-SwiftGenerator::MetaDataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+SwiftGenerator::MetadataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
 void
-SwiftGenerator::MetaDataVisitor::visitOperation(const OperationPtr& p)
+SwiftGenerator::MetadataVisitor::visitOperation(const OperationPtr& p)
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(p->container());
-    StringList metaData = p->getMetaData();
+    StringList metadata = p->getMetadata();
 
     const UnitPtr ut = p->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(p->file());
     assert(dc);
 
-    p->setMetaData(validate(p, metaData, p->file(), p->line()));
+    p->setMetadata(validate(p, metadata, p->file(), p->line()));
     for (auto& param : p->allMembers())
     {
-        param->setMetaData(validate(param->type(), param->getMetaData(), p->file(), param->line()));
+        param->setMetadata(validate(param->type(), param->getMetadata(), p->file(), param->line()));
     }
 }
 
 bool
-SwiftGenerator::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
+SwiftGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetaData(validate(member->type(), member->getMetaData(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
     }
     return true;
 }
 
 bool
-SwiftGenerator::MetaDataVisitor::visitStructStart(const StructPtr& p)
+SwiftGenerator::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     for (auto& member : p->dataMembers())
     {
-        member->setMetaData(validate(member->type(), member->getMetaData(), p->file(), member->line()));
+        member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
     }
     return true;
 }
 
 void
-SwiftGenerator::MetaDataVisitor::visitSequence(const SequencePtr& p)
+SwiftGenerator::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
-SwiftGenerator::MetaDataVisitor::visitDictionary(const DictionaryPtr& p)
+SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string prefix = "swift:";
     const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
     assert(dc);
 
-    StringList newMetaData = p->keyMetaData();
-    for(StringList::const_iterator q = newMetaData.begin(); q != newMetaData.end();)
+    StringList newMetadata = p->keyMetadata();
+    for(StringList::const_iterator q = newMetadata.begin(); q != newMetadata.end();)
     {
         string s = *q++;
         if(s.find(prefix) != 0)
@@ -2572,9 +2572,9 @@ SwiftGenerator::MetaDataVisitor::visitDictionary(const DictionaryPtr& p)
         dc->error(p->file(), p->line(), "invalid metadata `" + s + "' for dictionary key type");
     }
 
-    newMetaData = p->valueMetaData();
+    newMetadata = p->valueMetadata();
     TypePtr t = p->valueType();
-    for(StringList::const_iterator q = newMetaData.begin(); q != newMetaData.end();)
+    for(StringList::const_iterator q = newMetadata.begin(); q != newMetadata.end();)
     {
         string s = *q++;
         if(s.find(prefix) != 0)
@@ -2584,31 +2584,31 @@ SwiftGenerator::MetaDataVisitor::visitDictionary(const DictionaryPtr& p)
         dc->error(p->file(), p->line(), "error invalid metadata `" + s + "' for dictionary value type");
     }
 
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
-SwiftGenerator::MetaDataVisitor::visitEnum(const EnumPtr& p)
+SwiftGenerator::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
-SwiftGenerator::MetaDataVisitor::visitConst(const ConstPtr& p)
+SwiftGenerator::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 StringList
-SwiftGenerator::MetaDataVisitor::validate(const SyntaxTreeBasePtr& cont, const StringList& metaData,
+SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& cont, const StringList& metadata,
                                           const string& file, int line)
 {
-    StringList newMetaData = metaData;
+    StringList newMetadata = metadata;
     const string prefix = "swift:";
     const UnitPtr ut = cont->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    for(StringList::const_iterator p = newMetaData.begin(); p != newMetaData.end();)
+    for(StringList::const_iterator p = newMetadata.begin(); p != newMetadata.end();)
     {
         string s = *p++;
         if(s.find(prefix) != 0)
@@ -2640,9 +2640,9 @@ SwiftGenerator::MetaDataVisitor::validate(const SyntaxTreeBasePtr& cont, const S
             continue;
         }
 
-        dc->warning(InvalidMetaData, file, line, "ignoring invalid metadata `" + s + "'");
-        newMetaData.remove(s);
+        dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "'");
+        newMetadata.remove(s);
         continue;
     }
-    return newMetaData;
+    return newMetadata;
 }

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -50,7 +50,7 @@ public:
 
     virtual ~SwiftGenerator() {};
 
-    static void validateMetaData(const UnitPtr&);
+    static void validateMetadata(const UnitPtr&);
 
 protected:
 
@@ -133,7 +133,7 @@ protected:
 
 private:
 
-    class MetaDataVisitor : public ParserVisitor
+    class MetadataVisitor : public ParserVisitor
     {
     public:
 


### PR DESCRIPTION
I'm updating the metadata syntax, and opening this PR separately to make my real PR (when I open it) less cluttered and more easily reviewable.

Some time ago we all agreed that 'Metadata' was a single word and not two words. In the compilers/parser we used a combination of 'Metadata' (1 word) and 'MetaData' (2 words). This PR just replaces all the 2-word versions with the 1-word.

This PR also removes the ICE_FILE_METADATA_IGNORE token from the scanner. But this is an incredibly minor change. It's purpose was to signal we should report an error when file metadata is written after a slice definition, but it's simpler to issue this error directly from the scanner, and not create this extra token for the parser to catch.