### PR TITLE
Removed `cs:property` and `format:default` Metadata

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4429,7 +4429,7 @@ Slice::Operation::format() const
     optional<FormatType> format = parseFormatMetadata();
     if (!format)
     {
-        // Fall back to checking if it inherits a format from it's interface.
+        // Fall back to checking if it inherits a format from its interface.
         format = ContainedPtr::dynamicCast(_container)->parseFormatMetadata();
     }
     return format;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -954,7 +954,7 @@ Slice::Contained::setMetadata(const list<string>& metadata)
     _metadata = metadata;
 }
 
-std::optional<FormatType>
+optional<FormatType>
 Slice::Contained::parseFormatMetadata() const
 {
     string tag = findMetadataWithPrefix("format:");

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -49,7 +49,6 @@ enum NodeType
 // Format preference for classes and exceptions.
 enum FormatType
 {
-    DefaultFormat,    // No preference was specified.
     CompactFormat,    // Minimal format.
     SlicedFormat      // Full format.
 };
@@ -419,7 +418,7 @@ public:
     std::list<std::string> getAllMetadata() const;
     void setMetadata(const std::list<std::string>&);
 
-    FormatType parseFormatMetadata() const;
+    std::optional<FormatType> parseFormatMetadata() const;
 
     virtual bool uses(const ContainedPtr&) const = 0;
     virtual std::string kindOf() const = 0;
@@ -726,7 +725,7 @@ public:
     bool returnsMultipleValues() const;
     bool hasReturnAndOut() const;
     bool hasSingleReturnType() const;
-    FormatType format() const;
+    std::optional<FormatType> format() const;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -685,16 +685,16 @@ Slice::operationModeToString(Operation::Mode mode)
 string
 Slice::opFormatTypeToString(const OperationPtr& op)
 {
-    switch(op->format())
+    if (auto format = op->format())
     {
-    case DefaultFormat:
-        return "::Ice::FormatType::DefaultFormat";
-    case CompactFormat:
-        return "::Ice::FormatType::CompactFormat";
-    case SlicedFormat:
-        return "::Ice::FormatType::SlicedFormat";
+        switch (*format)
+        {
+            case CompactFormat: return "::Ice::FormatType::CompactFormat";
+            case SlicedFormat:  return "::Ice::FormatType::SlicedFormat";
+        }
     }
-    throw logic_error("");
+    // TODO: replace DefaultFormat with CompactFormat in the mapping.
+    return "::Ice::FormatType::DefaultFormat";
 }
 
 //

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -3154,7 +3154,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     {
         C << nl << "inS.readEmptyParams();";
     }
-    if(p->format() != DefaultFormat)
+    if (p->format())
     {
         C << nl << "inS.setFormat(" << opFormatTypeToString(p) << ");";
     }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1578,20 +1578,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
             }
             else if(StructPtr::dynamicCast(cont))
             {
-                if(s.substr(csPrefix.size()) == "property")
-                {
-                    newLocalMetadata.push_back(s);
-                    continue;
-                }
                 if(s.substr(csPrefix.size()) == "readonly")
-                {
-                    newLocalMetadata.push_back(s);
-                    continue;
-                }
-            }
-            else if(ClassDefPtr::dynamicCast(cont))
-            {
-                if(s.substr(csPrefix.size()) == "property")
                 {
                     newLocalMetadata.push_back(s);
                     continue;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -66,20 +66,16 @@ isDefaultInitialized(const MemberPtr& member, bool considerDefaultValue)
 string
 opFormatTypeToString(const OperationPtr& op)
 {
-    // TODO: eliminate DefaultFormat in the parser (DefaultFormat means the communicator default that was removed in
-    // Ice 4.0)
-    switch (op->format())
+    if (auto format = op->format())
     {
-        case DefaultFormat:
-        case CompactFormat:
-            return "default"; // same as Compact
-        case SlicedFormat:
-            return "ZeroC.Ice.FormatType.Sliced";
-        default:
-            assert(false);
+        switch (*format)
+        {
+            case CompactFormat: return "ZeroC.Ice.FormatType.Compact";
+            case SlicedFormat:  return "ZeroC.Ice.FormatType.Sliced";
+        }
     }
-
-    return "???";
+    // "default" is the same as Compact.
+    return "default";
 }
 
 void

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -66,16 +66,12 @@ isDefaultInitialized(const MemberPtr& member, bool considerDefaultValue)
 string
 opFormatTypeToString(const OperationPtr& op)
 {
-    if (auto format = op->format())
+    switch (op->format().value_or(CompactFormat))
     {
-        switch (*format)
-        {
-            case CompactFormat: return "ZeroC.Ice.FormatType.Compact";
-            case SlicedFormat:  return "ZeroC.Ice.FormatType.Sliced";
-        }
+        case CompactFormat: return "ZeroC.Ice.FormatType.Compact";
+        case SlicedFormat:  return "ZeroC.Ice.FormatType.Sliced";
     }
-    // "default" is the same as Compact.
-    return "default";
+    throw illegal_argument("unknown format type");
 }
 
 void

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2083,14 +2083,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const MemberPtr& p)
     }
     _out << typeToString(p->type(), getNamespace(cont));
     _out << " " << fixId(fieldName(p), ExceptionPtr::dynamicCast(cont) ? Slice::ExceptionType : Slice::ObjectType);
-    if(cont->hasMetadata("cs:property"))
-    {
-        _out << "{ get; set; }";
-    }
-    else
-    {
-        _out << ";";
-    }
+    _out << ";";
 }
 
 Slice::Gen::ProxyVisitor::ProxyVisitor(IceUtilInternal::Output& out) :

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -44,23 +44,17 @@ sliceModeToIceMode(Operation::Mode opMode)
 string
 opFormatTypeToString(const OperationPtr& op)
 {
-    string format = "com.zeroc.Ice.FormatType.";
-    switch(op->format())
+    if (auto format = op->format())
     {
-    case DefaultFormat:
-        format = "null"; // shorthand for most common case
-        break;
-    case CompactFormat:
-        format += "CompactFormat";
-        break;
-    case SlicedFormat:
-        format += "SlicedFormat";
-        break;
-    default:
-        assert(false);
-        break;
+        switch (*format)
+        {
+            case CompactFormat: return "com.zeroc.Ice.FormatType.CompactFormat";
+            case SlicedFormat:  return "com.zeroc.Ice.FormatType.SlicedFormat";
+        }
     }
-    return format;
+    // TODO: replace DefaultFormat with CompactFormat in the mapping.
+    // Return null for DefaultFormat.
+    return "null";
 }
 
 string
@@ -1116,7 +1110,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
             out << nl << "inS.readEmptyParams();";
         }
 
-        if(op->format() != DefaultFormat)
+        if (op->format())
         {
             out << nl << "inS.setFormat(" << opFormatTypeToString(op) << ");";
         }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -50,19 +50,17 @@ sliceModeToIceMode(Operation::Mode opMode)
 string
 opFormatTypeToString(const OperationPtr& op)
 {
-    switch(op->format())
+    if (auto format = op->format())
     {
-    case DefaultFormat:
-        return "0";
-    case CompactFormat:
-        return "1";
-    case SlicedFormat:
-        return "2";
-    default:
-        assert(false);
+        switch (*format)
+        {
+            case CompactFormat: return "1";
+            case SlicedFormat:  return "2";
+        }
     }
-
-    return "???";
+    // TODO: replace DefaultFormat with CompactFormat in the mapping.
+    // Return "0" for DefaultFormat.
+    return "0";
 }
 
 void
@@ -1542,7 +1540,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             _out << ", ";
 
-            if (op->format() != DefaultFormat)
+            if (op->format())
             {
                 _out << opFormatTypeToString(op); // Format.
             }

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1605,7 +1605,7 @@ private:
     void getOutParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
 
     string getTagFormat(const TypePtr&);
-    string getFormatType(FormatType);
+    string getFormatType(const OperationPtr&);
 
     void marshal(IceUtilInternal::Output&, const string&, const string&, const TypePtr&, bool, int);
     void unmarshal(IceUtilInternal::Output&, const string&, const string&, const TypePtr&, bool, int);
@@ -2097,13 +2097,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         if(!allInParams.empty())
         {
-            if(op->format() == DefaultFormat)
+            if (op->format())
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
+                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op) << ");";
             }
             else
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op->format()) << ");";
+                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
             }
             for(ParamInfoList::const_iterator r = requiredInParams.begin(); r != requiredInParams.end(); ++r)
             {
@@ -2260,13 +2260,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         if(!allInParams.empty())
         {
-            if(op->format() == DefaultFormat)
+            if (op->format())
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
+                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op) << ");";
             }
             else
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op->format()) << ");";
+                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
             }
             for(ParamInfoList::const_iterator r = requiredInParams.begin(); r != requiredInParams.end(); ++r)
             {
@@ -3785,21 +3785,18 @@ CodeVisitor::getTagFormat(const TypePtr& type)
 }
 
 string
-CodeVisitor::getFormatType(FormatType type)
+CodeVisitor::getFormatType(const OperationPtr& op)
 {
-    switch(type)
+    if (auto format = op->format())
     {
-    case DefaultFormat:
-        return "Ice.FormatType.DefaultFormat";
-    case CompactFormat:
-        return "Ice.FormatType.CompactFormat";
-    case SlicedFormat:
-        return "Ice.FormatType.SlicedFormat";
-    default:
-        assert(false);
+        switch (*format)
+        {
+            case CompactFormat: return "Ice.FormatType.CompactFormat";
+            case SlicedFormat:  return "Ice.FormatType.SlicedFormat";
+        }
     }
-
-    return "???";
+    // TODO: replace DefaultFormat with CompactFormat in the mapping.
+    return "Ice.FormatType.DefaultFormat";
 }
 
 void

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -85,28 +85,18 @@ replace(string s, string patt, string val)
 }
 
 string
-opFormatTypeToString(const OperationPtr& op )
+opFormatTypeToString(const OperationPtr& op)
 {
-    switch(op->format())
+    if (auto format = op->format())
     {
-        case DefaultFormat:
+        switch (*format)
         {
-            return ".DefaultFormat";
-        }
-        case CompactFormat:
-        {
-            return ".CompactFormat";
-        }
-        case SlicedFormat:
-        {
-            return ".SlicedFormat";
-        }
-        default:
-        {
-            assert(false);
+            case CompactFormat: return ".CompactFormat";
+            case SlicedFormat:  return ".SlicedFormat";
         }
     }
-    return "???";
+    // TODO: replace DefaultFormat with CompactFormat in the mapping.
+    return ".DefaultFormat";
 }
 
 }
@@ -2261,7 +2251,7 @@ SwiftGenerator::writeProxyOperation(::IceUtilInternal::Output& out, const Operat
     out << "operation: \"" << op->name() << "\",";
     out << nl << "mode: " << modeToString(op->sendMode()) << ",";
 
-    if(op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "format: " << opFormatTypeToString(op);
         out << ",";
@@ -2349,7 +2339,7 @@ SwiftGenerator::writeProxyAsyncOperation(::IceUtilInternal::Output& out, const O
     out << "operation: \"" << op->name() << "\",";
     out << nl << "mode: " << modeToString(op->sendMode()) << ",";
 
-    if(op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "format: " << opFormatTypeToString(op);
         out << ",";
@@ -2416,7 +2406,7 @@ SwiftGenerator::writeDispatchOperation(::IceUtilInternal::Output& out, const Ope
         writeUnmarshalInParams(out, op);
     }
 
-    if(op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "inS.setFormat(" << opFormatTypeToString(op) << ")";
     }
@@ -2477,7 +2467,7 @@ SwiftGenerator::writeDispatchAsyncOperation(::IceUtilInternal::Output& out, cons
         writeUnmarshalInParams(out, op);
     }
 
-    if(op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "inS.setFormat(" << opFormatTypeToString(op) << ")";
     }

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -105,46 +105,6 @@ namespace ZeroC.Ice.Test.DefaultValue
                 TestHelper.Assert(v.ZeroDotD == 0);
             }
 
-            {
-                var v = new ClassProperty();
-                TestHelper.Assert(!v.BoolFalse);
-                TestHelper.Assert(v.BoolTrue);
-                TestHelper.Assert(v.B == 1);
-                TestHelper.Assert(v.S == 2);
-                TestHelper.Assert(v.I == 3);
-                TestHelper.Assert(v.L == 4);
-                TestHelper.Assert(v.F == 5.1F);
-                TestHelper.Assert(v.D == 6.2);
-                TestHelper.Assert(v.Str.Equals("foo bar"));
-                TestHelper.Assert(v.NoDefault == null);
-                TestHelper.Assert(v.ZeroI == 0);
-                TestHelper.Assert(v.ZeroL == 0);
-                TestHelper.Assert(v.ZeroF == 0);
-                TestHelper.Assert(v.ZeroDotF == 0);
-                TestHelper.Assert(v.ZeroD == 0);
-                TestHelper.Assert(v.ZeroDotD == 0);
-            }
-
-            {
-                var v = new ExceptionProperty();
-                TestHelper.Assert(!v.BoolFalse);
-                TestHelper.Assert(v.BoolTrue);
-                TestHelper.Assert(v.B == 1);
-                TestHelper.Assert(v.S == 2);
-                TestHelper.Assert(v.I == 3);
-                TestHelper.Assert(v.L == 4);
-                TestHelper.Assert(v.F == 5.1F);
-                TestHelper.Assert(v.D == 6.2);
-                TestHelper.Assert(v.Str.Equals("foo bar"));
-                TestHelper.Assert(v.NoDefault == null);
-                TestHelper.Assert(v.ZeroI == 0);
-                TestHelper.Assert(v.ZeroL == 0);
-                TestHelper.Assert(v.ZeroF == 0);
-                TestHelper.Assert(v.ZeroDotF == 0);
-                TestHelper.Assert(v.ZeroD == 0);
-                TestHelper.Assert(v.ZeroDotD == 0);
-            }
-
             output.WriteLine("ok");
         }
     }

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -100,50 +100,6 @@ exception DerivedEx : BaseEx
     Nested::Color nc3 = ConstNestedColor3;
 }
 
-[cs:property]
-class ClassProperty
-{
-    bool boolFalse = false;
-    bool boolTrue = true;
-    byte b = 1;
-    short s = 2;
-    int i = 3;
-    long l = 4;
-    float f = 5.1;
-    double d = 6.2;
-    string str = "foo bar";
-    tag(1) string? noDefault;
-    int zeroI = 0;
-    long zeroL = 0;
-    float zeroF = 0;
-    float zeroDotF = 0.0;
-    double zeroD = 0;
-    double zeroDotD = 0;
-}
-
-// Exceptions don't support "cs:property" metadata, but
-// we want to ensure that the generated code compiles.
-[cs:property]
-exception ExceptionProperty
-{
-    bool boolFalse = false;
-    bool boolTrue = true;
-    byte b = 1;
-    short s = 2;
-    int i = 3;
-    long l = 4;
-    float f = 5.1;
-    double d = 6.2;
-    string str = "foo bar";
-    tag(1) string? noDefault;
-    int zeroI = 0;
-    long zeroL = 0;
-    float zeroF = 0;
-    float zeroDotF = 0.0;
-    double zeroD = 0;
-    double zeroDotD = 0;
-}
-
 sequence<byte> ByteSeq;
 sequence<int> IntSeq;
 dictionary<int, string> IntStringDict;

--- a/csharp/test/Ice/tagged/Test.ice
+++ b/csharp/test/Ice/tagged/Test.ice
@@ -166,7 +166,6 @@ exception RequiredException : TaggedException
     VarStruct vs2;
 }
 
-[cs:property]
 class TaggedWithCustom
 {
     tag(1) SmallStructList? l;


### PR DESCRIPTION
This PR removes support for the `cs:property` metadata, and the `default` argument for the `format` metadata.
It also removes anywhere they were used or tested.

It does not remove support for `DefaultFormat` from the language mappings themselves.