### PR TITLE
Fix request forwarding

### DIFF
--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -122,40 +122,6 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>If this response holds a 1.1-encoded system exception, reads and throws this exception.</summary>
-        internal Exception? ReadIce1SystemException(Communicator communicator)
-        {
-            if (ResultType == ResultType.Failure && Encoding == Encoding.V11)
-            {
-                var replyStatus = (ReplyStatus)Payload[0]; // can be reassigned below
-
-                InputStream? istr = null;
-                if (Protocol == Protocol.Ice1)
-                {
-                    if (replyStatus != ReplyStatus.UserException)
-                    {
-                        istr = new InputStream(Payload.Slice(1), Encoding.V11);
-                    }
-                }
-                else
-                {
-                    istr = new InputStream(Payload.Slice(1),
-                                           Ice2Definitions.Encoding,
-                                           communicator,
-                                           startEncapsulation: true);
-
-                    replyStatus = istr.ReadReplyStatus();
-                    if (replyStatus == ReplyStatus.UserException)
-                    {
-                        istr = null; // we are not throwing this user exception here
-                    }
-                }
-
-                return istr?.ReadIce1SystemException(replyStatus);
-            }
-            return null;
-        }
-
         private protected override ArraySegment<byte> GetEncapsulation()
         {
             // Can only be called for a frame with an encapsulation:

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -192,9 +192,8 @@ namespace ZeroC.Ice
                                                                       Ice2Definitions.Encoding,
                                                                       response.Payload.Count + 2,
                                                                       Encoding);
-                            buffer[tail.Offset++] = (byte)replyStatus;
                             Data[0] = Data[0].Slice(0, tail.Offset);
-                            Data.Add(response.Payload.Slice(1));
+                            Data.Add(response.Payload);
                         }
                     }
                 }

--- a/csharp/src/Ice/OutgoingResponseFrame.cs
+++ b/csharp/src/Ice/OutgoingResponseFrame.cs
@@ -161,10 +161,6 @@ namespace ZeroC.Ice
                         }
                         else
                         {
-                            // TODO: this code is currently unreachable because the application never gets an incoming
-                            // response frame carrying a system exception - this system exception is always thrown.
-                            Debug.Assert(false);
-
                             Data[0] = Data[0].Slice(0, 1);
                         }
                         // 1 for the result type in the response, then sizeLength + 2 to skip the encapsulation header,
@@ -190,19 +186,15 @@ namespace ZeroC.Ice
                         }
                         else
                         {
-                            // TODO: this code is currently unreachable because the application never gets an incoming
-                            // response frame carrying a system exception - this system exception is always thrown.
-                            Debug.Assert(false);
-
                             OutputStream.Position tail =
                                 OutputStream.WriteEncapsulationHeader(Data,
                                                                       EncapsulationStart,
                                                                       Ice2Definitions.Encoding,
-                                                                      response.Payload.Count,
+                                                                      response.Payload.Count + 2,
                                                                       Encoding);
                             buffer[tail.Offset++] = (byte)replyStatus;
                             Data[0] = Data[0].Slice(0, tail.Offset);
-                            Data.Add(response.Payload);
+                            Data.Add(response.Payload.Slice(1));
                         }
                     }
                 }

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -443,31 +443,14 @@ namespace ZeroC.Ice
 
                         if (lastException == null)
                         {
-                            Debug.Assert(response != null &&
-                                         response.ResultType == ResultType.Failure &&
-                                         !releaseRequestAfterSent);
+                            Debug.Assert(response!.ResultType == ResultType.Failure);
+                            Debug.Assert(!releaseRequestAfterSent);
+                            Debug.Assert(retryPolicy == RetryPolicy.NoRetry);
+
                             observer?.RemoteException();
-                            if (response.ReadIce1SystemException(proxy.Communicator) is Exception systemException &&
-                                systemException is ObjectNotExistException one)
+                            if (response.Protocol == Protocol.Ice1)
                             {
-                                // 1.1 System exceptions
-                                if (reference.RouterInfo != null && one.Origin!.Value.Operation == "ice_add_proxy")
-                                {
-                                    // If we have a router, an ObjectNotExistException with an operation name
-                                    // "ice_add_proxy" indicates to the client that the router isn't aware of the proxy
-                                    // (for example, because it was evicted by the router). In this case, we must
-                                    // *always* retry, so that the missing proxy is added to the router.
-                                    reference.RouterInfo.ClearCache(reference);
-                                    retryPolicy = RetryPolicy.AfterDelay(TimeSpan.Zero);
-                                }
-                                else if (reference.IsIndirect)
-                                {
-                                    if (reference.IsWellKnown)
-                                    {
-                                        reference.LocatorInfo?.ClearCache(reference);
-                                    }
-                                    retryPolicy = RetryPolicy.AfterDelay(TimeSpan.Zero);
-                                }
+                                retryPolicy = Ice1Definitions.GetRetryPolicy(response, reference);
                             }
                             else if (response.BinaryContext.TryGetValue((int)BinaryContext.RetryPolicy,
                                                                          out ReadOnlyMemory<byte> value))

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -196,7 +196,7 @@ namespace ZeroC.Ice
 #else
                 // The stack trace of the inner exception can include sensitive information we don't want to send
                 // "over the wire" in non-debug builds.
-                message += $":\n{InnerException.Message}";
+                message += $":\n{InnerException!.Message}";
 #endif
                 return message;
             }

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -1116,15 +1116,9 @@ namespace ZeroC.Ice.Test.Metrics
             rim1 = (ChildInvocationMetrics)im1.Children[0]!;
             TestHelper.Assert(rim1.Current <= 1 && rim1.Total == 2 && rim1.Failures == 0);
             TestHelper.Assert(rim1.Size == (ice1 ? 94 : 102) && rim1.ReplySize > 7);
-            if (ice1)
-            {
-                CheckFailure(clientMetrics, "Invocation", im1.Id, "ZeroC.Ice.ObjectNotExistException", 2, output);
-            }
-            else
-            {
-                // TODO: observers needs fixing to report a better exception than System.Exception
-                CheckFailure(clientMetrics, "Invocation", im1.Id, "System.Exception", 2, output);
-            }
+
+            // TODO: observers needs fixing to report a better exception than System.Exception
+            CheckFailure(clientMetrics, "Invocation", im1.Id, "System.Exception", 2, output);
 
             im1 = (InvocationMetrics)map["opWithUnknownException"];
             TestHelper.Assert(im1.Current <= 1 && im1.Total == 2 && im1.Retry == 0);

--- a/csharp/test/Ice/protocolBridging/TestI.cs
+++ b/csharp/test/Ice/protocolBridging/TestI.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Test;
-using ZeroC.Ice;
 
 namespace ZeroC.Ice.Test.ProtocolBridging
 {


### PR DESCRIPTION
This PR fixes IceInvoke to not throw 1.1 system exceptions, it also fixes the OutgoingResposeFrame forwarding constructor to correctly forward 1.1 system exceptions