### PR TITLE
Faceted well-known proxies

### DIFF
--- a/csharp/src/Ice/IceDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceDiscovery/Locator.cs
@@ -53,6 +53,7 @@ namespace ZeroC.IceDiscovery
 
         public async ValueTask<IObjectPrx?> FindObjectByIdAsync(
             Identity identity,
+            string? facet,
             Current current,
             CancellationToken cancel)
         {
@@ -63,7 +64,7 @@ namespace ZeroC.IceDiscovery
                     ILookupReplyPrx lookupReply =
                         dummyReply.Clone(ILookupReplyPrx.Factory, identity: replyServant.Identity);
 
-                    return lookup.FindObjectByIdAsync(_domainId, identity, lookupReply, cancel: cancel);
+                    return lookup.FindObjectByIdAsync(_domainId, identity, facet, lookupReply, cancel: cancel);
                 },
                 replyServant).ConfigureAwait(false);
         }
@@ -110,6 +111,7 @@ namespace ZeroC.IceDiscovery
 
         public async ValueTask<(IEnumerable<EndpointData>, IEnumerable<string>)> ResolveWellKnownProxyAsync(
             Identity identity,
+            string facet,
             Current current,
             CancellationToken cancel)
         {
@@ -123,6 +125,7 @@ namespace ZeroC.IceDiscovery
 
                     return lookup.ResolveWellKnownProxyAsync(_domainId,
                                                              identity,
+                                                             facet,
                                                              reply,
                                                              cancel: cancel);
                 },

--- a/csharp/src/Ice/IceDiscovery/LocatorRegistry.cs
+++ b/csharp/src/Ice/IceDiscovery/LocatorRegistry.cs
@@ -105,7 +105,10 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal async ValueTask<IObjectPrx?> FindObjectAsync(Identity identity, CancellationToken cancel)
+        internal async ValueTask<IObjectPrx?> FindObjectAsync(
+            Identity identity,
+            string? facet,
+            CancellationToken cancel)
         {
             if (identity.Name.Length == 0)
             {
@@ -132,6 +135,7 @@ namespace ZeroC.IceDiscovery
                     IObjectPrx proxy = _dummyIce1Proxy.Clone(
                         IObjectPrx.Factory,
                         identity: identity,
+                        facet: facet,
                         location: ImmutableArray.Create(id));
                     await proxy.IcePingAsync(cancel: cancel).ConfigureAwait(false);
                     return proxy;
@@ -164,7 +168,10 @@ namespace ZeroC.IceDiscovery
             }
         }
 
-        internal async ValueTask<string> ResolveWellKnownProxyAsync(Identity identity, CancellationToken cancel)
+        internal async ValueTask<string> ResolveWellKnownProxyAsync(
+            Identity identity,
+            string facet,
+            CancellationToken cancel)
         {
             if (identity.Name.Length == 0)
             {
@@ -191,6 +198,7 @@ namespace ZeroC.IceDiscovery
                     IObjectPrx proxy = _dummyIce2Proxy.Clone(
                         IObjectPrx.Factory,
                         identity: identity,
+                        facet: facet,
                         location: ImmutableArray.Create(id));
                     await proxy.IcePingAsync(cancel: cancel).ConfigureAwait(false);
                     return id;

--- a/csharp/src/Ice/IceDiscovery/LocatorRegistry.cs
+++ b/csharp/src/Ice/IceDiscovery/LocatorRegistry.cs
@@ -22,7 +22,7 @@ namespace ZeroC.IceDiscovery
 
         private readonly object _mutex = new ();
 
-        private readonly Dictionary<(string, Protocol), HashSet<string>> _replicaGroups = new ();
+        private readonly Dictionary<(string AdapterId, Protocol Protocol), HashSet<string>> _replicaGroups = new ();
 
         public void RegisterAdapterEndpoints(
             string adapterId,
@@ -122,7 +122,7 @@ namespace ZeroC.IceDiscovery
                 // We check the local replica groups before the local adapters.
 
                 candidates =
-                    _replicaGroups.Keys.Where(k => k.Item2 == Protocol.Ice1).Select(k => k.Item1).ToList();
+                    _replicaGroups.Keys.Where(k => k.Protocol == Protocol.Ice1).Select(k => k.AdapterId).ToList();
 
                 candidates.AddRange(_ice1Adapters.Keys);
             }
@@ -185,7 +185,7 @@ namespace ZeroC.IceDiscovery
                 // We check the local replica groups before the local adapters.
 
                 candidates =
-                    _replicaGroups.Keys.Where(k => k.Item2 == Protocol.Ice2).Select(k => k.Item1).ToList();
+                    _replicaGroups.Keys.Where(k => k.Protocol == Protocol.Ice2).Select(k => k.AdapterId).ToList();
 
                 candidates.AddRange(_ice2Adapters.Keys);
             }

--- a/csharp/src/Ice/IceDiscovery/Lookup.cs
+++ b/csharp/src/Ice/IceDiscovery/Lookup.cs
@@ -48,6 +48,7 @@ namespace ZeroC.IceDiscovery
         public async ValueTask FindObjectByIdAsync(
             string domainId,
             Identity id,
+            string? facet,
             ILookupReplyPrx reply,
             Current current,
             CancellationToken cancel)
@@ -57,7 +58,7 @@ namespace ZeroC.IceDiscovery
                 return; // Ignore
             }
 
-            if (await _registryServant.FindObjectAsync(id, cancel).ConfigureAwait(false) is IObjectPrx proxy)
+            if (await _registryServant.FindObjectAsync(id, facet, cancel).ConfigureAwait(false) is IObjectPrx proxy)
             {
                 // Reply to the multicast request using the given proxy.
                 try
@@ -102,6 +103,7 @@ namespace ZeroC.IceDiscovery
         public async ValueTask ResolveWellKnownProxyAsync(
             string domainId,
             Identity identity,
+            string facet,
             IResolveWellKnownProxyReplyPrx reply,
             Current current,
             CancellationToken cancel)
@@ -112,7 +114,7 @@ namespace ZeroC.IceDiscovery
             }
 
             string adapterId =
-                await _registryServant.ResolveWellKnownProxyAsync(identity, cancel).ConfigureAwait(false);
+                await _registryServant.ResolveWellKnownProxyAsync(identity, facet, cancel).ConfigureAwait(false);
 
             if (adapterId.Length > 0)
             {

--- a/csharp/src/Ice/IceLocatorDiscovery/Locator.cs
+++ b/csharp/src/Ice/IceLocatorDiscovery/Locator.cs
@@ -16,7 +16,8 @@ namespace ZeroC.IceLocatorDiscovery
     internal class VoidLocator : ILocator
     {
         public IObjectPrx? FindAdapterById(string id, Current current, CancellationToken cancel) => null;
-        public IObjectPrx? FindObjectById(Identity id, Current current, CancellationToken cancel) => null;
+        public IObjectPrx? FindObjectById(Identity id, string? facet, Current current, CancellationToken cancel) =>
+            null;
         public ILocatorRegistryPrx? GetRegistry(Current current, CancellationToken cancel) => null;
 
         public (IEnumerable<EndpointData>, IEnumerable<string>) ResolveLocation(
@@ -26,6 +27,7 @@ namespace ZeroC.IceLocatorDiscovery
 
         public (IEnumerable<EndpointData>, IEnumerable<string>) ResolveWellKnownProxy(
             Identity identity,
+            string facet,
             Current current,
             CancellationToken cancel) => (ImmutableArray<EndpointData>.Empty, ImmutableArray<string>.Empty);
     }

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -23,9 +23,9 @@ namespace ZeroC.Ice.Test.Location
             TestHelper.Assert(registry != null);
 
             System.IO.TextWriter output = helper.Output;
-            output.Write("testing stringToProxy... ");
+            output.Write("testing ice1 string/URI parsing... ");
             output.Flush();
-            IObjectPrx base1, base2, base3, base4, base5, base6;
+            IObjectPrx base1, base2, base3, base4, base5, base6, base7;
             if (ice1)
             {
                 base1 = IObjectPrx.Parse("test @ TestAdapter", communicator);
@@ -34,6 +34,7 @@ namespace ZeroC.Ice.Test.Location
                 base4 = IObjectPrx.Parse("ServerManager", communicator);
                 base5 = IObjectPrx.Parse("test2", communicator);
                 base6 = IObjectPrx.Parse("test @ ReplicatedAdapter", communicator);
+                base7 = IObjectPrx.Parse("test3 -f facet", communicator);
             }
             else
             {
@@ -43,6 +44,7 @@ namespace ZeroC.Ice.Test.Location
                 base4 = IObjectPrx.Parse("ice:ServerManager", communicator);
                 base5 = IObjectPrx.Parse("ice:test2", communicator);
                 base6 = IObjectPrx.Parse("ice:ReplicatedAdapter//test", communicator);
+                base7 = IObjectPrx.Parse("ice:test3#facet", communicator);
             }
             output.WriteLine("ok");
 
@@ -278,6 +280,21 @@ namespace ZeroC.Ice.Test.Location
             TestHelper.Assert(hello != null);
             TestHelper.Assert(hello.Location.Count == 1 && hello.Location[0] == "ReplicatedAdapter");
             hello.SayHello();
+            output.WriteLine("ok");
+
+            output.Write("testing well-known proxy with facet... ");
+            output.Flush();
+            hello = IHelloPrx.Parse(ice1 ? "bonjour -f abc" : "ice:bonjour#abc", communicator);
+            hello.SayHello();
+            hello = IHelloPrx.Parse(ice1 ? "hello -f abc" : "ice:hello#abc", communicator);
+            try
+            {
+                hello.SayHello();
+                TestHelper.Assert(false);
+            }
+            catch (NoEndpointException) // hello does not have an abc facet
+            {
+            }
             output.WriteLine("ok");
 
             output.Write("testing locator request queuing... ");

--- a/csharp/test/Ice/location/ServerLocator.cs
+++ b/csharp/test/Ice/location/ServerLocator.cs
@@ -32,14 +32,14 @@ namespace ZeroC.Ice.Test.Location
             return _registry.GetIce1Adapter(adapter);
         }
 
-        public IObjectPrx? FindObjectById(Identity id, Current current, CancellationToken cancel)
+        public IObjectPrx? FindObjectById(Identity id, string? facet, Current current, CancellationToken cancel)
         {
             ++_requestCount;
             // We add a small delay to make sure locator request queuing gets tested when
             // running the test on a fast machine
             System.Threading.Thread.Sleep(1);
 
-            return _registry.GetIce1Object(id);
+            return _registry.GetIce1Object(id, facet ?? "");
         }
 
         public ILocatorRegistryPrx GetRegistry(Current current, CancellationToken cancel) => _registryPrx;
@@ -61,6 +61,7 @@ namespace ZeroC.Ice.Test.Location
 
         public (IEnumerable<EndpointData>, IEnumerable<string>) ResolveWellKnownProxy(
             Identity identity,
+            string facet,
             Current current,
             CancellationToken cancel)
         {
@@ -69,7 +70,7 @@ namespace ZeroC.Ice.Test.Location
             // running the test on a fast machine
             System.Threading.Thread.Sleep(1);
 
-            return _registry.GetIce2Object(identity);
+            return _registry.GetIce2Object(identity, facet);
         }
     }
 }

--- a/csharp/test/Ice/location/ServerLocatorRegistry.cs
+++ b/csharp/test/Ice/location/ServerLocatorRegistry.cs
@@ -17,14 +17,14 @@ namespace ZeroC.Ice.Test.Location
         private readonly IDictionary<string, IObjectPrx> _ice1Adapters =
             new ConcurrentDictionary<string, IObjectPrx>();
 
-        private readonly IDictionary<Identity, IObjectPrx> _ice1Objects =
-            new ConcurrentDictionary<Identity, IObjectPrx>();
+        private readonly IDictionary<(Identity, string), IObjectPrx> _ice1Objects =
+            new ConcurrentDictionary<(Identity, string), IObjectPrx>();
 
         private readonly IDictionary<string, IReadOnlyList<EndpointData>> _ice2Adapters =
             new ConcurrentDictionary<string, IReadOnlyList<EndpointData>>();
 
-        private readonly IDictionary<Identity, (IReadOnlyList<EndpointData>, IReadOnlyList<string>)>
-            _ice2Objects = new ConcurrentDictionary<Identity, (IReadOnlyList<EndpointData>, IReadOnlyList<string>)>();
+        private readonly IDictionary<(Identity, string), (IReadOnlyList<EndpointData>, IReadOnlyList<string>)> _ice2Objects =
+            new ConcurrentDictionary<(Identity, string), (IReadOnlyList<EndpointData>, IReadOnlyList<string>)>();
 
         public void AddObject(IObjectPrx obj, Current current, CancellationToken cancel)
         {
@@ -102,25 +102,25 @@ namespace ZeroC.Ice.Test.Location
         internal IObjectPrx? GetIce1Adapter(string adapter) =>
             _ice1Adapters.TryGetValue(adapter, out IObjectPrx? proxy) ? proxy : null;
 
-        internal IObjectPrx? GetIce1Object(Identity id) =>
-            _ice1Objects.TryGetValue(id, out IObjectPrx? obj) ? obj : null;
+        internal IObjectPrx? GetIce1Object(Identity id, string facet) =>
+            _ice1Objects.TryGetValue((id, facet), out IObjectPrx? obj) ? obj : null;
 
         internal IReadOnlyList<EndpointData> GetIce2Adapter(string adapter) =>
             _ice2Adapters.TryGetValue(adapter, out IReadOnlyList<EndpointData>? endpoints) ? endpoints :
                 ImmutableArray<EndpointData>.Empty;
-        internal (IReadOnlyList<EndpointData>, IReadOnlyList<string>) GetIce2Object(Identity id) =>
-            _ice2Objects.TryGetValue(id, out var entry) ? entry :
+        internal (IReadOnlyList<EndpointData>, IReadOnlyList<string>) GetIce2Object(Identity id, string facet) =>
+            _ice2Objects.TryGetValue((id, facet), out var entry) ? entry :
                 (ImmutableArray<EndpointData>.Empty, ImmutableArray<string>.Empty);
 
         internal void AddObject(IObjectPrx obj)
         {
             if (obj.Protocol == Protocol.Ice1)
             {
-                _ice1Objects[obj.Identity] = obj;
+                _ice1Objects[(obj.Identity, obj.Facet)] = obj;
             }
             else
             {
-                _ice2Objects[obj.Identity] = (obj.Endpoints.ToEndpointDataList(), obj.Location);
+                _ice2Objects[(obj.Identity, obj.Facet)] = (obj.Endpoints.ToEndpointDataList(), obj.Location);
             }
         }
     }

--- a/csharp/test/Ice/location/TestI.cs
+++ b/csharp/test/Ice/location/TestI.cs
@@ -7,6 +7,10 @@ namespace ZeroC.Ice.Test.Location
 {
     public class TestIntf : ITestIntf
     {
+        private ObjectAdapter _adapter1;
+        private ObjectAdapter _adapter2;
+        private ServerLocatorRegistry _registry;
+
         internal TestIntf(ObjectAdapter adapter1, ObjectAdapter adapter2, ServerLocatorRegistry registry)
         {
             _adapter1 = adapter1;
@@ -14,6 +18,7 @@ namespace ZeroC.Ice.Test.Location
             _registry = registry;
 
             _registry.AddObject(_adapter1.Add("hello", new Hello(), IObjectPrx.Factory));
+            _registry.AddObject(_adapter1.Add("bonjour#abc", new Hello(), IObjectPrx.Factory));
         }
 
         public void Shutdown(Current current, CancellationToken cancel) => _adapter1.Communicator.ShutdownAsync();
@@ -40,9 +45,5 @@ namespace ZeroC.Ice.Test.Location
                 _registry.AddObject(_adapter1.Add(id, servant, IObjectPrx.Factory), current, cancel);
             }
         }
-
-        private ObjectAdapter _adapter1;
-        private ObjectAdapter _adapter2;
-        private ServerLocatorRegistry _registry;
     }
 }

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -16,12 +16,18 @@ namespace ZeroC.IceDiscovery.Test.Simple
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
             var proxies = new List<IControllerPrx>();
+            var facetedProxies = new List<IControllerPrx>();
             var indirectProxies = new List<IControllerPrx>();
             bool ice1 = helper.Protocol == Protocol.Ice1;
 
             for (int i = 0; i < num; ++i)
             {
                 proxies.Add(IControllerPrx.Parse(ice1 ? $"controller{i}" : $"ice:controller{i}", communicator));
+
+                facetedProxies.Add(IControllerPrx.Parse(
+                    ice1 ? $"faceted-controller{i} -f abc" : $"ice:faceted-controller{i}#abc",
+                    communicator));
+
                 indirectProxies.Add(
                     IControllerPrx.Parse(ice1 ? $"controller{i} @ control{i}" : $"ice:control{i}//controller{i}",
                                          communicator));
@@ -41,6 +47,16 @@ namespace ZeroC.IceDiscovery.Test.Simple
             output.Flush();
             {
                 foreach (IControllerPrx prx in proxies)
+                {
+                    prx.IcePing();
+                }
+            }
+            output.WriteLine("ok");
+
+            output.Write("testing faceted well-known proxies... ");
+            output.Flush();
+            {
+                foreach (IControllerPrx prx in facetedProxies)
                 {
                     prx.IcePing();
                 }

--- a/csharp/test/IceDiscovery/simple/Server.cs
+++ b/csharp/test/IceDiscovery/simple/Server.cs
@@ -28,6 +28,7 @@ namespace ZeroC.IceDiscovery.Test.Simple
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ControlAdapter");
             adapter.Add($"controller{num}", new Controller());
+            adapter.Add($"faceted-controller{num}#abc", new Controller());
             await adapter.ActivateAsync();
 
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/IceDiscovery/simple/Test.ice
+++ b/csharp/test/IceDiscovery/simple/Test.ice
@@ -19,8 +19,8 @@ interface Controller
     void activateObjectAdapter(string name, string adapterId, string replicaGroupId);
     void deactivateObjectAdapter(string name);
 
-    void addObject(string oaName, string id);
-    void removeObject(string oaName, string id);
+    void addObject(string oaName, string identityAndFacet);
+    void removeObject(string oaName, string identityAndFacet);
 
     void shutdown();
 }

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -9,6 +9,8 @@ namespace ZeroC.IceDiscovery.Test.Simple
 {
     public sealed class Controller : IController
     {
+        private readonly Dictionary<string, ObjectAdapter> _adapters = new Dictionary<string, ObjectAdapter>();
+
         public void ActivateObjectAdapter(
             string name,
             string adapterId,
@@ -32,22 +34,20 @@ namespace ZeroC.IceDiscovery.Test.Simple
             _adapters.Remove(name);
         }
 
-        public void AddObject(string oaName, string id, Current current, CancellationToken cancel)
+        public void AddObject(string oaName, string identityAndFacet, Current current, CancellationToken cancel)
         {
             TestHelper.Assert(_adapters.ContainsKey(oaName));
-            _adapters[oaName].Add(id, new TestIntf());
+            _adapters[oaName].Add(identityAndFacet, new TestIntf());
         }
 
-        public void RemoveObject(string oaName, string id, Current current, CancellationToken cancel)
+        public void RemoveObject(string oaName, string identityAndFacet, Current current, CancellationToken cancel)
         {
             TestHelper.Assert(_adapters.ContainsKey(oaName));
-            _adapters[oaName].Remove(id);
+            _adapters[oaName].Remove(identityAndFacet);
         }
 
         public void Shutdown(Current current, CancellationToken cancel) =>
             current.Adapter.Communicator.ShutdownAsync();
-
-        private readonly Dictionary<string, ObjectAdapter> _adapters = new Dictionary<string, ObjectAdapter>();
     }
 
     public sealed class TestIntf : ITestIntf

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -53,13 +53,13 @@ module Ice
     interface Locator
     {
 #ifdef __SLICE2CS__
-        /// Finds an object by identity and returns a proxy that provides a location or endpoint(s) that can be used
-        /// to reach the object using the ice1 protocol.
+        /// Finds an object by identity and facet and returns a proxy that provides a location or endpoint(s) that can
+        /// be used to reach the object using the ice1 protocol.
         /// @param id The identity.
         /// @param facet The facet. A null value is equivalent to the empty string.
         /// @return An ice1 proxy that provides a location or endpoint(s), or null if an object with the requested
         /// identity and facet was not found.
-        /// @throws ObjectNotFoundException Thrown if an object with the request identity and facet was not found. The
+        /// @throws ObjectNotFoundException Thrown if an object with the requested identity and facet was not found. The
         /// caller should treat this exception like a null return value.
         idempotent Object? findObjectById(Identity id, tag(1) string? facet);
 

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -56,11 +56,12 @@ module Ice
         /// Finds an object by identity and returns a proxy that provides a location or endpoint(s) that can be used
         /// to reach the object using the ice1 protocol.
         /// @param id The identity.
-        /// @return An ice1 proxy that provides a location or endpoint(s), or null if an object with identity `id' was
-        /// not found.
-        /// @throws ObjectNotFoundException Thrown if an object with identity `id' was not found. The caller should
-        /// treat this exception like a null return value.
-        idempotent Object? findObjectById(Identity id);
+        /// @param facet The facet. A null value is equivalent to the empty string.
+        /// @return An ice1 proxy that provides a location or endpoint(s), or null if an object with the requested
+        /// identity and facet was not found.
+        /// @throws ObjectNotFoundException Thrown if an object with the request identity and facet was not found. The
+        /// caller should treat this exception like a null return value.
+        idempotent Object? findObjectById(Identity id, tag(1) string? facet);
 
         /// Finds an object adapter by id and returns a proxy that provides the object adapter's endpoint(s). This
         /// operation is for object adapters using the ice1 protocol.
@@ -82,12 +83,15 @@ module Ice
         /// returns a new location which is typically location[1..].
         idempotent (EndpointDataSeq endpoints, StringSeq newLocation) resolveLocation(StringSeq location);
 
-        /// Locates the well-known object with the given identity. This object must be reachable using the ice2
-        /// protocol.
+        /// Locates the well-known object with the given identity and facet. This object must be reachable using the
+        /// ice2 protocol.
         /// @param identity The identity of the well-known Ice object.
+        /// @param facet The facet of the well-known Ice object.
         /// @return A sequence of one or more endpoints and/or a non-empty location if the Locator could resolve the
-        /// identity. Otherwise, an empty sequence of endpoints and an empty location.
-        idempotent (EndpointDataSeq endpoints, StringSeq location) resolveWellKnownProxy(Identity identity);
+        /// identity and facet. Otherwise, an empty sequence of endpoints and an empty location.
+        idempotent (EndpointDataSeq endpoints, StringSeq location) resolveWellKnownProxy(
+            Identity identity,
+            string facet);
 
 #else
         [amd] [nonmutating] [cpp:const] idempotent Object? findObjectById(Identity id)

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -46,27 +46,34 @@ module IceDiscovery
         /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
         /// domain ID that matches the server's configured domain ID.
         /// @param id The object identity.
+        /// @param facet The facet of the object. Null is equivalent to the empty string.
         /// @param reply A proxy to a LookupReply object created by the caller. The server calls foundObjectById on this
-        /// object when it hosts an object with the requested identity in an ice1 object adapter.
-        idempotent void findObjectById(string domainId, Ice::Identity id, LookupReply reply);
+        /// object when it hosts an object with the requested identity and facet in an ice1 object adapter.
+        idempotent void findObjectById(string domainId, Ice::Identity id, tag(1) string? facet, LookupReply reply);
 
 #ifdef __SLICE2CS__
         /// Finds an ice2 object adapter hosted by the target object's server.
         /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
         /// domain ID that matches the server's configured domain ID.
         /// @param adapterId The adapter ID.
-        /// @param reply A proxy to a ResolveAdapterIdReply object created by the caller. The server calls found
-        /// on this object when it hosts an ice2 object adapter that has the requested adapter ID (or replica group ID).
+        /// @param reply A proxy to a ResolveAdapterIdReply object created by the caller. The server calls
+        /// foundAdapterId on this object when it hosts an ice2 object adapter that has the requested adapter ID (or
+        /// replica group ID).
         void resolveAdapterId(string domainId, string adapterId, ResolveAdapterIdReply reply);
 
         /// Finds an object hosted by an ice2 object adapter of the target object's server.
         /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
         /// domain ID that matches the server's configured domain ID.
         /// @param identity The identity of the object.
+        /// @param facet The facet of the object.
         /// @param reply A proxy to a ResolvedWellKnownProxyReply object created by the caller. The server calls
-        /// foundAdapterId or foundEndpoints on this object when it has an ice2 object adapter that hosts an object with
-        /// the given identity.
-        void resolveWellKnownProxy(string domainId, Ice::Identity identity, ResolveWellKnownProxyReply reply);
+        /// foundWellKnownProxy on this object when it has an ice2 object adapter that hosts an object with the given
+        /// identity and facet.
+        void resolveWellKnownProxy(
+            string domainId,
+            Ice::Identity identity,
+            string facet,
+            ResolveWellKnownProxyReply reply);
 #endif
     }
 


### PR DESCRIPTION
This PR adds facet support to well-known proxies.

Before this PR, facets were simply ignored during Locator resolution: the facet of the well-known proxy was not sent, and the Locator naturally did not take it into account.

With this PR, the desired facet is always sent. I believe it's compatible with the 3.7 behavior.
- 3.7 client to 4.0 Locator: receives empty facet and succeeds only if 4.0 Locator has well-known object with empty facet (like in 3.7)

- 4.0 client to 3.7 Locator: sends the facet, but the server ignores it. Equivalent to the 3.7 to 3.7 behavior where the facet was not sent at all.