### PR TITLE
Update C# mapping for sequence and struct parameters

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -50,6 +50,7 @@ Slice::paramTypeStr(const MemberPtr& param, bool readOnly)
 {
     return CsGenerator::typeToString(param->type(),
                                      getNamespace(InterfaceDefPtr::dynamicCast(param->operation()->container())),
+                                     readOnly,
                                      readOnly);
 }
 
@@ -308,8 +309,13 @@ Slice::fixId(const string& name, unsigned int baseTypes)
 }
 
 string
-Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, bool readOnly)
+Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, bool readOnly, bool readOnlyParam)
 {
+    if (readOnlyParam)
+    {
+        assert(readOnly);
+    }
+
     if(!type)
     {
         return "void";
@@ -377,8 +383,8 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
         if (readOnly)
         {
             auto elementType = seq->type();
-            string elementTypeStr = "<" + typeToString(elementType, package) + ">";
-            if (isMappedToReadOnlyMemory(seq))
+            string elementTypeStr = "<" + typeToString(elementType, package, readOnly) + ">";
+            if (isFixedSizeNumericSequence(seq) && customType.empty() && readOnlyParam)
             {
                 return "global::System.ReadOnlyMemory" + elementTypeStr; // same for optional!
             }
@@ -525,7 +531,7 @@ Slice::isReferenceType(const TypePtr& type)
 }
 
 bool
-Slice::isMappedToReadOnlyMemory(const SequencePtr& seq)
+Slice::isFixedSizeNumericSequence(const SequencePtr& seq)
 {
     TypePtr type = seq->type();
     if (auto en = EnumPtr::dynamicCast(type); en && en->underlying())
@@ -534,8 +540,7 @@ Slice::isMappedToReadOnlyMemory(const SequencePtr& seq)
     }
 
     BuiltinPtr builtin = BuiltinPtr::dynamicCast(type);
-    return builtin && builtin->isNumericTypeOrBool() && !builtin->isVariableLength() &&
-        !seq->hasMetadataWithPrefix("cs:generic");
+    return builtin && builtin->isNumericTypeOrBool() && !builtin->isVariableLength();
 }
 
 vector<string>
@@ -610,7 +615,7 @@ Slice::toTupleType(const MemberList& params, bool readOnly)
 }
 
 string
-Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope, bool forNestedType)
+Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope, bool readOnly, bool readOnlyParam)
 {
     ostringstream out;
     if (auto optional = OptionalPtr::dynamicCast(type))
@@ -651,7 +656,7 @@ Slice::CsGenerator::outputStreamWriter(const TypePtr& type, const string& scope,
     {
         // We generate the sequence writer inline, so this function must not be called when the top-level object is
         // not cached.
-        out << "(ostr, sequence) => " << sequenceMarshalCode(seq, scope, "sequence", forNestedType);
+        out << "(ostr, sequence) => " << sequenceMarshalCode(seq, scope, "sequence", readOnly, readOnlyParam);
     }
     else
     {
@@ -727,13 +732,13 @@ Slice::CsGenerator::writeMarshalCode(
         {
             out << nl << "ostr.Write" << builtinSuffixTable[builtin->kind()] << "(" << param << ");";
         }
-        else if (auto st = StructPtr::dynamicCast(type))
+        else if (StructPtr::dynamicCast(type))
         {
             out << nl << param << ".IceWrite(ostr);";
         }
         else if (auto seq = SequencePtr::dynamicCast(type))
         {
-            out << nl << sequenceMarshalCode(seq, scope, param, forNestedType) << ";";
+            out << nl << sequenceMarshalCode(seq, scope, param, !forNestedType, !forNestedType) << ";";
         }
         else if (auto dict = DictionaryPtr::dynamicCast(type))
         {
@@ -921,18 +926,26 @@ Slice::CsGenerator::writeTaggedMarshalCode(
     {
         const TypePtr elementType = seq->type();
         builtin = BuiltinPtr::dynamicCast(elementType);
-        if (isMappedToReadOnlyMemory(seq))
+
+        bool hasCustomType = seq->hasMetadataWithPrefix("cs:generic");
+        bool readOnly = !isDataMember;
+
+        if (isFixedSizeNumericSequence(seq) && (readOnly || !hasCustomType))
         {
-            out << nl << "ostr";
-            if (isDataMember)
+            if (readOnly && !hasCustomType)
             {
-                out << ".WriteTaggedArray(" << tag << ", " << param;
+                out << nl << "ostr.WriteTaggedSequence(" << tag << ", " << param << ".Span" << ");";
+            }
+            else if (readOnly)
+            {
+                // param is an IEnumerable<T>
+                out << nl << "ostr.WriteTaggedSequence(" << tag << ", " << param << ");";
             }
             else
             {
-                out << ".WriteTaggedSequence(" << tag << ", " << param << ".Span";
+                assert(!hasCustomType);
+                out << nl << "ostr.WriteTaggedArray(" << tag << ", " << param << ");";
             }
-            out << ");";
         }
         else if (auto optional = OptionalPtr::dynamicCast(elementType); optional && optional->encodedUsingBitSequence())
         {
@@ -942,32 +955,19 @@ Slice::CsGenerator::writeTaggedMarshalCode(
             {
                 out << ", withBitSequence: true";
             }
-            if (!StructPtr::dynamicCast(underlying))
-            {
-                out << ", " << outputStreamWriter(underlying, scope, true);
-            }
-            out << ");";
+            out << ", " << outputStreamWriter(underlying, scope, !isDataMember) << ");";
         }
         else if (elementType->isVariableLength())
         {
-            out << nl << "ostr.WriteTaggedSequence(" << tag << ", " << param;
-            if (!StructPtr::dynamicCast(elementType))
-            {
-                out << ", " << outputStreamWriter(elementType, scope, true);
-            }
-            out << ");";
+            out << nl << "ostr.WriteTaggedSequence(" << tag << ", " << param
+                << ", " << outputStreamWriter(elementType, scope, !isDataMember) << ");";
         }
         else
         {
             // Fixed size = min-size
             out << nl << "ostr.WriteTaggedSequence(" << tag << ", " << param << ", "
-                << "elementSize: " << elementType->minWireSize();
-
-            if (!StructPtr::dynamicCast(elementType))
-            {
-                out << ", " << outputStreamWriter(elementType, scope, true);
-            }
-            out << ");";
+                << "elementSize: " << elementType->minWireSize()
+                << ", " << outputStreamWriter(elementType, scope, !isDataMember) << ");";
         }
     }
     else
@@ -996,15 +996,8 @@ Slice::CsGenerator::writeTaggedMarshalCode(
         {
             out << ", withBitSequence: true";
         }
-        if (!StructPtr::dynamicCast(keyType))
-        {
-            out << ", " << outputStreamWriter(keyType, scope, true);
-        }
-        if (!StructPtr::dynamicCast(valueType))
-        {
-            out << ", " << outputStreamWriter(valueType, scope, true);
-        }
-        out << ");";
+        out << ", " << outputStreamWriter(keyType, scope)
+            << ", " << outputStreamWriter(valueType, scope) << ");";
     }
 }
 
@@ -1056,7 +1049,7 @@ Slice::CsGenerator::writeTaggedUnmarshalCode(
     else if (seq)
     {
         const TypePtr elementType = seq->type();
-        if (isMappedToReadOnlyMemory(seq))
+        if (isFixedSizeNumericSequence(seq) && !seq->hasMetadataWithPrefix("cs:generic"))
         {
             out << "istr.ReadTaggedArray";
             if (auto enElement = EnumPtr::dynamicCast(elementType); enElement && !enElement->isUnchecked())
@@ -1151,45 +1144,51 @@ string
 Slice::CsGenerator::sequenceMarshalCode(
     const SequencePtr& seq,
     const string& scope,
-    const string& param,
-    bool forNestedType)
+    const string& v,
+    bool readOnly,
+    bool readOnlyParam)
 {
     TypePtr type = seq->type();
     ostringstream out;
 
-    if (isMappedToReadOnlyMemory(seq))
+    if (readOnlyParam)
     {
-        if (forNestedType)
+        assert(readOnly);
+    }
+
+    bool hasCustomType = seq->hasMetadataWithPrefix("cs:generic");
+
+    if (isFixedSizeNumericSequence(seq) && (readOnly || !hasCustomType))
+    {
+        if (readOnlyParam && !hasCustomType)
         {
-            out << "ostr.WriteArray(" << param << ")";
+            out << "ostr.WriteSequence(" << v << ".Span)";
+        }
+        else if (readOnly)
+        {
+            // v is an IEnumerable<T>
+            out << "ostr.WriteSequence(" << v << ")";
         }
         else
         {
-            out << "ostr.WriteSequence(" << param << ".Span)";
+            assert(!hasCustomType);
+            out << "ostr.WriteArray(" << v << ")";
         }
     }
     else if (auto optional = OptionalPtr::dynamicCast(type); optional && optional->encodedUsingBitSequence())
     {
         TypePtr underlying = optional->underlying();
-        out << "ostr.WriteSequence(" << param;
+        out << "ostr.WriteSequence(" << v;
         if (isReferenceType(underlying))
         {
             out << ", withBitSequence: true";
         }
-        if (!StructPtr::dynamicCast(underlying))
-        {
-            out << ", " << outputStreamWriter(underlying, scope, true);
-        }
+        out << ", " << outputStreamWriter(underlying, scope, readOnly);
         out << ")";
     }
     else
     {
-        out << "ostr.WriteSequence(" << param;
-        if (!StructPtr::dynamicCast(type))
-        {
-            out << ", " << outputStreamWriter(type, scope, true);
-        }
-        out << ")";
+        out << "ostr.WriteSequence(" << v << ", " << outputStreamWriter(type, scope, readOnly) << ")";
     }
     return out.str();
 }
@@ -1290,16 +1289,8 @@ Slice::CsGenerator::dictionaryMarshalCode(const DictionaryPtr& dict, const strin
     {
         out << ", withBitSequence: true";
     }
-    if (!StructPtr::dynamicCast(key))
-    {
-        out << ", " << outputStreamWriter(key, scope, true);
-    }
-    if (!StructPtr::dynamicCast(value))
-    {
-        out << ", " << outputStreamWriter(value, scope, true);
-    }
-    out << ")";
-
+    out << ", " << outputStreamWriter(key, scope)
+        << ", " << outputStreamWriter(value, scope) << ")";
     return out.str();
 }
 

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -48,7 +48,7 @@ std::string returnTaskStr(const OperationPtr& operation, const std::string& ns, 
 bool isCollectionType(const TypePtr&);
 bool isValueType(const TypePtr&); // value with C# "struct" meaning
 bool isReferenceType(const TypePtr&); // opposite of value
-bool isMappedToReadOnlyMemory(const SequencePtr& seq);
+bool isFixedSizeNumericSequence(const SequencePtr& seq);
 
 std::vector<std::string> getNames(const MemberList& params, const std::string& prefix = "");
 std::vector<std::string> getNames(const MemberList& params, std::function<std::string (const MemberPtr&)> fn);
@@ -76,11 +76,19 @@ public:
     // Validate all metadata in the unit with a "cs:" prefix.
     static void validateMetadata(const UnitPtr&);
 
-    static std::string typeToString(const TypePtr& type, const std::string& package, bool readOnly = false);
+    static std::string typeToString(
+        const TypePtr& type,
+        const std::string& package,
+        bool readOnly = false,
+        bool readOnlyParam = false);
 
 protected:
 
-    std::string outputStreamWriter(const TypePtr& type, const std::string& scope, bool forNestedType);
+    std::string outputStreamWriter(
+        const TypePtr& type,
+        const std::string& scope,
+        bool readOnly = false,
+        bool readOnlyParam = false);
 
     void writeMarshalCode(
         ::IceUtilInternal::Output& out,
@@ -127,8 +135,9 @@ private:
     std::string sequenceMarshalCode(
         const SequencePtr& seq,
         const std::string& scope,
-        const std::string& param,
-        bool forNestedType = false);
+        const std::string& v,
+        bool readOnly = false,
+        bool readOnlyParam = false);
 
     std::string sequenceUnmarshalCode(const SequencePtr& seq, const std::string& scope);
 

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -135,7 +135,7 @@ private:
     std::string sequenceMarshalCode(
         const SequencePtr& seq,
         const std::string& scope,
-        const std::string& v,
+        const std::string& value,
         bool readOnly = false,
         bool readOnlyParam = false);
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -409,11 +409,7 @@ getInvocationParams(const OperationPtr& op, const string& ns)
     {
         ostringstream param;
         param << getParamAttributes(p);
-        if(StructPtr::dynamicCast(p->type()))
-        {
-            param << "in ";
-        }
-        param << CsGenerator::typeToString(p->type(), ns, true) << " " << paramName(p);
+        param << CsGenerator::typeToString(p->type(), ns, true, true) << " " << paramName(p);
         params.push_back(param.str());
     }
     params.push_back("global::System.Collections.Generic.IReadOnlyDictionary<string, string>? " +
@@ -430,11 +426,7 @@ getInvocationParamsAMI(const OperationPtr& op, const string& ns, bool defaultVal
     {
         ostringstream param;
         param << getParamAttributes(p);
-        if(StructPtr::dynamicCast(p->type()))
-        {
-            param << "in ";
-        }
-        param << CsGenerator::typeToString(p->type(), ns, true) << " " << paramName(p, prefix);
+        param << CsGenerator::typeToString(p->type(), ns, true, true) << " " << paramName(p, prefix);
         params.push_back(param.str());
     }
 
@@ -1805,7 +1797,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << sp;
     _out << nl << "/// <summary>A <see cref=\"ZeroC.Ice.InputStreamReader{T}\"/> used to read <see cref=\""
          << name << "\"/> instances.</summary>";
-    _out << nl << "public static ZeroC.Ice.InputStreamReader<" << name << "> IceReader =";
+    _out << nl << "public static readonly ZeroC.Ice.InputStreamReader<" << name << "> IceReader =";
     _out.inc();
     _out << nl << "istr => new " << name << "(istr);";
     _out.dec();
@@ -1813,9 +1805,9 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << sp;
     _out << nl << "/// <summary>A <see cref=\"ZeroC.Ice.OutputStreamWriter{T}\"/> used to write <see cref=\""
          << name << "\"/> instances.</summary>";
-    _out << nl << "public static ZeroC.Ice.OutputStreamValueWriter<" << name << "> IceWriter =";
+    _out << nl << "public static readonly ZeroC.Ice.OutputStreamWriter<" << name << "> IceWriter =";
     _out.inc();
-    _out << nl << "(ZeroC.Ice.OutputStream ostr, in " << name << " value) => value.IceWrite(ostr);";
+    _out << nl << "(ostr, value) => value.IceWrite(ostr);";
     _out.dec();
     return true;
 }
@@ -1883,24 +1875,10 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << eb;
 
-    _out << sp;
-    _out << nl << "/// <inheritdoc/>";
-    _out << nl << "public override int GetHashCode()";
-    _out << sb;
-    _out << nl << "var hash = new global::System.HashCode();";
-    for(const auto& i : dataMembers)
-    {
-        _out << nl << "hash.Add(this." << fixId(fieldName(i), Slice::ObjectType) << ");";
-    }
-    _out << nl << "return hash.ToHashCode();";
-    _out << eb;
-
-    //
     // Equals implementation
-    //
     _out << sp;
     _out << nl << "/// <inheritdoc/>";
-    _out << nl << "public bool Equals(" << fixId(p->name()) << " other)";
+    _out << nl << "public readonly bool Equals(" << fixId(p->name()) << " other)";
 
     _out << " =>";
     _out.inc();
@@ -1932,19 +1910,30 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     _out << nl << "/// <inheritdoc/>";
-    _out << nl << "public override bool Equals(object? other) => other is " << name << " value && this.Equals(value);";
+    _out << nl << "public readonly override bool Equals(object? other) => other is " << name
+        << " value && this.Equals(value);";
 
     emitEqualityOperators(name);
 
     _out << sp;
-    _out << nl << "/// <summary>Marshals the struct by writing its data to the <see cref=\"ZeroC.Ice.OutputStream\"/>."
-         << "</summary>";
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public readonly override int GetHashCode()";
+    _out << sb;
+    _out << nl << "var hash = new global::System.HashCode();";
+    for(const auto& i : dataMembers)
+    {
+        _out << nl << "hash.Add(this." << fixId(fieldName(i), Slice::ObjectType) << ");";
+    }
+    _out << nl << "return hash.ToHashCode();";
+    _out << eb;
+
+    _out << sp;
+    _out << nl << "/// <summary>Marshals the struct by writing its fields to the "
+        << "<see cref=\"ZeroC.Ice.OutputStream\"/>.</summary>";
     _out << nl << "/// <param name=\"ostr\">The stream to write to.</param>";
     _out << nl << "public readonly void IceWrite(ZeroC.Ice.OutputStream ostr)";
     _out << sb;
-
     writeMarshalDataMembers(dataMembers, ns, 0);
-
     _out << eb;
     _out << eb;
 }
@@ -2198,7 +2187,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             if (paramCount > 0)
             {
-                inValue = paramCount > 1 || StructPtr::dynamicCast(params.front()->type());
+                inValue = paramCount > 1;
                 _out << (inValue ? "in " : "") << toTupleType(params, true) << " args" << ", ";
             }
             _out << "global::System.Collections.Generic.IReadOnlyDictionary<string, string>? context) =>";
@@ -2465,7 +2454,7 @@ Slice::Gen::ProxyVisitor::writeOutgoingRequestWriter(const OperationPtr& operati
     if (defaultWriter)
     {
         // This includes operations with a single struct parameter.
-        _out << outputStreamWriter(params.front()->type(), ns, false);
+        _out << outputStreamWriter(params.front()->type(), ns, true, true);
     }
     else
     {
@@ -2612,7 +2601,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             if (returnCount > 0)
             {
                 _out << sp;
-                bool inValue = returnCount > 1 || StructPtr::dynamicCast(returns.front()->type());
+                bool inValue = returnCount > 1;
                 _out << nl << "/// <summary>Creates an <see cref=\"ZeroC.Ice.OutgoingResponseFrame\"/> for operation "
                      << fixId(operationName(operation)) << ".</summary>";
                 _out << nl << "/// <param name=\"current\">Holds decoded header data and other information about the "
@@ -2982,7 +2971,7 @@ Slice::Gen::DispatcherVisitor::writeOutgoingResponseWriter(const OperationPtr& o
     if (defaultWriter)
     {
         // This includes operations with a single struct return type.
-        _out << outputStreamWriter(returns.front()->type(), ns, false);
+        _out << outputStreamWriter(returns.front()->type(), ns, true, true);
     }
     else
     {

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -147,8 +147,7 @@ namespace ZeroC.Ice
             return data;
         }
 
-        /// <summary>Helper method to write the request header body without constructing an Ice1RequestHeaderBody
-        /// struct.</summary>
+        /// <summary>Writes a request header body without constructing an Ice1RequestHeaderBody instance.</summary>
         internal static void WriteIce1RequestHeaderBody(
             this OutputStream ostr,
             Identity identity,

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -214,7 +214,10 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a request header body without constructing an Ice1RequestHeaderBody instance.</summary>
+        /// <summary>Writes a request header body without constructing an Ice1RequestHeaderBody instance. This
+        /// implementation is slightly more efficient than the generated code because it avoids the allocation of a
+        /// string[] to write the facet and the allocation of a Dictionary{string, string} to write the context.
+        /// </summary>
         internal static void WriteIce1RequestHeaderBody(
             this OutputStream ostr,
             Identity identity,

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -18,7 +18,9 @@ namespace ZeroC.Ice
             Response = 2,
         }
 
-        /// <summary>Writes a request header body without constructing an Ice2RequestHeaderBody instance.</summary>
+        /// <summary>Writes a request header body without constructing an Ice2RequestHeaderBody instance. This
+        /// implementation is slightly more efficient than the generated code because it avoids the allocation of a
+        /// string[] to write the location.</summary>
         internal static void WriteIce2RequestHeaderBody(
             this OutputStream ostr,
             Identity identity,
@@ -28,7 +30,7 @@ namespace ZeroC.Ice
             bool idempotent)
         {
             Debug.Assert(ostr.Encoding == Encoding);
-            BitSequence bitSequence = ostr.WriteBitSequence(3); // bit set to true (set) by default
+            BitSequence bitSequence = ostr.WriteBitSequence(4); // bit set to true (set) by default
 
             identity.IceWrite(ostr);
             if (facet.Length > 0)
@@ -50,8 +52,17 @@ namespace ZeroC.Ice
             }
 
             ostr.WriteString(operation);
-            ostr.WriteBool(idempotent);
-            bitSequence[2] = false; // TODO: source for priority.
+
+            if (idempotent)
+            {
+                ostr.WriteBool(true);
+            }
+            else
+            {
+                bitSequence[2] = false;
+            }
+
+            bitSequence[3] = false; // TODO: source for priority.
         }
     }
 }

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -1,5 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Collections.Generic;
+using System.Diagnostics;
+
 namespace ZeroC.Ice
 {
     // Definitions for the ice2 protocol.
@@ -13,6 +16,43 @@ namespace ZeroC.Ice
         {
             Request = 0,
             Response = 2,
+        }
+
+        /// <summary>Helper method to write the request header body without constructing an Ice2RequestHeaderBody
+        /// struct.</summary>
+        internal static void WriteIce2RequestHeaderBody(
+            this OutputStream ostr,
+            Identity identity,
+            string facet,
+            IReadOnlyList<string> location,
+            string operation,
+            bool idempotent)
+        {
+            Debug.Assert(ostr.Encoding == Encoding);
+            BitSequence bitSequence = ostr.WriteBitSequence(3); // bit set to true (set) by default
+
+            identity.IceWrite(ostr);
+            if (facet.Length > 0)
+            {
+                ostr.WriteString(facet);
+            }
+            else
+            {
+                bitSequence[0] = false;
+            }
+
+            if (location.Count > 0)
+            {
+                ostr.WriteSequence(location, OutputStream.IceWriterFromString);
+            }
+            else
+            {
+                bitSequence[1] = false;
+            }
+
+            ostr.WriteString(operation);
+            ostr.WriteBool(idempotent);
+            bitSequence[2] = false; // TODO: source for priority.
         }
     }
 }

--- a/csharp/src/Ice/Ice2Definitions.cs
+++ b/csharp/src/Ice/Ice2Definitions.cs
@@ -18,8 +18,7 @@ namespace ZeroC.Ice
             Response = 2,
         }
 
-        /// <summary>Helper method to write the request header body without constructing an Ice2RequestHeaderBody
-        /// struct.</summary>
+        /// <summary>Writes a request header body without constructing an Ice2RequestHeaderBody instance.</summary>
         internal static void WriteIce2RequestHeaderBody(
             this OutputStream ostr,
             Identity identity,

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -60,7 +60,7 @@ namespace ZeroC.Ice
                 Facet = requestHeaderBody.Facet ?? "";
                 Location = requestHeaderBody.Location ?? Array.Empty<string>();
                 Operation = requestHeaderBody.Operation;
-                IsIdempotent = requestHeaderBody.Idempotent;
+                IsIdempotent = requestHeaderBody.Idempotent ?? false;
                 Priority = requestHeaderBody.Priority ?? default;
                 Context = null!; // initialized below
 

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -44,27 +44,25 @@ namespace ZeroC.Ice
 
             if (Protocol == Protocol.Ice1)
             {
-                Identity = new Identity(istr);
-                Facet = istr.ReadFacet11();
+                var requestHeaderBody = new Ice1RequestHeaderBody(istr);
+                Identity = requestHeaderBody.Identity;
+                Facet = Ice1Definitions.GetFacet(requestHeaderBody.FacetPath);
                 Location = Array.Empty<string>();
-                Operation = istr.ReadString();
-                IsIdempotent = istr.ReadOperationMode() != OperationMode.Normal;
-                Context = istr.ReadDictionary(minKeySize: 1,
-                                              minValueSize: 1,
-                                              InputStream.IceReaderIntoString,
-                                              InputStream.IceReaderIntoString);
+                Operation = requestHeaderBody.Operation;
+                IsIdempotent = requestHeaderBody.OperationMode != OperationMode.Normal;
+                Context = requestHeaderBody.Context;
                 Priority = default;
             }
             else
             {
-                var requestHeader = new Ice2RequestHeader(istr);
-                Identity = requestHeader.Identity;
-                Facet = requestHeader.Facet ?? "";
-                Location = requestHeader.Location ?? Array.Empty<string>();
-                Operation = requestHeader.Operation;
-                IsIdempotent = requestHeader.Idempotent;
-                Priority = requestHeader.Priority ?? default;
-                Context = new Dictionary<string, string>();
+                var requestHeaderBody = new Ice2RequestHeaderBody(istr);
+                Identity = requestHeaderBody.Identity;
+                Facet = requestHeaderBody.Facet ?? "";
+                Location = requestHeaderBody.Location ?? Array.Empty<string>();
+                Operation = requestHeaderBody.Operation;
+                IsIdempotent = requestHeaderBody.Idempotent;
+                Priority = requestHeaderBody.Priority ?? default;
+                Context = null!; // initialized below
 
                 if (Location.Any(segment => segment.Length == 0))
                 {
@@ -87,12 +85,20 @@ namespace ZeroC.Ice
 
             Payload = Data.Slice(istr.Pos, size + sizeLength); // the payload is the encapsulation
 
-            if (Protocol == Protocol.Ice2 && BinaryContext.TryGetValue(0, out ReadOnlyMemory<byte> value))
+            if (Protocol == Protocol.Ice2)
             {
-                Context = value.Read(istr => istr.ReadDictionary(minKeySize: 1,
-                                                                 minValueSize: 1,
-                                                                 InputStream.IceReaderIntoString,
-                                                                 InputStream.IceReaderIntoString));
+                // BinaryContext is a computed property that depends on Payload.
+                if (BinaryContext.TryGetValue(0, out ReadOnlyMemory<byte> value))
+                {
+                    Context = value.Read(istr => istr.ReadDictionary(minKeySize: 1,
+                                                                     minValueSize: 1,
+                                                                     InputStream.IceReaderIntoString,
+                                                                     InputStream.IceReaderIntoString));
+                }
+                else
+                {
+                    Context = new Dictionary<string, string>();
+                }
             }
 
             if (protocol == Protocol.Ice1 && size + 4 + istr.Pos != data.Count)

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -164,7 +164,7 @@ namespace ZeroC.Ice
 
                 if (istr != null)
                 {
-                    throw istr.ReadSystemException11(replyStatus);
+                    throw istr.ReadIce1SystemException(replyStatus);
                 }
             }
         }
@@ -207,7 +207,7 @@ namespace ZeroC.Ice
             Exception exception;
             if (Encoding == Encoding.V11 && replyStatus != ReplyStatus.UserException)
             {
-                exception = istr.ReadSystemException11(replyStatus);
+                exception = istr.ReadIce1SystemException(replyStatus);
                 istr.CheckEndOfBuffer(skipTaggedParams: false);
             }
             else

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1128,58 +1128,6 @@ namespace ZeroC.Ice
             return endpoint;
         }
 
-        /// <summary>Reads a facet in the old ice1 format from the stream.</summary>
-        /// <returns>The facet read from the stream.</returns>
-        internal string ReadFacet11()
-        {
-            Debug.Assert(OldEncoding);
-            string[] facets = ReadArray(1, IceReaderIntoString);
-            if (facets.Length > 1)
-            {
-                throw new InvalidDataException($"read ice1 facet path with {facets.Length} elements");
-            }
-            return facets.Length == 1 ? facets[0] : "";
-        }
-
-        /// <summary>Reads a system exception encoded using the 1.1 encoding, based on the provided reply status.
-        /// </summary>
-        /// <param name="replyStatus">The reply status.</param>
-        /// <returns>The exception read from the stream.</returns>
-        internal DispatchException ReadSystemException11(ReplyStatus replyStatus)
-        {
-            Debug.Assert(OldEncoding);
-            Debug.Assert((byte)replyStatus > (byte)ReplyStatus.UserException);
-
-            DispatchException systemException;
-
-            switch (replyStatus)
-            {
-                case ReplyStatus.FacetNotExistException:
-                case ReplyStatus.ObjectNotExistException:
-                case ReplyStatus.OperationNotExistException:
-                    var identity = new Identity(this);
-                    string facet = ReadFacet11();
-                    string operation = ReadString();
-
-                    if (replyStatus == ReplyStatus.OperationNotExistException)
-                    {
-                        systemException = new OperationNotExistException(identity, facet, operation);
-                    }
-                    else
-                    {
-                        systemException = new ObjectNotExistException(identity, facet, operation);
-                    }
-                    break;
-
-                default:
-                    systemException = new UnhandledException(ReadString(), Identity.Empty, "", "");
-                    break;
-            }
-
-            systemException.ConvertToUnhandled = true;
-            return systemException;
-        }
-
         internal void Skip(int size)
         {
             if (size < 0 || size > _buffer.Length - Pos)

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -105,25 +105,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a binary context entry to the frame with the given key and value.</summary>
-        /// <param name="key">The binary context entry key.</param>
-        /// <param name="value">The value to marshal as the binary context entry value.</param>
-        /// <param name="writer">The writer used to marshal the value.</param>
-        /// <exception cref="NotSupportedException">If the frame protocol doesn't support binary context.</exception>
-        /// <exception cref="ArgumentException">If the key is already in use.</exception>
-        public void AddBinaryContextEntry<T>(int key, in T value, OutputStreamValueWriter<T> writer) where T : struct
-        {
-            OutputStream ostr = StartBinaryContext();
-            if (AddKey(key))
-            {
-                ostr.WriteBinaryContextEntry(key, value, writer);
-            }
-            else
-            {
-                throw new ArgumentException($"key `{key}' is already in use", nameof(key));
-            }
-        }
-
         /// <summary>Compresses the encapsulation payload using GZip compression. Compressed encapsulation payload is
         /// only supported with the 2.0 encoding.</summary>
         /// <returns>A <see cref="CompressionResult"/> value indicating the result of the compression operation.

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -309,42 +309,12 @@ namespace ZeroC.Ice
 
             if (Protocol == Protocol.Ice1)
             {
-                // Marshaled "by hand" to avoid allocating a string[] for the facet and a new dictionary for the
-                // context.
-                Identity.IceWrite(ostr);
-                ostr.WriteFacet11(Facet);
-                ostr.WriteString(Operation);
-                ostr.Write(IsIdempotent ? OperationMode.Idempotent : OperationMode.Normal);
-                ostr.WriteDictionary(_initialContext,
-                                     OutputStream.IceWriterFromString,
-                                     OutputStream.IceWriterFromString);
+                ostr.WriteIce1RequestHeaderBody(Identity, Facet, Operation, IsIdempotent, _initialContext);
             }
             else
             {
                 Debug.Assert(Protocol == Protocol.Ice2);
-
-                // Marshaled "by hand" to avoid allocating a string[] for the location.
-                BitSequence bitSequence = ostr.WriteBitSequence(3); // bit set to true (set) by default
-                Identity.IceWrite(ostr);
-                if (Facet.Length > 0)
-                {
-                    ostr.WriteString(Facet);
-                }
-                else
-                {
-                    bitSequence[0] = false;
-                }
-                if (Location.Count > 0)
-                {
-                    ostr.WriteSequence(Location, OutputStream.IceWriterFromString);
-                }
-                else
-                {
-                    bitSequence[1] = false;
-                }
-                ostr.WriteString(operation);
-                ostr.WriteBool(IsIdempotent);
-                bitSequence[2] = false; // TODO: source for priority.
+                ostr.WriteIce2RequestHeaderBody(Identity, Facet, Location, Operation, IsIdempotent);
             }
             PayloadStart = ostr.Tail;
 

--- a/csharp/src/Ice/OutgoingRequestFrame.cs
+++ b/csharp/src/Ice/OutgoingRequestFrame.cs
@@ -133,7 +133,7 @@ namespace ZeroC.Ice
                                         request.PayloadStart,
                                         request.Encoding,
                                         format);
-            writer(ostr, args);
+            writer(ostr, in args);
             request.PayloadEnd = ostr.Finish();
             if (compress && proxy.Encoding == Encoding.V20)
             {

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -81,7 +81,7 @@ namespace ZeroC.Ice
             where T : struct
         {
             (OutgoingResponseFrame response, OutputStream ostr) = PrepareReturnValue(current, compress, format);
-            writer(ostr, returnValue);
+            writer(ostr, in returnValue);
             response.PayloadEnd = ostr.Finish();
             if (compress && current.Encoding == Encoding.V20)
             {
@@ -287,7 +287,7 @@ namespace ZeroC.Ice
                     case ReplyStatus.OperationNotExistException:
                         var dispatchException = (DispatchException)exception;
                         dispatchException.Identity.IceWrite(ostr);
-                        ostr.WriteFacet11(dispatchException.Facet);
+                        ostr.WriteIce1Facet(dispatchException.Facet);
                         ostr.WriteString(dispatchException.Operation);
                         break;
 

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -24,8 +25,8 @@ namespace ZeroC.Ice
     /// <param name="value">The value to write to the stream.</param>
     public delegate void OutputStreamWriter<in T>(OutputStream ostr, T value);
 
-    /// <summary>A delegate that writes a value passed as in-reference to an output stream. This value is typically an
-    /// instance of a mapped Slice struct, or the parameters or return value of an operation.</summary>
+    /// <summary>A delegate that writes a value passed as in-reference to an output stream. This value typically
+    /// corresponds to the argument tuple or return value tuple of an operation.</summary>
     /// <typeparam name="T">The type of the value to write (a struct).</typeparam>
     /// <param name="ostr">The output stream to write to.</param>
     /// <param name="value">The value to write to the stream.</param>
@@ -342,54 +343,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct.</summary>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue> v,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-        {
-            WriteSize(v.Count);
-            foreach ((TKey key, TValue value) in v)
-            {
-                key.IceWrite(this);
-                valueWriter(this, value);
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. The dictionary's value is a mapped Slice struct.</summary>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue> v,
-            OutputStreamWriter<TKey> keyWriter)
-            where TKey : notnull
-            where TValue : struct, IStreamableStruct
-        {
-            WriteSize(v.Count);
-            foreach ((TKey key, TValue value) in v)
-            {
-                keyWriter(this, key);
-                value.IceWrite(this);
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. Both the dictionary's key and value are mapped Slice structs.
-        /// </summary>
-        /// <param name="v">The dictionary to write.</param>
-        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> v)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct, IStreamableStruct
-        {
-            WriteSize(v.Count);
-            foreach ((TKey key, TValue value) in v)
-            {
-                key.IceWrite(this);
-                value.IceWrite(this);
-            }
-        }
-
         /// <summary>Writes a dictionary to the stream. The dictionary's value type is reference type.</summary>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
@@ -430,7 +383,7 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a dictionary to the stream. The dictionary's value type is nullable value type.
+        /// <summary>Writes a dictionary to the stream. The dictionary's value type is a nullable value type.
         /// </summary>
         /// <param name="v">The dictionary to write.</param>
         /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
@@ -452,129 +405,6 @@ namespace ZeroC.Ice
                 if (value is TValue actualValue)
                 {
                     valueWriter(this, actualValue);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct and the
-        /// dictionary's value type is a reference type.</summary>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
-        /// false.</param>
-        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue?> v,
-            bool withBitSequence,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-            where TValue : class
-        {
-            if (withBitSequence)
-            {
-                int count = v.Count;
-                WriteSize(count);
-                BitSequence bitSequence = WriteBitSequence(count);
-                int index = 0;
-                foreach ((TKey key, TValue? value) in v)
-                {
-                    key.IceWrite(this);
-                    if (value != null)
-                    {
-                        valueWriter(this, value);
-                    }
-                    else
-                    {
-                        bitSequence[index] = false;
-                    }
-                    index++;
-                }
-            }
-            else
-            {
-                WriteDictionary((IReadOnlyDictionary<TKey, TValue>)v, valueWriter);
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. The dictionary's key is a mapped Slice struct and the
-        /// dictionary's value type is a nullable value type.</summary>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue?> v,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct
-        {
-            int count = v.Count;
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach ((TKey key, TValue? value) in v)
-            {
-                key.IceWrite(this);
-                if (value is TValue actualValue)
-                {
-                    valueWriter(this, actualValue);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. The dictionary's value is a nullable mapped Slice struct.
-        /// </summary>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteDictionary<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue?> v,
-            OutputStreamWriter<TKey> keyWriter)
-            where TKey : notnull
-            where TValue : struct, IStreamableStruct
-        {
-            int count = v.Count;
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach ((TKey key, TValue? value) in v)
-            {
-                keyWriter(this, key);
-                if (value is TValue actualValue)
-                {
-                    actualValue.IceWrite(this);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
-        /// <summary>Writes a dictionary to the stream. Both the dictionary's key and value are mapped Slice structs,
-        /// and the values are nullable.</summary>
-        /// <param name="v">The dictionary to write.</param>
-        public void WriteDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue?> v)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct, IStreamableStruct
-        {
-            int count = v.Count;
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach ((TKey key, TValue? value) in v)
-            {
-                key.IceWrite(this);
-                if (value is TValue actualValue)
-                {
-                    actualValue.IceWrite(this);
                 }
                 else
                 {
@@ -622,6 +452,24 @@ namespace ZeroC.Ice
             }
         }
 
+        /// <summary>Writes a sequence of fixed-size numeric values, such as int and long, to the stream.</summary>
+        /// <param name="v">The sequence of numeric values.</param>
+        public void WriteSequence<T>(IEnumerable<T> v) where T : struct
+        {
+            if (v is T[] vArray)
+            {
+                WriteArray(vArray);
+            }
+            else if (v is ImmutableArray<T> vImmutableArray)
+            {
+                WriteSequence(vImmutableArray.AsSpan());
+            }
+            else
+            {
+                WriteSequence(v, (ostr, element) => ostr.WriteFixedSizeNumeric(element));
+            }
+        }
+
         /// <summary>Writes a sequence to the stream.</summary>
         /// <param name="v">The sequence to write.</param>
         /// <param name="writer">The delegate that writes each element to the stream.</param>
@@ -631,17 +479,6 @@ namespace ZeroC.Ice
             foreach (T item in v)
             {
                 writer(this, item);
-            }
-        }
-
-        /// <summary>Writes a sequence to the stream. Elements of the sequence are mapped Slice structs.</summary>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteSequence<T>(IEnumerable<T> v) where T : struct, IStreamableStruct
-        {
-            WriteSize(v.Count()); // potentially slow Linq Count()
-            foreach (T item in v)
-            {
-                item.IceWrite(this);
             }
         }
 
@@ -700,31 +537,9 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a sequence of nullable values to the stream. The values are mapped Slice structs.</summary>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteSequence<T>(IEnumerable<T?> v) where T : struct, IStreamableStruct
-        {
-            int count = v.Count(); // potentially slow Linq Count()
-            WriteSize(count);
-            BitSequence bitSequence = WriteBitSequence(count);
-            int index = 0;
-            foreach (T? item in v)
-            {
-                if (item is T value)
-                {
-                    value.IceWrite(this);
-                }
-                else
-                {
-                    bitSequence[index] = false;
-                }
-                index++;
-            }
-        }
-
         /// <summary>Writes a mapped Slice struct to the stream.</summary>
         /// <param name="v">The struct instance to write.</param>
-        public void WriteStruct<T>(in T v) where T : struct, IStreamableStruct => v.IceWrite(this);
+        public void WriteStruct<T>(T v) where T : struct, IStreamableStruct => v.IceWrite(this);
 
         // Write methods for tagged basic types
 
@@ -940,75 +755,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged dictionary with fixed-size entries to the stream. The dictionary's key is a mapped
-        /// Slice struct.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
-        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
-            int entrySize,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-        {
-            Debug.Assert(entrySize > 1);
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-                int count = dict.Count;
-                WriteSize(count == 0 ? 1 : (count * entrySize) + GetSizeLength(count));
-                WriteDictionary(dict, valueWriter);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary with fixed-size entries to the stream. The dictionary's value is a
-        /// mapped Slice struct.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
-        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
-            int entrySize,
-            OutputStreamWriter<TKey> keyWriter)
-            where TKey : notnull
-            where TValue : struct, IStreamableStruct
-        {
-            Debug.Assert(entrySize > 1);
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-                int count = dict.Count;
-                WriteSize(count == 0 ? 1 : (count * entrySize) + GetSizeLength(count));
-                WriteDictionary(dict, keyWriter);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary with fixed-size entries to the stream. Both the dictionary's key and
-        /// value are mapped Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="entrySize">The size of each entry (key + value), in bytes.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
-            int entrySize)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct, IStreamableStruct
-        {
-            Debug.Assert(entrySize > 1);
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-                int count = dict.Count;
-                WriteSize(count == 0 ? 1 : (count * entrySize) + GetSizeLength(count));
-                WriteDictionary(dict);
-            }
-        }
-
         /// <summary>Writes a tagged dictionary with variable-size elements to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The dictionary to write.</param>
@@ -1026,66 +772,6 @@ namespace ZeroC.Ice
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
                 WriteDictionary(dict, keyWriter, valueWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. The dictionary's key is
-        /// a mapped Slice struct.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="valueWriter">The delegate that writes each value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict, valueWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. The dictionary's value is a
-        /// mapped Slice struct.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v,
-            OutputStreamWriter<TKey> keyWriter)
-            where TKey : notnull
-            where TValue : struct, IStreamableStruct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict, keyWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary with variable-size elements to the stream. Both the dictionary's key and
-        /// value are mapped Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue>? v)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct, IStreamableStruct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict);
                 EndFixedLengthSize(pos);
             }
         }
@@ -1138,90 +824,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged dictionary to the stream. The dictionary's key is a mapped Slice struct.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="withBitSequence">When true, encodes entries with a null value using a bit sequence; otherwise,
-        /// false.</param>
-        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v,
-            bool withBitSequence,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-            where TValue : class
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict, withBitSequence, valueWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary to the stream. The dictionary's key is a mapped Slice struct,
-        /// and the dictionary's value type is a nullable value type.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="valueWriter">The delegate that writes each non-null value to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v,
-            OutputStreamWriter<TValue> valueWriter)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict, valueWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary to the stream. The dictionary's value is a nullable mapped Slice struct.
-        /// </summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        /// <param name="keyWriter">The delegate that writes each key to the stream.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v,
-            OutputStreamWriter<TKey> keyWriter)
-            where TKey : notnull
-            where TValue : struct, IStreamableStruct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict, keyWriter);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged dictionary to the stream. Both the dictionary's key and value are mapped Slice
-        /// structs, and the value's type is nullable.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The dictionary to write.</param>
-        public void WriteTaggedDictionary<TKey, TValue>(
-            int tag,
-            IReadOnlyDictionary<TKey, TValue?>? v)
-            where TKey : struct, IStreamableStruct
-            where TValue : struct, IStreamableStruct
-        {
-            if (v is IReadOnlyDictionary<TKey, TValue?> dict)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteDictionary(dict);
-                EndFixedLengthSize(pos);
-            }
-        }
-
         /// <summary>Writes a tagged proxy to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The proxy to write.</param>
@@ -1254,6 +856,28 @@ namespace ZeroC.Ice
                     WriteSize(v.IsEmpty ? 1 : (v.Length * elementSize) + GetSizeLength(v.Length));
                 }
                 WriteSequence(v);
+            }
+        }
+
+        /// <summary>Writes a tagged sequence of fixed-size numeric values to the stream.</summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="v">The sequence to write.</param>
+        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v) where T : struct
+        {
+            if (v is IEnumerable<T> value)
+            {
+                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
+
+                int elementSize = Unsafe.SizeOf<T>();
+                if (elementSize > 1)
+                {
+                    int count = value.Count(); // potentially slow Linq Count()
+
+                    // First write the size in bytes, so that the reader can skip it. We optimize-out this byte size
+                    // when elementSize is 1.
+                    WriteSize(count == 0 ? 1 : (count * elementSize) + GetSizeLength(count));
+                }
+                WriteSequence(value);
             }
         }
 
@@ -1301,52 +925,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a tagged sequence of variable-size values to the stream. Elements of the sequence are
-        /// mapped Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v) where T : struct, IStreamableStruct
-        {
-            if (v is IEnumerable<T> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteSequence(value);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged sequence of fixed-size values to the stream. Elements of the sequence are
-        /// mapped Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        /// <param name="elementSize">The fixed size of each element of the sequence, in bytes.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T>? v, int elementSize)
-            where T : struct, IStreamableStruct
-        {
-            Debug.Assert(elementSize > 0);
-            if (v is IEnumerable<T> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.VSize);
-
-                int count = value.Count(); // potentially slow Linq Count()
-
-                if (elementSize > 1)
-                {
-                    // First write the size in bytes, so that the reader can skip it. We optimize-out this byte size
-                    // when elementSize is 1.
-                    WriteSize(count == 0 ? 1 : (count * elementSize) + GetSizeLength(count));
-                }
-
-                // Write the sequence "inline" instead of calling WriteSequence to avoid recomputing count.
-                WriteSize(count);
-                foreach (T item in value)
-                {
-                    item.IceWrite(this);
-                }
-            }
-        }
-
         /// <summary>Writes a tagged sequence of nullable elements to the stream.</summary>
         /// <param name="tag">The tag.</param>
         /// <param name="v">The sequence to write.</param>
@@ -1380,22 +958,6 @@ namespace ZeroC.Ice
                 WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
                 Position pos = StartFixedLengthSize();
                 WriteSequence(value, writer);
-                EndFixedLengthSize(pos);
-            }
-        }
-
-        /// <summary>Writes a tagged sequence of nullable values to the stream. Elements of the sequence are mapped
-        /// Slice structs.</summary>
-        /// <param name="tag">The tag.</param>
-        /// <param name="v">The sequence to write.</param>
-        public void WriteTaggedSequence<T>(int tag, IEnumerable<T?>? v)
-            where T : struct, IStreamableStruct
-        {
-            if (v is IEnumerable<T?> value)
-            {
-                WriteTaggedParamHeader(tag, EncodingDefinitions.TagFormat.FSize);
-                Position pos = StartFixedLengthSize();
-                WriteSequence(value);
                 EndFixedLengthSize(pos);
             }
         }
@@ -2007,7 +1569,6 @@ namespace ZeroC.Ice
         private void WriteFixedSizeNumeric<T>(T v) where T : struct
         {
             int elementSize = Unsafe.SizeOf<T>();
-            Debug.Assert(elementSize > 1); // for size 1, we write the byte directly
             Span<byte> data = stackalloc byte[elementSize];
             MemoryMarshal.Write(data, ref v);
             WriteByteSpan(data);

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1053,10 +1053,6 @@ namespace ZeroC.Ice
 
         internal static void WriteInt(int v, Span<byte> data) => MemoryMarshal.Write(data, ref v);
 
-        // TODO: this is a temporary helper method that writes a 2.0 size on 4 bytes.
-        internal static void WriteSize20(int size, Span<byte> data) =>
-            WriteFixedLengthSize20(size, data);
-
         // Constructor for protocol frame header and other non-encapsulated data.
         internal OutputStream(Encoding encoding, IList<ArraySegment<byte>> data, Position startAt = default)
         {
@@ -1175,24 +1171,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Writes a facet to the stream.</summary>
-        /// <param name="facet">The facet to write to the stream.</param>
-        internal void WriteFacet11(string facet)
-        {
-            Debug.Assert(OldEncoding);
-
-            // The old facet-path style used by the ice1 protocol.
-            if (facet.Length == 0)
-            {
-                WriteSize(0);
-            }
-            else
-            {
-                WriteSize(1);
-                WriteString(facet);
-            }
-        }
-
         internal void WriteBinaryContextEntry(int key, ReadOnlySpan<byte> value)
         {
             WriteVarInt(key);
@@ -1201,14 +1179,6 @@ namespace ZeroC.Ice
         }
 
         internal void WriteBinaryContextEntry<T>(int key, T value, OutputStreamWriter<T> writer)
-        {
-            WriteVarInt(key);
-            Position pos = StartFixedLengthSize(2); // 2-bytes size place holder
-            writer(this, value);
-            EndFixedLengthSize(pos, 2);
-        }
-
-        internal void WriteBinaryContextEntry<T>(int key, in T value, OutputStreamValueWriter<T> writer) where T : struct
         {
             WriteVarInt(key);
             Position pos = StartFixedLengthSize(2); // 2-bytes size place holder

--- a/csharp/src/Ice/ProxyDataExtensions.cs
+++ b/csharp/src/Ice/ProxyDataExtensions.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ZeroC.Ice
+{
+    /// <summary>Extension class for OutputStream to marshal ProxyData11 and ProxyData20 without creating a
+    /// ProxyData11/20 instance.</summary>
+    internal static class ProxyDataExtensions
+    {
+        internal static void WriteProxyData11(
+            this OutputStream ostr,
+            string facet,
+            InvocationMode invocationMode,
+            Protocol protocol,
+            Encoding encoding)
+        {
+            Debug.Assert(ostr.Encoding == Encoding.V11);
+            ostr.WriteFacet11(facet);
+            ostr.Write(invocationMode);
+            ostr.WriteBool(false); // "secure"
+            ostr.Write(protocol);
+            ostr.WriteByte(0); // protocol minor
+            encoding.IceWrite(ostr);
+        }
+
+        internal static void WriteProxyData20(
+            this OutputStream ostr,
+            Identity identity,
+            Protocol protocol,
+            Encoding encoding,
+            IReadOnlyList<string> location,
+            InvocationMode invocationMode,
+            string facet)
+        {
+            Debug.Assert(ostr.Encoding == Encoding.V20);
+
+            BitSequence bitSequence = ostr.WriteBitSequence(5);
+            identity.IceWrite(ostr);
+
+            if (protocol != Protocol.Ice2)
+            {
+                ostr.Write(protocol);
+            }
+            else
+            {
+                bitSequence[0] = false;
+            }
+
+            if (encoding != Encoding.V20)
+            {
+                encoding.IceWrite(ostr);
+            }
+            else
+            {
+                bitSequence[1] = false;
+            }
+
+            if (location.Count > 0)
+            {
+                ostr.WriteSequence(location, OutputStream.IceWriterFromString);
+            }
+            else
+            {
+                bitSequence[2] = false;
+            }
+
+            // We only write a non-null invocation mode for ice1.
+            if (protocol == Protocol.Ice1 && invocationMode != InvocationMode.Twoway)
+            {
+                ostr.Write(invocationMode);
+            }
+            else
+            {
+                bitSequence[3] = false;
+            }
+
+            if (facet.Length > 0)
+            {
+                ostr.WriteString(facet);
+            }
+            else
+            {
+                bitSequence[4] = false;
+            }
+        }
+    }
+}

--- a/csharp/src/Ice/ProxyDataExtensions.cs
+++ b/csharp/src/Ice/ProxyDataExtensions.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice
             Encoding encoding)
         {
             Debug.Assert(ostr.Encoding == Encoding.V11);
-            ostr.WriteFacet11(facet);
+            ostr.WriteIce1Facet(facet);
             ostr.Write(invocationMode);
             ostr.WriteBool(false); // "secure"
             ostr.Write(protocol);

--- a/csharp/src/Ice/ProxyDataExtensions.cs
+++ b/csharp/src/Ice/ProxyDataExtensions.cs
@@ -7,7 +7,9 @@ using System.Diagnostics;
 namespace ZeroC.Ice
 {
     /// <summary>Extension class for OutputStream to marshal ProxyData11 and ProxyData20 without creating a
-    /// ProxyData11/20 instance.</summary>
+    /// ProxyData11/20 instance. This implementation is slightly more efficient than the generated code because it
+    /// avoids the allocation of a string[] to write the facet (ProxyData11) and of a string[] to write the location
+    /// (ProxyData20)</summary>
     internal static class ProxyDataExtensions
     {
         internal static void WriteProxyData11(

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1284,13 +1284,7 @@ namespace ZeroC.Ice
             if (ostr.Encoding == Encoding.V11)
             {
                 Identity.IceWrite(ostr);
-                var proxyData = new ProxyData11(Facet.Length > 0 ? new string[] { Facet } : Array.Empty<string>(),
-                                                InvocationMode,
-                                                secure: false,
-                                                Protocol,
-                                                protocolMinor: 0,
-                                                Encoding);
-                proxyData.IceWrite(ostr);
+                ostr.WriteProxyData11(Facet, InvocationMode, Protocol, Encoding);
                 ostr.WriteSequence(Endpoints, (ostr, endpoint) => ostr.WriteEndpoint(endpoint));
 
                 if (Endpoints.Count == 0)
@@ -1304,19 +1298,7 @@ namespace ZeroC.Ice
                 Debug.Assert(ostr.Encoding == Encoding.V20);
 
                 ostr.Write(Endpoints.Count > 0 ? ProxyKind.Direct : ProxyKind.Indirect);
-
-                // For non ice1 proxies, invocation mode is not marshaled so we "adjust" it to Twoway which gets
-                // converted to null below.
-                InvocationMode adjustedMode = Protocol == Protocol.Ice1 ? InvocationMode : InvocationMode.Twoway;
-
-                var proxyData = new ProxyData20(Identity,
-                                                Protocol == Protocol.Ice2 ? null : Protocol,
-                                                Encoding == Encoding.V20 ? null : Encoding,
-                                                Location.Count > 0 ? Location.ToArray() : null,
-                                                adjustedMode != InvocationMode.Twoway ? adjustedMode : null,
-                                                Facet.Length > 0 ? Facet : null);
-
-                proxyData.IceWrite(ostr);
+                ostr.WriteProxyData20(Identity, Protocol, Encoding, Location, InvocationMode, Facet);
 
                 if (Endpoints.Count > 0)
                 {

--- a/csharp/test/Ice/dictMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/dictMapping/MyClassAMDI.cs
@@ -15,43 +15,39 @@ namespace ZeroC.Ice.Test.DictMapping
 
         public ValueTask<(IReadOnlyDictionary<int, int>, IReadOnlyDictionary<int, int>)> OpNVAsync(
             Dictionary<int, int> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>)> OpNRAsync(
             Dictionary<string, string> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, Dictionary<int, int>>,
                           IReadOnlyDictionary<string, Dictionary<int, int>>)> OpNDVAsync(
             Dictionary<string, Dictionary<int, int>> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, Dictionary<string, string>>,
                           IReadOnlyDictionary<string, Dictionary<string, string>>)> OpNDRAsync(
             Dictionary<string, Dictionary<string, string>> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, int[]>,
                           IReadOnlyDictionary<string, int[]>)> OpNDAISAsync(
-            Dictionary<string, int[]> i, Current current) => ToReturnValue(i);
+            Dictionary<string, int[]> i, Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, List<int>>,
                           IReadOnlyDictionary<string, List<int>>)> OpNDGISAsync(
             Dictionary<string, List<int>> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, string[]>,
                           IReadOnlyDictionary<string, string[]>)> OpNDASSAsync(
             Dictionary<string, string[]> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IReadOnlyDictionary<string, List<string>>,
                           IReadOnlyDictionary<string, List<string>>)> OpNDGSSAsync(
             Dictionary<string, List<string>> i,
-            Current current) => ToReturnValue(i);
-
-        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>
-        ToReturnValue<TKey, TValue>(Dictionary<TKey, TValue> input) where TKey : notnull =>
-            new ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>((input, input));
+            Current current) => new ((i, i));
     }
 }

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -860,7 +860,7 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(collocated ? map.Count == 5 : map.Count == 6);
 
             // TODO: temporary, currently we often save 2 bytes with the ice2 protocol
-            int protocolRequestSizeAdjustment = ice1 ? 0 : -3;
+            int protocolRequestSizeAdjustment = ice1 ? 0 : -4;
             int protocolReplySizeAdjustment = ice1 ? 0 : -2;
 
             DispatchMetrics dm1;
@@ -1070,7 +1070,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
             else
             {
-                TestHelper.Assert(rim1.Size == 36 && rim1.ReplySize == 10);
+                TestHelper.Assert(rim1.Size == 34 && rim1.ReplySize == 10);
             }
 
             if (ice1) // TODO: enable ice2
@@ -1199,7 +1199,7 @@ namespace ZeroC.Ice.Test.Metrics
             }
             else
             {
-                TestHelper.Assert(rim1.Size == 36 && rim1.ReplySize == 0);
+                TestHelper.Assert(rim1.Size == 34 && rim1.ReplySize == 0);
             }
 
             TestAttribute(clientMetrics, clientProps, update, "Invocation", "mode", "oneway",

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -109,10 +109,10 @@ namespace ZeroC.Ice.Test.Operations
                 r[i] = p1[^(i + 1)];
             }
 
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<bool[]>, IEnumerable<bool[]>)> OpBoolSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<bool>>, IEnumerable<IEnumerable<bool>>)> OpBoolSSAsync(
             bool[][] p1,
             bool[][] p2,
             Current current)
@@ -127,7 +127,7 @@ namespace ZeroC.Ice.Test.Operations
                 r[i] = p1[^(i + 1)];
             }
 
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
         public ValueTask<(byte, byte)> OpByteAsync(byte p1, byte p2, Current current) =>
@@ -136,7 +136,7 @@ namespace ZeroC.Ice.Test.Operations
         public ValueTask<(IReadOnlyDictionary<byte, bool>, IReadOnlyDictionary<byte, bool>)> OpByteBoolDAsync(
             Dictionary<byte, bool> p1,
             Dictionary<byte, bool> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> OpByteSAsync(
             byte[] p1,
@@ -153,10 +153,10 @@ namespace ZeroC.Ice.Test.Operations
             Array.Copy(p1, r, p1.Length);
             Array.Copy(p2, 0, r, p1.Length, p2.Length);
 
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<byte[]>, IEnumerable<byte[]>)> OpByteSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<byte>>, IEnumerable<IEnumerable<byte>>)> OpByteSSAsync(
             byte[][] p1,
             byte[][] p2,
             Current current)
@@ -171,7 +171,7 @@ namespace ZeroC.Ice.Test.Operations
             Array.Copy(p1, r, p1.Length);
             Array.Copy(p2, 0, r, p1.Length, p2.Length);
 
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
         public ValueTask<(double, float, double)> OpFloatDoubleAsync(float p1, double p2, Current current) =>
@@ -197,10 +197,10 @@ namespace ZeroC.Ice.Test.Operations
                 r[p2.Length + i] = p1[i];
             }
 
-            return new ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<float>, ReadOnlyMemory<double>)>((r, p3, p4));
+            return new ((r, p3, p4));
         }
 
-        public ValueTask<(IEnumerable<double[]>, IEnumerable<float[]>, IEnumerable<double[]>)> OpFloatDoubleSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<double>>, IEnumerable<IEnumerable<float>>, IEnumerable<IEnumerable<double>>)> OpFloatDoubleSSAsync(
             float[][] p1,
             double[][] p2,
             Current current)
@@ -224,18 +224,18 @@ namespace ZeroC.Ice.Test.Operations
                 }
             }
 
-            return new ValueTask<(IEnumerable<double[]>, IEnumerable<float[]>, IEnumerable<double[]>)>((r, p3, p4 ));
+            return new ((r, p3, p4));
         }
 
         public ValueTask<(IReadOnlyDictionary<long, float>, IReadOnlyDictionary<long, float>)> OpLongFloatDAsync(
             Dictionary<long, float> p1,
             Dictionary<long, float> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(IReadOnlyDictionary<ulong, float>, IReadOnlyDictionary<ulong, float>)> OpULongFloatDAsync(
             Dictionary<ulong, float> p1,
             Dictionary<ulong, float> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(IMyClassPrx?, IMyClassPrx?, IMyClassPrx?)> OpMyClassAsync(IMyClassPrx? p1, Current current) =>
             new ValueTask<(IMyClassPrx?, IMyClassPrx?, IMyClassPrx?)>((
@@ -249,12 +249,12 @@ namespace ZeroC.Ice.Test.Operations
         public ValueTask<(IReadOnlyDictionary<short, int>, IReadOnlyDictionary<short, int>)> OpShortIntDAsync(
             Dictionary<short, int> p1,
             Dictionary<short, int> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(IReadOnlyDictionary<ushort, uint>, IReadOnlyDictionary<ushort, uint>)> OpUShortUIntDAsync(
             Dictionary<ushort, uint> p1,
             Dictionary<ushort, uint> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(long, short, int, long)> OpShortIntLongAsync(short p1, int p2, long p3, Current current) =>
             new ValueTask<(long, short, int, long)>((p3, p1, p2, p3));
@@ -286,11 +286,8 @@ namespace ZeroC.Ice.Test.Operations
             long[]? p6 = new long[p3.Length + p3.Length];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return new ValueTask<(
-                ReadOnlyMemory<long>,
-                ReadOnlyMemory<short>,
-                ReadOnlyMemory<int>,
-                ReadOnlyMemory<long>)>((p3, p4, p5, p6));
+
+            return new ((p3, p4, p5, p6));
         }
 
         public ValueTask<(ReadOnlyMemory<ulong>, ReadOnlyMemory<ushort>, ReadOnlyMemory<uint>, ReadOnlyMemory<ulong>)>
@@ -305,11 +302,8 @@ namespace ZeroC.Ice.Test.Operations
             ulong[] p6 = new ulong[p3.Length + p3.Length];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return new ValueTask<(
-                ReadOnlyMemory<ulong>,
-                ReadOnlyMemory<ushort>,
-                ReadOnlyMemory<uint>,
-                ReadOnlyMemory<ulong>)>((p3, p4, p5, p6));
+
+            return new ((p3, p4, p5, p6));
         }
 
         public ValueTask<(IEnumerable<long>, IEnumerable<int>, IEnumerable<long>)>
@@ -325,7 +319,7 @@ namespace ZeroC.Ice.Test.Operations
             Array.Copy(p2, p5, p2.Length);
             Array.Copy(p2, 0, p5, p2.Length, p2.Length);
 
-            return new ValueTask<(IEnumerable<long>, IEnumerable<int>, IEnumerable<long>)>((p2, p4, p5));
+            return new ((p2, p4, p5));
         }
 
         public ValueTask<(IEnumerable<ulong>, IEnumerable<uint>, IEnumerable<ulong>)>
@@ -341,10 +335,10 @@ namespace ZeroC.Ice.Test.Operations
             Array.Copy(p2, p5, p2.Length);
             Array.Copy(p2, 0, p5, p2.Length, p2.Length);
 
-            return new ValueTask<(IEnumerable<ulong>, IEnumerable<uint>, IEnumerable<ulong>)>((p2, p4, p5));
+            return new ((p2, p4, p5));
         }
 
-        public ValueTask<(IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>)>
+        public ValueTask<(IEnumerable<IEnumerable<long>>, IEnumerable<IEnumerable<short>>, IEnumerable<IEnumerable<int>>, IEnumerable<IEnumerable<long>>)>
         OpShortIntLongSSAsync(short[][] p1, int[][] p2, long[][] p3, Current current)
         {
             short[][] p4 = p1;
@@ -358,11 +352,10 @@ namespace ZeroC.Ice.Test.Operations
             long[][] p6 = new long[p3.Length + p3.Length][];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return new ValueTask<(IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>)>(
-                (p3, p4, p5, p6));
+            return new ((p3, p4, p5, p6));
         }
 
-        public ValueTask<(IEnumerable<ulong[]>, IEnumerable<ushort[]>, IEnumerable<uint[]>, IEnumerable<ulong[]>)>
+        public ValueTask<(IEnumerable<IEnumerable<ulong>>, IEnumerable<IEnumerable<ushort>>, IEnumerable<IEnumerable<uint>>, IEnumerable<IEnumerable<ulong>>)>
         OpUShortUIntULongSSAsync(ushort[][] p1, uint[][] p2, ulong[][] p3, Current current)
         {
             ushort[][] p4 = p1;
@@ -376,11 +369,8 @@ namespace ZeroC.Ice.Test.Operations
             ulong[][]? p6 = new ulong[p3.Length + p3.Length][];
             Array.Copy(p3, p6, p3.Length);
             Array.Copy(p3, 0, p6, p3.Length, p3.Length);
-            return new ValueTask<(
-                IEnumerable<ulong[]>,
-                IEnumerable<ushort[]>,
-                IEnumerable<uint[]>,
-                IEnumerable<ulong[]>)>((p3, p4, p5, p6));
+
+            return new ((p3, p4, p5, p6));
         }
 
         public ValueTask<(string, string)>
@@ -389,19 +379,19 @@ namespace ZeroC.Ice.Test.Operations
 
         public ValueTask<(IReadOnlyDictionary<string, MyEnum>, IReadOnlyDictionary<string, MyEnum>)>
         OpStringMyEnumDAsync(Dictionary<string, MyEnum> p1, Dictionary<string, MyEnum> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(IReadOnlyDictionary<MyEnum, string>, IReadOnlyDictionary<MyEnum, string>)>
         OpMyEnumStringDAsync(Dictionary<MyEnum, string> p1, Dictionary<MyEnum, string> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(IReadOnlyDictionary<MyStruct, MyEnum>, IReadOnlyDictionary<MyStruct, MyEnum>)>
         OpMyStructMyEnumDAsync(
             Dictionary<MyStruct, MyEnum> p1,
             Dictionary<MyStruct, MyEnum> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            Current current) => new ((MergeDictionaries(p1, p2), p1));
 
-        public ValueTask<(IEnumerable<Dictionary<byte, bool>>, IEnumerable<Dictionary<byte, bool>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<byte, bool>>, IEnumerable<IReadOnlyDictionary<byte, bool>>)>
         OpByteBoolDSAsync(Dictionary<byte, bool>[] p1, Dictionary<byte, bool>[] p2, Current current)
         {
             var p3 = new Dictionary<byte, bool>[p1.Length + p2.Length];
@@ -413,10 +403,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<short, int>>, IEnumerable<Dictionary<short, int>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<short, int>>, IEnumerable<IReadOnlyDictionary<short, int>>)>
         OpShortIntDSAsync(Dictionary<short, int>[] p1, Dictionary<short, int>[] p2, Current current)
         {
             var p3 = new Dictionary<short, int>[p1.Length + p2.Length];
@@ -428,10 +418,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<ushort, uint>>, IEnumerable<Dictionary<ushort, uint>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<ushort, uint>>, IEnumerable<IReadOnlyDictionary<ushort, uint>>)>
         OpUShortUIntDSAsync(Dictionary<ushort, uint>[] p1, Dictionary<ushort, uint>[] p2, Current current)
         {
             var p3 = new Dictionary<ushort, uint>[p1.Length + p2.Length];
@@ -443,10 +433,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<long, float>>, IEnumerable<IReadOnlyDictionary<long, float>>)>
         OpLongFloatDSAsync(Dictionary<long, float>[] p1, Dictionary<long, float>[] p2, Current current)
         {
             var p3 = new Dictionary<long, float>[p1.Length + p2.Length];
@@ -458,10 +448,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<ulong, float>>, IEnumerable<Dictionary<ulong, float>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<ulong, float>>, IEnumerable<IReadOnlyDictionary<ulong, float>>)>
         OpULongFloatDSAsync(Dictionary<ulong, float>[] p1, Dictionary<ulong, float>[] p2, Current current)
         {
             var p3 = new Dictionary<ulong, float>[p1.Length + p2.Length];
@@ -473,10 +463,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<string, string>>, IEnumerable<Dictionary<string, string>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<string, string>>, IEnumerable<IReadOnlyDictionary<string, string>>)>
         OpStringStringDSAsync(Dictionary<string, string>[] p1, Dictionary<string, string>[] p2, Current current)
         {
             var p3 = new Dictionary<string, string>[p1.Length + p2.Length];
@@ -488,10 +478,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<string, MyEnum>>, IEnumerable<Dictionary<string, MyEnum>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<string, MyEnum>>, IEnumerable<IReadOnlyDictionary<string, MyEnum>>)>
         OpStringMyEnumDSAsync(Dictionary<string, MyEnum>[] p1, Dictionary<string, MyEnum>[] p2, Current current)
         {
             var p3 = new Dictionary<string, MyEnum>[p1.Length + p2.Length];
@@ -503,10 +493,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<MyEnum, string>>, IEnumerable<Dictionary<MyEnum, string>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<MyEnum, string>>, IEnumerable<IReadOnlyDictionary<MyEnum, string>>)>
         OpMyEnumStringDSAsync(Dictionary<MyEnum, string>[] p1, Dictionary<MyEnum, string>[] p2, Current current)
         {
             var p3 = new Dictionary<MyEnum, string>[p1.Length + p2.Length];
@@ -518,10 +508,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<Dictionary<MyStruct, MyEnum>>, IEnumerable<Dictionary<MyStruct, MyEnum>>)>
+        public ValueTask<(IEnumerable<IReadOnlyDictionary<MyStruct, MyEnum>>, IEnumerable<IReadOnlyDictionary<MyStruct, MyEnum>>)>
         OpMyStructMyEnumDSAsync(Dictionary<MyStruct, MyEnum>[] p1,
                                 Dictionary<MyStruct, MyEnum>[] p2,
                                 Current current)
@@ -535,58 +525,58 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
         public ValueTask<(IReadOnlyDictionary<byte, byte[]>, IReadOnlyDictionary<byte, byte[]>)>
         OpByteByteSDAsync(Dictionary<byte, byte[]> p1, Dictionary<byte, byte[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<bool, bool[]>, IReadOnlyDictionary<bool, bool[]>)>
         OpBoolBoolSDAsync(Dictionary<bool, bool[]> p1, Dictionary<bool, bool[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<short, short[]>, IReadOnlyDictionary<short, short[]>)>
         OpShortShortSDAsync(Dictionary<short, short[]> p1, Dictionary<short, short[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<ushort, ushort[]>, IReadOnlyDictionary<ushort, ushort[]>)>
         OpUShortUShortSDAsync(Dictionary<ushort, ushort[]> p1, Dictionary<ushort, ushort[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<int, int[]>, IReadOnlyDictionary<int, int[]>)>
         OpIntIntSDAsync(Dictionary<int, int[]> p1, Dictionary<int, int[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<uint, uint[]>, IReadOnlyDictionary<uint, uint[]>)>
         OpUIntUIntSDAsync(Dictionary<uint, uint[]> p1, Dictionary<uint, uint[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<long, long[]>, IReadOnlyDictionary<long, long[]>)>
         OpLongLongSDAsync(Dictionary<long, long[]> p1, Dictionary<long, long[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<ulong, ulong[]>, IReadOnlyDictionary<ulong, ulong[]>)>
         OpULongULongSDAsync(Dictionary<ulong, ulong[]> p1, Dictionary<ulong, ulong[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<string, float[]>, IReadOnlyDictionary<string, float[]>)>
         OpStringFloatSDAsync(Dictionary<string, float[]> p1, Dictionary<string, float[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<string, double[]>, IReadOnlyDictionary<string, double[]>)>
         OpStringDoubleSDAsync(Dictionary<string, double[]> p1, Dictionary<string, double[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<string, string[]>, IReadOnlyDictionary<string, string[]>)>
         OpStringStringSDAsync(Dictionary<string, string[]> p1, Dictionary<string, string[]> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<(IReadOnlyDictionary<MyEnum, MyEnum[]>, IReadOnlyDictionary<MyEnum, MyEnum[]>)>
         OpMyEnumMyEnumSDAsync(
             Dictionary<MyEnum, MyEnum[]> p1,
             Dictionary<MyEnum, MyEnum[]> p2,
-            Current current) => ToReturnValue(MergeDicitionaries(p1, p2), p2);
+            Current current) => new ((MergeDictionaries(p1, p2), p2));
 
         public ValueTask<ReadOnlyMemory<int>> OpIntSAsync(int[] s, Current current)
         {
@@ -595,7 +585,8 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = -s[i];
             }
-            return new ValueTask<ReadOnlyMemory<int>>(r);
+
+            return new (r);
         }
 
         public ValueTask<IReadOnlyDictionary<string, string>> OpContextAsync(Current current) =>
@@ -618,7 +609,7 @@ namespace ZeroC.Ice.Test.Operations
             {
                 int count = _opByteSOnewayCallCount;
                 _opByteSOnewayCallCount = 0;
-                return new ValueTask<int>(count);
+                return new (count);
             }
         }
 
@@ -646,10 +637,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p1[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<string[]>, IEnumerable<string[]>)> OpStringSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<string>>, IEnumerable<IEnumerable<string>>)> OpStringSSAsync(
             string[][] p1,
             string[][] p2,
             Current current)
@@ -662,10 +653,10 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p2[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
-        public ValueTask<(IEnumerable<string[][]>, IEnumerable<string[][]>)>
+        public ValueTask<(IEnumerable<IEnumerable<IEnumerable<string>>>, IEnumerable<IEnumerable<IEnumerable<string>>>)>
         OpStringSSSAsync(string[][][] p1, string[][][] p2, Current current)
         {
             string[][][] p3 = new string[p1.Length + p2.Length][][];
@@ -677,18 +668,18 @@ namespace ZeroC.Ice.Test.Operations
             {
                 r[i] = p2[^(i + 1)];
             }
-            return ToReturnValue(r, p3);
+            return new ((r, p3));
         }
 
         public ValueTask<(IReadOnlyDictionary<string, string>, IReadOnlyDictionary<string, string>)>
         OpStringStringDAsync(Dictionary<string, string> p1, Dictionary<string, string> p2, Current current) =>
-            ToReturnValue(MergeDicitionaries(p1, p2), p1);
+            new ((MergeDictionaries(p1, p2), p1));
 
         public ValueTask<(Structure, Structure)> OpStructAsync(Structure p1, Structure p2, Current current)
         {
             Structure p3 = p1;
             p3.S.S = "a new string";
-            return new ValueTask<(Structure, Structure)>((p2, p3));
+            return new ((p2, p3));
         }
 
         public ValueTask OpIdempotentAsync(Current current)
@@ -861,21 +852,7 @@ namespace ZeroC.Ice.Test.Operations
             return new IMyClass.OpMDict2MarshaledReturnValue(p1, p1, current);
         }
 
-        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(
-            T[] input1,
-            T[] input2) where T : struct => new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input1, input2));
-
-        private static ValueTask<(IEnumerable<T>, IEnumerable<T>)> ToReturnValue<T>(
-            IEnumerable<T> input1,
-            IEnumerable<T> input2) => new ValueTask<(IEnumerable<T>, IEnumerable<T>)>((input1, input2));
-
-        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>
-        ToReturnValue<TKey, TValue>(
-            IReadOnlyDictionary<TKey, TValue> input1,
-            IReadOnlyDictionary<TKey, TValue> input2) where TKey : notnull =>
-            new ValueTask<(IReadOnlyDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>)>((input1, input2));
-
-        private static IReadOnlyDictionary<TKey, TValue> MergeDicitionaries<TKey, TValue>(
+        private static IReadOnlyDictionary<TKey, TValue> MergeDictionaries<TKey, TValue>(
             IReadOnlyDictionary<TKey, TValue> first,
             IReadOnlyDictionary<TKey, TValue> second) where TKey : notnull
         {

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -55,7 +55,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<bool[]>, IEnumerable<bool[]>) OpBoolSS(bool[][] p1, bool[][] p2, Current current)
+        public (IEnumerable<IEnumerable<bool>>, IEnumerable<IEnumerable<bool>>) OpBoolSS(bool[][] p1, bool[][] p2, Current current)
         {
             bool[][] p3 = new bool[p1.Length + p2.Length][];
             Array.Copy(p1, p3, p1.Length);
@@ -100,7 +100,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<byte[]>, IEnumerable<byte[]>) OpByteSS(byte[][] p1, byte[][] p2, Current current)
+        public (IEnumerable<IEnumerable<byte>>, IEnumerable<IEnumerable<byte>>) OpByteSS(byte[][] p1, byte[][] p2, Current current)
         {
             byte[][] p3 = new byte[p1.Length][];
             for (int i = 0; i < p1.Length; i++)
@@ -134,7 +134,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p1, p4);
         }
 
-        public (IEnumerable<double[]>, IEnumerable<float[]>, IEnumerable<double[]>) OpFloatDoubleSS(float[][] p1,
+        public (IEnumerable<IEnumerable<double>>, IEnumerable<IEnumerable<float>>, IEnumerable<IEnumerable<double>>) OpFloatDoubleSS(float[][] p1,
             double[][] p2, Current current)
         {
             double[][] p4 = new double[p2.Length][];
@@ -293,7 +293,7 @@ namespace ZeroC.Ice.Test.Operations
             return (p2, p4, p5);
         }
 
-        public (IEnumerable<long[]>, IEnumerable<short[]>, IEnumerable<int[]>, IEnumerable<long[]>) OpShortIntLongSS(
+        public (IEnumerable<IEnumerable<long>>, IEnumerable<IEnumerable<short>>, IEnumerable<IEnumerable<int>>, IEnumerable<IEnumerable<long>>) OpShortIntLongSS(
             short[][] p1, int[][] p2, long[][] p3, Current current)
         {
             int[][] p5 = new int[p2.Length][];
@@ -309,7 +309,7 @@ namespace ZeroC.Ice.Test.Operations
             return (p3, p1, p5, p6);
         }
 
-        public (IEnumerable<ulong[]>, IEnumerable<ushort[]>, IEnumerable<uint[]>, IEnumerable<ulong[]>)
+        public (IEnumerable<IEnumerable<ulong>>, IEnumerable<IEnumerable<ushort>>, IEnumerable<IEnumerable<uint>>, IEnumerable<IEnumerable<ulong>>)
         OpUShortUIntULongSS(ushort[][] p1, uint[][] p2, ulong[][] p3, Current current)
         {
             uint[][] p5 = new uint[p2.Length][];
@@ -366,7 +366,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p1);
         }
 
-        public (IEnumerable<Dictionary<byte, bool>>, IEnumerable<Dictionary<byte, bool>>) OpByteBoolDS(
+        public (IEnumerable<IReadOnlyDictionary<byte, bool>>, IEnumerable<IReadOnlyDictionary<byte, bool>>) OpByteBoolDS(
             Dictionary<byte, bool>[] p1,
             Dictionary<byte, bool>[] p2,
             Current current)
@@ -383,7 +383,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<short, int>>, IEnumerable<Dictionary<short, int>>) OpShortIntDS(
+        public (IEnumerable<IReadOnlyDictionary<short, int>>, IEnumerable<IReadOnlyDictionary<short, int>>) OpShortIntDS(
             Dictionary<short, int>[] p1,
             Dictionary<short, int>[] p2,
             Current current)
@@ -400,7 +400,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<ushort, uint>>, IEnumerable<Dictionary<ushort, uint>>) OpUShortUIntDS(
+        public (IEnumerable<IReadOnlyDictionary<ushort, uint>>, IEnumerable<IReadOnlyDictionary<ushort, uint>>) OpUShortUIntDS(
             Dictionary<ushort, uint>[] p1,
             Dictionary<ushort, uint>[] p2,
             Current current)
@@ -417,7 +417,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<long, float>>, IEnumerable<Dictionary<long, float>>) OpLongFloatDS(
+        public (IEnumerable<IReadOnlyDictionary<long, float>>, IEnumerable<IReadOnlyDictionary<long, float>>) OpLongFloatDS(
             Dictionary<long, float>[] p1,
             Dictionary<long, float>[] p2,
             Current current)
@@ -434,7 +434,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<ulong, float>>, IEnumerable<Dictionary<ulong, float>>) OpULongFloatDS(
+        public (IEnumerable<IReadOnlyDictionary<ulong, float>>, IEnumerable<IReadOnlyDictionary<ulong, float>>) OpULongFloatDS(
             Dictionary<ulong, float>[] p1,
             Dictionary<ulong, float>[] p2,
             Current current)
@@ -451,7 +451,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<string, string>>, IEnumerable<Dictionary<string, string>>) OpStringStringDS(
+        public (IEnumerable<IReadOnlyDictionary<string, string>>, IEnumerable<IReadOnlyDictionary<string, string>>) OpStringStringDS(
             Dictionary<string, string>[] p1,
             Dictionary<string, string>[] p2,
             Current current)
@@ -468,7 +468,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<string, MyEnum>>, IEnumerable<Dictionary<string, MyEnum>>) OpStringMyEnumDS(
+        public (IEnumerable<IReadOnlyDictionary<string, MyEnum>>, IEnumerable<IReadOnlyDictionary<string, MyEnum>>) OpStringMyEnumDS(
             Dictionary<string, MyEnum>[] p1,
             Dictionary<string, MyEnum>[] p2,
             Current current)
@@ -485,7 +485,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<MyEnum, string>>, IEnumerable<Dictionary<MyEnum, string>>) OpMyEnumStringDS(
+        public (IEnumerable<IReadOnlyDictionary<MyEnum, string>>, IEnumerable<IReadOnlyDictionary<MyEnum, string>>) OpMyEnumStringDS(
             Dictionary<MyEnum, string>[] p1,
             Dictionary<MyEnum, string>[] p2,
             Current current)
@@ -502,8 +502,8 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<Dictionary<MyStruct, MyEnum>>,
-                IEnumerable<Dictionary<MyStruct, MyEnum>>) OpMyStructMyEnumDS(
+        public (IEnumerable<IReadOnlyDictionary<MyStruct, MyEnum>>,
+                IEnumerable<IReadOnlyDictionary<MyStruct, MyEnum>>) OpMyStructMyEnumDS(
             Dictionary<MyStruct, MyEnum>[] p1,
             Dictionary<MyStruct, MyEnum>[] p2,
             Current current)
@@ -728,7 +728,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<string[]>, IEnumerable<string[]>) OpStringSS(string[][] p1, string[][] p2, Current current)
+        public (IEnumerable<IEnumerable<string>>, IEnumerable<IEnumerable<string>>) OpStringSS(string[][] p1, string[][] p2, Current current)
         {
             string[][] p3 = new string[p1.Length + p2.Length][];
             Array.Copy(p1, p3, p1.Length);
@@ -742,7 +742,7 @@ namespace ZeroC.Ice.Test.Operations
             return (r, p3);
         }
 
-        public (IEnumerable<string[][]>, IEnumerable<string[][]>) OpStringSSS(string[][][] p1, string[][][] p2,
+        public (IEnumerable<IEnumerable<IEnumerable<string>>>, IEnumerable<IEnumerable<IEnumerable<string>>>) OpStringSSS(string[][][] p1, string[][][] p2,
             Current current)
         {
             string[][][]? p3 = new string[p1.Length + p2.Length][][];

--- a/csharp/test/Ice/seqMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/seqMapping/MyClassAMDI.cs
@@ -15,282 +15,274 @@ namespace ZeroC.Ice.Test.SeqMapping
         }
 
         public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> OpAByteSAsync(byte[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> OpLByteSAsync(List<byte> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> OpKByteSAsync(LinkedList<byte> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> OpQByteSAsync(Queue<byte> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> OpSByteSAsync(Stack<byte> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<byte>, IEnumerable<byte>)> OpCByteSAsync(Custom<byte> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<bool>, ReadOnlyMemory<bool>)> OpABoolSAsync(bool[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> OpLBoolSAsync(List<bool> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> OpKBoolSAsync(LinkedList<bool> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> OpQBoolSAsync(Queue<bool> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> OpSBoolSAsync(Stack<bool> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<bool>, IEnumerable<bool>)> OpCBoolSAsync(Custom<bool> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<short>, ReadOnlyMemory<short>)> OpAShortSAsync(short[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<short>, IEnumerable<short>)> OpLShortSAsync(List<short> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<short>, IEnumerable<short>)> OpKShortSAsync(LinkedList<short> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<short>, IEnumerable<short>)> OpQShortSAsync(Queue<short> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<short>, IEnumerable<short>)> OpSShortSAsync(Stack<short> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<short>, IEnumerable<short>)> OpCShortSAsync(Custom<short> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<int>, ReadOnlyMemory<int>)> OpAIntSAsync(int[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpLIntSAsync(List<int> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpKIntSAsync(LinkedList<int> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpQIntSAsync(Queue<int> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpSIntSAsync(Stack<int> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpCIntSAsync(Custom<int> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<long>)> OpALongSAsync(long[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<long>, IEnumerable<long>)> OpLLongSAsync(List<long> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<long>, IEnumerable<long>)> OpKLongSAsync(LinkedList<long> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<long>, IEnumerable<long>)> OpQLongSAsync(Queue<long> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<long>, IEnumerable<long>)> OpSLongSAsync(Stack<long> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<long>, IEnumerable<long>)> OpCLongSAsync(Custom<long> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<float>, ReadOnlyMemory<float>)> OpAFloatSAsync(float[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<float>, IEnumerable<float>)> OpLFloatSAsync(List<float> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<float>, IEnumerable<float>)> OpKFloatSAsync(LinkedList<float> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<float>, IEnumerable<float>)> OpQFloatSAsync(Queue<float> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<float>, IEnumerable<float>)> OpSFloatSAsync(Stack<float> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<float>, IEnumerable<float>)> OpCFloatSAsync(Custom<float> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<double>)> OpADoubleSAsync(double[] i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<double>, IEnumerable<double>)> OpLDoubleSAsync(List<double> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<double>, IEnumerable<double>)> OpKDoubleSAsync(LinkedList<double> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<double>, IEnumerable<double>)> OpQDoubleSAsync(Queue<double> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<double>, IEnumerable<double>)> OpSDoubleSAsync(Stack<double> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<double>, IEnumerable<double>)> OpCDoubleSAsync(Custom<double> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpAStringSAsync(string[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpLStringSAsync(List<string> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpKStringSAsync(LinkedList<string> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpQStringSAsync(Queue<string> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpSStringSAsync(Stack<string> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<string>, IEnumerable<string>)> OpCStringSAsync(Custom<string> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<AnyClass?>, IEnumerable<AnyClass?>)> OpAObjectSAsync(AnyClass?[] i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<AnyClass?>, IEnumerable<AnyClass?>)> OpLObjectSAsync(List<AnyClass?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<AnyClass?>, IEnumerable<AnyClass?>)> OpCObjectSAsync(Custom<AnyClass?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpAObjectPrxSAsync(IObjectPrx?[] i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpLObjectPrxSAsync(List<IObjectPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpKObjectPrxSAsync(
-            LinkedList<IObjectPrx?> i, Current current) => ToReturnValue(i);
+            LinkedList<IObjectPrx?> i, Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpQObjectPrxSAsync(Queue<IObjectPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpSObjectPrxSAsync(Stack<IObjectPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IObjectPrx?>, IEnumerable<IObjectPrx?>)> OpCObjectPrxSAsync(Custom<IObjectPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpAStructSAsync(S[] i, Current current) =>
-            ToReturnValue(i as IEnumerable<S>);
+        public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpAStructSAsync(S[] i, Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpLStructSAsync(List<S> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpKStructSAsync(LinkedList<S> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpQStructSAsync(Queue<S> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpSStructSAsync(Stack<S> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<S>, IEnumerable<S>)> OpCStructSAsync(Custom<S> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpAStructSDAsync(SD[] i, Current current) =>
-            ToReturnValue(i as IEnumerable<SD>);
+        public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpAStructSDAsync(SD[] i, Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpLStructSDAsync(List<SD> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpKStructSDAsync(LinkedList<SD> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpQStructSDAsync(Queue<SD> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpSStructSDAsync(Stack<SD> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<SD>, IEnumerable<SD>)> OpCStructSDAsync(Custom<SD> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<CV?>, IEnumerable<CV?>)> OpACVSAsync(CV?[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<CV?>, IEnumerable<CV?>)> OpLCVSAsync(List<CV?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpAIPrxSAsync(IIPrx?[] i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpLIPrxSAsync(List<IIPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpKIPrxSAsync(LinkedList<IIPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpQIPrxSAsync(Queue<IIPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpSIPrxSAsync(Stack<IIPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<IIPrx?>, IEnumerable<IIPrx?>)> OpCIPrxSAsync(Custom<IIPrx?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<CR?>, IEnumerable<CR?>)> OpACRSAsync(CR?[] i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<CR?>, IEnumerable<CR?>)> OpLCRSAsync(List<CR?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        public ValueTask<(IEnumerable<CR?>, IEnumerable<CR?>)> OpCCRSAsync(Custom<CR?> i,
-            Current current) => ToReturnValue(i);
+        public ValueTask<(IEnumerable<CR?>, IEnumerable<CR?>)> OpCCRSAsync(Custom<CR?> i, Current current) =>
+            new ((i, i));
 
-        public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpAEnSAsync(En[] i, Current current) =>
-            ToReturnValue(i as IEnumerable<En>);
+        public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpAEnSAsync(En[] i, Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpLEnSAsync(List<En> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpKEnSAsync(LinkedList<En> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpQEnSAsync(Queue<En> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpSEnSAsync(Stack<En> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<En>, IEnumerable<En>)> OpCEnSAsync(Custom<En> i, Current current) =>
-            ToReturnValue(i);
+            new ((i, i));
 
         public ValueTask<(IEnumerable<int>, IEnumerable<int>)> OpCustomIntSAsync(Custom<int> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
         public ValueTask<(IEnumerable<CV?>, IEnumerable<CV?>)> OpCustomCVSAsync(
             Custom<CV?> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        public ValueTask<(IEnumerable<Custom<int>>, IEnumerable<Custom<int>>)> OpCustomIntSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<int>>, IEnumerable<IEnumerable<int>>)> OpCustomIntSSAsync(
             Custom<Custom<int>> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        public ValueTask<(IEnumerable<Custom<CV?>>, IEnumerable<Custom<CV?>>)> OpCustomCVSSAsync(
+        public ValueTask<(IEnumerable<IEnumerable<CV?>>, IEnumerable<IEnumerable<CV?>>)> OpCustomCVSSAsync(
             Custom<Custom<CV?>> i,
-            Current current) => ToReturnValue(i);
+            Current current) => new ((i, i));
 
-        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(T[] input) where T : struct =>
-            new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input, input));
-
-        private static ValueTask<(IEnumerable<T>, IEnumerable<T>)> ToReturnValue<T>(IEnumerable<T> input) =>
-            new ValueTask<(IEnumerable<T>, IEnumerable<T>)>((input, input));
     }
 }

--- a/csharp/test/Ice/seqMapping/MyClassI.cs
+++ b/csharp/test/Ice/seqMapping/MyClassI.cs
@@ -185,8 +185,8 @@ namespace ZeroC.Ice.Test.SeqMapping
 
         public (IEnumerable<CV?>, IEnumerable<CV?>) OpCustomCVS(Custom<CV?> i, Current current) => (i, i);
 
-        public (IEnumerable<Custom<int>>, IEnumerable<Custom<int>>) OpCustomIntSS(Custom<Custom<int>> i, Current current) => (i, i);
+        public (IEnumerable<IEnumerable<int>>, IEnumerable<IEnumerable<int>>) OpCustomIntSS(Custom<Custom<int>> i, Current current) => (i, i);
 
-        public (IEnumerable<Custom<CV?>>, IEnumerable<Custom<CV?>>) OpCustomCVSS(Custom<Custom<CV?>> i, Current current) => (i, i);
+        public (IEnumerable<IEnumerable<CV?>>, IEnumerable<IEnumerable<CV?>>) OpCustomCVSS(Custom<Custom<CV?>> i, Current current) => (i, i);
     }
 }

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -62,7 +62,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             var b = new B();
             b.Sb = "B1.sb";
             b.Pb = b;
-            return new ValueTask<B?>(b);
+            return new (b);
         }
 
         public ValueTask<B?> TwoElementCycleAsync(Current current)
@@ -73,7 +73,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             b2.Sb = "B2.sb";
             b2.Pb = b1;
             b1.Pb = b2;
-            return new ValueTask<B?>(b1);
+            return new (b1);
         }
 
         public ValueTask<B?> D1AsBAsync(Current current)
@@ -88,7 +88,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return new ValueTask<B?>(d1);
+            return new (d1);
         }
 
         public ValueTask<D1?> D1AsD1Async(Current current)
@@ -103,7 +103,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return new ValueTask<D1?>(d1);
+            return new (d1);
         }
 
         public ValueTask<B?> D2AsBAsync(Current current)
@@ -118,7 +118,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d1.Pd1 = d2;
             d2.Pb = d1;
             d2.Pd2 = d1;
-            return new ValueTask<B?>(d2);
+            return new (d2);
         }
 
         public ValueTask<(B?, B?)> ParamTest1Async(Current current)
@@ -133,7 +133,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return MakeValueTask(((B?)d1, (B?)d2));
+            return new ((d1, d2));
         }
 
         public ValueTask<(B?, B?)> ParamTest2Async(Current current)
@@ -148,7 +148,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return MakeValueTask(((B?)d2, (B?)d1));
+            return new ((d2, d1));
         }
 
         public ValueTask<(B?, B?, B?)> ParamTest3Async(Current current)
@@ -177,7 +177,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d3.Pd1 = null;
             d4.Pd2 = d3;
 
-            return MakeValueTask(((B?)d3, (B?)d2, (B?)d4));
+            return new ((d3, d2, d4));
         }
 
         public ValueTask<(B?, B?)> ParamTest4Async(Current current)
@@ -189,7 +189,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d4.P1.Sb = "B.sb (1)";
             d4.P2 = new B();
             d4.P2.Sb = "B.sb (2)";
-            return MakeValueTask(((B?)d4.P2, (B?)d4));
+            return new ((d4.P2, d4));
         }
 
         public ValueTask<(B?, B?, B?)> ReturnTest1Async(Current current)
@@ -204,7 +204,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return MakeValueTask(((B?)d2, (B?)d2, (B?)d1));
+            return new ((d2, d2, d1));
         }
 
         public ValueTask<(B?, B?, B?)> ReturnTest2Async(Current current)
@@ -219,12 +219,12 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             d2.Pd2 = d1;
             d1.Pb = d2;
             d1.Pd1 = d2;
-            return new ValueTask<(B?, B?, B?)>((d1, d1, d2));
+            return new ((d1, d1, d2));
         }
 
-        public ValueTask<B?> ReturnTest3Async(B? p1, B? p2, Current current) => MakeValueTask(p1);
+        public ValueTask<B?> ReturnTest3Async(B? p1, B? p2, Current current) => new (p1);
 
-        public ValueTask<SS3> SequenceTestAsync(SS1? p1, SS2? p2, Current current) => MakeValueTask(new SS3(p1, p2));
+        public ValueTask<SS3> SequenceTestAsync(SS1? p1, SS2? p2, Current current) => new (new SS3(p1, p2));
 
         public ValueTask<(IReadOnlyDictionary<int, B?>, IReadOnlyDictionary<int, B?>)> DictionaryTestAsync(
             Dictionary<int, B?> bin,
@@ -255,13 +255,13 @@ namespace ZeroC.Ice.Test.Slicing.Objects
                 d1.Pd1 = d1;
                 r[i * 20] = d1;
             }
-            return new ValueTask<(IReadOnlyDictionary<int, B?>, IReadOnlyDictionary<int, B?>)>((r, bout));
+            return new ((r, bout));
         }
 
-        public ValueTask<PBase?> ExchangePBaseAsync(PBase? pb, Current current) => MakeValueTask(pb);
+        public ValueTask<PBase?> ExchangePBaseAsync(PBase? pb, Current current) => new (pb);
 
         public ValueTask<Preserved?> PBSUnknownAsPreservedAsync(Current current) =>
-            new ValueTask<Preserved?>(new PSUnknown(5, "preserved", "unknown", null, new MyClass(15)));
+            new (new PSUnknown(5, "preserved", "unknown", null, new MyClass(15)));
 
         public ValueTask CheckPBSUnknownAsync(Preserved? p, Current current)
         {
@@ -283,7 +283,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             graph.Next.Next.Next = graph;
 
             var r = new PSUnknown(5, "preserved", "unknown", graph, null);
-            return new ValueTask<Preserved?>(r);
+            return new (r);
         }
 
         public ValueTask CheckPBSUnknownWithGraphAsync(Preserved? p, Current current)
@@ -316,7 +316,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<PNode?> ExchangePNodeAsync(PNode? pn, Current current) => MakeValueTask(pn);
+        public ValueTask<PNode?> ExchangePNodeAsync(PNode? pn, Current current) => new (pn);
 
         public ValueTask ThrowBaseAsBaseAsync(Current current)
         {
@@ -375,8 +375,5 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             f.H.F = f;
             return new ValueTask<Forward?>(f);
         }
-
-        // Type-inference helper method
-        private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
     }
 }

--- a/csharp/test/Ice/tagged/AllTests.cs
+++ b/csharp/test/Ice/tagged/AllTests.cs
@@ -1498,6 +1498,34 @@ namespace ZeroC.Ice.Test.Tagged
             }
 
             {
+                List<int>? p1 = null;
+                (List<int>? r1, List<int>? r2) = initial.OpIntList(p1);
+                TestHelper.Assert(r1 == null && r2 == null);
+
+                p1 = new List<int> { 7, 8, 13 };
+                (r1, r2) = initial.OpIntList(p1);
+                TestHelper.Assert(p1.SequenceEqual(r1!) && p1.SequenceEqual(r2!));
+            }
+
+            {
+                int[][]? p1 = null;
+                (int[][]? r1, int[][]? r2) = initial.OpIntSeqSeq(p1);
+                TestHelper.Assert(r1 == null && r2 == null);
+
+                p1 = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } };
+                (r1, r2) = initial.OpIntSeqSeq(p1);
+
+                TestHelper.Assert(r1 != null && r2 != null);
+                TestHelper.Assert(p1.Length == r1.Length);
+                TestHelper.Assert(p1.Length == r2.Length);
+                for (int i = 0; i < p1.Length; ++i)
+                {
+                    TestHelper.Assert(p1[i].SequenceEqual(r1[i]));
+                    TestHelper.Assert(p1[i].SequenceEqual(r2[i]));
+                }
+            }
+
+            {
                 Dictionary<int, int>? p1 = null;
                 (Dictionary<int, int>? r1, Dictionary<int, int>? r2) = initial.OpIntIntDict(p1);
                 TestHelper.Assert(r1 == null && r2 == null);

--- a/csharp/test/Ice/tagged/Test.ice
+++ b/csharp/test/Ice/tagged/Test.ice
@@ -53,6 +53,8 @@ sequence<MyEnum> MyEnumSeq;
 sequence<ushort> UShortSeq;
 sequence<varulong> VarULongSeq;
 
+sequence<IntSeq> IntSeqSeq;
+
 [cs:generic:List] sequence<byte> ByteList;
 [cs:generic:List] sequence<bool> BoolList;
 [cs:generic:List] sequence<short> ShortList;
@@ -93,7 +95,6 @@ class MultiTagged
     tag(15) StringIntDict? sid;
     tag(16) FixedStruct? fs;
     tag(17) VarStruct? vs;
-
     tag(18) ShortSeq? shs;
     tag(19) MyEnumSeq? es;
     tag(20) FixedStructSeq? fss;
@@ -242,6 +243,8 @@ interface Initial
     (tag(1) FixedStructList? r1, tag(2) FixedStructList? r2) opFixedStructList(tag(1) FixedStructList? p1);
 
     (tag(1) VarStructSeq? r1, tag(2) VarStructSeq? r2) opVarStructSeq(tag(1) VarStructSeq? p1);
+
+    (tag(1) IntSeqSeq? r1, tag(2) IntSeqSeq? r2) opIntSeqSeq(tag(1) IntSeqSeq? p1);
 
     (tag(1) IntIntDict? r1, tag(2) IntIntDict? r2) opIntIntDict(tag(1) IntIntDict? p1);
 

--- a/csharp/test/Ice/tagged/TestAMDI.cs
+++ b/csharp/test/Ice/tagged/TestAMDI.cs
@@ -14,7 +14,7 @@ namespace ZeroC.Ice.Test.Tagged
             return new ValueTask(Task.CompletedTask);
         }
 
-        public ValueTask<AnyClass?> PingPongAsync(AnyClass? obj, Current current) => MakeValueTask(obj);
+        public ValueTask<AnyClass?> PingPongAsync(AnyClass? obj, Current current) => new (obj);
 
         public ValueTask OpTaggedExceptionAsync(int? a, string? b, VarStruct? vs, Current c) =>
             throw new TaggedException(false, a, b, vs);
@@ -27,165 +27,166 @@ namespace ZeroC.Ice.Test.Tagged
             throw new RequiredException(false, a, b, vs, b ?? "test", vs ?? new VarStruct(""));
         }
 
-        public ValueTask<(byte?, byte?)> OpByteAsync(byte? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(byte?, byte?)> OpByteAsync(byte? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(bool?, bool?)> OpBoolAsync(bool? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(bool?, bool?)> OpBoolAsync(bool? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(short?, short?)> OpShortAsync(short? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(short?, short?)> OpShortAsync(short? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(int?, int?)> OpIntAsync(int? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(int?, int?)> OpIntAsync(int? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(long?, long?)> OpLongAsync(long? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(long?, long?)> OpLongAsync(long? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(float?, float?)> OpFloatAsync(float? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(float?, float?)> OpFloatAsync(float? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(double?, double?)> OpDoubleAsync(double? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(double?, double?)> OpDoubleAsync(double? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(string?, string?)> OpStringAsync(string? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(string?, string?)> OpStringAsync(string? p1, Current current) => new ((p1, p1));
 
-        public ValueTask<(MyEnum?, MyEnum?)> OpMyEnumAsync(MyEnum? p1, Current current) =>
-            MakeValueTask((p1, p1));
+        public ValueTask<(MyEnum?, MyEnum?)> OpMyEnumAsync(MyEnum? p1, Current current) => new ((p1, p1));
 
         public ValueTask<(SmallStruct?, SmallStruct?)> OpSmallStructAsync(SmallStruct? p1, Current current) =>
-            MakeValueTask((p1, p1));
+            new ((p1, p1));
 
         public ValueTask<(FixedStruct?, FixedStruct?)> OpFixedStructAsync(FixedStruct? p1, Current current) =>
-            MakeValueTask((p1, p1));
+            new ((p1, p1));
 
-        public ValueTask<(VarStruct?, VarStruct?)>
-        OpVarStructAsync(VarStruct? p1, Current current) => MakeValueTask((p1, p1));
+        public ValueTask<(VarStruct?, VarStruct?)> OpVarStructAsync(VarStruct? p1, Current current) =>
+            new ((p1, p1));
+
+        public ValueTask<(IEnumerable<IEnumerable<int>>?, IEnumerable<IEnumerable<int>>?)> OpIntSeqSeqAsync(
+            int[][]? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)> OpByteSeqAsync(byte[]? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
         public ValueTask<(IEnumerable<byte>?, IEnumerable<byte>?)> OpByteListAsync(List<byte>? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
 
         public ValueTask<(ReadOnlyMemory<bool>, ReadOnlyMemory<bool>)> OpBoolSeqAsync(bool[]? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
 
         public ValueTask<(IEnumerable<bool>?, IEnumerable<bool>?)> OpBoolListAsync(List<bool>? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
 
-        public ValueTask<(ReadOnlyMemory<short>, ReadOnlyMemory<short>)> OpShortSeqAsync(short[]? p1,
-            Current current) => ToReturnValue(p1);
+        public ValueTask<(ReadOnlyMemory<short>, ReadOnlyMemory<short>)> OpShortSeqAsync(
+            short[]? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IEnumerable<short>?, IEnumerable<short>?)> OpShortListAsync(List<short>? p1,
-            Current current) => ToReturnValue(p1);
+        public ValueTask<(IEnumerable<short>?, IEnumerable<short>?)> OpShortListAsync(
+            List<short>? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask<(ReadOnlyMemory<int>, ReadOnlyMemory<int>)> OpIntSeqAsync(int[]? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
         public ValueTask<(IEnumerable<int>?, IEnumerable<int>?)> OpIntListAsync(List<int>? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
 
         public ValueTask<(ReadOnlyMemory<long>, ReadOnlyMemory<long>)> OpLongSeqAsync(long[]? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
         public ValueTask<(IEnumerable<long>?, IEnumerable<long>?)> OpLongListAsync(List<long>? p1, Current current) =>
-            ToReturnValue(p1);
+            new ((p1, p1));
 
-        public ValueTask<(ReadOnlyMemory<float>, ReadOnlyMemory<float>)> OpFloatSeqAsync(float[]? p1, Current current) =>
-            ToReturnValue(p1);
-        public ValueTask<(IEnumerable<float>?, IEnumerable<float>?)> OpFloatListAsync(List<float>? p1, Current current) =>
-            ToReturnValue(p1);
+        public ValueTask<(ReadOnlyMemory<float>, ReadOnlyMemory<float>)> OpFloatSeqAsync(
+            float[]? p1,
+            Current current) => new ((p1, p1));
+        public ValueTask<(IEnumerable<float>?, IEnumerable<float>?)> OpFloatListAsync(
+            List<float>? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<double>)> OpDoubleSeqAsync(double[]? p1, Current current) =>
-            ToReturnValue(p1);
-        public ValueTask<(IEnumerable<double>?, IEnumerable<double>?)> OpDoubleListAsync(List<double>? p1, Current current) =>
-            ToReturnValue(p1);
+        public ValueTask<(ReadOnlyMemory<double>, ReadOnlyMemory<double>)> OpDoubleSeqAsync(
+            double[]? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> OpStringSeqAsync(string[]? p1, Current current) =>
-            ToReturnValue(p1);
-        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> OpStringListAsync(List<string>? p1, Current current) =>
-            ToReturnValue(p1);
+        public ValueTask<(IEnumerable<double>?, IEnumerable<double>?)> OpDoubleListAsync(
+            List<double>? p1,
+            Current current) => new ((p1, p1));
+
+        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> OpStringSeqAsync(
+            string[]? p1,
+            Current current) => new ((p1, p1));
+        public ValueTask<(IEnumerable<string>?, IEnumerable<string>?)> OpStringListAsync(
+            List<string>? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask<(IEnumerable<SmallStruct>?, IEnumerable<SmallStruct>?)> OpSmallStructSeqAsync(
-            SmallStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<SmallStruct>);
+            SmallStruct[]? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IEnumerable<SmallStruct>?, IEnumerable<SmallStruct>?)>
-        OpSmallStructListAsync(List<SmallStruct>? p1, Current current) => ToReturnValue(p1);
+        public ValueTask<(IEnumerable<SmallStruct>?, IEnumerable<SmallStruct>?)> OpSmallStructListAsync(
+            List<SmallStruct>? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask<(IEnumerable<FixedStruct>?, IEnumerable<FixedStruct>?)> OpFixedStructSeqAsync(
-            FixedStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<FixedStruct>);
+            FixedStruct[]? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IEnumerable<FixedStruct>?, IEnumerable<FixedStruct>?)>
-        OpFixedStructListAsync(LinkedList<FixedStruct>? p1, Current current) => ToReturnValue(p1);
+        public ValueTask<(IEnumerable<FixedStruct>?, IEnumerable<FixedStruct>?)> OpFixedStructListAsync(
+            LinkedList<FixedStruct>? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask<(IEnumerable<VarStruct>?, IEnumerable<VarStruct>?)> OpVarStructSeqAsync(
-            VarStruct[]? p1, Current current) => ToReturnValue(p1 as IEnumerable<VarStruct>);
+            VarStruct[]? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IReadOnlyDictionary<int, int>?, IReadOnlyDictionary<int, int>?)>
-        OpIntIntDictAsync(Dictionary<int, int>? p1, Current current) => ToReturnValue(p1);
+        public ValueTask<(IReadOnlyDictionary<int, int>?, IReadOnlyDictionary<int, int>?)> OpIntIntDictAsync(
+            Dictionary<int, int>? p1,
+            Current current) => new ((p1, p1));
 
-        public ValueTask<(IReadOnlyDictionary<string, int>?, IReadOnlyDictionary<string, int>?)>
-        OpStringIntDictAsync(Dictionary<string, int>? p1, Current current) => ToReturnValue(p1);
+        public ValueTask<(IReadOnlyDictionary<string, int>?, IReadOnlyDictionary<string, int>?)> OpStringIntDictAsync(
+            Dictionary<string, int>? p1,
+            Current current) => new ((p1, p1));
 
         public ValueTask OpClassAndUnknownTaggedAsync(A? p, Current current) => new ValueTask(Task.CompletedTask);
 
         public ValueTask OpVoidAsync(Current current) => new ValueTask(Task.CompletedTask);
 
-        public async ValueTask<IInitial.OpMStruct1MarshaledReturnValue>
-        OpMStruct1Async(Current current)
+        public async ValueTask<IInitial.OpMStruct1MarshaledReturnValue> OpMStruct1Async(Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMStruct1MarshaledReturnValue(new SmallStruct(), current);
         }
 
-        public async ValueTask<IInitial.OpMStruct2MarshaledReturnValue>
-        OpMStruct2Async(SmallStruct? p1, Current current)
+        public async ValueTask<IInitial.OpMStruct2MarshaledReturnValue> OpMStruct2Async(
+            SmallStruct? p1,
+            Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMStruct2MarshaledReturnValue(p1, p1, current);
         }
 
-        public async ValueTask<IInitial.OpMSeq1MarshaledReturnValue>
-        OpMSeq1Async(Current current)
+        public async ValueTask<IInitial.OpMSeq1MarshaledReturnValue> OpMSeq1Async(Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMSeq1MarshaledReturnValue(Array.Empty<string>(), current);
         }
 
-        public async ValueTask<IInitial.OpMSeq2MarshaledReturnValue>
-        OpMSeq2Async(string[]? p1, Current current)
+        public async ValueTask<IInitial.OpMSeq2MarshaledReturnValue> OpMSeq2Async(string[]? p1, Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMSeq2MarshaledReturnValue(p1, p1, current);
         }
 
-        public async ValueTask<IInitial.OpMDict1MarshaledReturnValue>
-        OpMDict1Async(Current current)
+        public async ValueTask<IInitial.OpMDict1MarshaledReturnValue> OpMDict1Async(Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMDict1MarshaledReturnValue(new Dictionary<string, int>(), current);
         }
 
-        public async ValueTask<IInitial.OpMDict2MarshaledReturnValue>
-        OpMDict2Async(Dictionary<string, int>? p1, Current current)
+        public async ValueTask<IInitial.OpMDict2MarshaledReturnValue> OpMDict2Async(
+            Dictionary<string, int>? p1,
+            Current current)
         {
             await Task.Delay(0);
             return new IInitial.OpMDict2MarshaledReturnValue(p1, p1, current);
         }
 
-        public ValueTask<bool>
-        SupportsRequiredParamsAsync(Current current) => MakeValueTask(false);
+        public ValueTask<bool> SupportsRequiredParamsAsync(Current current) => new (false);
 
-        public ValueTask<bool>
-        SupportsJavaSerializableAsync(Current current) => MakeValueTask(false);
+        public ValueTask<bool> SupportsJavaSerializableAsync(Current current) => new (false);
 
-        public ValueTask<bool>
-        SupportsCppStringViewAsync(Current current) => MakeValueTask(false);
+        public ValueTask<bool> SupportsCppStringViewAsync(Current current) => new (false);
 
-        public ValueTask<bool>
-        SupportsNullTaggedAsync(Current current) => MakeValueTask(true);
-
-        private static ValueTask<T> MakeValueTask<T>(T result) => new ValueTask<T>(result);
-
-        private static ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)> ToReturnValue<T>(T[]? input)
-            where T : struct => new ValueTask<(ReadOnlyMemory<T>, ReadOnlyMemory<T>)>((input, input));
-
-        private static ValueTask<(IEnumerable<T>?, IEnumerable<T>?)> ToReturnValue<T>(IEnumerable<T>? input) =>
-            new ValueTask<(IEnumerable<T>?, IEnumerable<T>?)>((input, input));
-
-        private static ValueTask<(IReadOnlyDictionary<TKey, TValue>?, IReadOnlyDictionary<TKey, TValue>?)>
-        ToReturnValue<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? input) where TKey : notnull =>
-            new ValueTask<(IReadOnlyDictionary<TKey, TValue>?, IReadOnlyDictionary<TKey, TValue>?)>((input, input));
+        public ValueTask<bool> SupportsNullTaggedAsync(Current current) => new (true);
     }
 }

--- a/csharp/test/Ice/tagged/TestI.cs
+++ b/csharp/test/Ice/tagged/TestI.cs
@@ -84,6 +84,10 @@ namespace ZeroC.Ice.Test.Tagged
 
         public (IEnumerable<VarStruct>?, IEnumerable<VarStruct>?) OpVarStructSeq(VarStruct[]? p1, Current current) => (p1, p1);
 
+        public (IEnumerable<IEnumerable<int>>?, IEnumerable<IEnumerable<int>>?) OpIntSeqSeq(
+            int[][]? p1,
+            Current current) => (p1, p1);
+
         public (IReadOnlyDictionary<int, int>?, IReadOnlyDictionary<int, int>?)
         OpIntIntDict(Dictionary<int, int>? p1, Current current) => (p1, p1);
 

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -17,13 +17,11 @@
 [cs:namespace:ZeroC]
 module Ice
 {
-    /// The identity of an Ice object. In a proxy, an empty {@link Identity#name} denotes a nil
-    /// proxy. An identity with an empty {@link Identity#name} and a non-empty {@link Identity#category}
-    /// is illegal. You cannot add a servant with an empty name to the Active Servant Map.
+    /// The identity of an Ice object.
     [cs:readonly]
     struct Identity
     {
-        /// The name of the Ice object.
+        /// The name of the Ice object. An empty name is not a valid name.
         string name;
 
         /// The Ice object category.

--- a/slice/Ice/RequestEncoding.ice
+++ b/slice/Ice/RequestEncoding.ice
@@ -72,7 +72,7 @@ module Ice
         string? facet = "";      // null equivalent to empty string
         StringSeq? location;     // null equivalent to empty sequence
         string operation;
-        bool \idempotent;
+        bool? \idempotent;       // null equivalent to false
         Priority? priority;      // null equivalent to 0
     }
 #endif

--- a/slice/Ice/RequestEncoding.ice
+++ b/slice/Ice/RequestEncoding.ice
@@ -52,9 +52,21 @@ module Ice
     {
     }
 
-    /// The header for ice2 requests. All the data members are encoded using the 2.0 encoding.
+    // A request header consists of two parts: a prologue which contains the frame type and frame size (and occasionally
+    // more) and a body which contains the target's identity, operation name and more.
+
     [cs:readonly]
-    struct Ice2RequestHeader
+    struct Ice1RequestHeaderBody
+    {
+        Identity identity;
+        StringSeq facetPath;
+        string operation;
+        OperationMode operationMode;
+        Context context;
+    }
+
+    [cs:readonly]
+    struct Ice2RequestHeaderBody
     {
         Identity identity;
         string? facet = "";      // null equivalent to empty string


### PR DESCRIPTION
This PR updates:
- the C# mapping for outgoing sequence parameters.
Before: `sequence<sequence<T>>` was mapped to `IEnumerable<T[]>` or `IEnumerable<Custom<T>>`.
With this PR, it's mapped to `IEnumerable<IEnumerable<T>>`. Same for `sequence<dictionary<K, V>>` that are now mapped to `IEnumerable<IReadOnlyDictionary<K, V>>`.

- the C# mapping for struct parameters: they are now mapped just like other value types (int, byte, enums) and are no longer passed with `in`. This simplifies OutputStream quite a bit. args tuples and return value tuples still use `in`.

It also refactors the proxy and request marshaling, and simplifies "amd" servants in tests to take advantage of new C#9 target-typed new expressions when returning ValueTask<(...)>.  

