### PR TITLE
Remove Ice.PreferIPv6Address and update discovery plugins

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -382,6 +382,7 @@ generated from the section label.
         <property name="Package.[any]" />
         <property name="Plugin.[any]" />
         <property name="PluginLoadOrder" />
+        <!-- TODO: remove PreferIPv6Address -->
         <property name="PreferIPv6Address" />
         <property name="PreloadAssemblies" />
         <property name="PrintAdapterReady" />
@@ -444,6 +445,7 @@ generated from the section label.
         <property name="Timeout"/>
         <property name="RetryCount"/>
         <property name="LatencyMultiplier"/>
+        <!-- TODO: Remove Address, Port, and Interface -->
         <property name="Address"/>
         <property name="Port"/>
         <property name="Interface"/>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -162,7 +162,6 @@ namespace ZeroC.Ice
         internal IReadOnlyList<InvocationInterceptor> InvocationInterceptors => _invocationInterceptors;
         internal bool IsDisposed => _disposeTask != null;
         internal INetworkProxy? NetworkProxy { get; }
-        internal bool PreferIPv6 { get; }
 
         /// <summary>Gets the maximum number of invocation attempts made to send a request including the original
         /// invocation. It must be a number greater than 0.</summary>
@@ -524,8 +523,6 @@ namespace ZeroC.Ice
                 ToStringMode = GetPropertyAsEnum<ToStringMode>("Ice.ToStringMode") ?? default;
 
                 _backgroundLocatorCacheUpdates = GetPropertyAsBool("Ice.BackgroundLocatorCacheUpdates") ?? false;
-
-                PreferIPv6 = GetPropertyAsBool("Ice.PreferIPv6Address") ?? false;
 
                 NetworkProxy = CreateNetworkProxy(Network.EnableBoth);
 

--- a/csharp/src/Ice/INetworkProxy.cs
+++ b/csharp/src/Ice/INetworkProxy.cs
@@ -87,7 +87,6 @@ namespace ZeroC.Ice
                                                                  _port,
                                                                  ipVersion,
                                                                  EndpointSelectionType.Random,
-                                                                 false,
                                                                  cancel).ConfigureAwait(false);
             return new SOCKSNetworkProxy(addresses.First());
         }
@@ -165,7 +164,6 @@ namespace ZeroC.Ice
                                                                  _port,
                                                                  ipVersion,
                                                                  EndpointSelectionType.Random,
-                                                                 false,
                                                                  cancel).ConfigureAwait(false);
             return new HTTPNetworkProxy(addresses.First(), ipVersion);
         }

--- a/csharp/src/Ice/IPEndpoint.cs
+++ b/csharp/src/Ice/IPEndpoint.cs
@@ -115,7 +115,6 @@ namespace ZeroC.Ice
                                                                      Port,
                                                                      ipVersion,
                                                                      endptSelection,
-                                                                     Communicator.PreferIPv6,
                                                                      cancel).ConfigureAwait(false);
                 return addrs.Select(item => CreateConnector(item, networkProxy));
             }
@@ -141,8 +140,7 @@ namespace ZeroC.Ice
             IEnumerable<IPEndPoint> addresses = Network.GetAddresses(Host,
                                                                      Port,
                                                                      Network.EnableBoth,
-                                                                     EndpointSelectionType.Ordered,
-                                                                     Communicator.PreferIPv6);
+                                                                     EndpointSelectionType.Ordered);
 
             if (addresses.Count() == 1)
             {

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -52,12 +52,8 @@ namespace ZeroC.IceDiscovery
                                           $"{defaultIPv4Endpoint}:{defaultIPv6Endpoint}");
             }
 
-            string lookupEndpoints;
-            if (_communicator.GetProperty("IceDiscovery.Lookup") is string prop)
-            {
-                lookupEndpoints = prop;
-            }
-            else
+            string? lookupEndpoints = _communicator.GetProperty("IceDiscovery.Lookup");
+            if (lookupEndpoints == null)
             {
                 List<string> endpoints = new ();
                 List<string> ipv4Interfaces = Network.GetInterfacesForMulticast("0.0.0.0", Network.EnableIPv4);

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -384,12 +384,8 @@ namespace ZeroC.IceLocatorDiscovery
             const string defaultIPv4Endpoint = "udp -h 239.255.0.1 -p 4061";
             const string defaultIPv6Endpoint = "udp -h \"ff15::1\" -p 4061";
 
-            string lookupEndpoints;
-            if (_communicator.GetProperty($"{_name}.Lookup") is string prop)
-            {
-                lookupEndpoints = prop;
-            }
-            else
+            string? lookupEndpoints = _communicator.GetProperty($"{_name}.Lookup");
+            if (lookupEndpoints == null)
             {
 
                 List<string> endpoints = new ();

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -317,13 +317,11 @@ namespace ZeroC.Ice
                 {
                     goto repeatGetHostByName;
                 }
-                // TODO: is there a better host to use?
-                throw new DNSException("0.0.0.0", ex);
+                throw new TransportException("error retrieving local network interface IP addresses", ex);
             }
             catch (Exception ex)
             {
-                // TODO: is there a better host to use?
-                throw new DNSException("0.0.0.0", ex);
+                throw new TransportException("error retrieving local network interface IP addresses", ex);
             }
 
             return addresses.ToArray();

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -51,8 +51,7 @@ namespace ZeroC.Ice
 
             _addr = Network.GetAddressForServerEndpoint(endpoint.Host,
                                                         endpoint.Port,
-                                                        Network.EnableBoth,
-                                                        endpoint.Communicator.PreferIPv6);
+                                                        Network.EnableBoth);
 
             _socket = Network.CreateServerSocket(endpoint, _addr.AddressFamily);
 

--- a/csharp/src/Ice/UdpConnector.cs
+++ b/csharp/src/Ice/UdpConnector.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice
 
             if (obj is UdpConnector udpConnector)
             {
-                if (!_endpoint.MulticastInterface.Equals(udpConnector._endpoint.MulticastInterface))
+                if (_endpoint.MulticastInterface != udpConnector._endpoint.MulticastInterface)
                 {
                     return false;
                 }

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -201,7 +201,7 @@ namespace ZeroC.Ice
             {
                 MulticastInterface = argument ?? throw new FormatException(
                     $"no argument provided for --interface option in endpoint `{endpointString}'");
-                // TODO: should we do anything for ::0 and 0.0.0.0?
+
                 if (MulticastInterface == "*")
                 {
                     if (oaEndpoint)

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -26,7 +26,7 @@ namespace ZeroC.Ice
         public override Transport Transport => Transport.UDP;
 
         /// <summary>The local network interface used to send multicast datagrams.</summary>
-        internal string MulticastInterface { get; } = "";
+        internal string? MulticastInterface { get; }
 
         /// <summary>The time-to-live of the multicast datagrams, in hops.</summary>
         internal int MulticastTtl { get; } = -1;
@@ -78,8 +78,9 @@ namespace ZeroC.Ice
 
             base.AppendOptions(sb, optionSeparator);
 
-            if (MulticastInterface.Length > 0)
+            if (MulticastInterface != null)
             {
+                Debug.Assert(MulticastInterface.Length > 0);
                 bool addQuote = MulticastInterface.IndexOf(':') != -1;
                 sb.Append(" --interface ");
                 if (addQuote)
@@ -200,12 +201,12 @@ namespace ZeroC.Ice
             {
                 MulticastInterface = argument ?? throw new FormatException(
                     $"no argument provided for --interface option in endpoint `{endpointString}'");
-
+                // TODO: should we do anything for ::0 and 0.0.0.0?
                 if (MulticastInterface == "*")
                 {
                     if (oaEndpoint)
                     {
-                        MulticastInterface = "";
+                        MulticastInterface = null;
                     }
                     else
                     {

--- a/csharp/src/Ice/UdpTransceiver.cs
+++ b/csharp/src/Ice/UdpTransceiver.cs
@@ -64,7 +64,6 @@ namespace ZeroC.Ice
                         MulticastAddress.Port = _addr.Port;
                     }
 
-                    Debug.Assert(_multicastInterface != null);
                     Network.SetMulticastGroup(Socket, MulticastAddress.Address, _multicastInterface);
                 }
                 else
@@ -210,7 +209,6 @@ namespace ZeroC.Ice
                 }
                 else
                 {
-                    Debug.Assert(_multicastInterface != null);
                     interfaces = Network.GetInterfacesForMulticast(_multicastInterface,
                                                                    Network.GetIPVersion(MulticastAddress.Address));
                 }
@@ -270,7 +268,7 @@ namespace ZeroC.Ice
             Communicator communicator,
             EndPoint addr,
             IPAddress? sourceAddr,
-            string multicastInterface,
+            string? multicastInterface,
             int multicastTtl)
         {
             _communicator = communicator;
@@ -291,8 +289,9 @@ namespace ZeroC.Ice
 
                 if (Network.IsMulticast(_addr))
                 {
-                    if (_multicastInterface.Length > 0)
+                    if (_multicastInterface != null)
                     {
+                        Debug.Assert(_multicastInterface.Length > 0);
                         Network.SetMulticastInterface(Socket, _multicastInterface, _addr.AddressFamily);
                     }
                     if (multicastTtl != -1)
@@ -312,8 +311,7 @@ namespace ZeroC.Ice
         internal UdpTransceiver(UdpEndpoint endpoint, Communicator communicator)
         {
             _communicator = communicator;
-            _addr = Network.GetAddressForServerEndpoint(
-                endpoint.Host, endpoint.Port, Network.EnableBoth, communicator.PreferIPv6);
+            _addr = Network.GetAddressForServerEndpoint(endpoint.Host, endpoint.Port, Network.EnableBoth);
             _multicastInterface = endpoint.MulticastInterface;
             _incoming = true;
 

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -75,9 +75,8 @@ namespace ZeroC.Ice.Test.Info
             output.Write("test object adapter endpoint information... ");
             output.Flush();
             {
-                string host = (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false) ? "::1" : "127.0.0.1";
-                communicator.SetProperty("TestAdapter.Endpoints", "tcp -h \"" + host +
-                    "\" -t 15000:udp -h \"" + host + "\"");
+                communicator.SetProperty("TestAdapter.Endpoints", "tcp -h \"" + helper.Host +
+                    "\" -t 15000:udp -h \"" + helper.Host + "\"");
                 adapter = communicator.CreateObjectAdapter("TestAdapter");
 
                 IReadOnlyList<Endpoint> endpoints = adapter.GetEndpoints();
@@ -92,12 +91,12 @@ namespace ZeroC.Ice.Test.Info
                                   tcpEndpoint.Transport == Transport.WS ||
                                   tcpEndpoint.Transport == Transport.WSS);
 
-                TestHelper.Assert(tcpEndpoint.Host == host);
+                TestHelper.Assert(tcpEndpoint.Host == helper.Host);
                 TestHelper.Assert(tcpEndpoint.Port > 0);
                 TestHelper.Assert(tcpEndpoint["timeout"] is string value && int.Parse(value) == 15000);
 
                 Endpoint udpEndpoint = endpoints[1];
-                TestHelper.Assert(udpEndpoint.Host == host);
+                TestHelper.Assert(udpEndpoint.Host == helper.Host);
                 TestHelper.Assert(udpEndpoint.IsDatagram);
                 TestHelper.Assert(udpEndpoint.Port > 0);
 

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -154,8 +154,8 @@ namespace ZeroC.Ice.Test.UDP
 
             var sb = new StringBuilder("test -d:udp -h ");
 
-            // Use loopback to prevent other machines to answer.
-            if (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false)
+            // Use loopback to prevent other machines from answering.
+            if (helper.Host.Contains(":"))
             {
                 sb.Append("\"ff15::1:1\"");
             }
@@ -167,14 +167,8 @@ namespace ZeroC.Ice.Test.UDP
             sb.Append(helper.BasePort + 10);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (communicator.GetPropertyAsBool("Ice.PreferIPv6Address") ?? false)
-                {
-                    sb.Append(" --interface \"::1\"");
-                }
-                else
-                {
-                    sb.Append(" --interface 127.0.0.1");
-                }
+                string intf = helper.Host.Contains(":") ? $"\"{helper.Host}\"" : helper.Host;
+                sb.Append($" --interface {intf}");
             }
             var objMcast = ITestIntfPrx.Parse(sb.ToString(), communicator);
 

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -43,7 +43,7 @@ namespace ZeroC.Ice.Test.UDP
             var endpoint = new StringBuilder();
 
             // Use loopback to prevent other machines to answer.
-            if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
+            if (Host.Contains(":"))
             {
                 endpoint.Append("udp -h \"ff15::1:1\"");
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -208,7 +208,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
             output.Flush();
             {
                 string multicast;
-                if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
+                if (helper.Host.Contains(":"))
                 {
                     multicast = "\"ff15::1\"";
                 }
@@ -233,14 +233,10 @@ namespace ZeroC.IceDiscovery.Test.Simple
                 }
                 {
                     Dictionary<string, string> properties = communicator.GetProperties();
-                    string intf = communicator.GetProperty("IceDiscovery.Interface") ?? "";
-                    if (intf.Length > 0)
-                    {
-                        intf = $" --interface \"{intf}\"";
-                    }
-                    string port = communicator.GetProperty("IceDiscovery.Port") ?? "";
+                    string port = $"{helper.BasePort + 10}";
+                    string intf = helper.Host;
                     properties["IceDiscovery.Lookup"] =
-                        $"udp -h {multicast} --interface unknown:udp -h {multicast} -p {port}{intf}";
+                        $"udp -h {multicast} --interface unknown:udp -h {multicast} -p {port} --interface {intf}";
                     using var comm = new Communicator(properties);
                     TestHelper.Assert(comm.DefaultLocator != null);
                     IObjectPrx.Parse("controller0@control0", comm).IcePing();

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -109,7 +109,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 }
 
                 string multicast;
-                if (communicator.GetProperty("Ice.PreferIPv6Address") == "1")
+                if (helper.Host.Contains(":"))
                 {
                     multicast = "\"ff15::1\"";
                 }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -53,11 +53,6 @@ namespace ZeroC.IceSSL.Test.Configuration
                 properties["Test.Host"] = value;
             }
 
-            if (defaultProperties.TryGetValue("Ice.PreferIPv6Address", out value))
-            {
-                properties["Ice.PreferIPv6Address"] = value;
-            }
-
             properties["Ice.RetryIntervals"] = "-1";
 
             if (cert != null)

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3092,6 +3092,13 @@ class Driver:
         initData.properties.setProperty("Ice.Plugin.IceDiscovery", "IceDiscovery:createIceDiscovery")
         initData.properties.setProperty("IceDiscovery.DomainId", "TestController")
         initData.properties.setProperty("IceDiscovery.Interface", self.interface)
+        initData.properties.setProperty("IceDiscovery.Multicast.Endpoints",
+            "udp -h 239.255.0.1 -p 4061 --interface 127.0.0.1:udp -h \"ff15::1\" -p 4061 --interface \"::1\" ")
+        initData.properties.setProperty("IceDiscovery.Lookup",
+            "udp -h 239.255.0.1 -p 4061 --interface 127.0.0.1:udp -h \"ff15::1\" -p 4061 --interface \"::1\" ")
+        initData.properties.setProperty("IceDiscovery.Reply.Endpoints",
+                                        "udp -h 127.0.0.1 -p 0:udp -h \"::1\" -p 0")
+
         initData.properties.setProperty("Ice.Default.Host", self.interface)
         initData.properties.setProperty("Ice.ThreadPool.Server.Size", "10")
         # initData.properties.setProperty("Ice.Trace.Protocol", "1")

--- a/scripts/tests/IceDiscovery/simple.py
+++ b/scripts/tests/IceDiscovery/simple.py
@@ -12,6 +12,12 @@ props = lambda process, current: {
     "IceDiscovery.Timeout": "50ms" if isinstance(current.testcase.getMapping(), CSharpMapping) else "50",
     "IceDiscovery.RetryCount": 20,
     "IceDiscovery.DomainId": domainId,
+     "IceDiscovery.Multicast.Endpoints":
+        f"udp -h 239.255.0.1 -p {current.driver.getTestPort(10)} --interface 127.0.0.1:udp -h \"ff15::1\" -p {current.driver.getTestPort(10)} --interface \"::1\"",
+    "IceDiscovery.Lookup":
+        f"udp -h 239.255.0.1 -p {current.driver.getTestPort(10)} --interface 127.0.0.1:udp -h \"ff15::1\" -p {current.driver.getTestPort(10)} --interface \"::1\"",
+    "IceDiscovery.Reply.Endpoints": "udp -h 127.0.0.1 -p 0:udp -h \"::1\" -p 0",
+    # TODO remove Interface and Port properties once all tests are fixed to not use them
     "IceDiscovery.Interface": "" if isinstance(platform, Linux) else "::1" if current.config.ipv6 else "127.0.0.1",
     "IceDiscovery.Port": current.driver.getTestPort(10),
     "Ice.Plugin.IceDiscovery": current.getPluginEntryPoint("IceDiscovery", process),


### PR DESCRIPTION
This PR removes the `Ice.PreferIPv6Address` from C#.  

IceDiscovery and IceLocatorDiscovery relied on this property to determine if they would use IPv4 **or** IPv6. They now listen on both by default. 

Additionally the `IceDiscovery.Address`, `IceDiscovery.Port`, and `IceDiscovery.Interface` properties have been removed as well.