### PR TITLE
Replace Async Suffix with Prefix in the Generated C# Servant Skeletons

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -71,7 +71,7 @@ Slice::interfaceName(const InterfaceDeclPtr& decl, bool isAsync)
     {
         if (isAsync)
         {
-            // We remove the 'I' prefix, so we can add a fully 'IAsync' prefix instead.
+            // We remove the 'I' prefix, and replace it with the full 'IAsync' prefix.
             return "IAsync" + name.substr(1);
         }
         return name;

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -67,7 +67,7 @@ Slice::interfaceName(const InterfaceDeclPtr& decl, bool isAsync)
     string name = normalizeCase(decl) ? pascalCase(decl->name()) : decl->name();
 
     // Check if the interface already follows the 'I' prefix convention.
-    if (name.at(0) == 'I' && isupper(name.at(1)))
+    if (name.size() > 2 && name.at(0) == 'I' && isupper(name.at(1)))
     {
         if (isAsync)
         {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -62,16 +62,27 @@ Slice::fieldName(const MemberPtr& member)
 }
 
 std::string
-Slice::interfaceName(const InterfaceDeclPtr& decl)
+Slice::interfaceName(const InterfaceDeclPtr& decl, bool isAsync)
 {
     string name = normalizeCase(decl) ? pascalCase(decl->name()) : decl->name();
-    return name.find("II") == 0 ? name : "I" + name;
+
+    // Check if the interface already follows the 'I' prefix convention.
+    if (name.at(0) == 'I' && isupper(name.at(1)))
+    {
+        if (isAsync)
+        {
+            // We remove the 'I' prefix, so we can add a fully 'IAsync' prefix instead.
+            return "IAsync" + name.substr(1);
+        }
+        return name;
+    }
+    return string("I") + (isAsync ? "Async" : "") + name;
 }
 
 std::string
-Slice::interfaceName(const InterfaceDefPtr& def)
+Slice::interfaceName(const InterfaceDefPtr& def, bool isAsync)
 {
-    return interfaceName(def->declaration());
+    return interfaceName(def->declaration(), isAsync);
 }
 
 std::string

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -35,8 +35,8 @@ std::string paramName(const MemberPtr& param, const std::string& prefix = "");
 std::string paramTypeStr(const MemberPtr& param, bool readOnly = false);
 
 std::string fieldName(const MemberPtr&);
-std::string interfaceName(const InterfaceDeclPtr&);
-std::string interfaceName(const InterfaceDefPtr&);
+std::string interfaceName(const InterfaceDeclPtr&, bool isAsync = false);
+std::string interfaceName(const InterfaceDefPtr&, bool isAsync = false);
 
 std::string helperName(const TypePtr&, const std::string&);
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2520,7 +2520,7 @@ bool
 Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
-    string name = interfaceName(p) + (_generateAllAsync ? "Async" : "");
+    string name = interfaceName(p, _generateAllAsync);
     string ns = getNamespace(p);
 
     _out << sp;
@@ -2537,7 +2537,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for(InterfaceList::const_iterator q = bases.begin(); q != bases.end();)
         {
-            _out << getUnqualified(getNamespace(*q) + "." + (interfaceName(*q) + (_generateAllAsync ? "Async" : "")), ns);
+            _out << getUnqualified(getNamespace(*q) + "." + interfaceName(*q, _generateAllAsync), ns);
             if(++q != bases.end())
             {
                 _out << ", ";

--- a/csharp/test/Ice/dictMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/dictMapping/MyClassAMDI.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.DictMapping
 {
-    public sealed class MyClassAsync : IMyClassAsync
+    public sealed class AsyncMyClass : IAsyncMyClass
     {
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {

--- a/csharp/test/Ice/dictMapping/ServerAMD.cs
+++ b/csharp/test/Ice/dictMapping/ServerAMD.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.DictMapping
             await using Communicator communicator = Initialize(ref args);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("test", new MyClassAsync());
+            adapter.Add("test", new AsyncMyClass());
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Exceptions
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");
             ObjectAdapter adapter3 = communicator.CreateObjectAdapter("TestAdapter3");
-            var obj = new ThrowerAsync();
+            var obj = new AsyncThrower();
             adapter.Add("thrower", obj);
             adapter2.Add("thrower", obj);
             adapter3.Add("thrower", obj);

--- a/csharp/test/Ice/exceptions/ThrowerAMDI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerAMDI.cs
@@ -9,7 +9,7 @@ namespace ZeroC.Ice.Test.Exceptions
 {
     public class AsyncThrower : IAsyncThrower
     {
-        public ThrowerAsync()
+        public AsyncThrower()
         {
         }
 

--- a/csharp/test/Ice/exceptions/ThrowerAMDI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerAMDI.cs
@@ -7,7 +7,7 @@ using Test;
 
 namespace ZeroC.Ice.Test.Exceptions
 {
-    public class ThrowerAsync : IThrowerAsync
+    public class AsyncThrower : IAsyncThrower
     {
         public ThrowerAsync()
         {

--- a/csharp/test/Ice/inheritance/AllTests.cs
+++ b/csharp/test/Ice/inheritance/AllTests.cs
@@ -15,10 +15,10 @@ namespace ZeroC.Ice.Test.Inheritance
 
             output.Write("getting proxies for interface hierarchy... ");
             output.Flush();
-            MA.IIAPrx? ia = initial.Iaop();
-            MB.IIB1Prx? ib1 = initial.Ib1op();
-            MB.IIB2Prx? ib2 = initial.Ib2op();
-            MA.IICPrx? ic = initial.Icop();
+            MA.IAPrx? ia = initial.Iaop();
+            MB.IB1Prx? ib1 = initial.Ib1op();
+            MB.IB2Prx? ib2 = initial.Ib2op();
+            MA.ICPrx? ic = initial.Icop();
             TestHelper.Assert(ia != null);
             TestHelper.Assert(ib1 != null);
             TestHelper.Assert(ib2 != null);
@@ -32,10 +32,10 @@ namespace ZeroC.Ice.Test.Inheritance
 
             output.Write("invoking proxy operations on interface hierarchy... ");
             output.Flush();
-            MA.IIAPrx? iao;
-            MB.IIB1Prx? ib1o;
-            MB.IIB2Prx? ib2o;
-            MA.IICPrx? ico;
+            MA.IAPrx? iao;
+            MB.IB1Prx? ib1o;
+            MB.IB2Prx? ib2o;
+            MA.ICPrx? ico;
 
             iao = ia.Iaop(ia);
             TestHelper.Assert(iao!.Equals(ia));

--- a/csharp/test/Ice/inheritance/IAI.cs
+++ b/csharp/test/Ice/inheritance/IAI.cs
@@ -4,8 +4,8 @@ using System.Threading;
 
 namespace ZeroC.Ice.Test.Inheritance
 {
-    public sealed class IA : MA.IIA
+    public sealed class A : MA.IA
     {
-        public MA.IIAPrx? Iaop(MA.IIAPrx? p, Current current, CancellationToken cancel) => p;
+        public MA.IAPrx? Iaop(MA.IAPrx? p, Current current, CancellationToken cancel) => p;
     }
 }

--- a/csharp/test/Ice/inheritance/IB1I.cs
+++ b/csharp/test/Ice/inheritance/IB1I.cs
@@ -4,10 +4,10 @@ using System.Threading;
 
 namespace ZeroC.Ice.Test.Inheritance
 {
-    public sealed class IB1 : MB.IIB1
+    public sealed class B1 : MB.IB1
     {
-        public MA.IIAPrx? Iaop(MA.IIAPrx? p, Current current, CancellationToken cancel) => p;
+        public MA.IAPrx? Iaop(MA.IAPrx? p, Current current, CancellationToken cancel) => p;
 
-        public MB.IIB1Prx? Ib1op(MB.IIB1Prx? p, Current current, CancellationToken cancel) => p;
+        public MB.IB1Prx? Ib1op(MB.IB1Prx? p, Current current, CancellationToken cancel) => p;
     }
 }

--- a/csharp/test/Ice/inheritance/IB2I.cs
+++ b/csharp/test/Ice/inheritance/IB2I.cs
@@ -4,10 +4,10 @@ using System.Threading;
 
 namespace ZeroC.Ice.Test.Inheritance
 {
-    public sealed class IB2 : MB.IIB2
+    public sealed class B2 : MB.IB2
     {
-        public MA.IIAPrx? Iaop(MA.IIAPrx? p, Current current, CancellationToken cancel) => p;
+        public MA.IAPrx? Iaop(MA.IAPrx? p, Current current, CancellationToken cancel) => p;
 
-        public MB.IIB2Prx? Ib2op(MB.IIB2Prx? p, Current current, CancellationToken cancel) => p;
+        public MB.IB2Prx? Ib2op(MB.IB2Prx? p, Current current, CancellationToken cancel) => p;
     }
 }

--- a/csharp/test/Ice/inheritance/ICI.cs
+++ b/csharp/test/Ice/inheritance/ICI.cs
@@ -4,14 +4,14 @@ using System.Threading;
 
 namespace ZeroC.Ice.Test.Inheritance
 {
-    public sealed class IC : MA.IIC
+    public sealed class C : MA.IC
     {
-        public MA.IIAPrx? Iaop(MA.IIAPrx? p, Current current, CancellationToken cancel) => p;
+        public MA.IAPrx? Iaop(MA.IAPrx? p, Current current, CancellationToken cancel) => p;
 
-        public MA.IICPrx? Icop(MA.IICPrx? p, Current current, CancellationToken cancel) => p;
+        public MA.ICPrx? Icop(MA.ICPrx? p, Current current, CancellationToken cancel) => p;
 
-        public MB.IIB1Prx? Ib1op(MB.IIB1Prx? p, Current current, CancellationToken cancel) => p;
+        public MB.IB1Prx? Ib1op(MB.IB1Prx? p, Current current, CancellationToken cancel) => p;
 
-        public MB.IIB2Prx? Ib2op(MB.IIB2Prx? p, Current current, CancellationToken cancel) => p;
+        public MB.IB2Prx? Ib2op(MB.IB2Prx? p, Current current, CancellationToken cancel) => p;
     }
 }

--- a/csharp/test/Ice/inheritance/InitialI.cs
+++ b/csharp/test/Ice/inheritance/InitialI.cs
@@ -10,25 +10,25 @@ namespace ZeroC.Ice.Test.Inheritance
     {
         public InitialI(ObjectAdapter adapter)
         {
-            _ia = adapter.AddWithUUID(new IA(), IIAPrx.Factory);
-            _ib1 = adapter.AddWithUUID(new IB1(), IIB1Prx.Factory);
-            _ib2 = adapter.AddWithUUID(new IB2(), IIB2Prx.Factory);
-            _ic = adapter.AddWithUUID(new IC(), IICPrx.Factory);
+            _ia = adapter.AddWithUUID(new A(), IAPrx.Factory);
+            _ib1 = adapter.AddWithUUID(new B1(), IB1Prx.Factory);
+            _ib2 = adapter.AddWithUUID(new B2(), IB2Prx.Factory);
+            _ic = adapter.AddWithUUID(new C(), ICPrx.Factory);
         }
 
-        public IIAPrx Iaop(Current current, CancellationToken cancel) => _ia;
-        public IIB1Prx Ib1op(Current current, CancellationToken cancel) => _ib1;
+        public IAPrx Iaop(Current current, CancellationToken cancel) => _ia;
+        public IB1Prx Ib1op(Current current, CancellationToken cancel) => _ib1;
 
-        public IIB2Prx Ib2op(Current current, CancellationToken cancel) => _ib2;
+        public IB2Prx Ib2op(Current current, CancellationToken cancel) => _ib2;
 
-        public IICPrx Icop(Current current, CancellationToken cancel) => _ic;
+        public ICPrx Icop(Current current, CancellationToken cancel) => _ic;
 
         public void Shutdown(Current current, CancellationToken cancel) =>
             current.Adapter.Communicator.ShutdownAsync();
 
-        private readonly IIAPrx _ia;
-        private readonly IIB1Prx _ib1;
-        private readonly IIB2Prx _ib2;
-        private readonly IICPrx _ic;
+        private readonly IAPrx _ia;
+        private readonly IB1Prx _ib1;
+        private readonly IB2Prx _ib2;
+        private readonly ICPrx _ic;
     }
 }

--- a/csharp/test/Ice/interceptor/ServerAMD.cs
+++ b/csharp/test/Ice/interceptor/ServerAMD.cs
@@ -26,7 +26,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 });
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("test", new MyObjectAsync());
+            adapter.Add("test", new AsyncMyObject());
             await DispatchInterceptors.ActivateAsync(adapter);
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/interceptor/TestAMDI.cs
+++ b/csharp/test/Ice/interceptor/TestAMDI.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Interceptor
 {
-    public sealed class MyObjectAsync : IMyObjectAsync
+    public sealed class AsyncMyObject : IAsyncMyObject
     {
         public ValueTask<int> AddAsync(int x, int y, Current current, CancellationToken cancel) =>
             new ValueTask<int>(x + y);

--- a/csharp/test/Ice/metrics/MetricsAMDI.cs
+++ b/csharp/test/Ice/metrics/MetricsAMDI.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Metrics
 {
-    public sealed class MetricsAsync : IMetricsAsync
+    public sealed class AsyncMetrics : IAsyncMetrics
     {
         public ValueTask OpAsync(Current current, CancellationToken cancel) => default;
 

--- a/csharp/test/Ice/metrics/ServerAMD.cs
+++ b/csharp/test/Ice/metrics/ServerAMD.cs
@@ -23,13 +23,13 @@ namespace ZeroC.Ice.Test.Metrics
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("metrics", new MetricsAsync());
+            adapter.Add("metrics", new AsyncMetrics());
             await adapter.ActivateAsync();
 
             var schedulerPair = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default);
             ObjectAdapter adapter2 = communicator.CreateObjectAdapterWithEndpoints("TestAdapterExclusiveTS", GetTestEndpoint(2),
                 taskScheduler: schedulerPair.ExclusiveScheduler);
-            adapter2.Add("metrics", new MetricsAsync());
+            adapter2.Add("metrics", new AsyncMetrics());
             await adapter2.ActivateAsync();
 
             communicator.SetProperty("ControllerAdapter.Endpoints", GetTestEndpoint(1));

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -9,7 +9,7 @@ using Test;
 
 namespace ZeroC.Ice.Test.Operations
 {
-    public sealed class MyDerivedClassAsync : IMyDerivedClassAsync
+    public sealed class AsyncMyDerivedClass : IAsyncMyDerivedClass
     {
         private readonly object _mutex = new object();
         private int _opByteSOnewayCallCount;

--- a/csharp/test/Ice/operations/ServerAMD.cs
+++ b/csharp/test/Ice/operations/ServerAMD.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Operations
             await using var communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("test", new MyDerivedClassAsync());
+            adapter.Add("test", new AsyncMyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Proxy
 {
-    public sealed class MyDerivedClassAsync : IMyDerivedClassAsync
+    public sealed class AsyncMyDerivedClass : IAsyncMyDerivedClass
     {
         public ValueTask<IObjectPrx?> EchoAsync(IObjectPrx? obj, Current c, CancellationToken cancel) =>
             new ValueTask<IObjectPrx?>(obj);

--- a/csharp/test/Ice/proxy/ServerAMD.cs
+++ b/csharp/test/Ice/proxy/ServerAMD.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Proxy
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("test", new MyDerivedClassAsync());
+            adapter.Add("test", new AsyncMyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/seqMapping/MyClassAMDI.cs
+++ b/csharp/test/Ice/seqMapping/MyClassAMDI.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.SeqMapping
 {
-    public sealed class MyClassAsync : IMyClassAsync
+    public sealed class AsyncMyClass : IAsyncMyClass
     {
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {

--- a/csharp/test/Ice/seqMapping/ServerAMD.cs
+++ b/csharp/test/Ice/seqMapping/ServerAMD.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.SeqMapping
             await using Communicator communicator = Initialize(ref args);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("test", new MyClassAsync());
+            adapter.Add("test", new AsyncMyClass());
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("Test", new TestIntfAsync());
+            adapter.Add("Test", new AsyncTestIntf());
             await adapter.ActivateAsync();
             await communicator.WaitForShutdownAsync();
         }

--- a/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/exceptions/TestAMDI.cs
@@ -6,7 +6,7 @@ using Test;
 
 namespace ZeroC.Ice.Test.Slicing.Exceptions
 {
-    public sealed class TestIntfAsync : ITestIntfAsync
+    public sealed class AsyncTestIntf : IAsyncTestIntf
     {
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {

--- a/csharp/test/Ice/slicing/objects/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/objects/ServerAMD.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("Test", new TestIntfAsync());
+            adapter.Add("Test", new AsyncTestIntf());
             await adapter.ActivateAsync();
             await communicator.WaitForShutdownAsync();
         }

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -8,7 +8,7 @@ using Test;
 
 namespace ZeroC.Ice.Test.Slicing.Objects
 {
-    public sealed class TestIntfAsync : ITestIntfAsync
+    public sealed class AsyncTestIntf : IAsyncTestIntf
     {
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {

--- a/csharp/test/Ice/tagged/ServerAMD.cs
+++ b/csharp/test/Ice/tagged/ServerAMD.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Tagged
             await using Communicator communicator = Initialize(ref args);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            adapter.Add("initial", new InitialAsync());
+            adapter.Add("initial", new AsyncInitial());
             await adapter.ActivateAsync();
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/tagged/TestAMDI.cs
+++ b/csharp/test/Ice/tagged/TestAMDI.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Tagged
 {
-    public class InitialAsync : IInitialAsync
+    public class AsyncInitial : IAsyncInitial
     {
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {


### PR DESCRIPTION
This PR fixes #1093. Previously in C# we generated the async servant skeletons with names like `IFooAsync`; this PR reworks this to generate the names as `IAsyncFoo` instead, to better follow the C# naming conventions.
It also fixes the names of all the corresponding servant implementations in the tests.

One caveat of this PR is it changes our check for determining if a Slice interface already conforms to the `I` prefix convention. Previously, if an interface's name started with `II` we would assume it already abides by the convention. Now we check if it starts with `I[A-Z]`, so `I` followed by any capital letter. This change required alterations to the Ice/inheritance test.