### PR TITLE
Enable SocketOptionName.ExclusiveAddressUse

### DIFF
--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -29,7 +29,7 @@ namespace ZeroC.Ice
                 {
                     socket.SetSocketOption(SocketOptionLevel.IPv6,
                                            SocketOptionName.IPv6Only,
-                                           endpoint.IsIPv6Only ? 1 : 0);
+                                           endpoint.IsIPv6Only ? true : false);
                 }
                 catch (SocketException ex)
                 {
@@ -37,6 +37,7 @@ namespace ZeroC.Ice
                     throw new TransportException(ex);
                 }
             }
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, true);
             return socket;
         }
 

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -38,7 +38,8 @@ namespace ZeroC.Ice
             {
                 if (Network.IsMulticast(_addr))
                 {
-                    Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+                    Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, false);
+                    Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
                     MulticastAddress = _addr;
                     if (OperatingSystem.IsWindows())


### PR DESCRIPTION
This PR enables the `ExclusiveAddressUse` socket option to ensure that bound ports cannot and be hijacked and that wildcard addresses bind to all interfaces. This socket option only affects Windows.

For more information see:
- https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#enhanced-socket-security
- https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.exclusiveaddressuse?view=net-5.0