### PR TITLE
Add location and protocol support to Locator

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1196,7 +1196,7 @@ namespace ZeroC.Ice
                 return null;
             });
 
-        internal LocatorInfo? GetLocatorInfo(ILocatorPrx? locator, Encoding encoding)
+        internal LocatorInfo? GetLocatorInfo(ILocatorPrx? locator)
         {
             // Returns locator info for a given locator. Automatically creates the locator info if it doesn't exist
             // yet.
@@ -1205,10 +1205,10 @@ namespace ZeroC.Ice
                 return null;
             }
 
-            if (locator.Locator != null || locator.Encoding != encoding)
+            if (locator.Locator != null)
             {
                 // The locator can't be located.
-                locator = locator.Clone(clearLocator: true, encoding: encoding);
+                locator = locator.Clone(clearLocator: true);
             }
 
             return _locatorInfoMap.GetOrAdd(locator,

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1274,7 +1274,7 @@ namespace ZeroC.Ice
                 {
                     if (TraceLevels.Location >= 1)
                     {
-                        Logger.Trace(TraceLevels.LocationCategory,
+                        Logger.Trace(TraceLevels.LocatorCategory,
                             $"could not register server `{serverId}' with the locator registry:\n{ex}");
                     }
                     throw;
@@ -1282,7 +1282,7 @@ namespace ZeroC.Ice
 
                 if (TraceLevels.Location >= 1)
                 {
-                    Logger.Trace(TraceLevels.LocationCategory, $"registered server `{serverId}' with the locator registry");
+                    Logger.Trace(TraceLevels.LocatorCategory, $"registered server `{serverId}' with the locator registry");
                 }
             }
         }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -286,6 +286,8 @@ namespace ZeroC.Ice
             this StringBuilder sb,
             IReadOnlyList<Endpoint> endpoints)
         {
+            Debug.Assert(endpoints.Count > 0);
+
             if (endpoints[0].Protocol == Protocol.Ice1)
             {
                 sb.Append(string.Join(":", endpoints));

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -281,5 +281,33 @@ namespace ZeroC.Ice
             }
             return sb;
         }
+
+        internal static StringBuilder AppendEndpointList(
+            this StringBuilder sb,
+            IReadOnlyList<Endpoint> endpoints)
+        {
+            if (endpoints[0].Protocol == Protocol.Ice1)
+            {
+                sb.Append(string.Join(":", endpoints));
+            }
+            else
+            {
+                sb.AppendEndpoint(endpoints[0]);
+                if (endpoints.Count > 1)
+                {
+                    Transport mainTransport = endpoints[0].Transport;
+                    sb.Append("?alt-endpoint=");
+                    for (int i = 1; i < endpoints.Count; ++i)
+                    {
+                        if (i > 1)
+                        {
+                            sb.Append(',');
+                        }
+                        sb.AppendEndpoint(endpoints[i], "", mainTransport != endpoints[i].Transport, '$');
+                    }
+                }
+            }
+            return sb;
+        }
     }
 }

--- a/csharp/src/Ice/IceDiscovery/Lookup.cs
+++ b/csharp/src/Ice/IceDiscovery/Lookup.cs
@@ -34,8 +34,7 @@ namespace ZeroC.IceDiscovery
                 return; // Ignore
             }
 
-            (IObjectPrx? proxy, bool isReplicaGroup) =
-                _registry.FindAdapter(adapterId, protocol ?? Protocol.Ice1);
+            (IObjectPrx? proxy, bool isReplicaGroup) = _registry.FindAdapter(adapterId, protocol ?? Protocol.Ice1);
             if (proxy != null)
             {
                 // Reply to the multicast request using the given proxy.
@@ -250,8 +249,8 @@ namespace ZeroC.IceDiscovery
         }
     }
 
-     // TODO: missing IDisposable?
-     internal class LookupReply : ILookupReply
+    // TODO: missing IDisposable?
+    internal class LookupReply : ILookupReply
     {
         internal CancellationTokenSource CancellationSource { get; }
         internal TaskCompletionSource<IObjectPrx?> CompletionSource { get; }

--- a/csharp/src/Ice/IceDiscovery/Lookup.cs
+++ b/csharp/src/Ice/IceDiscovery/Lookup.cs
@@ -12,13 +12,10 @@ namespace ZeroC.IceDiscovery
 {
     internal class Lookup : ILookup
     {
-        private readonly Dictionary<string, LookupReply> _adapterReplies = new ();
         private readonly string _domainId;
         private readonly int _latencyMultiplier;
         private readonly ILookupPrx _lookup;
         private readonly Dictionary<ILookupPrx, ILookupReplyPrx> _lookups = new ();
-        private readonly object _mutex = new ();
-        private readonly Dictionary<Identity, LookupReply> _objectReplies = new ();
         private readonly LocatorRegistry _registry;
         private readonly ObjectAdapter _replyAdapter;
         private readonly int _retryCount;
@@ -28,6 +25,7 @@ namespace ZeroC.IceDiscovery
             string domainId,
             string adapterId,
             ILookupReplyPrx reply,
+            Protocol? protocol,
             Current current,
             CancellationToken cancel)
         {
@@ -36,7 +34,8 @@ namespace ZeroC.IceDiscovery
                 return; // Ignore
             }
 
-            (IObjectPrx? proxy, bool isReplicaGroup) = _registry.FindAdapter(adapterId);
+            (IObjectPrx? proxy, bool isReplicaGroup) =
+                _registry.FindAdapter(adapterId, protocol ?? Protocol.Ice1);
             if (proxy != null)
             {
                 // Reply to the multicast request using the given proxy.
@@ -55,6 +54,7 @@ namespace ZeroC.IceDiscovery
             string domainId,
             Identity id,
             ILookupReplyPrx reply,
+            Protocol? protocol,
             Current current,
             CancellationToken cancel)
         {
@@ -63,7 +63,7 @@ namespace ZeroC.IceDiscovery
                 return; // Ignore
             }
 
-            if (_registry.FindObject(id) is IObjectPrx proxy)
+            if (_registry.FindObject(id, protocol ?? Protocol.Ice1) is IObjectPrx proxy)
             {
                 // Reply to the multicast request using the given proxy.
                 try
@@ -134,92 +134,66 @@ namespace ZeroC.IceDiscovery
             Debug.Assert(_lookups.Count > 0);
         }
 
-        internal async ValueTask<IObjectPrx?> FindAdapterAsync(string id)
+        // This is a wrapper for the call to FindAdapterByIdAsync on the lookup proxy. The caller (LocatorInfo) ensures
+        // there is no concurrent resolution for the same location.
+        internal async ValueTask<IObjectPrx?> FindAdapterByIdAsync(string[] location, Protocol protocol)
         {
-            Task<IObjectPrx?>? task = null;
-            LookupReply? replyServant;
-            lock (_mutex)
+            if (location.Length == 0)
             {
-                if (!_adapterReplies.TryGetValue(id, out replyServant))
-                {
-                    replyServant = new LookupReply();
-                    _adapterReplies.Add(id, replyServant);
-                }
-                else
-                {
-                    task = replyServant.CompletionSource.Task;
-                }
+                return null;
             }
 
-            if (task == null)
-            {
-                task = InvokeAsync(
-                    async (lookup, lookupReply) =>
+            var replyServant = new LookupReply(protocol);
+            IObjectPrx? proxy = await InvokeAsync(
+                async (lookup, lookupReply) =>
+                {
+                    try
                     {
-                        try
-                        {
-                            await lookup.FindAdapterByIdAsync(_domainId, id, lookupReply).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new InvalidOperationException(
-                                $"failed to lookup adapter `{id}' with lookup proxy `{_lookup}'", ex);
-                        }
-                    },
-                    replyServant);
+                        await lookup.FindAdapterByIdAsync(_domainId,
+                                                          location[0],
+                                                          lookupReply,
+                                                          protocol).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // TODO: is InvalidOperationException really appropriate here?
+                        throw new InvalidOperationException(
+                            $"failed to lookup adapter `{location[0]}' with lookup proxy `{_lookup}'", ex);
+                    }
+                },
+                replyServant).ConfigureAwait(false);
 
-                await task.ConfigureAwait(false);
-
-                lock (_mutex)
-                {
-                    _adapterReplies.Remove(id);
-                }
+            if (proxy != null && location.Length > 1)
+            {
+                // We just consume the first segment of the location. The proxy returned by FindAdapterById has no
+                // location.
+                proxy = proxy.Clone(location: location[1..]);
             }
-            return await task.ConfigureAwait(false);
+            return proxy;
         }
 
-        internal async ValueTask<IObjectPrx?> FindObjectAsync(Identity id)
+        // This is a wrapper for FindObjectByIdAsync on the lookup proxy. The caller (LocatorInfo) ensures there is no
+        // concurrent resolution for the same identity.
+        internal async ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity identity, Protocol protocol)
         {
-            Task<IObjectPrx?>? task = null;
-            LookupReply? replyServant;
-            lock (_mutex)
-            {
-                if (!_objectReplies.TryGetValue(id, out replyServant))
+            var replyServant = new LookupReply(protocol);
+            return await InvokeAsync(
+                async (lookup, lookupReply) =>
                 {
-                    replyServant = new LookupReply();
-                    _objectReplies.Add(id, replyServant);
-                }
-                else
-                {
-                    task = replyServant.CompletionSource.Task;
-                }
-            }
-
-            if (task == null)
-            {
-                task = InvokeAsync(
-                    async (lookup, lookupReply) =>
+                    try
                     {
-                        try
-                        {
-                            await lookup.FindObjectByIdAsync(_domainId, id, lookupReply).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new InvalidOperationException(
-                                $"failed to lookup object `{id}' with lookup proxy `{_lookup}'", ex);
-                        }
-                    },
-                    replyServant);
-
-                await task.ConfigureAwait(false);
-
-                lock (_mutex)
-                {
-                    _objectReplies.Remove(id);
-                }
-            }
-            return await task.ConfigureAwait(false);
+                        await lookup.FindObjectByIdAsync(_domainId,
+                                                         identity,
+                                                         lookupReply,
+                                                         protocol).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            $"failed to lookup object `{identity}' with lookup proxy `{_lookup}'", ex);
+                    }
+                },
+                replyServant).ConfigureAwait(false);
         }
 
         private async Task<IObjectPrx?> InvokeAsync(
@@ -235,9 +209,9 @@ namespace ZeroC.IceDiscovery
                 {
                     TimeSpan start = Time.Elapsed;
                     int failureCount = 0;
-                    foreach ((ILookupPrx lookup, ILookupReplyPrx? reply) in _lookups)
+                    foreach ((ILookupPrx lookup, ILookupReplyPrx reply) in _lookups)
                     {
-                        ILookupReplyPrx? lookupReply = reply.Clone(ILookupReplyPrx.Factory, identity: requestId);
+                        ILookupReplyPrx lookupReply = reply.Clone(ILookupReplyPrx.Factory, identity: requestId);
                         try
                         {
                             await find(lookup, lookupReply);
@@ -262,7 +236,8 @@ namespace ZeroC.IceDiscovery
                     {
                         // If the timeout was canceled we delay the completion of the request to give a chance to other
                         // members of this replica group to reply
-                        return await replyServant.WaitForReplicaGroupRepliesAsync(start, _latencyMultiplier);
+                        return await replyServant.WaitForReplicaGroupRepliesAsync(start, _latencyMultiplier)
+                            .ConfigureAwait(false);
                     }
                 }
                 replyServant.CompletionSource.SetResult(null); // Timeout
@@ -275,41 +250,48 @@ namespace ZeroC.IceDiscovery
         }
     }
 
-    internal class LookupReply : ILookupReply
+     // TODO: missing IDisposable?
+     internal class LookupReply : ILookupReply
     {
         internal CancellationTokenSource CancellationSource { get; }
         internal TaskCompletionSource<IObjectPrx?> CompletionSource { get; }
 
         private readonly object _mutex = new object();
+
+        private readonly Protocol _protocol;
         private readonly HashSet<IObjectPrx> _proxies = new HashSet<IObjectPrx>();
 
-        public void FoundObjectById(Identity id, IObjectPrx? proxy, Current current, CancellationToken cancel) =>
+        public void FoundObjectById(Identity id, IObjectPrx proxy, Current current, CancellationToken cancel) =>
             CompletionSource.SetResult(proxy);
 
         public void FoundAdapterById(
             string adapterId,
-            IObjectPrx? proxy,
+            IObjectPrx proxy,
             bool isReplicaGroup,
             Current current,
             CancellationToken cancel)
         {
-            if (isReplicaGroup)
+            if (proxy.Protocol == _protocol)
             {
-                lock (_mutex)
+                if (isReplicaGroup)
                 {
-                    _proxies.Add(proxy!);
-                    if (_proxies.Count == 1)
+                    lock (_mutex)
                     {
-                        // Cancel the request timeout and let InvokeAsync wait for additional replies from the replica
-                        // group
-                        CancellationSource.Cancel();
+                        _proxies.Add(proxy);
+                        if (_proxies.Count == 1)
+                        {
+                            // Cancel the request timeout and let InvokeAsync wait for additional replies from the
+                            // replica group
+                            CancellationSource.Cancel();
+                        }
                     }
                 }
+                else
+                {
+                    CompletionSource.SetResult(proxy);
+                }
             }
-            else
-            {
-                CompletionSource.SetResult(proxy);
-            }
+            // else bogus proxy. TODO: add trace?
         }
 
         internal async Task<IObjectPrx?> WaitForReplicaGroupRepliesAsync(TimeSpan start, int latencyMultiplier)
@@ -329,25 +311,16 @@ namespace ZeroC.IceDiscovery
                 IObjectPrx result = _proxies.First();
                 foreach (IObjectPrx prx in _proxies)
                 {
-                    if (prx.Protocol != result.Protocol)
-                    {
-                        prx.Communicator.Logger.Trace(
-                            "Lookup",
-                            @$"ignoring replica group reply, the proxy protocol {prx.Protocol
-                               } doesn't match the replica group protocol");
-                    }
-                    else
-                    {
-                        endpoints.AddRange(prx.Endpoints);
-                    }
+                    endpoints.AddRange(prx.Endpoints);
                 }
                 CompletionSource.SetResult(result.Clone(endpoints: endpoints));
             }
             return CompletionSource.Task.Result;
         }
 
-        internal LookupReply()
+        internal LookupReply(Protocol protocol)
         {
+            _protocol = protocol;
             CancellationSource = new CancellationTokenSource();
             CompletionSource = new TaskCompletionSource<IObjectPrx?>();
         }

--- a/csharp/src/Ice/IceDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceDiscovery/Plugin.cs
@@ -79,6 +79,12 @@ namespace ZeroC.IceDiscovery
             _replyAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Reply");
             _locatorAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Locator");
 
+            // This undocumented object adapter hosts the locator and locator registry servants.
+            if (_locatorAdapter.Protocol != Protocol.Ice2)
+            {
+                throw new InvalidConfigurationException("the IceDiscovery.Locator object adapter must use ice2");
+            }
+
             // Setup locator registry.
             LocatorRegistry locatorRegistry = new ();
             ILocatorRegistryPrx locatorRegistryPrx =

--- a/csharp/src/Ice/IceLocatorDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Locator.cs
@@ -1,0 +1,356 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroC.Ice;
+
+namespace ZeroC.IceLocatorDiscovery
+{
+    // A Locator implementation that always returns null. (temporary)
+    internal class VoidLocator : ILocator
+    {
+        public IObjectPrx? FindAdapterById(string id, Current current, CancellationToken cancel) => null;
+        public IObjectPrx? FindObjectById(Identity id, Current current, CancellationToken cancel) => null;
+        public ILocatorRegistryPrx? GetRegistry(Current current, CancellationToken cancel) => null;
+
+        public IObjectPrx? ResolveLocation(
+            string[] location,
+            Protocol protocol,
+            Current current,
+            CancellationToken cancel) => null;
+
+        public IObjectPrx? ResolveWellKnownProxy(
+            Identity identity,
+            Protocol protocol,
+            Current current,
+            CancellationToken cancel) => null;
+    }
+
+    internal class LookupReply : ILookupReply
+    {
+        private readonly Locator _locatorServant;
+        public void FoundLocator(ILocatorPrx locator, Current current, CancellationToken cancel) =>
+            _locatorServant.FoundLocator(locator);
+        internal LookupReply(Locator locatorServant) => _locatorServant = locatorServant;
+    }
+    internal class Locator : IObject
+    {
+        private TaskCompletionSource<ILocatorPrx>? _completionSource;
+        private Task<ILocatorPrx>? _findLocatorTask;
+        private string _instanceName;
+        private ILocatorPrx? _locator;
+        private readonly ILookupPrx _lookup;
+        private readonly Dictionary<ILookupPrx, ILookupReplyPrx> _lookups = new ();
+        private readonly object _mutex = new object();
+        private TimeSpan _nextRetry;
+        private readonly int _retryCount;
+        private readonly TimeSpan _retryDelay;
+        private readonly TimeSpan _timeout;
+        private readonly int _traceLevel;
+        private readonly ILocatorPrx _voidLocator;
+
+        internal Locator(
+            string name,
+            ILookupPrx lookup,
+            Communicator communicator,
+            string instanceName,
+            ILocatorPrx voidLocator,
+            ILookupReplyPrx lookupReply)
+        {
+            _lookup = lookup;
+            _timeout = communicator.GetPropertyAsTimeSpan($"{name}.Timeout") ?? TimeSpan.FromMilliseconds(300);
+            if (_timeout == System.Threading.Timeout.InfiniteTimeSpan)
+            {
+                _timeout = TimeSpan.FromMilliseconds(300);
+            }
+            _retryCount = Math.Max(communicator.GetPropertyAsInt($"{name}.RetryCount") ?? 3, 1);
+            _retryDelay = communicator.GetPropertyAsTimeSpan($"{name}.RetryDelay") ?? TimeSpan.FromMilliseconds(2000);
+            _traceLevel = communicator.GetPropertyAsInt($"{name}.Trace.Lookup") ?? 0;
+            _instanceName = instanceName;
+            _locator = lookup.Communicator.DefaultLocator;
+            _voidLocator = voidLocator;
+
+            // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
+            // datagram on each endpoint.
+            var single = new Endpoint[1];
+            foreach (Endpoint endpoint in lookup.Endpoints)
+            {
+                // lookup's invocation mode is Datagram
+                Debug.Assert(endpoint.Transport == Transport.UDP);
+
+                single[0] = endpoint;
+                ILookupPrx key = lookup.Clone(endpoints: single);
+                if (endpoint["interface"] is string mcastInterface && mcastInterface.Length > 0)
+                {
+                    Endpoint? q = lookupReply.Endpoints.FirstOrDefault(e => e.Host == mcastInterface);
+
+                    if (q != null)
+                    {
+                        single[0] = q;
+                        _lookups[key] = lookupReply.Clone(endpoints: single);
+                    }
+                }
+
+                if (!_lookups.ContainsKey(key))
+                {
+                    // Fallback: just use the given lookup reply proxy if no matching endpoint found.
+                    _lookups[key] = lookupReply;
+                }
+            }
+            Debug.Assert(_lookups.Count > 0);
+        }
+
+        public async ValueTask<OutgoingResponseFrame> DispatchAsync(
+            IncomingRequestFrame incomingRequest,
+            Current current,
+            CancellationToken cancel)
+        {
+            ILocatorPrx? badLocator = null;
+            Exception? exception = null;
+            while (true)
+            {
+                // Get the locator to send the request to (this will return the void locator if no locator is found)
+                ILocatorPrx newLocator = await GetLocatorAsync().ConfigureAwait(false);
+                if (!newLocator.Equals(badLocator))
+                {
+                    try
+                    {
+                        return
+                            await newLocator.ForwardAsync(false, incomingRequest, cancel: cancel).ConfigureAwait(false);
+                    }
+                    catch (ObjectNotExistException ex)
+                    {
+                        ex.ConvertToUnhandled = false;
+                        throw;
+                    }
+                    catch (NoEndpointException)
+                    {
+                        throw new ObjectNotExistException(current);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw new ObjectNotExistException(current);
+                    }
+                    catch (Exception ex)
+                    {
+                        lock (_mutex)
+                        {
+                            badLocator = newLocator;
+                            // If the current locator is equal to the one we use to send the request,
+                            // clear it and retry, this will trigger the lookup of a new locator.
+                            if (_locator != null && _locator.Equals(newLocator))
+                            {
+                                _locator = null;
+                            }
+                        }
+                        exception = ex;
+                    }
+                }
+                else
+                {
+                    // We got the same locator after a previous failure, throw the saved exception now.
+                    Debug.Assert(exception != null);
+                    throw exception;
+                }
+            }
+        }
+
+        internal void FoundLocator(ILocatorPrx locator)
+        {
+            lock (_mutex)
+            {
+                if (_instanceName.Length > 0 && locator.Identity.Category != _instanceName)
+                {
+                    if (_traceLevel > 2)
+                    {
+                        _lookup.Communicator.Logger.Trace("Lookup",
+                            @$"ignoring locator reply: instance name doesn't match\nexpected = {_instanceName
+                            } received = {locator.Identity.Category}");
+                    }
+                    return;
+                }
+
+                // If we already have a locator assigned, ensure the given locator has the same identity and protocol,
+                // otherwise ignore it.
+                if (_locator != null)
+                {
+                    if (locator.Identity.Category != _locator.Identity.Category)
+                    {
+                        var sb = new StringBuilder();
+                        sb.Append("received Ice locator with different instance name:\n")
+                          .Append("using = `").Append(_locator.Identity.Category).Append("'\n")
+                          .Append("received = `").Append(locator.Identity.Category).Append("'\n")
+                          .Append("This is typically the case if multiple Ice locators with different ")
+                          .Append("instance names are deployed and the property `IceLocatorDiscovery.InstanceName' ")
+                          .Append("is not set.");
+                        locator.Communicator.Logger.Warning(sb.ToString());
+                        return;
+                    }
+
+                    if (locator.Protocol != _locator.Protocol)
+                    {
+                        var sb = new StringBuilder();
+                        sb.Append("ignoring Ice locator with different protocol:\n")
+                          .Append("using = `").Append(_locator.Protocol).Append("'\n")
+                          .Append("received = `").Append(locator.Protocol).Append("'\n");
+                        locator.Communicator.Logger.Warning(sb.ToString());
+                        return;
+                    }
+                }
+
+                if (_traceLevel > 0)
+                {
+                    var sb = new StringBuilder("locator lookup succeeded:\nlocator = ");
+                    sb.Append(locator);
+                    if (_instanceName.Length > 0)
+                    {
+                        sb.Append("\ninstance name = ").Append(_instanceName);
+                    }
+                    _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
+                }
+
+                if (_locator == null)
+                {
+                    _locator = locator;
+                    if (_instanceName.Length == 0)
+                    {
+                        _instanceName = _locator.Identity.Category; // Stick to the first locator
+                    }
+                    Debug.Assert(_completionSource != null);
+                    _completionSource.TrySetResult(locator);
+                }
+                else
+                {
+                    // We found another locator replica, append its endpoints to the current locator proxy endpoints,
+                    // while eliminating duplicates.
+                    _locator = _locator.Clone(endpoints: _locator.Endpoints.Concat(locator.Endpoints).Distinct());
+                }
+            }
+        }
+
+        private async Task<ILocatorPrx> GetLocatorAsync()
+        {
+            Task<ILocatorPrx> findLocatorTask;
+            lock (_mutex)
+            {
+                // If we already have a locator we use it.
+                if (_locator != null)
+                {
+                    return _locator;
+                }
+                // If the retry delay has not elapsed since the last failure return the void locator that always
+                // replies with a null proxy.
+                else if (Time.Elapsed < _nextRetry)
+                {
+                    return _voidLocator;
+                }
+                // If a locator lookup is running we await on it otherwise we start a new lookup.
+                else if (_findLocatorTask == null)
+                {
+                    _findLocatorTask = FindLocatorAsync();
+                }
+                findLocatorTask = _findLocatorTask;
+            }
+            ILocatorPrx locator = await findLocatorTask.ConfigureAwait(false);
+            lock (_mutex)
+            {
+                _findLocatorTask = null;
+            }
+            return locator;
+        }
+
+        private async Task<ILocatorPrx> FindLocatorAsync()
+        {
+            lock (_mutex)
+            {
+                Debug.Assert(_locator == null);
+                Debug.Assert(_findLocatorTask == null);
+                _completionSource = new TaskCompletionSource<ILocatorPrx>();
+            }
+
+            if (_traceLevel > 1)
+            {
+                var sb = new StringBuilder("looking up locator:\nlookup = ");
+                sb.Append(_lookup);
+                if (_instanceName.Length > 0)
+                {
+                    sb.Append("\ninstance name = ").Append(_instanceName);
+                }
+                _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
+            }
+
+            int failureCount = 0;
+            for (int i = 0; i < _retryCount; ++i)
+            {
+                foreach ((ILookupPrx lookup, ILookupReplyPrx lookupReply) in _lookups)
+                {
+                    try
+                    {
+                        await lookup.FindLocatorAsync(_instanceName, lookupReply).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        lock (_mutex)
+                        {
+                            if (++failureCount == _lookups.Count)
+                            {
+                                // All the lookup calls failed propagate the error to the requests.
+                                if (_traceLevel > 0)
+                                {
+                                    var sb = new StringBuilder("locator lookup failed:\nlookup = ");
+                                    sb.Append(_lookup);
+                                    if (_instanceName.Length > 0)
+                                    {
+                                        sb.Append("\ninstance name = ").Append(_instanceName);
+                                    }
+                                    sb.Append("\nwith lookup proxy `{_lookup}':\n");
+                                    sb.Append(ex);
+                                    _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
+                                }
+                                return _voidLocator;
+                            }
+                        }
+                    }
+                }
+
+                Task t = await Task.WhenAny(_completionSource.Task, Task.Delay(_timeout)).ConfigureAwait(false);
+                if (t == _completionSource.Task)
+                {
+                    return await _completionSource.Task.ConfigureAwait(false);
+                }
+            }
+
+            lock (_mutex)
+            {
+                if (_completionSource.Task.IsCompleted)
+                {
+                    // we got a concurrent reply after the timeout
+                    Debug.Assert(_locator != null);
+                    return _locator;
+                }
+                else
+                {
+                    // Locator lookup timeout and no more retries
+                    if (_traceLevel > 0)
+                    {
+                        var sb = new StringBuilder("locator lookup timed out:\nlookup = ");
+                        sb.Append(_lookup);
+                        if (_instanceName.Length > 0)
+                        {
+                            sb.Append("\ninstance name = ").Append(_instanceName);
+                        }
+                        _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
+                    }
+
+                    _nextRetry = Time.Elapsed + _retryDelay;
+                    return _voidLocator;
+                }
+            }
+        }
+    }
+}

--- a/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Plugin.cs
@@ -18,345 +18,13 @@ namespace ZeroC.IceLocatorDiscovery
         public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(name, communicator);
     }
 
-    internal class VoidLocator : ILocator
-    {
-        public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string id, Current current, CancellationToken cancel) =>
-            default;
-        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current, CancellationToken cancel) =>
-            default;
-        public ILocatorRegistryPrx? GetRegistry(Current current, CancellationToken cancel) => null;
-    }
-
-    internal class Locator : IObject
-    {
-        private TaskCompletionSource<ILocatorPrx>? _completionSource;
-        private Task<ILocatorPrx>? _findLocatorTask;
-        private string _instanceName;
-        private ILocatorPrx? _locator;
-        private readonly ILookupPrx _lookup;
-        private readonly Dictionary<ILookupPrx, ILookupReplyPrx> _lookups = new ();
-        private readonly object _mutex = new object();
-        private TimeSpan _nextRetry;
-        private readonly int _retryCount;
-        private readonly TimeSpan _retryDelay;
-        private readonly TimeSpan _timeout;
-        private readonly int _traceLevel;
-        private readonly ILocatorPrx _voidLocator;
-
-        internal Locator(
-            string name,
-            ILookupPrx lookup,
-            Communicator communicator,
-            string instanceName,
-            ILocatorPrx voidLocator,
-            ILookupReplyPrx lookupReply)
-        {
-            _lookup = lookup;
-            _timeout = communicator.GetPropertyAsTimeSpan($"{name}.Timeout") ?? TimeSpan.FromMilliseconds(300);
-            if (_timeout == System.Threading.Timeout.InfiniteTimeSpan)
-            {
-                _timeout = TimeSpan.FromMilliseconds(300);
-            }
-            _retryCount = Math.Max(communicator.GetPropertyAsInt($"{name}.RetryCount") ?? 3, 1);
-            _retryDelay = communicator.GetPropertyAsTimeSpan($"{name}.RetryDelay") ?? TimeSpan.FromMilliseconds(2000);
-            _traceLevel = communicator.GetPropertyAsInt($"{name}.Trace.Lookup") ?? 0;
-            _instanceName = instanceName;
-            _locator = lookup.Communicator.DefaultLocator;
-            _voidLocator = voidLocator;
-
-            // Create one lookup proxy per endpoint from the given proxy. We want to send a multicast
-            // datagram on each endpoint.
-            var single = new Endpoint[1];
-            foreach (Endpoint endpoint in lookup.Endpoints)
-            {
-                // lookup's invocation mode is Datagram
-                Debug.Assert(endpoint.Transport == Transport.UDP);
-
-                single[0] = endpoint;
-                ILookupPrx key = lookup.Clone(endpoints: single);
-                if (endpoint["interface"] is string mcastInterface && mcastInterface.Length > 0)
-                {
-                    Endpoint? q = lookupReply.Endpoints.FirstOrDefault(e => e.Host == mcastInterface);
-
-                    if (q != null)
-                    {
-                        single[0] = q;
-                        _lookups[key] = lookupReply.Clone(endpoints: single);
-                    }
-                }
-
-                if (!_lookups.ContainsKey(key))
-                {
-                    // Fallback: just use the given lookup reply proxy if no matching endpoint found.
-                    _lookups[key] = lookupReply;
-                }
-            }
-            Debug.Assert(_lookups.Count > 0);
-        }
-
-        public async ValueTask<OutgoingResponseFrame> DispatchAsync(
-            IncomingRequestFrame incomingRequest,
-            Current current,
-            CancellationToken cancel)
-        {
-            ILocatorPrx? locator = null;
-            Exception? exception = null;
-            while (true)
-            {
-                // Get the locator to send the request to (this will return the void locator if no locator is found)
-                ILocatorPrx newLocator = await GetLocatorAsync().ConfigureAwait(false);
-                if (!newLocator.Equals(locator))
-                {
-                    try
-                    {
-                        return
-                            await newLocator.ForwardAsync(false, incomingRequest, cancel: cancel).ConfigureAwait(false);
-                    }
-                    catch (ObjectNotExistException)
-                    {
-                        throw;
-                    }
-                    catch (NoEndpointException)
-                    {
-                        throw new ObjectNotExistException(current);
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        throw new ObjectNotExistException(current);
-                    }
-                    catch (Exception ex)
-                    {
-                        lock (_mutex)
-                        {
-                            locator = newLocator;
-                            // If the current locator is equal to the one we use to send the request,
-                            // clear it and retry, this will trigger the lookup of a new locator.
-                            if (_locator == newLocator)
-                            {
-                                _locator = null;
-                            }
-                        }
-                        exception = ex;
-                    }
-                }
-                else
-                {
-                    // We got the same locator after a previous failure, throw the saved exception now.
-                    Debug.Assert(exception != null);
-                    throw exception;
-                }
-            }
-        }
-
-        internal void FoundLocator(ILocatorPrx locator)
-        {
-            lock (_mutex)
-            {
-                if (_instanceName.Length > 0 && locator.Identity.Category != _instanceName)
-                {
-                    if (_traceLevel > 2)
-                    {
-                        _lookup.Communicator.Logger.Trace("Lookup",
-                            @$"ignoring locator reply: instance name doesn't match\nexpected = {_instanceName
-                            } received = {locator.Identity.Category}");
-                    }
-                    return;
-                }
-
-                // If we already have a locator assigned, ensure the given locator has the same identity and protocol,
-                // otherwise ignore it.
-                if (_locator != null)
-                {
-                    if (locator.Identity.Category != _locator.Identity.Category)
-                    {
-                        var sb = new StringBuilder();
-                        sb.Append("received Ice locator with different instance name:\n")
-                          .Append("using = `").Append(_locator.Identity.Category).Append("'\n")
-                          .Append("received = `").Append(locator.Identity.Category).Append("'\n")
-                          .Append("This is typically the case if multiple Ice locators with different ")
-                          .Append("instance names are deployed and the property `IceLocatorDiscovery.InstanceName' ")
-                          .Append("is not set.");
-                        locator.Communicator.Logger.Warning(sb.ToString());
-                        return;
-                    }
-
-                    if (locator.Protocol != _locator.Protocol)
-                    {
-                        var sb = new StringBuilder();
-                        sb.Append("ignoring Ice locator with different protocol:\n")
-                          .Append("using = `").Append(_locator.Protocol).Append("'\n")
-                          .Append("received = `").Append(locator.Protocol).Append("'\n");
-                        locator.Communicator.Logger.Warning(sb.ToString());
-                        return;
-                    }
-                }
-
-                if (_traceLevel > 0)
-                {
-                    var s = new StringBuilder("locator lookup succeeded:\nlocator = ");
-                    s.Append(locator);
-                    if (_instanceName.Length > 0)
-                    {
-                        s.Append("\ninstance name = ").Append(_instanceName);
-                    }
-                    _lookup.Communicator.Logger.Trace("Lookup", s.ToString());
-                }
-
-                if (_locator == null)
-                {
-                    _locator = locator;
-                    if (_instanceName.Length == 0)
-                    {
-                        _instanceName = _locator.Identity.Category; // Stick to the first locator
-                    }
-                    Debug.Assert(_completionSource != null);
-                    _completionSource.TrySetResult(locator);
-                }
-                else
-                {
-                    // We found another locator replica, append its endpoints to the current locator proxy endpoints,
-                    // while eliminating duplicates.
-                    _locator = _locator.Clone(endpoints: _locator.Endpoints.Concat(locator.Endpoints).Distinct());
-                }
-            }
-        }
-
-        private async Task<ILocatorPrx> GetLocatorAsync()
-        {
-            Task<ILocatorPrx> findLocatorTask;
-            lock (_mutex)
-            {
-                // If we already have a locator we use it.
-                if (_locator != null)
-                {
-                    return _locator;
-                }
-                // If the retry delay has not elapsed since the last failure return the void locator that always
-                // replies with a null proxy.
-                else if (Time.Elapsed < _nextRetry)
-                {
-                    return _voidLocator;
-                }
-                // If a locator lookup is running we await on it otherwise we start a new lookup.
-                else if (_findLocatorTask == null)
-                {
-                    _findLocatorTask = FindLocatorAsync();
-                }
-                findLocatorTask = _findLocatorTask;
-            }
-            ILocatorPrx locator = await findLocatorTask.ConfigureAwait(false);
-            lock (_mutex)
-            {
-                _findLocatorTask = null;
-            }
-            return locator;
-        }
-
-        private async Task<ILocatorPrx> FindLocatorAsync()
-        {
-            lock (_mutex)
-            {
-                Debug.Assert(_locator == null);
-                Debug.Assert(_findLocatorTask == null);
-                _completionSource = new TaskCompletionSource<ILocatorPrx>();
-            }
-
-            if (_traceLevel > 1)
-            {
-                var sb = new StringBuilder("looking up locator:\nlookup = ");
-                sb.Append(_lookup);
-                if (_instanceName.Length > 0)
-                {
-                    sb.Append("\ninstance name = ").Append(_instanceName);
-                }
-                _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
-            }
-
-            int failureCount = 0;
-            for (int i = 0; i < _retryCount; ++i)
-            {
-                foreach ((ILookupPrx lookup, ILookupReplyPrx lookupReply) in _lookups)
-                {
-                    try
-                    {
-                        await lookup.FindLocatorAsync(_instanceName, lookupReply).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        lock (_mutex)
-                        {
-                            if (++failureCount == _lookups.Count)
-                            {
-                                // All the lookup calls failed propagate the error to the requests.
-                                if (_traceLevel > 0)
-                                {
-                                    var sb = new StringBuilder("locator lookup failed:\nlookup = ");
-                                    sb.Append(_lookup);
-                                    if (_instanceName.Length > 0)
-                                    {
-                                        sb.Append("\ninstance name = ").Append(_instanceName);
-                                    }
-                                    sb.Append("\nwith lookup proxy `{_lookup}':\n");
-                                    sb.Append(ex);
-                                    _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
-                                }
-                                return _voidLocator;
-                            }
-                        }
-                    }
-                }
-
-                Task t = await Task.WhenAny(_completionSource.Task, Task.Delay(_timeout)).ConfigureAwait(false);
-                if (t == _completionSource.Task)
-                {
-                    return await _completionSource.Task.ConfigureAwait(false);
-                }
-            }
-
-            lock (_mutex)
-            {
-                if (_completionSource.Task.IsCompleted)
-                {
-                    // we got a concurrent reply after the timeout
-                    Debug.Assert(_locator != null);
-                    return _locator;
-                }
-                else
-                {
-                    // Locator lookup timeout and no more retries
-                    if (_traceLevel > 0)
-                    {
-                        var sb = new StringBuilder("locator lookup timed out:\nlookup = ");
-                        sb.Append(_lookup);
-                        if (_instanceName.Length > 0)
-                        {
-                            sb.Append("\ninstance name = ").Append(_instanceName);
-                        }
-                        _lookup.Communicator.Logger.Trace("Lookup", sb.ToString());
-                    }
-
-                    _nextRetry = Time.Elapsed + _retryDelay;
-                    return _voidLocator;
-                }
-            }
-        }
-    }
-
-    internal class LookupReply : ILookupReply
-    {
-        private readonly Locator _locator;
-        public void FoundLocator(ILocatorPrx locator, Current current, CancellationToken cancel) =>
-            _locator.FoundLocator(locator);
-        internal LookupReply(Locator locator) => _locator = locator;
-    }
-
     internal class Plugin : IPlugin
     {
         private readonly Communicator _communicator;
         private ILocatorPrx? _defaultLocator;
-        private Locator? _locator;
+        private Locator? _locatorServant;
         private ObjectAdapter? _locatorAdapter;
-        private ILocatorPrx? _locatorPrx;
+        private ILocatorPrx? _locator;
         private readonly string _name;
         private ObjectAdapter? _replyAdapter;
 
@@ -372,7 +40,7 @@ namespace ZeroC.IceLocatorDiscovery
                 await _locatorAdapter.DisposeAsync().ConfigureAwait(false);
             }
 
-            if (IObjectPrx.Equals(_communicator.DefaultLocator, _locatorPrx))
+            if (IObjectPrx.Equals(_communicator.DefaultLocator, _locator))
             {
                 // Restore original default locator proxy, if the user didn't change it in the meantime
                 _communicator.DefaultLocator = _defaultLocator;
@@ -405,7 +73,9 @@ namespace ZeroC.IceLocatorDiscovery
 
             if (_communicator.GetProperty($"{_name}.Locator.Endpoints") == null)
             {
-                _communicator.SetProperty($"{_name}.Locator.AdapterId", Guid.NewGuid().ToString());
+                // TODO: temporary to use ice1
+                _communicator.SetProperty($"{_name}.Locator.Endpoints", "tcp -h localhost");
+                // _communicator.SetProperty($"{_name}.Locator.AdapterId", Guid.NewGuid().ToString());
             }
 
             _replyAdapter = _communicator.CreateObjectAdapter(_name + ".Reply");
@@ -427,11 +97,11 @@ namespace ZeroC.IceLocatorDiscovery
 
             string instanceName = _communicator.GetProperty($"{_name}.InstanceName") ?? "";
             var locatorId = new Identity("Locator", instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString());
-            _locator = new Locator(_name, lookupPrx, _communicator, instanceName, voidLocator, locatorReplyPrx);
-            _locatorPrx = _locatorAdapter.Add(locatorId, _locator, ILocatorPrx.Factory);
-            _communicator.DefaultLocator = _locatorPrx;
+            _locatorServant = new Locator(_name, lookupPrx, _communicator, instanceName, voidLocator, locatorReplyPrx);
+            _locator = _locatorAdapter.Add(locatorId, _locatorServant, ILocatorPrx.Factory);
+            _communicator.DefaultLocator = _locator;
 
-            _replyAdapter.Add(lookupReplyId, new LookupReply(_locator));
+            _replyAdapter.Add(lookupReplyId, new LookupReply(_locatorServant));
 
             _replyAdapter.Activate();
             _locatorAdapter.Activate();

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,27 +14,31 @@ namespace ZeroC.Ice
     /// <summary>The locator info class caches information specific to a given locator proxy. The communicator holds a
     /// locator info instance per locator proxy set either with Ice.Default.Locator or the proxy's Locator property. It
     /// caches the locator registry proxy and keeps track of requests to the locator to prevent multiple concurrent
-    /// locator requests for the same adapter or well-known object.</summary>
+    /// identical requests.</summary>
     internal sealed class LocatorInfo
     {
         internal ILocatorPrx Locator { get; }
 
-        private readonly ConcurrentDictionary<string, (TimeSpan InsertionTime, IReadOnlyList<Endpoint> Endpoints)>
-            _adapterEndpointsTable = new ();
-
-        private readonly Dictionary<string, Task<IReadOnlyList<Endpoint>>> _adapterRequests = new ();
+        private static readonly IEqualityComparer<Reference> _locationComparer = new LocationComparer();
+        private static readonly IEqualityComparer<Reference> _wellKnownProxyComparer = new WellKnownProxyComparer();
 
         private readonly bool _background;
 
+        private readonly ConcurrentDictionary<Reference, (TimeSpan InsertionTime, Reference Reference)>
+            _locationCache = new (_locationComparer);
+
+        private readonly Dictionary<Reference, Task<Reference?>> _locationRequests = new (_locationComparer);
+
         private ILocatorRegistryPrx? _locatorRegistry;
 
-        // _mutex protects _adapterRequests and _objectRequests
+        // _mutex protects _locationRequests and _wellKnownProxyRequests
         private readonly object _mutex = new ();
 
-        private readonly ConcurrentDictionary<Identity, (TimeSpan InsertionTime, Reference Reference)>
-            _objectReferenceTable = new ();
+        private readonly ConcurrentDictionary<Reference, (TimeSpan InsertionTime, Reference Reference)>
+            _wellKnownProxyCache = new (_wellKnownProxyComparer);
 
-        private readonly Dictionary<Identity, Task<Reference?>> _objectRequests = new ();
+        private readonly Dictionary<Reference, Task<Reference?>> _wellKnownProxyRequests =
+            new (_wellKnownProxyComparer);
 
         internal LocatorInfo(ILocatorPrx locator, bool background)
         {
@@ -48,119 +52,112 @@ namespace ZeroC.Ice
 
             if (reference.IsWellKnown)
             {
-                if (RemoveObjectReference(reference.Identity) is Reference resolvedReference)
+                if (RemoveWellKnownProxy(reference) is Reference resolvedWellKnownProxy)
                 {
-                    if (resolvedReference.IsIndirect)
+                    if (resolvedWellKnownProxy.IsIndirect)
                     {
                         // We don't cache bogus well-known resolved references.
-                        Debug.Assert(!resolvedReference.IsWellKnown);
+                        Debug.Assert(!resolvedWellKnownProxy.IsWellKnown);
 
                         if (reference.Communicator.TraceLevels.Location >= 2)
                         {
-                            Trace("removed adapter for well-known object from locator cache",
-                                  reference,
-                                  resolvedReference);
+                            TraceWellKnown("removed well-known proxy without endpoints from locator cache",
+                                           reference,
+                                           resolvedWellKnownProxy);
                         }
-                        ClearCache(resolvedReference);
+                        ClearCache(resolvedWellKnownProxy); // i.e clears location cache
                     }
                     else
                     {
                         if (reference.Communicator.TraceLevels.Location >= 2)
                         {
-                            Trace("removed endpoints for well-known object from locator cache",
+                            TraceDirect("removed well-known proxy with endpoints from locator cache",
                                   reference,
-                                  resolvedReference.Endpoints);
+                                  resolvedWellKnownProxy);
                         }
                     }
                 }
             }
             else
             {
-                if (RemoveAdapterEndpoints(reference.AdapterId) is IReadOnlyList<Endpoint> endpoints &&
+                if (RemoveLocation(reference) is Reference resolvedLocation &&
                     reference.Communicator.TraceLevels.Location >= 2)
                 {
-                    Trace("removed endpoints for adapter from locator cache", reference, endpoints);
+                    TraceDirect("removed endpoints for location from locator cache", reference, resolvedLocation);
                 }
             }
         }
 
-        internal async ValueTask<(IReadOnlyList<Endpoint>, bool)> GetEndpointsAsync(
+        /// <summary>Resolves an indirect reference using the locator proxy or cache.</summary>
+        internal async ValueTask<(Reference? DirectReference, bool Cached)> ResolveIndirectReferenceAsync(
             Reference reference,
-            TimeSpan ttl,
             CancellationToken cancel)
         {
             Debug.Assert(reference.IsIndirect);
-            IReadOnlyList<Endpoint> endpoints;
+            Reference? directReference;
             bool cached;
             if (reference.IsWellKnown)
             {
-                // First, we resolve the well-known reference. The resolved reference either embeds the endpoints
-                // or an adapter ID.
-                Reference? resolvedReference;
-                (resolvedReference, cached) = GetObjectReference(reference.Identity, ttl);
+                // First, we resolve the well-known reference. The resolved reference can be direct or indirect, but
+                // cannot be well-known.
+                Reference? resolvedWellKnownProxy;
+                (resolvedWellKnownProxy, cached) = GetResolvedWellKnownProxyFromCache(reference, reference.LocatorCacheTimeout);
                 if (!cached)
                 {
-                    if (_background && resolvedReference != null)
+                    if (_background && resolvedWellKnownProxy != null)
                     {
                         // Reference is returned from the cache but TTL was reached, if backgrounds updates
                         // are configured, we obtain a new reference to refresh the cache but use the stale
                         // reference to not block the caller.
-                        _ = GetObjectReferenceAsync(reference, cancel: default);
+                        _ = ResolveWellKnownProxyAsync(reference, cancel: default);
                     }
                     else
                     {
-                        resolvedReference = await GetObjectReferenceAsync(reference, cancel).ConfigureAwait(false);
+                        resolvedWellKnownProxy =
+                            await ResolveWellKnownProxyAsync(reference, cancel).ConfigureAwait(false);
                     }
                 }
 
-                if (resolvedReference == null || resolvedReference.Encoding != reference.Encoding)
+                if (resolvedWellKnownProxy == null || !resolvedWellKnownProxy.IsIndirect)
                 {
-                    // If the resolved reference is null or the encoding doesn't match, we can't use it.
-                    endpoints = ImmutableArray<Endpoint>.Empty;
-                }
-                else if (!resolvedReference.IsIndirect)
-                {
-                    // If it's a direct reference, just get its endpoints.
-                    endpoints = resolvedReference.Endpoints;
+                    // If it's null or a direct reference, we're done
+                    directReference = resolvedWellKnownProxy;
                 }
                 else
                 {
                     // Otherwise, it's an indirect reference (but can't be a well-known reference because
-                    // GetObjectReferenceAsync doesn't return well-known references). We need to resolve its endpoints.
-                    Debug.Assert(!resolvedReference.IsWellKnown);
+                    // ResolveWellKnownProxyAsync doesn't return well-known references). We need to resolve its location
+                    // to get a direct reference.
+                    Debug.Assert(!resolvedWellKnownProxy.IsWellKnown);
 
                     // Get the endpoints for the adapter from the resolved reference.
                     bool adapterCached;
-                    (endpoints, adapterCached) = GetAdapterEndpoints(resolvedReference.AdapterId, ttl);
+                    (directReference, adapterCached) =
+                        GetResolvedLocationFromCache(resolvedWellKnownProxy, reference.LocatorCacheTimeout);
+
                     if (!adapterCached)
                     {
-                        if (_background && endpoints.Count > 0)
+                        if (_background && directReference != null)
                         {
                             // Endpoints are returned from the cache but TTL was reached, if backgrounds updates
                             // are configured, we obtain new endpoints but continue using the stale endpoints to
                             // not block the caller.
-                            _ = GetAdapterEndpointsAsync(resolvedReference, cancel: default);
+                            _ = ResolveLocationAsync(resolvedWellKnownProxy, cancel: default);
                         }
                         else
                         {
-                            bool adapterNotFound = false;
                             try
                             {
-                                endpoints =
-                                    await GetAdapterEndpointsAsync(resolvedReference, cancel).ConfigureAwait(false);
-                            }
-                            catch (AdapterNotFoundException)
-                            {
-                                adapterNotFound = true;
-                                throw;
+                                directReference =
+                                    await ResolveLocationAsync(resolvedWellKnownProxy, cancel).ConfigureAwait(false);
                             }
                             finally
                             {
-                                // If we can't resolve the endpoints, we clear the resolved object reference from
+                                // If we can't resolve the location, we clear the resolved well known proxy from
                                 // the cache.
-                                if (endpoints.Count == 0 || adapterNotFound)
+                                if (directReference == null)
                                 {
-                                    RemoveObjectReference(reference.Identity);
+                                    RemoveWellKnownProxy(reference);
                                 }
                             }
                         }
@@ -169,86 +166,89 @@ namespace ZeroC.Ice
             }
             else
             {
-                (endpoints, cached) = GetAdapterEndpoints(reference.AdapterId, ttl);
+                (directReference, cached) = GetResolvedLocationFromCache(reference, reference.LocatorCacheTimeout);
                 if (!cached)
                 {
-                    if (_background && endpoints.Count > 0)
+                    if (_background && directReference != null)
                     {
                         // Endpoints are returned from the cache but TTL was reached, if backgrounds updates
                         // are configured, we obtain new endpoints but continue using the stale endpoints to
                         // not block the caller.
-                        _ = GetAdapterEndpointsAsync(reference, cancel: default);
+                        _ = ResolveLocationAsync(reference, cancel: default);
                     }
                     else
                     {
-                        endpoints = await GetAdapterEndpointsAsync(reference, cancel).ConfigureAwait(false);
+                        directReference =
+                            await ResolveLocationAsync(reference, cancel).ConfigureAwait(false);
                     }
                 }
             }
 
             if (reference.Communicator.TraceLevels.Location >= 1)
             {
-                if (endpoints.Count > 0)
+                if (directReference != null)
                 {
                     if (cached)
                     {
                         if (reference.IsWellKnown)
                         {
-                            Trace("found endpoints for well-known proxy in locator cache", reference, endpoints);
+                            TraceDirect("found entry for well-known proxy in locator cache",
+                                        reference,
+                                        directReference);
                         }
                         else
                         {
-                            Trace("found endpoints for adapter in locator cache", reference, endpoints);
+                            TraceDirect("found entry for location in locator cache", reference, directReference);
                         }
                     }
                     else
                     {
                         if (reference.IsWellKnown)
                         {
-                            Trace("retrieved endpoints for well-known proxy from locator, adding to locator cache",
-                                  reference,
-                                  endpoints);
+                            TraceDirect("resolved well-known proxy using locator, adding to locator cache",
+                                         reference,
+                                         directReference);
                         }
                         else
                         {
-                            Trace("retrieved endpoints for adapter from locator, adding to locator cache",
-                                  reference,
-                                  endpoints);
+                            TraceDirect("resolved location using locator, adding to locator cache",
+                                        reference,
+                                        directReference);
                         }
                     }
                 }
                 else
                 {
                     Communicator communicator = reference.Communicator;
-                    var sb = new StringBuilder();
-                    sb.Append("no endpoints configured for ");
-                    if (reference.AdapterId.Length > 0)
+                    var sb = new System.Text.StringBuilder();
+                    sb.Append("could not find endpoint(s) for ");
+                    if (reference.Location.Count > 0)
                     {
-                        sb.Append("adapter\n");
-                        sb.Append("adapter = " + reference.AdapterId);
+                        sb.Append("location ");
+                        sb.Append(reference.LocationAsString);
                     }
                     else
                     {
-                        sb.Append("well-known object\n");
-                        sb.Append("well-known proxy = " + reference.ToString());
+                        sb.Append("well-known proxy ");
+                        sb.Append(reference);
                     }
                     communicator.Logger.Trace(communicator.TraceLevels.LocationCategory, sb.ToString());
                 }
             }
-            return (endpoints, cached);
+
+            return (directReference, cached);
         }
 
-        // Encoding represents the encoding used to send the getRegistry request.
-        internal async ValueTask<ILocatorRegistryPrx?> GetLocatorRegistryAsync(Encoding encoding)
+        internal async ValueTask<ILocatorRegistryPrx?> GetLocatorRegistryAsync()
         {
             if (_locatorRegistry == null)
             {
-                ILocatorRegistryPrx? prx =
-                    await Locator.Clone(encoding: encoding).GetRegistryAsync().ConfigureAwait(false);
+                ILocatorRegistryPrx? registry = await Locator.GetRegistryAsync().ConfigureAwait(false);
 
                 // The locator registry can't be located and we use ordered endpoint selection in case the locator
                 // returned a proxy with some endpoints which are preferred to be tried first.
-                _locatorRegistry = prx?.Clone(clearLocator: true, endpointSelection: EndpointSelectionType.Ordered);
+                _locatorRegistry =
+                    registry?.Clone(clearLocator: true, endpointSelection: EndpointSelectionType.Ordered);
             }
             return _locatorRegistry;
         }
@@ -256,145 +256,64 @@ namespace ZeroC.Ice
         private static bool CheckTTL(TimeSpan insertionTime, TimeSpan ttl) =>
             ttl == Timeout.InfiniteTimeSpan || (Time.Elapsed - insertionTime) <= ttl;
 
-        private static void Trace(string msg, Reference r, IReadOnlyList<Endpoint> endpoints)
+        private static void TraceDirect(string msg, Reference reference, Reference directReference)
         {
-            var sb = new StringBuilder();
-            sb.Append(msg + "\n");
-            if (r.AdapterId.Length > 0)
+            var sb = new System.Text.StringBuilder(msg);
+            sb.Append('\n');
+            if (reference.Location.Count > 0)
             {
-                sb.Append("adapter = ");
-                sb.Append(r.AdapterId);
+                sb.Append("protocol = ");
+                sb.Append(reference.Protocol.GetName());
+                sb.Append("\nlocation = ");
+                sb.Append(reference.LocationAsString);
                 sb.Append('\n');
             }
             else
             {
                 sb.Append("well-known proxy = ");
-                sb.Append(r);
+                sb.Append(reference);
                 sb.Append('\n');
             }
             sb.Append("endpoints = ");
-            sb.Append(string.Join(":", endpoints));
-            r.Communicator.Logger.Trace(r.Communicator.TraceLevels.LocationCategory, sb.ToString());
+            sb.AppendEndpointList(directReference.Endpoints);
+            if (directReference.Location.Count > 0)
+            {
+                sb.Append("\nnew location = ");
+                sb.Append(directReference.LocationAsString);
+            }
+            reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory, sb.ToString());
         }
 
-        private static void Trace(string msg, Reference wellKnown, Reference resolved)
+        private static void TraceInvalid(Reference reference, Reference invalidReference)
+        {
+            var sb = new System.Text.StringBuilder("locator returned an invalid proxy when resolving ");
+            sb.Append(reference);
+            sb.Append("\n received = ");
+            sb.Append(invalidReference);
+            reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory, sb.ToString());
+        }
+
+        private static void TraceWellKnown(string msg, Reference wellKnown, Reference indirectReference)
         {
             Debug.Assert(wellKnown.IsWellKnown);
-            var sb = new StringBuilder();
-            sb.Append(msg);
+            var sb = new System.Text.StringBuilder(msg);
             sb.Append('\n');
             sb.Append("well-known proxy = ");
             sb.Append(wellKnown);
             sb.Append('\n');
-            sb.Append("adapter = ");
-            sb.Append(resolved.AdapterId);
+            sb.Append("location = ");
+            sb.Append(indirectReference.LocationAsString);
             wellKnown.Communicator.Logger.Trace(wellKnown.Communicator.TraceLevels.LocationCategory, sb.ToString());
         }
 
-        private (IReadOnlyList<Endpoint> Endpoints, bool Cached) GetAdapterEndpoints(string adapter, TimeSpan ttl)
-        {
-            if (ttl == TimeSpan.Zero) // Locator cache disabled.
-            {
-                return (ImmutableArray<Endpoint>.Empty, false);
-            }
-
-            if (_adapterEndpointsTable.TryGetValue(
-                adapter,
-                out (TimeSpan InsertionTime, IReadOnlyList<Endpoint> Endpoints) entry))
-            {
-                return (entry.Endpoints, CheckTTL(entry.InsertionTime, ttl));
-            }
-            else
-            {
-                return (ImmutableArray<Endpoint>.Empty, false);
-            }
-        }
-
-        private async Task<IReadOnlyList<Endpoint>> GetAdapterEndpointsAsync(
-            Reference reference,
-            CancellationToken cancel)
-        {
-            if (reference.Communicator.TraceLevels.Location > 0)
-            {
-                reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
-                    $"searching for adapter by id\nadapter = {reference.AdapterId}");
-            }
-
-            Task<IReadOnlyList<Endpoint>>? task;
-            lock (_mutex)
-            {
-                if (!_adapterRequests.TryGetValue(reference.AdapterId, out task))
-                {
-                    // If there's no locator request in progress for this adapter, we invoke one and cache it to prevent
-                    // making too many requests on the locator. It's removed once the locator response is received.
-                    task = PerformGetAdapterEndpointsAsync(reference);
-                    if (!task.IsCompleted)
-                    {
-                        // If PerformGetAdapterEndpointsAsync completed, don't add the task (it would leak since
-                        // PerformGetAdapterEndpointsAsync is responsible for removing it).
-                        _adapterRequests.Add(reference.AdapterId, task);
-                    }
-                }
-            }
-
-            return await task.WaitAsync(cancel).ConfigureAwait(false);
-
-            async Task<IReadOnlyList<Endpoint>> PerformGetAdapterEndpointsAsync(Reference reference)
-            {
-                try
-                {
-                    IObjectPrx? proxy = await Locator.FindAdapterByIdAsync(
-                        reference.AdapterId,
-                        cancel: CancellationToken.None).ConfigureAwait(false);
-                    if (proxy != null && !proxy.IceReference.IsIndirect)
-                    {
-                        // Cache the adapter endpoints.
-                        _adapterEndpointsTable[reference.AdapterId] = (Time.Elapsed, proxy.IceReference.Endpoints);
-                        return proxy.IceReference.Endpoints;
-                    }
-                    else
-                    {
-                        return ImmutableArray<Endpoint>.Empty;
-                    }
-                }
-                catch (AdapterNotFoundException)
-                {
-                    if (reference.Communicator.TraceLevels.Location > 0)
-                    {
-                        reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
-                            $"adapter not found\nadapter = {reference.AdapterId}");
-                    }
-                    RemoveAdapterEndpoints(reference.AdapterId);
-                    throw;
-                }
-                catch (Exception exception)
-                {
-                    if (reference.Communicator.TraceLevels.Location > 0)
-                    {
-                        reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
-                            "could not contact the locator to retrieve endpoints\n" +
-                            $"adapter = {reference.AdapterId}\nreason = {exception}");
-                    }
-                    throw;
-                }
-                finally
-                {
-                    lock (_mutex)
-                    {
-                        _adapterRequests.Remove(reference.AdapterId);
-                    }
-                }
-            }
-        }
-
-        private (Reference? Reference, bool Cached) GetObjectReference(Identity id, TimeSpan ttl)
+        private (Reference? Reference, bool Cached) GetResolvedLocationFromCache(Reference reference, TimeSpan ttl)
         {
             if (ttl == TimeSpan.Zero) // Locator cache disabled.
             {
                 return (null, false);
             }
 
-            if (_objectReferenceTable.TryGetValue(id, out (TimeSpan InsertionTime, Reference Reference) entry))
+            if (_locationCache.TryGetValue(reference, out (TimeSpan InsertionTime, Reference Reference) entry))
             {
                 return (entry.Reference, CheckTTL(entry.InsertionTime, ttl));
             }
@@ -404,7 +323,138 @@ namespace ZeroC.Ice
             }
         }
 
-        private async Task<Reference?> GetObjectReferenceAsync(Reference reference, CancellationToken cancel)
+        private async Task<Reference?> ResolveLocationAsync(
+            Reference reference,
+            CancellationToken cancel)
+        {
+            if (reference.Communicator.TraceLevels.Location > 0)
+            {
+                reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
+                    $"searching for adapter by id\nadapter = {reference.AdapterId}");
+            }
+
+            Task<Reference?>? task;
+            lock (_mutex)
+            {
+                if (!_locationRequests.TryGetValue(reference, out task))
+                {
+                    // If there is no request in progress for this location, we invoke one and cache the request to
+                    // prevent concurrent identical requests. It's removed once the response is received.
+                    task = PerformResolveLocationAsync(reference);
+                    if (!task.IsCompleted)
+                    {
+                        // If PerformResolveLocationAsync completed, don't add the task (it would leak since
+                        // PerformResolveLocationAsync is responsible for removing it).
+                        // Since PerformResolveLocationAsync locks _mutex in its finally block, the only way it can be
+                        // completed now is if completed synchronously.
+                        _locationRequests.Add(reference, task);
+                    }
+                }
+            }
+
+            return await task.WaitAsync(cancel).ConfigureAwait(false);
+
+            async Task<Reference?> PerformResolveLocationAsync(Reference reference)
+            {
+                try
+                {
+                    IObjectPrx? proxy;
+
+                    if (Locator.Protocol == Protocol.Ice1)
+                    {
+                        if (reference.Protocol != Protocol.Ice1)
+                        {
+                            throw new NotSupportedException("cannot resolve an ice2 proxy with an ice1 locator");
+                        }
+
+                        try
+                        {
+#pragma warning disable CS0618 // FindAdapterByIdAsync is deprecated
+                            proxy = await Locator.FindAdapterByIdAsync(
+                                reference.AdapterId,
+                                cancel: CancellationToken.None).ConfigureAwait(false);
+#pragma warning restore CS0618
+                        }
+                        catch (AdapterNotFoundException)
+                        {
+                            // We treat AdapterNotFoundException just like a null return value.
+                            proxy = null;
+                        }
+                    }
+                    else
+                    {
+                        proxy = await Locator.ResolveLocationAsync(
+                            reference.Location,
+                            reference.Protocol,
+                            cancel: CancellationToken.None).ConfigureAwait(false);
+                    }
+
+                    if (proxy == null)
+                    {
+                        RemoveLocation(reference); // clear cache if it's in there.
+                        return null;
+                    }
+                    else
+                    {
+                        Reference resolved = proxy.IceReference;
+                        if (resolved.IsIndirect ||
+                            resolved.Protocol != reference.Protocol)
+                        {
+                            if (reference.Communicator.TraceLevels.Location >= 1)
+                            {
+                                TraceInvalid(reference, resolved);
+                            }
+                            return null;
+                        }
+                        else
+                        {
+                            // Cache the resolved location
+                            _locationCache[reference] = (Time.Elapsed, resolved);
+                            return resolved;
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    if (reference.Communicator.TraceLevels.Location > 0)
+                    {
+                        reference.Communicator.Logger.Trace(
+                            reference.Communicator.TraceLevels.LocationCategory,
+                            @$"could not contact the locator to resolve location `{reference.LocationAsString
+                                }'\nreason = {exception}");
+                    }
+                    throw;
+                }
+                finally
+                {
+                    lock (_mutex)
+                    {
+                        _locationRequests.Remove(reference);
+                    }
+                }
+            }
+        }
+
+        private (Reference? Reference, bool Cached) GetResolvedWellKnownProxyFromCache(
+            Reference reference,
+            TimeSpan ttl)
+        {
+            if (ttl == TimeSpan.Zero) // Locator cache disabled.
+            {
+                return (null, false);
+            }
+
+            if (_wellKnownProxyCache.TryGetValue(reference, out (TimeSpan InsertionTime, Reference Reference) entry))
+            {
+                return (entry.Reference, CheckTTL(entry.InsertionTime, ttl));
+            }
+            else
+            {
+                return (null, false);
+            }
+        }
+
+        private async Task<Reference?> ResolveWellKnownProxyAsync(Reference reference, CancellationToken cancel)
         {
             if (reference.Communicator.TraceLevels.Location > 0)
             {
@@ -415,58 +465,88 @@ namespace ZeroC.Ice
             Task<Reference?>? task;
             lock (_mutex)
             {
-                if (!_objectRequests.TryGetValue(reference.Identity, out task))
+                if (!_wellKnownProxyRequests.TryGetValue(reference, out task))
                 {
                     // If there's no locator request in progress for this object, we make one and cache it to prevent
                     // making too many requests on the locator. It's removed once the locator response is received.
-                    task = PerformGetObjectProxyAsync(reference);
+                    task = PerformResolveWellKnownProxyAsync(reference);
                     if (!task.IsCompleted)
                     {
                         // If PerformGetObjectProxyAsync completed, don't add the task (it would leak since
                         // PerformGetObjectProxyAsync is responsible for removing it).
-                        _objectRequests.Add(reference.Identity, task);
+                        _wellKnownProxyRequests.Add(reference, task);
                     }
                 }
             }
 
             return await task.WaitAsync(cancel).ConfigureAwait(false);
 
-            async Task<Reference?> PerformGetObjectProxyAsync(Reference reference)
+            async Task<Reference?> PerformResolveWellKnownProxyAsync(Reference reference)
             {
                 try
                 {
-                    IObjectPrx? proxy = await Locator.FindObjectByIdAsync(
-                        reference.Identity,
-                        cancel: CancellationToken.None).ConfigureAwait(false);
-                    if (proxy != null && !proxy.IceReference.IsWellKnown)
+                    IObjectPrx? proxy;
+
+                    if (Locator.Protocol == Protocol.Ice1)
                     {
-                        // Cache the object reference.
-                        _objectReferenceTable[reference.Identity] = (Time.Elapsed, proxy.IceReference);
-                        return proxy.IceReference;
+                        if (reference.Protocol != Protocol.Ice1)
+                        {
+                            throw new NotSupportedException("cannot resolve an ice2 proxy with an ice1 locator");
+                        }
+
+                        try
+                        {
+#pragma warning disable CS0618 // FindObjectByIdAsync is deprecated
+                            proxy = await Locator.FindObjectByIdAsync(
+                                reference.Identity,
+                                cancel: CancellationToken.None).ConfigureAwait(false);
+#pragma warning restore CS0618
+                        }
+                        catch (ObjectNotFoundException)
+                        {
+                            // We treat ObjectNotFoundException just like a null return value.
+                            proxy = null;
+                        }
                     }
                     else
                     {
+                        proxy = await Locator.ResolveWellKnownProxyAsync(
+                            reference.Identity,
+                            reference.Protocol,
+                            cancel: CancellationToken.None).ConfigureAwait(false);
+                    }
+
+                    if (proxy == null)
+                    {
+                        RemoveWellKnownProxy(reference); // clear cache if it's in there.
                         return null;
                     }
-                }
-                catch (ObjectNotFoundException)
-                {
-                    if (reference.Communicator.TraceLevels.Location > 0)
+                    else
                     {
-                        reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
-                            "object not found\n" +
-                            $"object = {reference.Identity.ToString(reference.Communicator.ToStringMode)}");
+                        Reference resolved = proxy.IceReference;
+                        if (resolved.IsWellKnown || resolved.Protocol != reference.Protocol)
+                        {
+                            if (reference.Communicator.TraceLevels.Location >= 1)
+                            {
+                                TraceInvalid(reference, resolved);
+                            }
+                            return null;
+                        }
+                        else
+                        {
+                            _wellKnownProxyCache[reference] = (Time.Elapsed, resolved);
+                            return resolved;
+                        }
                     }
-                    RemoveObjectReference(reference.Identity);
-                    throw;
                 }
                 catch (Exception exception)
                 {
                     if (reference.Communicator.TraceLevels.Location > 0)
                     {
-                        reference.Communicator.Logger.Trace(reference.Communicator.TraceLevels.LocationCategory,
-                            "could not contact the locator to retrieve endpoints\n" +
-                            $"well-known proxy = {reference}\nreason = {exception}");
+                        reference.Communicator.Logger.Trace(
+                            reference.Communicator.TraceLevels.LocationCategory,
+                            @$"could not contact the locator to retrieve endpoints for well-known proxy `{reference
+                                }'\nreason = {exception}");
                     }
                     throw;
                 }
@@ -474,18 +554,43 @@ namespace ZeroC.Ice
                 {
                     lock (_mutex)
                     {
-                        _objectRequests.Remove(reference.Identity);
+                        _wellKnownProxyRequests.Remove(reference);
                     }
                 }
             }
         }
 
-        private IReadOnlyList<Endpoint>? RemoveAdapterEndpoints(string adapter) =>
-            _adapterEndpointsTable.TryRemove(adapter,
-                out (TimeSpan InsertionTime, IReadOnlyList<Endpoint> Endpoints) entry) ? entry.Endpoints : null;
+        private Reference? RemoveLocation(Reference reference) =>
+            _locationCache.TryRemove(reference, out (TimeSpan InsertionTime, Reference Reference) entry) ?
+                entry.Reference : null;
 
-        private Reference? RemoveObjectReference(Identity id) =>
-            _objectReferenceTable.TryRemove(id,
+        private Reference? RemoveWellKnownProxy(Reference reference) =>
+            _wellKnownProxyCache.TryRemove(reference,
                 out (TimeSpan InsertionTime, Reference Reference) entry) ? entry.Reference : null;
+
+        private sealed class LocationComparer : IEqualityComparer<Reference>
+        {
+            public bool Equals(Reference? x, Reference? y) =>
+                x!.Location.SequenceEqual(y!.Location) && x.Protocol == y.Protocol;
+
+            public int GetHashCode(Reference obj)
+            {
+                var hash = new HashCode();
+                foreach (string s in obj.Location)
+                {
+                    hash.Add(s);
+                }
+                hash.Add(obj.Protocol);
+                return hash.ToHashCode();
+            }
+        }
+
+        private sealed class WellKnownProxyComparer : IEqualityComparer<Reference>
+        {
+            public bool Equals(Reference? x, Reference? y) =>
+                x!.Identity == y!.Identity && x.Protocol == y.Protocol;
+
+            public int GetHashCode(Reference obj) => HashCode.Combine(obj.Identity, obj.Protocol);
+        }
     }
 }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1201,12 +1201,12 @@ namespace ZeroC.Ice
                 {
                     if (_replicaGroupId.Length == 0)
                     {
-                        Communicator.Logger.Trace(Communicator.TraceLevels.LocationCategory,
+                        Communicator.Logger.Trace(Communicator.TraceLevels.LocatorCategory,
                             $"could not update the endpoints of object adapter `{_id}' in the locator registry:\n{ex}");
                     }
                     else
                     {
-                        Communicator.Logger.Trace(Communicator.TraceLevels.LocationCategory,
+                        Communicator.Logger.Trace(Communicator.TraceLevels.LocatorCategory,
                             @$"could not update the endpoints of object adapter `{_id
                                 }' with replica group `{_replicaGroupId}' in the locator registry:\n{ex}");
                     }
@@ -1223,7 +1223,7 @@ namespace ZeroC.Ice
                 {
                     sb.Append(string.Join(":", proxy.Endpoints));
                 }
-                Communicator.Logger.Trace(Communicator.TraceLevels.LocationCategory, sb.ToString());
+                Communicator.Logger.Trace(Communicator.TraceLevels.LocatorCategory, sb.ToString());
             }
         }
 

--- a/csharp/src/Ice/TraceLevels.cs
+++ b/csharp/src/Ice/TraceLevels.cs
@@ -5,7 +5,7 @@ namespace ZeroC.Ice
     internal sealed class TraceLevels
     {
         internal readonly int Transport;
-        internal readonly string TransportCategory;
+        internal readonly string TransportCategory; // TODO: these are not constants?
         internal readonly int Protocol;
         internal readonly string ProtocolCategory;
         internal readonly int Retry;
@@ -20,7 +20,7 @@ namespace ZeroC.Ice
             TransportCategory = "Transport";
             ProtocolCategory = "Protocol";
             RetryCategory = "Retry";
-            LocationCategory = "Locator";
+            LocationCategory = "Locator"; // TODO why this inconsistency?
             SlicingCategory = "Slicing";
 
             string keyBase = "Ice.Trace.";

--- a/csharp/src/Ice/TraceLevels.cs
+++ b/csharp/src/Ice/TraceLevels.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice
         internal readonly int Retry;
         internal readonly string RetryCategory;
         internal readonly int Location;
-        internal readonly string LocationCategory;
+        internal readonly string LocatorCategory;
         internal readonly int Slicing;
         internal readonly string SlicingCategory;
 
@@ -20,7 +20,7 @@ namespace ZeroC.Ice
             TransportCategory = "Transport";
             ProtocolCategory = "Protocol";
             RetryCategory = "Retry";
-            LocationCategory = "Locator"; // TODO why this inconsistency?
+            LocatorCategory = "Locator"; // TODO why this inconsistency?
             SlicingCategory = "Slicing";
 
             string keyBase = "Ice.Trace.";
@@ -28,7 +28,7 @@ namespace ZeroC.Ice
             Transport = communicator.GetPropertyAsInt(keyBase + TransportCategory) ?? 0;
             Protocol = communicator.GetPropertyAsInt(keyBase + ProtocolCategory) ?? 0;
             Retry = communicator.GetPropertyAsInt(keyBase + RetryCategory) ?? 0;
-            Location = communicator.GetPropertyAsInt(keyBase + LocationCategory) ?? 0;
+            Location = communicator.GetPropertyAsInt(keyBase + LocatorCategory) ?? 0;
             Slicing = communicator.GetPropertyAsInt(keyBase + SlicingCategory) ?? 0;
         }
     }

--- a/csharp/test/Ice/location/ServerLocator.cs
+++ b/csharp/test/Ice/location/ServerLocator.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,6 +8,10 @@ namespace ZeroC.Ice.Test.Location
 {
     public class ServerLocator : ITestLocator
     {
+        private readonly ServerLocatorRegistry _registry;
+        private readonly ILocatorRegistryPrx _registryPrx;
+        private int _requestCount;
+
         public ServerLocator(ServerLocatorRegistry registry, ILocatorRegistryPrx registryPrx)
         {
             _registry = registry;
@@ -14,30 +19,48 @@ namespace ZeroC.Ice.Test.Location
             _requestCount = 0;
         }
 
-        public ValueTask<IObjectPrx?> FindAdapterByIdAsync(string adapter, Current current, CancellationToken cancel)
+        public IObjectPrx? FindAdapterById(string adapter, Current current, CancellationToken cancel)
         {
-            ++_requestCount;
-            // We add a small delay to make sure locator request queuing gets tested when
-            // running the test on a fast machine
-            System.Threading.Thread.Sleep(1);
-            return new ValueTask<IObjectPrx?>(_registry.GetAdapter(adapter).Clone(encoding: current.Encoding));
+            Debug.Assert(current.Protocol == Protocol.Ice1);
+            return ResolveLocation(new string[] { adapter }, Protocol.Ice1, current, cancel);
         }
 
-        public ValueTask<IObjectPrx?> FindObjectByIdAsync(Identity id, Current current, CancellationToken cancel)
+        public IObjectPrx? FindObjectById(Identity id, Current current, CancellationToken cancel)
         {
-            ++_requestCount;
-            // We add a small delay to make sure locator request queuing gets tested when
-            // running the test on a fast machine
-            System.Threading.Thread.Sleep(1);
-            return new ValueTask<IObjectPrx?>(_registry.GetObject(id).Clone(encoding: current.Encoding));
+            Debug.Assert(current.Protocol == Protocol.Ice1);
+            return ResolveWellKnownProxy(id, Protocol.Ice1, current, cancel);
         }
 
         public ILocatorRegistryPrx GetRegistry(Current current, CancellationToken cancel) => _registryPrx;
 
         public int GetRequestCount(Current current, CancellationToken cancel) => _requestCount;
 
-        private readonly ServerLocatorRegistry _registry;
-        private readonly ILocatorRegistryPrx _registryPrx;
-        private int _requestCount;
+        public IObjectPrx? ResolveLocation(
+            string[] location,
+            Protocol protocol,
+            Current current,
+            CancellationToken cancel)
+        {
+            ++_requestCount;
+            // We add a small delay to make sure locator request queuing gets tested when
+            // running the test on a fast machine
+            System.Threading.Thread.Sleep(1);
+
+            return _registry.GetAdapter(location[0]);
+        }
+
+        public IObjectPrx? ResolveWellKnownProxy(
+            Identity identity,
+            Protocol protocol,
+            Current current,
+            CancellationToken cancel)
+        {
+            ++_requestCount;
+            // We add a small delay to make sure locator request queuing gets tested when
+            // running the test on a fast machine
+            System.Threading.Thread.Sleep(1);
+
+            return _registry.GetObject(identity);
+        }
     }
 }

--- a/csharp/test/Ice/location/Test.ice
+++ b/csharp/test/Ice/location/Test.ice
@@ -13,10 +13,8 @@ module ZeroC::Ice::Test::Location
 
 interface TestLocatorRegistry : ::Ice::LocatorRegistry
 {
-    //
     // Allow remote addition of objects to the locator registry.
-    //
-    void addObject(Object* obj);
+    void addObject(Object obj);
 }
 
 interface TestLocator : ::Ice::Locator

--- a/csharp/test/IceDiscovery/simple/Client.cs
+++ b/csharp/test/IceDiscovery/simple/Client.cs
@@ -10,10 +10,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
     {
         public override async Task RunAsync(string[] args)
         {
-            var properties = CreateTestProperties(ref args);
-            // TODO: see server
-            properties["Test.Protocol"] = "ice1";
-            await using Ice.Communicator communicator = Initialize(properties);
+            await using Ice.Communicator communicator = Initialize(ref args);
             int num;
             try
             {

--- a/csharp/test/IceDiscovery/simple/Server.cs
+++ b/csharp/test/IceDiscovery/simple/Server.cs
@@ -13,13 +13,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
     {
         public override async Task RunAsync(string[] args)
         {
-            Dictionary<string, string>? properties = CreateTestProperties(ref args);
-            // TODO: we currently force ice1 for this test because Test.Protocol is the only way to select
-            // the protocol used by object adapters. Once this is fixed, we should run this test with both ice1 and
-            // ice2, and use only ice1 for the udp object adapter.
-            properties["Test.Protocol"] = "ice1";
-
-            await using Communicator communicator = Initialize(properties);
+            await using Communicator communicator = Initialize(ref args);
             int num = 0;
             try
             {

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -20,7 +20,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             communicator.SetProperty($"{name}.AdapterId", adapterId);
             communicator.SetProperty($"{name}.ReplicaGroupId", replicaGroupId);
-            communicator.SetProperty($"{name}.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1");
+            communicator.SetProperty($"{name}.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0");
             ObjectAdapter oa = communicator.CreateObjectAdapter(name);
             _adapters[name] = oa;
             oa.Activate();

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -211,7 +211,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 IObjectPrx.Parse("unknown/unknown", communicator).IcePing();
                 TestHelper.Assert(false);
             }
-            catch (ObjectNotFoundException)
+            catch (NoEndpointException)
             {
                 // expected
             }
@@ -224,7 +224,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 IObjectPrx.Parse("test @ TestAdapterUnknown", communicator).IcePing();
                 TestHelper.Assert(false);
             }
-            catch (AdapterNotFoundException)
+            catch (NoEndpointException)
             {
                 // expected
             }

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -164,14 +164,14 @@ class Ice(Component):
             return None
 
         # Define here Ice tests which are slow to execute and for which it's not useful to test different options
-        if testcase.getTestSuite().getId() in ["Ice/binding", "Ice/faultTolerance", "Ice/location"]:
+        if testcase.getTestSuite().getId() in ["Ice/binding", "Ice/faultTolerance"]:
             return self.serviceOptions
 
         # We only run the client/server tests defined for cross testing with all transports (we skip them for
         # AMD/Tie client/server tests however).
         if type(testcase) is ClientServerTestCase and self.isCross(testcase.getTestSuite().getId()):
             return self.transportOptions
-        elif parent in ["Ice", "IceBox"]:
+        elif parent in ["Ice", "IceBox", "IceDiscovery"]:
             return self.coreOptions
         else:
             return self.serviceOptions

--- a/slice/Ice/Encoding.ice
+++ b/slice/Ice/Encoding.ice
@@ -1,6 +1,4 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
@@ -13,8 +11,8 @@
 
 [[python:pkgdir:Ice]]
 
-[[java:package:com.zeroc]]
 [cs:namespace:ZeroC]
+[java:package:com.zeroc]
 module Ice
 {
     /// The Ice encoding defines how Slice constructs are marshaled to and later unmarshaled from sequences of bytes.

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -12,30 +12,27 @@
 
 [[python:pkgdir:Ice]]
 
+#include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 #include <Ice/Process.ice>
+#include <Ice/Protocol.ice>
 
-[[java:package:com.zeroc]]
 [cs:namespace:ZeroC]
+[java:package:com.zeroc]
 module Ice
 {
+    /// This exception is thrown when a server tries to register endpoints for an object adapter that is already active.
+    exception AdapterAlreadyActiveException
+    {
+    }
+
     /// This exception is thrown when an object adapter was not found.
     exception AdapterNotFoundException
     {
     }
 
-    /// This exception is thrown when the provided proxy is invalid.
-    exception InvalidProxyException
-    {
-    }
-
     /// This exception is thrown when the provided replica group is invalid.
     exception InvalidReplicaGroupIdException
-    {
-    }
-
-    /// This exception is thrown when a server tries to register endpoints for an object adapter that is already active.
-    exception AdapterAlreadyActiveException
     {
     }
 
@@ -51,39 +48,85 @@ module Ice
 
     interface LocatorRegistry;
 
-    /// The Ice locator interface. This interface is used by clients to lookup adapters and objects. It is also used by
-    /// servers to get the locator registry proxy.
+    /// Client applications use Locator to resolve locations and well-known proxies. The Locator object also allows
+    /// server applications to retrieve a proxy to the LocatorRegistry object.
     interface Locator
     {
+#ifdef __SLICE2CS__
         /// Finds an object by identity and returns a proxy that provides a location or endpoint(s) that can be used
-        /// to reach the object.
+        /// to reach the object. Calling this operation is equivalent to calling
+        /// resolveWellKnownProxy(id, Protocol::Ice1).
         /// @param id The identity.
         /// @return A proxy that provides a location or endpoint(s) or null if an object with identity `id' was
         /// not found.
-        /// @throws ObjectNotFoundException Thrown if an object with identity `id' was not found. This exception
-        /// is equivalent to a null return value.
-        [amd] [nonmutating] [cpp:const] idempotent Object? findObjectById(Identity id)
-            throws ObjectNotFoundException;
+        /// @throws ObjectNotFoundException Thrown if an object with identity `id' was not found. The caller should
+        /// treat this exception like a null return value.
+        [deprecate:use resolveWellKnownProxy]
+        idempotent Object? findObjectById(Identity id);
 
-        /// Finds an object adapter by id and returns a proxy that provides the object adapter's endpoint(s).
+        /// Finds an object adapter by id and returns a proxy that provides the object adapter's endpoint(s). Calling
+        /// this operation is equivalent to calling resolveLocation([id], Protocol::Ice1).
         /// @param id The adapter ID.
         /// @return A proxy with the adapter's endpoint(s) or null if an object adapter with adapter ID `id' was
         /// not found.
-        /// @throws AdapterNotFoundException Thrown if an object adapter with this adapter ID was not found. This
-        /// exception is equivalent to a null return value.
-        [amd] [nonmutating] [cpp:const] idempotent Object? findAdapterById(string id)
-            throws AdapterNotFoundException;
+        /// @throws AdapterNotFoundException Thrown if an object adapter with this adapter ID was not found. The caller
+        /// should treat this exception like a null return value.
+        [deprecate:use resolveLocation]
+        idempotent Object? findAdapterById(string id);
 
         /// Gets the locator registry.
         /// @return The locator registry, or null if this locator has no registry.
-        [nonmutating] [cpp:const] idempotent LocatorRegistry? getRegistry();
+        idempotent LocatorRegistry? getRegistry();
+
+        /// Resolves the location of a proxy.
+        /// @param location The location to resolve.
+        /// @param protocol The protocol of the proxy being resolved.
+        /// @return A direct proxy that provides the endpoint(s) plus optionally a revised location for the supplied
+        /// location (ice2 only), or null when the location cannot be resolved. When not null, the proxy has the
+        /// specified protocol.
+        idempotent Object? resolveLocation(StringSeq location, Protocol protocol);
+
+        /// Locates the well-known object with the given identity.
+        /// @param identity The identity of the well-known Ice object.
+        /// @param protocol The protocol of the proxy being resolved.
+        /// @return A proxy that provides the location or endpoint(s) of the well-known object, or null if an object
+        /// with identity `identity' was not found.
+        idempotent Object? resolveWellKnownProxy(Identity identity, Protocol protocol);
+
+#else
+        [amd] [nonmutating] [cpp:const] idempotent Object? findObjectById(Identity id)
+            throws ObjectNotFoundException;
+
+        [amd] [nonmutating] [cpp:const] idempotent Object? findAdapterById(string id)
+            throws AdapterNotFoundException;
+
+        [cpp:const] idempotent LocatorRegistry? getRegistry();
+#endif
     }
 
-    /// The Ice locator registry interface. This interface is used by a server to register the endpoints of its object
-    /// adapters with the locator.
+    /// A LocatorRegistry object can be reached with the ice2 protocol but not with the ice1 protocol. A server
+    /// application registers the endpoints of its indirect object adapters with this object.
     interface LocatorRegistry
     {
-        /// Registers or unregisters the endpoints of an object adapter.
+#ifdef __SLICE2CS__
+        /// Registers the endpoints of an object adapter. Since Ice 4.0.
+        /// @param adapterId The adapter ID.
+        /// @param replicaGroupId The replica groupd ID. It is set to the empty string when the object adapter does not
+        /// belong to a replica group.
+        /// @param proxy A dummy direct proxy created by the object adapter that provides the object adapter's
+        /// endpoints. The locator considers an object adapter to be active after it has registered its endpoints.
+        /// @throws AdapterAlreadyActiveException Thrown if an object adapter with the same adapter ID has already
+        /// registered its endpoints.
+        /// @throws AdapterNotFoundException Thrown if the locator only allows registered object adapters to register
+        /// their active endpoints and no object adapter with this adapter ID and replica group ID (if applicable) was
+        /// registered with the locator.
+        /// @throws InvalidReplicaGroupIdException Thrown if the given replica group does not match the replica group
+        /// associated with the adapter ID in the locator's database.
+        void registerAdapterEndpoints(string adapterId, string replicaGroupId, Object proxy);
+
+        /// Registers or unregisters the endpoints of an object adapter. When proxy is not null, calling this operation
+        /// is equivalent to calling registerAdapterEndpoints(id, "", proxy). When proxy is null, calling this operation
+        /// is equivalent to calling unregisterAdapterEndpoints(id, "", Protocol::Ice1).
         /// @param id The adapter ID.
         /// @param proxy A dummy direct proxy created by the object adapter that provides the object adapter's
         /// endpoints. The locator considers an object adapter to be active after it has registered its endpoints. When
@@ -92,10 +135,14 @@ module Ice
         /// their active endpoints and no object adapter with this adapter ID was registered with the locator.
         /// @throws AdapterAlreadyActiveException Thrown if an object adapter with the same adapter ID has already
         /// registered its endpoints.
-        [amd] idempotent void setAdapterDirectProxy(string id, Object? proxy)
-            throws AdapterNotFoundException, AdapterAlreadyActiveException;
+        // Note: idempotent is not quite correct, and kept only for backwards compatibility with old implementations.
+        [deprecate:use registerAdapterEndpoints or unregisterAdapterEndpoints]
+        idempotent void setAdapterDirectProxy(string id, Object? proxy);
 
-        /// Registers or unregisters the endpoints of an object adapter that is a member of a replica group.
+        /// Registers or unregisters the endpoints of an object adapter that is a member of a replica group.  When proxy
+        /// is not null, calling this operation is equivalent to calling
+        /// registerReplicagedAdapterEndpoints(adapterId, replicaGroupId, proxy). When proxy is null, calling this
+        /// operation is equivalent to calling unregisterAdapterEndpoints(adapterId, replicaGroupId, Protocol::Ice1).
         /// @param adapterId The adapter ID.
         /// @param replicaGroupId The replica group ID.
         /// @param proxy A dummy direct proxy created by the object adapter that provides the object adapter's
@@ -106,20 +153,44 @@ module Ice
         /// @throws AdapterAlreadyActiveException Thrown if an object adapter with the same adapter ID has already
         /// @throws InvalidReplicaGroupIdException Thrown if the given replica group does not match the replica group
         /// associated with the adapter ID in the locator's database.
+        [deprecate:use registerAdapterEndpoints or unregisterAdapterEndpoints]
+        // Note: idempotent is not quite correct, and kept only for backwards compatibility with old implementations.
+        idempotent void setReplicatedAdapterDirectProxy(string adapterId, string replicaGroupId, Object? proxy);
+
+        /// Registers a proxy for a server's Process object.
+        /// @param serverId The server ID.
+        /// @param proxy A proxy for the server's Process object.
+        /// @throws ServerNotFoundException Thrown if the locator does not know a server with this server ID.
+        idempotent void setServerProcessProxy(string serverId, Process proxy);
+
+        /// Unregisters the endpoints of an object adapter, if this object adapter has registered its endpoints. Since
+        /// Ice 4.0.
+        /// @param adapterId The adapter ID.
+        /// @param replicaGroupId The replica groupd ID. It is set to the empty string when the object adapter does not
+        /// belong to a replica group.
+        /// @param protocol The protocol of object adapter being unregistered.
+        /// @throws AdapterNotFoundException Thrown if the locator only allows registered object adapters to register
+        /// their active endpoints and no object adapter with this adapter ID and replica group ID (if applicable) was
+        /// registered with the locator.
+        /// @throws InvalidReplicaGroupIdException Thrown if the given replica group does not match the replica group
+        /// associated with the adapter ID in the locator's database.
+        idempotent void unregisterAdapterEndpoints(string adapterId, string replicaGroupId, Protocol protocol);
+
+#else
+        [amd] idempotent void setAdapterDirectProxy(string id, Object? proxy)
+            throws AdapterNotFoundException, AdapterAlreadyActiveException;
+
         [amd] idempotent void setReplicatedAdapterDirectProxy(string adapterId, string replicaGroupId, Object? proxy)
             throws AdapterNotFoundException, AdapterAlreadyActiveException, InvalidReplicaGroupIdException;
 
-        /// Registers a proxy for a server's Process object.
-        /// @param id The server ID.
-        /// @param proxy A proxy for the server's Process object.
-        /// @throws ServerNotFoundException Thrown if the locator does not know a server with this server ID.
         [amd] idempotent void setServerProcessProxy(string id, Process proxy)
             throws ServerNotFoundException;
+#endif
     }
 
-    /// This interface is implemented by services that implement the Ice::Locator interface, and is advertised as an
-    /// Ice object with the identity `Ice/LocatorFinder'. This allows clients to retrieve the locator proxy with just
-    /// the endpoint information of the service.
+    /// This interface is implemented by services that implement the Ice::Locator interface, and is advertised as an Ice
+    /// object with the identity `Ice/LocatorFinder'. This allows clients to retrieve the locator proxy with just the
+    /// endpoint information of the service.
     interface LocatorFinder
     {
         /// Gets the locator proxy implemented by the service hosting this finder object. The proxy might point to

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -104,8 +104,7 @@ module Ice
 #endif
     }
 
-    /// A LocatorRegistry object can be reached with the ice2 protocol but not with the ice1 protocol. A server
-    /// application registers the endpoints of its indirect object adapters with this object.
+    /// A server application registers the endpoints of its indirect object adapters with the LocatorRegistry object.
     interface LocatorRegistry
     {
 #ifdef __SLICE2CS__

--- a/slice/Ice/Protocol.ice
+++ b/slice/Ice/Protocol.ice
@@ -1,6 +1,4 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
@@ -13,8 +11,8 @@
 
 [[python:pkgdir:Ice]]
 
-[[java:package:com.zeroc]]
 [cs:namespace:ZeroC]
+[java:package:com.zeroc]
 module Ice
 {
     /// Represents a version of the Ice protocol.

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -11,6 +11,7 @@
 [[python:pkgdir:IceDiscovery]]
 
 #include <Ice/Identity.ice>
+#include <Ice/Protocol.ice>
 
 /// The IceDiscovery plug-in implements the {@see Ice::Locator} interface to locate (or discover) objects and object
 /// adapters using UDP multicast. It also implements the {@see Ice::LocatorDiscovery} interface to allow servers to
@@ -39,20 +40,37 @@ module IceDiscovery
     /// requests from clients.
     interface Lookup
     {
-        /// Finds an object hosted by the target object's server.
-        /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
-        /// domain ID that matches the server's configured domain ID.
-        /// @param id The object identity.
-        /// @param reply A proxy to the client's LookupReply object. The server calls foundObjectById on this object
-        /// when it hosts an object with identity `id`, provided the domain IDs match.
-        idempotent void findObjectById(string domainId, Ice::Identity id, LookupReply reply);
-
+#ifdef __SLICE2CS__
         /// Finds an object adapter hosted by the target object's server.
         /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
         /// domain ID that matches the server's configured domain ID.
         /// @param id The adapter ID.
-        /// @param reply A proxy to the client's LookupReply object. The server calls foundAdapterById on this object
-        /// when it hosts an object adapter with adapter ID `id`, provided the domain IDs match.
+        /// @param reply A proxy to the caller's LookupReply object. The server calls foundAdapterById on this object
+        /// when it hosts an object adapter that has the requested adapter ID (or replica group ID) and this object
+        /// adapter uses the specified protocol.
+        /// @param protocol The protocol of the object adapter (optional). Not set is equivalent to Protocol::Ice1.
+        idempotent void findAdapterById(
+            string domainId,
+            string id,
+            LookupReply reply,
+            tag(1) Ice::Protocol? protocol);
+
+        /// Finds an object hosted by the target object's server.
+        /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
+        /// domain ID that matches the server's configured domain ID.
+        /// @param id The object identity.
+        /// @param reply A proxy to the caller's LookupReply object. The server calls foundObjectById on this object
+        /// when it hosts an object with the requested identity in an object adapter that uses the specified protocol.
+        /// @param protocol The protocol of the object adapter hosting the desired object (optional). Not set is
+        /// equivalent to Protocol::Ice1.
+        idempotent void findObjectById(
+            string domainId,
+            Ice::Identity id,
+            LookupReply reply,
+            tag(1) Ice::Protocol? protocol);
+#else
         idempotent void findAdapterById(string domainId, string id, LookupReply reply);
+        idempotent void findObjectById(string domainId, Ice::Identity id, LookupReply reply);
+#endif
     }
 }


### PR DESCRIPTION
This PR further refactors Locator with new operations that add support for location resolution and protocol selection.

With this PR, each location becomes protocol-specific. For example it's possible to resolve with the Locator and get different endpoints for `hello @ foobar` and `ice:foobar//hello`. Likewise, you can register two different object adapters with adapter ID `foobar` provided these two object adapters use different protocols.

This PR reworks the IceDiscovery implementation, but did not change much the IceLocatorDiscovery implementation. The update of IceLocatorDiscovery is for a follow-up PR.


