### PR TITLE
Move discovery plugin to Ice/Discovery

### DIFF
--- a/csharp/src/Ice/Discovery/LocatorRegistry.cs
+++ b/csharp/src/Ice/Discovery/LocatorRegistry.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ZeroC.Ice;
-
-namespace ZeroC.IceDiscovery
+namespace ZeroC.Ice.Discovery
 {
     /// <summary>Servant class that implements the Slice interface Ice::LocatorRegistry.</summary>
     internal class LocatorRegistry : ILocatorRegistry

--- a/csharp/src/Ice/Discovery/Lookup.cs
+++ b/csharp/src/Ice/Discovery/Lookup.cs
@@ -5,21 +5,21 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ZeroC.Ice;
-
-namespace ZeroC.IceDiscovery
+namespace ZeroC.Ice.Discovery
 {
-    /// <summary>Servant class that implements the Slice interface IceDiscovery::Lookup using the local LocatorRegistry
-    /// servant.</summary>
+    /// <summary>Servant class that implements the Slice interface Ice::Discovery::Lookup using the local
+    /// LocatorRegistry servant.</summary>
     internal class Lookup : IAsyncLookup
     {
         private readonly string _domainId;
+
+        private readonly string _pluginName;
         private readonly LocatorRegistry _registryServant;
 
         public async ValueTask FindAdapterByIdAsync(
             string domainId,
             string adapterId,
-            ILookupReplyPrx reply,
+            IFindAdapterByIdReplyPrx reply,
             Current current,
             CancellationToken cancel)
         {
@@ -40,7 +40,7 @@ namespace ZeroC.IceDiscovery
                 catch (Exception ex)
                 {
                     current.Communicator.Logger.Warning(
-                        $"IceDiscovery failed to send foundAdapterById to `{reply}':\n{ex}");
+                        $"{_pluginName} failed to send foundAdapterById to `{reply}':\n{ex}");
                 }
             }
         }
@@ -49,7 +49,7 @@ namespace ZeroC.IceDiscovery
             string domainId,
             Identity id,
             string? facet,
-            ILookupReplyPrx reply,
+            IFindObjectByIdReplyPrx reply,
             Current current,
             CancellationToken cancel)
         {
@@ -68,7 +68,7 @@ namespace ZeroC.IceDiscovery
                 catch (Exception ex)
                 {
                     current.Communicator.Logger.Warning(
-                        $"IceDiscovery failed to send foundObjectById to `{reply}':\n{ex}");
+                        $"{_pluginName} failed to send foundObjectById to `{reply}':\n{ex}");
                 }
             }
         }
@@ -95,7 +95,7 @@ namespace ZeroC.IceDiscovery
                 catch (Exception ex)
                 {
                     current.Communicator.Logger.Warning(
-                        $"IceDiscovery failed to send foundAdapterId to `{reply}':\n{ex}");
+                        $"{_pluginName} failed to send foundAdapterId to `{reply}':\n{ex}");
                 }
             }
         }
@@ -125,15 +125,16 @@ namespace ZeroC.IceDiscovery
                 catch (Exception ex)
                 {
                     current.Communicator.Logger.Warning(
-                        $"IceDiscovery failed to send foundWellKnownProxy to `{reply}':\n{ex}");
+                        $"{_pluginName} failed to send foundWellKnownProxy to `{reply}':\n{ex}");
                 }
             }
         }
 
-        internal Lookup(LocatorRegistry registryServant, Communicator communicator)
+        internal Lookup(LocatorRegistry registryServant, string pluginName, Communicator communicator)
         {
+            _pluginName = pluginName;
             _registryServant = registryServant;
-            _domainId = communicator.GetProperty("IceDiscovery.DomainId") ?? "";
+            _domainId = communicator.GetProperty($"{_pluginName}.DomainId") ?? "";
         }
     }
 }

--- a/csharp/src/Ice/Discovery/Plugin.cs
+++ b/csharp/src/Ice/Discovery/Plugin.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ZeroC.Ice;
 
-namespace ZeroC.IceDiscovery
+namespace ZeroC.Ice.Discovery
 {
     internal sealed class Plugin : IPlugin
     {
@@ -15,6 +15,7 @@ namespace ZeroC.IceDiscovery
         private ILocatorPrx? _locator;
         private ObjectAdapter? _locatorAdapter;
         private ObjectAdapter? _multicastAdapter;
+        private readonly string _pluginName;
         private ObjectAdapter? _replyAdapter;
 
         public async ValueTask DisposeAsync()
@@ -46,13 +47,13 @@ namespace ZeroC.IceDiscovery
             const string defaultIPv4Endpoint = "udp -h 239.255.0.1 -p 4061";
             const string defaultIPv6Endpoint = "udp -h \"ff15::1\" -p 4061";
 
-            if (_communicator.GetProperty("IceDiscovery.Multicast.Endpoints") == null)
+            if (_communicator.GetProperty($"{_pluginName}.Multicast.Endpoints") == null)
             {
-                _communicator.SetProperty("IceDiscovery.Multicast.Endpoints",
+                _communicator.SetProperty($"{_pluginName}.Multicast.Endpoints",
                                           $"{defaultIPv4Endpoint}:{defaultIPv6Endpoint}");
             }
 
-            string? lookupEndpoints = _communicator.GetProperty("IceDiscovery.Lookup");
+            string? lookupEndpoints = _communicator.GetProperty($"{_pluginName}.Lookup");
             if (lookupEndpoints == null)
             {
                 List<string> endpoints = new ();
@@ -65,19 +66,19 @@ namespace ZeroC.IceDiscovery
                 lookupEndpoints = string.Join(":", endpoints);
             }
 
-            if (_communicator.GetProperty("IceDiscovery.Reply.Endpoints") == null)
+            if (_communicator.GetProperty($"{_pluginName}.Reply.Endpoints") == null)
             {
-                _communicator.SetProperty("IceDiscovery.Reply.Endpoints", "udp -h \"::0\" -p 0");
+                _communicator.SetProperty($"{_pluginName}.Reply.Endpoints", "udp -h \"::0\" -p 0");
             }
 
-            if (_communicator.GetProperty("IceDiscovery.Locator.Endpoints") == null)
+            if (_communicator.GetProperty($"{_pluginName}.Locator.Endpoints") == null)
             {
-                _communicator.SetProperty("IceDiscovery.Locator.AdapterId", Guid.NewGuid().ToString());
+                _communicator.SetProperty($"{_pluginName}.Locator.AdapterId", Guid.NewGuid().ToString());
             }
 
-            _multicastAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Multicast");
-            _replyAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Reply");
-            _locatorAdapter = _communicator.CreateObjectAdapter("IceDiscovery.Locator");
+            _multicastAdapter = _communicator.CreateObjectAdapter($"{_pluginName}.Multicast");
+            _replyAdapter = _communicator.CreateObjectAdapter($"{_pluginName}.Reply");
+            _locatorAdapter = _communicator.CreateObjectAdapter($"{_pluginName}.Locator");
 
             // Setup locator registry.
             var locatorRegistryServant = new LocatorRegistry(_communicator);
@@ -88,11 +89,11 @@ namespace ZeroC.IceDiscovery
                 ILookupPrx.Parse($"IceDiscovery/Lookup -d:{lookupEndpoints}", _communicator).Clone(clearRouter: true);
 
             // Add lookup Ice object
-            var lookupServant = new Lookup(locatorRegistryServant, _communicator);
+            var lookupServant = new Lookup(locatorRegistryServant, _pluginName, _communicator);
             _multicastAdapter.Add("IceDiscovery/Lookup", lookupServant);
 
             // Setup locator on the communicator.
-            _locator = _locatorAdapter.AddWithUUID(new Locator(locatorRegistry, lookup, _replyAdapter),
+            _locator = _locatorAdapter.AddWithUUID(new Locator(locatorRegistry, lookup, _replyAdapter, _pluginName),
                                                    ILocatorPrx.Factory);
 
             _defaultLocator = _communicator.DefaultLocator;
@@ -103,13 +104,18 @@ namespace ZeroC.IceDiscovery
             _locatorAdapter.Activate();
         }
 
-        internal Plugin(Communicator communicator) => _communicator = communicator;
+        internal Plugin(Communicator communicator, string name)
+        {
+            _communicator = communicator;
+            _pluginName = name;
+        }
     }
 
     /// <summary>The IceDiscovery plug-in's factory.</summary>
     public sealed class PluginFactory : IPluginFactory
     {
         /// <inheritdoc/>
-        public IPlugin Create(Communicator communicator, string name, string[] args) => new Plugin(communicator);
+        public IPlugin Create(Communicator communicator, string name, string[] args) =>
+            new Plugin(communicator, name);
     }
 }

--- a/csharp/src/Ice/ice.csproj
+++ b/csharp/src/Ice/ice.csproj
@@ -9,7 +9,9 @@
     <ItemGroup>
         <SliceCompile Include="../../../slice/$(AssemblyName)/*.ice"
             Exclude="../../../slice/$(AssemblyName)/*F.ice;../../../slice/$(AssemblyName)/BuiltinSequences.ice;../../../slice/$(AssemblyName)/Context.ice"/>
-        <SliceCompile Include="../../../slice/IceDiscovery/*.ice" />
+        <Compile Update="generated\Discovery.cs">
+          <SliceCompileSource>..\..\..\slice\Ice\Discovery.ice</SliceCompileSource>
+        </Compile>
         <Compile Update="generated\Identity.cs">
           <SliceCompileSource>..\..\..\slice\Ice\Identity.ice</SliceCompileSource>
         </Compile>

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -4,9 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Test;
-using ZeroC.Ice;
 
-namespace ZeroC.IceDiscovery.Test.Simple
+namespace ZeroC.Ice.Test.Discovery
 {
     public class AllTests
     {

--- a/csharp/test/IceDiscovery/simple/Client.cs
+++ b/csharp/test/IceDiscovery/simple/Client.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Test;
 
-namespace ZeroC.IceDiscovery.Test.Simple
+namespace ZeroC.Ice.Test.Discovery
 {
     public class Client : TestHelper
     {

--- a/csharp/test/IceDiscovery/simple/Server.cs
+++ b/csharp/test/IceDiscovery/simple/Server.cs
@@ -5,9 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Test;
 
-using ZeroC.Ice;
-
-namespace ZeroC.IceDiscovery.Test.Simple
+namespace ZeroC.Ice.Test.Discovery
 {
     public class Server : TestHelper
     {

--- a/csharp/test/IceDiscovery/simple/Test.ice
+++ b/csharp/test/IceDiscovery/simple/Test.ice
@@ -4,25 +4,25 @@
 
 #pragma once
 
+// TODO: move this test to Ice/discovery
+
 [[suppress-warning(reserved-identifier)]]
 
-module ZeroC::IceDiscovery::Test::Simple
+module ZeroC::Ice::Test::Discovery
 {
+    interface TestIntf
+    {
+        string getAdapterId();
+    }
 
-interface TestIntf
-{
-    string getAdapterId();
-}
+    interface Controller
+    {
+        void activateObjectAdapter(string name, string adapterId, string replicaGroupId);
+        void deactivateObjectAdapter(string name);
 
-interface Controller
-{
-    void activateObjectAdapter(string name, string adapterId, string replicaGroupId);
-    void deactivateObjectAdapter(string name);
+        void addObject(string oaName, string identityAndFacet);
+        void removeObject(string oaName, string identityAndFacet);
 
-    void addObject(string oaName, string identityAndFacet);
-    void removeObject(string oaName, string identityAndFacet);
-
-    void shutdown();
-}
-
+        void shutdown();
+    }
 }

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Collections.Generic;
-using ZeroC.Ice;
 using Test;
 using System.Threading;
 
-namespace ZeroC.IceDiscovery.Test.Simple
+namespace ZeroC.Ice.Test.Discovery
 {
     public sealed class Controller : IController
     {

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3479,7 +3479,7 @@ class CSharpMapping(Mapping):
 
         return {
             "IceSSL" : plugindir + "Ice.dll:ZeroC.Ice.SslPluginFactory",
-            "IceDiscovery" : plugindir + "Ice.dll:ZeroC.IceDiscovery.PluginFactory",
+            "IceDiscovery" : plugindir + "Ice.dll:ZeroC.Ice.Discovery.PluginFactory",
             "IceLocatorDiscovery" : plugindir + "Ice:ZeroC.Ice.LocatorDiscovery.PluginFactory"
         }[plugin]
 

--- a/slice/Ice/Discovery.ice
+++ b/slice/Ice/Discovery.ice
@@ -1,0 +1,121 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+#pragma once
+
+#ifdef __SLICE2CS__
+
+[[cpp:doxygen:include(Ice/Discovery.h)]]
+[[cpp:header-ext(h)]]
+
+[[suppress-warning(reserved-identifier)]]
+[[js:module(ice)]]
+
+[[python:pkgdir(IceDiscovery)]]
+
+#include <Ice/Endpoint.ice>
+#include <Ice/Identity.ice>
+
+/// The Discovery plug-in implements the {@see Ice::Locator} interface to locate (or discover) objects and object
+/// adapters using UDP multicast. It also implements the {@see Ice::LocatorDiscovery} interface to allow servers to
+/// respond to such multicast discovery requests. This plug-in is usually named IceDiscovery in Ice configuration.
+[cs:namespace(ZeroC)]
+[java:package(com.zeroc)]
+module Ice::Discovery
+{
+    interface FindAdapterByIdReply;
+    interface FindObjectByIdReply;
+    interface ResolveAdapterIdReply;
+    interface ResolveWellKnownProxyReply;
+
+    /// The <plugin-name>.Multicast object adapter of a server application hosts a Lookup object that receives discovery
+    /// requests from Discovery clients.
+    interface Lookup
+    {
+        /// Finds an ice1 object adapter hosted by the target object's server.
+        /// @param domainId The Discovery domain ID. An Discovery server only replies to requests that include a domain
+        /// ID that matches the server's configured domain ID.
+        /// @param id The adapter ID.
+        /// @param reply A proxy to a FindAdapterByIdReply object created by the caller. The server calls
+        /// foundAdapterById on this object when it hosts an ice1 object adapter that has the requested adapter ID (or
+        /// replica group ID).
+        [oneway] idempotent void findAdapterById(string domainId, string id, FindAdapterByIdReply reply);
+
+        /// Finds an object hosted by an ice1 object adapter of the target object's server
+        /// @param domainId The Discovery domain ID. An Discovery server only replies to requests that include a domain
+        /// ID that matches the server's configured domain ID.
+        /// @param id The object identity.
+        /// @param facet The facet of the object. Null is equivalent to the empty string.
+        /// @param reply A proxy to a FindObjectByIdReply object created by the caller. The server calls foundObjectById
+        /// on this object when it hosts an object with the requested identity and facet in an ice1 object adapter.
+        [oneway] idempotent void findObjectById(
+            string domainId,
+            Ice::Identity id,
+            tag(1) string? facet,
+            FindObjectByIdReply reply);
+
+        /// Finds an ice2 object adapter hosted by the target object's server.
+        /// @param domainId The Discovery domain ID. An Discovery server only replies to requests that include a domain
+        /// ID that matches the server's configured domain ID.
+        /// @param adapterId The adapter ID.
+        /// @param reply A proxy to a ResolveAdapterIdReply object created by the caller. The server calls
+        /// foundAdapterId on this object when it hosts an ice2 object adapter that has the requested adapter ID (or
+        /// replica group ID).
+        [oneway] void resolveAdapterId(string domainId, string adapterId, ResolveAdapterIdReply reply);
+
+        /// Finds an object hosted by an ice2 object adapter of the target object's server.
+        /// @param domainId The Discovery domain ID. An Discovery server only replies to requests that include a domain
+        /// ID that matches the server's configured domain ID.
+        /// @param identity The identity of the object.
+        /// @param facet The facet of the object.
+        /// @param reply A proxy to a ResolvedWellKnownProxyReply object created by the caller. The server calls
+        /// foundWellKnownProxy on this object when it has an ice2 object adapter that hosts an object with the given
+        /// identity and facet.
+        [oneway] void resolveWellKnownProxy(
+            string domainId,
+            Ice::Identity identity,
+            string facet,
+            ResolveWellKnownProxyReply reply);
+    }
+
+    /// Handles the reply or replies to findAdapterById calls on {@see Lookup}.
+    // Note: for compatibility with Ice 3.7, the operation name (and its parameters) must remain unchanged.
+    interface FindAdapterByIdReply
+    {
+        /// Provides the endpoints for an object adapter in response to a findAdapterById call on a Lookup object.
+        /// @param id The adapter or replica group ID, as specified in the findAdapterById call.
+        /// @param proxy A dummy proxy that carries the endpoints of the object adapter.
+        /// @param isReplicaGroup True if `id` corresponds to a replica group ID and false otherwise.
+        [oneway] void foundAdapterById(string id, Object proxy, bool isReplicaGroup);
+    }
+
+    /// Handles the reply or replies to findObjectById calls on {@see Lookup}.
+    // Note: for compatibility with Ice 3.7, the operation name (and its parameters) must remain unchanged.
+    interface FindObjectByIdReply
+    {
+        /// Provides the adapter ID or endpoints for an object in response to a findObjectById call on a Lookup object.
+        /// @param id The identity of the object, as specified in the findObjectById call.
+        /// @param proxy A dummy proxy that carries the adapter ID or endpoints for the well-known object.
+        [oneway] void foundObjectById(Ice::Identity id, Object proxy);
+    }
+
+    /// Handles the reply or replies to resolveAdapterId calls on {@see Lookup}.
+    interface ResolveAdapterIdReply
+    {
+        /// Provides the endpoints for an object adapter in response to a resolveAdapterId call on a Lookup object.
+        /// @param endpoints A sequence of endpoints. Cannot be empty.
+        /// @param isReplicaGroup True if the adapter ID provided to the resolveAdapterId call corresponds to a replica
+        /// group ID and false otherwise.
+        [oneway] void foundAdapterId(Ice::EndpointDataSeq endpoints, bool isReplicaGroup);
+    }
+
+    /// Handles the reply or replies to resolveWellKnownProxy calls on {@see Lookup}.
+    interface ResolveWellKnownProxyReply
+    {
+        /// Provides the adapter ID or replica group ID for an object adapter that hosts the desired well-known object,
+        /// in response to a resolveWellKnownProxy call on a Lookup object.
+        /// @param adapterId The adapter ID or replica group ID of the object adapter that hosts the object.
+        [oneway] void foundWellKnownProxy(string adapterId);
+    }
+}
+
+#endif

--- a/slice/Ice/Discovery.ice
+++ b/slice/Ice/Discovery.ice
@@ -27,7 +27,7 @@ module Ice::Discovery
     interface ResolveAdapterIdReply;
     interface ResolveWellKnownProxyReply;
 
-    /// The <plugin-name>.Multicast object adapter of a server application hosts a Lookup object that receives discovery
+    /// The {plugin-name}.Multicast object adapter of a server application hosts a Lookup object that receives discovery
     /// requests from Discovery clients.
     interface Lookup
     {

--- a/slice/Ice/LocatorDiscovery.ice
+++ b/slice/Ice/LocatorDiscovery.ice
@@ -22,7 +22,7 @@
 [java:package(com.zeroc)]
 module Ice::LocatorDiscovery
 {
-    /// The <plug-in name>.Reply object adapter of a client application hosts a LookupReply object that processes
+    /// The {plug-in name}.Reply object adapter of a client application hosts a LookupReply object that processes
     /// replies to locator discovery requests.
     interface LookupReply
     {

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -39,10 +39,9 @@ module IceDiscovery
         /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
         /// domain ID that matches the server's configured domain ID.
         /// @param id The object identity.
-        /// @param facet The facet of the object. Null is equivalent to the empty string.
         /// @param reply A proxy to a LookupReply object created by the caller. The server calls foundObjectById on this
-        /// object when it hosts an object with the requested identity and facet in an ice1 object adapter.
-        idempotent void findObjectById(string domainId, Ice::Identity id, tag(1) string? facet, LookupReply reply);
+        /// object when it hosts an object with the requested identity in an ice1 object adapter.
+        idempotent void findObjectById(string domainId, Ice::Identity id, LookupReply reply);
     }
 
     /// Handles the reply or replies to findAdapterById and findObjectById calls on {@see Lookup}.

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -14,8 +14,8 @@
 
 #include <Ice/Identity.ice>
 
-/// The IceDiscovery plug-in implements the {@see Ice::Locator} interface to locate (or discover) objects and object
-/// adapters using UDP multicast. It also implements the {@see Ice::LocatorDiscovery} interface to allow servers to
+/// The IceDiscovery plug-in implements the {@link Ice::Locator} interface to locate (or discover) objects and object
+/// adapters using UDP multicast. It also implements the {@link Ice::LocatorDiscovery} interface to allow servers to
 /// respond to such multicast discovery requests.
 [cs:namespace(ZeroC)]
 [java:package(com.zeroc)]
@@ -44,7 +44,7 @@ module IceDiscovery
         idempotent void findObjectById(string domainId, Ice::Identity id, LookupReply reply);
     }
 
-    /// Handles the reply or replies to findAdapterById and findObjectById calls on {@see Lookup}.
+    /// Handles the reply or replies to findAdapterById and findObjectById calls on {@link Lookup}.
     interface LookupReply
     {
         /// Provides the endpoints for an object adapter in response to a findAdapterById call on a Lookup object.

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -2,6 +2,8 @@
 
 #pragma once
 
+// TODO: these definitions moved to Ice/Discovery.ice. Remove this file when all languages mappings are updated.
+
 [[cpp:doxygen:include(IceDiscovery/IceDiscovery.h)]]
 [[cpp:header-ext(h)]]
 
@@ -9,10 +11,6 @@
 [[js:module(ice)]]
 
 [[python:pkgdir(IceDiscovery)]]
-
-#ifdef __SLICE2CS__
-#include <Ice/Endpoint.ice>
-#endif
 
 #include <Ice/Identity.ice>
 
@@ -24,11 +22,6 @@
 module IceDiscovery
 {
     interface LookupReply;
-
-#ifdef __SLICE2CS__
-    interface ResolveAdapterIdReply;
-    interface ResolveWellKnownProxyReply;
-#endif
 
     /// The IceDiscovery.Multicast object adapter of a server application hosts a Lookup object that receives discovery
     /// requests from Discovery clients.
@@ -50,31 +43,6 @@ module IceDiscovery
         /// @param reply A proxy to a LookupReply object created by the caller. The server calls foundObjectById on this
         /// object when it hosts an object with the requested identity and facet in an ice1 object adapter.
         idempotent void findObjectById(string domainId, Ice::Identity id, tag(1) string? facet, LookupReply reply);
-
-#ifdef __SLICE2CS__
-        /// Finds an ice2 object adapter hosted by the target object's server.
-        /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
-        /// domain ID that matches the server's configured domain ID.
-        /// @param adapterId The adapter ID.
-        /// @param reply A proxy to a ResolveAdapterIdReply object created by the caller. The server calls
-        /// foundAdapterId on this object when it hosts an ice2 object adapter that has the requested adapter ID (or
-        /// replica group ID).
-        void resolveAdapterId(string domainId, string adapterId, ResolveAdapterIdReply reply);
-
-        /// Finds an object hosted by an ice2 object adapter of the target object's server.
-        /// @param domainId The IceDiscovery domain ID. An IceDiscovery server only replies to requests that include a
-        /// domain ID that matches the server's configured domain ID.
-        /// @param identity The identity of the object.
-        /// @param facet The facet of the object.
-        /// @param reply A proxy to a ResolvedWellKnownProxyReply object created by the caller. The server calls
-        /// foundWellKnownProxy on this object when it has an ice2 object adapter that hosts an object with the given
-        /// identity and facet.
-        void resolveWellKnownProxy(
-            string domainId,
-            Ice::Identity identity,
-            string facet,
-            ResolveWellKnownProxyReply reply);
-#endif
     }
 
     /// Handles the reply or replies to findAdapterById and findObjectById calls on {@see Lookup}.
@@ -91,25 +59,4 @@ module IceDiscovery
         /// @param proxy A dummy proxy that carries the adapter ID or endpoints for the well-known object.
         void foundObjectById(Ice::Identity id, Object proxy);
     }
-
-#ifdef __SLICE2CS__
-    /// Handles the reply or replies to resolveAdapterId calls on {@see Lookup}.
-    interface ResolveAdapterIdReply
-    {
-        /// Provides the endpoints for an object adapter in response to a resolveAdapterId call on a Lookup object.
-        /// @param endpoints A sequence of endpoints. Cannot be empty.
-        /// @param isReplicaGroup True if the adapter ID provided to the resolveAdapterId call corresponds to a replica
-        /// group ID and false otherwise.
-        void foundAdapterId(Ice::EndpointDataSeq endpoints, bool isReplicaGroup);
-    }
-
-    /// Handles the reply or replies to resolveWellKnownProxy calls on {@see Lookup}.
-    interface ResolveWellKnownProxyReply
-    {
-        /// Provides the adapter ID or replica group ID for an object adapter that hosts the desired well-known object,
-        /// in response to a resolveWellKnownProxy call on a Lookup object.
-        /// @param adapterId The adapter ID or replica group ID of the object adapter that hosts the object.
-        void foundWellKnownProxy(string adapterId);
-    }
-#endif
 }

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -16,13 +16,13 @@
 
 /// LocatorDiscovery is an Ice plug-in that enables the discovery of IceGrid and custom locators via UDP multicast.
 /// This plug-in is usually named IceLocatorDiscovery in Ice configuration. The LocatorDiscovery plug-in implements the
-/// {@see Ice::Locator} interface to locate (or discover) locators such as the IceGrid registry or custom IceGrid-like
+/// {@link Ice::Locator} interface to locate (or discover) locators such as the IceGrid registry or custom IceGrid-like
 /// locator implementations using UDP multicast.
 [cs:namespace(ZeroC)]
 [java:package(com.zeroc)]
 module IceLocatorDiscovery
 {
-    /// The <plug-in name>.Reply object adapter of a client application hosts a LookupReply object that processes
+    /// The {plug-in name}.Reply object adapter of a client application hosts a LookupReply object that processes
     /// replies to locator discovery requests.
     interface LookupReply
     {


### PR DESCRIPTION
This PR moves the Discovery plugin definitions and C# implementation from `IceDiscovery/IceDiscovery.ice` and `src/Ice/IceDiscovery/` to `Ice/Discovery.ice` and `src/Ice/Discovery/`. LocatorDiscovery made the same move in a prior PR.

This PR also splits the existing LookupReply interface in 2 interfaces - one per operation. This split does not break backwards compatibility as all that matter for these oneway datagram invocations in the operation name and parameters, not the interface names.