### PR TITLE
Disallow IPv4 any addres & IPv6 any address in proxy endpoints

### DIFF
--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -214,6 +214,17 @@ namespace ZeroC.Ice
             : base(communicator, protocol)
         {
             Debug.Assert(protocol == Protocol.Ice2);
+            if (!oaEndpoint && IPAddress.TryParse(host, out IPAddress? address))
+            {
+                if (address.Equals(IPAddress.Any))
+                {
+                    throw new ArgumentException("Any IPv4 address not allowed in proxy endpoint", nameof(host));
+                }
+                else if (address.Equals(IPAddress.IPv6Any))
+                {
+                    throw new ArgumentException("Any IPv6 address not allowed in proxy endpoint", nameof(host));
+                }
+            }
             Host = host;
             Port = port;
             if (!oaEndpoint) // parsing a URI that represents a proxy
@@ -241,6 +252,18 @@ namespace ZeroC.Ice
             if (Host.Length == 0)
             {
                 throw new InvalidDataException("endpoint host is empty");
+            }
+
+            if (IPAddress.TryParse(Host, out IPAddress? address))
+            {
+                if (address.Equals(IPAddress.Any))
+                {
+                    throw new InvalidDataException("Any IPv4 address not allowed in proxy endpoint");
+                }
+                else if (address.Equals(IPAddress.IPv6Any))
+                {
+                    throw new ArgumentException("Any IPv6 address not allowed in proxy endpoint");
+                }
             }
 
             if (protocol == Protocol.Ice1)
@@ -277,6 +300,19 @@ namespace ZeroC.Ice
                     Host = oaEndpoint ? "::0" :
                         throw new FormatException($"`-h *' not valid for proxy endpoint `{endpointString}'");
                 }
+
+                if (!oaEndpoint && IPAddress.TryParse(Host, out IPAddress? address))
+                {
+                    if (address.Equals(IPAddress.Any))
+                    {
+                        throw new FormatException("Any IPv4 address not allowed in proxy endpoint");
+                    }
+                    else if (address.Equals(IPAddress.IPv6Any))
+                    {
+                        throw new FormatException("Any IPv6 address not allowed in proxy endpoint");
+                    }
+                }
+
                 options.Remove("-h");
             }
             else

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -216,14 +216,7 @@ namespace ZeroC.Ice
             Debug.Assert(protocol == Protocol.Ice2);
             if (!oaEndpoint && IPAddress.TryParse(host, out IPAddress? address))
             {
-                if (address.Equals(IPAddress.Any))
-                {
-                    throw new ArgumentException("Any IPv4 address not allowed in proxy endpoint", nameof(host));
-                }
-                else if (address.Equals(IPAddress.IPv6Any))
-                {
-                    throw new ArgumentException("Any IPv6 address not allowed in proxy endpoint", nameof(host));
-                }
+                throw new ArgumentException("0.0.0.0 or [::0] is not a valid host in a proxy endpoint", nameof(host));
             }
             Host = host;
             Port = port;
@@ -252,18 +245,6 @@ namespace ZeroC.Ice
             if (Host.Length == 0)
             {
                 throw new InvalidDataException("endpoint host is empty");
-            }
-
-            if (IPAddress.TryParse(Host, out IPAddress? address))
-            {
-                if (address.Equals(IPAddress.Any))
-                {
-                    throw new InvalidDataException("Any IPv4 address not allowed in proxy endpoint");
-                }
-                else if (address.Equals(IPAddress.IPv6Any))
-                {
-                    throw new ArgumentException("Any IPv6 address not allowed in proxy endpoint");
-                }
             }
 
             if (protocol == Protocol.Ice1)
@@ -303,14 +284,7 @@ namespace ZeroC.Ice
 
                 if (!oaEndpoint && IPAddress.TryParse(Host, out IPAddress? address))
                 {
-                    if (address.Equals(IPAddress.Any))
-                    {
-                        throw new FormatException("Any IPv4 address not allowed in proxy endpoint");
-                    }
-                    else if (address.Equals(IPAddress.IPv6Any))
-                    {
-                        throw new FormatException("Any IPv6 address not allowed in proxy endpoint");
-                    }
+                    throw new FormatException("0.0.0.0 or [::0] is not a valid host in a proxy endpoint");
                 }
 
                 options.Remove("-h");

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -140,6 +140,10 @@ namespace ZeroC.Ice.Test.Proxy
                 "id:opaque -t -1 -v abcd", // -t must be >= 0
                 "id:opaque -t 99 -v x?c", // invalid char in v
                 "id:opaque -t 99 -v xc", // invalid length for base64 input
+                "ice+tcp://0.0.0.0/identity#facet", // Invalid Any IPv4 address in proxy endpoint
+                "ice+tcp://[::0]/identity#facet", // Invalid Any IPv6 address in proxy endpoint
+                "identity:tcp -h 0.0.0.0", // Invalid Any IPv4 address in proxy endpoint
+                "identity:tcp -h [::0]", // Invalid Any IPv6 address in proxy endpoint
             };
 
             foreach (string str in badProxyArray)


### PR DESCRIPTION
This PR updates IPEndpoint to disallow using IPv4 any address and IPv6 any address in the proxy endpoints