### PR TITLE
Use new metadata syntax

### DIFF
--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>
@@ -45,7 +44,7 @@ module IceGrid
         string icepatch;
 
         /// The source directories.
-        [java:type:java.util.LinkedList<String>] Ice::StringSeq directories;
+        Ice::StringSeq directories;
     }
 
     dictionary<string, PropertyDescriptorSeq> PropertyDescriptorSeqDict;

--- a/cpp/src/IceStorm/DBTypes.ice
+++ b/cpp/src/IceStorm/DBTypes.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <IceStorm/SubscriberRecord.ice>
 #include <IceStorm/LLURecord.ice>

--- a/cpp/src/IceStorm/DBTypes.ice
+++ b/cpp/src/IceStorm/DBTypes.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <IceStorm/SubscriberRecord.ice>
 #include <IceStorm/LLURecord.ice>

--- a/cpp/src/IceStorm/DBTypes.ice
+++ b/cpp/src/IceStorm/DBTypes.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <IceStorm/SubscriberRecord.ice>
 #include <IceStorm/LLURecord.ice>

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <IceStorm/IceStorm.ice>
 #include <IceStorm/Election.ice>

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <IceStorm/IceStorm.ice>
 #include <IceStorm/Election.ice>
@@ -14,7 +13,7 @@
 #include <Ice/Context.ice>
 #include <Ice/Ice1Definitions.ice> // for Ice::OperationMode
 
-[[cpp:include:deque]]
+[[cpp:include(deque)]]
 
 module IceStorm
 {
@@ -32,7 +31,7 @@ module IceStorm
     }
 
     /// A sequence of EventData.
-    [cpp:type:std::deque<IceStorm::EventData>] sequence<EventData> EventDataSeq;
+    [cpp:type(std::deque<IceStorm::EventData>)] sequence<EventData> EventDataSeq;
 
     /// The TopicLink interface. This is used to forward events between
     /// federated Topic instances.

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <IceStorm/IceStorm.ice>
 #include <IceStorm/Election.ice>

--- a/cpp/src/IceStorm/LLURecord.ice
+++ b/cpp/src/IceStorm/LLURecord.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/LLURecord.ice
+++ b/cpp/src/IceStorm/LLURecord.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/LLURecord.ice
+++ b/cpp/src/IceStorm/LLURecord.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/LinkRecord.ice
+++ b/cpp/src/IceStorm/LinkRecord.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStormInternal.ice>

--- a/cpp/src/IceStorm/LinkRecord.ice
+++ b/cpp/src/IceStorm/LinkRecord.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStormInternal.ice>

--- a/cpp/src/IceStorm/LinkRecord.ice
+++ b/cpp/src/IceStorm/LinkRecord.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStormInternal.ice>

--- a/cpp/src/IceStorm/SubscriberRecord.ice
+++ b/cpp/src/IceStorm/SubscriberRecord.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStorm.ice>

--- a/cpp/src/IceStorm/SubscriberRecord.ice
+++ b/cpp/src/IceStorm/SubscriberRecord.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStorm.ice>

--- a/cpp/src/IceStorm/SubscriberRecord.ice
+++ b/cpp/src/IceStorm/SubscriberRecord.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStorm.ice>

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -163,8 +163,23 @@ slice_error(const char* s)
     }
 }
 
+// TODO this function is only temporarily necessary to convert between the old and new syntax styles.
+void convertMetadata(StringListTokPtr& metadata)
+{
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
+}
 
-#line 168 "src/Slice/Grammar.cpp"
+
+#line 183 "src/Slice/Grammar.cpp"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -356,7 +371,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 
 
-#line 360 "src/Slice/Grammar.cpp"
+#line 375 "src/Slice/Grammar.cpp"
 
 #ifdef short
 # undef short
@@ -727,31 +742,31 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   188,   188,   194,   195,   201,   222,   238,   256,   265,
-     273,   282,   289,   288,   294,   293,   298,   303,   302,   308,
-     307,   312,   317,   316,   322,   321,   326,   331,   330,   336,
-     335,   340,   345,   344,   350,   349,   354,   359,   358,   363,
-     368,   367,   373,   372,   377,   381,   391,   390,   429,   428,
-     506,   510,   521,   532,   531,   557,   565,   574,   592,   666,
-     672,   683,   705,   783,   793,   808,   812,   823,   834,   833,
-     874,   878,   889,   914,  1004,  1016,  1029,  1028,  1062,  1096,
-    1105,  1106,  1112,  1127,  1149,  1150,  1151,  1155,  1161,  1162,
-    1168,  1180,  1196,  1211,  1220,  1225,  1234,  1269,  1304,  1338,
-    1378,  1377,  1400,  1399,  1422,  1440,  1444,  1445,  1451,  1455,
-    1466,  1480,  1479,  1513,  1548,  1583,  1588,  1593,  1607,  1611,
-    1620,  1627,  1639,  1651,  1662,  1670,  1684,  1694,  1710,  1714,
-    1723,  1739,  1753,  1752,  1773,  1772,  1791,  1795,  1804,  1805,
-    1806,  1815,  1824,  1838,  1852,  1867,  1887,  1891,  1929,  1933,
-    1942,  1961,  1962,  1968,  1969,  1975,  1979,  1988,  1989,  1995,
-    1996,  2007,  2008,  2009,  2010,  2011,  2012,  2013,  2014,  2015,
-    2016,  2017,  2018,  2019,  2020,  2021,  2026,  2030,  2034,  2038,
-    2046,  2051,  2062,  2066,  2078,  2083,  2109,  2141,  2169,  2184,
-    2198,  2209,  2221,  2232,  2243,  2254,  2260,  2266,  2273,  2285,
-    2294,  2303,  2343,  2350,  2357,  2369,  2378,  2392,  2393,  2394,
-    2395,  2396,  2397,  2398,  2399,  2400,  2401,  2402,  2403,  2404,
-    2405,  2406,  2407,  2408,  2409,  2410,  2411,  2412,  2413,  2414,
-    2415,  2416,  2417,  2418,  2419,  2420,  2421,  2422,  2423,  2424,
-    2425,  2426,  2427,  2428
+       0,   203,   203,   209,   210,   216,   227,   233,   242,   251,
+     259,   268,   275,   274,   280,   279,   284,   289,   288,   294,
+     293,   298,   303,   302,   308,   307,   312,   317,   316,   322,
+     321,   326,   331,   330,   336,   335,   340,   345,   344,   349,
+     354,   353,   359,   358,   363,   367,   377,   376,   415,   414,
+     492,   496,   507,   518,   517,   543,   551,   560,   578,   652,
+     658,   669,   691,   769,   779,   794,   798,   809,   820,   819,
+     860,   864,   875,   900,   990,  1002,  1015,  1014,  1048,  1082,
+    1091,  1092,  1098,  1113,  1135,  1136,  1137,  1141,  1147,  1148,
+    1154,  1166,  1182,  1197,  1206,  1211,  1220,  1255,  1290,  1324,
+    1364,  1363,  1386,  1385,  1408,  1426,  1430,  1431,  1437,  1441,
+    1452,  1466,  1465,  1499,  1534,  1569,  1574,  1579,  1593,  1597,
+    1606,  1613,  1625,  1637,  1648,  1656,  1670,  1680,  1696,  1700,
+    1709,  1725,  1739,  1738,  1759,  1758,  1777,  1781,  1790,  1791,
+    1792,  1801,  1810,  1824,  1838,  1853,  1873,  1877,  1915,  1919,
+    1928,  1947,  1948,  1954,  1955,  1961,  1965,  1974,  1975,  1981,
+    1982,  1993,  1994,  1995,  1996,  1997,  1998,  1999,  2000,  2001,
+    2002,  2003,  2004,  2005,  2006,  2007,  2012,  2016,  2020,  2024,
+    2032,  2037,  2048,  2052,  2064,  2069,  2095,  2127,  2155,  2170,
+    2184,  2195,  2207,  2218,  2229,  2240,  2246,  2252,  2259,  2271,
+    2280,  2289,  2329,  2336,  2343,  2355,  2364,  2378,  2379,  2380,
+    2381,  2382,  2383,  2384,  2385,  2386,  2387,  2388,  2389,  2390,
+    2391,  2392,  2393,  2394,  2395,  2396,  2397,  2398,  2399,  2400,
+    2401,  2402,  2403,  2404,  2405,  2406,  2407,  2408,  2409,  2410,
+    2411,  2412,  2413,  2414
 };
 #endif
 
@@ -1843,77 +1858,48 @@ yyreduce:
   switch (yyn)
     {
   case 5: /* file_metadata: ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE  */
-#line 202 "src/Slice/Grammar.y"
+#line 217 "src/Slice/Grammar.y"
 {
-    //TODOREMOVE
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
-    for (auto& m : metadata->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
+    convertMetadata(metadata);
     yyval = metadata;
 }
-#line 1863 "src/Slice/Grammar.cpp"
+#line 1868 "src/Slice/Grammar.cpp"
     break;
 
   case 6: /* local_metadata: ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 223 "src/Slice/Grammar.y"
+#line 228 "src/Slice/Grammar.y"
 {
-    //TODOREMOVE
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
-    for (auto& m : metadata->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
-    yyval = yyvsp[-1];
+    convertMetadata(metadata);
+    yyval = metadata;
 }
-#line 1883 "src/Slice/Grammar.cpp"
+#line 1878 "src/Slice/Grammar.cpp"
     break;
 
   case 7: /* local_metadata: local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 239 "src/Slice/Grammar.y"
+#line 234 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata1 = StringListTokPtr::dynamicCast(yyvsp[-3]);
     StringListTokPtr metadata2 = StringListTokPtr::dynamicCast(yyvsp[-1]);
     metadata1->v.splice(metadata1->v.end(), metadata2->v);
-    //TODOREMOVE
-    for (auto& m : metadata1->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
+
+    convertMetadata(metadata1);
     yyval = metadata1;
 }
-#line 1905 "src/Slice/Grammar.cpp"
+#line 1891 "src/Slice/Grammar.cpp"
     break;
 
   case 8: /* local_metadata: %empty  */
-#line 257 "src/Slice/Grammar.y"
+#line 243 "src/Slice/Grammar.y"
 {
     yyval = new StringListTok;
 }
-#line 1913 "src/Slice/Grammar.cpp"
+#line 1899 "src/Slice/Grammar.cpp"
     break;
 
   case 9: /* definitions: definitions file_metadata  */
-#line 266 "src/Slice/Grammar.y"
+#line 252 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[0]);
     if(!metadata->v.empty())
@@ -1921,11 +1907,11 @@ yyreduce:
         unit->addFileMetadata(metadata->v);
     }
 }
-#line 1925 "src/Slice/Grammar.cpp"
+#line 1911 "src/Slice/Grammar.cpp"
     break;
 
   case 10: /* definitions: definitions local_metadata definition  */
-#line 274 "src/Slice/Grammar.y"
+#line 260 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     ContainedPtr contained = ContainedPtr::dynamicCast(yyvsp[0]);
@@ -1934,179 +1920,179 @@ yyreduce:
         contained->setMetadata(metadata->v);
     }
 }
-#line 1938 "src/Slice/Grammar.cpp"
+#line 1924 "src/Slice/Grammar.cpp"
     break;
 
   case 12: /* $@1: %empty  */
-#line 289 "src/Slice/Grammar.y"
+#line 275 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ModulePtr::dynamicCast(yyvsp[0]));
 }
-#line 1946 "src/Slice/Grammar.cpp"
+#line 1932 "src/Slice/Grammar.cpp"
     break;
 
   case 14: /* $@2: %empty  */
-#line 294 "src/Slice/Grammar.y"
+#line 280 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1954 "src/Slice/Grammar.cpp"
+#line 1940 "src/Slice/Grammar.cpp"
     break;
 
   case 16: /* definition: class_decl  */
-#line 299 "src/Slice/Grammar.y"
+#line 285 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after class forward declaration");
 }
-#line 1962 "src/Slice/Grammar.cpp"
+#line 1948 "src/Slice/Grammar.cpp"
     break;
 
   case 17: /* $@3: %empty  */
-#line 303 "src/Slice/Grammar.y"
+#line 289 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1970 "src/Slice/Grammar.cpp"
+#line 1956 "src/Slice/Grammar.cpp"
     break;
 
   case 19: /* $@4: %empty  */
-#line 308 "src/Slice/Grammar.y"
+#line 294 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1978 "src/Slice/Grammar.cpp"
+#line 1964 "src/Slice/Grammar.cpp"
     break;
 
   case 21: /* definition: interface_decl  */
-#line 313 "src/Slice/Grammar.y"
+#line 299 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after interface forward declaration");
 }
-#line 1986 "src/Slice/Grammar.cpp"
+#line 1972 "src/Slice/Grammar.cpp"
     break;
 
   case 22: /* $@5: %empty  */
-#line 317 "src/Slice/Grammar.y"
+#line 303 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1994 "src/Slice/Grammar.cpp"
+#line 1980 "src/Slice/Grammar.cpp"
     break;
 
   case 24: /* $@6: %empty  */
+#line 308 "src/Slice/Grammar.y"
+{
+    assert(yyvsp[0] == 0);
+}
+#line 1988 "src/Slice/Grammar.cpp"
+    break;
+
+  case 26: /* definition: exception_decl  */
+#line 313 "src/Slice/Grammar.y"
+{
+    unit->error("`;' missing after exception forward declaration");
+}
+#line 1996 "src/Slice/Grammar.cpp"
+    break;
+
+  case 27: /* $@7: %empty  */
+#line 317 "src/Slice/Grammar.y"
+{
+    assert(yyvsp[0] == 0 || ExceptionPtr::dynamicCast(yyvsp[0]));
+}
+#line 2004 "src/Slice/Grammar.cpp"
+    break;
+
+  case 29: /* $@8: %empty  */
 #line 322 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0);
 }
-#line 2002 "src/Slice/Grammar.cpp"
-    break;
-
-  case 26: /* definition: exception_decl  */
-#line 327 "src/Slice/Grammar.y"
-{
-    unit->error("`;' missing after exception forward declaration");
-}
-#line 2010 "src/Slice/Grammar.cpp"
-    break;
-
-  case 27: /* $@7: %empty  */
-#line 331 "src/Slice/Grammar.y"
-{
-    assert(yyvsp[0] == 0 || ExceptionPtr::dynamicCast(yyvsp[0]));
-}
-#line 2018 "src/Slice/Grammar.cpp"
-    break;
-
-  case 29: /* $@8: %empty  */
-#line 336 "src/Slice/Grammar.y"
-{
-    assert(yyvsp[0] == 0);
-}
-#line 2026 "src/Slice/Grammar.cpp"
+#line 2012 "src/Slice/Grammar.cpp"
     break;
 
   case 31: /* definition: struct_decl  */
-#line 341 "src/Slice/Grammar.y"
+#line 327 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after struct forward declaration");
 }
-#line 2034 "src/Slice/Grammar.cpp"
+#line 2020 "src/Slice/Grammar.cpp"
     break;
 
   case 32: /* $@9: %empty  */
-#line 345 "src/Slice/Grammar.y"
+#line 331 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || StructPtr::dynamicCast(yyvsp[0]));
 }
-#line 2042 "src/Slice/Grammar.cpp"
+#line 2028 "src/Slice/Grammar.cpp"
     break;
 
   case 34: /* $@10: %empty  */
-#line 350 "src/Slice/Grammar.y"
+#line 336 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || SequencePtr::dynamicCast(yyvsp[0]));
 }
-#line 2050 "src/Slice/Grammar.cpp"
+#line 2036 "src/Slice/Grammar.cpp"
     break;
 
   case 36: /* definition: sequence_def  */
-#line 355 "src/Slice/Grammar.y"
+#line 341 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after sequence definition");
 }
-#line 2058 "src/Slice/Grammar.cpp"
+#line 2044 "src/Slice/Grammar.cpp"
     break;
 
   case 37: /* $@11: %empty  */
-#line 359 "src/Slice/Grammar.y"
+#line 345 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || DictionaryPtr::dynamicCast(yyvsp[0]));
 }
-#line 2066 "src/Slice/Grammar.cpp"
+#line 2052 "src/Slice/Grammar.cpp"
     break;
 
   case 39: /* definition: dictionary_def  */
-#line 364 "src/Slice/Grammar.y"
+#line 350 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after dictionary definition");
 }
-#line 2074 "src/Slice/Grammar.cpp"
+#line 2060 "src/Slice/Grammar.cpp"
     break;
 
   case 40: /* $@12: %empty  */
-#line 368 "src/Slice/Grammar.y"
+#line 354 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || EnumPtr::dynamicCast(yyvsp[0]));
 }
-#line 2082 "src/Slice/Grammar.cpp"
+#line 2068 "src/Slice/Grammar.cpp"
     break;
 
   case 42: /* $@13: %empty  */
-#line 373 "src/Slice/Grammar.y"
+#line 359 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ConstPtr::dynamicCast(yyvsp[0]));
 }
-#line 2090 "src/Slice/Grammar.cpp"
+#line 2076 "src/Slice/Grammar.cpp"
     break;
 
   case 44: /* definition: const_def  */
-#line 378 "src/Slice/Grammar.y"
+#line 364 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after const definition");
 }
-#line 2098 "src/Slice/Grammar.cpp"
+#line 2084 "src/Slice/Grammar.cpp"
     break;
 
   case 45: /* definition: error ';'  */
-#line 382 "src/Slice/Grammar.y"
+#line 368 "src/Slice/Grammar.y"
 {
     yyerrok;
 }
-#line 2106 "src/Slice/Grammar.cpp"
+#line 2092 "src/Slice/Grammar.cpp"
     break;
 
   case 46: /* @14: %empty  */
-#line 391 "src/Slice/Grammar.y"
+#line 377 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2132,11 +2118,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2136 "src/Slice/Grammar.cpp"
+#line 2122 "src/Slice/Grammar.cpp"
     break;
 
   case 47: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
-#line 417 "src/Slice/Grammar.y"
+#line 403 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2148,11 +2134,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2152 "src/Slice/Grammar.cpp"
+#line 2138 "src/Slice/Grammar.cpp"
     break;
 
   case 48: /* @15: %empty  */
-#line 429 "src/Slice/Grammar.y"
+#line 415 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2207,11 +2193,11 @@ yyreduce:
 
     yyval = parent;
 }
-#line 2211 "src/Slice/Grammar.cpp"
+#line 2197 "src/Slice/Grammar.cpp"
     break;
 
   case 49: /* module_def: ICE_MODULE ICE_SCOPED_IDENTIFIER @15 '{' definitions '}'  */
-#line 484 "src/Slice/Grammar.y"
+#line 470 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2229,38 +2215,38 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2233 "src/Slice/Grammar.cpp"
+#line 2219 "src/Slice/Grammar.cpp"
     break;
 
   case 50: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
-#line 507 "src/Slice/Grammar.y"
+#line 493 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2241 "src/Slice/Grammar.cpp"
+#line 2227 "src/Slice/Grammar.cpp"
     break;
 
   case 51: /* exception_id: ICE_EXCEPTION keyword  */
-#line 511 "src/Slice/Grammar.y"
+#line 497 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2251 "src/Slice/Grammar.cpp"
+#line 2237 "src/Slice/Grammar.cpp"
     break;
 
   case 52: /* exception_decl: exception_id  */
-#line 522 "src/Slice/Grammar.y"
+#line 508 "src/Slice/Grammar.y"
 {
     unit->error("exceptions cannot be forward declared");
     yyval = 0;
 }
-#line 2260 "src/Slice/Grammar.cpp"
+#line 2246 "src/Slice/Grammar.cpp"
     break;
 
   case 53: /* @16: %empty  */
-#line 532 "src/Slice/Grammar.y"
+#line 518 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ExceptionPtr base = ExceptionPtr::dynamicCast(yyvsp[0]);
@@ -2273,11 +2259,11 @@ yyreduce:
     }
     yyval = ex;
 }
-#line 2277 "src/Slice/Grammar.cpp"
+#line 2263 "src/Slice/Grammar.cpp"
     break;
 
   case 54: /* exception_def: exception_id exception_extends @16 '{' data_members '}'  */
-#line 545 "src/Slice/Grammar.y"
+#line 531 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2285,11 +2271,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 2289 "src/Slice/Grammar.cpp"
+#line 2275 "src/Slice/Grammar.cpp"
     break;
 
   case 55: /* exception_extends: extends scoped_name  */
-#line 558 "src/Slice/Grammar.y"
+#line 544 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2297,19 +2283,19 @@ yyreduce:
     cont->checkIntroduced(scoped->v);
     yyval = contained;
 }
-#line 2301 "src/Slice/Grammar.cpp"
+#line 2287 "src/Slice/Grammar.cpp"
     break;
 
   case 56: /* exception_extends: %empty  */
-#line 566 "src/Slice/Grammar.y"
+#line 552 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2309 "src/Slice/Grammar.cpp"
+#line 2295 "src/Slice/Grammar.cpp"
     break;
 
   case 57: /* tag: ICE_TAG '(' ICE_INTEGER_LITERAL ')'  */
-#line 575 "src/Slice/Grammar.y"
+#line 561 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2327,11 +2313,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2331 "src/Slice/Grammar.cpp"
+#line 2317 "src/Slice/Grammar.cpp"
     break;
 
   case 58: /* tag: ICE_TAG '(' scoped_name ')'  */
-#line 593 "src/Slice/Grammar.y"
+#line 579 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2405,31 +2391,31 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2409 "src/Slice/Grammar.cpp"
+#line 2395 "src/Slice/Grammar.cpp"
     break;
 
   case 59: /* tag: ICE_TAG '(' ')'  */
-#line 667 "src/Slice/Grammar.y"
+#line 653 "src/Slice/Grammar.y"
 {
     unit->error("missing tag");
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2419 "src/Slice/Grammar.cpp"
+#line 2405 "src/Slice/Grammar.cpp"
     break;
 
   case 60: /* tag: ICE_TAG  */
-#line 673 "src/Slice/Grammar.y"
+#line 659 "src/Slice/Grammar.y"
 {
     unit->error("missing tag");
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2429 "src/Slice/Grammar.cpp"
+#line 2415 "src/Slice/Grammar.cpp"
     break;
 
   case 61: /* optional: ICE_OPTIONAL '(' ICE_INTEGER_LITERAL ')'  */
-#line 684 "src/Slice/Grammar.y"
+#line 670 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2451,11 +2437,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2455 "src/Slice/Grammar.cpp"
+#line 2441 "src/Slice/Grammar.cpp"
     break;
 
   case 62: /* optional: ICE_OPTIONAL '(' scoped_name ')'  */
-#line 706 "src/Slice/Grammar.y"
+#line 692 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2533,11 +2519,25 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2537 "src/Slice/Grammar.cpp"
+#line 2523 "src/Slice/Grammar.cpp"
     break;
 
   case 63: /* optional: ICE_OPTIONAL '(' ')'  */
-#line 784 "src/Slice/Grammar.y"
+#line 770 "src/Slice/Grammar.y"
+{
+    if (!unit->compatMode())
+    {
+        unit->warning(Deprecated, string("The `optional' keyword is deprecated, use `tag' instead"));
+    }
+    unit->error("missing tag");
+    TaggedDefTokPtr m = new TaggedDefTok; // Dummy
+    yyval = m;
+}
+#line 2537 "src/Slice/Grammar.cpp"
+    break;
+
+  case 64: /* optional: ICE_OPTIONAL  */
+#line 780 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -2550,49 +2550,35 @@ yyreduce:
 #line 2551 "src/Slice/Grammar.cpp"
     break;
 
-  case 64: /* optional: ICE_OPTIONAL  */
-#line 794 "src/Slice/Grammar.y"
-{
-    if (!unit->compatMode())
-    {
-        unit->warning(Deprecated, string("The `optional' keyword is deprecated, use `tag' instead"));
-    }
-    unit->error("missing tag");
-    TaggedDefTokPtr m = new TaggedDefTok; // Dummy
-    yyval = m;
-}
-#line 2565 "src/Slice/Grammar.cpp"
-    break;
-
   case 65: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
-#line 809 "src/Slice/Grammar.y"
+#line 795 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2573 "src/Slice/Grammar.cpp"
+#line 2559 "src/Slice/Grammar.cpp"
     break;
 
   case 66: /* struct_id: ICE_STRUCT keyword  */
-#line 813 "src/Slice/Grammar.y"
+#line 799 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as struct name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2583 "src/Slice/Grammar.cpp"
+#line 2569 "src/Slice/Grammar.cpp"
     break;
 
   case 67: /* struct_decl: struct_id  */
-#line 824 "src/Slice/Grammar.y"
+#line 810 "src/Slice/Grammar.y"
 {
     unit->error("structs cannot be forward declared");
     yyval = 0; // Dummy
 }
-#line 2592 "src/Slice/Grammar.cpp"
+#line 2578 "src/Slice/Grammar.cpp"
     break;
 
   case 68: /* @17: %empty  */
-#line 834 "src/Slice/Grammar.y"
+#line 820 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -2610,11 +2596,11 @@ yyreduce:
     }
     yyval = st;
 }
-#line 2614 "src/Slice/Grammar.cpp"
+#line 2600 "src/Slice/Grammar.cpp"
     break;
 
   case 69: /* struct_def: struct_id @17 '{' data_members '}'  */
-#line 852 "src/Slice/Grammar.y"
+#line 838 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2632,29 +2618,29 @@ yyreduce:
         unit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
     }
 }
-#line 2636 "src/Slice/Grammar.cpp"
+#line 2622 "src/Slice/Grammar.cpp"
     break;
 
   case 70: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
-#line 875 "src/Slice/Grammar.y"
+#line 861 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2644 "src/Slice/Grammar.cpp"
+#line 2630 "src/Slice/Grammar.cpp"
     break;
 
   case 71: /* class_name: ICE_CLASS keyword  */
-#line 879 "src/Slice/Grammar.y"
+#line 865 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as class name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2654 "src/Slice/Grammar.cpp"
+#line 2640 "src/Slice/Grammar.cpp"
     break;
 
   case 72: /* class_id: ICE_CLASS unscoped_name '(' ICE_INTEGER_LITERAL ')'  */
-#line 890 "src/Slice/Grammar.y"
+#line 876 "src/Slice/Grammar.y"
 {
     IceUtil::Int64 id = IntegerTokPtr::dynamicCast(yyvsp[-1])->v;
     if(id < 0)
@@ -2679,11 +2665,11 @@ yyreduce:
     classId->t = static_cast<int>(id);
     yyval = classId;
 }
-#line 2683 "src/Slice/Grammar.cpp"
+#line 2669 "src/Slice/Grammar.cpp"
     break;
 
   case 73: /* class_id: ICE_CLASS unscoped_name '(' scoped_name ')'  */
-#line 915 "src/Slice/Grammar.y"
+#line 901 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2773,33 +2759,33 @@ yyreduce:
     yyval = classId;
 
 }
-#line 2777 "src/Slice/Grammar.cpp"
+#line 2763 "src/Slice/Grammar.cpp"
     break;
 
   case 74: /* class_id: class_name  */
-#line 1005 "src/Slice/Grammar.y"
+#line 991 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr classId = new ClassIdTok();
     classId->v = StringTokPtr::dynamicCast(yyvsp[0])->v;
     classId->t = -1;
     yyval = classId;
 }
-#line 2788 "src/Slice/Grammar.cpp"
+#line 2774 "src/Slice/Grammar.cpp"
     break;
 
   case 75: /* class_decl: class_name  */
-#line 1017 "src/Slice/Grammar.y"
+#line 1003 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
     ClassDeclPtr cl = cont->createClassDecl(ident->v);
     yyval = cl;
 }
-#line 2799 "src/Slice/Grammar.cpp"
+#line 2785 "src/Slice/Grammar.cpp"
     break;
 
   case 76: /* @18: %empty  */
-#line 1029 "src/Slice/Grammar.y"
+#line 1015 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr ident = ClassIdTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -2816,11 +2802,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2820 "src/Slice/Grammar.cpp"
+#line 2806 "src/Slice/Grammar.cpp"
     break;
 
   case 77: /* class_def: class_id class_extends @18 '{' data_members '}'  */
-#line 1046 "src/Slice/Grammar.y"
+#line 1032 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2832,11 +2818,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2836 "src/Slice/Grammar.cpp"
+#line 2822 "src/Slice/Grammar.cpp"
     break;
 
   case 78: /* class_extends: extends scoped_name  */
-#line 1063 "src/Slice/Grammar.y"
+#line 1049 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2870,19 +2856,19 @@ yyreduce:
         }
     }
 }
-#line 2874 "src/Slice/Grammar.cpp"
+#line 2860 "src/Slice/Grammar.cpp"
     break;
 
   case 79: /* class_extends: %empty  */
-#line 1097 "src/Slice/Grammar.y"
+#line 1083 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2882 "src/Slice/Grammar.cpp"
+#line 2868 "src/Slice/Grammar.cpp"
     break;
 
   case 82: /* data_member: member  */
-#line 1113 "src/Slice/Grammar.y"
+#line 1099 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2897,11 +2883,11 @@ yyreduce:
         }
     }
 }
-#line 2901 "src/Slice/Grammar.cpp"
+#line 2887 "src/Slice/Grammar.cpp"
     break;
 
   case 83: /* data_member: member '=' const_initializer  */
-#line 1128 "src/Slice/Grammar.y"
+#line 1114 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-2]);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast(yyvsp[0]);
@@ -2918,19 +2904,19 @@ yyreduce:
         }
     }
 }
-#line 2922 "src/Slice/Grammar.cpp"
+#line 2908 "src/Slice/Grammar.cpp"
     break;
 
   case 86: /* data_member_list: data_member  */
-#line 1152 "src/Slice/Grammar.y"
+#line 1138 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 2930 "src/Slice/Grammar.cpp"
+#line 2916 "src/Slice/Grammar.cpp"
     break;
 
   case 90: /* return_tuple: out_qualifier member  */
-#line 1169 "src/Slice/Grammar.y"
+#line 1155 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2942,11 +2928,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2946 "src/Slice/Grammar.cpp"
+#line 2932 "src/Slice/Grammar.cpp"
     break;
 
   case 91: /* return_tuple: return_tuple ',' out_qualifier member  */
-#line 1181 "src/Slice/Grammar.y"
+#line 1167 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2958,11 +2944,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2962 "src/Slice/Grammar.cpp"
+#line 2948 "src/Slice/Grammar.cpp"
     break;
 
   case 92: /* return_type: tagged_type  */
-#line 1197 "src/Slice/Grammar.y"
+#line 1183 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     // For unnamed return types we infer their name to be 'returnValue'.
@@ -2977,11 +2963,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2981 "src/Slice/Grammar.cpp"
+#line 2967 "src/Slice/Grammar.cpp"
     break;
 
   case 93: /* return_type: '(' return_tuple ')'  */
-#line 1212 "src/Slice/Grammar.y"
+#line 1198 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     if (returnMembers->v.size() == 1)
@@ -2990,28 +2976,28 @@ yyreduce:
     }
     yyval = yyvsp[-1];
 }
-#line 2994 "src/Slice/Grammar.cpp"
+#line 2980 "src/Slice/Grammar.cpp"
     break;
 
   case 94: /* return_type: '(' ')'  */
-#line 1221 "src/Slice/Grammar.y"
+#line 1207 "src/Slice/Grammar.y"
 {
     unit->error("return tuples must contain at least 2 elements");
     yyval = new TaggedDefListTok();
 }
-#line 3003 "src/Slice/Grammar.cpp"
+#line 2989 "src/Slice/Grammar.cpp"
     break;
 
   case 95: /* return_type: ICE_VOID  */
-#line 1226 "src/Slice/Grammar.y"
+#line 1212 "src/Slice/Grammar.y"
 {
     yyval = new TaggedDefListTok();
 }
-#line 3011 "src/Slice/Grammar.cpp"
+#line 2997 "src/Slice/Grammar.cpp"
     break;
 
   case 96: /* operation_preamble: return_type unscoped_name '('  */
-#line 1235 "src/Slice/Grammar.y"
+#line 1221 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3046,11 +3032,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3050 "src/Slice/Grammar.cpp"
+#line 3036 "src/Slice/Grammar.cpp"
     break;
 
   case 97: /* operation_preamble: ICE_IDEMPOTENT return_type unscoped_name '('  */
-#line 1270 "src/Slice/Grammar.y"
+#line 1256 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3085,11 +3071,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3089 "src/Slice/Grammar.cpp"
+#line 3075 "src/Slice/Grammar.cpp"
     break;
 
   case 98: /* operation_preamble: return_type keyword '('  */
-#line 1305 "src/Slice/Grammar.y"
+#line 1291 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3123,11 +3109,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3127 "src/Slice/Grammar.cpp"
+#line 3113 "src/Slice/Grammar.cpp"
     break;
 
   case 99: /* operation_preamble: ICE_IDEMPOTENT return_type keyword '('  */
-#line 1339 "src/Slice/Grammar.y"
+#line 1325 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3161,11 +3147,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3165 "src/Slice/Grammar.cpp"
+#line 3151 "src/Slice/Grammar.cpp"
     break;
 
   case 100: /* @19: %empty  */
-#line 1378 "src/Slice/Grammar.y"
+#line 1364 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3177,11 +3163,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3181 "src/Slice/Grammar.cpp"
+#line 3167 "src/Slice/Grammar.cpp"
     break;
 
   case 101: /* operation: operation_preamble parameters ')' @19 throws  */
-#line 1390 "src/Slice/Grammar.y"
+#line 1376 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3191,11 +3177,11 @@ yyreduce:
         op->setExceptionList(el->v);
     }
 }
-#line 3195 "src/Slice/Grammar.cpp"
+#line 3181 "src/Slice/Grammar.cpp"
     break;
 
   case 102: /* @20: %empty  */
-#line 1400 "src/Slice/Grammar.y"
+#line 1386 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3203,11 +3189,11 @@ yyreduce:
     }
     yyerrok;
 }
-#line 3207 "src/Slice/Grammar.cpp"
+#line 3193 "src/Slice/Grammar.cpp"
     break;
 
   case 103: /* operation: operation_preamble error ')' @20 throws  */
-#line 1408 "src/Slice/Grammar.y"
+#line 1394 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3217,11 +3203,11 @@ yyreduce:
         op->setExceptionList(el->v); // Dummy
     }
 }
-#line 3221 "src/Slice/Grammar.cpp"
+#line 3207 "src/Slice/Grammar.cpp"
     break;
 
   case 104: /* operation_list: local_metadata operation ';' operation_list  */
-#line 1423 "src/Slice/Grammar.y"
+#line 1409 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     OperationPtr operation = OperationPtr::dynamicCast(yyvsp[-2]);
@@ -3239,37 +3225,37 @@ yyreduce:
         }
     }
 }
-#line 3243 "src/Slice/Grammar.cpp"
+#line 3229 "src/Slice/Grammar.cpp"
     break;
 
   case 105: /* operation_list: local_metadata operation  */
-#line 1441 "src/Slice/Grammar.y"
+#line 1427 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 3251 "src/Slice/Grammar.cpp"
+#line 3237 "src/Slice/Grammar.cpp"
     break;
 
   case 108: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
-#line 1452 "src/Slice/Grammar.y"
+#line 1438 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3259 "src/Slice/Grammar.cpp"
+#line 3245 "src/Slice/Grammar.cpp"
     break;
 
   case 109: /* interface_id: ICE_INTERFACE keyword  */
-#line 1456 "src/Slice/Grammar.y"
+#line 1442 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as interface name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 3269 "src/Slice/Grammar.cpp"
+#line 3255 "src/Slice/Grammar.cpp"
     break;
 
   case 110: /* interface_decl: interface_id  */
-#line 1467 "src/Slice/Grammar.y"
+#line 1453 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -3277,11 +3263,11 @@ yyreduce:
     cont->checkIntroduced(ident->v, cl);
     yyval = cl;
 }
-#line 3281 "src/Slice/Grammar.cpp"
+#line 3267 "src/Slice/Grammar.cpp"
     break;
 
   case 111: /* @21: %empty  */
-#line 1480 "src/Slice/Grammar.y"
+#line 1466 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -3298,11 +3284,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3302 "src/Slice/Grammar.cpp"
+#line 3288 "src/Slice/Grammar.cpp"
     break;
 
   case 112: /* interface_def: interface_id interface_extends @21 '{' operation_list '}'  */
-#line 1497 "src/Slice/Grammar.y"
+#line 1483 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -3314,11 +3300,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3318 "src/Slice/Grammar.cpp"
+#line 3304 "src/Slice/Grammar.cpp"
     break;
 
   case 113: /* interface_list: scoped_name ',' interface_list  */
-#line 1514 "src/Slice/Grammar.y"
+#line 1500 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = InterfaceListTokPtr::dynamicCast(yyvsp[0]);
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-2]);
@@ -3353,11 +3339,11 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3357 "src/Slice/Grammar.cpp"
+#line 3343 "src/Slice/Grammar.cpp"
     break;
 
   case 114: /* interface_list: scoped_name  */
-#line 1549 "src/Slice/Grammar.y"
+#line 1535 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = new InterfaceListTok;
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3392,29 +3378,29 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3396 "src/Slice/Grammar.cpp"
+#line 3382 "src/Slice/Grammar.cpp"
     break;
 
   case 115: /* interface_list: ICE_OBJECT  */
-#line 1584 "src/Slice/Grammar.y"
+#line 1570 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type Object");
     yyval = new InterfaceListTok; // Dummy
 }
-#line 3405 "src/Slice/Grammar.cpp"
+#line 3391 "src/Slice/Grammar.cpp"
     break;
 
   case 116: /* interface_list: ICE_ANYCLASS  */
-#line 1589 "src/Slice/Grammar.y"
+#line 1575 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type AnyClass");
     yyval = new ClassListTok; // Dummy
 }
-#line 3414 "src/Slice/Grammar.cpp"
+#line 3400 "src/Slice/Grammar.cpp"
     break;
 
   case 117: /* interface_list: ICE_VALUE  */
-#line 1594 "src/Slice/Grammar.y"
+#line 1580 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3423,49 +3409,49 @@ yyreduce:
     unit->error("illegal inheritance from type Value");
     yyval = new ClassListTok; // Dummy
 }
-#line 3427 "src/Slice/Grammar.cpp"
+#line 3413 "src/Slice/Grammar.cpp"
     break;
 
   case 118: /* interface_extends: extends interface_list  */
-#line 1608 "src/Slice/Grammar.y"
+#line 1594 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3435 "src/Slice/Grammar.cpp"
+#line 3421 "src/Slice/Grammar.cpp"
     break;
 
   case 119: /* interface_extends: %empty  */
-#line 1612 "src/Slice/Grammar.y"
+#line 1598 "src/Slice/Grammar.y"
 {
     yyval = new InterfaceListTok;
 }
-#line 3443 "src/Slice/Grammar.cpp"
+#line 3429 "src/Slice/Grammar.cpp"
     break;
 
   case 120: /* exception_list: exception ',' exception_list  */
-#line 1621 "src/Slice/Grammar.y"
+#line 1607 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[-2]);
     ExceptionListTokPtr exceptionList = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3454 "src/Slice/Grammar.cpp"
+#line 3440 "src/Slice/Grammar.cpp"
     break;
 
   case 121: /* exception_list: exception  */
-#line 1628 "src/Slice/Grammar.y"
+#line 1614 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[0]);
     ExceptionListTokPtr exceptionList = new ExceptionListTok;
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3465 "src/Slice/Grammar.cpp"
+#line 3451 "src/Slice/Grammar.cpp"
     break;
 
   case 122: /* exception: scoped_name  */
-#line 1640 "src/Slice/Grammar.y"
+#line 1626 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -3477,21 +3463,21 @@ yyreduce:
     cont->checkIntroduced(scoped->v, exception);
     yyval = exception;
 }
-#line 3481 "src/Slice/Grammar.cpp"
+#line 3467 "src/Slice/Grammar.cpp"
     break;
 
   case 123: /* exception: keyword  */
-#line 1652 "src/Slice/Grammar.y"
+#line 1638 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = unit->currentModule()->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
 }
-#line 3491 "src/Slice/Grammar.cpp"
+#line 3477 "src/Slice/Grammar.cpp"
     break;
 
   case 124: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1663 "src/Slice/Grammar.y"
+#line 1649 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3499,11 +3485,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createSequence(ident->v, type, metadata->v);
 }
-#line 3503 "src/Slice/Grammar.cpp"
+#line 3489 "src/Slice/Grammar.cpp"
     break;
 
   case 125: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' keyword  */
-#line 1671 "src/Slice/Grammar.y"
+#line 1657 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3512,11 +3498,11 @@ yyreduce:
     yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
-#line 3516 "src/Slice/Grammar.cpp"
+#line 3502 "src/Slice/Grammar.cpp"
     break;
 
   case 126: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1685 "src/Slice/Grammar.y"
+#line 1671 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3526,11 +3512,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
-#line 3530 "src/Slice/Grammar.cpp"
+#line 3516 "src/Slice/Grammar.cpp"
     break;
 
   case 127: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' keyword  */
-#line 1695 "src/Slice/Grammar.y"
+#line 1681 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3541,27 +3527,27 @@ yyreduce:
     yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
-#line 3545 "src/Slice/Grammar.cpp"
+#line 3531 "src/Slice/Grammar.cpp"
     break;
 
   case 128: /* enum_start: ICE_UNCHECKED ICE_ENUM  */
-#line 1711 "src/Slice/Grammar.y"
+#line 1697 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3553 "src/Slice/Grammar.cpp"
+#line 3539 "src/Slice/Grammar.cpp"
     break;
 
   case 129: /* enum_start: ICE_ENUM  */
-#line 1715 "src/Slice/Grammar.y"
+#line 1701 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3561 "src/Slice/Grammar.cpp"
+#line 3547 "src/Slice/Grammar.cpp"
     break;
 
   case 130: /* enum_id: enum_start ICE_IDENTIFIER  */
-#line 1724 "src/Slice/Grammar.y"
+#line 1710 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3577,11 +3563,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3581 "src/Slice/Grammar.cpp"
+#line 3567 "src/Slice/Grammar.cpp"
     break;
 
   case 131: /* enum_id: enum_start keyword  */
-#line 1740 "src/Slice/Grammar.y"
+#line 1726 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3589,22 +3575,22 @@ yyreduce:
     unit->error("keyword `" + ident->v + "' cannot be used as enumeration name");
     yyval = cont->createEnum(IceUtil::generateUUID(), unchecked, Dummy);
 }
-#line 3593 "src/Slice/Grammar.cpp"
+#line 3579 "src/Slice/Grammar.cpp"
     break;
 
   case 132: /* @22: %empty  */
-#line 1753 "src/Slice/Grammar.y"
+#line 1739 "src/Slice/Grammar.y"
 {
     EnumPtr en = EnumPtr::dynamicCast(yyvsp[-1]);
     en->initUnderlying(TypePtr::dynamicCast(yyvsp[0]));
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3604 "src/Slice/Grammar.cpp"
+#line 3590 "src/Slice/Grammar.cpp"
     break;
 
   case 133: /* enum_def: enum_id enum_underlying @22 '{' enumerator_list_or_empty '}'  */
-#line 1760 "src/Slice/Grammar.y"
+#line 1746 "src/Slice/Grammar.y"
 {
     if (EnumPtr en = EnumPtr::dynamicCast(yyvsp[-3]))
     {
@@ -3617,11 +3603,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 3621 "src/Slice/Grammar.cpp"
+#line 3607 "src/Slice/Grammar.cpp"
     break;
 
   case 134: /* @23: %empty  */
-#line 1773 "src/Slice/Grammar.y"
+#line 1759 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[0])->v;
     unit->error("missing enumeration name");
@@ -3630,44 +3616,44 @@ yyreduce:
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3634 "src/Slice/Grammar.cpp"
+#line 3620 "src/Slice/Grammar.cpp"
     break;
 
   case 135: /* enum_def: enum_start @23 '{' enumerator_list_or_empty '}'  */
-#line 1782 "src/Slice/Grammar.y"
+#line 1768 "src/Slice/Grammar.y"
 {
     unit->popContainer();
     yyval = yyvsp[-4];
 }
-#line 3643 "src/Slice/Grammar.cpp"
+#line 3629 "src/Slice/Grammar.cpp"
     break;
 
   case 136: /* enum_underlying: ':' type  */
-#line 1792 "src/Slice/Grammar.y"
+#line 1778 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3651 "src/Slice/Grammar.cpp"
+#line 3637 "src/Slice/Grammar.cpp"
     break;
 
   case 137: /* enum_underlying: %empty  */
-#line 1796 "src/Slice/Grammar.y"
+#line 1782 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 3659 "src/Slice/Grammar.cpp"
+#line 3645 "src/Slice/Grammar.cpp"
     break;
 
   case 140: /* enumerator_list_or_empty: %empty  */
-#line 1807 "src/Slice/Grammar.y"
+#line 1793 "src/Slice/Grammar.y"
 {
     yyval = new EnumeratorListTok;
 }
-#line 3667 "src/Slice/Grammar.cpp"
+#line 3653 "src/Slice/Grammar.cpp"
     break;
 
   case 141: /* enumerator_list: enumerator_list ',' enumerator  */
-#line 1816 "src/Slice/Grammar.y"
+#line 1802 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast(yyvsp[-2]);
     if (EnumeratorPtr en = EnumeratorPtr::dynamicCast(yyvsp[0]))
@@ -3676,11 +3662,11 @@ yyreduce:
     }
     yyval = enumerators;
 }
-#line 3680 "src/Slice/Grammar.cpp"
+#line 3666 "src/Slice/Grammar.cpp"
     break;
 
   case 142: /* enumerator_list: enumerator  */
-#line 1825 "src/Slice/Grammar.y"
+#line 1811 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr enumerators = new EnumeratorListTok;
     if (EnumeratorPtr en = EnumeratorPtr::dynamicCast(yyvsp[0]))
@@ -3689,11 +3675,11 @@ yyreduce:
     }
     yyval = enumerators;
 }
-#line 3693 "src/Slice/Grammar.cpp"
+#line 3679 "src/Slice/Grammar.cpp"
     break;
 
   case 143: /* enumerator: local_metadata ICE_IDENTIFIER  */
-#line 1839 "src/Slice/Grammar.y"
+#line 1825 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3707,11 +3693,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3711 "src/Slice/Grammar.cpp"
+#line 3697 "src/Slice/Grammar.cpp"
     break;
 
   case 144: /* enumerator: local_metadata ICE_IDENTIFIER '=' enumerator_initializer  */
-#line 1853 "src/Slice/Grammar.y"
+#line 1839 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-2]);
@@ -3726,11 +3712,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3730 "src/Slice/Grammar.cpp"
+#line 3716 "src/Slice/Grammar.cpp"
     break;
 
   case 145: /* enumerator: local_metadata keyword  */
-#line 1868 "src/Slice/Grammar.y"
+#line 1854 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3745,19 +3731,19 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3749 "src/Slice/Grammar.cpp"
+#line 3735 "src/Slice/Grammar.cpp"
     break;
 
   case 146: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
-#line 1888 "src/Slice/Grammar.y"
+#line 1874 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3757 "src/Slice/Grammar.cpp"
+#line 3743 "src/Slice/Grammar.cpp"
     break;
 
   case 147: /* enumerator_initializer: scoped_name  */
-#line 1892 "src/Slice/Grammar.y"
+#line 1878 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainedList cl = unit->currentContainer()->lookupContained(scoped->v);
@@ -3790,27 +3776,27 @@ yyreduce:
 
     yyval = tok;
 }
-#line 3794 "src/Slice/Grammar.cpp"
+#line 3780 "src/Slice/Grammar.cpp"
     break;
 
   case 148: /* out_qualifier: ICE_OUT  */
-#line 1930 "src/Slice/Grammar.y"
+#line 1916 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3802 "src/Slice/Grammar.cpp"
+#line 3788 "src/Slice/Grammar.cpp"
     break;
 
   case 149: /* out_qualifier: %empty  */
-#line 1934 "src/Slice/Grammar.y"
+#line 1920 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3810 "src/Slice/Grammar.cpp"
+#line 3796 "src/Slice/Grammar.cpp"
     break;
 
   case 150: /* parameter: out_qualifier member  */
-#line 1943 "src/Slice/Grammar.y"
+#line 1929 "src/Slice/Grammar.y"
 {
     BoolTokPtr isOutParam = BoolTokPtr::dynamicCast(yyvsp[-1]);
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
@@ -3825,151 +3811,151 @@ yyreduce:
         }
     }
 }
-#line 3829 "src/Slice/Grammar.cpp"
+#line 3815 "src/Slice/Grammar.cpp"
     break;
 
   case 155: /* throws: ICE_THROWS exception_list  */
-#line 1976 "src/Slice/Grammar.y"
+#line 1962 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3837 "src/Slice/Grammar.cpp"
+#line 3823 "src/Slice/Grammar.cpp"
     break;
 
   case 156: /* throws: %empty  */
-#line 1980 "src/Slice/Grammar.y"
+#line 1966 "src/Slice/Grammar.y"
 {
     yyval = new ExceptionListTok;
 }
-#line 3845 "src/Slice/Grammar.cpp"
+#line 3831 "src/Slice/Grammar.cpp"
     break;
 
   case 160: /* unscoped_name: ICE_SCOPED_IDENTIFIER  */
-#line 1997 "src/Slice/Grammar.y"
+#line 1983 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("Identifier cannot be scoped: `" + (ident->v) + "'");
     yyval = yyvsp[0];
 }
-#line 3855 "src/Slice/Grammar.cpp"
+#line 3841 "src/Slice/Grammar.cpp"
     break;
 
   case 161: /* builtin: ICE_BOOL  */
-#line 2007 "src/Slice/Grammar.y"
+#line 1993 "src/Slice/Grammar.y"
            {}
-#line 3861 "src/Slice/Grammar.cpp"
+#line 3847 "src/Slice/Grammar.cpp"
     break;
 
   case 162: /* builtin: ICE_BYTE  */
-#line 2008 "src/Slice/Grammar.y"
+#line 1994 "src/Slice/Grammar.y"
            {}
-#line 3867 "src/Slice/Grammar.cpp"
+#line 3853 "src/Slice/Grammar.cpp"
     break;
 
   case 163: /* builtin: ICE_SHORT  */
-#line 2009 "src/Slice/Grammar.y"
+#line 1995 "src/Slice/Grammar.y"
             {}
-#line 3873 "src/Slice/Grammar.cpp"
+#line 3859 "src/Slice/Grammar.cpp"
     break;
 
   case 164: /* builtin: ICE_USHORT  */
-#line 2010 "src/Slice/Grammar.y"
+#line 1996 "src/Slice/Grammar.y"
              {}
-#line 3879 "src/Slice/Grammar.cpp"
+#line 3865 "src/Slice/Grammar.cpp"
     break;
 
   case 165: /* builtin: ICE_INT  */
-#line 2011 "src/Slice/Grammar.y"
+#line 1997 "src/Slice/Grammar.y"
           {}
-#line 3885 "src/Slice/Grammar.cpp"
+#line 3871 "src/Slice/Grammar.cpp"
     break;
 
   case 166: /* builtin: ICE_UINT  */
-#line 2012 "src/Slice/Grammar.y"
+#line 1998 "src/Slice/Grammar.y"
            {}
-#line 3891 "src/Slice/Grammar.cpp"
+#line 3877 "src/Slice/Grammar.cpp"
     break;
 
   case 167: /* builtin: ICE_VARINT  */
-#line 2013 "src/Slice/Grammar.y"
+#line 1999 "src/Slice/Grammar.y"
              {}
-#line 3897 "src/Slice/Grammar.cpp"
+#line 3883 "src/Slice/Grammar.cpp"
     break;
 
   case 168: /* builtin: ICE_VARUINT  */
-#line 2014 "src/Slice/Grammar.y"
+#line 2000 "src/Slice/Grammar.y"
               {}
-#line 3903 "src/Slice/Grammar.cpp"
+#line 3889 "src/Slice/Grammar.cpp"
     break;
 
   case 169: /* builtin: ICE_LONG  */
-#line 2015 "src/Slice/Grammar.y"
+#line 2001 "src/Slice/Grammar.y"
            {}
-#line 3909 "src/Slice/Grammar.cpp"
+#line 3895 "src/Slice/Grammar.cpp"
     break;
 
   case 170: /* builtin: ICE_ULONG  */
-#line 2016 "src/Slice/Grammar.y"
+#line 2002 "src/Slice/Grammar.y"
             {}
-#line 3915 "src/Slice/Grammar.cpp"
+#line 3901 "src/Slice/Grammar.cpp"
     break;
 
   case 171: /* builtin: ICE_VARLONG  */
-#line 2017 "src/Slice/Grammar.y"
+#line 2003 "src/Slice/Grammar.y"
               {}
-#line 3921 "src/Slice/Grammar.cpp"
+#line 3907 "src/Slice/Grammar.cpp"
     break;
 
   case 172: /* builtin: ICE_VARULONG  */
-#line 2018 "src/Slice/Grammar.y"
+#line 2004 "src/Slice/Grammar.y"
                {}
-#line 3927 "src/Slice/Grammar.cpp"
+#line 3913 "src/Slice/Grammar.cpp"
     break;
 
   case 173: /* builtin: ICE_FLOAT  */
-#line 2019 "src/Slice/Grammar.y"
+#line 2005 "src/Slice/Grammar.y"
             {}
-#line 3933 "src/Slice/Grammar.cpp"
+#line 3919 "src/Slice/Grammar.cpp"
     break;
 
   case 174: /* builtin: ICE_DOUBLE  */
-#line 2020 "src/Slice/Grammar.y"
+#line 2006 "src/Slice/Grammar.y"
              {}
-#line 3939 "src/Slice/Grammar.cpp"
+#line 3925 "src/Slice/Grammar.cpp"
     break;
 
   case 175: /* builtin: ICE_STRING  */
-#line 2021 "src/Slice/Grammar.y"
+#line 2007 "src/Slice/Grammar.y"
              {}
-#line 3945 "src/Slice/Grammar.cpp"
+#line 3931 "src/Slice/Grammar.cpp"
     break;
 
   case 176: /* type: ICE_OBJECT '*'  */
-#line 2027 "src/Slice/Grammar.y"
+#line 2013 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3953 "src/Slice/Grammar.cpp"
+#line 3939 "src/Slice/Grammar.cpp"
     break;
 
   case 177: /* type: ICE_OBJECT '?'  */
-#line 2031 "src/Slice/Grammar.y"
+#line 2017 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3961 "src/Slice/Grammar.cpp"
+#line 3947 "src/Slice/Grammar.cpp"
     break;
 
   case 178: /* type: ICE_ANYCLASS '?'  */
-#line 2035 "src/Slice/Grammar.y"
+#line 2021 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3969 "src/Slice/Grammar.cpp"
+#line 3955 "src/Slice/Grammar.cpp"
     break;
 
   case 179: /* type: ICE_VALUE '?'  */
-#line 2039 "src/Slice/Grammar.y"
+#line 2025 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3977,20 +3963,20 @@ yyreduce:
     }
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3981 "src/Slice/Grammar.cpp"
+#line 3967 "src/Slice/Grammar.cpp"
     break;
 
   case 180: /* type: builtin '?'  */
-#line 2047 "src/Slice/Grammar.y"
+#line 2033 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[-1]);
     yyval = unit->optionalBuiltin(Builtin::kindFromString(typeName->v).value());
 }
-#line 3990 "src/Slice/Grammar.cpp"
+#line 3976 "src/Slice/Grammar.cpp"
     break;
 
   case 181: /* type: ICE_OBJECT  */
-#line 2052 "src/Slice/Grammar.y"
+#line 2038 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -4001,19 +3987,19 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindObject);
     }
 }
-#line 4005 "src/Slice/Grammar.cpp"
+#line 3991 "src/Slice/Grammar.cpp"
     break;
 
   case 182: /* type: ICE_ANYCLASS  */
-#line 2063 "src/Slice/Grammar.y"
+#line 2049 "src/Slice/Grammar.y"
 {
     yyval = unit->builtin(Builtin::KindAnyClass);
 }
-#line 4013 "src/Slice/Grammar.cpp"
+#line 3999 "src/Slice/Grammar.cpp"
     break;
 
   case 183: /* type: ICE_VALUE  */
-#line 2067 "src/Slice/Grammar.y"
+#line 2053 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -4025,20 +4011,20 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindAnyClass);
     }
 }
-#line 4029 "src/Slice/Grammar.cpp"
+#line 4015 "src/Slice/Grammar.cpp"
     break;
 
   case 184: /* type: builtin  */
-#line 2079 "src/Slice/Grammar.y"
+#line 2065 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[0]);
     yyval = unit->builtin(Builtin::kindFromString(typeName->v).value());
 }
-#line 4038 "src/Slice/Grammar.cpp"
+#line 4024 "src/Slice/Grammar.cpp"
     break;
 
   case 185: /* type: scoped_name  */
-#line 2084 "src/Slice/Grammar.y"
+#line 2070 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -4064,11 +4050,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4068 "src/Slice/Grammar.cpp"
+#line 4054 "src/Slice/Grammar.cpp"
     break;
 
   case 186: /* type: scoped_name '*'  */
-#line 2110 "src/Slice/Grammar.y"
+#line 2096 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4100,11 +4086,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4104 "src/Slice/Grammar.cpp"
+#line 4090 "src/Slice/Grammar.cpp"
     break;
 
   case 187: /* type: scoped_name '?'  */
-#line 2142 "src/Slice/Grammar.y"
+#line 2128 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4127,11 +4113,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4131 "src/Slice/Grammar.cpp"
+#line 4117 "src/Slice/Grammar.cpp"
     break;
 
   case 188: /* tagged_type: tag type  */
-#line 2170 "src/Slice/Grammar.y"
+#line 2156 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4146,11 +4132,11 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4150 "src/Slice/Grammar.cpp"
+#line 4136 "src/Slice/Grammar.cpp"
     break;
 
   case 189: /* tagged_type: optional type  */
-#line 2185 "src/Slice/Grammar.y"
+#line 2171 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4164,21 +4150,21 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4168 "src/Slice/Grammar.cpp"
+#line 4154 "src/Slice/Grammar.cpp"
     break;
 
   case 190: /* tagged_type: type  */
-#line 2199 "src/Slice/Grammar.y"
+#line 2185 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = new TaggedDefTok;
     taggedDef->type = TypePtr::dynamicCast(yyvsp[0]);
     yyval = taggedDef;
 }
-#line 4178 "src/Slice/Grammar.cpp"
+#line 4164 "src/Slice/Grammar.cpp"
     break;
 
   case 191: /* member: tagged_type ICE_IDENTIFIER  */
-#line 2210 "src/Slice/Grammar.y"
+#line 2196 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4190,11 +4176,11 @@ yyreduce:
 
     yyval = def;
 }
-#line 4194 "src/Slice/Grammar.cpp"
+#line 4180 "src/Slice/Grammar.cpp"
     break;
 
   case 192: /* member: tagged_type keyword  */
-#line 2222 "src/Slice/Grammar.y"
+#line 2208 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4205,11 +4191,11 @@ yyreduce:
     unit->error("keyword `" + def->name + "' cannot be used as an identifier");
     yyval = def;
 }
-#line 4209 "src/Slice/Grammar.cpp"
+#line 4195 "src/Slice/Grammar.cpp"
     break;
 
   case 193: /* member: tagged_type  */
-#line 2233 "src/Slice/Grammar.y"
+#line 2219 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->name = IceUtil::generateUUID(); // Dummy
@@ -4220,53 +4206,53 @@ yyreduce:
     unit->error("missing identifier");
     yyval = def;
 }
-#line 4224 "src/Slice/Grammar.cpp"
+#line 4210 "src/Slice/Grammar.cpp"
     break;
 
   case 194: /* member: local_metadata member  */
-#line 2244 "src/Slice/Grammar.y"
+#line 2230 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->metadata = StringListTokPtr::dynamicCast(yyvsp[-1])->v;
     yyval = def;
 }
-#line 4234 "src/Slice/Grammar.cpp"
+#line 4220 "src/Slice/Grammar.cpp"
     break;
 
   case 195: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2255 "src/Slice/Grammar.y"
+#line 2241 "src/Slice/Grammar.y"
 {
     StringTokPtr str1 = StringTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr str2 = StringTokPtr::dynamicCast(yyvsp[0]);
     str1->v += str2->v;
 }
-#line 4244 "src/Slice/Grammar.cpp"
+#line 4230 "src/Slice/Grammar.cpp"
     break;
 
   case 197: /* string_list: string_list ',' string_literal  */
-#line 2267 "src/Slice/Grammar.y"
+#line 2253 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = StringListTokPtr::dynamicCast(yyvsp[-2]);
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4255 "src/Slice/Grammar.cpp"
+#line 4241 "src/Slice/Grammar.cpp"
     break;
 
   case 198: /* string_list: string_literal  */
-#line 2274 "src/Slice/Grammar.y"
+#line 2260 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = new StringListTok;
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4266 "src/Slice/Grammar.cpp"
+#line 4252 "src/Slice/Grammar.cpp"
     break;
 
   case 199: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2286 "src/Slice/Grammar.y"
+#line 2272 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindLong);
     IntegerTokPtr intVal = IntegerTokPtr::dynamicCast(yyvsp[0]);
@@ -4275,11 +4261,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), intVal->literal);
     yyval = def;
 }
-#line 4279 "src/Slice/Grammar.cpp"
+#line 4265 "src/Slice/Grammar.cpp"
     break;
 
   case 200: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2295 "src/Slice/Grammar.y"
+#line 2281 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindDouble);
     FloatingTokPtr floatVal = FloatingTokPtr::dynamicCast(yyvsp[0]);
@@ -4288,11 +4274,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), floatVal->literal);
     yyval = def;
 }
-#line 4292 "src/Slice/Grammar.cpp"
+#line 4278 "src/Slice/Grammar.cpp"
     break;
 
   case 201: /* const_initializer: scoped_name  */
-#line 2304 "src/Slice/Grammar.y"
+#line 2290 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def;
@@ -4332,44 +4318,44 @@ yyreduce:
     }
     yyval = def;
 }
-#line 4336 "src/Slice/Grammar.cpp"
+#line 4322 "src/Slice/Grammar.cpp"
     break;
 
   case 202: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2344 "src/Slice/Grammar.y"
+#line 2330 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindString);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, literal->v, literal->literal);
     yyval = def;
 }
-#line 4347 "src/Slice/Grammar.cpp"
+#line 4333 "src/Slice/Grammar.cpp"
     break;
 
   case 203: /* const_initializer: ICE_FALSE  */
-#line 2351 "src/Slice/Grammar.y"
+#line 2337 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "false", "false");
     yyval = def;
 }
-#line 4358 "src/Slice/Grammar.cpp"
+#line 4344 "src/Slice/Grammar.cpp"
     break;
 
   case 204: /* const_initializer: ICE_TRUE  */
-#line 2358 "src/Slice/Grammar.y"
+#line 2344 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "true", "true");
     yyval = def;
 }
-#line 4369 "src/Slice/Grammar.cpp"
+#line 4355 "src/Slice/Grammar.cpp"
     break;
 
   case 205: /* const_def: ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer  */
-#line 2370 "src/Slice/Grammar.y"
+#line 2356 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-4]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-3]);
@@ -4378,11 +4364,11 @@ yyreduce:
     yyval = unit->currentModule()->createConst(ident->v, const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral);
 }
-#line 4382 "src/Slice/Grammar.cpp"
+#line 4368 "src/Slice/Grammar.cpp"
     break;
 
   case 206: /* const_def: ICE_CONST local_metadata type '=' const_initializer  */
-#line 2379 "src/Slice/Grammar.y"
+#line 2365 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-2]);
@@ -4391,233 +4377,233 @@ yyreduce:
     yyval = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
 }
-#line 4395 "src/Slice/Grammar.cpp"
+#line 4381 "src/Slice/Grammar.cpp"
     break;
 
   case 207: /* keyword: ICE_MODULE  */
-#line 2392 "src/Slice/Grammar.y"
+#line 2378 "src/Slice/Grammar.y"
              {}
-#line 4401 "src/Slice/Grammar.cpp"
+#line 4387 "src/Slice/Grammar.cpp"
     break;
 
   case 208: /* keyword: ICE_CLASS  */
-#line 2393 "src/Slice/Grammar.y"
+#line 2379 "src/Slice/Grammar.y"
             {}
-#line 4407 "src/Slice/Grammar.cpp"
+#line 4393 "src/Slice/Grammar.cpp"
     break;
 
   case 209: /* keyword: ICE_INTERFACE  */
-#line 2394 "src/Slice/Grammar.y"
+#line 2380 "src/Slice/Grammar.y"
                 {}
-#line 4413 "src/Slice/Grammar.cpp"
+#line 4399 "src/Slice/Grammar.cpp"
     break;
 
   case 210: /* keyword: ICE_EXCEPTION  */
-#line 2395 "src/Slice/Grammar.y"
+#line 2381 "src/Slice/Grammar.y"
                 {}
-#line 4419 "src/Slice/Grammar.cpp"
+#line 4405 "src/Slice/Grammar.cpp"
     break;
 
   case 211: /* keyword: ICE_STRUCT  */
-#line 2396 "src/Slice/Grammar.y"
+#line 2382 "src/Slice/Grammar.y"
              {}
-#line 4425 "src/Slice/Grammar.cpp"
+#line 4411 "src/Slice/Grammar.cpp"
     break;
 
   case 212: /* keyword: ICE_SEQUENCE  */
-#line 2397 "src/Slice/Grammar.y"
+#line 2383 "src/Slice/Grammar.y"
                {}
-#line 4431 "src/Slice/Grammar.cpp"
+#line 4417 "src/Slice/Grammar.cpp"
     break;
 
   case 213: /* keyword: ICE_DICTIONARY  */
-#line 2398 "src/Slice/Grammar.y"
+#line 2384 "src/Slice/Grammar.y"
                  {}
-#line 4437 "src/Slice/Grammar.cpp"
+#line 4423 "src/Slice/Grammar.cpp"
     break;
 
   case 214: /* keyword: ICE_ENUM  */
-#line 2399 "src/Slice/Grammar.y"
+#line 2385 "src/Slice/Grammar.y"
            {}
-#line 4443 "src/Slice/Grammar.cpp"
+#line 4429 "src/Slice/Grammar.cpp"
     break;
 
   case 215: /* keyword: ICE_OUT  */
-#line 2400 "src/Slice/Grammar.y"
+#line 2386 "src/Slice/Grammar.y"
           {}
-#line 4449 "src/Slice/Grammar.cpp"
+#line 4435 "src/Slice/Grammar.cpp"
     break;
 
   case 216: /* keyword: ICE_EXTENDS  */
-#line 2401 "src/Slice/Grammar.y"
+#line 2387 "src/Slice/Grammar.y"
               {}
-#line 4455 "src/Slice/Grammar.cpp"
+#line 4441 "src/Slice/Grammar.cpp"
     break;
 
   case 217: /* keyword: ICE_IMPLEMENTS  */
-#line 2402 "src/Slice/Grammar.y"
+#line 2388 "src/Slice/Grammar.y"
                  {}
-#line 4461 "src/Slice/Grammar.cpp"
+#line 4447 "src/Slice/Grammar.cpp"
     break;
 
   case 218: /* keyword: ICE_THROWS  */
-#line 2403 "src/Slice/Grammar.y"
+#line 2389 "src/Slice/Grammar.y"
              {}
-#line 4467 "src/Slice/Grammar.cpp"
+#line 4453 "src/Slice/Grammar.cpp"
     break;
 
   case 219: /* keyword: ICE_VOID  */
-#line 2404 "src/Slice/Grammar.y"
+#line 2390 "src/Slice/Grammar.y"
            {}
-#line 4473 "src/Slice/Grammar.cpp"
+#line 4459 "src/Slice/Grammar.cpp"
     break;
 
   case 220: /* keyword: ICE_BOOL  */
-#line 2405 "src/Slice/Grammar.y"
+#line 2391 "src/Slice/Grammar.y"
            {}
-#line 4479 "src/Slice/Grammar.cpp"
+#line 4465 "src/Slice/Grammar.cpp"
     break;
 
   case 221: /* keyword: ICE_BYTE  */
-#line 2406 "src/Slice/Grammar.y"
+#line 2392 "src/Slice/Grammar.y"
            {}
-#line 4485 "src/Slice/Grammar.cpp"
+#line 4471 "src/Slice/Grammar.cpp"
     break;
 
   case 222: /* keyword: ICE_SHORT  */
-#line 2407 "src/Slice/Grammar.y"
+#line 2393 "src/Slice/Grammar.y"
             {}
-#line 4491 "src/Slice/Grammar.cpp"
+#line 4477 "src/Slice/Grammar.cpp"
     break;
 
   case 223: /* keyword: ICE_USHORT  */
-#line 2408 "src/Slice/Grammar.y"
+#line 2394 "src/Slice/Grammar.y"
              {}
-#line 4497 "src/Slice/Grammar.cpp"
+#line 4483 "src/Slice/Grammar.cpp"
     break;
 
   case 224: /* keyword: ICE_INT  */
-#line 2409 "src/Slice/Grammar.y"
+#line 2395 "src/Slice/Grammar.y"
           {}
-#line 4503 "src/Slice/Grammar.cpp"
+#line 4489 "src/Slice/Grammar.cpp"
     break;
 
   case 225: /* keyword: ICE_UINT  */
-#line 2410 "src/Slice/Grammar.y"
+#line 2396 "src/Slice/Grammar.y"
            {}
-#line 4509 "src/Slice/Grammar.cpp"
+#line 4495 "src/Slice/Grammar.cpp"
     break;
 
   case 226: /* keyword: ICE_VARINT  */
-#line 2411 "src/Slice/Grammar.y"
+#line 2397 "src/Slice/Grammar.y"
              {}
-#line 4515 "src/Slice/Grammar.cpp"
+#line 4501 "src/Slice/Grammar.cpp"
     break;
 
   case 227: /* keyword: ICE_VARUINT  */
-#line 2412 "src/Slice/Grammar.y"
+#line 2398 "src/Slice/Grammar.y"
               {}
-#line 4521 "src/Slice/Grammar.cpp"
+#line 4507 "src/Slice/Grammar.cpp"
     break;
 
   case 228: /* keyword: ICE_LONG  */
-#line 2413 "src/Slice/Grammar.y"
+#line 2399 "src/Slice/Grammar.y"
            {}
-#line 4527 "src/Slice/Grammar.cpp"
+#line 4513 "src/Slice/Grammar.cpp"
     break;
 
   case 229: /* keyword: ICE_ULONG  */
-#line 2414 "src/Slice/Grammar.y"
+#line 2400 "src/Slice/Grammar.y"
             {}
-#line 4533 "src/Slice/Grammar.cpp"
+#line 4519 "src/Slice/Grammar.cpp"
     break;
 
   case 230: /* keyword: ICE_VARLONG  */
-#line 2415 "src/Slice/Grammar.y"
+#line 2401 "src/Slice/Grammar.y"
               {}
-#line 4539 "src/Slice/Grammar.cpp"
+#line 4525 "src/Slice/Grammar.cpp"
     break;
 
   case 231: /* keyword: ICE_VARULONG  */
-#line 2416 "src/Slice/Grammar.y"
+#line 2402 "src/Slice/Grammar.y"
                {}
-#line 4545 "src/Slice/Grammar.cpp"
+#line 4531 "src/Slice/Grammar.cpp"
     break;
 
   case 232: /* keyword: ICE_FLOAT  */
-#line 2417 "src/Slice/Grammar.y"
+#line 2403 "src/Slice/Grammar.y"
             {}
-#line 4551 "src/Slice/Grammar.cpp"
+#line 4537 "src/Slice/Grammar.cpp"
     break;
 
   case 233: /* keyword: ICE_DOUBLE  */
-#line 2418 "src/Slice/Grammar.y"
+#line 2404 "src/Slice/Grammar.y"
              {}
-#line 4557 "src/Slice/Grammar.cpp"
+#line 4543 "src/Slice/Grammar.cpp"
     break;
 
   case 234: /* keyword: ICE_STRING  */
-#line 2419 "src/Slice/Grammar.y"
+#line 2405 "src/Slice/Grammar.y"
              {}
-#line 4563 "src/Slice/Grammar.cpp"
+#line 4549 "src/Slice/Grammar.cpp"
     break;
 
   case 235: /* keyword: ICE_OBJECT  */
-#line 2420 "src/Slice/Grammar.y"
+#line 2406 "src/Slice/Grammar.y"
              {}
-#line 4569 "src/Slice/Grammar.cpp"
+#line 4555 "src/Slice/Grammar.cpp"
     break;
 
   case 236: /* keyword: ICE_CONST  */
-#line 2421 "src/Slice/Grammar.y"
+#line 2407 "src/Slice/Grammar.y"
             {}
-#line 4575 "src/Slice/Grammar.cpp"
+#line 4561 "src/Slice/Grammar.cpp"
     break;
 
   case 237: /* keyword: ICE_FALSE  */
-#line 2422 "src/Slice/Grammar.y"
+#line 2408 "src/Slice/Grammar.y"
             {}
-#line 4581 "src/Slice/Grammar.cpp"
+#line 4567 "src/Slice/Grammar.cpp"
     break;
 
   case 238: /* keyword: ICE_TRUE  */
-#line 2423 "src/Slice/Grammar.y"
+#line 2409 "src/Slice/Grammar.y"
            {}
-#line 4587 "src/Slice/Grammar.cpp"
+#line 4573 "src/Slice/Grammar.cpp"
     break;
 
   case 239: /* keyword: ICE_IDEMPOTENT  */
-#line 2424 "src/Slice/Grammar.y"
+#line 2410 "src/Slice/Grammar.y"
                  {}
-#line 4593 "src/Slice/Grammar.cpp"
+#line 4579 "src/Slice/Grammar.cpp"
     break;
 
   case 240: /* keyword: ICE_TAG  */
-#line 2425 "src/Slice/Grammar.y"
+#line 2411 "src/Slice/Grammar.y"
           {}
-#line 4599 "src/Slice/Grammar.cpp"
+#line 4585 "src/Slice/Grammar.cpp"
     break;
 
   case 241: /* keyword: ICE_OPTIONAL  */
-#line 2426 "src/Slice/Grammar.y"
+#line 2412 "src/Slice/Grammar.y"
                {}
-#line 4605 "src/Slice/Grammar.cpp"
+#line 4591 "src/Slice/Grammar.cpp"
     break;
 
   case 242: /* keyword: ICE_ANYCLASS  */
-#line 2427 "src/Slice/Grammar.y"
+#line 2413 "src/Slice/Grammar.y"
                {}
-#line 4611 "src/Slice/Grammar.cpp"
+#line 4597 "src/Slice/Grammar.cpp"
     break;
 
   case 243: /* keyword: ICE_VALUE  */
-#line 2428 "src/Slice/Grammar.y"
+#line 2414 "src/Slice/Grammar.y"
             {}
-#line 4617 "src/Slice/Grammar.cpp"
+#line 4603 "src/Slice/Grammar.cpp"
     break;
 
 
-#line 4621 "src/Slice/Grammar.cpp"
+#line 4607 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4816,5 +4802,5 @@ yyreturn:
   return yyresult;
 }
 
-#line 2431 "src/Slice/Grammar.y"
+#line 2417 "src/Slice/Grammar.y"
 

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -727,31 +727,31 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   188,   188,   194,   195,   201,   210,   214,   221,   230,
-     238,   247,   254,   253,   259,   258,   263,   268,   267,   273,
-     272,   277,   282,   281,   287,   286,   291,   296,   295,   301,
-     300,   305,   310,   309,   315,   314,   319,   324,   323,   328,
-     333,   332,   338,   337,   342,   346,   356,   355,   394,   393,
-     471,   475,   486,   497,   496,   522,   530,   539,   557,   631,
-     637,   648,   670,   748,   758,   773,   777,   788,   799,   798,
-     839,   843,   854,   879,   969,   981,   994,   993,  1027,  1061,
-    1070,  1071,  1077,  1092,  1114,  1115,  1116,  1120,  1126,  1127,
-    1133,  1145,  1161,  1176,  1185,  1190,  1199,  1234,  1269,  1303,
-    1343,  1342,  1365,  1364,  1387,  1405,  1409,  1410,  1416,  1420,
-    1431,  1445,  1444,  1478,  1513,  1548,  1553,  1558,  1572,  1576,
-    1585,  1592,  1604,  1616,  1627,  1635,  1649,  1659,  1675,  1679,
-    1688,  1704,  1718,  1717,  1738,  1737,  1756,  1760,  1769,  1770,
-    1771,  1780,  1789,  1803,  1817,  1832,  1852,  1856,  1894,  1898,
-    1907,  1926,  1927,  1933,  1934,  1940,  1944,  1953,  1954,  1960,
-    1961,  1972,  1973,  1974,  1975,  1976,  1977,  1978,  1979,  1980,
-    1981,  1982,  1983,  1984,  1985,  1986,  1991,  1995,  1999,  2003,
-    2011,  2016,  2027,  2031,  2043,  2048,  2074,  2106,  2134,  2149,
-    2163,  2174,  2186,  2197,  2208,  2219,  2225,  2231,  2238,  2250,
-    2259,  2268,  2308,  2315,  2322,  2334,  2343,  2357,  2358,  2359,
-    2360,  2361,  2362,  2363,  2364,  2365,  2366,  2367,  2368,  2369,
-    2370,  2371,  2372,  2373,  2374,  2375,  2376,  2377,  2378,  2379,
-    2380,  2381,  2382,  2383,  2384,  2385,  2386,  2387,  2388,  2389,
-    2390,  2391,  2392,  2393
+       0,   188,   188,   194,   195,   201,   222,   238,   256,   265,
+     273,   282,   289,   288,   294,   293,   298,   303,   302,   308,
+     307,   312,   317,   316,   322,   321,   326,   331,   330,   336,
+     335,   340,   345,   344,   350,   349,   354,   359,   358,   363,
+     368,   367,   373,   372,   377,   381,   391,   390,   429,   428,
+     506,   510,   521,   532,   531,   557,   565,   574,   592,   666,
+     672,   683,   705,   783,   793,   808,   812,   823,   834,   833,
+     874,   878,   889,   914,  1004,  1016,  1029,  1028,  1062,  1096,
+    1105,  1106,  1112,  1127,  1149,  1150,  1151,  1155,  1161,  1162,
+    1168,  1180,  1196,  1211,  1220,  1225,  1234,  1269,  1304,  1338,
+    1378,  1377,  1400,  1399,  1422,  1440,  1444,  1445,  1451,  1455,
+    1466,  1480,  1479,  1513,  1548,  1583,  1588,  1593,  1607,  1611,
+    1620,  1627,  1639,  1651,  1662,  1670,  1684,  1694,  1710,  1714,
+    1723,  1739,  1753,  1752,  1773,  1772,  1791,  1795,  1804,  1805,
+    1806,  1815,  1824,  1838,  1852,  1867,  1887,  1891,  1929,  1933,
+    1942,  1961,  1962,  1968,  1969,  1975,  1979,  1988,  1989,  1995,
+    1996,  2007,  2008,  2009,  2010,  2011,  2012,  2013,  2014,  2015,
+    2016,  2017,  2018,  2019,  2020,  2021,  2026,  2030,  2034,  2038,
+    2046,  2051,  2062,  2066,  2078,  2083,  2109,  2141,  2169,  2184,
+    2198,  2209,  2221,  2232,  2243,  2254,  2260,  2266,  2273,  2285,
+    2294,  2303,  2343,  2350,  2357,  2369,  2378,  2392,  2393,  2394,
+    2395,  2396,  2397,  2398,  2399,  2400,  2401,  2402,  2403,  2404,
+    2405,  2406,  2407,  2408,  2409,  2410,  2411,  2412,  2413,  2414,
+    2415,  2416,  2417,  2418,  2419,  2420,  2421,  2422,  2423,  2424,
+    2425,  2426,  2427,  2428
 };
 #endif
 
@@ -1845,40 +1845,75 @@ yyreduce:
   case 5: /* file_metadata: ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE  */
 #line 202 "src/Slice/Grammar.y"
 {
-    yyval = yyvsp[-1];
+    //TODOREMOVE
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
+    yyval = metadata;
 }
-#line 1851 "src/Slice/Grammar.cpp"
+#line 1863 "src/Slice/Grammar.cpp"
     break;
 
   case 6: /* local_metadata: ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 211 "src/Slice/Grammar.y"
+#line 223 "src/Slice/Grammar.y"
 {
+    //TODOREMOVE
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
     yyval = yyvsp[-1];
 }
-#line 1859 "src/Slice/Grammar.cpp"
+#line 1883 "src/Slice/Grammar.cpp"
     break;
 
   case 7: /* local_metadata: local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE  */
-#line 215 "src/Slice/Grammar.y"
+#line 239 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata1 = StringListTokPtr::dynamicCast(yyvsp[-3]);
     StringListTokPtr metadata2 = StringListTokPtr::dynamicCast(yyvsp[-1]);
     metadata1->v.splice(metadata1->v.end(), metadata2->v);
+    //TODOREMOVE
+    for (auto& m : metadata1->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
     yyval = metadata1;
 }
-#line 1870 "src/Slice/Grammar.cpp"
+#line 1905 "src/Slice/Grammar.cpp"
     break;
 
   case 8: /* local_metadata: %empty  */
-#line 222 "src/Slice/Grammar.y"
+#line 257 "src/Slice/Grammar.y"
 {
     yyval = new StringListTok;
 }
-#line 1878 "src/Slice/Grammar.cpp"
+#line 1913 "src/Slice/Grammar.cpp"
     break;
 
   case 9: /* definitions: definitions file_metadata  */
-#line 231 "src/Slice/Grammar.y"
+#line 266 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[0]);
     if(!metadata->v.empty())
@@ -1886,11 +1921,11 @@ yyreduce:
         unit->addFileMetadata(metadata->v);
     }
 }
-#line 1890 "src/Slice/Grammar.cpp"
+#line 1925 "src/Slice/Grammar.cpp"
     break;
 
   case 10: /* definitions: definitions local_metadata definition  */
-#line 239 "src/Slice/Grammar.y"
+#line 274 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     ContainedPtr contained = ContainedPtr::dynamicCast(yyvsp[0]);
@@ -1899,179 +1934,179 @@ yyreduce:
         contained->setMetadata(metadata->v);
     }
 }
-#line 1903 "src/Slice/Grammar.cpp"
+#line 1938 "src/Slice/Grammar.cpp"
     break;
 
   case 12: /* $@1: %empty  */
-#line 254 "src/Slice/Grammar.y"
+#line 289 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ModulePtr::dynamicCast(yyvsp[0]));
 }
-#line 1911 "src/Slice/Grammar.cpp"
+#line 1946 "src/Slice/Grammar.cpp"
     break;
 
   case 14: /* $@2: %empty  */
-#line 259 "src/Slice/Grammar.y"
+#line 294 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1919 "src/Slice/Grammar.cpp"
+#line 1954 "src/Slice/Grammar.cpp"
     break;
 
   case 16: /* definition: class_decl  */
-#line 264 "src/Slice/Grammar.y"
+#line 299 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after class forward declaration");
 }
-#line 1927 "src/Slice/Grammar.cpp"
+#line 1962 "src/Slice/Grammar.cpp"
     break;
 
   case 17: /* $@3: %empty  */
-#line 268 "src/Slice/Grammar.y"
+#line 303 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ClassDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1935 "src/Slice/Grammar.cpp"
+#line 1970 "src/Slice/Grammar.cpp"
     break;
 
   case 19: /* $@4: %empty  */
-#line 273 "src/Slice/Grammar.y"
+#line 308 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDeclPtr::dynamicCast(yyvsp[0]));
 }
-#line 1943 "src/Slice/Grammar.cpp"
+#line 1978 "src/Slice/Grammar.cpp"
     break;
 
   case 21: /* definition: interface_decl  */
-#line 278 "src/Slice/Grammar.y"
+#line 313 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after interface forward declaration");
 }
-#line 1951 "src/Slice/Grammar.cpp"
+#line 1986 "src/Slice/Grammar.cpp"
     break;
 
   case 22: /* $@5: %empty  */
-#line 282 "src/Slice/Grammar.y"
+#line 317 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || InterfaceDefPtr::dynamicCast(yyvsp[0]));
 }
-#line 1959 "src/Slice/Grammar.cpp"
+#line 1994 "src/Slice/Grammar.cpp"
     break;
 
   case 24: /* $@6: %empty  */
-#line 287 "src/Slice/Grammar.y"
+#line 322 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0);
 }
-#line 1967 "src/Slice/Grammar.cpp"
+#line 2002 "src/Slice/Grammar.cpp"
     break;
 
   case 26: /* definition: exception_decl  */
-#line 292 "src/Slice/Grammar.y"
+#line 327 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after exception forward declaration");
 }
-#line 1975 "src/Slice/Grammar.cpp"
+#line 2010 "src/Slice/Grammar.cpp"
     break;
 
   case 27: /* $@7: %empty  */
-#line 296 "src/Slice/Grammar.y"
+#line 331 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ExceptionPtr::dynamicCast(yyvsp[0]));
 }
-#line 1983 "src/Slice/Grammar.cpp"
+#line 2018 "src/Slice/Grammar.cpp"
     break;
 
   case 29: /* $@8: %empty  */
-#line 301 "src/Slice/Grammar.y"
+#line 336 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0);
 }
-#line 1991 "src/Slice/Grammar.cpp"
+#line 2026 "src/Slice/Grammar.cpp"
     break;
 
   case 31: /* definition: struct_decl  */
-#line 306 "src/Slice/Grammar.y"
+#line 341 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after struct forward declaration");
 }
-#line 1999 "src/Slice/Grammar.cpp"
+#line 2034 "src/Slice/Grammar.cpp"
     break;
 
   case 32: /* $@9: %empty  */
-#line 310 "src/Slice/Grammar.y"
+#line 345 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || StructPtr::dynamicCast(yyvsp[0]));
 }
-#line 2007 "src/Slice/Grammar.cpp"
+#line 2042 "src/Slice/Grammar.cpp"
     break;
 
   case 34: /* $@10: %empty  */
-#line 315 "src/Slice/Grammar.y"
+#line 350 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || SequencePtr::dynamicCast(yyvsp[0]));
 }
-#line 2015 "src/Slice/Grammar.cpp"
+#line 2050 "src/Slice/Grammar.cpp"
     break;
 
   case 36: /* definition: sequence_def  */
-#line 320 "src/Slice/Grammar.y"
+#line 355 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after sequence definition");
 }
-#line 2023 "src/Slice/Grammar.cpp"
+#line 2058 "src/Slice/Grammar.cpp"
     break;
 
   case 37: /* $@11: %empty  */
-#line 324 "src/Slice/Grammar.y"
+#line 359 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || DictionaryPtr::dynamicCast(yyvsp[0]));
 }
-#line 2031 "src/Slice/Grammar.cpp"
+#line 2066 "src/Slice/Grammar.cpp"
     break;
 
   case 39: /* definition: dictionary_def  */
-#line 329 "src/Slice/Grammar.y"
+#line 364 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after dictionary definition");
 }
-#line 2039 "src/Slice/Grammar.cpp"
+#line 2074 "src/Slice/Grammar.cpp"
     break;
 
   case 40: /* $@12: %empty  */
-#line 333 "src/Slice/Grammar.y"
+#line 368 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || EnumPtr::dynamicCast(yyvsp[0]));
 }
-#line 2047 "src/Slice/Grammar.cpp"
+#line 2082 "src/Slice/Grammar.cpp"
     break;
 
   case 42: /* $@13: %empty  */
-#line 338 "src/Slice/Grammar.y"
+#line 373 "src/Slice/Grammar.y"
 {
     assert(yyvsp[0] == 0 || ConstPtr::dynamicCast(yyvsp[0]));
 }
-#line 2055 "src/Slice/Grammar.cpp"
+#line 2090 "src/Slice/Grammar.cpp"
     break;
 
   case 44: /* definition: const_def  */
-#line 343 "src/Slice/Grammar.y"
+#line 378 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after const definition");
 }
-#line 2063 "src/Slice/Grammar.cpp"
+#line 2098 "src/Slice/Grammar.cpp"
     break;
 
   case 45: /* definition: error ';'  */
-#line 347 "src/Slice/Grammar.y"
+#line 382 "src/Slice/Grammar.y"
 {
     yyerrok;
 }
-#line 2071 "src/Slice/Grammar.cpp"
+#line 2106 "src/Slice/Grammar.cpp"
     break;
 
   case 46: /* @14: %empty  */
-#line 356 "src/Slice/Grammar.y"
+#line 391 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2097,11 +2132,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2101 "src/Slice/Grammar.cpp"
+#line 2136 "src/Slice/Grammar.cpp"
     break;
 
   case 47: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
-#line 382 "src/Slice/Grammar.y"
+#line 417 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2113,11 +2148,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2117 "src/Slice/Grammar.cpp"
+#line 2152 "src/Slice/Grammar.cpp"
     break;
 
   case 48: /* @15: %empty  */
-#line 394 "src/Slice/Grammar.y"
+#line 429 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2172,11 +2207,11 @@ yyreduce:
 
     yyval = parent;
 }
-#line 2176 "src/Slice/Grammar.cpp"
+#line 2211 "src/Slice/Grammar.cpp"
     break;
 
   case 49: /* module_def: ICE_MODULE ICE_SCOPED_IDENTIFIER @15 '{' definitions '}'  */
-#line 449 "src/Slice/Grammar.y"
+#line 484 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2194,38 +2229,38 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2198 "src/Slice/Grammar.cpp"
+#line 2233 "src/Slice/Grammar.cpp"
     break;
 
   case 50: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
-#line 472 "src/Slice/Grammar.y"
+#line 507 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2206 "src/Slice/Grammar.cpp"
+#line 2241 "src/Slice/Grammar.cpp"
     break;
 
   case 51: /* exception_id: ICE_EXCEPTION keyword  */
-#line 476 "src/Slice/Grammar.y"
+#line 511 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2216 "src/Slice/Grammar.cpp"
+#line 2251 "src/Slice/Grammar.cpp"
     break;
 
   case 52: /* exception_decl: exception_id  */
-#line 487 "src/Slice/Grammar.y"
+#line 522 "src/Slice/Grammar.y"
 {
     unit->error("exceptions cannot be forward declared");
     yyval = 0;
 }
-#line 2225 "src/Slice/Grammar.cpp"
+#line 2260 "src/Slice/Grammar.cpp"
     break;
 
   case 53: /* @16: %empty  */
-#line 497 "src/Slice/Grammar.y"
+#line 532 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ExceptionPtr base = ExceptionPtr::dynamicCast(yyvsp[0]);
@@ -2238,11 +2273,11 @@ yyreduce:
     }
     yyval = ex;
 }
-#line 2242 "src/Slice/Grammar.cpp"
+#line 2277 "src/Slice/Grammar.cpp"
     break;
 
   case 54: /* exception_def: exception_id exception_extends @16 '{' data_members '}'  */
-#line 510 "src/Slice/Grammar.y"
+#line 545 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2250,11 +2285,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 2254 "src/Slice/Grammar.cpp"
+#line 2289 "src/Slice/Grammar.cpp"
     break;
 
   case 55: /* exception_extends: extends scoped_name  */
-#line 523 "src/Slice/Grammar.y"
+#line 558 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2262,19 +2297,19 @@ yyreduce:
     cont->checkIntroduced(scoped->v);
     yyval = contained;
 }
-#line 2266 "src/Slice/Grammar.cpp"
+#line 2301 "src/Slice/Grammar.cpp"
     break;
 
   case 56: /* exception_extends: %empty  */
-#line 531 "src/Slice/Grammar.y"
+#line 566 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2274 "src/Slice/Grammar.cpp"
+#line 2309 "src/Slice/Grammar.cpp"
     break;
 
   case 57: /* tag: ICE_TAG '(' ICE_INTEGER_LITERAL ')'  */
-#line 540 "src/Slice/Grammar.y"
+#line 575 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2292,11 +2327,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2296 "src/Slice/Grammar.cpp"
+#line 2331 "src/Slice/Grammar.cpp"
     break;
 
   case 58: /* tag: ICE_TAG '(' scoped_name ')'  */
-#line 558 "src/Slice/Grammar.y"
+#line 593 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2370,31 +2405,31 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2374 "src/Slice/Grammar.cpp"
+#line 2409 "src/Slice/Grammar.cpp"
     break;
 
   case 59: /* tag: ICE_TAG '(' ')'  */
-#line 632 "src/Slice/Grammar.y"
+#line 667 "src/Slice/Grammar.y"
 {
     unit->error("missing tag");
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2384 "src/Slice/Grammar.cpp"
+#line 2419 "src/Slice/Grammar.cpp"
     break;
 
   case 60: /* tag: ICE_TAG  */
-#line 638 "src/Slice/Grammar.y"
+#line 673 "src/Slice/Grammar.y"
 {
     unit->error("missing tag");
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2394 "src/Slice/Grammar.cpp"
+#line 2429 "src/Slice/Grammar.cpp"
     break;
 
   case 61: /* optional: ICE_OPTIONAL '(' ICE_INTEGER_LITERAL ')'  */
-#line 649 "src/Slice/Grammar.y"
+#line 684 "src/Slice/Grammar.y"
 {
     IntegerTokPtr i = IntegerTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2416,11 +2451,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(tag);
     yyval = m;
 }
-#line 2420 "src/Slice/Grammar.cpp"
+#line 2455 "src/Slice/Grammar.cpp"
     break;
 
   case 62: /* optional: ICE_OPTIONAL '(' scoped_name ')'  */
-#line 671 "src/Slice/Grammar.y"
+#line 706 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     if (!unit->compatMode())
@@ -2498,11 +2533,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok(static_cast<int>(tag));
     yyval = m;
 }
-#line 2502 "src/Slice/Grammar.cpp"
+#line 2537 "src/Slice/Grammar.cpp"
     break;
 
   case 63: /* optional: ICE_OPTIONAL '(' ')'  */
-#line 749 "src/Slice/Grammar.y"
+#line 784 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -2512,11 +2547,11 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2516 "src/Slice/Grammar.cpp"
+#line 2551 "src/Slice/Grammar.cpp"
     break;
 
   case 64: /* optional: ICE_OPTIONAL  */
-#line 759 "src/Slice/Grammar.y"
+#line 794 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -2526,38 +2561,38 @@ yyreduce:
     TaggedDefTokPtr m = new TaggedDefTok; // Dummy
     yyval = m;
 }
-#line 2530 "src/Slice/Grammar.cpp"
+#line 2565 "src/Slice/Grammar.cpp"
     break;
 
   case 65: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
-#line 774 "src/Slice/Grammar.y"
+#line 809 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2538 "src/Slice/Grammar.cpp"
+#line 2573 "src/Slice/Grammar.cpp"
     break;
 
   case 66: /* struct_id: ICE_STRUCT keyword  */
-#line 778 "src/Slice/Grammar.y"
+#line 813 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as struct name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2548 "src/Slice/Grammar.cpp"
+#line 2583 "src/Slice/Grammar.cpp"
     break;
 
   case 67: /* struct_decl: struct_id  */
-#line 789 "src/Slice/Grammar.y"
+#line 824 "src/Slice/Grammar.y"
 {
     unit->error("structs cannot be forward declared");
     yyval = 0; // Dummy
 }
-#line 2557 "src/Slice/Grammar.cpp"
+#line 2592 "src/Slice/Grammar.cpp"
     break;
 
   case 68: /* @17: %empty  */
-#line 799 "src/Slice/Grammar.y"
+#line 834 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -2575,11 +2610,11 @@ yyreduce:
     }
     yyval = st;
 }
-#line 2579 "src/Slice/Grammar.cpp"
+#line 2614 "src/Slice/Grammar.cpp"
     break;
 
   case 69: /* struct_def: struct_id @17 '{' data_members '}'  */
-#line 817 "src/Slice/Grammar.y"
+#line 852 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2597,29 +2632,29 @@ yyreduce:
         unit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
     }
 }
-#line 2601 "src/Slice/Grammar.cpp"
+#line 2636 "src/Slice/Grammar.cpp"
     break;
 
   case 70: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
-#line 840 "src/Slice/Grammar.y"
+#line 875 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 2609 "src/Slice/Grammar.cpp"
+#line 2644 "src/Slice/Grammar.cpp"
     break;
 
   case 71: /* class_name: ICE_CLASS keyword  */
-#line 844 "src/Slice/Grammar.y"
+#line 879 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as class name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 2619 "src/Slice/Grammar.cpp"
+#line 2654 "src/Slice/Grammar.cpp"
     break;
 
   case 72: /* class_id: ICE_CLASS unscoped_name '(' ICE_INTEGER_LITERAL ')'  */
-#line 855 "src/Slice/Grammar.y"
+#line 890 "src/Slice/Grammar.y"
 {
     IceUtil::Int64 id = IntegerTokPtr::dynamicCast(yyvsp[-1])->v;
     if(id < 0)
@@ -2644,11 +2679,11 @@ yyreduce:
     classId->t = static_cast<int>(id);
     yyval = classId;
 }
-#line 2648 "src/Slice/Grammar.cpp"
+#line 2683 "src/Slice/Grammar.cpp"
     break;
 
   case 73: /* class_id: ICE_CLASS unscoped_name '(' scoped_name ')'  */
-#line 880 "src/Slice/Grammar.y"
+#line 915 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
 
@@ -2738,33 +2773,33 @@ yyreduce:
     yyval = classId;
 
 }
-#line 2742 "src/Slice/Grammar.cpp"
+#line 2777 "src/Slice/Grammar.cpp"
     break;
 
   case 74: /* class_id: class_name  */
-#line 970 "src/Slice/Grammar.y"
+#line 1005 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr classId = new ClassIdTok();
     classId->v = StringTokPtr::dynamicCast(yyvsp[0])->v;
     classId->t = -1;
     yyval = classId;
 }
-#line 2753 "src/Slice/Grammar.cpp"
+#line 2788 "src/Slice/Grammar.cpp"
     break;
 
   case 75: /* class_decl: class_name  */
-#line 982 "src/Slice/Grammar.y"
+#line 1017 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
     ClassDeclPtr cl = cont->createClassDecl(ident->v);
     yyval = cl;
 }
-#line 2764 "src/Slice/Grammar.cpp"
+#line 2799 "src/Slice/Grammar.cpp"
     break;
 
   case 76: /* @18: %empty  */
-#line 994 "src/Slice/Grammar.y"
+#line 1029 "src/Slice/Grammar.y"
 {
     ClassIdTokPtr ident = ClassIdTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -2781,11 +2816,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2785 "src/Slice/Grammar.cpp"
+#line 2820 "src/Slice/Grammar.cpp"
     break;
 
   case 77: /* class_def: class_id class_extends @18 '{' data_members '}'  */
-#line 1011 "src/Slice/Grammar.y"
+#line 1046 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -2797,11 +2832,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 2801 "src/Slice/Grammar.cpp"
+#line 2836 "src/Slice/Grammar.cpp"
     break;
 
   case 78: /* class_extends: extends scoped_name  */
-#line 1028 "src/Slice/Grammar.y"
+#line 1063 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -2835,19 +2870,19 @@ yyreduce:
         }
     }
 }
-#line 2839 "src/Slice/Grammar.cpp"
+#line 2874 "src/Slice/Grammar.cpp"
     break;
 
   case 79: /* class_extends: %empty  */
-#line 1062 "src/Slice/Grammar.y"
+#line 1097 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 2847 "src/Slice/Grammar.cpp"
+#line 2882 "src/Slice/Grammar.cpp"
     break;
 
   case 82: /* data_member: member  */
-#line 1078 "src/Slice/Grammar.y"
+#line 1113 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
 
@@ -2862,11 +2897,11 @@ yyreduce:
         }
     }
 }
-#line 2866 "src/Slice/Grammar.cpp"
+#line 2901 "src/Slice/Grammar.cpp"
     break;
 
   case 83: /* data_member: member '=' const_initializer  */
-#line 1093 "src/Slice/Grammar.y"
+#line 1128 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-2]);
     ConstDefTokPtr value = ConstDefTokPtr::dynamicCast(yyvsp[0]);
@@ -2883,19 +2918,19 @@ yyreduce:
         }
     }
 }
-#line 2887 "src/Slice/Grammar.cpp"
+#line 2922 "src/Slice/Grammar.cpp"
     break;
 
   case 86: /* data_member_list: data_member  */
-#line 1117 "src/Slice/Grammar.y"
+#line 1152 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 2895 "src/Slice/Grammar.cpp"
+#line 2930 "src/Slice/Grammar.cpp"
     break;
 
   case 90: /* return_tuple: out_qualifier member  */
-#line 1134 "src/Slice/Grammar.y"
+#line 1169 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2907,11 +2942,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2911 "src/Slice/Grammar.cpp"
+#line 2946 "src/Slice/Grammar.cpp"
     break;
 
   case 91: /* return_tuple: return_tuple ',' out_qualifier member  */
-#line 1146 "src/Slice/Grammar.y"
+#line 1181 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     if (BoolTokPtr::dynamicCast(yyvsp[-1])->v)
@@ -2923,11 +2958,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2927 "src/Slice/Grammar.cpp"
+#line 2962 "src/Slice/Grammar.cpp"
     break;
 
   case 92: /* return_type: tagged_type  */
-#line 1162 "src/Slice/Grammar.y"
+#line 1197 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr returnMember = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     // For unnamed return types we infer their name to be 'returnValue'.
@@ -2942,11 +2977,11 @@ yyreduce:
     returnMembers->v.push_back(returnMember);
     yyval = returnMembers;
 }
-#line 2946 "src/Slice/Grammar.cpp"
+#line 2981 "src/Slice/Grammar.cpp"
     break;
 
   case 93: /* return_type: '(' return_tuple ')'  */
-#line 1177 "src/Slice/Grammar.y"
+#line 1212 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-1]);
     if (returnMembers->v.size() == 1)
@@ -2955,66 +2990,27 @@ yyreduce:
     }
     yyval = yyvsp[-1];
 }
-#line 2959 "src/Slice/Grammar.cpp"
+#line 2994 "src/Slice/Grammar.cpp"
     break;
 
   case 94: /* return_type: '(' ')'  */
-#line 1186 "src/Slice/Grammar.y"
+#line 1221 "src/Slice/Grammar.y"
 {
     unit->error("return tuples must contain at least 2 elements");
     yyval = new TaggedDefListTok();
 }
-#line 2968 "src/Slice/Grammar.cpp"
+#line 3003 "src/Slice/Grammar.cpp"
     break;
 
   case 95: /* return_type: ICE_VOID  */
-#line 1191 "src/Slice/Grammar.y"
+#line 1226 "src/Slice/Grammar.y"
 {
     yyval = new TaggedDefListTok();
 }
-#line 2976 "src/Slice/Grammar.cpp"
+#line 3011 "src/Slice/Grammar.cpp"
     break;
 
   case 96: /* operation_preamble: return_type unscoped_name '('  */
-#line 1200 "src/Slice/Grammar.y"
-{
-    TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
-    string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
-
-    if (InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(unit->currentContainer()))
-    {
-        if (OperationPtr op = interface->createOperation(name))
-        {
-            interface->checkIntroduced(name, op);
-            unit->pushContainer(op);
-
-            // Set the return members for the operation.
-            for (const auto& returnMember : returnMembers->v)
-            {
-                MemberPtr p = op->createReturnMember(returnMember->name, returnMember->type, returnMember->isTagged,
-                                                     returnMember->tag);
-                if (p && !returnMember->metadata.empty())
-                {
-                    p->setMetadata(returnMember->metadata);
-                }
-            }
-
-            yyval = op;
-        }
-        else
-        {
-            yyval = 0;
-        }
-    }
-    else
-    {
-        yyval = 0;
-    }
-}
-#line 3015 "src/Slice/Grammar.cpp"
-    break;
-
-  case 97: /* operation_preamble: ICE_IDEMPOTENT return_type unscoped_name '('  */
 #line 1235 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
@@ -3022,6 +3018,45 @@ yyreduce:
 
     if (InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(unit->currentContainer()))
     {
+        if (OperationPtr op = interface->createOperation(name))
+        {
+            interface->checkIntroduced(name, op);
+            unit->pushContainer(op);
+
+            // Set the return members for the operation.
+            for (const auto& returnMember : returnMembers->v)
+            {
+                MemberPtr p = op->createReturnMember(returnMember->name, returnMember->type, returnMember->isTagged,
+                                                     returnMember->tag);
+                if (p && !returnMember->metadata.empty())
+                {
+                    p->setMetadata(returnMember->metadata);
+                }
+            }
+
+            yyval = op;
+        }
+        else
+        {
+            yyval = 0;
+        }
+    }
+    else
+    {
+        yyval = 0;
+    }
+}
+#line 3050 "src/Slice/Grammar.cpp"
+    break;
+
+  case 97: /* operation_preamble: ICE_IDEMPOTENT return_type unscoped_name '('  */
+#line 1270 "src/Slice/Grammar.y"
+{
+    TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
+    string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
+
+    if (InterfaceDefPtr interface = InterfaceDefPtr::dynamicCast(unit->currentContainer()))
+    {
         if (OperationPtr op = interface->createOperation(name, Operation::Idempotent))
         {
             interface->checkIntroduced(name, op);
@@ -3050,11 +3085,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3054 "src/Slice/Grammar.cpp"
+#line 3089 "src/Slice/Grammar.cpp"
     break;
 
   case 98: /* operation_preamble: return_type keyword '('  */
-#line 1270 "src/Slice/Grammar.y"
+#line 1305 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3088,11 +3123,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3092 "src/Slice/Grammar.cpp"
+#line 3127 "src/Slice/Grammar.cpp"
     break;
 
   case 99: /* operation_preamble: ICE_IDEMPOTENT return_type keyword '('  */
-#line 1304 "src/Slice/Grammar.y"
+#line 1339 "src/Slice/Grammar.y"
 {
     TaggedDefListTokPtr returnMembers = TaggedDefListTokPtr::dynamicCast(yyvsp[-2]);
     string name = StringTokPtr::dynamicCast(yyvsp[-1])->v;
@@ -3126,11 +3161,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3130 "src/Slice/Grammar.cpp"
+#line 3165 "src/Slice/Grammar.cpp"
     break;
 
   case 100: /* @19: %empty  */
-#line 1343 "src/Slice/Grammar.y"
+#line 1378 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3142,11 +3177,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3146 "src/Slice/Grammar.cpp"
+#line 3181 "src/Slice/Grammar.cpp"
     break;
 
   case 101: /* operation: operation_preamble parameters ')' @19 throws  */
-#line 1355 "src/Slice/Grammar.y"
+#line 1390 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3156,11 +3191,11 @@ yyreduce:
         op->setExceptionList(el->v);
     }
 }
-#line 3160 "src/Slice/Grammar.cpp"
+#line 3195 "src/Slice/Grammar.cpp"
     break;
 
   case 102: /* @20: %empty  */
-#line 1365 "src/Slice/Grammar.y"
+#line 1400 "src/Slice/Grammar.y"
 {
     if(yyvsp[-2])
     {
@@ -3168,11 +3203,11 @@ yyreduce:
     }
     yyerrok;
 }
-#line 3172 "src/Slice/Grammar.cpp"
+#line 3207 "src/Slice/Grammar.cpp"
     break;
 
   case 103: /* operation: operation_preamble error ')' @20 throws  */
-#line 1373 "src/Slice/Grammar.y"
+#line 1408 "src/Slice/Grammar.y"
 {
     OperationPtr op = OperationPtr::dynamicCast(yyvsp[-1]);
     ExceptionListTokPtr el = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
@@ -3182,11 +3217,11 @@ yyreduce:
         op->setExceptionList(el->v); // Dummy
     }
 }
-#line 3186 "src/Slice/Grammar.cpp"
+#line 3221 "src/Slice/Grammar.cpp"
     break;
 
   case 104: /* operation_list: local_metadata operation ';' operation_list  */
-#line 1388 "src/Slice/Grammar.y"
+#line 1423 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     OperationPtr operation = OperationPtr::dynamicCast(yyvsp[-2]);
@@ -3204,37 +3239,37 @@ yyreduce:
         }
     }
 }
-#line 3208 "src/Slice/Grammar.cpp"
+#line 3243 "src/Slice/Grammar.cpp"
     break;
 
   case 105: /* operation_list: local_metadata operation  */
-#line 1406 "src/Slice/Grammar.y"
+#line 1441 "src/Slice/Grammar.y"
 {
     unit->error("`;' missing after definition");
 }
-#line 3216 "src/Slice/Grammar.cpp"
+#line 3251 "src/Slice/Grammar.cpp"
     break;
 
   case 108: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
-#line 1417 "src/Slice/Grammar.y"
+#line 1452 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3224 "src/Slice/Grammar.cpp"
+#line 3259 "src/Slice/Grammar.cpp"
     break;
 
   case 109: /* interface_id: ICE_INTERFACE keyword  */
-#line 1421 "src/Slice/Grammar.y"
+#line 1456 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as interface name");
     yyval = yyvsp[0]; // Dummy
 }
-#line 3234 "src/Slice/Grammar.cpp"
+#line 3269 "src/Slice/Grammar.cpp"
     break;
 
   case 110: /* interface_decl: interface_id  */
-#line 1432 "src/Slice/Grammar.y"
+#line 1467 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     ModulePtr cont = unit->currentModule();
@@ -3242,11 +3277,11 @@ yyreduce:
     cont->checkIntroduced(ident->v, cl);
     yyval = cl;
 }
-#line 3246 "src/Slice/Grammar.cpp"
+#line 3281 "src/Slice/Grammar.cpp"
     break;
 
   case 111: /* @21: %empty  */
-#line 1445 "src/Slice/Grammar.y"
+#line 1480 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-1]);
     ModulePtr cont = unit->currentModule();
@@ -3263,11 +3298,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3267 "src/Slice/Grammar.cpp"
+#line 3302 "src/Slice/Grammar.cpp"
     break;
 
   case 112: /* interface_def: interface_id interface_extends @21 '{' operation_list '}'  */
-#line 1462 "src/Slice/Grammar.y"
+#line 1497 "src/Slice/Grammar.y"
 {
     if(yyvsp[-3])
     {
@@ -3279,11 +3314,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 3283 "src/Slice/Grammar.cpp"
+#line 3318 "src/Slice/Grammar.cpp"
     break;
 
   case 113: /* interface_list: scoped_name ',' interface_list  */
-#line 1479 "src/Slice/Grammar.y"
+#line 1514 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = InterfaceListTokPtr::dynamicCast(yyvsp[0]);
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-2]);
@@ -3318,11 +3353,11 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3322 "src/Slice/Grammar.cpp"
+#line 3357 "src/Slice/Grammar.cpp"
     break;
 
   case 114: /* interface_list: scoped_name  */
-#line 1514 "src/Slice/Grammar.y"
+#line 1549 "src/Slice/Grammar.y"
 {
     InterfaceListTokPtr intfs = new InterfaceListTok;
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3357,29 +3392,29 @@ yyreduce:
     }
     yyval = intfs;
 }
-#line 3361 "src/Slice/Grammar.cpp"
+#line 3396 "src/Slice/Grammar.cpp"
     break;
 
   case 115: /* interface_list: ICE_OBJECT  */
-#line 1549 "src/Slice/Grammar.y"
+#line 1584 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type Object");
     yyval = new InterfaceListTok; // Dummy
 }
-#line 3370 "src/Slice/Grammar.cpp"
+#line 3405 "src/Slice/Grammar.cpp"
     break;
 
   case 116: /* interface_list: ICE_ANYCLASS  */
-#line 1554 "src/Slice/Grammar.y"
+#line 1589 "src/Slice/Grammar.y"
 {
     unit->error("illegal inheritance from type AnyClass");
     yyval = new ClassListTok; // Dummy
 }
-#line 3379 "src/Slice/Grammar.cpp"
+#line 3414 "src/Slice/Grammar.cpp"
     break;
 
   case 117: /* interface_list: ICE_VALUE  */
-#line 1559 "src/Slice/Grammar.y"
+#line 1594 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3388,49 +3423,49 @@ yyreduce:
     unit->error("illegal inheritance from type Value");
     yyval = new ClassListTok; // Dummy
 }
-#line 3392 "src/Slice/Grammar.cpp"
+#line 3427 "src/Slice/Grammar.cpp"
     break;
 
   case 118: /* interface_extends: extends interface_list  */
-#line 1573 "src/Slice/Grammar.y"
+#line 1608 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3400 "src/Slice/Grammar.cpp"
+#line 3435 "src/Slice/Grammar.cpp"
     break;
 
   case 119: /* interface_extends: %empty  */
-#line 1577 "src/Slice/Grammar.y"
+#line 1612 "src/Slice/Grammar.y"
 {
     yyval = new InterfaceListTok;
 }
-#line 3408 "src/Slice/Grammar.cpp"
+#line 3443 "src/Slice/Grammar.cpp"
     break;
 
   case 120: /* exception_list: exception ',' exception_list  */
-#line 1586 "src/Slice/Grammar.y"
+#line 1621 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[-2]);
     ExceptionListTokPtr exceptionList = ExceptionListTokPtr::dynamicCast(yyvsp[0]);
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3419 "src/Slice/Grammar.cpp"
+#line 3454 "src/Slice/Grammar.cpp"
     break;
 
   case 121: /* exception_list: exception  */
-#line 1593 "src/Slice/Grammar.y"
+#line 1628 "src/Slice/Grammar.y"
 {
     ExceptionPtr exception = ExceptionPtr::dynamicCast(yyvsp[0]);
     ExceptionListTokPtr exceptionList = new ExceptionListTok;
     exceptionList->v.push_front(exception);
     yyval = exceptionList;
 }
-#line 3430 "src/Slice/Grammar.cpp"
+#line 3465 "src/Slice/Grammar.cpp"
     break;
 
   case 122: /* exception: scoped_name  */
-#line 1605 "src/Slice/Grammar.y"
+#line 1640 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -3442,21 +3477,21 @@ yyreduce:
     cont->checkIntroduced(scoped->v, exception);
     yyval = exception;
 }
-#line 3446 "src/Slice/Grammar.cpp"
+#line 3481 "src/Slice/Grammar.cpp"
     break;
 
   case 123: /* exception: keyword  */
-#line 1617 "src/Slice/Grammar.y"
+#line 1652 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("keyword `" + ident->v + "' cannot be used as exception name");
     yyval = unit->currentModule()->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
 }
-#line 3456 "src/Slice/Grammar.cpp"
+#line 3491 "src/Slice/Grammar.cpp"
     break;
 
   case 124: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1628 "src/Slice/Grammar.y"
+#line 1663 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3464,11 +3499,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createSequence(ident->v, type, metadata->v);
 }
-#line 3468 "src/Slice/Grammar.cpp"
+#line 3503 "src/Slice/Grammar.cpp"
     break;
 
   case 125: /* sequence_def: ICE_SEQUENCE '<' local_metadata type '>' keyword  */
-#line 1636 "src/Slice/Grammar.y"
+#line 1671 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
@@ -3477,11 +3512,11 @@ yyreduce:
     yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
-#line 3481 "src/Slice/Grammar.cpp"
+#line 3516 "src/Slice/Grammar.cpp"
     break;
 
   case 126: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' ICE_IDENTIFIER  */
-#line 1650 "src/Slice/Grammar.y"
+#line 1685 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3491,11 +3526,11 @@ yyreduce:
     ModulePtr cont = unit->currentModule();
     yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
-#line 3495 "src/Slice/Grammar.cpp"
+#line 3530 "src/Slice/Grammar.cpp"
     break;
 
   case 127: /* dictionary_def: ICE_DICTIONARY '<' local_metadata type ',' local_metadata type '>' keyword  */
-#line 1660 "src/Slice/Grammar.y"
+#line 1695 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr keyMetadata = StringListTokPtr::dynamicCast(yyvsp[-6]);
@@ -3506,27 +3541,27 @@ yyreduce:
     yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     unit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
-#line 3510 "src/Slice/Grammar.cpp"
+#line 3545 "src/Slice/Grammar.cpp"
     break;
 
   case 128: /* enum_start: ICE_UNCHECKED ICE_ENUM  */
-#line 1676 "src/Slice/Grammar.y"
+#line 1711 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3518 "src/Slice/Grammar.cpp"
+#line 3553 "src/Slice/Grammar.cpp"
     break;
 
   case 129: /* enum_start: ICE_ENUM  */
-#line 1680 "src/Slice/Grammar.y"
+#line 1715 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3526 "src/Slice/Grammar.cpp"
+#line 3561 "src/Slice/Grammar.cpp"
     break;
 
   case 130: /* enum_id: enum_start ICE_IDENTIFIER  */
-#line 1689 "src/Slice/Grammar.y"
+#line 1724 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3542,11 +3577,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3546 "src/Slice/Grammar.cpp"
+#line 3581 "src/Slice/Grammar.cpp"
     break;
 
   case 131: /* enum_id: enum_start keyword  */
-#line 1705 "src/Slice/Grammar.y"
+#line 1740 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[-1])->v;
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3554,22 +3589,22 @@ yyreduce:
     unit->error("keyword `" + ident->v + "' cannot be used as enumeration name");
     yyval = cont->createEnum(IceUtil::generateUUID(), unchecked, Dummy);
 }
-#line 3558 "src/Slice/Grammar.cpp"
+#line 3593 "src/Slice/Grammar.cpp"
     break;
 
   case 132: /* @22: %empty  */
-#line 1718 "src/Slice/Grammar.y"
+#line 1753 "src/Slice/Grammar.y"
 {
     EnumPtr en = EnumPtr::dynamicCast(yyvsp[-1]);
     en->initUnderlying(TypePtr::dynamicCast(yyvsp[0]));
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3569 "src/Slice/Grammar.cpp"
+#line 3604 "src/Slice/Grammar.cpp"
     break;
 
   case 133: /* enum_def: enum_id enum_underlying @22 '{' enumerator_list_or_empty '}'  */
-#line 1725 "src/Slice/Grammar.y"
+#line 1760 "src/Slice/Grammar.y"
 {
     if (EnumPtr en = EnumPtr::dynamicCast(yyvsp[-3]))
     {
@@ -3582,11 +3617,11 @@ yyreduce:
     }
     yyval = yyvsp[-3];
 }
-#line 3586 "src/Slice/Grammar.cpp"
+#line 3621 "src/Slice/Grammar.cpp"
     break;
 
   case 134: /* @23: %empty  */
-#line 1738 "src/Slice/Grammar.y"
+#line 1773 "src/Slice/Grammar.y"
 {
     bool unchecked = BoolTokPtr::dynamicCast(yyvsp[0])->v;
     unit->error("missing enumeration name");
@@ -3595,44 +3630,44 @@ yyreduce:
     unit->pushContainer(en);
     yyval = en;
 }
-#line 3599 "src/Slice/Grammar.cpp"
+#line 3634 "src/Slice/Grammar.cpp"
     break;
 
   case 135: /* enum_def: enum_start @23 '{' enumerator_list_or_empty '}'  */
-#line 1747 "src/Slice/Grammar.y"
+#line 1782 "src/Slice/Grammar.y"
 {
     unit->popContainer();
     yyval = yyvsp[-4];
 }
-#line 3608 "src/Slice/Grammar.cpp"
+#line 3643 "src/Slice/Grammar.cpp"
     break;
 
   case 136: /* enum_underlying: ':' type  */
-#line 1757 "src/Slice/Grammar.y"
+#line 1792 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3616 "src/Slice/Grammar.cpp"
+#line 3651 "src/Slice/Grammar.cpp"
     break;
 
   case 137: /* enum_underlying: %empty  */
-#line 1761 "src/Slice/Grammar.y"
+#line 1796 "src/Slice/Grammar.y"
 {
     yyval = 0;
 }
-#line 3624 "src/Slice/Grammar.cpp"
+#line 3659 "src/Slice/Grammar.cpp"
     break;
 
   case 140: /* enumerator_list_or_empty: %empty  */
-#line 1772 "src/Slice/Grammar.y"
+#line 1807 "src/Slice/Grammar.y"
 {
     yyval = new EnumeratorListTok;
 }
-#line 3632 "src/Slice/Grammar.cpp"
+#line 3667 "src/Slice/Grammar.cpp"
     break;
 
   case 141: /* enumerator_list: enumerator_list ',' enumerator  */
-#line 1781 "src/Slice/Grammar.y"
+#line 1816 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr enumerators = EnumeratorListTokPtr::dynamicCast(yyvsp[-2]);
     if (EnumeratorPtr en = EnumeratorPtr::dynamicCast(yyvsp[0]))
@@ -3641,11 +3676,11 @@ yyreduce:
     }
     yyval = enumerators;
 }
-#line 3645 "src/Slice/Grammar.cpp"
+#line 3680 "src/Slice/Grammar.cpp"
     break;
 
   case 142: /* enumerator_list: enumerator  */
-#line 1790 "src/Slice/Grammar.y"
+#line 1825 "src/Slice/Grammar.y"
 {
     EnumeratorListTokPtr enumerators = new EnumeratorListTok;
     if (EnumeratorPtr en = EnumeratorPtr::dynamicCast(yyvsp[0]))
@@ -3654,11 +3689,11 @@ yyreduce:
     }
     yyval = enumerators;
 }
-#line 3658 "src/Slice/Grammar.cpp"
+#line 3693 "src/Slice/Grammar.cpp"
     break;
 
   case 143: /* enumerator: local_metadata ICE_IDENTIFIER  */
-#line 1804 "src/Slice/Grammar.y"
+#line 1839 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3672,11 +3707,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3676 "src/Slice/Grammar.cpp"
+#line 3711 "src/Slice/Grammar.cpp"
     break;
 
   case 144: /* enumerator: local_metadata ICE_IDENTIFIER '=' enumerator_initializer  */
-#line 1818 "src/Slice/Grammar.y"
+#line 1853 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[-2]);
@@ -3691,11 +3726,11 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3695 "src/Slice/Grammar.cpp"
+#line 3730 "src/Slice/Grammar.cpp"
     break;
 
   case 145: /* enumerator: local_metadata keyword  */
-#line 1833 "src/Slice/Grammar.y"
+#line 1868 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
@@ -3710,19 +3745,19 @@ yyreduce:
     }
     yyval = en;
 }
-#line 3714 "src/Slice/Grammar.cpp"
+#line 3749 "src/Slice/Grammar.cpp"
     break;
 
   case 146: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
-#line 1853 "src/Slice/Grammar.y"
+#line 1888 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3722 "src/Slice/Grammar.cpp"
+#line 3757 "src/Slice/Grammar.cpp"
     break;
 
   case 147: /* enumerator_initializer: scoped_name  */
-#line 1857 "src/Slice/Grammar.y"
+#line 1892 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainedList cl = unit->currentContainer()->lookupContained(scoped->v);
@@ -3755,27 +3790,27 @@ yyreduce:
 
     yyval = tok;
 }
-#line 3759 "src/Slice/Grammar.cpp"
+#line 3794 "src/Slice/Grammar.cpp"
     break;
 
   case 148: /* out_qualifier: ICE_OUT  */
-#line 1895 "src/Slice/Grammar.y"
+#line 1930 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(true);
 }
-#line 3767 "src/Slice/Grammar.cpp"
+#line 3802 "src/Slice/Grammar.cpp"
     break;
 
   case 149: /* out_qualifier: %empty  */
-#line 1899 "src/Slice/Grammar.y"
+#line 1934 "src/Slice/Grammar.y"
 {
     yyval = new BoolTok(false);
 }
-#line 3775 "src/Slice/Grammar.cpp"
+#line 3810 "src/Slice/Grammar.cpp"
     break;
 
   case 150: /* parameter: out_qualifier member  */
-#line 1908 "src/Slice/Grammar.y"
+#line 1943 "src/Slice/Grammar.y"
 {
     BoolTokPtr isOutParam = BoolTokPtr::dynamicCast(yyvsp[-1]);
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
@@ -3790,151 +3825,151 @@ yyreduce:
         }
     }
 }
-#line 3794 "src/Slice/Grammar.cpp"
+#line 3829 "src/Slice/Grammar.cpp"
     break;
 
   case 155: /* throws: ICE_THROWS exception_list  */
-#line 1941 "src/Slice/Grammar.y"
+#line 1976 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[0];
 }
-#line 3802 "src/Slice/Grammar.cpp"
+#line 3837 "src/Slice/Grammar.cpp"
     break;
 
   case 156: /* throws: %empty  */
-#line 1945 "src/Slice/Grammar.y"
+#line 1980 "src/Slice/Grammar.y"
 {
     yyval = new ExceptionListTok;
 }
-#line 3810 "src/Slice/Grammar.cpp"
+#line 3845 "src/Slice/Grammar.cpp"
     break;
 
   case 160: /* unscoped_name: ICE_SCOPED_IDENTIFIER  */
-#line 1962 "src/Slice/Grammar.y"
+#line 1997 "src/Slice/Grammar.y"
 {
     StringTokPtr ident = StringTokPtr::dynamicCast(yyvsp[0]);
     unit->error("Identifier cannot be scoped: `" + (ident->v) + "'");
     yyval = yyvsp[0];
 }
-#line 3820 "src/Slice/Grammar.cpp"
+#line 3855 "src/Slice/Grammar.cpp"
     break;
 
   case 161: /* builtin: ICE_BOOL  */
-#line 1972 "src/Slice/Grammar.y"
+#line 2007 "src/Slice/Grammar.y"
            {}
-#line 3826 "src/Slice/Grammar.cpp"
+#line 3861 "src/Slice/Grammar.cpp"
     break;
 
   case 162: /* builtin: ICE_BYTE  */
-#line 1973 "src/Slice/Grammar.y"
+#line 2008 "src/Slice/Grammar.y"
            {}
-#line 3832 "src/Slice/Grammar.cpp"
+#line 3867 "src/Slice/Grammar.cpp"
     break;
 
   case 163: /* builtin: ICE_SHORT  */
-#line 1974 "src/Slice/Grammar.y"
+#line 2009 "src/Slice/Grammar.y"
             {}
-#line 3838 "src/Slice/Grammar.cpp"
+#line 3873 "src/Slice/Grammar.cpp"
     break;
 
   case 164: /* builtin: ICE_USHORT  */
-#line 1975 "src/Slice/Grammar.y"
+#line 2010 "src/Slice/Grammar.y"
              {}
-#line 3844 "src/Slice/Grammar.cpp"
+#line 3879 "src/Slice/Grammar.cpp"
     break;
 
   case 165: /* builtin: ICE_INT  */
-#line 1976 "src/Slice/Grammar.y"
+#line 2011 "src/Slice/Grammar.y"
           {}
-#line 3850 "src/Slice/Grammar.cpp"
+#line 3885 "src/Slice/Grammar.cpp"
     break;
 
   case 166: /* builtin: ICE_UINT  */
-#line 1977 "src/Slice/Grammar.y"
+#line 2012 "src/Slice/Grammar.y"
            {}
-#line 3856 "src/Slice/Grammar.cpp"
+#line 3891 "src/Slice/Grammar.cpp"
     break;
 
   case 167: /* builtin: ICE_VARINT  */
-#line 1978 "src/Slice/Grammar.y"
+#line 2013 "src/Slice/Grammar.y"
              {}
-#line 3862 "src/Slice/Grammar.cpp"
+#line 3897 "src/Slice/Grammar.cpp"
     break;
 
   case 168: /* builtin: ICE_VARUINT  */
-#line 1979 "src/Slice/Grammar.y"
+#line 2014 "src/Slice/Grammar.y"
               {}
-#line 3868 "src/Slice/Grammar.cpp"
+#line 3903 "src/Slice/Grammar.cpp"
     break;
 
   case 169: /* builtin: ICE_LONG  */
-#line 1980 "src/Slice/Grammar.y"
+#line 2015 "src/Slice/Grammar.y"
            {}
-#line 3874 "src/Slice/Grammar.cpp"
+#line 3909 "src/Slice/Grammar.cpp"
     break;
 
   case 170: /* builtin: ICE_ULONG  */
-#line 1981 "src/Slice/Grammar.y"
+#line 2016 "src/Slice/Grammar.y"
             {}
-#line 3880 "src/Slice/Grammar.cpp"
+#line 3915 "src/Slice/Grammar.cpp"
     break;
 
   case 171: /* builtin: ICE_VARLONG  */
-#line 1982 "src/Slice/Grammar.y"
+#line 2017 "src/Slice/Grammar.y"
               {}
-#line 3886 "src/Slice/Grammar.cpp"
+#line 3921 "src/Slice/Grammar.cpp"
     break;
 
   case 172: /* builtin: ICE_VARULONG  */
-#line 1983 "src/Slice/Grammar.y"
+#line 2018 "src/Slice/Grammar.y"
                {}
-#line 3892 "src/Slice/Grammar.cpp"
+#line 3927 "src/Slice/Grammar.cpp"
     break;
 
   case 173: /* builtin: ICE_FLOAT  */
-#line 1984 "src/Slice/Grammar.y"
+#line 2019 "src/Slice/Grammar.y"
             {}
-#line 3898 "src/Slice/Grammar.cpp"
+#line 3933 "src/Slice/Grammar.cpp"
     break;
 
   case 174: /* builtin: ICE_DOUBLE  */
-#line 1985 "src/Slice/Grammar.y"
+#line 2020 "src/Slice/Grammar.y"
              {}
-#line 3904 "src/Slice/Grammar.cpp"
+#line 3939 "src/Slice/Grammar.cpp"
     break;
 
   case 175: /* builtin: ICE_STRING  */
-#line 1986 "src/Slice/Grammar.y"
+#line 2021 "src/Slice/Grammar.y"
              {}
-#line 3910 "src/Slice/Grammar.cpp"
+#line 3945 "src/Slice/Grammar.cpp"
     break;
 
   case 176: /* type: ICE_OBJECT '*'  */
-#line 1992 "src/Slice/Grammar.y"
+#line 2027 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3918 "src/Slice/Grammar.cpp"
+#line 3953 "src/Slice/Grammar.cpp"
     break;
 
   case 177: /* type: ICE_OBJECT '?'  */
-#line 1996 "src/Slice/Grammar.y"
+#line 2031 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindObject);
 }
-#line 3926 "src/Slice/Grammar.cpp"
+#line 3961 "src/Slice/Grammar.cpp"
     break;
 
   case 178: /* type: ICE_ANYCLASS '?'  */
-#line 2000 "src/Slice/Grammar.y"
+#line 2035 "src/Slice/Grammar.y"
 {
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3934 "src/Slice/Grammar.cpp"
+#line 3969 "src/Slice/Grammar.cpp"
     break;
 
   case 179: /* type: ICE_VALUE '?'  */
-#line 2004 "src/Slice/Grammar.y"
+#line 2039 "src/Slice/Grammar.y"
 {
     if (!unit->compatMode())
     {
@@ -3942,20 +3977,20 @@ yyreduce:
     }
     yyval = unit->optionalBuiltin(Builtin::KindAnyClass);
 }
-#line 3946 "src/Slice/Grammar.cpp"
+#line 3981 "src/Slice/Grammar.cpp"
     break;
 
   case 180: /* type: builtin '?'  */
-#line 2012 "src/Slice/Grammar.y"
+#line 2047 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[-1]);
     yyval = unit->optionalBuiltin(Builtin::kindFromString(typeName->v).value());
 }
-#line 3955 "src/Slice/Grammar.cpp"
+#line 3990 "src/Slice/Grammar.cpp"
     break;
 
   case 181: /* type: ICE_OBJECT  */
-#line 2017 "src/Slice/Grammar.y"
+#line 2052 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -3966,19 +4001,19 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindObject);
     }
 }
-#line 3970 "src/Slice/Grammar.cpp"
+#line 4005 "src/Slice/Grammar.cpp"
     break;
 
   case 182: /* type: ICE_ANYCLASS  */
-#line 2028 "src/Slice/Grammar.y"
+#line 2063 "src/Slice/Grammar.y"
 {
     yyval = unit->builtin(Builtin::KindAnyClass);
 }
-#line 3978 "src/Slice/Grammar.cpp"
+#line 4013 "src/Slice/Grammar.cpp"
     break;
 
   case 183: /* type: ICE_VALUE  */
-#line 2032 "src/Slice/Grammar.y"
+#line 2067 "src/Slice/Grammar.y"
 {
     if (unit->compatMode())
     {
@@ -3990,20 +4025,20 @@ yyreduce:
         yyval = unit->builtin(Builtin::KindAnyClass);
     }
 }
-#line 3994 "src/Slice/Grammar.cpp"
+#line 4029 "src/Slice/Grammar.cpp"
     break;
 
   case 184: /* type: builtin  */
-#line 2044 "src/Slice/Grammar.y"
+#line 2079 "src/Slice/Grammar.y"
 {
     StringTokPtr typeName = StringTokPtr::dynamicCast(yyvsp[0]);
     yyval = unit->builtin(Builtin::kindFromString(typeName->v).value());
 }
-#line 4003 "src/Slice/Grammar.cpp"
+#line 4038 "src/Slice/Grammar.cpp"
     break;
 
   case 185: /* type: scoped_name  */
-#line 2049 "src/Slice/Grammar.y"
+#line 2084 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ContainerPtr cont = unit->currentContainer();
@@ -4029,11 +4064,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4033 "src/Slice/Grammar.cpp"
+#line 4068 "src/Slice/Grammar.cpp"
     break;
 
   case 186: /* type: scoped_name '*'  */
-#line 2075 "src/Slice/Grammar.y"
+#line 2110 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4065,11 +4100,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4069 "src/Slice/Grammar.cpp"
+#line 4104 "src/Slice/Grammar.cpp"
     break;
 
   case 187: /* type: scoped_name '?'  */
-#line 2107 "src/Slice/Grammar.y"
+#line 2142 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[-1]);
     ContainerPtr cont = unit->currentContainer();
@@ -4092,11 +4127,11 @@ yyreduce:
         yyval = 0;
     }
 }
-#line 4096 "src/Slice/Grammar.cpp"
+#line 4131 "src/Slice/Grammar.cpp"
     break;
 
   case 188: /* tagged_type: tag type  */
-#line 2135 "src/Slice/Grammar.y"
+#line 2170 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4111,11 +4146,11 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4115 "src/Slice/Grammar.cpp"
+#line 4150 "src/Slice/Grammar.cpp"
     break;
 
   case 189: /* tagged_type: optional type  */
-#line 2150 "src/Slice/Grammar.y"
+#line 2185 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     OptionalPtr type = OptionalPtr::dynamicCast(yyvsp[0]);
@@ -4129,21 +4164,21 @@ yyreduce:
     taggedDef->type = type;
     yyval = taggedDef;
 }
-#line 4133 "src/Slice/Grammar.cpp"
+#line 4168 "src/Slice/Grammar.cpp"
     break;
 
   case 190: /* tagged_type: type  */
-#line 2164 "src/Slice/Grammar.y"
+#line 2199 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr taggedDef = new TaggedDefTok;
     taggedDef->type = TypePtr::dynamicCast(yyvsp[0]);
     yyval = taggedDef;
 }
-#line 4143 "src/Slice/Grammar.cpp"
+#line 4178 "src/Slice/Grammar.cpp"
     break;
 
   case 191: /* member: tagged_type ICE_IDENTIFIER  */
-#line 2175 "src/Slice/Grammar.y"
+#line 2210 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4155,11 +4190,11 @@ yyreduce:
 
     yyval = def;
 }
-#line 4159 "src/Slice/Grammar.cpp"
+#line 4194 "src/Slice/Grammar.cpp"
     break;
 
   case 192: /* member: tagged_type keyword  */
-#line 2187 "src/Slice/Grammar.y"
+#line 2222 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[-1]);
     def->name = StringTokPtr::dynamicCast(yyvsp[0])->v;
@@ -4170,11 +4205,11 @@ yyreduce:
     unit->error("keyword `" + def->name + "' cannot be used as an identifier");
     yyval = def;
 }
-#line 4174 "src/Slice/Grammar.cpp"
+#line 4209 "src/Slice/Grammar.cpp"
     break;
 
   case 193: /* member: tagged_type  */
-#line 2198 "src/Slice/Grammar.y"
+#line 2233 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->name = IceUtil::generateUUID(); // Dummy
@@ -4185,53 +4220,53 @@ yyreduce:
     unit->error("missing identifier");
     yyval = def;
 }
-#line 4189 "src/Slice/Grammar.cpp"
+#line 4224 "src/Slice/Grammar.cpp"
     break;
 
   case 194: /* member: local_metadata member  */
-#line 2209 "src/Slice/Grammar.y"
+#line 2244 "src/Slice/Grammar.y"
 {
     TaggedDefTokPtr def = TaggedDefTokPtr::dynamicCast(yyvsp[0]);
     def->metadata = StringListTokPtr::dynamicCast(yyvsp[-1])->v;
     yyval = def;
 }
-#line 4199 "src/Slice/Grammar.cpp"
+#line 4234 "src/Slice/Grammar.cpp"
     break;
 
   case 195: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2220 "src/Slice/Grammar.y"
+#line 2255 "src/Slice/Grammar.y"
 {
     StringTokPtr str1 = StringTokPtr::dynamicCast(yyvsp[-1]);
     StringTokPtr str2 = StringTokPtr::dynamicCast(yyvsp[0]);
     str1->v += str2->v;
 }
-#line 4209 "src/Slice/Grammar.cpp"
+#line 4244 "src/Slice/Grammar.cpp"
     break;
 
   case 197: /* string_list: string_list ',' string_literal  */
-#line 2232 "src/Slice/Grammar.y"
+#line 2267 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = StringListTokPtr::dynamicCast(yyvsp[-2]);
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4220 "src/Slice/Grammar.cpp"
+#line 4255 "src/Slice/Grammar.cpp"
     break;
 
   case 198: /* string_list: string_literal  */
-#line 2239 "src/Slice/Grammar.y"
+#line 2274 "src/Slice/Grammar.y"
 {
     StringTokPtr str = StringTokPtr::dynamicCast(yyvsp[0]);
     StringListTokPtr stringList = new StringListTok;
     stringList->v.push_back(str->v);
     yyval = stringList;
 }
-#line 4231 "src/Slice/Grammar.cpp"
+#line 4266 "src/Slice/Grammar.cpp"
     break;
 
   case 199: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2251 "src/Slice/Grammar.y"
+#line 2286 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindLong);
     IntegerTokPtr intVal = IntegerTokPtr::dynamicCast(yyvsp[0]);
@@ -4240,11 +4275,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), intVal->literal);
     yyval = def;
 }
-#line 4244 "src/Slice/Grammar.cpp"
+#line 4279 "src/Slice/Grammar.cpp"
     break;
 
   case 200: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2260 "src/Slice/Grammar.y"
+#line 2295 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindDouble);
     FloatingTokPtr floatVal = FloatingTokPtr::dynamicCast(yyvsp[0]);
@@ -4253,11 +4288,11 @@ yyreduce:
     ConstDefTokPtr def = new ConstDefTok(type, sstr.str(), floatVal->literal);
     yyval = def;
 }
-#line 4257 "src/Slice/Grammar.cpp"
+#line 4292 "src/Slice/Grammar.cpp"
     break;
 
   case 201: /* const_initializer: scoped_name  */
-#line 2269 "src/Slice/Grammar.y"
+#line 2304 "src/Slice/Grammar.y"
 {
     StringTokPtr scoped = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def;
@@ -4297,44 +4332,44 @@ yyreduce:
     }
     yyval = def;
 }
-#line 4301 "src/Slice/Grammar.cpp"
+#line 4336 "src/Slice/Grammar.cpp"
     break;
 
   case 202: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2309 "src/Slice/Grammar.y"
+#line 2344 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindString);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, literal->v, literal->literal);
     yyval = def;
 }
-#line 4312 "src/Slice/Grammar.cpp"
+#line 4347 "src/Slice/Grammar.cpp"
     break;
 
   case 203: /* const_initializer: ICE_FALSE  */
-#line 2316 "src/Slice/Grammar.y"
+#line 2351 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "false", "false");
     yyval = def;
 }
-#line 4323 "src/Slice/Grammar.cpp"
+#line 4358 "src/Slice/Grammar.cpp"
     break;
 
   case 204: /* const_initializer: ICE_TRUE  */
-#line 2323 "src/Slice/Grammar.y"
+#line 2358 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = unit->builtin(Builtin::KindBool);
     StringTokPtr literal = StringTokPtr::dynamicCast(yyvsp[0]);
     ConstDefTokPtr def = new ConstDefTok(type, "true", "true");
     yyval = def;
 }
-#line 4334 "src/Slice/Grammar.cpp"
+#line 4369 "src/Slice/Grammar.cpp"
     break;
 
   case 205: /* const_def: ICE_CONST local_metadata type ICE_IDENTIFIER '=' const_initializer  */
-#line 2335 "src/Slice/Grammar.y"
+#line 2370 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-4]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-3]);
@@ -4343,11 +4378,11 @@ yyreduce:
     yyval = unit->currentModule()->createConst(ident->v, const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral);
 }
-#line 4347 "src/Slice/Grammar.cpp"
+#line 4382 "src/Slice/Grammar.cpp"
     break;
 
   case 206: /* const_def: ICE_CONST local_metadata type '=' const_initializer  */
-#line 2344 "src/Slice/Grammar.y"
+#line 2379 "src/Slice/Grammar.y"
 {
     StringListTokPtr metadata = StringListTokPtr::dynamicCast(yyvsp[-3]);
     TypePtr const_type = TypePtr::dynamicCast(yyvsp[-2]);
@@ -4356,233 +4391,233 @@ yyreduce:
     yyval = unit->currentModule()->createConst(IceUtil::generateUUID(), const_type, metadata->v, value->v,
                                                value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
 }
-#line 4360 "src/Slice/Grammar.cpp"
+#line 4395 "src/Slice/Grammar.cpp"
     break;
 
   case 207: /* keyword: ICE_MODULE  */
-#line 2357 "src/Slice/Grammar.y"
+#line 2392 "src/Slice/Grammar.y"
              {}
-#line 4366 "src/Slice/Grammar.cpp"
+#line 4401 "src/Slice/Grammar.cpp"
     break;
 
   case 208: /* keyword: ICE_CLASS  */
-#line 2358 "src/Slice/Grammar.y"
+#line 2393 "src/Slice/Grammar.y"
             {}
-#line 4372 "src/Slice/Grammar.cpp"
+#line 4407 "src/Slice/Grammar.cpp"
     break;
 
   case 209: /* keyword: ICE_INTERFACE  */
-#line 2359 "src/Slice/Grammar.y"
+#line 2394 "src/Slice/Grammar.y"
                 {}
-#line 4378 "src/Slice/Grammar.cpp"
+#line 4413 "src/Slice/Grammar.cpp"
     break;
 
   case 210: /* keyword: ICE_EXCEPTION  */
-#line 2360 "src/Slice/Grammar.y"
+#line 2395 "src/Slice/Grammar.y"
                 {}
-#line 4384 "src/Slice/Grammar.cpp"
+#line 4419 "src/Slice/Grammar.cpp"
     break;
 
   case 211: /* keyword: ICE_STRUCT  */
-#line 2361 "src/Slice/Grammar.y"
+#line 2396 "src/Slice/Grammar.y"
              {}
-#line 4390 "src/Slice/Grammar.cpp"
+#line 4425 "src/Slice/Grammar.cpp"
     break;
 
   case 212: /* keyword: ICE_SEQUENCE  */
-#line 2362 "src/Slice/Grammar.y"
+#line 2397 "src/Slice/Grammar.y"
                {}
-#line 4396 "src/Slice/Grammar.cpp"
+#line 4431 "src/Slice/Grammar.cpp"
     break;
 
   case 213: /* keyword: ICE_DICTIONARY  */
-#line 2363 "src/Slice/Grammar.y"
+#line 2398 "src/Slice/Grammar.y"
                  {}
-#line 4402 "src/Slice/Grammar.cpp"
+#line 4437 "src/Slice/Grammar.cpp"
     break;
 
   case 214: /* keyword: ICE_ENUM  */
-#line 2364 "src/Slice/Grammar.y"
+#line 2399 "src/Slice/Grammar.y"
            {}
-#line 4408 "src/Slice/Grammar.cpp"
+#line 4443 "src/Slice/Grammar.cpp"
     break;
 
   case 215: /* keyword: ICE_OUT  */
-#line 2365 "src/Slice/Grammar.y"
+#line 2400 "src/Slice/Grammar.y"
           {}
-#line 4414 "src/Slice/Grammar.cpp"
+#line 4449 "src/Slice/Grammar.cpp"
     break;
 
   case 216: /* keyword: ICE_EXTENDS  */
-#line 2366 "src/Slice/Grammar.y"
+#line 2401 "src/Slice/Grammar.y"
               {}
-#line 4420 "src/Slice/Grammar.cpp"
+#line 4455 "src/Slice/Grammar.cpp"
     break;
 
   case 217: /* keyword: ICE_IMPLEMENTS  */
-#line 2367 "src/Slice/Grammar.y"
+#line 2402 "src/Slice/Grammar.y"
                  {}
-#line 4426 "src/Slice/Grammar.cpp"
+#line 4461 "src/Slice/Grammar.cpp"
     break;
 
   case 218: /* keyword: ICE_THROWS  */
-#line 2368 "src/Slice/Grammar.y"
+#line 2403 "src/Slice/Grammar.y"
              {}
-#line 4432 "src/Slice/Grammar.cpp"
+#line 4467 "src/Slice/Grammar.cpp"
     break;
 
   case 219: /* keyword: ICE_VOID  */
-#line 2369 "src/Slice/Grammar.y"
+#line 2404 "src/Slice/Grammar.y"
            {}
-#line 4438 "src/Slice/Grammar.cpp"
+#line 4473 "src/Slice/Grammar.cpp"
     break;
 
   case 220: /* keyword: ICE_BOOL  */
-#line 2370 "src/Slice/Grammar.y"
+#line 2405 "src/Slice/Grammar.y"
            {}
-#line 4444 "src/Slice/Grammar.cpp"
+#line 4479 "src/Slice/Grammar.cpp"
     break;
 
   case 221: /* keyword: ICE_BYTE  */
-#line 2371 "src/Slice/Grammar.y"
+#line 2406 "src/Slice/Grammar.y"
            {}
-#line 4450 "src/Slice/Grammar.cpp"
+#line 4485 "src/Slice/Grammar.cpp"
     break;
 
   case 222: /* keyword: ICE_SHORT  */
-#line 2372 "src/Slice/Grammar.y"
+#line 2407 "src/Slice/Grammar.y"
             {}
-#line 4456 "src/Slice/Grammar.cpp"
+#line 4491 "src/Slice/Grammar.cpp"
     break;
 
   case 223: /* keyword: ICE_USHORT  */
-#line 2373 "src/Slice/Grammar.y"
+#line 2408 "src/Slice/Grammar.y"
              {}
-#line 4462 "src/Slice/Grammar.cpp"
+#line 4497 "src/Slice/Grammar.cpp"
     break;
 
   case 224: /* keyword: ICE_INT  */
-#line 2374 "src/Slice/Grammar.y"
+#line 2409 "src/Slice/Grammar.y"
           {}
-#line 4468 "src/Slice/Grammar.cpp"
+#line 4503 "src/Slice/Grammar.cpp"
     break;
 
   case 225: /* keyword: ICE_UINT  */
-#line 2375 "src/Slice/Grammar.y"
+#line 2410 "src/Slice/Grammar.y"
            {}
-#line 4474 "src/Slice/Grammar.cpp"
+#line 4509 "src/Slice/Grammar.cpp"
     break;
 
   case 226: /* keyword: ICE_VARINT  */
-#line 2376 "src/Slice/Grammar.y"
+#line 2411 "src/Slice/Grammar.y"
              {}
-#line 4480 "src/Slice/Grammar.cpp"
+#line 4515 "src/Slice/Grammar.cpp"
     break;
 
   case 227: /* keyword: ICE_VARUINT  */
-#line 2377 "src/Slice/Grammar.y"
+#line 2412 "src/Slice/Grammar.y"
               {}
-#line 4486 "src/Slice/Grammar.cpp"
+#line 4521 "src/Slice/Grammar.cpp"
     break;
 
   case 228: /* keyword: ICE_LONG  */
-#line 2378 "src/Slice/Grammar.y"
+#line 2413 "src/Slice/Grammar.y"
            {}
-#line 4492 "src/Slice/Grammar.cpp"
+#line 4527 "src/Slice/Grammar.cpp"
     break;
 
   case 229: /* keyword: ICE_ULONG  */
-#line 2379 "src/Slice/Grammar.y"
+#line 2414 "src/Slice/Grammar.y"
             {}
-#line 4498 "src/Slice/Grammar.cpp"
+#line 4533 "src/Slice/Grammar.cpp"
     break;
 
   case 230: /* keyword: ICE_VARLONG  */
-#line 2380 "src/Slice/Grammar.y"
+#line 2415 "src/Slice/Grammar.y"
               {}
-#line 4504 "src/Slice/Grammar.cpp"
+#line 4539 "src/Slice/Grammar.cpp"
     break;
 
   case 231: /* keyword: ICE_VARULONG  */
-#line 2381 "src/Slice/Grammar.y"
+#line 2416 "src/Slice/Grammar.y"
                {}
-#line 4510 "src/Slice/Grammar.cpp"
+#line 4545 "src/Slice/Grammar.cpp"
     break;
 
   case 232: /* keyword: ICE_FLOAT  */
-#line 2382 "src/Slice/Grammar.y"
+#line 2417 "src/Slice/Grammar.y"
             {}
-#line 4516 "src/Slice/Grammar.cpp"
+#line 4551 "src/Slice/Grammar.cpp"
     break;
 
   case 233: /* keyword: ICE_DOUBLE  */
-#line 2383 "src/Slice/Grammar.y"
+#line 2418 "src/Slice/Grammar.y"
              {}
-#line 4522 "src/Slice/Grammar.cpp"
+#line 4557 "src/Slice/Grammar.cpp"
     break;
 
   case 234: /* keyword: ICE_STRING  */
-#line 2384 "src/Slice/Grammar.y"
+#line 2419 "src/Slice/Grammar.y"
              {}
-#line 4528 "src/Slice/Grammar.cpp"
+#line 4563 "src/Slice/Grammar.cpp"
     break;
 
   case 235: /* keyword: ICE_OBJECT  */
-#line 2385 "src/Slice/Grammar.y"
+#line 2420 "src/Slice/Grammar.y"
              {}
-#line 4534 "src/Slice/Grammar.cpp"
+#line 4569 "src/Slice/Grammar.cpp"
     break;
 
   case 236: /* keyword: ICE_CONST  */
-#line 2386 "src/Slice/Grammar.y"
+#line 2421 "src/Slice/Grammar.y"
             {}
-#line 4540 "src/Slice/Grammar.cpp"
+#line 4575 "src/Slice/Grammar.cpp"
     break;
 
   case 237: /* keyword: ICE_FALSE  */
-#line 2387 "src/Slice/Grammar.y"
+#line 2422 "src/Slice/Grammar.y"
             {}
-#line 4546 "src/Slice/Grammar.cpp"
+#line 4581 "src/Slice/Grammar.cpp"
     break;
 
   case 238: /* keyword: ICE_TRUE  */
-#line 2388 "src/Slice/Grammar.y"
+#line 2423 "src/Slice/Grammar.y"
            {}
-#line 4552 "src/Slice/Grammar.cpp"
+#line 4587 "src/Slice/Grammar.cpp"
     break;
 
   case 239: /* keyword: ICE_IDEMPOTENT  */
-#line 2389 "src/Slice/Grammar.y"
+#line 2424 "src/Slice/Grammar.y"
                  {}
-#line 4558 "src/Slice/Grammar.cpp"
+#line 4593 "src/Slice/Grammar.cpp"
     break;
 
   case 240: /* keyword: ICE_TAG  */
-#line 2390 "src/Slice/Grammar.y"
+#line 2425 "src/Slice/Grammar.y"
           {}
-#line 4564 "src/Slice/Grammar.cpp"
+#line 4599 "src/Slice/Grammar.cpp"
     break;
 
   case 241: /* keyword: ICE_OPTIONAL  */
-#line 2391 "src/Slice/Grammar.y"
+#line 2426 "src/Slice/Grammar.y"
                {}
-#line 4570 "src/Slice/Grammar.cpp"
+#line 4605 "src/Slice/Grammar.cpp"
     break;
 
   case 242: /* keyword: ICE_ANYCLASS  */
-#line 2392 "src/Slice/Grammar.y"
+#line 2427 "src/Slice/Grammar.y"
                {}
-#line 4576 "src/Slice/Grammar.cpp"
+#line 4611 "src/Slice/Grammar.cpp"
     break;
 
   case 243: /* keyword: ICE_VALUE  */
-#line 2393 "src/Slice/Grammar.y"
+#line 2428 "src/Slice/Grammar.y"
             {}
-#line 4582 "src/Slice/Grammar.cpp"
+#line 4617 "src/Slice/Grammar.cpp"
     break;
 
 
-#line 4586 "src/Slice/Grammar.cpp"
+#line 4621 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4781,5 +4816,5 @@ yyreturn:
   return yyresult;
 }
 
-#line 2396 "src/Slice/Grammar.y"
+#line 2431 "src/Slice/Grammar.y"
 

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -113,6 +113,21 @@ slice_error(const char* s)
     }
 }
 
+// TODO this function is only temporarily necessary to convert between the old and new syntax styles.
+void convertMetadata(StringListTokPtr& metadata)
+{
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
+}
+
 %}
 
 // Directs Bison to generate a re-entrant parser.
@@ -200,18 +215,8 @@ file_metadata
 // ----------------------------------------------------------------------
 : ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE
 {
-    //TODOREMOVE
     StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
-    for (auto& m : metadata->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
+    convertMetadata(metadata);
     $$ = metadata;
 }
 ;
@@ -221,36 +226,17 @@ local_metadata
 // ----------------------------------------------------------------------
 : ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE
 {
-    //TODOREMOVE
     StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
-    for (auto& m : metadata->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
-    $$ = $2;
+    convertMetadata(metadata);
+    $$ = metadata;
 }
 | local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE
 {
     StringListTokPtr metadata1 = StringListTokPtr::dynamicCast($1);
     StringListTokPtr metadata2 = StringListTokPtr::dynamicCast($3);
     metadata1->v.splice(metadata1->v.end(), metadata2->v);
-    //TODOREMOVE
-    for (auto& m : metadata1->v)
-    {
-        auto pos = m.find('(');
-        if (pos != string::npos)
-        {
-            m[pos] = ':';
-            assert(m.back() == ')');
-            m.pop_back();
-        }
-    }
+
+    convertMetadata(metadata1);
     $$ = metadata1;
 }
 | %empty

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -200,7 +200,19 @@ file_metadata
 // ----------------------------------------------------------------------
 : ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE
 {
-    $$ = $2;
+    //TODOREMOVE
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
+    $$ = metadata;
 }
 ;
 
@@ -209,6 +221,18 @@ local_metadata
 // ----------------------------------------------------------------------
 : ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE
 {
+    //TODOREMOVE
+    StringListTokPtr metadata = StringListTokPtr::dynamicCast($2);
+    for (auto& m : metadata->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
     $$ = $2;
 }
 | local_metadata ICE_LOCAL_METADATA_OPEN string_list ICE_LOCAL_METADATA_CLOSE
@@ -216,6 +240,17 @@ local_metadata
     StringListTokPtr metadata1 = StringListTokPtr::dynamicCast($1);
     StringListTokPtr metadata2 = StringListTokPtr::dynamicCast($3);
     metadata1->v.splice(metadata1->v.end(), metadata2->v);
+    //TODOREMOVE
+    for (auto& m : metadata1->v)
+    {
+        auto pos = m.find('(');
+        if (pos != string::npos)
+        {
+            m[pos] = ':';
+            assert(m.back() == ')');
+            m.pop_back();
+        }
+    }
     $$ = metadata1;
 }
 | %empty

--- a/cpp/src/icegriddb/DBTypes.ice
+++ b/cpp/src/icegriddb/DBTypes.ice
@@ -6,8 +6,7 @@
 
 #include <IceGrid/Admin.ice>
 
-[[suppress-warning:reserved-identifier]]
-[[cpp:header-ext:h]]
+[[suppress-warning(reserved-identifier)]]
 
 module IceGrid
 {

--- a/cpp/src/icegriddb/DBTypes.ice
+++ b/cpp/src/icegriddb/DBTypes.ice
@@ -7,7 +7,7 @@
 #include <IceGrid/Admin.ice>
 
 [[suppress-warning(reserved-identifier)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 module IceGrid
 {

--- a/cpp/src/icegriddb/DBTypes.ice
+++ b/cpp/src/icegriddb/DBTypes.ice
@@ -7,6 +7,7 @@
 #include <IceGrid/Admin.ice>
 
 [[suppress-warning(reserved-identifier)]]
+[[cpp:header-ext:h]]
 
 module IceGrid
 {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1247,7 +1247,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
                             "ignoring invalid metadata `" + s + "' for operation with void return type");
                 metadata.remove(s);
             }
-            else if(s.find("cpp:const") == 0 || s.find("cpp:noexcept") == 0)
+            else if(s.find("cpp:const") == 0)
             {
                 continue;
             }
@@ -1325,7 +1325,7 @@ Slice::Gen::MetadataVisitor::validate(const SyntaxTreeBasePtr& cont, const Strin
     {
         string s = *p++;
 
-        if(operation && (s == "cpp:const" || s == "cpp:noexcept"))
+        if(operation && (s == "cpp:const"))
         {
             continue;
         }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -348,11 +348,6 @@ private:
                             result.push_back(s);
                             continue;
                         }
-                        else if(rest == "tie")
-                        {
-                            result.push_back(s);
-                            continue;
-                        }
                         else if(rest == "UserException")
                         {
                             result.push_back(s);
@@ -495,9 +490,7 @@ private:
         StringList newMetadata;
         for(StringList::const_iterator i = metadata.begin(); i != metadata.end(); ++i)
         {
-            //
             // The "getset" metadata can only be specified on a class, struct, exception or data member.
-            //
             if((*i) == "java:getset" &&
                (!ClassDefPtr::dynamicCast(p) && !StructPtr::dynamicCast(p) && !ExceptionPtr::dynamicCast(p) &&
                 !MemberPtr::dynamicCast(p)))

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -694,7 +694,7 @@ Slice::Gen::generate(const UnitPtr& p)
     printGeneratedHeader(_jsout, _fileBase + ".ice");
 
     //
-    // Check for global "js:module:ice" metadata. If this is set then we are building Ice.
+    // Check for global "js:module(ice)" metadata. If this is set then we are building Ice.
     //
     bool icejs = module == "ice";
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -129,22 +129,17 @@ Gen::ImportVisitor::ImportVisitor(IceUtilInternal::Output& o) : out(o)
 bool
 Gen::ImportVisitor::visitModuleStart(const ModulePtr& p)
 {
-    //
     // Always import Ice module first if not building Ice
-    //
-    if(UnitPtr::dynamicCast(p->container()) && _imports.empty())
+    if (UnitPtr::dynamicCast(p->container()) && _imports.empty())
     {
-        string swiftModule = getSwiftModule(p);
-        if(swiftModule != "Ice")
+        if (getSwiftModule(p) != "Ice")
         {
             addImport("Ice");
         }
     }
 
-    //
-    // Add PromiseKit import for interfaces and local interfaces which contain "async-oneway" metadata
-    //
-    if(p->hasInterfaceDefs())
+    // Add PromiseKit import for interfaces.
+    if (p->hasInterfaceDefs())
     {
         addImport("PromiseKit");
     }

--- a/cpp/test/Ice/background/Test.ice
+++ b/cpp/test/Ice/background/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[cpp:dll-export:TEST_API]]
+[[cpp:dll-export(TEST_API)]]
 
 module Test
 {

--- a/cpp/test/Ice/custom/Test.ice
+++ b/cpp/test/Ice/custom/Test.ice
@@ -4,38 +4,38 @@
 
 #pragma once
 
-[[cpp:include:deque]]
-[[cpp:include:list]]
-[[cpp:include:MyByteSeq.h]]
-[[cpp:include:CustomMap.h]]
-[[cpp:include:CustomBuffer.h]]
-[[cpp:include:StringView.h]]
+[[cpp:include(deque)]]
+[[cpp:include(list)]]
+[[cpp:include(MyByteSeq.h)]]
+[[cpp:include(CustomMap.h)]]
+[[cpp:include(CustomBuffer.h)]]
+[[cpp:include(StringView.h)]]
 
 module Test
 {
 
 sequence<bool> BoolSeq;
-[cpp:type:std::list<bool>] sequence<bool> BoolList;
+[cpp:type(std::list<bool>)] sequence<bool> BoolList;
 
-[cpp:type:std::list< ::Test::BoolList>] sequence<BoolList> BoolListList;
+[cpp:type(std::list< ::Test::BoolList>)] sequence<BoolList> BoolListList;
 sequence<BoolList> BoolListSeq;
-[cpp:type:std::list< ::Test::BoolSeq>] sequence<BoolSeq> BoolSeqList;
+[cpp:type(std::list< ::Test::BoolSeq>)] sequence<BoolSeq> BoolSeqList;
 
-[cpp:type:std::list<std::deque<bool> >] sequence<[cpp:type:std::deque<bool>] BoolSeq> BoolDequeList;
+[cpp:type(std::list<std::deque<bool> >)] sequence<[cpp:type(std::deque<bool>)] BoolSeq> BoolDequeList;
 
 sequence<byte> ByteSeq;
-[cpp:type:std::list< ::Ice::Byte>] sequence<byte> ByteList;
+[cpp:type(std::list< ::Ice::Byte>)] sequence<byte> ByteList;
 
-[cpp:type:std::list< ::Test::ByteList>] sequence<ByteList> ByteListList;
+[cpp:type(std::list< ::Test::ByteList>)] sequence<ByteList> ByteListList;
 sequence<ByteList> ByteListSeq;
-[cpp:type:std::list< ::Test::ByteSeq>] sequence<ByteSeq> ByteSeqList;
+[cpp:type(std::list< ::Test::ByteSeq>)] sequence<ByteSeq> ByteSeqList;
 
 sequence<string> StringSeq;
-[cpp:type:std::list<std::string>] sequence<string> StringList;
+[cpp:type(std::list<std::string>)] sequence<string> StringList;
 
-[cpp:type:std::list< ::Test::StringList>] sequence<StringList> StringListList;
+[cpp:type(std::list< ::Test::StringList>)] sequence<StringList> StringListList;
 sequence<StringList> StringListSeq;
-[cpp:type:std::list< ::Test::StringSeq>] sequence<StringSeq> StringSeqList;
+[cpp:type(std::list< ::Test::StringSeq>)] sequence<StringSeq> StringSeqList;
 
 struct Fixed
 {
@@ -43,61 +43,61 @@ struct Fixed
 }
 
 sequence<Fixed> FixedSeq;
-[cpp:type:std::list< ::Test::Fixed>] sequence<Fixed> FixedList;
+[cpp:type(std::list< ::Test::Fixed>)] sequence<Fixed> FixedList;
 
-[cpp:type:std::list< ::Test::FixedList>] sequence<FixedList> FixedListList;
+[cpp:type(std::list< ::Test::FixedList>)] sequence<FixedList> FixedListList;
 sequence<FixedList> FixedListSeq;
-[cpp:type:std::list< ::Test::FixedSeq>] sequence<FixedSeq> FixedSeqList;
+[cpp:type(std::list< ::Test::FixedSeq>)] sequence<FixedSeq> FixedSeqList;
 
 struct Variable
 {
     string s;
     BoolList bl;
-    [cpp:type:std::list<std::string>] StringSeq ss;
+    [cpp:type(std::list<std::string>)] StringSeq ss;
 }
 
 sequence<Variable> VariableSeq;
-[cpp:type:std::list< ::Test::Variable>] sequence<Variable> VariableList;
+[cpp:type(std::list< ::Test::Variable>)] sequence<Variable> VariableList;
 
-[cpp:type:std::list< ::Test::VariableList>] sequence<VariableList> VariableListList;
+[cpp:type(std::list< ::Test::VariableList>)] sequence<VariableList> VariableListList;
 sequence<VariableList> VariableListSeq;
-[cpp:type:std::list< ::Test::VariableSeq>] sequence<VariableSeq> VariableSeqList;
+[cpp:type(std::list< ::Test::VariableSeq>)] sequence<VariableSeq> VariableSeqList;
 
 dictionary<string, string> StringStringDict;
 sequence<StringStringDict> StringStringDictSeq;
-[cpp:type:std::list< ::Test::StringStringDict>] sequence<StringStringDict> StringStringDictList;
+[cpp:type(std::list< ::Test::StringStringDict>)] sequence<StringStringDict> StringStringDictList;
 
-[cpp:type:std::list< ::Test::StringStringDictList>] sequence<StringStringDictList> StringStringDictListList;
+[cpp:type(std::list< ::Test::StringStringDictList>)] sequence<StringStringDictList> StringStringDictListList;
 sequence<StringStringDictList> StringStringDictListSeq;
-[cpp:type:std::list< ::Test::StringStringDictSeq>] sequence<StringStringDictSeq> StringStringDictSeqList;
+[cpp:type(std::list< ::Test::StringStringDictSeq>)] sequence<StringStringDictSeq> StringStringDictSeqList;
 
 enum E { E1, E2, E3 }
 sequence<E> ESeq;
-[cpp:type:std::list< ::Test::E>] sequence<E> EList;
+[cpp:type(std::list< ::Test::E>)] sequence<E> EList;
 
-[cpp:type:std::list< ::Test::EList>] sequence<EList> EListList;
+[cpp:type(std::list< ::Test::EList>)] sequence<EList> EListList;
 sequence<EList> EListSeq;
-[cpp:type:std::list< ::Test::ESeq>] sequence<ESeq> ESeqList;
+[cpp:type(std::list< ::Test::ESeq>)] sequence<ESeq> ESeqList;
 
 class C {}
 sequence<C> CSeq;
-[cpp:type:std::list<std::shared_ptr<::Test::C>>] sequence<C> CList;
+[cpp:type(std::list<std::shared_ptr<::Test::C>>)] sequence<C> CList;
 
-[cpp:type:std::list< ::Test::CList>] sequence<CList> CListList;
+[cpp:type(std::list< ::Test::CList>)] sequence<CList> CListList;
 sequence<CList> CListSeq;
-[cpp:type:std::list< ::Test::CSeq>] sequence<CSeq> CSeqList;
+[cpp:type(std::list< ::Test::CSeq>)] sequence<CSeq> CSeqList;
 
 interface D {}
 sequence<D*> DPrxSeq;
-[cpp:type:std::list<std::shared_ptr<DPrx>>] sequence<D*> DPrxList;
+[cpp:type(std::list<std::shared_ptr<DPrx>>)] sequence<D*> DPrxList;
 
-[cpp:type:std::list< ::Test::DPrxList>] sequence<DPrxList> DPrxListList;
+[cpp:type(std::list< ::Test::DPrxList>)] sequence<DPrxList> DPrxListList;
 sequence<DPrxList> DPrxListSeq;
-[cpp:type:std::list< ::Test::DPrxSeq>] sequence<DPrxSeq> DPrxSeqList;
+[cpp:type(std::list< ::Test::DPrxSeq>)] sequence<DPrxSeq> DPrxSeqList;
 
 sequence<double> DoubleSeq;
 
-[cpp:type:Test::CustomMap<Ice::Int, std::string>] dictionary<int, string> IntStringDict;
+[cpp:type(Test::CustomMap<Ice::Int, std::string>)] dictionary<int, string> IntStringDict;
 dictionary<long, long> LongLongDict;
 dictionary<string, int> StringIntDict;
 
@@ -106,13 +106,13 @@ class DictClass
     IntStringDict isdict;
 }
 
-[cpp:type:Test::CustomBuffer<bool>] sequence<bool> BoolBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Short>] sequence<short> ShortBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Int>] sequence<int> IntBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Long>] sequence<long> LongBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Float>] sequence<float> FloatBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Double>] sequence<double> DoubleBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Byte>] sequence<byte> ByteBuffer;
+[cpp:type(Test::CustomBuffer<bool>)] sequence<bool> BoolBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Short>)] sequence<short> ShortBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Int>)] sequence<int> IntBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Long>)] sequence<long> LongBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Float>)] sequence<float> FloatBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Double>)] sequence<double> DoubleBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Byte>)] sequence<byte> ByteBuffer;
 struct BufferStruct
 {
     ByteBuffer byteBuf;
@@ -134,8 +134,8 @@ interface TestIntf
 
     [cpp:array] VariableList opVariableArray([cpp:array] VariableList inSeq, out [cpp:array] VariableList outSeq);
 
-    [cpp:type:std::deque<bool>] BoolSeq
-    opBoolSeq([cpp:type:std::deque<bool>] BoolSeq inSeq, out [cpp:type:std::deque<bool>] BoolSeq outSeq);
+    [cpp:type(std::deque<bool>)] BoolSeq
+    opBoolSeq([cpp:type(std::deque<bool>)] BoolSeq inSeq, out [cpp:type(std::deque<bool>)] BoolSeq outSeq);
 
     BoolList opBoolList(BoolList inSeq, out BoolList outSeq);
 
@@ -143,57 +143,57 @@ interface TestIntf
     [cpp:array] BoolDequeList opBoolDequeListArray([cpp:array] BoolDequeList inSeq,
                                                 out [cpp:array] BoolDequeList outSeq);
 
-    [cpp:type:std::deque< ::Ice::Byte>] ByteSeq
-    opByteSeq([cpp:type:std::deque< ::Ice::Byte>] ByteSeq inSeq,
-              out [cpp:type:std::deque< ::Ice::Byte>] ByteSeq outSeq);
+    [cpp:type(std::deque< ::Ice::Byte>)] ByteSeq
+    opByteSeq([cpp:type(std::deque< ::Ice::Byte>)] ByteSeq inSeq,
+              out [cpp:type(std::deque< ::Ice::Byte>)] ByteSeq outSeq);
 
     ByteList opByteList(ByteList inSeq, out ByteList outSeq);
 
-    [cpp:type:MyByteSeq] ByteSeq
-    opMyByteSeq([cpp:type:MyByteSeq] ByteSeq inSeq, out [cpp:type:MyByteSeq] ByteSeq outSeq);
+    [cpp:type(MyByteSeq)] ByteSeq
+    opMyByteSeq([cpp:type(MyByteSeq)] ByteSeq inSeq, out [cpp:type(MyByteSeq)] ByteSeq outSeq);
 
-    [cpp:view-type:Util::string_view] string
-    opString([cpp:view-type:Util::string_view] string inString,
-             out [cpp:view-type:Util::string_view] string outString);
+    [cpp:view-type(Util::string_view)] string
+    opString([cpp:view-type(Util::string_view)] string inString,
+             out [cpp:view-type(Util::string_view)] string outString);
 
-    [cpp:type:std::deque<std::string>] StringSeq
-    opStringSeq([cpp:type:std::deque<std::string>] StringSeq inSeq,
-                out [cpp:type:std::deque<std::string>] StringSeq outSeq);
+    [cpp:type(std::deque<std::string>)] StringSeq
+    opStringSeq([cpp:type(std::deque<std::string>)] StringSeq inSeq,
+                out [cpp:type(std::deque<std::string>)] StringSeq outSeq);
 
     StringList opStringList(StringList inSeq, out StringList outSeq);
 
-    [cpp:type:std::deque< ::Test::Fixed>] FixedSeq
-    opFixedSeq([cpp:type:std::deque< ::Test::Fixed>] FixedSeq inSeq,
-               out [cpp:type:std::deque< ::Test::Fixed>] FixedSeq outSeq);
+    [cpp:type(std::deque< ::Test::Fixed>)] FixedSeq
+    opFixedSeq([cpp:type(std::deque< ::Test::Fixed>)] FixedSeq inSeq,
+               out [cpp:type(std::deque< ::Test::Fixed>)] FixedSeq outSeq);
 
     FixedList opFixedList(FixedList inSeq, out FixedList outSeq);
 
-    [cpp:type:std::deque< ::Test::Variable>] VariableSeq
-    opVariableSeq([cpp:type:std::deque< ::Test::Variable>] VariableSeq inSeq,
-                  out [cpp:type:std::deque< ::Test::Variable>] VariableSeq outSeq);
+    [cpp:type(std::deque< ::Test::Variable>)] VariableSeq
+    opVariableSeq([cpp:type(std::deque< ::Test::Variable>)] VariableSeq inSeq,
+                  out [cpp:type(std::deque< ::Test::Variable>)] VariableSeq outSeq);
 
     VariableList opVariableList(VariableList inSeq, out VariableList outSeq);
 
-    [cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq
-    opStringStringDictSeq([cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq inSeq,
-                          out [cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq outSeq);
+    [cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq
+    opStringStringDictSeq([cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq inSeq,
+                          out [cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq outSeq);
 
     StringStringDictList opStringStringDictList(StringStringDictList inSeq, out StringStringDictList outSeq);
 
-    [cpp:type:std::deque< ::Test::E>] ESeq
-    opESeq([cpp:type:std::deque< ::Test::E>] ESeq inSeq, out [cpp:type:std::deque< ::Test::E>] ESeq outSeq);
+    [cpp:type(std::deque< ::Test::E>)] ESeq
+    opESeq([cpp:type(std::deque< ::Test::E>)] ESeq inSeq, out [cpp:type(std::deque< ::Test::E>)] ESeq outSeq);
 
     EList opEList(EList inSeq, out EList outSeq);
 
-    [cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq
-    opDPrxSeq([cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq inSeq,
-              out [cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq outSeq);
+    [cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq
+    opDPrxSeq([cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq inSeq,
+              out [cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq outSeq);
 
     DPrxList opDPrxList(DPrxList inSeq, out DPrxList outSeq);
 
-    [cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq
-    opCSeq([cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq inSeq,
-           out [cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq outSeq);
+    [cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq
+    opCSeq([cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq inSeq,
+           out [cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq outSeq);
 
     CList opCList(CList inSeq, out CList outSeq);
 
@@ -201,20 +201,20 @@ interface TestIntf
 
     IntStringDict opIntStringDict(IntStringDict idict, out IntStringDict odict);
 
-    [cpp:type:::Test::CustomMap< ::Ice::Long, ::Ice::Long>] LongLongDict
-    opVarDict([cpp:type:::Test::CustomMap<std::string, ::Ice::Int>] StringIntDict idict,
-              out [cpp:type:::Test::CustomMap<std::string, ::Ice::Int>] StringIntDict odict);
+    [cpp:type(::Test::CustomMap< ::Ice::Long, ::Ice::Long>)] LongLongDict
+    opVarDict([cpp:type(::Test::CustomMap<std::string, ::Ice::Int>)] StringIntDict idict,
+              out [cpp:type(::Test::CustomMap<std::string, ::Ice::Int>)] StringIntDict odict);
 
-    [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict
+    [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict
     opCustomIntStringDict(
-        [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict idict,
-        out [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict odict);
+        [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict idict,
+        out [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict odict);
 
     ShortBuffer opShortBuffer(ShortBuffer inS, out ShortBuffer outS);
 
-    [cpp:type:::Test::CustomBuffer<bool>] BoolSeq opBoolBuffer(
-        [cpp:type:::Test::CustomBuffer<bool>] BoolSeq inS,
-        out [cpp:type:::Test::CustomBuffer<bool>] BoolSeq outS);
+    [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq opBoolBuffer(
+        [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq inS,
+        out [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq outS);
 
     BufferStruct opBufferStruct(BufferStruct s);
 

--- a/cpp/test/Ice/custom/TestAMD.ice
+++ b/cpp/test/Ice/custom/TestAMD.ice
@@ -4,36 +4,36 @@
 
 #pragma once
 
-[[cpp:include:deque]]
-[[cpp:include:list]]
-[[cpp:include:MyByteSeq.h]]
-[[cpp:include:CustomMap.h]]
-[[cpp:include:CustomBuffer.h]]
-[[cpp:include:StringView.h]]
+[[cpp:include(deque)]]
+[[cpp:include(list)]]
+[[cpp:include(MyByteSeq.h)]]
+[[cpp:include(CustomMap.h)]]
+[[cpp:include(CustomBuffer.h)]]
+[[cpp:include(StringView.h)]]
 
 module Test
 {
 
 sequence<bool> BoolSeq;
-[cpp:type:std::list<bool>] sequence<bool> BoolList;
+[cpp:type(std::list<bool>)] sequence<bool> BoolList;
 
-[cpp:type:std::list< ::Test::BoolList>] sequence<BoolList> BoolListList;
+[cpp:type(std::list< ::Test::BoolList>)] sequence<BoolList> BoolListList;
 sequence<BoolList> BoolListSeq;
-[cpp:type:std::list< ::Test::BoolSeq>] sequence<BoolSeq> BoolSeqList;
+[cpp:type(std::list< ::Test::BoolSeq>)] sequence<BoolSeq> BoolSeqList;
 
 sequence<byte> ByteSeq;
-[cpp:type:std::list< ::Ice::Byte>] sequence<byte> ByteList;
+[cpp:type(std::list< ::Ice::Byte>)] sequence<byte> ByteList;
 
-[cpp:type:std::list< ::Test::ByteList>] sequence<ByteList> ByteListList;
+[cpp:type(std::list< ::Test::ByteList>)] sequence<ByteList> ByteListList;
 sequence<ByteList> ByteListSeq;
-[cpp:type:std::list< ::Test::ByteSeq>] sequence<ByteSeq> ByteSeqList;
+[cpp:type(std::list< ::Test::ByteSeq>)] sequence<ByteSeq> ByteSeqList;
 
 sequence<string> StringSeq;
-[cpp:type:std::list<std::string>] sequence<string> StringList;
+[cpp:type(std::list<std::string>)] sequence<string> StringList;
 
-[cpp:type:std::list< ::Test::StringList>] sequence<StringList> StringListList;
+[cpp:type(std::list< ::Test::StringList>)] sequence<StringList> StringListList;
 sequence<StringList> StringListSeq;
-[cpp:type:std::list< ::Test::StringSeq>] sequence<StringSeq> StringSeqList;
+[cpp:type(std::list< ::Test::StringSeq>)] sequence<StringSeq> StringSeqList;
 
 struct Fixed
 {
@@ -41,61 +41,61 @@ struct Fixed
 }
 
 sequence<Fixed> FixedSeq;
-[cpp:type:std::list< ::Test::Fixed>] sequence<Fixed> FixedList;
+[cpp:type(std::list< ::Test::Fixed>)] sequence<Fixed> FixedList;
 
-[cpp:type:std::list< ::Test::FixedList>] sequence<FixedList> FixedListList;
+[cpp:type(std::list< ::Test::FixedList>)] sequence<FixedList> FixedListList;
 sequence<FixedList> FixedListSeq;
-[cpp:type:std::list< ::Test::FixedSeq>] sequence<FixedSeq> FixedSeqList;
+[cpp:type(std::list< ::Test::FixedSeq>)] sequence<FixedSeq> FixedSeqList;
 
 struct Variable
 {
     string s;
     BoolList bl;
-    [cpp:type:std::list<std::string>] StringSeq ss;
+    [cpp:type(std::list<std::string>)] StringSeq ss;
 }
 
 sequence<Variable> VariableSeq;
-[cpp:type:std::list< ::Test::Variable>] sequence<Variable> VariableList;
+[cpp:type(std::list< ::Test::Variable>)] sequence<Variable> VariableList;
 
-[cpp:type:std::list< ::Test::VariableList>] sequence<VariableList> VariableListList;
+[cpp:type(std::list< ::Test::VariableList>)] sequence<VariableList> VariableListList;
 sequence<VariableList> VariableListSeq;
-[cpp:type:std::list< ::Test::VariableSeq>] sequence<VariableSeq> VariableSeqList;
+[cpp:type(std::list< ::Test::VariableSeq>)] sequence<VariableSeq> VariableSeqList;
 
 dictionary<string, string> StringStringDict;
 sequence<StringStringDict> StringStringDictSeq;
-[cpp:type:std::list< ::Test::StringStringDict>] sequence<StringStringDict> StringStringDictList;
+[cpp:type(std::list< ::Test::StringStringDict>)] sequence<StringStringDict> StringStringDictList;
 
-[cpp:type:std::list< ::Test::StringStringDictList>] sequence<StringStringDictList> StringStringDictListList;
+[cpp:type(std::list< ::Test::StringStringDictList>)] sequence<StringStringDictList> StringStringDictListList;
 sequence<StringStringDictList> StringStringDictListSeq;
-[cpp:type:std::list< ::Test::StringStringDictSeq>] sequence<StringStringDictSeq> StringStringDictSeqList;
+[cpp:type(std::list< ::Test::StringStringDictSeq>)] sequence<StringStringDictSeq> StringStringDictSeqList;
 
 enum E { E1, E2, E3 }
 sequence<E> ESeq;
-[cpp:type:std::list< ::Test::E>] sequence<E> EList;
+[cpp:type(std::list< ::Test::E>)] sequence<E> EList;
 
-[cpp:type:std::list< ::Test::EList>] sequence<EList> EListList;
+[cpp:type(std::list< ::Test::EList>)] sequence<EList> EListList;
 sequence<EList> EListSeq;
-[cpp:type:std::list< ::Test::ESeq>] sequence<ESeq> ESeqList;
+[cpp:type(std::list< ::Test::ESeq>)] sequence<ESeq> ESeqList;
 
 class C {}
 sequence<C> CSeq;
-[cpp:type:std::list<std::shared_ptr<::Test::C>>] sequence<C> CList;
+[cpp:type(std::list<std::shared_ptr<::Test::C>>)] sequence<C> CList;
 
-[cpp:type:std::list< ::Test::CList>] sequence<CList> CListList;
+[cpp:type(std::list< ::Test::CList>)] sequence<CList> CListList;
 sequence<CList> CListSeq;
-[cpp:type:std::list< ::Test::CSeq>] sequence<CSeq> CSeqList;
+[cpp:type(std::list< ::Test::CSeq>)] sequence<CSeq> CSeqList;
 
 interface D{}
 sequence<D*> DPrxSeq;
-[cpp:type:std::list<std::shared_ptr<::Test::DPrx>>] sequence<D*> DPrxList;
+[cpp:type(std::list<std::shared_ptr<::Test::DPrx>>)] sequence<D*> DPrxList;
 
-[cpp:type:std::list< ::Test::DPrxList>] sequence<DPrxList> DPrxListList;
+[cpp:type(std::list< ::Test::DPrxList>)] sequence<DPrxList> DPrxListList;
 sequence<DPrxList> DPrxListSeq;
-[cpp:type:std::list< ::Test::DPrxSeq>] sequence<DPrxSeq> DPrxSeqList;
+[cpp:type(std::list< ::Test::DPrxSeq>)] sequence<DPrxSeq> DPrxSeqList;
 
 sequence<double> DoubleSeq;
 
-[cpp:type:Test::CustomMap<Ice::Int, std::string>] dictionary<int, string> IntStringDict;
+[cpp:type(Test::CustomMap<Ice::Int, std::string>)] dictionary<int, string> IntStringDict;
 dictionary<long, long> LongLongDict;
 dictionary<string, int> StringIntDict;
 
@@ -104,13 +104,13 @@ class DictClass
     IntStringDict isdict;
 }
 
-[cpp:type:Test::CustomBuffer<bool>] sequence<bool> BoolBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Short>] sequence<short> ShortBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Int>] sequence<int> IntBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Long>] sequence<long> LongBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Float>] sequence<float> FloatBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Double>] sequence<double> DoubleBuffer;
-[cpp:type:Test::CustomBuffer<Ice::Byte>] sequence<byte> ByteBuffer;
+[cpp:type(Test::CustomBuffer<bool>)] sequence<bool> BoolBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Short>)] sequence<short> ShortBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Int>)] sequence<int> IntBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Long>)] sequence<long> LongBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Float>)] sequence<float> FloatBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Double>)] sequence<double> DoubleBuffer;
+[cpp:type(Test::CustomBuffer<Ice::Byte>)] sequence<byte> ByteBuffer;
 struct BufferStruct
 {
     ByteBuffer byteBuf;
@@ -132,62 +132,62 @@ struct BufferStruct
 
     VariableList opVariableArray([cpp:array] VariableList inSeq, out VariableList outSeq);
 
-    [cpp:type:std::deque<bool>] BoolSeq
-    opBoolSeq([cpp:type:std::deque<bool>] BoolSeq inSeq, out [cpp:type:std::deque<bool>] BoolSeq outSeq);
+    [cpp:type(std::deque<bool>)] BoolSeq
+    opBoolSeq([cpp:type(std::deque<bool>)] BoolSeq inSeq, out [cpp:type(std::deque<bool>)] BoolSeq outSeq);
 
     BoolList opBoolList(BoolList inSeq, out BoolList outSeq);
 
-    [cpp:type:std::deque< ::Ice::Byte>] ByteSeq
-    opByteSeq([cpp:type:std::deque< ::Ice::Byte>] ByteSeq inSeq,
-              out [cpp:type:std::deque< ::Ice::Byte>] ByteSeq outSeq);
+    [cpp:type(std::deque< ::Ice::Byte>)] ByteSeq
+    opByteSeq([cpp:type(std::deque< ::Ice::Byte>)] ByteSeq inSeq,
+              out [cpp:type(std::deque< ::Ice::Byte>)] ByteSeq outSeq);
 
     ByteList opByteList(ByteList inSeq, out ByteList outSeq);
 
-    [cpp:type:MyByteSeq] ByteSeq
-    opMyByteSeq([cpp:type:MyByteSeq] ByteSeq inSeq, out [cpp:type:MyByteSeq] ByteSeq outSeq);
+    [cpp:type(MyByteSeq)] ByteSeq
+    opMyByteSeq([cpp:type(MyByteSeq)] ByteSeq inSeq, out [cpp:type(MyByteSeq)] ByteSeq outSeq);
 
-    [cpp:view-type:Util::string_view] string
-    opString([cpp:view-type:Util::string_view] string inString,
-             out [cpp:view-type:Util::string_view] string outString);
+    [cpp:view-type(Util::string_view)] string
+    opString([cpp:view-type(Util::string_view)] string inString,
+             out [cpp:view-type(Util::string_view)] string outString);
 
-    [cpp:type:std::deque<std::string>] StringSeq
-    opStringSeq([cpp:type:std::deque<std::string>] StringSeq inSeq,
-                out [cpp:type:std::deque<std::string>] StringSeq outSeq);
+    [cpp:type(std::deque<std::string>)] StringSeq
+    opStringSeq([cpp:type(std::deque<std::string>)] StringSeq inSeq,
+                out [cpp:type(std::deque<std::string>)] StringSeq outSeq);
 
     StringList opStringList(StringList inSeq, out StringList outSeq);
 
-    [cpp:type:std::deque< ::Test::Fixed>] FixedSeq
-    opFixedSeq([cpp:type:std::deque< ::Test::Fixed>] FixedSeq inSeq,
-               out [cpp:type:std::deque< ::Test::Fixed>] FixedSeq outSeq);
+    [cpp:type(std::deque< ::Test::Fixed>)] FixedSeq
+    opFixedSeq([cpp:type(std::deque< ::Test::Fixed>)] FixedSeq inSeq,
+               out [cpp:type(std::deque< ::Test::Fixed>)] FixedSeq outSeq);
 
     FixedList opFixedList(FixedList inSeq, out FixedList outSeq);
 
-    [cpp:type:std::deque< ::Test::Variable>] VariableSeq
-    opVariableSeq([cpp:type:std::deque< ::Test::Variable>] VariableSeq inSeq,
-                  out [cpp:type:std::deque< ::Test::Variable>] VariableSeq outSeq);
+    [cpp:type(std::deque< ::Test::Variable>)] VariableSeq
+    opVariableSeq([cpp:type(std::deque< ::Test::Variable>)] VariableSeq inSeq,
+                  out [cpp:type(std::deque< ::Test::Variable>)] VariableSeq outSeq);
 
     VariableList opVariableList(VariableList inSeq, out VariableList outSeq);
 
-    [cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq
-    opStringStringDictSeq([cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq inSeq,
-                          out [cpp:type:std::deque< ::Test::StringStringDict>] StringStringDictSeq outSeq);
+    [cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq
+    opStringStringDictSeq([cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq inSeq,
+                          out [cpp:type(std::deque< ::Test::StringStringDict>)] StringStringDictSeq outSeq);
 
     StringStringDictList opStringStringDictList(StringStringDictList inSeq, out StringStringDictList outSeq);
 
-    [cpp:type:std::deque< ::Test::E>] ESeq
-    opESeq([cpp:type:std::deque< ::Test::E>] ESeq inSeq, out [cpp:type:std::deque< ::Test::E>] ESeq outSeq);
+    [cpp:type(std::deque< ::Test::E>)] ESeq
+    opESeq([cpp:type(std::deque< ::Test::E>)] ESeq inSeq, out [cpp:type(std::deque< ::Test::E>)] ESeq outSeq);
 
     EList opEList(EList inSeq, out EList outSeq);
 
-    [cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq
-    opDPrxSeq([cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq inSeq,
-              out [cpp:type:std::deque<std::shared_ptr<::Test::DPrx>>] DPrxSeq outSeq);
+    [cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq
+    opDPrxSeq([cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq inSeq,
+              out [cpp:type(std::deque<std::shared_ptr<::Test::DPrx>>)] DPrxSeq outSeq);
 
     DPrxList opDPrxList(DPrxList inSeq, out DPrxList outSeq);
 
-    [cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq
-    opCSeq([cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq inSeq,
-           out [cpp:type:std::deque<std::shared_ptr<Test::C>>] CSeq outSeq);
+    [cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq
+    opCSeq([cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq inSeq,
+           out [cpp:type(std::deque<std::shared_ptr<Test::C>>)] CSeq outSeq);
 
     CList opCList(CList inSeq, out CList outSeq);
 
@@ -195,20 +195,20 @@ struct BufferStruct
 
     IntStringDict opIntStringDict(IntStringDict idict, out IntStringDict odict);
 
-    [cpp:type:::Test::CustomMap< ::Ice::Long, ::Ice::Long>] LongLongDict
-    opVarDict([cpp:type:::Test::CustomMap<std::string, ::Ice::Int>] StringIntDict idict,
-              out [cpp:type:::Test::CustomMap<std::string, ::Ice::Int>] StringIntDict odict);
+    [cpp:type(::Test::CustomMap< ::Ice::Long, ::Ice::Long>)] LongLongDict
+    opVarDict([cpp:type(::Test::CustomMap<std::string, ::Ice::Int>)] StringIntDict idict,
+              out [cpp:type(::Test::CustomMap<std::string, ::Ice::Int>)] StringIntDict odict);
 
-    [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict
+    [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict
     opCustomIntStringDict(
-        [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict idict,
-        out [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] IntStringDict odict);
+        [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict idict,
+        out [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] IntStringDict odict);
 
     ShortBuffer opShortBuffer(ShortBuffer inS, out ShortBuffer outS);
 
-    [cpp:type:::Test::CustomBuffer<bool>] BoolSeq opBoolBuffer(
-        [cpp:type:::Test::CustomBuffer<bool>] BoolSeq inS,
-        out [cpp:type:::Test::CustomBuffer<bool>] BoolSeq outS);
+    [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq opBoolBuffer(
+        [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq inS,
+        out [cpp:type(::Test::CustomBuffer<bool>)] BoolSeq outS);
 
     BufferStruct opBufferStruct(BufferStruct s);
 

--- a/cpp/test/Ice/custom/Wstring.ice
+++ b/cpp/test/Ice/custom/Wstring.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[cpp:type:wstring] module Test1
+[cpp:type(wstring)] module Test1
 {
 
 sequence<string> WstringSeq;
@@ -36,21 +36,21 @@ interface WstringClass
 module Test2
 {
 
-sequence<[cpp:type:wstring] string> WstringSeq;
+sequence<[cpp:type(wstring)] string> WstringSeq;
 
-dictionary<[cpp:type:wstring] string, [cpp:type:wstring] string> WstringWStringDict;
+dictionary<[cpp:type(wstring)] string, [cpp:type(wstring)] string> WstringWStringDict;
 
-[cpp:type:wstring] struct WstringStruct
+[cpp:type(wstring)] struct WstringStruct
 {
     string s;
 }
 
-[cpp:type:wstring] exception WstringException
+[cpp:type(wstring)] exception WstringException
 {
     string reason;
 }
 
-[cpp:type:wstring] interface WstringClass
+[cpp:type(wstring)] interface WstringClass
 {
     string opString(string s1, out string s2);
 

--- a/cpp/test/Ice/custom/WstringAMD.ice
+++ b/cpp/test/Ice/custom/WstringAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[cpp:type:wstring] module Test1
+[cpp:type(wstring)] module Test1
 {
 
 sequence<string> WstringSeq;
@@ -36,21 +36,21 @@ exception WstringException
 module Test2
 {
 
-sequence<[cpp:type:wstring] string> WstringSeq;
+sequence<[cpp:type(wstring)] string> WstringSeq;
 
-dictionary<[cpp:type:wstring] string, [cpp:type:wstring] string> WstringWStringDict;
+dictionary<[cpp:type(wstring)] string, [cpp:type(wstring)] string> WstringWStringDict;
 
-[cpp:type:wstring] struct WstringStruct
+[cpp:type(wstring)] struct WstringStruct
 {
     string s;
 }
 
-[cpp:type:wstring] exception WstringException
+[cpp:type(wstring)] exception WstringException
 {
     string reason;
 }
 
-[amd] [cpp:type:wstring] interface WstringClass
+[amd] [cpp:type(wstring)] interface WstringClass
 {
     string opString(string s1, out string s2);
 

--- a/cpp/test/Ice/defaultValue/Test.ice
+++ b/cpp/test/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/cpp/test/Ice/impl/Test.ice
+++ b/cpp/test/Ice/impl/Test.ice
@@ -40,7 +40,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -353,29 +353,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const [cpp:type:wstring] string ws0 = "\u005c";                           // backslash
-const [cpp:type:wstring] string ws1 = "\u0041";                           // A
-const [cpp:type:wstring] string ws2 = "\u0049\u0063\u0065";               // Ice
-const [cpp:type:wstring] string ws3 = "\u004121";                         // A21
-const [cpp:type:wstring] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const [cpp:type:wstring] string ws5 = "\u00FF";                           // ÿ
-const [cpp:type:wstring] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const [cpp:type:wstring] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string ws0 = "\u005c";                           // backslash
+const [cpp:type(wstring)] string ws1 = "\u0041";                           // A
+const [cpp:type(wstring)] string ws2 = "\u0049\u0063\u0065";               // Ice
+const [cpp:type(wstring)] string ws3 = "\u004121";                         // A21
+const [cpp:type(wstring)] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const [cpp:type(wstring)] string ws5 = "\u00FF";                           // ÿ
+const [cpp:type(wstring)] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const [cpp:type(wstring)] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const [cpp:type:wstring] string wsw0 = "\U0000005c";                      // backslash
-const [cpp:type:wstring] string wsw1 = "\U00000041";                      // A
-const [cpp:type:wstring] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const [cpp:type:wstring] string wsw3 = "\U0000004121";                    // A21
-const [cpp:type:wstring] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const [cpp:type:wstring] string wsw5 = "\U000000FF";                      // ÿ
-const [cpp:type:wstring] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string wsw0 = "\U0000005c";                      // backslash
+const [cpp:type(wstring)] string wsw1 = "\U00000041";                      // A
+const [cpp:type(wstring)] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const [cpp:type(wstring)] string wsw3 = "\U0000004121";                    // A21
+const [cpp:type(wstring)] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const [cpp:type(wstring)] string wsw5 = "\U000000FF";                      // ÿ
+const [cpp:type(wstring)] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const [cpp:type(wstring)] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -390,13 +390,13 @@ const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sin
 \t      horizontal tab  byte 0x09 in ASCII encoding
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
-const [cpp:type:wstring] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const [cpp:type:wstring] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const [cpp:type:wstring] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const [cpp:type(wstring)] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const [cpp:type(wstring)] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const [cpp:type(wstring)] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const [cpp:type:wstring] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const [cpp:type:wstring] string wss4 = "\\\u0041\\"; /* \A\     */
-const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
+const [cpp:type(wstring)] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const [cpp:type(wstring)] string wss4 = "\\\u0041\\"; /* \A\     */
+const [cpp:type(wstring)] string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -412,8 +412,8 @@ const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const [cpp:type:wstring] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const [cpp:type:wstring] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const [cpp:type:wstring] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const [cpp:type(wstring)] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }

--- a/cpp/test/Ice/impl/TestAMD.ice
+++ b/cpp/test/Ice/impl/TestAMD.ice
@@ -40,7 +40,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -349,29 +349,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const [cpp:type:wstring] string ws0 = "\u005c";                           // backslash
-const [cpp:type:wstring] string ws1 = "\u0041";                           // A
-const [cpp:type:wstring] string ws2 = "\u0049\u0063\u0065";               // Ice
-const [cpp:type:wstring] string ws3 = "\u004121";                         // A21
-const [cpp:type:wstring] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const [cpp:type:wstring] string ws5 = "\u00FF";                           // ÿ
-const [cpp:type:wstring] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const [cpp:type:wstring] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string ws0 = "\u005c";                           // backslash
+const [cpp:type(wstring)] string ws1 = "\u0041";                           // A
+const [cpp:type(wstring)] string ws2 = "\u0049\u0063\u0065";               // Ice
+const [cpp:type(wstring)] string ws3 = "\u004121";                         // A21
+const [cpp:type(wstring)] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const [cpp:type(wstring)] string ws5 = "\u00FF";                           // ÿ
+const [cpp:type(wstring)] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const [cpp:type(wstring)] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const [cpp:type:wstring] string wsw0 = "\U0000005c";                      // backslash
-const [cpp:type:wstring] string wsw1 = "\U00000041";                      // A
-const [cpp:type:wstring] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const [cpp:type:wstring] string wsw3 = "\U0000004121";                    // A21
-const [cpp:type:wstring] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const [cpp:type:wstring] string wsw5 = "\U000000FF";                      // ÿ
-const [cpp:type:wstring] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string wsw0 = "\U0000005c";                      // backslash
+const [cpp:type(wstring)] string wsw1 = "\U00000041";                      // A
+const [cpp:type(wstring)] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const [cpp:type(wstring)] string wsw3 = "\U0000004121";                    // A21
+const [cpp:type(wstring)] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const [cpp:type(wstring)] string wsw5 = "\U000000FF";                      // ÿ
+const [cpp:type(wstring)] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const [cpp:type(wstring)] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -387,13 +387,13 @@ const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sin
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
 
-const [cpp:type:wstring] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const [cpp:type:wstring] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const [cpp:type:wstring] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const [cpp:type(wstring)] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const [cpp:type(wstring)] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const [cpp:type(wstring)] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const [cpp:type:wstring] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const [cpp:type:wstring] string wss4 = "\\\u0041\\"; /* \A\     */
-const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
+const [cpp:type(wstring)] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const [cpp:type(wstring)] string wss4 = "\\\u0041\\"; /* \A\     */
+const [cpp:type(wstring)] string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -409,8 +409,8 @@ const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const [cpp:type:wstring] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const [cpp:type:wstring] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const [cpp:type:wstring] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const [cpp:type(wstring)] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }

--- a/cpp/test/Ice/interceptor/Test.ice
+++ b/cpp/test/Ice/interceptor/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[cpp:dll-export:INTERCEPTOR_TEST_API]]
+[[cpp:dll-export(INTERCEPTOR_TEST_API)]]
 
 module Test
 {

--- a/cpp/test/Ice/library/Test.ice
+++ b/cpp/test/Ice/library/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[cpp:dll-export:LIBRARY_TEST_API]]
+[[cpp:dll-export(LIBRARY_TEST_API)]]
 
 module Test
 {

--- a/cpp/test/Ice/location/Test.ice
+++ b/cpp/test/Ice/location/Test.ice
@@ -1,6 +1,4 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
@@ -11,17 +9,13 @@ module Test
 
 interface TestLocatorRegistry : ::Ice::LocatorRegistry
 {
-    //
     // Allow remote addition of objects to the locator registry.
-    //
     void addObject(Object* obj);
 }
 
 interface TestLocator : ::Ice::Locator
 {
-    //
     // Returns the number of request on the locator interface.
-    //
     [cpp:const] idempotent int getRequestCount();
 }
 

--- a/cpp/test/Ice/objects/Test.ice
+++ b/cpp/test/Ice/objects/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[cpp:source-include:Forward.h]]
+[[cpp:source-include(Forward.h)]]
 
 module Test
 {

--- a/cpp/test/Ice/operations/Test.ice
+++ b/cpp/test/Ice/operations/Test.ice
@@ -38,7 +38,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -353,29 +353,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const [cpp:type:wstring] string ws0 = "\u005c";                           // backslash
-const [cpp:type:wstring] string ws1 = "\u0041";                           // A
-const [cpp:type:wstring] string ws2 = "\u0049\u0063\u0065";               // Ice
-const [cpp:type:wstring] string ws3 = "\u004121";                         // A21
-const [cpp:type:wstring] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const [cpp:type:wstring] string ws5 = "\u00FF";                           // ÿ
-const [cpp:type:wstring] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const [cpp:type:wstring] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string ws0 = "\u005c";                           // backslash
+const [cpp:type(wstring)] string ws1 = "\u0041";                           // A
+const [cpp:type(wstring)] string ws2 = "\u0049\u0063\u0065";               // Ice
+const [cpp:type(wstring)] string ws3 = "\u004121";                         // A21
+const [cpp:type(wstring)] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const [cpp:type(wstring)] string ws5 = "\u00FF";                           // ÿ
+const [cpp:type(wstring)] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const [cpp:type(wstring)] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const [cpp:type:wstring] string wsw0 = "\U0000005c";                      // backslash
-const [cpp:type:wstring] string wsw1 = "\U00000041";                      // A
-const [cpp:type:wstring] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const [cpp:type:wstring] string wsw3 = "\U0000004121";                    // A21
-const [cpp:type:wstring] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const [cpp:type:wstring] string wsw5 = "\U000000FF";                      // ÿ
-const [cpp:type:wstring] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string wsw0 = "\U0000005c";                      // backslash
+const [cpp:type(wstring)] string wsw1 = "\U00000041";                      // A
+const [cpp:type(wstring)] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const [cpp:type(wstring)] string wsw3 = "\U0000004121";                    // A21
+const [cpp:type(wstring)] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const [cpp:type(wstring)] string wsw5 = "\U000000FF";                      // ÿ
+const [cpp:type(wstring)] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const [cpp:type(wstring)] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -390,13 +390,13 @@ const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sin
 \t      horizontal tab  byte 0x09 in ASCII encoding
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
-const [cpp:type:wstring] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const [cpp:type:wstring] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const [cpp:type:wstring] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const [cpp:type(wstring)] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const [cpp:type(wstring)] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const [cpp:type(wstring)] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const [cpp:type:wstring] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const [cpp:type:wstring] string wss4 = "\\\u0041\\"; /* \A\     */
-const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
+const [cpp:type(wstring)] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const [cpp:type(wstring)] string wss4 = "\\\u0041\\"; /* \A\     */
+const [cpp:type(wstring)] string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -412,9 +412,9 @@ const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const [cpp:type:wstring] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const [cpp:type:wstring] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const [cpp:type:wstring] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const [cpp:type(wstring)] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }
 

--- a/cpp/test/Ice/operations/TestAMD.ice
+++ b/cpp/test/Ice/operations/TestAMD.ice
@@ -38,7 +38,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -349,29 +349,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const [cpp:type:wstring] string ws0 = "\u005c";                           // backslash
-const [cpp:type:wstring] string ws1 = "\u0041";                           // A
-const [cpp:type:wstring] string ws2 = "\u0049\u0063\u0065";               // Ice
-const [cpp:type:wstring] string ws3 = "\u004121";                         // A21
-const [cpp:type:wstring] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const [cpp:type:wstring] string ws5 = "\u00FF";                           // ÿ
-const [cpp:type:wstring] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const [cpp:type:wstring] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string ws0 = "\u005c";                           // backslash
+const [cpp:type(wstring)] string ws1 = "\u0041";                           // A
+const [cpp:type(wstring)] string ws2 = "\u0049\u0063\u0065";               // Ice
+const [cpp:type(wstring)] string ws3 = "\u004121";                         // A21
+const [cpp:type(wstring)] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const [cpp:type(wstring)] string ws5 = "\u00FF";                           // ÿ
+const [cpp:type(wstring)] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const [cpp:type(wstring)] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const [cpp:type:wstring] string wsw0 = "\U0000005c";                      // backslash
-const [cpp:type:wstring] string wsw1 = "\U00000041";                      // A
-const [cpp:type:wstring] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const [cpp:type:wstring] string wsw3 = "\U0000004121";                    // A21
-const [cpp:type:wstring] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const [cpp:type:wstring] string wsw5 = "\U000000FF";                      // ÿ
-const [cpp:type:wstring] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string wsw0 = "\U0000005c";                      // backslash
+const [cpp:type(wstring)] string wsw1 = "\U00000041";                      // A
+const [cpp:type(wstring)] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const [cpp:type(wstring)] string wsw3 = "\U0000004121";                    // A21
+const [cpp:type(wstring)] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const [cpp:type(wstring)] string wsw5 = "\U000000FF";                      // ÿ
+const [cpp:type(wstring)] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const [cpp:type(wstring)] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -387,13 +387,13 @@ const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sin
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
 
-const [cpp:type:wstring] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const [cpp:type:wstring] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const [cpp:type:wstring] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const [cpp:type(wstring)] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const [cpp:type(wstring)] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const [cpp:type(wstring)] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const [cpp:type:wstring] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const [cpp:type:wstring] string wss4 = "\\\u0041\\"; /* \A\     */
-const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
+const [cpp:type(wstring)] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const [cpp:type(wstring)] string wss4 = "\\\u0041\\"; /* \A\     */
+const [cpp:type(wstring)] string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -409,9 +409,9 @@ const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const [cpp:type:wstring] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const [cpp:type:wstring] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const [cpp:type:wstring] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const [cpp:type(wstring)] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }
 

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -4,9 +4,9 @@
 
 #pragma once
 
-[[cpp:include:list]]
-[[cpp:include:CustomMap.h]]
-[[cpp:include:StringView.h]]
+[[cpp:include(list)]]
+[[cpp:include(CustomMap.h)]]
+[[cpp:include(StringView.h)]]
 
 [[3.7]]
 
@@ -53,9 +53,9 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[cpp:type:std::list< ::Test::SmallStruct>] sequence<SmallStruct> SmallStructList;
+[cpp:type(std::list< ::Test::SmallStruct>)] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[cpp:type:std::list< ::Test::FixedStruct>] sequence<FixedStruct> FixedStructList;
+[cpp:type(std::list< ::Test::FixedStruct>)] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 sequence<byte> Serializable;
@@ -66,7 +66,7 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 
-[cpp:type:Test::CustomMap<Ice::Int, std::string>] dictionary<int, string> IntStringDict;
+[cpp:type(Test::CustomMap<Ice::Int, std::string>)] dictionary<int, string> IntStringDict;
 
 class MultiOptional
 {
@@ -186,9 +186,9 @@ interface Initial
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
 
-    [cpp:view-type:Util::string_view] optional(1) string
-    opCustomString([cpp:view-type:Util::string_view] optional(2) string p1,
-                   out [cpp:view-type:Util::string_view] optional(3) string p3);
+    [cpp:view-type(Util::string_view)] optional(1) string
+    opCustomString([cpp:view-type(Util::string_view)] optional(2) string p1,
+                   out [cpp:view-type(Util::string_view)] optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
@@ -242,10 +242,10 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(1) IntStringDict
+    [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(1) IntStringDict
     opCustomIntStringDict(
-        [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(2) IntStringDict p1,
-        out [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(3) IntStringDict p3);
+        [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(2) IntStringDict p1,
+        out [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(3) IntStringDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -4,9 +4,9 @@
 
 #pragma once
 
-[[cpp:include:list]]
-[[cpp:include:CustomMap.h]]
-[[cpp:include:StringView.h]]
+[[cpp:include(list)]]
+[[cpp:include(CustomMap.h)]]
+[[cpp:include(StringView.h)]]
 
 [[3.7]]
 
@@ -53,9 +53,9 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[cpp:type:std::list< ::Test::SmallStruct>] sequence<SmallStruct> SmallStructList;
+[cpp:type(std::list< ::Test::SmallStruct>)] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[cpp:type:std::list< ::Test::FixedStruct>] sequence<FixedStruct> FixedStructList;
+[cpp:type(std::list< ::Test::FixedStruct>)] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 sequence<byte> Serializable;
@@ -66,7 +66,7 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 
-[cpp:type:Test::CustomMap<Ice::Int, std::string>] dictionary<int, string> IntStringDict;
+[cpp:type(Test::CustomMap<Ice::Int, std::string>)] dictionary<int, string> IntStringDict;
 
 class MultiOptional
 {
@@ -187,9 +187,9 @@ interface Initial
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
 
-    [cpp:view-type:Util::string_view] optional(1) string
-    opCustomString([cpp:view-type:Util::string_view] optional(2) string p1,
-                   out [cpp:view-type:Util::string_view] optional(3) string p3);
+    [cpp:view-type(Util::string_view)] optional(1) string
+    opCustomString([cpp:view-type(Util::string_view)] optional(2) string p1,
+                   out [cpp:view-type(Util::string_view)] optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
@@ -245,10 +245,10 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(1) IntStringDict
+    [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(1) IntStringDict
     opCustomIntStringDict(
-        [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(2) IntStringDict p1,
-        out [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(3) IntStringDict p3);
+        [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(2) IntStringDict p1,
+        out [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(3) IntStringDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/cpp/test/Ice/slicing/exceptions/Test.ice
+++ b/cpp/test/Ice/slicing/exceptions/Test.ice
@@ -44,7 +44,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -54,7 +54,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -73,7 +73,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/cpp/test/Ice/slicing/exceptions/TestAMD.ice
+++ b/cpp/test/Ice/slicing/exceptions/TestAMD.ice
@@ -44,7 +44,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -54,7 +54,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -73,7 +73,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/cpp/test/Ice/slicing/objects/Test.ice
+++ b/cpp/test/Ice/slicing/objects/Test.ice
@@ -99,7 +99,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -109,7 +109,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/cpp/test/Ice/slicing/objects/TestAMD.ice
+++ b/cpp/test/Ice/slicing/objects/TestAMD.ice
@@ -94,7 +94,7 @@ exception PreservedException
 {
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -104,7 +104,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/cpp/test/Ice/stringConverter/Test.ice
+++ b/cpp/test/Ice/stringConverter/Test.ice
@@ -11,8 +11,8 @@ exception BadEncodingException {}
 
 interface MyObject
 {
-    [cpp:type:wstring] string widen(string msg) throws BadEncodingException;
-    string narrow([cpp:type:wstring] string wmsg);
+    [cpp:type(wstring)] string widen(string msg) throws BadEncodingException;
+    string narrow([cpp:type(wstring)] string wmsg);
 
     void shutdown();
 }

--- a/cpp/test/Slice/errorDetection/Reserved.ice
+++ b/cpp/test/Slice/errorDetection/Reserved.ice
@@ -57,7 +57,7 @@ module _a__b__ {}      // Illegal underscores
 
 // Ensure that warnings can be suppressed with local metadata.
 
-[suppress-warning:reserved-identifier]
+[suppress-warning(reserved-identifier)]
 module suppressed
 {
 const long PrxA = 0;

--- a/cpp/test/Slice/errorDetection/ReservedSuppressed.ice
+++ b/cpp/test/Slice/errorDetection/ReservedSuppressed.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <include/IcePrefix.ice>
 

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
@@ -9,12 +9,13 @@ WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:dll-e
 WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:dll-export:'
 WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:include'
 WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:include:'
+WarningInvalidMetaData.ice:32: warning: ignoring invalid metadata `cpp:foo'
 WarningInvalidMetaData.ice:35: warning: ignoring invalid metadata `cpp:type:std::list< ::std::string>' for operation with void return type
 WarningInvalidMetaData.ice:38: warning: ignoring invalid metadata `cpp:view-type:std::experimental::string_view' for operation with void return type
 WarningInvalidMetaData.ice:41: warning: ignoring invalid metadata `cpp:array' for operation with void return type
 WarningInvalidMetaData.ice:44: warning: ignoring invalid metadata `cpp:range'
-WarningInvalidMetaData.ice:49: warning: ignoring invalid metadata `cpp:class'
-WarningInvalidMetaData.ice:49: warning: ignoring invalid metadata `cpp:comparable'
+WarningInvalidMetaData.ice:49: warning: ignoring invalid metadata `cpp:foo'
+WarningInvalidMetaData.ice:49: warning: ignoring invalid metadata `cpp:bar'
 WarningInvalidMetaData.ice:54: warning: ignoring invalid metadata `cpp:const'
 WarningInvalidMetaData.ice:54: warning: ignoring invalid metadata `cpp:ice_print'
 WarningInvalidMetaData.ice:60: warning: ignoring invalid metadata `cpp:virtual'

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
@@ -2,39 +2,39 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[cpp:header-ext:hh]]
-[[cpp:header-ext:hh]]
+[[cpp:header-ext(hh)]]
+[[cpp:header-ext(hh)]]
 
-[[cpp:source-ext:cc]]
-[[cpp:source-ext:cc]]
+[[cpp:source-ext(cc)]]
+[[cpp:source-ext(cc)]]
 
-[[cpp:dll-export:Test]]
-[[cpp:dll-export:Test]]
+[[cpp:dll-export(Test)]]
+[[cpp:dll-export(Test)]]
 
 [[cpp:header-ext]]
-[[cpp:header-ext:]]
+[[cpp:header-ext()]]
 
 [[cpp:source-ext]]
-[[cpp:source-ext:]]
+[[cpp:source-ext()]]
 
 [[cpp:dll-export]]
-[[cpp:dll-export:]]
+[[cpp:dll-export()]]
 
 [[cpp:include]]
-[[cpp:include:]]
+[[cpp:include()]]
 
 module Test
 {
 
 interface I
 {
-    [cpp:noexcept]
+    [cpp:foo]
     void op();
 
-    [cpp:type:std::list< ::std::string>]
+    [cpp:type(std::list< ::std::string>)]
     void op1();
 
-    [cpp:view-type:std::experimental::string_view]
+    [cpp:view-type(std::experimental::string_view)]
     void op2();
 
     [cpp:array]
@@ -44,7 +44,7 @@ interface I
     void op4();
 }
 
-[cpp:class] [cpp:comparable]
+[cpp:foo] [cpp:bar]
 class C
 {
 }

--- a/cpp/test/Slice/errorDetection/WarningSuppressInvalidMetaData.ice
+++ b/cpp/test/Slice/errorDetection/WarningSuppressInvalidMetaData.ice
@@ -2,41 +2,41 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:invalid-metadata]]
+[[suppress-warning(invalid-metadata)]]
 
-[[cpp:header-ext:hh]]
-[[cpp:header-ext:hh]]
+[[cpp:header-ext(hh)]]
+[[cpp:header-ext(hh)]]
 
-[[cpp:source-ext:cc]]
-[[cpp:source-ext:cc]]
+[[cpp:source-ext(cc)]]
+[[cpp:source-ext(cc)]]
 
-[[cpp:dll-export:Test]]
-[[cpp:dll-export:Test]]
+[[cpp:dll-export(Test)]]
+[[cpp:dll-export(Test)]]
 
 [[cpp:header-ext]]
-[[cpp:header-ext:]]
+[[cpp:header-ext()]]
 
 [[cpp:source-ext]]
-[[cpp:source-ext:]]
+[[cpp:source-ext()]]
 
 [[cpp:dll-export]]
-[[cpp:dll-export:]]
+[[cpp:dll-export()]]
 
 [[cpp:include]]
-[[cpp:include:]]
+[[cpp:include()]]
 
 module Test
 {
 
 interface I
 {
-    [cpp:noexcept]
+    [cpp:foo]
     void op();
 
-    [cpp:type:std::list< ::std::string>]
+    [cpp:type(std::list< ::std::string>)]
     void op1();
 
-    [cpp:view-type:std::experimental::string_view]
+    [cpp:view-type(std::experimental::string_view)]
     void op2();
 
     [cpp:array]
@@ -46,7 +46,7 @@ interface I
     void op4();
 }
 
-[cpp:class] [cpp:comparable]
+[cpp:foo] [cpp:bar]
 class C
 {
 }

--- a/cpp/test/Slice/errorDetection/include/IcePrefix.ice
+++ b/cpp/test/Slice/errorDetection/include/IcePrefix.ice
@@ -2,5 +2,5 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 module IceSomething {}

--- a/cpp/test/Slice/escape/Clash.ice
+++ b/cpp/test/Slice/escape/Clash.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module Clash
 {

--- a/cpp/test/Slice/escape/Key.ice
+++ b/cpp/test/Slice/escape/Key.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module and
 {

--- a/cpp/test/Slice/structure/Test.ice
+++ b/cpp/test/Slice/structure/Test.ice
@@ -2,13 +2,13 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[cpp:include:list]]
+[[cpp:include(list)]]
 
 module Test
 {
 
 sequence<string> StringSeq;
-[cpp:type:std::list< ::Ice::Int>] sequence<int> IntList;
+[cpp:type(std::list< ::Ice::Int>)] sequence<int> IntList;
 dictionary<string, string> StringDict;
 
 class C

--- a/csharp/test/Glacier2/sessionHelper/Callback.ice
+++ b/csharp/test/Glacier2/sessionHelper/Callback.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Glacier2::Test::SessionHelper
 {

--- a/csharp/test/Ice/acm/Test.ice
+++ b/csharp/test/Ice/acm/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::ACM
 {

--- a/csharp/test/Ice/adapterDeactivation/Test.ice
+++ b/csharp/test/Ice/adapterDeactivation/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::AdapterDeactivation
 {

--- a/csharp/test/Ice/admin/Test.ice
+++ b/csharp/test/Ice/admin/Test.ice
@@ -7,7 +7,7 @@
 
 #include <Ice/PropertiesAdmin.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Admin
 {

--- a/csharp/test/Ice/ami/Test.ice
+++ b/csharp/test/Ice/ami/Test.ice
@@ -7,7 +7,7 @@
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::AMI
 {

--- a/csharp/test/Ice/assemblies/Core.ice
+++ b/csharp/test/Ice/assemblies/Core.ice
@@ -1,5 +1,5 @@
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Assemblies::Core
 {

--- a/csharp/test/Ice/assemblies/User.ice
+++ b/csharp/test/Ice/assemblies/User.ice
@@ -3,7 +3,7 @@
 
 [[3.7]]
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Assemblies::User
 {

--- a/csharp/test/Ice/binding/Test.ice
+++ b/csharp/test/Ice/binding/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Binding
 {

--- a/csharp/test/Ice/compress/Test.ice
+++ b/csharp/test/Ice/compress/Test.ice
@@ -20,7 +20,7 @@ interface TestIntf
 {
     [compress(params)] void opCompressParams(int size, ByteSeq p1);
     [compress(return)] ByteSeq opCompressReturn(int size);
-    [compress(params,return)] ByteSeq opCompressParamsAndReturn(ByteSeq p1);
+    [compress(params, return)] ByteSeq opCompressParamsAndReturn(ByteSeq p1);
 
     void opWithUserException(int size);
 

--- a/csharp/test/Ice/compress/Test.ice
+++ b/csharp/test/Ice/compress/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Compress
 {
@@ -18,9 +18,9 @@ exception MyException
 
 interface TestIntf
 {
-    [compress:params] void opCompressParams(int size, ByteSeq p1);
-    [compress:return] ByteSeq opCompressReturn(int size);
-    [compress:params,return] ByteSeq opCompressParamsAndReturn(ByteSeq p1);
+    [compress(params)] void opCompressParams(int size, ByteSeq p1);
+    [compress(return)] ByteSeq opCompressReturn(int size);
+    [compress(params,return)] ByteSeq opCompressParamsAndReturn(ByteSeq p1);
 
     void opWithUserException(int size);
 

--- a/csharp/test/Ice/defaultServant/Test.ice
+++ b/csharp/test/Ice/defaultServant/Test.ice
@@ -4,8 +4,7 @@
 
 #pragma once
 
-[[normalize-case]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::DefaultServant
 {

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -1,11 +1,9 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
 // deprecated for enumerator references
-[[suppress-warning:invalid-metadata, deprecated, reserved-identifier]]
+[[suppress-warning(all)]]
 
 module ZeroC::Ice::Test::DefaultValue
 {
@@ -123,10 +121,8 @@ class ClassProperty
     double zeroDotD = 0;
 }
 
-//
-// Exceptions don't support "clr:property" metadata, but
+// Exceptions don't support "cs:property" metadata, but
 // we want to ensure that the generated code compiles.
-//
 [cs:property]
 exception ExceptionProperty
 {

--- a/csharp/test/Ice/dictMapping/Test.ice
+++ b/csharp/test/Ice/dictMapping/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::DictMapping
 {
@@ -15,10 +15,10 @@ dictionary<string, NV> NDV;
 dictionary<string, NR> NDR;
 
 sequence<int> AIS;
-[cs:generic:List] sequence<int> GIS;
+[cs:generic(List)] sequence<int> GIS;
 
 sequence<string> ASS;
-[cs:generic:List] sequence<string> GSS;
+[cs:generic(List)] sequence<string> GSS;
 
 dictionary<string, AIS> NDAIS;
 dictionary<string, GIS> NDGIS;

--- a/csharp/test/Ice/echo/Test.ice
+++ b/csharp/test/Ice/echo/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Echo
 {

--- a/csharp/test/Ice/enums/Test.ice
+++ b/csharp/test/Ice/enums/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Enums
 {
@@ -166,7 +166,7 @@ enum FLSimpleEnum : byte
 }
 sequence<FLSimpleEnum> FLSimpleEnumSeq;
 
-[cs:attribute:System.Flags] unchecked enum MyFlags : uint
+[cs:attribute(System.Flags)] unchecked enum MyFlags : uint
 {
     E0 = 1,
     E1 = 2,

--- a/csharp/test/Ice/exceptions/Test.ice
+++ b/csharp/test/Ice/exceptions/Test.ice
@@ -7,7 +7,7 @@
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Exceptions.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Exceptions
 {

--- a/csharp/test/Ice/facets/Test.ice
+++ b/csharp/test/Ice/facets/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Facets
 {

--- a/csharp/test/Ice/faultTolerance/Test.ice
+++ b/csharp/test/Ice/faultTolerance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::FaultTolerance
 {

--- a/csharp/test/Ice/hash/Test.ice
+++ b/csharp/test/Ice/hash/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Hash
 {

--- a/csharp/test/Ice/impl/Test.ice
+++ b/csharp/test/Ice/impl/Test.ice
@@ -229,7 +229,7 @@ class MyClass1
     MyClass* myClass; // Same name as an already defined class
 }
 
-[cs:tie] interface MyDerivedClass : MyClass
+interface MyDerivedClass : MyClass
 {
     void opDerived();
     MyClass1 opMyClass1(MyClass1 opMyClass1);

--- a/csharp/test/Ice/info/Test.ice
+++ b/csharp/test/Ice/info/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Info
 {

--- a/csharp/test/Ice/inheritance/Test.ice
+++ b/csharp/test/Ice/inheritance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Inheritance
 {

--- a/csharp/test/Ice/interceptor/Test.ice
+++ b/csharp/test/Ice/interceptor/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Interceptor
 {

--- a/csharp/test/Ice/invoke/Test.ice
+++ b/csharp/test/Ice/invoke/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Invoke
 {

--- a/csharp/test/Ice/location/Test.ice
+++ b/csharp/test/Ice/location/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Locator.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Location
 {

--- a/csharp/test/Ice/metrics/Test.ice
+++ b/csharp/test/Ice/metrics/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Metrics
 {

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[cs:namespace:ZeroC.Ice.Test.NamespaceMD]
+[cs:namespace(ZeroC.Ice.Test.NamespaceMD)]
 module WithNamespace
 {
 class C1

--- a/csharp/test/Ice/namespacemd/NoNamespace.ice
+++ b/csharp/test/Ice/namespacemd/NoNamespace.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::NamespaceMD::NoNamespace
 {

--- a/csharp/test/Ice/namespacemd/Test.ice
+++ b/csharp/test/Ice/namespacemd/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Namespace.ice>
 #include <NoNamespace.ice>

--- a/csharp/test/Ice/networkProxy/Test.ice
+++ b/csharp/test/Ice/networkProxy/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::NetworkProxy
 {

--- a/csharp/test/Ice/objects/Forward.ice
+++ b/csharp/test/Ice/objects/Forward.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Objects
 {

--- a/csharp/test/Ice/objects/Test.ice
+++ b/csharp/test/Ice/objects/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Identity.ice>
 

--- a/csharp/test/Ice/operations/Test.ice
+++ b/csharp/test/Ice/operations/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Ice/Context.ice>
 

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Optional
 {

--- a/csharp/test/Ice/perf/Test.ice
+++ b/csharp/test/Ice/perf/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Perf
 {

--- a/csharp/test/Ice/protocolBridging/Test.ice
+++ b/csharp/test/Ice/protocolBridging/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::ProtocolBridging
 {

--- a/csharp/test/Ice/proxy/Test.ice
+++ b/csharp/test/Ice/proxy/Test.ice
@@ -7,7 +7,7 @@
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Context.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Proxy
 {

--- a/csharp/test/Ice/retry/Test.ice
+++ b/csharp/test/Ice/retry/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Retry
 {

--- a/csharp/test/Ice/scope/Test.ice
+++ b/csharp/test/Ice/scope/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Scope
 {

--- a/csharp/test/Ice/seqMapping/Test.ice
+++ b/csharp/test/Ice/seqMapping/Test.ice
@@ -5,77 +5,77 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::SeqMapping
 {
 
 sequence<byte> AByteS;
-[cs:generic:List] sequence<byte> LByteS;
-[cs:generic:LinkedList] sequence<byte> KByteS;
-[cs:generic:Queue] sequence<byte> QByteS;
-[cs:generic:Stack] sequence<byte> SByteS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<byte> CByteS;
+[cs:generic(List)] sequence<byte> LByteS;
+[cs:generic(LinkedList)] sequence<byte> KByteS;
+[cs:generic(Queue)] sequence<byte> QByteS;
+[cs:generic(Stack)] sequence<byte> SByteS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<byte> CByteS;
 
 sequence<bool> ABoolS;
-[cs:generic:List] sequence<bool> LBoolS;
-[cs:generic:LinkedList] sequence<bool> KBoolS;
-[cs:generic:Queue] sequence<bool> QBoolS;
-[cs:generic:Stack] sequence<bool> SBoolS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<bool> CBoolS;
+[cs:generic(List)] sequence<bool> LBoolS;
+[cs:generic(LinkedList)] sequence<bool> KBoolS;
+[cs:generic(Queue)] sequence<bool> QBoolS;
+[cs:generic(Stack)] sequence<bool> SBoolS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<bool> CBoolS;
 
 sequence<short> AShortS;
-[cs:generic:List] sequence<short> LShortS;
-[cs:generic:LinkedList] sequence<short> KShortS;
-[cs:generic:Queue] sequence<short> QShortS;
-[cs:generic:Stack] sequence<short> SShortS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<short> CShortS;
+[cs:generic(List)] sequence<short> LShortS;
+[cs:generic(LinkedList)] sequence<short> KShortS;
+[cs:generic(Queue)] sequence<short> QShortS;
+[cs:generic(Stack)] sequence<short> SShortS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<short> CShortS;
 
 sequence<int> AIntS;
-[cs:generic:List] sequence<int> LIntS;
-[cs:generic:LinkedList] sequence<int> KIntS;
-[cs:generic:Queue] sequence<int> QIntS;
-[cs:generic:Stack] sequence<int> SIntS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<int> CIntS;
+[cs:generic(List)] sequence<int> LIntS;
+[cs:generic(LinkedList)] sequence<int> KIntS;
+[cs:generic(Queue)] sequence<int> QIntS;
+[cs:generic(Stack)] sequence<int> SIntS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<int> CIntS;
 
 sequence<long> ALongS;
-[cs:generic:List] sequence<long> LLongS;
-[cs:generic:LinkedList] sequence<long> KLongS;
-[cs:generic:Queue] sequence<long> QLongS;
-[cs:generic:Stack] sequence<long> SLongS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<long> CLongS;
+[cs:generic(List)] sequence<long> LLongS;
+[cs:generic(LinkedList)] sequence<long> KLongS;
+[cs:generic(Queue)] sequence<long> QLongS;
+[cs:generic(Stack)] sequence<long> SLongS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<long> CLongS;
 
 sequence<float> AFloatS;
-[cs:generic:List] sequence<float> LFloatS;
-[cs:generic:LinkedList] sequence<float> KFloatS;
-[cs:generic:Queue] sequence<float> QFloatS;
-[cs:generic:Stack] sequence<float> SFloatS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<float> CFloatS;
+[cs:generic(List)] sequence<float> LFloatS;
+[cs:generic(LinkedList)] sequence<float> KFloatS;
+[cs:generic(Queue)] sequence<float> QFloatS;
+[cs:generic(Stack)] sequence<float> SFloatS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<float> CFloatS;
 
 sequence<double> ADoubleS;
-[cs:generic:List] sequence<double> LDoubleS;
-[cs:generic:LinkedList] sequence<double> KDoubleS;
-[cs:generic:Queue] sequence<double> QDoubleS;
-[cs:generic:Stack] sequence<double> SDoubleS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<double> CDoubleS;
+[cs:generic(List)] sequence<double> LDoubleS;
+[cs:generic(LinkedList)] sequence<double> KDoubleS;
+[cs:generic(Queue)] sequence<double> QDoubleS;
+[cs:generic(Stack)] sequence<double> SDoubleS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<double> CDoubleS;
 
 sequence<string> AStringS;
-[cs:generic:List] sequence<string> LStringS;
-[cs:generic:LinkedList] sequence<string> KStringS;
-[cs:generic:Queue] sequence<string> QStringS;
-[cs:generic:Stack] sequence<string> SStringS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<string> CStringS;
+[cs:generic(List)] sequence<string> LStringS;
+[cs:generic(LinkedList)] sequence<string> KStringS;
+[cs:generic(Queue)] sequence<string> QStringS;
+[cs:generic(Stack)] sequence<string> SStringS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<string> CStringS;
 
 sequence<Object> AObjectS;
-[cs:generic:List] sequence<Object> LObjectS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<Object> CObjectS;
+[cs:generic(List)] sequence<Object> LObjectS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<Object> CObjectS;
 
 sequence<Object*> AObjectPrxS;
-[cs:generic:List] sequence<Object*> LObjectPrxS;
-[cs:generic:LinkedList] sequence<Object*> KObjectPrxS;
-[cs:generic:Queue] sequence<Object*> QObjectPrxS;
-[cs:generic:Stack] sequence<Object*> SObjectPrxS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<Object*> CObjectPrxS;
+[cs:generic(List)] sequence<Object*> LObjectPrxS;
+[cs:generic(LinkedList)] sequence<Object*> KObjectPrxS;
+[cs:generic(Queue)] sequence<Object*> QObjectPrxS;
+[cs:generic(Stack)] sequence<Object*> SObjectPrxS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<Object*> CObjectPrxS;
 
 struct S
 {
@@ -83,11 +83,11 @@ struct S
 }
 
 sequence<S> AStructS;
-[cs:generic:List] sequence<S> LStructS;
-[cs:generic:LinkedList] sequence<S> KStructS;
-[cs:generic:Queue] sequence<S> QStructS;
-[cs:generic:Stack] sequence<S> SStructS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<S> CStructS;
+[cs:generic(List)] sequence<S> LStructS;
+[cs:generic(LinkedList)] sequence<S> KStructS;
+[cs:generic(Queue)] sequence<S> QStructS;
+[cs:generic(Stack)] sequence<S> SStructS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<S> CStructS;
 
 struct SD
 {
@@ -95,11 +95,11 @@ struct SD
 }
 
 sequence<SD> AStructSD;
-[cs:generic:List] sequence<SD> LStructSD;
-[cs:generic:LinkedList] sequence<SD> KStructSD;
-[cs:generic:Queue] sequence<SD> QStructSD;
-[cs:generic:Stack] sequence<SD> SStructSD;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<SD> CStructSD;
+[cs:generic(List)] sequence<SD> LStructSD;
+[cs:generic(LinkedList)] sequence<SD> KStructSD;
+[cs:generic(Queue)] sequence<SD> QStructSD;
+[cs:generic(Stack)] sequence<SD> SStructSD;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<SD> CStructSD;
 
 class CV
 {
@@ -107,15 +107,15 @@ class CV
 }
 
 sequence<CV> ACVS;
-[cs:generic:List] sequence<CV> LCVS;
+[cs:generic(List)] sequence<CV> LCVS;
 
 interface I {}
 sequence<I*> AIPrxS;
-[cs:generic:List] sequence<I*> LIPrxS;
-[cs:generic:LinkedList] sequence<I*> KIPrxS;
-[cs:generic:Queue] sequence<I*> QIPrxS;
-[cs:generic:Stack] sequence<I*> SIPrxS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<I*> CIPrxS;
+[cs:generic(List)] sequence<I*> LIPrxS;
+[cs:generic(LinkedList)] sequence<I*> KIPrxS;
+[cs:generic(Queue)] sequence<I*> QIPrxS;
+[cs:generic(Stack)] sequence<I*> SIPrxS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<I*> CIPrxS;
 
 class CR
 {
@@ -123,23 +123,23 @@ class CR
 }
 
 sequence<CR> ACRS;
-[cs:generic:List] sequence<CR> LCRS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<CR> CCRS;
+[cs:generic(List)] sequence<CR> LCRS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<CR> CCRS;
 
 enum En { A, B, C }
 
 sequence<En> AEnS;
-[cs:generic:List] sequence<En> LEnS;
-[cs:generic:LinkedList] sequence<En> KEnS;
-[cs:generic:Queue] sequence<En> QEnS;
-[cs:generic:Stack] sequence<En> SEnS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<En> CEnS;
+[cs:generic(List)] sequence<En> LEnS;
+[cs:generic(LinkedList)] sequence<En> KEnS;
+[cs:generic(Queue)] sequence<En> QEnS;
+[cs:generic(Stack)] sequence<En> SEnS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<En> CEnS;
 
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<int> CustomIntS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<CV> CustomCVS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<int> CustomIntS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<CV> CustomCVS;
 
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<CustomIntS> CustomIntSS;
-[cs:generic:ZeroC.Ice.Test.SeqMapping.Custom] sequence<CustomCVS> CustomCVSS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<CustomIntS> CustomIntSS;
+[cs:generic(ZeroC.Ice.Test.SeqMapping.Custom)] sequence<CustomCVS> CustomCVSS;
 
 interface MyClass
 {

--- a/csharp/test/Ice/slicing/exceptions/ClientPrivate.ice
+++ b/csharp/test/Ice/slicing/exceptions/ClientPrivate.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Test.ice>
 

--- a/csharp/test/Ice/slicing/exceptions/ServerPrivate.ice
+++ b/csharp/test/Ice/slicing/exceptions/ServerPrivate.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Test.ice>
 

--- a/csharp/test/Ice/slicing/exceptions/Test.ice
+++ b/csharp/test/Ice/slicing/exceptions/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Slicing::Exceptions
 {
@@ -46,7 +46,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase();
@@ -58,7 +58,7 @@ interface Relay
     void clientPrivateException();
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase();
@@ -77,7 +77,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate();
     void unknownMostDerived2AsBase();
 
-    [format:compact] void unknownMostDerived2AsBaseCompact();
+    [format(compact)] void unknownMostDerived2AsBaseCompact();
 
     void knownPreservedAsBase();
     void knownPreservedAsKnownPreserved();

--- a/csharp/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/csharp/test/Ice/slicing/objects/ClientPrivate.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Test.ice>
 

--- a/csharp/test/Ice/slicing/objects/ServerPrivate.ice
+++ b/csharp/test/Ice/slicing/objects/ServerPrivate.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 #include <Test.ice>
 

--- a/csharp/test/Ice/slicing/objects/Test.ice
+++ b/csharp/test/Ice/slicing/objects/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Slicing::Objects
 {
@@ -99,7 +99,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -110,7 +110,7 @@ interface TestIntf
     SBase SBSUnknownDerivedAsSBase();
     void CUnknownAsSBase(SBase cUnknown);
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/csharp/test/Ice/tagged/Test.ice
+++ b/csharp/test/Ice/tagged/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[3.7]]
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Tagged
 {
@@ -55,20 +55,20 @@ sequence<varulong> VarULongSeq;
 
 sequence<IntSeq> IntSeqSeq;
 
-[cs:generic:List] sequence<byte> ByteList;
-[cs:generic:List] sequence<bool> BoolList;
-[cs:generic:List] sequence<short> ShortList;
-[cs:generic:List] sequence<int> IntList;
-[cs:generic:List] sequence<long> LongList;
-[cs:generic:List] sequence<float> FloatList;
-[cs:generic:List] sequence<double> DoubleList;
-[cs:generic:List] sequence<string> StringList;
-[cs:generic:List] sequence<varint> VarIntList;
+[cs:generic(List)] sequence<byte> ByteList;
+[cs:generic(List)] sequence<bool> BoolList;
+[cs:generic(List)] sequence<short> ShortList;
+[cs:generic(List)] sequence<int> IntList;
+[cs:generic(List)] sequence<long> LongList;
+[cs:generic(List)] sequence<float> FloatList;
+[cs:generic(List)] sequence<double> DoubleList;
+[cs:generic(List)] sequence<string> StringList;
+[cs:generic(List)] sequence<varint> VarIntList;
 
 sequence<SmallStruct> SmallStructSeq;
-[cs:generic:List] sequence<SmallStruct> SmallStructList;
+[cs:generic(List)] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[cs:generic:LinkedList] sequence<FixedStruct> FixedStructList;
+[cs:generic(LinkedList)] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 dictionary<int, int> IntIntDict;

--- a/csharp/test/Ice/threading/Test.ice
+++ b/csharp/test/Ice/threading/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Threading
 {
@@ -17,7 +17,7 @@ exception TestFailedException
 interface TestIntf
 {
     void pingSync();
-    ["amd"] void ping();
+    [amd] void ping();
     void concurrent(int level);
     void reset();
     void shutdown();

--- a/csharp/test/Ice/timeout/Test.ice
+++ b/csharp/test/Ice/timeout/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::Timeout
 {

--- a/csharp/test/Ice/udp/Test.ice
+++ b/csharp/test/Ice/udp/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Identity.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::Ice::Test::UDP
 {

--- a/csharp/test/IceBox/admin/Test.ice
+++ b/csharp/test/IceBox/admin/Test.ice
@@ -7,7 +7,7 @@
 
 #include <Ice/PropertiesAdmin.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::IceBox::Test::Admin
 {

--- a/csharp/test/IceBox/configuration/Test.ice
+++ b/csharp/test/IceBox/configuration/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::IceBox::Test::Configuration
 {

--- a/csharp/test/IceDiscovery/simple/Test.ice
+++ b/csharp/test/IceDiscovery/simple/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::IceDiscovery::Test::Simple
 {

--- a/csharp/test/IceGrid/simple/Test.ice
+++ b/csharp/test/IceGrid/simple/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::IceGrid::Test::Simple
 {

--- a/csharp/test/IceSSL/configuration/Test.ice
+++ b/csharp/test/IceSSL/configuration/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module ZeroC::IceSSL::Test::Configuration
 {

--- a/csharp/test/Slice/escape/Clash.ice
+++ b/csharp/test/Slice/escape/Clash.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 [[preserve-case]]
 

--- a/java/test/Ice/translator/DoubleModuleWithPackage.ice
+++ b/java/test/Ice/translator/DoubleModuleWithPackage.ice
@@ -4,7 +4,7 @@
 
 // dmwp = double module with package
 
-[[java:package:dmwp]]
+[[java:package(dmwp)]]
 
 module M1::M2
 {

--- a/java/test/Ice/translator/Metadata.ice
+++ b/java/test/Ice/translator/Metadata.ice
@@ -5,22 +5,22 @@
 module MetadataTest
 {
     sequence<int> IntSeq;
-    [java:type:java.util.LinkedList<Integer>] sequence<int> IntList;
-    ["java:type:java.util.LinkedList<int[]>"] sequence<IntSeq> IntSeqList;
+    [java:type(java.util.LinkedList<Integer>)] sequence<int> IntList;
+    ["java:type(java.util.LinkedList<int[]>)"] sequence<IntSeq> IntSeqList;
 
     sequence<Object> ObjectSeq;
-    [java:type:java.util.LinkedList<Ice.Object>] sequence<Object> ObjectList;
-    ["java:type:java.util.LinkedList<Ice.Object[]>"] sequence<ObjectSeq> ObjectSeqList;
+    [java:type(java.util.LinkedList<Ice.Object>)] sequence<Object> ObjectList;
+    ["java:type(java.util.LinkedList<Ice.Object[]>)"] sequence<ObjectSeq> ObjectSeqList;
 
     dictionary<string, string> StringDict;
-    [java:type:java.util.TreeMap<String, String>] dictionary<string, string> StringMap;
+    [java:type(java.util.TreeMap<String, String>)] dictionary<string, string> StringMap;
 
     dictionary<string, Object> ObjectDict;
-    [java:type:java.util.TreeMap<String, Ice.Object>] dictionary<string, Object> ObjectMap;
+    [java:type(java.util.TreeMap<String, Ice.Object>)] dictionary<string, Object> ObjectMap;
 
     sequence<StringDict> StringDictSeq;
     sequence<string> StringSeq;
-    [java:type:java.util.ArrayList<String>] sequence<string> StringList;
+    [java:type(java.util.ArrayList<String>)] sequence<string> StringList;
     sequence<StringList> StringListSeq;
     sequence<StringListSeq> StringListSeqSeq;
 
@@ -32,23 +32,23 @@ module MetadataTest
     {
         IntSeq intSeqMember;
         IntList intListMember;
-        [java:type:java.util.ArrayList<Integer>] IntSeq modifiedIntSeqMember;
-        [java:type:Test.CustomList<Integer>] IntList modifiedIntListMember;
+        [java:type(java.util.ArrayList<Integer>)] IntSeq modifiedIntSeqMember;
+        [java:type(Test.CustomList<Integer>)] IntList modifiedIntListMember;
 
         ObjectSeq objectSeqMember;
         ObjectList objectListMember;
-        [java:type:java.util.ArrayList<Ice.Object>] ObjectSeq modifiedObjectSeqMember;
-        [java:type:Test.CustomList<Ice.Object>] ObjectList modifiedObjectListMember;
+        [java:type(java.util.ArrayList<Ice.Object>)] ObjectSeq modifiedObjectSeqMember;
+        [java:type(Test.CustomList<Ice.Object>)] ObjectList modifiedObjectListMember;
 
         StringDict stringDictMember;
         StringMap stringMapMember;
-        [java:type:java.util.TreeMap<String, String>] StringDict modifiedStringDictMember;
-        [java:type:java.util.IdentityHashMap<String, String>] StringMap modifiedStringMapMember;
+        [java:type(java.util.TreeMap<String, String>)] StringDict modifiedStringDictMember;
+        [java:type(java.util.IdentityHashMap<String, String>)] StringMap modifiedStringMapMember;
 
         ObjectDict objectDictMember;
         ObjectMap objectMapMember;
-        [java:type:java.util.TreeMap<String, Ice.Object>] ObjectDict modifiedObjectDictMember;
-        [java:type:java.util.IdentityHashMap<String, Ice.Object>] ObjectMap modifiedObjectMapMember;
+        [java:type(java.util.TreeMap<String, Ice.Object>)] ObjectDict modifiedObjectDictMember;
+        [java:type(java.util.IdentityHashMap<String, Ice.Object>)] ObjectMap modifiedObjectMapMember;
 
         IntSeq opIntSeq(IntSeq inArg, out IntSeq outArg);
         IntList opIntList(IntList inArg, out IntList outArg);
@@ -68,52 +68,52 @@ module MetadataTest
         [amd] StringDict opStringDictAMD(StringDict inArg, out StringDict outArg);
         [amd] StringMap opStringMapAMD(StringMap inArg, out StringMap outArg);
 
-        [java:type:java.util.LinkedList<Integer>] IntSeq
-        opIntSeq2([java:type:java.util.ArrayList<Integer>] IntSeq inArg,
-                  out [java:type:Test.CustomList<Integer>] IntSeq outArg);
+        [java:type(java.util.LinkedList<Integer>)] IntSeq
+        opIntSeq2([java:type(java.util.ArrayList<Integer>)] IntSeq inArg,
+                  out [java:type(Test.CustomList<Integer>)] IntSeq outArg);
 
-        [java:type:java.util.ArrayList<Integer>] IntList
-        opIntList2([java:type:java.util.ArrayList<Integer>] IntList inArg,
-                   out [java:type:Test.CustomList<Integer>] IntList outArg);
+        [java:type(java.util.ArrayList<Integer>)] IntList
+        opIntList2([java:type(java.util.ArrayList<Integer>)] IntList inArg,
+                   out [java:type(Test.CustomList<Integer>)] IntList outArg);
 
-        [java:type:java.util.LinkedList<Ice.Object>] ObjectSeq
-        opObjectSeq2([java:type:java.util.ArrayList<Ice.Object>] ObjectSeq inArg,
-                     out [java:type:Test.CustomList<Ice.Object>] ObjectSeq outArg);
+        [java:type(java.util.LinkedList<Ice.Object>)] ObjectSeq
+        opObjectSeq2([java:type(java.util.ArrayList<Ice.Object>)] ObjectSeq inArg,
+                     out [java:type(Test.CustomList<Ice.Object>)] ObjectSeq outArg);
 
-        [java:type:java.util.ArrayList<Ice.Object>] ObjectList
-        opObjectList2([java:type:java.util.ArrayList<Ice.Object>] ObjectList inArg,
-                      out [java:type:Test.CustomList<Ice.Object>] ObjectList outArg);
+        [java:type(java.util.ArrayList<Ice.Object>)] ObjectList
+        opObjectList2([java:type(java.util.ArrayList<Ice.Object>)] ObjectList inArg,
+                      out [java:type(Test.CustomList<Ice.Object>)] ObjectList outArg);
 
-        [java:type:java.util.IdentityHashMap<String, String>] StringMap
-        opStringMap2([java:type:java.util.IdentityHashMap<String, String>] StringMap inArg,
-                     out [java:type:java.util.IdentityHashMap<String, String>] StringMap outArg);
+        [java:type(java.util.IdentityHashMap<String, String>)] StringMap
+        opStringMap2([java:type(java.util.IdentityHashMap<String, String>)] StringMap inArg,
+                     out [java:type(java.util.IdentityHashMap<String, String>)] StringMap outArg);
 
-        [amd] [java:type:java.util.LinkedList<Integer>] IntSeq
-        opIntSeq2AMD([java:type:java.util.ArrayList<Integer>] IntSeq inArg,
-                     out [java:type:Test.CustomList<Integer>] IntSeq outArg);
+        [amd] [java:type(java.util.LinkedList<Integer>)] IntSeq
+        opIntSeq2AMD([java:type:java.util.ArrayList<Integer>)] IntSeq inArg,
+                     out [java:type:Test.CustomList<Integer>)] IntSeq outArg);
 
-        [amd] [java:type:java.util.ArrayList<Integer>] IntList
-        opIntList2AMD([java:type:java.util.ArrayList<Integer>] IntList inArg,
-                      out [java:type:Test.CustomList<Integer>] IntList outArg);
+        [amd] [java:type(java.util.ArrayList<Integer>)] IntList
+        opIntList2AMD([java:type:java.util.ArrayList<Integer>)] IntList inArg,
+                      out [java:type:Test.CustomList<Integer>)] IntList outArg);
 
-        [amd] [java:type:java.util.LinkedList<Ice.Object>] ObjectSeq
-        opObjectSeq2AMD([java:type:java.util.ArrayList<Ice.Object>] ObjectSeq inArg,
-                     out [java:type:Test.CustomList<Ice.Object>] ObjectSeq outArg);
+        [amd] [java:type(java.util.LinkedList<Ice.Object>)] ObjectSeq
+        opObjectSeq2AMD([java:type:java.util.ArrayList<Ice.Object>)] ObjectSeq inArg,
+                     out [java:type:Test.CustomList<Ice.Object>)] ObjectSeq outArg);
 
-        [amd] [java:type:java.util.ArrayList<Ice.Object>] ObjectList
-        opObjectList2AMD([java:type:java.util.ArrayList<Ice.Object>] ObjectList inArg,
-                      out [java:type:Test.CustomList<Ice.Object>] ObjectList outArg);
+        [amd] [java:type(java.util.ArrayList<Ice.Object>)] ObjectList
+        opObjectList2AMD([java:type:java.util.ArrayList<Ice.Object>)] ObjectList inArg,
+                      out [java:type:Test.CustomList<Ice.Object>)] ObjectList outArg);
     }
 
     [protected] [java:getset] class C2
     {
         IntSeq intSeqMember;
-        [java:type:java.util.ArrayList<Integer>] IntSeq modifiedIntSeqMember;
+        [java:type(java.util.ArrayList<Integer>)] IntSeq modifiedIntSeqMember;
     }
 
     class C3
     {
         [protected] IntSeq intSeqMember;
-        [protected] [java:type:java.util.ArrayList<Integer>] IntSeq modifiedIntSeqMember;
+        [protected] [java:type(java.util.ArrayList<Integer>)] IntSeq modifiedIntSeqMember;
     }
 }

--- a/java/test/Ice/translator/SingleModuleWithPackage.ice
+++ b/java/test/Ice/translator/SingleModuleWithPackage.ice
@@ -4,7 +4,7 @@
 
 // smwp = single module with package
 
-[[java:package:smwp]]
+[[java:package(smwp)]]
 
 module M
 {

--- a/java/test/Ice/translator/TestDoubleModuleNoPackage7.ice
+++ b/java/test/Ice/translator/TestDoubleModuleNoPackage7.ice
@@ -6,7 +6,7 @@
 
 #include <DoubleModuleNoPackage.ice>
 
-[[java:package:dmnpTest7]]
+[[java:package(dmnpTest7)]]
 
 module M1::M2
 {

--- a/java/test/Ice/translator/TestDoubleModuleWithPackage10.ice
+++ b/java/test/Ice/translator/TestDoubleModuleWithPackage10.ice
@@ -6,7 +6,7 @@
 
 #include <DoubleModuleWithPackage.ice>
 
-[[java:package:dmwpTest10]]
+[[java:package(dmwpTest10)]]
 
 module M1::M2
 {

--- a/java/test/Ice/translator/TestDoubleModuleWithPackage11.ice
+++ b/java/test/Ice/translator/TestDoubleModuleWithPackage11.ice
@@ -6,7 +6,7 @@
 
 #include <DoubleModuleWithPackage.ice>
 
-[[java:package:dmwp]]
+[[java:package(dmwp)]]
 
 module M1::M2
 {

--- a/java/test/Ice/translator/TestDoubleModuleWithPackage6.ice
+++ b/java/test/Ice/translator/TestDoubleModuleWithPackage6.ice
@@ -6,7 +6,7 @@
 
 #include <DoubleModuleWithPackage.ice>
 
-[[java:package:dmwpTest6]]
+[[java:package(dmwpTest6)]]
 
 module M1
 {

--- a/java/test/Ice/translator/TestDoubleModuleWithPackage7.ice
+++ b/java/test/Ice/translator/TestDoubleModuleWithPackage7.ice
@@ -6,7 +6,7 @@
 
 #include <DoubleModuleWithPackage.ice>
 
-[[java:package:dmwp]]
+[[java:package(dmwp)]]
 
 module M1
 {

--- a/java/test/Ice/translator/TestSingleModuleWithPackage11.ice
+++ b/java/test/Ice/translator/TestSingleModuleWithPackage11.ice
@@ -6,7 +6,7 @@
 
 #include <SingleModuleWithPackage.ice>
 
-[[java:package:smwpTest11]]
+[[java:package(smwpTest11)]]
 
 module T1::T2
 {

--- a/java/test/Ice/translator/TestSingleModuleWithPackage12.ice
+++ b/java/test/Ice/translator/TestSingleModuleWithPackage12.ice
@@ -6,7 +6,7 @@
 
 #include <SingleModuleWithPackage.ice>
 
-[[java:package:smwp]]
+[[java:package(smwp)]]
 
 module T1::T2
 {

--- a/java/test/Ice/translator/TestSingleModuleWithPackage13.ice
+++ b/java/test/Ice/translator/TestSingleModuleWithPackage13.ice
@@ -6,7 +6,7 @@
 
 #include <SingleModuleWithPackage.ice>
 
-[[java:package:smwp]]
+[[java:package(smwp)]]
 
 module M::N
 {

--- a/java/test/Ice/translator/TestSingleModuleWithPackage6.ice
+++ b/java/test/Ice/translator/TestSingleModuleWithPackage6.ice
@@ -6,7 +6,7 @@
 
 #include <SingleModuleWithPackage.ice>
 
-[[java:package:smwpTest6]]
+[[java:package(smwpTest6)]]
 
 module T1
 {

--- a/java/test/Ice/translator/TestSingleModuleWithPackage7.ice
+++ b/java/test/Ice/translator/TestSingleModuleWithPackage7.ice
@@ -6,7 +6,7 @@
 
 #include <SingleModuleWithPackage.ice>
 
-[[java:package:smwp]]
+[[java:package(smwp)]]
 
 module T1
 {

--- a/java/test/src/main/java/test/Glacier2/router/Callback.ice
+++ b/java/test/src/main/java/test/Glacier2/router/Callback.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Glacier2.router]]
+[[java:package(test.Glacier2.router)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Glacier2/sessionHelper/Callback.ice
+++ b/java/test/src/main/java/test/Glacier2/sessionHelper/Callback.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Glacier2.sessionHelper]]
+[[java:package(test.Glacier2.sessionHelper)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/acm/Test.ice
+++ b/java/test/src/main/java/test/Ice/acm/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.acm]]
+[[java:package(test.Ice.acm)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.adapterDeactivation]]
+[[java:package(test.Ice.adapterDeactivation)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/admin/Test.ice
+++ b/java/test/src/main/java/test/Ice/admin/Test.ice
@@ -7,7 +7,7 @@
 
 #include <Ice/PropertiesAdmin.ice>
 
-[[java:package:test.Ice.admin]]
+[[java:package(test.Ice.admin)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/ami/Test.ice
+++ b/java/test/src/main/java/test/Ice/ami/Test.ice
@@ -7,7 +7,7 @@
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 
-[[java:package:test.Ice.ami]]
+[[java:package(test.Ice.ami)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/background/Test.ice
+++ b/java/test/src/main/java/test/Ice/background/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.background]]
+[[java:package(test.Ice.background)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/binding/Test.ice
+++ b/java/test/src/main/java/test/Ice/binding/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.binding]]
+[[java:package(test.Ice.binding)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/classLoader/Test.ice
+++ b/java/test/src/main/java/test/Ice/classLoader/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.classLoader]]
+[[java:package(test.Ice.classLoader)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/custom/Test.ice
+++ b/java/test/src/main/java/test/Ice/custom/Test.ice
@@ -6,24 +6,24 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.custom]]
+[[java:package(test.Ice.custom)]]
 module Test
 {
 
 class C {}
 
 sequence<C> CSeq;
-[java:type:java.util.ArrayList<C>] sequence<C> CArray;
-[java:type:java.util.LinkedList<C>] sequence<C> CList;
+[java:type(java.util.ArrayList<C>)] sequence<C> CArray;
+[java:type(java.util.LinkedList<C>)] sequence<C> CList;
 
-[java:type:java.util.ArrayList<Boolean>] sequence<bool> BoolSeq;
-[java:type:java.util.ArrayList<Byte>] sequence<byte> ByteSeq;
-[java:type:java.util.ArrayList<Short>] sequence<short> ShortSeq;
-[java:type:java.util.ArrayList<Integer>] sequence<int> IntSeq;
-[java:type:java.util.ArrayList<Long>] sequence<long> LongSeq;
-[java:type:java.util.ArrayList<Float>] sequence<float> FloatSeq;
-[java:type:java.util.ArrayList<Double>] sequence<double> DoubleSeq;
-[java:type:java.util.ArrayList<String>] sequence<string> StringSeq;
+[java:type(java.util.ArrayList<Boolean>)] sequence<bool> BoolSeq;
+[java:type(java.util.ArrayList<Byte>)] sequence<byte> ByteSeq;
+[java:type(java.util.ArrayList<Short>)] sequence<short> ShortSeq;
+[java:type(java.util.ArrayList<Integer>)] sequence<int> IntSeq;
+[java:type(java.util.ArrayList<Long>)] sequence<long> LongSeq;
+[java:type(java.util.ArrayList<Float>)] sequence<float> FloatSeq;
+[java:type(java.util.ArrayList<Double>)] sequence<double> DoubleSeq;
+[java:type(java.util.ArrayList<String>)] sequence<string> StringSeq;
 
 [java:buffer] sequence<byte> ByteBuffer;
 [java:buffer] sequence<short> ShortBuffer;
@@ -33,18 +33,18 @@ sequence<C> CSeq;
 [java:buffer] sequence<double> DoubleBuffer;
 
 enum E { E1, E2, E3 }
-[java:type:java.util.ArrayList<E>] sequence<E> ESeq;
+[java:type(java.util.ArrayList<E>)] sequence<E> ESeq;
 
 struct S
 {
     E en;
 }
-[java:type:java.util.ArrayList<S>] sequence<S> SSeq;
+[java:type(java.util.ArrayList<S>)] sequence<S> SSeq;
 
 dictionary<int, string> D;
-[java:type:java.util.ArrayList<java.util.Map<Integer,String>>] sequence<D> DSeq;
+[java:type(java.util.ArrayList<java.util.Map<Integer,String>>)] sequence<D> DSeq;
 
-[java:type:java.util.LinkedList<java.util.List<String>>] sequence<StringSeq> StringSeqSeq;
+[java:type(java.util.LinkedList<java.util.List<String>>)] sequence<StringSeq> StringSeqSeq;
 
 interface TestIntf
 {

--- a/java/test/src/main/java/test/Ice/defaultServant/Test.ice
+++ b/java/test/src/main/java/test/Ice/defaultServant/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.defaultServant]]
+[[java:package(test.Ice.defaultServant)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/defaultValue/Test.ice
+++ b/java/test/src/main/java/test/Ice/defaultValue/Test.ice
@@ -4,9 +4,9 @@
 
 #pragma once
 
-[[java:package:test.Ice.defaultValue]]
+[[java:package(test.Ice.defaultValue)]]
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/java/test/src/main/java/test/Ice/dispatcher/Test.ice
+++ b/java/test/src/main/java/test/Ice/dispatcher/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.dispatcher]]
+[[java:package(test.Ice.dispatcher)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/echo/Test.ice
+++ b/java/test/src/main/java/test/Ice/echo/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.echo]]
+[[java:package(test.Ice.echo)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/enums/Test.ice
+++ b/java/test/src/main/java/test/Ice/enums/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.enums]]
+[[java:package(test.Ice.enums)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/exceptions/Test.ice
+++ b/java/test/src/main/java/test/Ice/exceptions/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.exceptions]]
+[[java:package(test.Ice.exceptions)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/exceptions/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/exceptions/TestAMD.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.exceptions.AMD]]
+[[java:package(test.Ice.exceptions.AMD)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/facets/Test.ice
+++ b/java/test/src/main/java/test/Ice/facets/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.facets]]
+[[java:package(test.Ice.facets)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/faultTolerance/Test.ice
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.faultTolerance]]
+[[java:package(test.Ice.faultTolerance)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/hash/Test.ice
+++ b/java/test/src/main/java/test/Ice/hash/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.hash]]
+[[java:package(test.Ice.hash)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/hold/Test.ice
+++ b/java/test/src/main/java/test/Ice/hold/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.hold]]
+[[java:package(test.Ice.hold)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/impl/Test.ice
+++ b/java/test/src/main/java/test/Ice/impl/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.impl]]
+[[java:package(test.Ice.impl)]]
 module Test
 {
 
@@ -69,13 +69,13 @@ dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
 dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
-[java:type:java.util.ArrayList<java.util.Map<Byte,Boolean>>] sequence<ByteBoolD> ByteBoolDS;
-[java:type:java.util.ArrayList<java.util.Map<Short,Integer>>] sequence<ShortIntD> ShortIntDS;
-[java:type:java.util.ArrayList<java.util.Map<Long,Float>>] sequence<LongFloatD> LongFloatDS;
-[java:type:java.util.ArrayList<java.util.Map<String,String>>] sequence<StringStringD> StringStringDS;
-[java:type:java.util.ArrayList<java.util.Map<String,MyEnum>>] sequence<StringMyEnumD> StringMyEnumDS;
-[java:type:java.util.ArrayList<java.util.Map<MyEnum,String>>] sequence<MyEnumStringD> MyEnumStringDS;
-[java:type:java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>] sequence<MyStructMyEnumD> MyStructMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<Byte,Boolean>>)] sequence<ByteBoolD> ByteBoolDS;
+[java:type(java.util.ArrayList<java.util.Map<Short,Integer>>)] sequence<ShortIntD> ShortIntDS;
+[java:type(java.util.ArrayList<java.util.Map<Long,Float>>)] sequence<LongFloatD> LongFloatDS;
+[java:type(java.util.ArrayList<java.util.Map<String,String>>)] sequence<StringStringD> StringStringDS;
+[java:type(java.util.ArrayList<java.util.Map<String,MyEnum>>)] sequence<StringMyEnumD> StringMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<MyEnum,String>>)] sequence<MyEnumStringD> MyEnumStringDS;
+[java:type(java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>)] sequence<MyStructMyEnumD> MyStructMyEnumDS;
 
 dictionary<byte, ByteS> ByteByteSD;
 dictionary<bool, BoolS> BoolBoolSD;

--- a/java/test/src/main/java/test/Ice/impl/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/impl/TestAMD.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.impl.AMD]]
+[[java:package(test.Ice.impl.AMD)]]
 module Test
 {
 
@@ -69,13 +69,13 @@ dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
 dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
-[java:type:java.util.ArrayList<java.util.Map<Byte,Boolean>>] sequence<ByteBoolD> ByteBoolDS;
-[java:type:java.util.ArrayList<java.util.Map<Short,Integer>>] sequence<ShortIntD> ShortIntDS;
-[java:type:java.util.ArrayList<java.util.Map<Long,Float>>] sequence<LongFloatD> LongFloatDS;
-[java:type:java.util.ArrayList<java.util.Map<String,String>>] sequence<StringStringD> StringStringDS;
-[java:type:java.util.ArrayList<java.util.Map<String,MyEnum>>] sequence<StringMyEnumD> StringMyEnumDS;
-[java:type:java.util.ArrayList<java.util.Map<MyEnum,String>>] sequence<MyEnumStringD> MyEnumStringDS;
-[java:type:java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>] sequence<MyStructMyEnumD> MyStructMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<Byte,Boolean>>)] sequence<ByteBoolD> ByteBoolDS;
+[java:type(java.util.ArrayList<java.util.Map<Short,Integer>>)] sequence<ShortIntD> ShortIntDS;
+[java:type(java.util.ArrayList<java.util.Map<Long,Float>>)] sequence<LongFloatD> LongFloatDS;
+[java:type(java.util.ArrayList<java.util.Map<String,String>>)] sequence<StringStringD> StringStringDS;
+[java:type(java.util.ArrayList<java.util.Map<String,MyEnum>>)] sequence<StringMyEnumD> StringMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<MyEnum,String>>)] sequence<MyEnumStringD> MyEnumStringDS;
+[java:type(java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>)] sequence<MyStructMyEnumD> MyStructMyEnumDS;
 
 dictionary<byte, ByteS> ByteByteSD;
 dictionary<bool, BoolS> BoolBoolSD;

--- a/java/test/src/main/java/test/Ice/info/Test.ice
+++ b/java/test/src/main/java/test/Ice/info/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.info]]
+[[java:package(test.Ice.info)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/inheritance/Test.ice
+++ b/java/test/src/main/java/test/Ice/inheritance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.inheritance]]
+[[java:package(test.Ice.inheritance)]]
 
 module Test
 {

--- a/java/test/src/main/java/test/Ice/interceptor/Test.ice
+++ b/java/test/src/main/java/test/Ice/interceptor/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.interceptor]]
+[[java:package(test.Ice.interceptor)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/interrupt/Test.ice
+++ b/java/test/src/main/java/test/Ice/interrupt/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.interrupt]]
+[[java:package(test.Ice.interrupt)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/invoke/Test.ice
+++ b/java/test/src/main/java/test/Ice/invoke/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.invoke]]
+[[java:package(test.Ice.invoke)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/location/Test.ice
+++ b/java/test/src/main/java/test/Ice/location/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Locator.ice>
 
-[[java:package:test.Ice.location]]
+[[java:package(test.Ice.location)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/metrics/Test.ice
+++ b/java/test/src/main/java/test/Ice/metrics/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.metrics]]
+[[java:package(test.Ice.metrics)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/metrics/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/metrics/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.metrics.AMD]]
+[[java:package(test.Ice.metrics.AMD)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/networkProxy/Test.ice
+++ b/java/test/src/main/java/test/Ice/networkProxy/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.networkProxy]]
+[[java:package(test.Ice.networkProxy)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/objects/Forward.ice
+++ b/java/test/src/main/java/test/Ice/objects/Forward.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.objects]]
+[[java:package(test.Ice.objects)]]
 
 module Test
 {

--- a/java/test/src/main/java/test/Ice/objects/Test.ice
+++ b/java/test/src/main/java/test/Ice/objects/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.objects]]
+[[java:package(test.Ice.objects)]]
 
 module Test
 {

--- a/java/test/src/main/java/test/Ice/operations/Test.ice
+++ b/java/test/src/main/java/test/Ice/operations/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.operations]]
+[[java:package(test.Ice.operations)]]
 
 module Test
 {
@@ -70,13 +70,13 @@ dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
 dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
-[java:type:java.util.ArrayList<java.util.Map<Byte,Boolean>>] sequence<ByteBoolD> ByteBoolDS;
-[java:type:java.util.ArrayList<java.util.Map<Short,Integer>>] sequence<ShortIntD> ShortIntDS;
-[java:type:java.util.ArrayList<java.util.Map<Long,Float>>] sequence<LongFloatD> LongFloatDS;
-[java:type:java.util.ArrayList<java.util.Map<String,String>>] sequence<StringStringD> StringStringDS;
-[java:type:java.util.ArrayList<java.util.Map<String,MyEnum>>] sequence<StringMyEnumD> StringMyEnumDS;
-[java:type:java.util.ArrayList<java.util.Map<MyEnum,String>>] sequence<MyEnumStringD> MyEnumStringDS;
-[java:type:java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>] sequence<MyStructMyEnumD> MyStructMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<Byte,Boolean>>)] sequence<ByteBoolD> ByteBoolDS;
+[java:type(java.util.ArrayList<java.util.Map<Short,Integer>>)] sequence<ShortIntD> ShortIntDS;
+[java:type(java.util.ArrayList<java.util.Map<Long,Float>>)] sequence<LongFloatD> LongFloatDS;
+[java:type(java.util.ArrayList<java.util.Map<String,String>>)] sequence<StringStringD> StringStringDS;
+[java:type(java.util.ArrayList<java.util.Map<String,MyEnum>>)] sequence<StringMyEnumD> StringMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<MyEnum,String>>)] sequence<MyEnumStringD> MyEnumStringDS;
+[java:type(java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>)] sequence<MyStructMyEnumD> MyStructMyEnumDS;
 
 dictionary<byte, ByteS> ByteByteSD;
 dictionary<bool, BoolS> BoolBoolSD;

--- a/java/test/src/main/java/test/Ice/operations/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/operations/TestAMD.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.operations.AMD]]
+[[java:package(test.Ice.operations.AMD)]]
 
 module Test
 {
@@ -70,13 +70,13 @@ dictionary<string, MyEnum> StringMyEnumD;
 dictionary<MyEnum, string> MyEnumStringD;
 dictionary<MyStruct, MyEnum> MyStructMyEnumD;
 
-[java:type:java.util.ArrayList<java.util.Map<Byte,Boolean>>] sequence<ByteBoolD> ByteBoolDS;
-[java:type:java.util.ArrayList<java.util.Map<Short,Integer>>] sequence<ShortIntD> ShortIntDS;
-[java:type:java.util.ArrayList<java.util.Map<Long,Float>>] sequence<LongFloatD> LongFloatDS;
-[java:type:java.util.ArrayList<java.util.Map<String,String>>] sequence<StringStringD> StringStringDS;
-[java:type:java.util.ArrayList<java.util.Map<String,MyEnum>>] sequence<StringMyEnumD> StringMyEnumDS;
-[java:type:java.util.ArrayList<java.util.Map<MyEnum,String>>] sequence<MyEnumStringD> MyEnumStringDS;
-[java:type:java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>] sequence<MyStructMyEnumD> MyStructMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<Byte,Boolean>>)] sequence<ByteBoolD> ByteBoolDS;
+[java:type(java.util.ArrayList<java.util.Map<Short,Integer>>)] sequence<ShortIntD> ShortIntDS;
+[java:type(java.util.ArrayList<java.util.Map<Long,Float>>)] sequence<LongFloatD> LongFloatDS;
+[java:type(java.util.ArrayList<java.util.Map<String,String>>)] sequence<StringStringD> StringStringDS;
+[java:type(java.util.ArrayList<java.util.Map<String,MyEnum>>)] sequence<StringMyEnumD> StringMyEnumDS;
+[java:type(java.util.ArrayList<java.util.Map<MyEnum,String>>)] sequence<MyEnumStringD> MyEnumStringDS;
+[java:type(java.util.ArrayList<java.util.Map<MyStruct,MyEnum>>)] sequence<MyStructMyEnumD> MyStructMyEnumDS;
 
 dictionary<byte, ByteS> ByteByteSD;
 dictionary<bool, BoolS> BoolBoolSD;

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.optional]]
+[[java:package(test.Ice.optional)]]
 
 module Test
 {
@@ -51,9 +51,9 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[java:type:java.util.ArrayList<SmallStruct>] sequence<SmallStruct> SmallStructList;
+[java:type(java.util.ArrayList<SmallStruct>)] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[java:type:java.util.ArrayList<FixedStruct>] sequence<FixedStruct> FixedStructList;
+[java:type(java.util.ArrayList<FixedStruct>)] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 [java:serializable:test.Ice.optional.SerializableClass] sequence<byte> Serializable;

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.optional.AMD]]
+[[java:package(test.Ice.optional.AMD)]]
 
 module Test
 {
@@ -51,9 +51,9 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[java:type:java.util.ArrayList<SmallStruct>] sequence<SmallStruct> SmallStructList;
+[java:type(java.util.ArrayList<SmallStruct>)] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[java:type:java.util.ArrayList<FixedStruct>] sequence<FixedStruct> FixedStructList;
+[java:type(java.util.ArrayList<FixedStruct>)] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 [java:serializable:test.Ice.optional.SerializableClass] sequence<byte> Serializable;

--- a/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.packagemd]]
+[[java:package(test.Ice.packagemd)]]
 module Test1
 {
 class C1

--- a/java/test/src/main/java/test/Ice/packagemd/Package.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/Package.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.packagemd.testpkg]]
+[[java:package(test.Ice.packagemd.testpkg)]]
 
 module Test2
 {
@@ -29,7 +29,7 @@ exception E2 : E1
 }
 }
 
-[java:package:test.Ice.packagemd.modpkg]
+[java:package(test.Ice.packagemd.modpkg)]
 module Test3
 {
 class C1

--- a/java/test/src/main/java/test/Ice/packagemd/Test.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/Test.ice
@@ -7,7 +7,7 @@
 #include <Package.ice>
 #include <NoPackage.ice>
 
-[[java:package:test.Ice.packagemd]]
+[[java:package(test.Ice.packagemd)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/proxy/Test.ice
+++ b/java/test/src/main/java/test/Ice/proxy/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[java:package:test.Ice.proxy]]
+[[java:package(test.Ice.proxy)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/proxy/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/proxy/TestAMD.ice
@@ -6,7 +6,7 @@
 
 #include<Ice/Context.ice>
 
-[[java:package:test.Ice.proxy.AMD]]
+[[java:package(test.Ice.proxy.AMD)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/retry/Test.ice
+++ b/java/test/src/main/java/test/Ice/retry/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.retry]]
+[[java:package(test.Ice.retry)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/scope/Test.ice
+++ b/java/test/src/main/java/test/Ice/scope/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.scope]]
+[[java:package(test.Ice.scope)]]
 module Test
 {
     struct S

--- a/java/test/src/main/java/test/Ice/seqMapping/Test.ice
+++ b/java/test/src/main/java/test/Ice/seqMapping/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.seqMapping]]
+[[java:package(test.Ice.seqMapping)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/seqMapping/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/seqMapping/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.seqMapping.AMD]]
+[[java:package(test.Ice.seqMapping.AMD)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/serialize/Test.ice
+++ b/java/test/src/main/java/test/Ice/serialize/Test.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.serialize]]
+[[java:package(test.Ice.serialize)]]
 module Test
 {
 
@@ -20,7 +20,7 @@ enum MyEnum
 interface Initial;
 class Base;
 
-[java:serialVersionUID:1001]
+[java:serialVersionUID(1001)]
 struct Struct1
 {
     bool bo;
@@ -45,7 +45,7 @@ dictionary<short, int> ShortIntD;
 dictionary<string, MyEnum> StringMyEnumD;
 dictionary<string, Base> StringBaseD;
 
-[java:serialVersionUID:1002]
+[java:serialVersionUID(1002)]
 class Base
 {
     Base b;
@@ -61,13 +61,13 @@ class Base
     StringBaseD d4;
 }
 
-[java:serialVersionUID:1003]
+[java:serialVersionUID(1003)]
 class Derived : Base
 {
     Object* p;
 }
 
-[java:serialVersionUID:1004]
+[java:serialVersionUID(1004)]
 exception Ex
 {
     Struct1 s;

--- a/java/test/src/main/java/test/Ice/servantLocator/Test.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.servantLocator]]
+[[java:package(test.Ice.servantLocator)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.servantLocator.AMD]]
+[[java:package(test.Ice.servantLocator.AMD)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/ClientPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/ClientPrivate.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.slicing.exceptions.client]]
+[[java:package(test.Ice.slicing.exceptions.client)]]
 module Test
 {
 
@@ -50,7 +50,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -60,7 +60,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -79,7 +79,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivate.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.slicing.exceptions.server]]
+[[java:package(test.Ice.slicing.exceptions.server)]]
 module Test
 {
 
@@ -50,7 +50,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -60,7 +60,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -79,7 +79,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.slicing.exceptions.serverAMD]]
+[[java:package(test.Ice.slicing.exceptions.serverAMD)]]
 module Test
 {
 
@@ -50,7 +50,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -60,7 +60,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -79,7 +79,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/java/test/src/main/java/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ClientPrivate.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.slicing.objects.client]]
+[[java:package(test.Ice.slicing.objects.client)]]
 module Test
 {
 
@@ -105,7 +105,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -115,7 +115,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivate.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.slicing.objects.server]]
+[[java:package(test.Ice.slicing.objects.server)]]
 module Test
 {
 
@@ -105,7 +105,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -115,7 +115,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivateAMD.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivateAMD.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[java:package:test.Ice.slicing.objects.serverAMD]]
+[[java:package(test.Ice.slicing.objects.serverAMD)]]
 module Test
 {
 
@@ -100,7 +100,7 @@ exception PreservedException
 {
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -110,7 +110,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/java/test/src/main/java/test/Ice/stream/Test.ice
+++ b/java/test/src/main/java/test/Ice/stream/Test.ice
@@ -8,7 +8,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.Ice.stream]]
+[[java:package(test.Ice.stream)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/threadPoolPriority/Test.ice
+++ b/java/test/src/main/java/test/Ice/threadPoolPriority/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.threadPoolPriority]]
+[[java:package(test.Ice.threadPoolPriority)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/timeout/Test.ice
+++ b/java/test/src/main/java/test/Ice/timeout/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.timeout]]
+[[java:package(test.Ice.timeout)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Ice/udp/Test.ice
+++ b/java/test/src/main/java/test/Ice/udp/Test.ice
@@ -5,7 +5,7 @@
 #pragma once
 #include <Ice/Identity.ice>
 
-[[java:package:test.Ice.udp]]
+[[java:package(test.Ice.udp)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/IceBox/admin/Test.ice
+++ b/java/test/src/main/java/test/IceBox/admin/Test.ice
@@ -7,7 +7,7 @@
 
 #include <Ice/PropertiesAdmin.ice>
 
-[[java:package:test.IceBox.admin]]
+[[java:package(test.IceBox.admin)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/IceBox/configuration/Test.ice
+++ b/java/test/src/main/java/test/IceBox/configuration/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:test.IceBox.configuration]]
+[[java:package(test.IceBox.configuration)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/IceDiscovery/simple/Test.ice
+++ b/java/test/src/main/java/test/IceDiscovery/simple/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.IceDiscovery.simple]]
+[[java:package(test.IceDiscovery.simple)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/IceGrid/simple/Test.ice
+++ b/java/test/src/main/java/test/IceGrid/simple/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.IceGrid.simple]]
+[[java:package(test.IceGrid.simple)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/IceSSL/configuration/Test.ice
+++ b/java/test/src/main/java/test/IceSSL/configuration/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.IceSSL.configuration]]
+[[java:package(test.IceSSL.configuration)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Slice/escape/Clash.ice
+++ b/java/test/src/main/java/test/Slice/escape/Clash.ice
@@ -2,8 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
-[[java:package:test.Slice.escape]]
+[[suppress-warning(reserved-identifier)]]
+[[java:package(test.Slice.escape)]]
 
 module Clash
 {

--- a/java/test/src/main/java/test/Slice/escape/Key.ice
+++ b/java/test/src/main/java/test/Slice/escape/Key.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Slice.escape]]
+[[java:package(test.Slice.escape)]]
 
 module abstract
 {

--- a/java/test/src/main/java/test/Slice/generation/File1.ice
+++ b/java/test/src/main/java/test/Slice/generation/File1.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Slice.generation]]
+[[java:package(test.Slice.generation)]]
 
 module Test
 {
@@ -16,7 +16,7 @@ interface Interface1
 
 }
 
-[java:package:test.Slice.generation.modpkg]
+[java:package(test.Slice.generation.modpkg)]
 module Test2
 {
 

--- a/java/test/src/main/java/test/Slice/generation/File2.ice
+++ b/java/test/src/main/java/test/Slice/generation/File2.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Slice.generation]]
+[[java:package(test.Slice.generation)]]
 module Test
 {
 

--- a/java/test/src/main/java/test/Slice/macros/Test.ice
+++ b/java/test/src/main/java/test/Slice/macros/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Slice.macros]]
+[[java:package(test.Slice.macros)]]
 
 //
 // This macro sets the default value only when compiling with slice2java.

--- a/java/test/src/main/java/test/Slice/structure/Test.ice
+++ b/java/test/src/main/java/test/Slice/structure/Test.ice
@@ -4,12 +4,12 @@
 
 #pragma once
 
-[[java:package:test.Slice.structure]]
+[[java:package(test.Slice.structure)]]
 module Test
 {
 
 sequence<string> StringSeq;
-[java:type:java.util.ArrayList<Integer>] sequence<int> IntList;
+[java:type(java.util.ArrayList<Integer>)] sequence<int> IntList;
 dictionary<string, string> StringDict;
 
 class C

--- a/js/test/Ice/acm/Test.ice
+++ b/js/test/Ice/acm/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.acm]]
+[[java:package(test.Ice.acm)]]
 module Test
 {
 

--- a/js/test/Ice/defaultValue/Test.ice
+++ b/js/test/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/js/test/Ice/operations/Test.ice
+++ b/js/test/Ice/operations/Test.ice
@@ -38,7 +38,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 

--- a/js/test/Ice/servantLocator/Test.ice
+++ b/js/test/Ice/servantLocator/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[java:package:test.Ice.servantLocator]]
+[[java:package(test.Ice.servantLocator)]]
 module Test
 {
 

--- a/js/test/Ice/slicing/exceptions/Test.ice
+++ b/js/test/Ice/slicing/exceptions/Test.ice
@@ -44,7 +44,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -54,7 +54,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -73,7 +73,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/js/test/Ice/slicing/objects/Test.ice
+++ b/js/test/Ice/slicing/objects/Test.ice
@@ -104,7 +104,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -114,7 +114,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/js/test/Ice/stream/Test.ice
+++ b/js/test/Ice/stream/Test.ice
@@ -9,7 +9,7 @@
 //
 // Suppress invalid metadata warnings
 //
-[[suppress-warning:invalid-metadata]]
+[[suppress-warning(invalid-metadata)]]
 
 #include <Ice/BuiltinSequences.ice>
 

--- a/js/test/Slice/escape/Clash.ice
+++ b/js/test/Slice/escape/Clash.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module Clash
 {

--- a/js/test/typescript/Ice/defaultValue/Test.ice
+++ b/js/test/typescript/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 [[js:es6-module]]
 
 module Test

--- a/js/test/typescript/Ice/operations/Test.ice
+++ b/js/test/typescript/Ice/operations/Test.ice
@@ -40,7 +40,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 

--- a/js/test/typescript/Ice/slicing/exceptions/Test.ice
+++ b/js/test/typescript/Ice/slicing/exceptions/Test.ice
@@ -46,7 +46,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -56,7 +56,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -75,7 +75,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/js/test/typescript/Ice/slicing/objects/Test.ice
+++ b/js/test/typescript/Ice/slicing/objects/Test.ice
@@ -105,7 +105,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -115,7 +115,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/js/test/typescript/Ice/stream/Test.ice
+++ b/js/test/typescript/Ice/stream/Test.ice
@@ -7,7 +7,7 @@
 //
 // Suppress invalid metadata warnings
 //
-[[suppress-warning:invalid-metadata]]
+[[suppress-warning(invalid-metadata)]]
 [[js:es6-module]]
 [[3.7]]
 

--- a/matlab/test/Ice/defaultValue/Test.ice
+++ b/matlab/test/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/matlab/test/Ice/slicing/exceptions/ClientPrivate.ice
+++ b/matlab/test/Ice/slicing/exceptions/ClientPrivate.ice
@@ -49,7 +49,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -59,7 +59,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -78,7 +78,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/matlab/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/matlab/test/Ice/slicing/objects/ClientPrivate.ice
@@ -104,7 +104,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -114,7 +114,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/python/test/Ice/custom/Test.ice
+++ b/python/test/Ice/custom/Test.ice
@@ -7,54 +7,54 @@
 module Test
 {
     sequence<byte> ByteString; /* By default, sequence<byte> is received as a string. */
-    [python:seq:list] sequence<byte> ByteList;
+    [python:list] sequence<byte> ByteList;
 
     sequence<string> StringList; /* By default, a sequence is received as a list. */
-    [python:seq:tuple] sequence<string> StringTuple;
+    [python:tuple] sequence<string> StringTuple;
 
     [python:array.array] sequence<bool> BoolSeq1;
-    [python:memoryview:Custom.myBoolSeq] sequence<bool> BoolSeq2;
+    [python:memoryview(Custom.myBoolSeq)] sequence<bool> BoolSeq2;
 
     [python:array.array] sequence<byte> ByteSeq1;
-    [python:memoryview:Custom.myByteSeq] sequence<byte> ByteSeq2;
+    [python:memoryview(Custom.myByteSeq)] sequence<byte> ByteSeq2;
 
     [python:array.array] sequence<short> ShortSeq1;
-    [python:memoryview:Custom.myShortSeq] sequence<short> ShortSeq2;
+    [python:memoryview(Custom.myShortSeq)] sequence<short> ShortSeq2;
 
     [python:array.array] sequence<int> IntSeq1;
-    [python:memoryview:Custom.myIntSeq] sequence<int> IntSeq2;
+    [python:memoryview(Custom.myIntSeq)] sequence<int> IntSeq2;
 
     [python:array.array] sequence<long> LongSeq1;
-    [python:memoryview:Custom.myLongSeq] sequence<long> LongSeq2;
+    [python:memoryview(Custom.myLongSeq)] sequence<long> LongSeq2;
 
     [python:array.array] sequence<float> FloatSeq1;
-    [python:memoryview:Custom.myFloatSeq] sequence<float> FloatSeq2;
+    [python:memoryview(Custom.myFloatSeq)] sequence<float> FloatSeq2;
 
     [python:array.array] sequence<double> DoubleSeq1;
-    [python:memoryview:Custom.myDoubleSeq] sequence<double> DoubleSeq2;
+    [python:memoryview(Custom.myDoubleSeq)] sequence<double> DoubleSeq2;
 
     struct S
     {
         ByteString b1;
-        [python:seq:list] ByteString b2;
-        [python:seq:default] ByteList b3;
+        [python:list] ByteString b2;
+        [python:default] ByteList b3;
         ByteList b4;
         StringList s1;
-        [python:seq:tuple] StringList s2;
+        [python:tuple] StringList s2;
         StringTuple s3;
-        [python:seq:default] StringTuple s4;
+        [python:default] StringTuple s4;
     }
 
     class C
     {
         ByteString b1;
-        [python:seq:list] ByteString b2;
-        [python:seq:default] ByteList b3;
+        [python:list] ByteString b2;
+        [python:default] ByteList b3;
         ByteList b4;
         StringList s1;
-        [python:seq:tuple] StringList s2;
+        [python:tuple] StringList s2;
         StringTuple s3;
-        [python:seq:default] StringTuple s4;
+        [python:default] StringTuple s4;
     }
 
     class D
@@ -71,20 +71,20 @@ module Test
     interface Custom
     {
         ByteString opByteString1(ByteString b1, out ByteString b2);
-        [python:seq:tuple] ByteString opByteString2([python:seq:list] ByteString b1,
-                                                      out [python:seq:list] ByteString b2);
+        [python:tuple] ByteString opByteString2([python:list] ByteString b1,
+                                                      out [python:list] ByteString b2);
 
         ByteList opByteList1(ByteList b1, out ByteList b2);
-        [python:seq:default] ByteList opByteList2([python:seq:tuple] ByteList b1,
-                                                    out [python:seq:tuple] ByteList b2);
+        [python:default] ByteList opByteList2([python:tuple] ByteList b1,
+                                                    out [python:tuple] ByteList b2);
 
         StringList opStringList1(StringList s1, out StringList s2);
-        [python:seq:tuple] StringList opStringList2([python:seq:tuple] StringList s1,
-                                                      out [python:seq:tuple] StringList s2);
+        [python:tuple] StringList opStringList2([python:tuple] StringList s1,
+                                                      out [python:tuple] StringList s2);
 
         StringTuple opStringTuple1(StringTuple s1, out StringTuple s2);
-        [python:seq:list] StringTuple opStringTuple2([python:seq:list] StringTuple s1,
-                                                        out [python:seq:default] StringTuple s2);
+        [python:list] StringTuple opStringTuple2([python:list] StringTuple s1,
+                                                        out [python:default] StringTuple s2);
 
         void sendS(S val);
         void sendC(C val);
@@ -97,12 +97,12 @@ module Test
         FloatSeq1 opFloatSeq(FloatSeq1 v1, out FloatSeq2 v2);
         DoubleSeq1 opDoubleSeq(DoubleSeq1 v1, out DoubleSeq2 v2);
 
-        [python:memoryview:Custom.myBogusArrayNotExistsFactory] BoolSeq1 opBogusArrayNotExistsFactory();
-        [python:memoryview:Custom.myBogusArrayThrowFactory] BoolSeq1 opBogusArrayThrowFactory();
-        [python:memoryview:Custom.myBogusArrayType] BoolSeq1 opBogusArrayType();
-        [python:memoryview:Custom.myBogusArrayNoneFactory] BoolSeq1 opBogusArrayNoneFactory();
-        [python:memoryview:Custom.myBogusArraySignatureFactory] BoolSeq1 opBogusArraySignatureFactory();
-        [python:memoryview:Custom.myNoCallableFactory] BoolSeq1 opBogusArrayNoCallableFactory();
+        [python:memoryview(Custom.myBogusArrayNotExistsFactory)] BoolSeq1 opBogusArrayNotExistsFactory();
+        [python:memoryview(Custom.myBogusArrayThrowFactory)] BoolSeq1 opBogusArrayThrowFactory();
+        [python:memoryview(Custom.myBogusArrayType)] BoolSeq1 opBogusArrayType();
+        [python:memoryview(Custom.myBogusArrayNoneFactory)] BoolSeq1 opBogusArrayNoneFactory();
+        [python:memoryview(Custom.myBogusArraySignatureFactory)] BoolSeq1 opBogusArraySignatureFactory();
+        [python:memoryview(Custom.myNoCallableFactory)] BoolSeq1 opBogusArrayNoCallableFactory();
 
         D opD(D d);
 

--- a/python/test/Ice/custom/TestNumPy.ice
+++ b/python/test/Ice/custom/TestNumPy.ice
@@ -9,27 +9,27 @@ module Test
     module NumPy
     {
         [python:numpy.ndarray] sequence<bool> BoolSeq1;
-        [python:memoryview:Custom.myNumPyBoolSeq] sequence<bool> BoolSeq2;
+        [python:memoryview(Custom.myNumPyBoolSeq)] sequence<bool> BoolSeq2;
 
         [python:numpy.ndarray] sequence<byte> ByteSeq1;
-        [python:memoryview:Custom.myNumPyByteSeq] sequence<byte> ByteSeq2;
+        [python:memoryview(Custom.myNumPyByteSeq)] sequence<byte> ByteSeq2;
 
         [python:numpy.ndarray] sequence<short> ShortSeq1;
-        [python:memoryview:Custom.myNumPyShortSeq] sequence<short> ShortSeq2;
+        [python:memoryview(Custom.myNumPyShortSeq)] sequence<short> ShortSeq2;
 
         [python:numpy.ndarray] sequence<int> IntSeq1;
-        [python:memoryview:Custom.myNumPyIntSeq] sequence<int> IntSeq2;
+        [python:memoryview(Custom.myNumPyIntSeq)] sequence<int> IntSeq2;
 
         [python:numpy.ndarray] sequence<long> LongSeq1;
-        [python:memoryview:Custom.myNumPyLongSeq] sequence<long> LongSeq2;
+        [python:memoryview(Custom.myNumPyLongSeq)] sequence<long> LongSeq2;
 
         [python:numpy.ndarray] sequence<float> FloatSeq1;
-        [python:memoryview:Custom.myNumPyFloatSeq] sequence<float> FloatSeq2;
+        [python:memoryview(Custom.myNumPyFloatSeq)] sequence<float> FloatSeq2;
 
         [python:numpy.ndarray] sequence<double> DoubleSeq1;
-        [python:memoryview:Custom.myNumPyDoubleSeq] sequence<double> DoubleSeq2;
+        [python:memoryview(Custom.myNumPyDoubleSeq)] sequence<double> DoubleSeq2;
 
-        [python:memoryview:Custom.myNumPyComplex128Seq] sequence<byte> Complex128Seq;
+        [python:memoryview(Custom.myNumPyComplex128Seq)] sequence<byte> Complex128Seq;
 
         class D
         {
@@ -53,15 +53,15 @@ module Test
             DoubleSeq1 opDoubleSeq(DoubleSeq1 v1, out DoubleSeq2 v2);
             Complex128Seq opComplex128Seq(Complex128Seq v1);
 
-            [python:memoryview:Custom.myNumPyMatrix3x3] BoolSeq1 opBoolMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] ByteSeq1 opByteMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] ShortSeq1 opShortMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] IntSeq1 opIntMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] LongSeq1 opLongMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] FloatSeq1 opFloatMatrix();
-            [python:memoryview:Custom.myNumPyMatrix3x3] DoubleSeq1 opDoubleMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] BoolSeq1 opBoolMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] ByteSeq1 opByteMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] ShortSeq1 opShortMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] IntSeq1 opIntMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] LongSeq1 opLongMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] FloatSeq1 opFloatMatrix();
+            [python:memoryview(Custom.myNumPyMatrix3x3)] DoubleSeq1 opDoubleMatrix();
 
-            [python:memoryview:Custom.myBogusNumpyArrayType] BoolSeq1 opBogusNumpyArrayType();
+            [python:memoryview(Custom.myBogusNumpyArrayType)] BoolSeq1 opBogusNumpyArrayType();
 
             D opD(D d);
 

--- a/python/test/Ice/defaultValue/Test.ice
+++ b/python/test/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For enumerator references
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/python/test/Ice/inheritance/Test.ice
+++ b/python/test/Ice/inheritance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For classes with operations
+[[suppress-warning(deprecated)]] // For classes with operations
 
 module Test
 {

--- a/python/test/Ice/objects/Test.ice
+++ b/python/test/Ice/objects/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]] // For classes with operations
+[[suppress-warning(deprecated)]] // For classes with operations
 
 module Test
 {

--- a/python/test/Ice/operations/Test.ice
+++ b/python/test/Ice/operations/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/Context.ice>
 
-[[suppress-warning:deprecated]] // For classes with operations
+[[suppress-warning(deprecated)]] // For classes with operations
 
 module Test
 {

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[suppress-warning:deprecated]]
+[[suppress-warning(deprecated)]]
 
 module Test
 {
@@ -49,9 +49,9 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[python:seq:tuple] sequence<SmallStruct> SmallStructList;
+[python:tuple] sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[python:seq:tuple] sequence<FixedStruct> FixedStructList;
+[python:tuple] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
 sequence<byte> Serializable;

--- a/python/test/Ice/packagemd/Package.ice
+++ b/python/test/Ice/packagemd/Package.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[python:package:testpkg]]
+[[python:package(testpkg)]]
 module Test2
 {
 class C1
@@ -28,7 +28,7 @@ exception E2 extends E1
 }
 }
 
-[python:package:modpkg]
+[python:package(modpkg)]
 module Test3
 {
 class C1

--- a/python/test/Ice/slicing/exceptions/Test.ice
+++ b/python/test/Ice/slicing/exceptions/Test.ice
@@ -44,7 +44,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -54,7 +54,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -73,7 +73,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/python/test/Ice/slicing/objects/Test.ice
+++ b/python/test/Ice/slicing/objects/Test.ice
@@ -97,7 +97,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -107,7 +107,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/python/test/Slice/escape/Clash.ice
+++ b/python/test/Slice/escape/Clash.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module Clash
 {

--- a/python/test/Slice/escape/Key.ice
+++ b/python/test/Slice/escape/Key.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:deprecated]]
+[[suppress-warning(deprecated)]]
 
 module and
 {

--- a/python/test/Slice/structure/Test.ice
+++ b/python/test/Slice/structure/Test.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[cpp:include:list]]
+[[cpp:include(list)]]
 
 module Test
 {

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -4,22 +4,21 @@
 
 #pragma once
 
-[[cpp:dll-export:GLACIER2_API]]
-[[cpp:doxygen:include:Glacier2/Glacier2.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:Glacier2/Config.h]]
+[[cpp:dll-export(GLACIER2_API)]]
+[[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:include(Glacier2/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Glacier2]]
+[[python:pkgdir(Glacier2)]]
 
 #include <Ice/Metrics.ice>
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[cs:namespace:ZeroC]
-[swift:module:Glacier2:MX]
+[cs:namespace(ZeroC)]
+[swift:module(Glacier2:MX)]
 module IceMX
 {
     /// Provides information on Glacier2 sessions.

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -4,19 +4,18 @@
 
 #pragma once
 
-[[cpp:dll-export:GLACIER2_API]]
-[[cpp:doxygen:include:Glacier2/Glacier2.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:Glacier2/Config.h]]
+[[cpp:dll-export(GLACIER2_API)]]
+[[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:include(Glacier2/Config.h)]]
 
-[[js:module:ice]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Glacier2]]
+[[python:pkgdir(Glacier2)]]
 
 #include <Glacier2/SSLInfo.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Glacier2
 {
     /// This exception is raised if a client is denied the ability to create
@@ -47,7 +46,7 @@ module Glacier2
         /// @throws PermissionDeniedException Raised if the user access is
         /// denied. This can be raised in place of returning false with a
         /// reason set in the reason out parameter.
-        [nonmutating] [cpp:const] [format:sliced]
+        [nonmutating] [cpp:const] [format(sliced)]
         idempotent bool checkPermissions(string userId, string password, out string reason)
             throws PermissionDeniedException;
     }
@@ -71,7 +70,7 @@ module Glacier2
         /// reason set in the reason out parameter.
         ///
         /// @see SSLInfo
-        [nonmutating] [cpp:const] [format:sliced]
+        [nonmutating] [cpp:const] [format(sliced)]
         idempotent bool authorize(SSLInfo info, out string reason)
             throws PermissionDeniedException;
     }

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:GLACIER2_API]]
-[[cpp:doxygen:include:Glacier2/Glacier2.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:Glacier2/Config.h]]
+[[cpp:dll-export(GLACIER2_API)]]
+[[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:include(Glacier2/Config.h)]]
 
-[[js:module:ice]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Glacier2]]
+[[python:pkgdir(Glacier2)]]
 
 #include <Ice/Router.ice>
 #include <Glacier2/Session.ice>
 #include <Glacier2/PermissionsVerifier.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 /// Glacier2 is a firewall solution for Ice. Glacier2 authenticates
 /// and filters client requests and allows callbacks to the client in a
 /// secure fashion. In combination with IceSSL, Glacier2 provides a
@@ -74,7 +73,7 @@ module Glacier2
         ///
         /// @throws CannotCreateSessionException Raised if the session
         /// cannot be created.
-        [amd] [format:sliced] Session* createSession(string userId, string password)
+        [amd] [format(sliced)] Session* createSession(string userId, string password)
             throws PermissionDeniedException, CannotCreateSessionException;
 
         /// Create a per-client session with the router. The user is
@@ -102,7 +101,7 @@ module Glacier2
         ///
         /// @throws CannotCreateSessionException Raised if the session
         /// cannot be created.
-        [amd] [format:sliced] Session* createSessionFromSecureConnection()
+        [amd] [format(sliced)] Session* createSessionFromSecureConnection()
             throws PermissionDeniedException, CannotCreateSessionException;
 
         /// Keep the calling client's session with this router alive.

--- a/slice/Glacier2/SSLInfo.ice
+++ b/slice/Glacier2/SSLInfo.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/SSLInfo.ice
+++ b/slice/Glacier2/SSLInfo.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/SSLInfo.ice
+++ b/slice/Glacier2/SSLInfo.ice
@@ -4,18 +4,17 @@
 
 #pragma once
 
-[[cpp:dll-export:GLACIER2_API]]
-[[cpp:doxygen:include:Glacier2/Glacier2.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:Glacier2/Config.h]]
+[[cpp:dll-export(GLACIER2_API)]]
+[[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:include(Glacier2/Config.h)]]
 
-[[js:module:ice]]
-[[python:pkgdir:Glacier2]]
+[[js:module(ice)]]
+[[python:pkgdir(Glacier2)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Glacier2
 {
     /// Information taken from an SSL connection used for permissions

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(GLACIER2_API)]]
 [[cpp:doxygen:include(Glacier2/Glacier2.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(Glacier2/Config.h)]]
 
 [[js:module(ice)]]

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:GLACIER2_API]]
-[[cpp:doxygen:include:Glacier2/Glacier2.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:Glacier2/Config.h]]
+[[cpp:dll-export(GLACIER2_API)]]
+[[cpp:doxygen:include(Glacier2/Glacier2.h)]]
+[[cpp:include(Glacier2/Config.h)]]
 
-[[js:module:ice]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Glacier2]]
+[[python:pkgdir(Glacier2)]]
 
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 #include <Glacier2/SSLInfo.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Glacier2
 {
     /// This exception is raised if an attempt to create a new session failed.
@@ -145,7 +144,7 @@ module Glacier2
         ///
         /// @throws CannotCreateSessionException Raised if the session
         /// cannot be created.
-        [format:sliced]
+        [format(sliced)]
         Session* create(string userId, SessionControl* control)
             throws CannotCreateSessionException;
     }
@@ -170,7 +169,7 @@ module Glacier2
         ///
         /// @throws CannotCreateSessionException Raised if the session
         /// cannot be created.
-        [format:sliced]
+        [format(sliced)]
         Session* create(SSLInfo info, SessionControl* control)
             throws CannotCreateSessionException;
     }

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
-[[js:module:ice]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
 [[3.7]] // TODO, temporary
 
-[cs:namespace:ZeroC]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// A sequence of bools.

--- a/slice/Ice/Context.ice
+++ b/slice/Ice/Context.ice
@@ -4,6 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Context.ice
+++ b/slice/Ice/Context.ice
@@ -2,17 +2,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// A request context. Each operation has a <code>Context</code> as its implicit final parameter.

--- a/slice/Ice/Context.ice
+++ b/slice/Ice/Context.ice
@@ -4,7 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Encoding.ice
+++ b/slice/Ice/Encoding.ice
@@ -4,6 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Encoding.ice
+++ b/slice/Ice/Encoding.ice
@@ -2,17 +2,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module Ice
 {
     /// The Ice encoding defines how Slice constructs are marshaled to and later unmarshaled from sequences of bytes.

--- a/slice/Ice/Encoding.ice
+++ b/slice/Ice/Encoding.ice
@@ -4,7 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Endpoint.ice
+++ b/slice/Ice/Endpoint.ice
@@ -4,19 +4,18 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
-[[js:module:ice]]
-[[python:pkgdir:Ice]]
+[[js:module(ice)]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module Ice
 {
     /// Identifies a transport protocol that Ice can use to send requests and receive responses. The enumerators of

--- a/slice/Ice/Endpoint.ice
+++ b/slice/Ice/Endpoint.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 

--- a/slice/Ice/Endpoint.ice
+++ b/slice/Ice/Endpoint.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 

--- a/slice/Ice/Exceptions.ice
+++ b/slice/Ice/Exceptions.ice
@@ -4,20 +4,19 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
 #include <Ice/Identity.ice>
 
-[cs:namespace:ZeroC]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// Represents the origin of a remote exception. With the Ice 2.0 encoding, all remote exceptions have an implicit

--- a/slice/Ice/Exceptions.ice
+++ b/slice/Ice/Exceptions.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Exceptions.ice
+++ b/slice/Ice/Exceptions.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Ice1Definitions.ice
+++ b/slice/Ice/Ice1Definitions.ice
@@ -5,7 +5,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Ice1Definitions.ice
+++ b/slice/Ice/Ice1Definitions.ice
@@ -3,21 +3,20 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Context.ice>
 #include <Ice/Identity.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     // These definitions help with the encoding of ice1 frames.

--- a/slice/Ice/Ice1Definitions.ice
+++ b/slice/Ice/Ice1Definitions.ice
@@ -5,6 +5,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Ice2Definitions.ice
+++ b/slice/Ice/Ice2Definitions.ice
@@ -4,6 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Ice2Definitions.ice
+++ b/slice/Ice/Ice2Definitions.ice
@@ -2,20 +2,19 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     // These definitions help with the encoding of ice2 frames.

--- a/slice/Ice/Ice2Definitions.ice
+++ b/slice/Ice/Ice2Definitions.ice
@@ -4,7 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -4,17 +4,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// The identity of an Ice object.

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -5,7 +5,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -5,6 +5,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -3,22 +3,21 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Identity.ice>
 #include <Ice/Process.ice>
 #include <Ice/Protocol.ice>
 
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module Ice
 {
     /// This exception is thrown when a server tries to register endpoints for an object adapter that is already active.
@@ -61,7 +60,7 @@ module Ice
         /// not found.
         /// @throws ObjectNotFoundException Thrown if an object with identity `id' was not found. The caller should
         /// treat this exception like a null return value.
-        [deprecate:use resolveWellKnownProxy]
+        [deprecate(use resolveWellKnownProxy)]
         idempotent Object? findObjectById(Identity id);
 
         /// Finds an object adapter by id and returns a proxy that provides the object adapter's endpoint(s). Calling
@@ -71,7 +70,7 @@ module Ice
         /// not found.
         /// @throws AdapterNotFoundException Thrown if an object adapter with this adapter ID was not found. The caller
         /// should treat this exception like a null return value.
-        [deprecate:use resolveLocation]
+        [deprecate(use resolveLocation)]
         idempotent Object? findAdapterById(string id);
 
         /// Gets the locator registry.
@@ -135,7 +134,7 @@ module Ice
         /// @throws AdapterAlreadyActiveException Thrown if an object adapter with the same adapter ID has already
         /// registered its endpoints.
         // Note: idempotent is not quite correct, and kept only for backwards compatibility with old implementations.
-        [deprecate:use registerAdapterEndpoints or unregisterAdapterEndpoints]
+        [deprecate(use registerAdapterEndpoints or unregisterAdapterEndpoints)]
         idempotent void setAdapterDirectProxy(string id, Object? proxy);
 
         /// Registers or unregisters the endpoints of an object adapter that is a member of a replica group.  When proxy
@@ -152,7 +151,7 @@ module Ice
         /// @throws AdapterAlreadyActiveException Thrown if an object adapter with the same adapter ID has already
         /// @throws InvalidReplicaGroupIdException Thrown if the given replica group does not match the replica group
         /// associated with the adapter ID in the locator's database.
-        [deprecate:use registerAdapterEndpoints or unregisterAdapterEndpoints]
+        [deprecate(use registerAdapterEndpoints or unregisterAdapterEndpoints)]
         // Note: idempotent is not quite correct, and kept only for backwards compatibility with old implementations.
         idempotent void setReplicatedAdapterDirectProxy(string adapterId, string replicaGroupId, Object? proxy);
 

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[swift:module:Ice:MX]
-[cs:namespace:ZeroC]
+[swift:module(Ice:MX)]
+[cs:namespace(ZeroC)]
 /// The Ice Management eXtension facility. It provides the {@link IceMX#MetricsAdmin} interface for management clients
 /// to retrieve metrics from Ice applications.
 module IceMX
@@ -76,7 +75,7 @@ module IceMX
 
     /// The metrics administrative facet interface. This interface allows remote administrative clients to access
     /// metrics of an application that enabled the Ice administrative facility and configured some metrics views.
-    [format:sliced]
+    [format(sliced)]
     interface MetricsAdmin
     {
         /// Get the names of enabled and disabled metrics.

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -4,17 +4,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// An administrative interface for process management. Managed servers must

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -4,19 +4,18 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// A simple collection of properties, represented as a dictionary of key/value pairs. Both key and value are
@@ -36,7 +35,7 @@ module Ice
         /// properties are returned.
         /// @param prefix The prefix to search for (empty string if none).
         /// @return The matching property set.
-        [java:type:java.util.TreeMap<String, String>] PropertyDict getPropertiesForPrefix(string prefix);
+        [java:type(java.util.TreeMap<String, String>)] PropertyDict getPropertiesForPrefix(string prefix);
 
         /// Update the communicator's properties with the given property set.
         /// @param newProperties Properties to be added, changed, or removed. If an entry in <em>newProperties</em>

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Protocol.ice
+++ b/slice/Ice/Protocol.ice
@@ -4,6 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Protocol.ice
+++ b/slice/Ice/Protocol.ice
@@ -2,17 +2,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module Ice
 {
     /// Represents a version of the Ice protocol.

--- a/slice/Ice/Protocol.ice
+++ b/slice/Ice/Protocol.ice
@@ -4,7 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/ProxyEncoding.ice
+++ b/slice/Ice/ProxyEncoding.ice
@@ -8,7 +8,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/ProxyEncoding.ice
+++ b/slice/Ice/ProxyEncoding.ice
@@ -6,22 +6,21 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 #include <Ice/Encoding.ice>
 #include <Ice/Identity.ice>
 #include <Ice/Protocol.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
     // These definitions help with the encoding of proxies.

--- a/slice/Ice/ProxyEncoding.ice
+++ b/slice/Ice/ProxyEncoding.ice
@@ -8,6 +8,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -8,7 +8,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(list)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -6,19 +6,18 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:list]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:include(list)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[cs:namespace:ZeroC]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// An enumeration representing the different types of log messages.
@@ -59,7 +58,7 @@ module Ice
     }
 
     /// A sequence of {@link LogMessage}.
-    [cpp:type:std::list<LogMessage>]
+    [cpp:type(std::list<LogMessage>)]
     sequence<LogMessage> LogMessageSeq;
 
     /// The Ice remote logger interface. An application can implement a

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -8,6 +8,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(list)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Ice/Retryable.ice
+++ b/slice/Ice/Retryable.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(list)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Ice/Retryable.ice
+++ b/slice/Ice/Retryable.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(list)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/Ice/Retryable.ice
+++ b/slice/Ice/Retryable.ice
@@ -4,19 +4,18 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:list]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:include(list)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[cs:namespace:ZeroC]
+[cs:namespace(ZeroC)]
 module Ice
 {
 

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -4,20 +4,19 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[cs:namespace:ZeroC]
+[cs:namespace(ZeroC)]
 module Ice
 {
     /// The Ice router interface. Routers can be set either globally with

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/SlicDefinitions.ice
+++ b/slice/Ice/SlicDefinitions.ice
@@ -4,6 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/Ice/SlicDefinitions.ice
+++ b/slice/Ice/SlicDefinitions.ice
@@ -2,17 +2,16 @@
 
 #pragma once
 
-[[cpp:dll-export:ICE_API]]
-[[cpp:doxygen:include:Ice/Ice.h]]
-[[cpp:header-ext:h]]
+[[cpp:dll-export(ICE_API)]]
+[[cpp:doxygen:include(Ice/Ice.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:Ice]]
+[[python:pkgdir(Ice)]]
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module Ice
 {
 #ifdef __SLICE2CS__

--- a/slice/Ice/SlicDefinitions.ice
+++ b/slice/Ice/SlicDefinitions.ice
@@ -4,7 +4,7 @@
 
 [[cpp:dll-export(ICE_API)]]
 [[cpp:doxygen:include(Ice/Ice.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -4,20 +4,19 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEBOX_API]]
-[[cpp:doxygen:include:IceBox/IceBox.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceBox/Config.h]]
+[[cpp:dll-export(ICEBOX_API)]]
+[[cpp:doxygen:include(IceBox/IceBox.h)]]
+[[cpp:include(IceBox/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceBox]]
+[[python:pkgdir(IceBox)]]
 
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 /// IceBox is an application server for Ice applications. IceBox can load IceBox services packaged as DLLs, .NET
 /// assemblies, Java classes and similar.
 module IceBox

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEBOX_API)]]
 [[cpp:doxygen:include(IceBox/IceBox.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceBox/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEBOX_API)]]
 [[cpp:doxygen:include(IceBox/IceBox.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceBox/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -3,6 +3,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceDiscovery/IceDiscovery.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -2,13 +2,12 @@
 
 #pragma once
 
-[[cpp:doxygen:include:IceDiscovery/IceDiscovery.h]]
-[[cpp:header-ext:h]]
+[[cpp:doxygen:include(IceDiscovery/IceDiscovery.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceDiscovery]]
+[[python:pkgdir(IceDiscovery)]]
 
 #include <Ice/Identity.ice>
 #include <Ice/Protocol.ice>
@@ -16,8 +15,8 @@
 /// The IceDiscovery plug-in implements the {@see Ice::Locator} interface to locate (or discover) objects and object
 /// adapters using UDP multicast. It also implements the {@see Ice::LocatorDiscovery} interface to allow servers to
 /// respond to such multicast discovery requests.
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module IceDiscovery
 {
     /// The IceDiscovery.Reply object adapter of a client application hosts a LookupReply object that processes

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -3,7 +3,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceDiscovery/IceDiscovery.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -4,15 +4,14 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEGRID_API]]
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:dll-export(ICEGRID_API)]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 [[3.7]]
 
@@ -22,8 +21,8 @@
 #include <IceGrid/Exception.ice>
 #include <IceGrid/Descriptor.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// An enumeration representing the state of the server.
@@ -194,7 +193,7 @@ module IceGrid
     }
 
     /// A sequence of {@link ApplicationInfo} structures.
-    [java:type:java.util.LinkedList<ApplicationInfo>] sequence<ApplicationInfo> ApplicationInfoSeq;
+    [java:type(java.util.LinkedList<ApplicationInfo>)] sequence<ApplicationInfo> ApplicationInfoSeq;
 
     /// Information about updates to an IceGrid application.
     struct ApplicationUpdateInfo
@@ -851,7 +850,7 @@ module IceGrid
     }
 
     /// A sequence of server dynamic information structures.
-    [java:type:java.util.LinkedList<ServerDynamicInfo>] sequence<ServerDynamicInfo> ServerDynamicInfoSeq;
+    [java:type(java.util.LinkedList<ServerDynamicInfo>)] sequence<ServerDynamicInfo> ServerDynamicInfoSeq;
 
     /// Dynamic information about the state of an adapter.
     struct AdapterDynamicInfo
@@ -864,7 +863,7 @@ module IceGrid
     }
 
     /// A sequence of adapter dynamic information structures.
-    [java:type:java.util.LinkedList<AdapterDynamicInfo>] sequence<AdapterDynamicInfo> AdapterDynamicInfoSeq;
+    [java:type(java.util.LinkedList<AdapterDynamicInfo>)] sequence<AdapterDynamicInfo> AdapterDynamicInfoSeq;
 
     /// Dynamic information about the state of a node.
     struct NodeDynamicInfo

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -4,26 +4,25 @@
 
 #pragma once
 
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 [[3.7]]
 
 #ifndef ICE_BUILDING_ICEGRIDDB
-[[cpp:dll-export:ICEGRID_API]]
+[[cpp:dll-export(ICEGRID_API)]]
 #endif
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// A mapping of string to string.
@@ -40,7 +39,7 @@ module IceGrid
     }
 
     /// A sequence of property descriptors.
-    [java:type:java.util.LinkedList<PropertyDescriptor>] sequence<PropertyDescriptor> PropertyDescriptorSeq;
+    [java:type(java.util.LinkedList<PropertyDescriptor>)] sequence<PropertyDescriptor> PropertyDescriptorSeq;
 
     /// A property set descriptor.
     struct PropertySetDescriptor
@@ -71,7 +70,7 @@ module IceGrid
     }
 
     /// A sequence of object descriptors.
-    [java:type:java.util.LinkedList<ObjectDescriptor>] sequence<ObjectDescriptor> ObjectDescriptorSeq;
+    [java:type(java.util.LinkedList<ObjectDescriptor>)] sequence<ObjectDescriptor> ObjectDescriptorSeq;
 
     /// An Ice object adapter descriptor.
     struct AdapterDescriptor
@@ -110,7 +109,7 @@ module IceGrid
     }
 
     /// A sequence of adapter descriptors.
-    [java:type:java.util.LinkedList<AdapterDescriptor>] sequence<AdapterDescriptor> AdapterDescriptorSeq;
+    [java:type(java.util.LinkedList<AdapterDescriptor>)] sequence<AdapterDescriptor> AdapterDescriptorSeq;
 
     /// A communicator descriptor.
     class CommunicatorDescriptor
@@ -148,10 +147,10 @@ module IceGrid
         string pwd;
 
         /// The command line options to pass to the server executable.
-        [java:type:java.util.LinkedList<String>] Ice::StringSeq options;
+        [java:type(java.util.LinkedList<String>)] Ice::StringSeq options;
 
         /// The server environment variables.
-        [java:type:java.util.LinkedList<String>] Ice::StringSeq envs;
+        [java:type(java.util.LinkedList<String>)] Ice::StringSeq envs;
 
         /// The server activation mode (possible values are "on-demand" or
         /// "manual").
@@ -173,7 +172,7 @@ module IceGrid
     }
 
     /// A sequence of server descriptors.
-    [java:type:java.util.LinkedList<ServerDescriptor>] sequence<ServerDescriptor> ServerDescriptorSeq;
+    [java:type(java.util.LinkedList<ServerDescriptor>)] sequence<ServerDescriptor> ServerDescriptorSeq;
 
     /// An IceBox service descriptor.
     class ServiceDescriptor : CommunicatorDescriptor
@@ -186,7 +185,7 @@ module IceGrid
     }
 
     /// A sequence of service descriptors.
-    [java:type:java.util.LinkedList<ServiceDescriptor>] sequence<ServiceDescriptor> ServiceDescriptorSeq;
+    [java:type(java.util.LinkedList<ServiceDescriptor>)] sequence<ServiceDescriptor> ServiceDescriptorSeq;
 
     /// A server template instance descriptor.
     struct ServerInstanceDescriptor
@@ -206,7 +205,7 @@ module IceGrid
     }
 
     /// A sequence of server instance descriptors.
-    [java:type:java.util.LinkedList<ServerInstanceDescriptor>]
+    [java:type(java.util.LinkedList<ServerInstanceDescriptor>)]
     sequence<ServerInstanceDescriptor> ServerInstanceDescriptorSeq;
 
     /// A template descriptor for server or service templates.
@@ -216,7 +215,7 @@ module IceGrid
         CommunicatorDescriptor descriptor;
 
         /// The parameters required to instantiate the template.
-        [java:type:java.util.LinkedList<String>] Ice::StringSeq parameters;
+        [java:type(java.util.LinkedList<String>)] Ice::StringSeq parameters;
 
         /// The parameters default values.
         StringStringDict parameterDefaults;
@@ -243,7 +242,7 @@ module IceGrid
     }
 
     /// A sequence of service instance descriptors.
-    [java:type:java.util.LinkedList<ServiceInstanceDescriptor>]
+    [java:type(java.util.LinkedList<ServiceInstanceDescriptor>)]
     sequence<ServiceInstanceDescriptor> ServiceInstanceDescriptorSeq;
 
     /// An IceBox server descriptor.
@@ -257,7 +256,7 @@ module IceGrid
     struct NodeDescriptor
     {
         /// The variables defined for the node.
-        [java:type:java.util.TreeMap<String, String>] StringStringDict variables;
+        [java:type(java.util.TreeMap<String, String>)] StringStringDict variables;
 
         /// The server instances.
         ServerInstanceDescriptorSeq serverInstances;
@@ -334,7 +333,7 @@ module IceGrid
     }
 
     /// A sequence of replica groups.
-    [java:type:java.util.LinkedList<ReplicaGroupDescriptor>] sequence<ReplicaGroupDescriptor> ReplicaGroupDescriptorSeq;
+    [java:type(java.util.LinkedList<ReplicaGroupDescriptor>)] sequence<ReplicaGroupDescriptor> ReplicaGroupDescriptorSeq;
 
     /// An application descriptor.
     struct ApplicationDescriptor
@@ -343,7 +342,7 @@ module IceGrid
         string name;
 
         /// The variables defined in the application descriptor.
-        [java:type:java.util.TreeMap<String, String>] StringStringDict variables;
+        [java:type(java.util.TreeMap<String, String>)] StringStringDict variables;
 
         /// The replica groups.
         ReplicaGroupDescriptorSeq replicaGroups;
@@ -365,7 +364,7 @@ module IceGrid
     }
 
     /// A sequence of application descriptors.
-    [java:type:java.util.LinkedList<ApplicationDescriptor>] sequence<ApplicationDescriptor> ApplicationDescriptorSeq;
+    [java:type(java.util.LinkedList<ApplicationDescriptor>)] sequence<ApplicationDescriptor> ApplicationDescriptorSeq;
 
     /// A "boxed" string.
     class BoxedString
@@ -385,7 +384,7 @@ module IceGrid
         BoxedString description;
 
         /// The variables to update.
-        [java:type:java.util.TreeMap<String, String>] StringStringDict variables;
+        [java:type(java.util.TreeMap<String, String>)] StringStringDict variables;
 
         /// The variables to remove.
         Ice::StringSeq removeVariables;
@@ -411,7 +410,7 @@ module IceGrid
     }
 
     /// A sequence of node update descriptors.
-    [java:type:java.util.LinkedList<NodeUpdateDescriptor>] sequence<NodeUpdateDescriptor> NodeUpdateDescriptorSeq;
+    [java:type(java.util.LinkedList<NodeUpdateDescriptor>)] sequence<NodeUpdateDescriptor> NodeUpdateDescriptorSeq;
 
     /// An application update descriptor to describe the updates to apply
     /// to a deployed application.
@@ -425,7 +424,7 @@ module IceGrid
         BoxedString description;
 
         /// The variables to update.
-        [java:type:java.util.TreeMap<String, String>] StringStringDict variables;
+        [java:type(java.util.TreeMap<String, String>)] StringStringDict variables;
 
         /// The variables to remove.
         Ice::StringSeq removeVariables;

--- a/slice/IceGrid/Exception.ice
+++ b/slice/IceGrid/Exception.ice
@@ -5,7 +5,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Exception.ice
+++ b/slice/IceGrid/Exception.ice
@@ -4,24 +4,23 @@
 
 #pragma once
 
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 #ifndef ICE_BUILDING_ICEGRIDDB
-[[cpp:dll-export:ICEGRID_API]]
+[[cpp:dll-export(ICEGRID_API)]]
 #endif
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// This exception is raised if an application does not exist.

--- a/slice/IceGrid/Exception.ice
+++ b/slice/IceGrid/Exception.ice
@@ -5,6 +5,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -4,20 +4,19 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEGRID_API]]
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:dll-export(ICEGRID_API)]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 #include <IceGrid/Admin.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// This exception is raised if an error occurs during parsing.

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -4,28 +4,27 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEGRID_API]]
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:dll-export(ICEGRID_API)]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 #include <IceGrid/Exception.ice>
 #include <IceGrid/Session.ice>
 #include <IceGrid/Admin.ice>
 #include <Ice/Locator.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// Determines which load sampling interval to use.
-    [cs:attribute:System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1712:Do not prefix enum values with type name",
-     Justification = "Cannot rename for backwards compatibility")]
+    [cs:attribute(System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1712:Do not prefix enum values with type name",
+     Justification = "Cannot rename for backwards compatibility"))]
     enum LoadSample
     {
         /// Sample every minute.

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEGRID_API]]
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:dll-export(ICEGRID_API)]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
 #include <Glacier2/Session.ice>
 #include <IceGrid/Exception.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// A session object is used by IceGrid clients to allocate and

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/UserAccountMapper.ice
+++ b/slice/IceGrid/UserAccountMapper.ice
@@ -4,18 +4,17 @@
 
 #pragma once
 
-[[cpp:dll-export:ICEGRID_API]]
-[[cpp:doxygen:include:IceGrid/IceGrid.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceGrid/Config.h]]
+[[cpp:dll-export(ICEGRID_API)]]
+[[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:include(IceGrid/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceGrid]]
+[[python:pkgdir(IceGrid)]]
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 module IceGrid
 {
     /// This exception is raised if a user account for a given session

--- a/slice/IceGrid/UserAccountMapper.ice
+++ b/slice/IceGrid/UserAccountMapper.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceGrid/UserAccountMapper.ice
+++ b/slice/IceGrid/UserAccountMapper.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICEGRID_API)]]
 [[cpp:doxygen:include(IceGrid/IceGrid.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceGrid/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -3,6 +3,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceLocatorDiscovery/IceLocatorDiscovery.h)]]
+[[cpp:header-ext:h]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -3,7 +3,7 @@
 #pragma once
 
 [[cpp:doxygen:include(IceLocatorDiscovery/IceLocatorDiscovery.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 
 [[suppress-warning(reserved-identifier)]]
 [[js:module(ice)]]

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -2,13 +2,12 @@
 
 #pragma once
 
-[[cpp:doxygen:include:IceLocatorDiscovery/IceLocatorDiscovery.h]]
-[[cpp:header-ext:h]]
+[[cpp:doxygen:include(IceLocatorDiscovery/IceLocatorDiscovery.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceLocatorDiscovery]]
+[[python:pkgdir(IceLocatorDiscovery)]]
 
 #include <Ice/Locator.ice>
 
@@ -16,8 +15,8 @@
 /// UDP multicast.
 /// The IceDiscovery plug-in implements the {@see Ice::Locator} interface to locate (or discover) locators such as
 /// the IceGrid registry or custom IceGrid-like locator implementations using UDP multicast.
-[cs:namespace:ZeroC]
-[java:package:com.zeroc]
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
 module IceLocatorDiscovery
 {
     /// The IceLocatorDiscovery.Reply object adapter of a client application hosts a LookupReply object that processes

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -4,22 +4,21 @@
 
 #pragma once
 
-[[cpp:dll-export:ICESTORM_API]]
-[[cpp:doxygen:include:IceStorm/IceStorm.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceStorm/Config.h]]
+[[cpp:dll-export(ICESTORM_API)]]
+[[cpp:doxygen:include(IceStorm/IceStorm.h)]]
+[[cpp:include(IceStorm/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[js:module:ice]]
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
 
-[[python:pkgdir:IceStorm]]
+[[python:pkgdir(IceStorm)]]
 
 #include <Ice/Identity.ice>
 
 #include <IceStorm/Metrics.ice>
 
-[[java:package:com.zeroc]]
-[cs:namespace:ZeroC]
+[[java:package(com.zeroc)]]
+[cs:namespace(ZeroC)]
 /// A messaging service with support for federation. In contrast to
 /// most other messaging or event services, IceStorm supports typed
 /// events, meaning that broadcasting a message over a federation is as

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICESTORM_API)]]
 [[cpp:doxygen:include(IceStorm/IceStorm.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceStorm/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICESTORM_API)]]
 [[cpp:doxygen:include(IceStorm/IceStorm.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceStorm/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -4,21 +4,20 @@
 
 #pragma once
 
-[[cpp:dll-export:ICESTORM_API]]
-[[cpp:doxygen:include:IceStorm/IceStorm.h]]
-[[cpp:header-ext:h]]
-[[cpp:include:IceStorm/Config.h]]
+[[cpp:dll-export(ICESTORM_API)]]
+[[cpp:doxygen:include(IceStorm/IceStorm.h)]]
+[[cpp:include(IceStorm/Config.h)]]
 
-[[suppress-warning:reserved-identifier]]
-[[python:pkgdir:IceStorm]]
+[[suppress-warning(reserved-identifier)]]
+[[python:pkgdir(IceStorm)]]
 
 #include <Ice/Metrics.ice>
 
-[[java:package:com.zeroc]]
+[[java:package(com.zeroc)]]
 
-[js:module:ice]
-[swift:module:IceStorm:MX]
-[cs:namespace:ZeroC]
+[js:module(ice)]
+[swift:module(IceStorm:MX)]
+[cs:namespace(ZeroC)]
 module IceMX
 {
     /// Provides information on IceStorm topics.

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -6,7 +6,7 @@
 
 [[cpp:dll-export(ICESTORM_API)]]
 [[cpp:doxygen:include(IceStorm/IceStorm.h)]]
-[[cpp:header-ext:h]]
+[[cpp:header-ext(h)]]
 [[cpp:include(IceStorm/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -6,6 +6,7 @@
 
 [[cpp:dll-export(ICESTORM_API)]]
 [[cpp:doxygen:include(IceStorm/IceStorm.h)]]
+[[cpp:header-ext:h]]
 [[cpp:include(IceStorm/Config.h)]]
 
 [[suppress-warning(reserved-identifier)]]

--- a/swift/test/Ice/defaultValue/Test.ice
+++ b/swift/test/Ice/defaultValue/Test.ice
@@ -4,8 +4,8 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceDefaultValue]]
-[[suppress-warning:deprecated]] // For enumerator references
+[[swift:class-resolver-prefix(IceDefaultValue)]]
+[[suppress-warning(deprecated)]] // For enumerator references
 
 module Test
 {

--- a/swift/test/Ice/exceptions/Test.ice
+++ b/swift/test/Ice/exceptions/Test.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[swift:class-resolver-prefix:IceExceptions]]
+[[swift:class-resolver-prefix(IceExceptions)]]
 
 module Test
 {

--- a/swift/test/Ice/exceptions/TestAMD.ice
+++ b/swift/test/Ice/exceptions/TestAMD.ice
@@ -6,7 +6,7 @@
 
 #include <Ice/BuiltinSequences.ice>
 
-[[swift:class-resolver-prefix:IceExceptionsAMD]]
+[[swift:class-resolver-prefix(IceExceptionsAMD)]]
 
 module Test
 {

--- a/swift/test/Ice/inheritance/Test.ice
+++ b/swift/test/Ice/inheritance/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceInheritance]]
+[[swift:class-resolver-prefix(IceInheritance)]]
 
 module Test
 {

--- a/swift/test/Ice/invoke/Test.ice
+++ b/swift/test/Ice/invoke/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceInvoke]]
+[[swift:class-resolver-prefix(IceInvoke)]]
 
 module Test
 {

--- a/swift/test/Ice/location/Test.ice
+++ b/swift/test/Ice/location/Test.ice
@@ -1,6 +1,4 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
@@ -11,17 +9,13 @@ module Test
 
 interface TestLocatorRegistry : ::Ice::LocatorRegistry
 {
-    //
     // Allow remote addition of objects to the locator registry.
-    //
     void addObject(Object* obj);
 }
 
 interface TestLocator : ::Ice::Locator
 {
-    //
     // Returns the number of request on the locator interface.
-    //
     [cpp:const] idempotent int getRequestCount();
 }
 

--- a/swift/test/Ice/objects/Test.ice
+++ b/swift/test/Ice/objects/Test.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[swift:class-resolver-prefix:IceObjects]]
+[[swift:class-resolver-prefix(IceObjects)]]
 
 module Test
 {

--- a/swift/test/Ice/operations/Test.ice
+++ b/swift/test/Ice/operations/Test.ice
@@ -8,7 +8,7 @@
 
 #include <Ice/Context.ice>
 
-[[swift:class-resolver-prefix:IceOperations]]
+[[swift:class-resolver-prefix(IceOperations)]]
 
 module Test
 {
@@ -42,7 +42,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<[cpp:type:wstring] string> WStringS;
+sequence<[cpp:type(wstring)] string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -357,29 +357,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const [cpp:type:wstring] string ws0 = "\u005c";                           // backslash
-const [cpp:type:wstring] string ws1 = "\u0041";                           // A
-const [cpp:type:wstring] string ws2 = "\u0049\u0063\u0065";               // Ice
-const [cpp:type:wstring] string ws3 = "\u004121";                         // A21
-const [cpp:type:wstring] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const [cpp:type:wstring] string ws5 = "\u00FF";                           // ÿ
-const [cpp:type:wstring] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const [cpp:type:wstring] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string ws0 = "\u005c";                           // backslash
+const [cpp:type(wstring)] string ws1 = "\u0041";                           // A
+const [cpp:type(wstring)] string ws2 = "\u0049\u0063\u0065";               // Ice
+const [cpp:type(wstring)] string ws3 = "\u004121";                         // A21
+const [cpp:type(wstring)] string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const [cpp:type(wstring)] string ws5 = "\u00FF";                           // ÿ
+const [cpp:type(wstring)] string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const [cpp:type(wstring)] string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const [cpp:type:wstring] string wsw0 = "\U0000005c";                      // backslash
-const [cpp:type:wstring] string wsw1 = "\U00000041";                      // A
-const [cpp:type:wstring] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const [cpp:type:wstring] string wsw3 = "\U0000004121";                    // A21
-const [cpp:type:wstring] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const [cpp:type:wstring] string wsw5 = "\U000000FF";                      // ÿ
-const [cpp:type:wstring] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const [cpp:type:wstring] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const [cpp:type:wstring] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const [cpp:type:wstring] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const [cpp:type(wstring)] string wsw0 = "\U0000005c";                      // backslash
+const [cpp:type(wstring)] string wsw1 = "\U00000041";                      // A
+const [cpp:type(wstring)] string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const [cpp:type(wstring)] string wsw3 = "\U0000004121";                    // A21
+const [cpp:type(wstring)] string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const [cpp:type(wstring)] string wsw5 = "\U000000FF";                      // ÿ
+const [cpp:type(wstring)] string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const [cpp:type(wstring)] string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const [cpp:type(wstring)] string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const [cpp:type(wstring)] string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const [cpp:type(wstring)] string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -394,13 +394,13 @@ const [cpp:type:wstring] string wsw10 = "\U00000DA7";                     // Sin
 \t      horizontal tab  byte 0x09 in ASCII encoding
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
-const [cpp:type:wstring] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const [cpp:type:wstring] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const [cpp:type:wstring] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const [cpp:type(wstring)] string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const [cpp:type(wstring)] string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const [cpp:type(wstring)] string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const [cpp:type:wstring] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const [cpp:type:wstring] string wss4 = "\\\u0041\\"; /* \A\     */
-const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
+const [cpp:type(wstring)] string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const [cpp:type(wstring)] string wss4 = "\\\u0041\\"; /* \A\     */
+const [cpp:type(wstring)] string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -416,13 +416,13 @@ const [cpp:type:wstring] string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const [cpp:type:wstring] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const [cpp:type:wstring] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const [cpp:type:wstring] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const [cpp:type(wstring)] string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const [cpp:type(wstring)] string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }
 
-[swift:module:Test:Test2]
+[swift:module(Test:Test2)]
 module Test2
 {
 
@@ -442,7 +442,7 @@ interface MyDerivedClass : Test::MyClass
 // Test proxy inheritance for class with operations
 // see: https://github.com/zeroc-ice/ice/issues/406
 //
-[swift:module:Test:M]
+[swift:module(Test:M)]
 module M
 {
     class A

--- a/swift/test/Ice/operations/TestAMD.ice
+++ b/swift/test/Ice/operations/TestAMD.ice
@@ -8,7 +8,7 @@
 
 #include <Ice/Context.ice>
 
-[[swift:class-resolver-prefix:IceOperationsAMD]]
+[[swift:class-resolver-prefix(IceOperationsAMD)]]
 
 module Test
 {
@@ -354,7 +354,7 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Test proxy inheritance for class with operations
 // see: https://github.com/zeroc-ice/ice/issues/406
 //
-[swift:module:Test:M]
+[swift:module(Test:M)]
 module M
 {
     class A

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -182,9 +182,9 @@ interface Initial
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
 
-    [cpp:view-type:Util::string_view] optional(1) string
-    opCustomString([cpp:view-type:Util::string_view] optional(2) string p1,
-                   out [cpp:view-type:Util::string_view] optional(3) string p3);
+    [cpp:view-type(Util::string_view)] optional(1) string
+    opCustomString([cpp:view-type(Util::string_view)] optional(2) string p1,
+                   out [cpp:view-type(Util::string_view)] optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
@@ -240,10 +240,10 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(1) IntStringDict
+    [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(1) IntStringDict
     opCustomIntStringDict(
-        [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(2) IntStringDict p1,
-        out [cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>] [cpp:type:::Test::CustomMap< ::Ice::Int, std::string>] optional(3) IntStringDict p3);
+        [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(2) IntStringDict p1,
+        out [cpp:view-type(::std::map< ::Ice::Int, ::Util::string_view>)] [cpp:type(::Test::CustomMap< ::Ice::Int, std::string>)] optional(3) IntStringDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -1,12 +1,10 @@
-//
 // Copyright (c) ZeroC, Inc. All rights reserved.
-//
 
 #pragma once
 
 [[3.7]]
 
-[[swift:class-resolver-prefix:IceOptionalAMD]]
+[[swift:class-resolver-prefix(IceOptionalAMD)]]
 
 module Test
 {
@@ -36,7 +34,6 @@ struct VarStruct
     string m;
 }
 
-[clr:class]
 struct ClassVarStruct
 {
     int a;
@@ -52,12 +49,11 @@ sequence<double> DoubleSeq;
 sequence<string> StringSeq;
 sequence<MyEnum> MyEnumSeq;
 sequence<SmallStruct> SmallStructSeq;
-[clr:generic:List] sequence<SmallStruct> SmallStructList;
+sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
-[clr:generic:LinkedList] sequence<FixedStruct> FixedStructList;
+sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
 
-[clr:serializable:Ice.optional.Test.SerializableClass]
 sequence<byte> Serializable;
 
 dictionary<int, int> IntIntDict;
@@ -146,7 +142,6 @@ exception RequiredException : OptionalException
     VarStruct vs2;
 }
 
-[clr:property]
 class OptionalWithCustom
 {
     optional(1) SmallStructList l;

--- a/swift/test/Ice/scope/Test.ice
+++ b/swift/test/Ice/scope/Test.ice
@@ -158,7 +158,7 @@ module Test
     }
 }
 
-[swift:module:Test:Inner]
+[swift:module(Test:Inner)]
 module Inner::Test::Inner2
 {
     interface I

--- a/swift/test/Ice/servantLocator/Test.ice
+++ b/swift/test/Ice/servantLocator/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceServantLocator]]
+[[swift:class-resolver-prefix(IceServantLocator)]]
 
 module Test
 {

--- a/swift/test/Ice/servantLocator/TestAMD.ice
+++ b/swift/test/Ice/servantLocator/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceServantLocatorAMD]]
+[[swift:class-resolver-prefix(IceServantLocatorAMD)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/exceptions/ClientPrivate.ice
+++ b/swift/test/Ice/slicing/exceptions/ClientPrivate.ice
@@ -8,7 +8,7 @@
 
 #include <Test.ice>
 
-[[swift:class-resolver-prefix:IceSlicingExceptionsClient]]
+[[swift:class-resolver-prefix(IceSlicingExceptionsClient)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/exceptions/ServerPrivate.ice
+++ b/swift/test/Ice/slicing/exceptions/ServerPrivate.ice
@@ -8,7 +8,7 @@
 
 #include <Test.ice>
 
-[[swift:class-resolver-prefix:IceSlicingExceptionsServer]]
+[[swift:class-resolver-prefix(IceSlicingExceptionsServer)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
+++ b/swift/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
@@ -8,7 +8,7 @@
 
 #include <TestAMD.ice>
 
-[[swift:class-resolver-prefix:IceSlicingExceptionsServerAMD]]
+[[swift:class-resolver-prefix(IceSlicingExceptionsServerAMD)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/exceptions/Test.ice
+++ b/swift/test/Ice/slicing/exceptions/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceSlicingExceptions]]
+[[swift:class-resolver-prefix(IceSlicingExceptions)]]
 module Test
 {
 
@@ -45,7 +45,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -55,7 +55,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -74,7 +74,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/swift/test/Ice/slicing/exceptions/TestAMD.ice
+++ b/swift/test/Ice/slicing/exceptions/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[[swift:class-resolver-prefix:IceSlicingExceptionsAMD]]
+[[swift:class-resolver-prefix(IceSlicingExceptionsAMD)]]
 module Test
 {
 
@@ -45,7 +45,7 @@ class BaseClass
     string bc;
 }
 
-[format:sliced]
+[format(sliced)]
 interface Relay
 {
     void knownPreservedAsBase() throws Base;
@@ -55,7 +55,7 @@ interface Relay
     void unknownPreservedAsKnownPreserved() throws KnownPreserved;
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     void baseAsBase() throws Base;
@@ -74,7 +74,7 @@ interface TestIntf
     void unknownMostDerived1AsKnownIntermediate() throws KnownIntermediate;
     void unknownMostDerived2AsBase() throws Base;
 
-    [format:compact] void unknownMostDerived2AsBaseCompact() throws Base;
+    [format(compact)] void unknownMostDerived2AsBaseCompact() throws Base;
 
     void knownPreservedAsBase() throws Base;
     void knownPreservedAsKnownPreserved() throws KnownPreserved;

--- a/swift/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/swift/test/Ice/slicing/objects/ClientPrivate.ice
@@ -8,7 +8,7 @@
 
 #include <Test.ice>
 
-[[swift:class-resolver-prefix:IceSlicingObjectsClient]]
+[[swift:class-resolver-prefix(IceSlicingObjectsClient)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/objects/ServerPrivate.ice
+++ b/swift/test/Ice/slicing/objects/ServerPrivate.ice
@@ -8,7 +8,7 @@
 
 #include <Test.ice>
 
-[[swift:class-resolver-prefix:IceSlicingObjectsServer]]
+[[swift:class-resolver-prefix(IceSlicingObjectsServer)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/objects/ServerPrivateAMD.ice
+++ b/swift/test/Ice/slicing/objects/ServerPrivateAMD.ice
@@ -8,7 +8,7 @@
 
 #include <TestAMD.ice>
 
-[[swift:class-resolver-prefix:IceSlicingObjectsServerAMD]]
+[[swift:class-resolver-prefix(IceSlicingObjectsServerAMD)]]
 
 module Test
 {

--- a/swift/test/Ice/slicing/objects/Test.ice
+++ b/swift/test/Ice/slicing/objects/Test.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[swift:class-resolver-prefix:IceSlicingObjects]]
+[[swift:class-resolver-prefix(IceSlicingObjects)]]
 
 module Test
 {
@@ -101,7 +101,7 @@ exception PreservedException
 {
 }
 
-[format:sliced]
+[format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -111,7 +111,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/swift/test/Ice/slicing/objects/TestAMD.ice
+++ b/swift/test/Ice/slicing/objects/TestAMD.ice
@@ -6,7 +6,7 @@
 
 [[3.7]]
 
-[[swift:class-resolver-prefix:IceSlicingObjectsAMD]]
+[[swift:class-resolver-prefix(IceSlicingObjectsAMD)]]
 
 module Test
 {
@@ -96,7 +96,7 @@ exception PreservedException
 {
 }
 
-[amd] [format:sliced]
+[amd] [format(sliced)]
 interface TestIntf
 {
     Object SBaseAsObject();
@@ -106,7 +106,7 @@ interface TestIntf
 
     SBase SBSUnknownDerivedAsSBase();
 
-    [format:compact] SBase SBSUnknownDerivedAsSBaseCompact();
+    [format(compact)] SBase SBSUnknownDerivedAsSBaseCompact();
 
     Object SUnknownAsObject();
     void checkSUnknown(Object o);

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -13,7 +13,7 @@ public class Client: TestHelperI {
 
         var initData = Ice.InitializationData()
         initData.properties = try createTestProperties(args)
-        initData.classResolverPrefix = ["IceStrem"]
+        initData.classResolverPrefix = ["IceStream"]
         let communicator = try initialize(initData)
         defer {
             communicator.destroy()

--- a/swift/test/Ice/stream/Test.ice
+++ b/swift/test/Ice/stream/Test.ice
@@ -11,9 +11,9 @@
 //
 // Suppress invalid metadata warnings
 //
-[[suppress-warning:invalid-metadata]]
+[[suppress-warning(invalid-metadata)]]
 
-[[swift:class-resolver-prefix:IceStrem]]
+[[swift:class-resolver-prefix(IceStream)]]
 module Test
 {
 
@@ -127,7 +127,7 @@ module Sub
 }
 }
 
-[swift:module:Test:Test2]
+[swift:module(Test:Test2)]
 module Test2::Sub2
 {
     enum NestedEnum2

--- a/swift/test/IceSSL/configuration/Test.ice
+++ b/swift/test/IceSSL/configuration/Test.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[swift:module:Test:SSL]
+[swift:module(Test:SSL)]
 
 module Test
 {

--- a/swift/test/Slice/escape/Clash.ice
+++ b/swift/test/Slice/escape/Clash.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module Clash
 {

--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[suppress-warning:reserved-identifier]]
+[[suppress-warning(reserved-identifier)]]
 
 module and
 {


### PR DESCRIPTION
Updates the metadata to use the new syntax of `language:directive(arguments)`.
I temporarily added a function for converting between the old and new syntax. It's only temporary, and will be removed in my next PR to finish my metadata changes.

Also some general metadata cleanup:
- In some files we would explicitly declare `[[cpp:header-ext:h]]`, but using a `.h` extension is already the default, so I removed these directives.
- Removed language specific directives where they didn't make sense.
- Removed leftovers from metadata we've removed (either bogus usage in a Slice file, or vestigial code in the compilers)