### PR TITLE
Compiler Cleanup and Metadata Helper Functions

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -911,6 +911,13 @@ Slice::Contained::hasMetadataWithPrefix(const string& prefix) const
     return !findMetadataWithPrefix(prefix).empty();
 }
 
+optional<string>
+Slice::Contained::findMetadata(const string& directive) const
+{
+    // TODO this is temporary until we can fully replace the current metadata logic.
+    return findMetadata(directive, parseMetadata(_metadata));
+}
+
 bool
 Slice::Contained::findMetadata(const string& prefix, string& meta) const
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1385,34 +1385,6 @@ Slice::Container::Container(const UnitPtr& ut) :
 }
 
 bool
-Slice::Container::checkFileMetadata(const StringList& m1, const StringList& m2)
-{
-    // Not all file metadata mismatches represent actual problems. We are only concerned about
-    // the prefixes listed below (also see bug 2766).
-    array<string, 2> prefixes =
-    {
-        "java:package",
-        "python:package"
-    };
-
-    // Collect the metadata that is unique to each list.
-    StringList diffs;
-    set_symmetric_difference(m1.begin(), m1.end(), m2.begin(), m2.end(), back_inserter(diffs));
-
-    for (const auto& diff : diffs)
-    {
-        for (const auto& prefix : prefixes)
-        {
-            if (diff.find(prefix) != string::npos)
-            {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-bool
 Slice::Container::validateConstant(const string& name, const TypePtr& lhsType, SyntaxTreeBasePtr& valueType,
                                    const string& value, bool isConstant)
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -915,7 +915,7 @@ optional<string>
 Slice::Contained::findMetadata(const string& directive) const
 {
     // TODO this is temporary until we can fully replace the current metadata logic.
-    return findMetadata(directive, parseMetadata(_metadata));
+    return Slice::findMetadata(directive, parseMetadata(_metadata));
 }
 
 bool

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -413,6 +413,7 @@ public:
 
     bool hasMetadata(const std::string&) const;
     bool hasMetadataWithPrefix(const std::string&) const;
+    std::optional<std::string> findMetadata(const std::string&) const;
     bool findMetadata(const std::string&, std::string&) const;
     std::string findMetadataWithPrefix(const std::string&) const;
     std::list<std::string> getAllMetadata() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -466,7 +466,6 @@ protected:
 
     Container(const UnitPtr&);
 
-    bool checkFileMetadata(const StringList&, const StringList&);
     bool validateConstant(const std::string&, const TypePtr&, SyntaxTreeBasePtr&, const std::string&, bool);
 
     std::map<std::string, ContainedPtr> _introducedMap;

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -788,3 +788,27 @@ bool Slice::opCompressReturn(const OperationPtr& op)
 {
     return opCompress(op, false);
 }
+
+string Slice::getDeprecateReason(const ContainedPtr& p, bool checkContainer)
+{
+    // Check if there was `deprecate` metadata directly on the entity.
+    auto deprecateMsg = p->findMetadata("deprecate");
+    // If the entity wasn't directly deprecated, check if it's container is.
+    if (!deprecateMsg && checkContainer)
+    {
+        if (ContainedPtr p2 = ContainedPtr::dynamicCast(p->container()))
+        {
+            deprecateMsg = p2->findMetadata("deprecate");
+        }
+    }
+
+    if (deprecateMsg)
+    {
+        if (deprecateMsg->empty())
+        {
+            return "This " + p->kindOf() + " has been deprecated";
+        }
+        return *deprecateMsg;
+    }
+    return "";
+}

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -823,12 +823,13 @@ pair<string, string> Slice::parseMetadata(const string& metadata)
 
     // We subtract 1 under the assumption that it ends with a ')' which shouldn't be included.
     auto length = metadata.length() - start - 1;
-    if (!metadata.ends_with(')')
+    // Check the raw string ends with a closing parentheses.
+    if (metadata.at(length + start) != ')')
     {
         unit->error("missing closing parentheses for metadata arguments");
         length += 1;
     }
-    return make_pair(metadata.substr(0, start), metadata.subst(start + 1, length))
+    return make_pair(metadata.substr(0, start), metadata.substr(start + 1, length));
 }
 
 map<string, string> Slice::parseMetadata(const StringList& metadata)
@@ -849,5 +850,5 @@ bool Slice::hasMetadata(const string& directive, const map<string, string>& meta
 optional<string> Slice::findMetadata(const string& directive, const map<string, string>& metadata)
 {
     auto match = metadata.find(directive);
-    return match != metadata.end() : match->second : nullopt;
+    return (match != metadata.end() ? make_optional(match->second) : nullopt);
 }

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -812,3 +812,48 @@ string Slice::getDeprecateReason(const ContainedPtr& p, bool checkContainer)
     }
     return "";
 }
+
+pair<string, string> Slice::parseMetadata(const string& metadata)
+{
+    // Check if the metadata has any arguments.
+    auto argumentStart = metadata.find("(");
+    if (argumentStart == string::npos)
+    {
+        return make_pair(metadata, "");
+    }
+    else
+    {
+        // Make sure the parentheses are balanced. For metadata with arguments, the final character must be ')'.
+        auto argumentEnd = metadata.length() - 1;
+        if (metadata.at(argumentEnd) != ')')
+        {
+            unit->error("missing closing parentheses for metadata arguments");
+        }
+        return make_pair(metadata.substr(0, argumentStart), metadata.substr(argumentStart + 1, argumentEnd));
+    }
+}
+
+map<string, string> Slice::parseMetadata(const StringList& metadata)
+{
+    map<string, string> parsedMetadata;
+    for (const auto& m : metadata)
+    {
+        parsedMetadata.insert(parseMetadata(m));
+    }
+    return parsedMetadata;
+}
+
+bool Slice::hasMetadata(const string& directive, const map<string, string>& metadata)
+{
+    return metadata.find(directive) != metadata.end();
+}
+
+optional<string> Slice::findMetadata(const string& directive, const map<string, string>& metadata)
+{
+    auto match = metadata.find(directive);
+    if (match != metadata.end())
+    {
+        return match->second;
+    }
+    return nullopt;
+}

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -101,6 +101,20 @@ bool opCompressReturn(const OperationPtr& op);
 // there isn't any). If the entity isn't deprecated, this returns the empty string.
 std::string getDeprecateReason(const ContainedPtr& p, bool checkContainer = false);
 
+// Parses a raw string of metadata, converting it into a directive and argument pair.
+std::pair<std::string, std::string> parseMetadata(const std::string& metadata);
+
+// Parses a list of raw metadata strings, converting it into a map of directives (keys) and arguments (values).
+std::map<std::string, std::string> parseMetadata(const StringList& metadata);
+
+// Returns true if `metadata` contains the specified metadata directive.
+bool hasMetadata(const std::string& directive, const std::map<std::string, std::string>& metadata);
+
+// Returns any arguments passed to the specified metadata directive if it's present.
+// Otherwise it returns a null optional to indicate the metadata isn't set.
+std::optional<std::string> findMetadata(const std::string& directive,
+                                        const std::map<std::string, std::string>& metadata);
+
 }
 
 #endif

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -97,6 +97,10 @@ bool opCompressParams(const OperationPtr& op);
 // Returns true if the compress:return metadata is set for the operation
 bool opCompressReturn(const OperationPtr& op);
 
+// Checks if a Slice entity is deprecated and returns the deprecation message if there is one (or a default message if
+// there isn't any). If the entity isn't deprecated, this returns the empty string.
+std::string getDeprecateReason(const ContainedPtr& p, bool checkContainer = false);
+
 }
 
 #endif

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -80,20 +80,14 @@ isConstexprType(const TypePtr& constType)
 }
 
 string
-getDeprecateSymbol(const ContainedPtr& p1, const ContainedPtr& p2)
+getDeprecateSymbol(const ContainedPtr& p1, bool checkContainer)
 {
-    string deprecateMetadata, deprecateSymbol;
-    if(p1->findMetadata("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
+    string deprecateMessage = getDeprecateReason(p1, checkContainer);
+    if(!deprecateMessage.empty())
     {
-        string msg = "is deprecated";
-        if(deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
-        {
-            msg = deprecateMetadata.substr(10);
-        }
-        deprecateSymbol = "ICE_DEPRECATED_API(\"" + msg + "\") ";
+        return "ICE_DEPRECATED_API(\"" + deprecateMessage + "\") ";
     }
-    return deprecateSymbol;
+    return "";
 }
 
 void
@@ -2226,7 +2220,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         futureT = resultStructName(name, fixKwd(interface->name()));
     }
 
-    const string deprecateSymbol = getDeprecateSymbol(p, interface);
+    const string deprecateSymbol = getDeprecateSymbol(p, true);
 
     CommentPtr comment = p->parseComment(false);
     const string contextDoc = "@param " + contextParam + " The Context map to send with the invocation.";
@@ -3108,7 +3102,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     string isConst = ((p->mode() == Operation::Nonmutating) || p->hasMetadata("cpp:const")) ? " const" : "";
 
     string opName = amd ? (name + "Async") : fixKwd(name);
-    string deprecateSymbol = getDeprecateSymbol(p, interface);
+    string deprecateSymbol = getDeprecateSymbol(p, true);
 
     H << sp;
     if(comment)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -83,27 +83,10 @@ opFormatTypeToString(const OperationPtr& op)
     return "???";
 }
 
-string
-getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
-{
-    string deprecateMetadata, deprecateReason;
-    if(p1->findMetadata("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
-    {
-        deprecateReason = "This " + type + " has been deprecated.";
-        const string prefix = "deprecate:";
-        if(deprecateMetadata.find(prefix) == 0 && deprecateMetadata.size() > prefix.size())
-        {
-            deprecateReason = deprecateMetadata.substr(prefix.size());
-        }
-    }
-    return deprecateReason;
-}
-
 void
-emitDeprecate(const ContainedPtr& p1, const ContainedPtr& p2, Output& out, const string& type)
+emitDeprecate(const ContainedPtr& p1, bool checkContainer, Output& out)
 {
-    string reason = getDeprecateReason(p1, p2, type);
+    string reason = getDeprecateReason(p1, checkContainer);
     if(!reason.empty())
     {
         out << nl << "[global::System.Obsolete(\"" << reason << "\")]";
@@ -1276,7 +1259,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     string scoped = fixId(p->scoped(), Slice::ObjectType);
     string ns = getNamespace(p);
     _out << sp;
-    writeTypeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeTypeDocComment(p, getDeprecateReason(p));
 
     emitCommonAttributes();
     emitTypeIdAttribute(p->scoped());
@@ -1578,8 +1561,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     ExceptionPtr base = p->base();
 
     _out << sp;
-    writeTypeDocComment(p, getDeprecateReason(p, 0, "type"));
-    emitDeprecate(p, 0, _out, "type");
+    writeTypeDocComment(p, getDeprecateReason(p));
+    emitDeprecate(p, false, _out);
 
     emitCommonAttributes();
     emitTypeIdAttribute(p->scoped());
@@ -1782,8 +1765,8 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     string ns = getNamespace(p);
     _out << sp;
 
-    writeTypeDocComment(p, getDeprecateReason(p, 0, "type"));
-    emitDeprecate(p, 0, _out, "type");
+    writeTypeDocComment(p, getDeprecateReason(p));
+    emitDeprecate(p, false, _out);
     emitCommonAttributes();
     emitCustomAttributes(p);
     _out << nl << "public ";
@@ -1956,8 +1939,8 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     string underlying = p->underlying() ? typeToString(p->underlying(), "") : "int";
 
     _out << sp;
-    emitDeprecate(p, 0, _out, "type");
-    writeTypeDocComment(p, getDeprecateReason(p, 0, "type"));
+    emitDeprecate(p, false, _out);
+    writeTypeDocComment(p, getDeprecateReason(p));
     emitCommonAttributes();
     emitCustomAttributes(p);
     _out << nl << "public enum " << name << " : " << underlying;
@@ -1975,7 +1958,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
             _out << sp;
         }
 
-        writeTypeDocComment(en, getDeprecateReason(en, 0, "enumerator"));
+        writeTypeDocComment(en, getDeprecateReason(en));
         _out << nl << fixId(en->name());
         if (p->explicitValue())
         {
@@ -2083,8 +2066,8 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
 
     bool readonly = StructPtr::dynamicCast(cont) && cont->hasMetadata("cs:readonly");
 
-    writeTypeDocComment(p, getDeprecateReason(p, cont, "member"));
-    emitDeprecate(p, cont, _out, "member");
+    writeTypeDocComment(p, getDeprecateReason(p, true));
+    emitDeprecate(p, true, _out);
     emitCustomAttributes(p);
     _out << nl << "public ";
     if(readonly)
@@ -2132,7 +2115,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string ns = getNamespace(p);
 
     _out << sp;
-    writeProxyDocComment(p, getDeprecateReason(p, 0, "interface"));
+    writeProxyDocComment(p, getDeprecateReason(p));
     emitCommonAttributes();
     emitTypeIdAttribute(p->scoped());
     emitCustomAttributes(p);
@@ -2358,7 +2341,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& operation)
     auto params = operation->params();
 
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
-    string deprecateReason = getDeprecateReason(operation, interface, "operation");
+    string deprecateReason = getDeprecateReason(operation, true);
 
     string ns = getNamespace(interface);
     string opName = operationName(operation);
@@ -2524,7 +2507,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string ns = getNamespace(p);
 
     _out << sp;
-    writeServantDocComment(p, getDeprecateReason(p, 0, "interface"));
+    writeServantDocComment(p, getDeprecateReason(p));
     emitCommonAttributes();
     emitTypeIdAttribute(p->scoped());
     emitCustomAttributes(p);
@@ -2766,7 +2749,7 @@ Slice::Gen::DispatcherVisitor::writeMethodDeclaration(const OperationPtr& operat
 {
     InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(operation->container());
     string ns = getNamespace(interface);
-    string deprecateReason = getDeprecateReason(operation, interface, "operation");
+    string deprecateReason = getDeprecateReason(operation, true);
     bool amd = _generateAllAsync || interface->hasMetadata("amd") || operation->hasMetadata("amd");
     const string name = fixId(operationName(operation) + (amd ? "Async" : ""));
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -113,13 +113,23 @@ long getSerialVersionUUID(const DataMemberContainerPtr& p)
         {
             string msg = "ignoring invalid serialVersionUID for class `" + p->scoped() + "'; generating default value";
             dc->warning(InvalidMetadata, "", -1, msg);
-            return computeSerialVersionUUID(p);
         }
     }
-    else
+
+    if (auto cont = ClassDefPtr::dynamicCast(p))
     {
-        return computeSerialVersionUUID(p);
+        return computeSerialVersionUUID(cont);
     }
+    if (auto cont = StructPtr::dynamicCast(p))
+    {
+        return computeSerialVersionUUID(cont);
+    }
+    if (auto cont = ExceptionPtr::dynamicCast(p))
+    {
+        return computeSerialVersionUUID(cont);
+    }
+    assert(false);
+    return -1;
 }
 
 }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -98,7 +98,7 @@ bool isValue(const TypePtr& constType)
     return (b && b->usesClasses()) || cl;
 }
 
-long getSerialVersionUID(const DataMemberContainerPtr& p)
+long getSerialVersionUUID(const DataMemberContainerPtr& p)
 {
     if (auto metadata = p->findMetadata("java:serialVersionUID"))
     {

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -90,14 +90,6 @@ getEscapedParamName(const MemberList& params, const string& name)
     return name;
 }
 
-bool
-isDeprecated(const ContainedPtr& p1, const ContainedPtr& p2)
-{
-    string deprecateMetadata;
-    return p1->findMetadata("deprecate", deprecateMetadata) ||
-            (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata));
-}
-
 bool isValue(const TypePtr& constType)
 {
     TypePtr type = unwrapIfOptional(constType);
@@ -1187,13 +1179,8 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         writeHiddenDocComment(out);
         for(const auto& op : allOps)
         {
-            //
             // Suppress deprecation warnings if this method dispatches to a deprecated operation.
-            //
-            ContainerPtr container = op->container();
-            InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(container);
-            assert(interface);
-            if(isDeprecated(op, interface))
+            if (!getDeprecateReason(op, true).empty())
             {
                 out << nl << "@SuppressWarnings(\"deprecation\")";
                 break;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -66,23 +66,6 @@ opFormatTypeToString(const OperationPtr& op)
     return "???";
 }
 
-string
-getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
-{
-    string deprecateMetadata, deprecateReason;
-    if(p1->findMetadata("deprecate", deprecateMetadata) ||
-       (p2 != 0 && p2->findMetadata("deprecate", deprecateMetadata)))
-    {
-        deprecateReason = "This " + type + " has been deprecated.";
-        const string prefix = "deprecate:";
-        if(deprecateMetadata.find(prefix) == 0 && deprecateMetadata.size() > prefix.size())
-        {
-            deprecateReason = deprecateMetadata.substr(prefix.size());
-        }
-    }
-    return deprecateReason;
-}
-
 void
 printHeader(IceUtilInternal::Output& out)
 {
@@ -1328,7 +1311,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << "];";
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocComment(p, getDeprecateReason(p));
     _out << nl << localScope << '.' << name << " = class";
     _out << " extends " << baseRef;
 
@@ -1441,7 +1424,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "];";
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocComment(p, getDeprecateReason(p));
     _out << nl << localScope << "." << p->name() << " = class extends Ice.Object";
     _out << sb;
 
@@ -1766,7 +1749,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocComment(p, getDeprecateReason(p));
     _out << nl << localScope << '.' << name << " = class extends " << baseRef;
     _out << sb;
 
@@ -1873,7 +1856,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     }
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocComment(p, getDeprecateReason(p));
     _out << nl << localScope << '.' << name << " = class";
     _out << sb;
 
@@ -1993,7 +1976,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     const string name = fixId(p->name());
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocComment(p, getDeprecateReason(p));
     _out << nl << localScope << '.' << name << " = Slice.defineEnum([";
     _out.inc();
     _out << nl;


### PR DESCRIPTION
This PR removes repetitive logic from the compilers:
- Moved our `SerialVersionUUID` logic into a function for slice2java (instead of having the same thing copied 3 times).
- Moved the 3 `getDeprecateReason` functions scattered around the compilers into a single version in SliceUtil (they were nearly identical anyways).
- Removed the `checkFileMetadata` method, which isn't used anywhere.

It also adds the following helper methods into SliceUtil:
- `parseMetadata`
- `findMetadata`
- `hasMetadata`
These are only needed by the new `getDeprecateReason` currently. In my 'real' PR they're all used extensively. Feel free to critique their implementation though.
I'm opening this PR first to keep the 'cleanup' somewhat separated from the rest of my changes.