### PR TITLE
Add RefreshEndpoints retry policy

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2683,7 +2683,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
              << "Async(request, current, cancel),";
     }
 
-    _out << nl << "_ => throw new ZeroC.Ice.OperationNotExistException()";
+    _out << nl << "_ => throw new ZeroC.Ice.OperationNotExistException(ZeroC.Ice.RetryPolicy.RefreshEndpoints)";
 
     _out << eb << ";"; // switch expression
     _out.dec(); // method

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -528,8 +528,8 @@ namespace ZeroC.Ice
                 {
                     if (stream.IsBidirectional)
                     {
-                        var exception = new ObjectNotExistException();
-                        response = new OutgoingResponseFrame(request, exception);
+                        response = new OutgoingResponseFrame(request,
+                                                             new ObjectNotExistException(RetryPolicy.RefreshEndpoints));
                         await stream.SendResponseFrameAsync(response, true, cancel).ConfigureAwait(false);
                     }
                     return;

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -78,7 +78,7 @@ namespace ZeroC.Ice
             AcmMonitor = new ConnectionFactoryAcmMonitor(communicator, communicator.ClientAcm);
         }
 
-        internal void AddHintFailure(IConnector connector) => _transportFailures[connector] = DateTime.Now;
+        internal void AddTransportFailure(IConnector connector) => _transportFailures[connector] = DateTime.Now;
 
         internal async ValueTask<Connection> CreateAsync(
             IReadOnlyList<Endpoint> endpoints,

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -154,14 +154,7 @@ namespace ZeroC.Ice
                         reference.RouterInfo.ClearCache(reference);
                         return RetryPolicy.AfterDelay(TimeSpan.Zero);
                     }
-                    else if (reference.IsIndirect)
-                    {
-                        if (reference.IsWellKnown)
-                        {
-                            reference.LocatorInfo?.ClearCache(reference);
-                        }
-                        return RetryPolicy.AfterDelay(TimeSpan.Zero);
-                    }
+                    return RetryPolicy.RefreshEndpoints;
                 }
             }
             return RetryPolicy.NoRetry;

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -133,7 +133,7 @@ namespace ZeroC.Ice
             {
                 if (_destroyed)
                 {
-                    throw new ObjectNotExistException();
+                    throw new ObjectNotExistException(RetryPolicy.RefreshEndpoints);
                 }
 
                 _sendLogCommunicator ??= CreateSendLogCommunicator(current.Adapter.Communicator, _logger.LocalLogger);

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -841,8 +841,7 @@ namespace ZeroC.Ice
                 IObject? servant = Find(current.Identity, current.Facet);
                 if (servant == null)
                 {
-                    throw new ObjectNotExistException(
-                        ReplicaGroupId.Length == 0 ? RetryPolicy.NoRetry : RetryPolicy.OtherReplica);
+                    throw new ObjectNotExistException(RetryPolicy.RefreshEndpoints);
                 }
 
                 // TODO: support input streamable data if Current.EndOfStream == false and output streamable data.

--- a/csharp/src/Ice/RemoteException.cs
+++ b/csharp/src/Ice/RemoteException.cs
@@ -19,6 +19,10 @@ namespace ZeroC.Ice
         /// </summary>
         public static readonly RetryPolicy OtherReplica = new RetryPolicy(Retryable.OtherReplica);
 
+        /// <summary>The RefreshEndpoints policy specifies that the exception can be retried on a different replica
+        /// after refreshing the endpoints.</summary>
+        public static readonly RetryPolicy RefreshEndpoints = new RetryPolicy(Retryable.RefreshEndpoints);
+
         /// <summary>Creates a retry policy that specifies that the exception can be retried after the given delay.</summary>
         /// <param name="delay">The delay after which the exception can be retried.</param>
         /// <returns>The retry policy.</returns>

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -914,7 +914,7 @@ namespace ZeroC.Ice.Test.Metrics
             else
             {
                 // We marshal the full ONE.
-                TestHelper.Assert(dm1.Size == 51 && dm1.ReplySize == 203);
+                TestHelper.Assert(dm1.Size == 51 && dm1.ReplySize == 209);
             }
 
             dm1 = (DispatchMetrics)map["opWithUnknownException"];
@@ -1108,7 +1108,7 @@ namespace ZeroC.Ice.Test.Metrics
             CheckFailure(clientMetrics, "Invocation", im1.Id, "System.Exception", 2, output);
 
             im1 = (InvocationMetrics)map["opWithRequestFailedException"];
-            TestHelper.Assert(im1.Current <= 1 && im1.Total == 2 && im1.Retry == 0);
+            TestHelper.Assert(im1.Current <= 1 && im1.Total == 2 && im1.Retry == 2);
             // System exceptions raised by the servant are reported as remote exceptions only with ice2, both as
             // a failure and remote exceptions with ice1.
             TestHelper.Assert(im1.Failures == 2 && im1.UserException == 2);

--- a/csharp/test/Ice/metrics/MetricsAMDI.cs
+++ b/csharp/test/Ice/metrics/MetricsAMDI.cs
@@ -20,7 +20,7 @@ namespace ZeroC.Ice.Test.Metrics
             throw new UserEx("custom UserEx message");
 
         public ValueTask OpWithRequestFailedExceptionAsync(Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ObjectNotExistException(RetryPolicy.RefreshEndpoints);
 
         public ValueTask OpWithLocalExceptionAsync(Current current, CancellationToken cancel) =>
             throw new InvalidConfigurationException("fake");

--- a/csharp/test/Ice/metrics/MetricsI.cs
+++ b/csharp/test/Ice/metrics/MetricsI.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Metrics
             throw new UserEx("custom UserEx message");
 
         public void OpWithRequestFailedException(Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ObjectNotExistException(RetryPolicy.RefreshEndpoints);
 
         public void OpWithLocalException(Current current, CancellationToken cancel) =>
             throw new InvalidConfigurationException("fake");

--- a/slice/Ice/Retryable.ice
+++ b/slice/Ice/Retryable.ice
@@ -27,6 +27,8 @@ module Ice
         /// retry same endpoint after delay ms
         AfterDelay,
         /// retry another replica known to the caller (if any)
-        OtherReplica
+        OtherReplica,
+        /// retry another replica after refreshing endpoints
+        RefreshEndpoints
     }
 }


### PR DESCRIPTION
This PR adds a new retry policy `RefreshEndpoints` that indicates the client should refresh endpoints after retrying using a different replica. For direct proxies, it is the same as OtherReplica for indirect proxies the client will clear the locator cache so that a new endpoint lookup is performed, the connector associated with the failure is excluded for the current retry sequence.

ONE and OpNE throw by Ice run-time have been updated to use this new policy.