### PR TITLE
CodeAnalysis fixes

### DIFF
--- a/csharp/msbuild/CodeAnalysis.Base.ruleset
+++ b/csharp/msbuild/CodeAnalysis.Base.ruleset
@@ -14,11 +14,9 @@
       <Rule Id="CA1710" Action="None" /> <!-- TODO disable on generated code - Identifiers should have correct suffix -->
       <Rule Id="CA1715" Action="None" /> <!-- TODO enable - Prefix generic type parameter with 'T' -->
       <Rule Id="CA1716" Action="None" /> <!-- TODO disable on generated code - Identifiers should not match keywords -->
-      <Rule Id="CA1717" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Only FlagsAttribute enums should have plural names -->
       <Rule Id="CA1720" Action="None" /> <!-- Identifiers should not contain type names -->
       <Rule Id="CA1724" Action="None" /> <!-- Type names should not match namespaces -->
       <Rule Id="CA2000" Action="None" /> <!-- TODO review - Dispose objects before losing scope -->
-      <Rule Id="CA2007" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Consider calling ConfigureAwait on the awaited task -->
       <Rule Id="CA2208" Action="None" /> <!-- Instantiate argument exceptions correctly -->
       <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
       <Rule Id="CA2227" Action="None" /> <!-- Collection properties should be read only -->
@@ -68,20 +66,5 @@
       <Rule Id="SA1629" Action="None" /> <!-- TODO enable - Documentation text should end with a period -->
       <Rule Id="SA1642" Action="None" /> <!-- TODO review -  Constructor summary documentation should begin with standard text -->
       <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
-
-      <!-- TODO temporary disable for test projects -->
-      <Rule Id="SA0001" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- XML comment analysis is disabled due to project configuration -->
-      <Rule Id="SA1012" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Opening brace should be preceded by a space -->
-      <Rule Id="SA1117" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- The parameters should all be placed on the same line or each parameter should be placed on its own line. -->
-      <Rule Id="SA1300" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Element should begin with an uppercase letter -->
-      <Rule Id="SA1303" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Const field names should begin with upper-case letter -->
-      <Rule Id="SA1307" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Field names should begin with upper-case letter -->
-      <Rule Id="SA1312" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Variable should begin with lower-case letter -->
-      <Rule Id="SA1313" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Parameter should begin with lower-case letter -->
-      <Rule Id="SA1407" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Arithmetic expressions should declare precedence -->
-      <Rule Id="SA1408" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Conditional expressions should declare precedence -->
-      <Rule Id="SA1500" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Braces for multi-line statements should not share line -->
-      <Rule Id="SA1501" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Statement should not be on a single line -->
-      <Rule Id="SA1503" Action="None" Condition="'$(TestProject)' == 'true'" /> <!-- Braces should not be omitted -->
   </Rules>
 </RuleSet>

--- a/csharp/msbuild/CodeAnalysis.Test.ruleset
+++ b/csharp/msbuild/CodeAnalysis.Test.ruleset
@@ -1,0 +1,22 @@
+﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
+  <Include Path="CodeAnalysis.Base.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+      <Rule Id="CA1717" Action="None" /> <!-- Only FlagsAttribute enums should have plural names -->
+      <Rule Id="CA2007" Action="None" /> <!-- Consider calling ConfigureAwait on the awaited task -->
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+      <Rule Id="SA0001" Action="None" /> <!-- XML comment analysis is disabled due to project configuration -->
+      <Rule Id="SA1012" Action="None" /> <!-- Opening brace should be preceded by a space -->
+      <Rule Id="SA1117" Action="None" /> <!-- The parameters should all be placed on the same line or each parameter should be placed on its own line. -->
+      <Rule Id="SA1300" Action="None" /> <!-- Element should begin with an uppercase letter -->
+      <Rule Id="SA1303" Action="None" /> <!-- Const field names should begin with upper-case letter -->
+      <Rule Id="SA1307" Action="None" /> <!-- Field names should begin with upper-case letter -->
+      <Rule Id="SA1312" Action="None" /> <!-- Variable should begin with lower-case letter -->
+      <Rule Id="SA1313" Action="None" /> <!-- Parameter should begin with lower-case letter -->
+      <Rule Id="SA1407" Action="None" /> <!-- Arithmetic expressions should declare precedence -->
+      <Rule Id="SA1408" Action="None" /> <!-- Conditional expressions should declare precedence -->
+      <Rule Id="SA1500" Action="None" /> <!-- Braces for multi-line statements should not share line -->
+      <Rule Id="SA1501" Action="None" /> <!-- Statement should not be on a single line -->
+      <Rule Id="SA1503" Action="None" /> <!-- Braces should not be omitted -->
+  </Rules>
+</RuleSet>

--- a/csharp/msbuild/ice.common.props
+++ b/csharp/msbuild/ice.common.props
@@ -21,7 +21,6 @@
         <NoWarn>1591</NoWarn>
         <!-- TODO enable all warnigns as error once we fix analyzer warnings -->
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>
@@ -29,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All"/>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02" PrivateAssets="All"/>
     </ItemGroup>

--- a/csharp/src/Directory.Build.props
+++ b/csharp/src/Directory.Build.props
@@ -3,8 +3,9 @@
     <Import Project="../msbuild/ice.props" />
     <PropertyGroup>
         <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net5</AppTargetFramework>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../msbuild/CodeAnalysis.Base.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
-        <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\msbuild\stylecop.json" Link="stylecop.json" />
+        <AdditionalFiles Include="$(MSBuildThisFileDirectory)../msbuild/stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 </Project>

--- a/csharp/src/Ice/Acm.cs
+++ b/csharp/src/Ice/Acm.cs
@@ -261,6 +261,6 @@ namespace ZeroC.Ice
             }
         }
 
-        public void Remove(Connection _) => _timer?.Dispose();
+        public void Remove(Connection connection) => _timer?.Dispose();
     }
 }

--- a/csharp/src/Ice/BufferedTransceiver.cs
+++ b/csharp/src/Ice/BufferedTransceiver.cs
@@ -91,7 +91,7 @@ namespace ZeroC.Ice
             // Receive additional data if there's not enough or no buffered data.
             if (_buffer.Count < byteCount || (byteCount == 0 && _buffer.Count == 0))
             {
-                await ReceiveInBufferAsync(byteCount, cancel);
+                await ReceiveInBufferAsync(byteCount, cancel).ConfigureAwait(false);
                 Debug.Assert(_buffer.Count >= byteCount);
             }
 
@@ -154,14 +154,14 @@ namespace ZeroC.Ice
             if (byteCount == 0)
             {
                 // Perform a single receive and we're done.
-                offset += await Underlying.ReceiveAsync(_buffer.Slice(offset), cancel);
+                offset += await Underlying.ReceiveAsync(_buffer.Slice(offset), cancel).ConfigureAwait(false);
             }
             else
             {
                 // Receive data until we have read at least "byteCount" bytes in the buffer.
                 while (offset < byteCount)
                 {
-                    offset += await Underlying.ReceiveAsync(_buffer.Slice(offset), cancel);
+                    offset += await Underlying.ReceiveAsync(_buffer.Slice(offset), cancel).ConfigureAwait(false);
                 }
             }
 

--- a/csharp/src/Ice/ColocatedTransceiver.cs
+++ b/csharp/src/Ice/ColocatedTransceiver.cs
@@ -92,8 +92,8 @@ namespace ZeroC.Ice
         {
             // Send our unidirectional semaphore to the peer. The peer will decrease the semaphore when the stream is
             // disposed.
-            await _writer.WriteAsync((-1, UnidirectionalSerializeSemaphore, false), cancel);
-            (_, object? semaphore, _) = await _reader.ReadAsync(cancel);
+            await _writer.WriteAsync((-1, UnidirectionalSerializeSemaphore, false), cancel).ConfigureAwait(false);
+            (_, object? semaphore, _) = await _reader.ReadAsync(cancel).ConfigureAwait(false);
 
             // Get the peer's unidirectional semaphore and keep track of it to be able to release it once a
             // unidirectional stream is disposed.

--- a/csharp/src/Ice/Communicator-Properties.cs
+++ b/csharp/src/Ice/Communicator-Properties.cs
@@ -514,7 +514,7 @@ namespace ZeroC.Ice
         /// <param name="prefix">Only arguments that start with --prefix are extracted.</param>
         public static void ParseArgs(this Dictionary<string, string> into, ref string[] args, string prefix = "")
         {
-            if (prefix.Length > 0 && !prefix.EndsWith("."))
+            if (prefix.Length > 0 && !prefix.EndsWith(".", StringComparison.InvariantCulture))
             {
                 prefix += '.';
             }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -571,7 +571,7 @@ namespace ZeroC.Ice
                 if (stream.IsBidirectional)
                 {
                     // Send the response over the stream
-                    await stream.SendResponseFrameAsync(response, fin, cancel);
+                    await stream.SendResponseFrameAsync(response, fin, cancel).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)
@@ -691,7 +691,7 @@ namespace ZeroC.Ice
             }
             catch (Exception ex)
             {
-                await AbortAsync(ex);
+                await AbortAsync(ex).ConfigureAwait(false);
             }
 
             async Task PerformGoAwayAsync((long Bidirectional, long Unidirectional) lastStreamIds, Exception exception)

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -595,6 +595,10 @@ namespace ZeroC.Ice
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2007:Consider calling ConfigureAwait on the awaited task",
+            Justification = "Ensure continuations execute on the object adapter scheduler if it is set")]
         private async ValueTask AcceptAsync()
         {
             while (true)
@@ -602,8 +606,6 @@ namespace ZeroC.Ice
                 Connection? connection = null;
                 try
                 {
-                    // We don't use ConfigureAwait(false) on purpose. We want to ensure continuations execute on the
-                    // object adapter scheduler if an adapter scheduler is set.
                     connection = await _acceptor.AcceptAsync();
 
                     if (_communicator.TraceLevels.Transport >= 2)

--- a/csharp/src/Ice/EndpointFactory.cs
+++ b/csharp/src/Ice/EndpointFactory.cs
@@ -40,8 +40,7 @@ namespace ZeroC.Ice
     /// dictionary.</param>
     /// <param name="communicator">The communicator.</param>
     /// <param name="oaEndpoint">When true, the new endpoint corresponds to an object adapter's endpoint configuration;
-    /// when false, uriString represents a proxy endpoint.</param>
-    /// <param name="uriString">The original URI endpoint string, for error messages and tracing.</param>
+    /// when false, represents a proxy endpoint.</param>
     /// <returns>A new endpoint for the ice2 protocol.</returns>
     public delegate Endpoint Ice2EndpointParser(
         Transport transport,
@@ -49,6 +48,5 @@ namespace ZeroC.Ice
         ushort port,
         Dictionary<string, string> options,
         Communicator communicator,
-        bool oaEndpoint,
-        string uriString);
+        bool oaEndpoint);
 }

--- a/csharp/src/Ice/INetworkProxy.cs
+++ b/csharp/src/Ice/INetworkProxy.cs
@@ -67,10 +67,10 @@ namespace ZeroC.Ice
             data[8] = 0x00; // User ID.
 
             // Send the request.
-            await socket.SendAsync(data, SocketFlags.None, cancel);
+            await socket.SendAsync(data, SocketFlags.None, cancel).ConfigureAwait(false);
 
             // Now wait for the response whose size is 8 bytes.
-            await socket.ReceiveAsync(data.AsMemory(0, 8), SocketFlags.None, cancel);
+            await socket.ReceiveAsync(data.AsMemory(0, 8), SocketFlags.None, cancel).ConfigureAwait(false);
             if (data[0] != 0x00 || data[1] != 0x5a)
             {
                 // TODO the retry always use the same proxy address
@@ -123,14 +123,18 @@ namespace ZeroC.Ice
             sb.Append("\r\n\r\n");
 
             // Send the connect request.
-            await socket.SendAsync(System.Text.Encoding.ASCII.GetBytes(sb.ToString()), SocketFlags.None, cancel);
+            await socket.SendAsync(System.Text.Encoding.ASCII.GetBytes(sb.ToString()),
+                                   SocketFlags.None,
+                                   cancel).ConfigureAwait(false);
 
             // Read the HTTP response, reserve enough space for reading at least HTTP1.1
             byte[] buffer = new byte[256];
             int received = 0;
             while (true)
             {
-                received += await socket.ReceiveAsync(buffer.AsMemory(received), SocketFlags.None, cancel);
+                received += await socket.ReceiveAsync(buffer.AsMemory(received),
+                                                      SocketFlags.None,
+                                                      cancel).ConfigureAwait(false);
 
                 // Check if we received the full HTTP response, if not, continue reading otherwise we're done.
                 int end = HttpParser.IsCompleteMessage(buffer.AsSpan(0, received));

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -38,15 +38,16 @@ namespace ZeroC.Ice
         // encoding of the frame header (always set to 1.0 with the an ice1 frame, even though we use 1.1).
         internal static readonly byte[] ProtocolBytes = new byte[] { 1, 0, 1, 0 };
 
-        internal static readonly List<ArraySegment<byte>> CloseConnectionFrame =
-            new List<ArraySegment<byte>> { new byte[]
-            {
-                Magic[0], Magic[1], Magic[2], Magic[3],
-                ProtocolBytes[0], ProtocolBytes[1], ProtocolBytes[2], ProtocolBytes[3],
-                (byte)FrameType.CloseConnection,
-                0, // Compression status.
-                HeaderSize, 0, 0, 0 // Frame size.
-            }
+        internal static readonly List<ArraySegment<byte>> CloseConnectionFrame = new List<ArraySegment<byte>>
+        {
+                new byte[]
+                {
+                    Magic[0], Magic[1], Magic[2], Magic[3],
+                    ProtocolBytes[0], ProtocolBytes[1], ProtocolBytes[2], ProtocolBytes[3],
+                    (byte)FrameType.CloseConnection,
+                    0, // Compression status.
+                    HeaderSize, 0, 0, 0 // Frame size.
+                }
         };
 
         internal static readonly byte[] RequestHeaderPrologue = new byte[]
@@ -68,8 +69,9 @@ namespace ZeroC.Ice
             0, 0, 0, 0 // Frame size (placeholder).
         };
 
-        internal static readonly List<ArraySegment<byte>> ValidateConnectionFrame =
-            new List<ArraySegment<byte>> { new byte[]
+        internal static readonly List<ArraySegment<byte>> ValidateConnectionFrame = new List<ArraySegment<byte>>
+        {
+            new byte[]
             {
                 Magic[0], Magic[1], Magic[2], Magic[3],
                 ProtocolBytes[0], ProtocolBytes[1], ProtocolBytes[2], ProtocolBytes[3],

--- a/csharp/src/Ice/InstrumentationI.cs
+++ b/csharp/src/Ice/InstrumentationI.cs
@@ -303,7 +303,8 @@ namespace ZeroC.Ice
         }
 
         protected override string DefaultResolve(string attribute) =>
-            attribute.StartsWith("context.") && _current.Context.TryGetValue(attribute.Substring(8), out string? v) ?
+            attribute.StartsWith("context.", StringComparison.InvariantCulture) &&
+            _current.Context.TryGetValue(attribute[8..], out string? v) ?
                 v : throw new MissingFieldException(attribute);
 
         private class AttributeResolverI : AttributeResolver
@@ -452,7 +453,8 @@ namespace ZeroC.Ice
         }
 
         protected override string DefaultResolve(string attribute) =>
-            attribute.StartsWith("context.") && _context.TryGetValue(attribute.Substring(8), out string? v) ?
+            attribute.StartsWith("context.", StringComparison.InvariantCulture) &&
+            _context.TryGetValue(attribute[8..], out string? v) ?
                 v : throw new MissingFieldException(attribute);
 
         private class AttributeResolverI : AttributeResolver

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -67,7 +67,7 @@ namespace ZeroC.Ice
                 try
                 {
                     // Wait for the previous request task to complete.
-                    await previousRequestTask;
+                    await previousRequestTask.ConfigureAwait(false);
 
                     if (_loggerAdmin.TraceLevel > 1)
                     {
@@ -77,7 +77,7 @@ namespace ZeroC.Ice
 
                     // Now send the given request. The IRemoteLogger requests are marked as [oneway] in the Slice so
                     // this should return once the request has been sent.
-                    await request(_remoteLoggerPrx);
+                    await request(_remoteLoggerPrx).ConfigureAwait(false);
 
                     if (_loggerAdmin.TraceLevel > 1)
                     {
@@ -363,10 +363,11 @@ namespace ZeroC.Ice
         {
             var properties = communicator.GetProperties().Where(p =>
                 p.Key == "Ice.Default.Locator" ||
-                p.Key.StartsWith("IceSSL.")).ToDictionary(p => p.Key, p => p.Value);
+                p.Key.StartsWith("IceSSL.", StringComparison.InvariantCulture)).ToDictionary(p => p.Key, p => p.Value);
 
             string[] args = communicator.GetPropertyAsList("Ice.Admin.Logger.Properties")?.Select(
-                v => v.StartsWith("--") ? v : $"--{v}").ToArray() ?? Array.Empty<string>();
+                v => v.StartsWith("--", StringComparison.InvariantCulture) ?
+                    v : $"--{v}").ToArray() ?? Array.Empty<string>();
             return new Communicator(ref args, properties, logger: logger);
         }
 

--- a/csharp/src/Ice/MetricsAdmin.cs
+++ b/csharp/src/Ice/MetricsAdmin.cs
@@ -574,7 +574,8 @@ namespace ZeroC.Ice
 
         internal void Updated(IReadOnlyDictionary<string, string> props)
         {
-            if (props.Keys.FirstOrDefault(key => key.IndexOf("IceMX.") == 0) != null)
+            if (props.Keys.FirstOrDefault(
+                    key => key.IndexOf("IceMX.", StringComparison.InvariantCulture) == 0) != null)
             {
                 // Update the metrics views using the new configuration.
                 try

--- a/csharp/src/Ice/ProtocolExtensions.cs
+++ b/csharp/src/Ice/ProtocolExtensions.cs
@@ -49,7 +49,7 @@ namespace ZeroC.Ice
                 case "ice2":
                     return Protocol.Ice2;
                 default:
-                    if (str.EndsWith(".0"))
+                    if (str.EndsWith(".0", StringComparison.InvariantCulture))
                     {
                         str = str[0..^2];
                     }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1099,7 +1099,7 @@ namespace ZeroC.Ice
 
                     if (RouterInfo != null)
                     {
-                        await RouterInfo.AddProxyAsync(IObjectPrx.Factory(this));
+                        await RouterInfo.AddProxyAsync(IObjectPrx.Factory(this)).ConfigureAwait(false);
 
                         // Set the object adapter for this router (if any) on the new connection, so that callbacks from
                         // the router can be received over this new connection.
@@ -1125,7 +1125,7 @@ namespace ZeroC.Ice
                                                       "connection to cached endpoints failed\n" +
                                                       $"removing endpoints from cache and trying again\n{ex}");
                         }
-                        return await GetConnectionAsync(excludedConnectors, cancel);
+                        return await GetConnectionAsync(excludedConnectors, cancel).ConfigureAwait(false);
                     }
                     throw;
                 }

--- a/csharp/src/Ice/RouterInfo.cs
+++ b/csharp/src/Ice/RouterInfo.cs
@@ -51,7 +51,8 @@ namespace ZeroC.Ice
             }
 
             // TODO: fix the Slice method addProxies to return non-nullable proxies.
-            IObjectPrx?[] evictedProxies = await Router.AddProxiesAsync(new IObjectPrx[] { proxy });
+            IObjectPrx?[] evictedProxies =
+                await Router.AddProxiesAsync(new IObjectPrx[] { proxy }).ConfigureAwait(false);
 
             lock (_mutex)
             {

--- a/csharp/src/Ice/SlicStream.cs
+++ b/csharp/src/Ice/SlicStream.cs
@@ -94,13 +94,16 @@ namespace ZeroC.Ice
         }
 
         protected override async ValueTask ResetAsync(long errorCode) =>
-            await _transceiver.PrepareAndSendFrameAsync(SlicDefinitions.FrameType.StreamReset, ostr =>
+            await _transceiver.PrepareAndSendFrameAsync(
+                SlicDefinitions.FrameType.StreamReset,
+                ostr =>
                 {
                     checked
                     {
                         new StreamResetBody((ulong)errorCode).IceWrite(ostr);
                     }
-                }, Id).ConfigureAwait(false);
+                },
+                Id).ConfigureAwait(false);
 
         protected override async ValueTask SendAsync(
             IList<ArraySegment<byte>> buffer,

--- a/csharp/src/Ice/SlicTransceiver.cs
+++ b/csharp/src/Ice/SlicTransceiver.cs
@@ -219,7 +219,8 @@ namespace ZeroC.Ice
             TimeSpan peerIdleTimeout;
             if (IsIncoming)
             {
-                (SlicDefinitions.FrameType type, ArraySegment<byte> data) = await ReceiveFrameAsync(cancel);
+                (SlicDefinitions.FrameType type, ArraySegment<byte> data) =
+                    await ReceiveFrameAsync(cancel).ConfigureAwait(false);
                 if (type != SlicDefinitions.FrameType.Initialize)
                 {
                     throw new InvalidDataException($"unexpected Slic frame with frame type `{type}'");
@@ -233,13 +234,16 @@ namespace ZeroC.Ice
                 {
                     // If unsupported Slic version, we stop reading there and reply with a VERSION frame to provide
                     // the client the supported Slic versions.
-                    await PrepareAndSendFrameAsync(SlicDefinitions.FrameType.Version, ostr =>
-                    {
-                        var versionBody = new VersionBody(new uint[] { 1 });
-                        versionBody.IceWrite(ostr);
-                    }, cancel: cancel).ConfigureAwait(false);
+                    await PrepareAndSendFrameAsync(
+                        SlicDefinitions.FrameType.Version,
+                        ostr =>
+                        {
+                            var versionBody = new VersionBody(new uint[] { 1 });
+                            versionBody.IceWrite(ostr);
+                        },
+                        cancel: cancel).ConfigureAwait(false);
 
-                    (type, data) = await ReceiveFrameAsync(cancel);
+                    (type, data) = await ReceiveFrameAsync(cancel).ConfigureAwait(false);
                     if (type != SlicDefinitions.FrameType.Initialize)
                     {
                         throw new InvalidDataException($"unexpected Slic frame with frame type `{type}'");
@@ -277,31 +281,38 @@ namespace ZeroC.Ice
                 peerIdleTimeout = TimeSpan.FromMilliseconds(initializeBody.IdleTimeout);
 
                 // Send back an INITIALIZE_ACK frame.
-                await PrepareAndSendFrameAsync(SlicDefinitions.FrameType.InitializeAck, ostr =>
-                {
-                    var initializeAckBody = new InitializeAckBody(
-                        (ulong)Options.MaxBidirectionalStreams,
-                        (ulong)Options.MaxUnidirectionalStreams,
-                        (ulong)Options.IdleTimeout.TotalMilliseconds);
-                    initializeAckBody.IceWrite(ostr);
-                }, cancel: cancel).ConfigureAwait(false);
+                await PrepareAndSendFrameAsync(
+                    SlicDefinitions.FrameType.InitializeAck,
+                    ostr =>
+                    {
+                        var initializeAckBody = new InitializeAckBody(
+                            (ulong)Options.MaxBidirectionalStreams,
+                            (ulong)Options.MaxUnidirectionalStreams,
+                            (ulong)Options.IdleTimeout.TotalMilliseconds);
+                        initializeAckBody.IceWrite(ostr);
+                    },
+                    cancel: cancel).ConfigureAwait(false);
             }
             else
             {
                 // Send the INITIALIZE frame.
-                await PrepareAndSendFrameAsync(SlicDefinitions.FrameType.Initialize, ostr =>
-                {
-                    var initializeBody = new InitializeBody(
-                        1,
-                        Protocol.Ice2.GetName(),
-                        (ulong)Options.MaxBidirectionalStreams,
-                        (ulong)Options.MaxUnidirectionalStreams,
-                        (ulong)Options.IdleTimeout.TotalMilliseconds);
-                    initializeBody.IceWrite(ostr);
-                }, cancel: cancel).ConfigureAwait(false);
+                await PrepareAndSendFrameAsync(
+                    SlicDefinitions.FrameType.Initialize,
+                    ostr =>
+                    {
+                        var initializeBody = new InitializeBody(
+                            1,
+                            Protocol.Ice2.GetName(),
+                            (ulong)Options.MaxBidirectionalStreams,
+                            (ulong)Options.MaxUnidirectionalStreams,
+                            (ulong)Options.IdleTimeout.TotalMilliseconds);
+                        initializeBody.IceWrite(ostr);
+                    },
+                    cancel: cancel).ConfigureAwait(false);
 
                 // Read the INITIALIZE_ACK or VERSION frame from the server
-                (SlicDefinitions.FrameType type, ArraySegment<byte> data) = await ReceiveFrameAsync(cancel);
+                (SlicDefinitions.FrameType type, ArraySegment<byte> data) =
+                    await ReceiveFrameAsync(cancel).ConfigureAwait(false);
 
                 var istr = new InputStream(data, SlicDefinitions.Encoding);
 

--- a/csharp/src/Ice/SslEngine.cs
+++ b/csharp/src/Ice/SslEngine.cs
@@ -118,10 +118,10 @@ namespace ZeroC.Ice
                         bool first = true;
                         while (true)
                         {
-                            startpos = strbuf.IndexOf(beginCertificateMark, endpos);
+                            startpos = strbuf.IndexOf(beginCertificateMark, endpos, StringComparison.InvariantCulture);
                             if (startpos != -1)
                             {
-                                endpos = strbuf.IndexOf(endCertificateMark, startpos);
+                                endpos = strbuf.IndexOf(endCertificateMark, startpos, StringComparison.InvariantCulture);
                                 if (endpos == -1)
                                 {
                                     throw new FormatException(

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -159,8 +159,7 @@ namespace ZeroC.Ice
             ushort port,
             Dictionary<string, string> options,
             Communicator communicator,
-            bool oaEndpoint,
-            string _)
+            bool oaEndpoint)
         {
             Debug.Assert(transport == Transport.TCP || transport == Transport.SSL);
             return new TcpEndpoint(new EndpointData(transport, host, port, Array.Empty<string>()),

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -211,7 +211,7 @@ namespace ZeroC.Ice
                                    oaEndpoint,
                                    endpointString);
         }
-        private protected override IConnector CreateConnector(EndPoint addr, INetworkProxy? _) =>
+        private protected override IConnector CreateConnector(EndPoint addr, INetworkProxy? proxy) =>
             new UdpConnector(this, addr);
 
         // Constructor for ice1 unmarshaling

--- a/csharp/src/Ice/UriParser.cs
+++ b/csharp/src/Ice/UriParser.cs
@@ -32,13 +32,15 @@ namespace ZeroC.Ice
         /// format.</summary>
         /// <param name="s">The string to check.</param>
         /// <returns>True when the string is most likely an ice+transport URI; otherwise, false.</returns>
-        internal static bool IsEndpointUri(string s) => s.StartsWith("ice+") && s.Contains("://");
+        internal static bool IsEndpointUri(string s) =>
+            s.StartsWith("ice+", StringComparison.InvariantCulture) && s.Contains("://");
 
         /// <summary>Checks if a string is an ice or ice+transport URI, and not a proxy string using the ice1 string
         /// format.</summary>
         /// <param name="s">The string to check.</param>
         /// <returns>True when the string is most likely an ice or ice+transport URI; otherwise, false.</returns>
-        internal static bool IsProxyUri(string s) => s.StartsWith("ice:") || IsEndpointUri(s);
+        internal static bool IsProxyUri(string s) =>
+            s.StartsWith("ice:", StringComparison.InvariantCulture) || IsEndpointUri(s);
 
         /// <summary>Parses an ice+transport URI string that represents one or more object adapter endpoints.</summary>
         /// <param name="uriString">The URI string to parse.</param>
@@ -128,11 +130,10 @@ namespace ZeroC.Ice
             bool oaEndpoint,
             Dictionary<string, string> options,
             Protocol protocol,
-            Uri uri,
-            string uriString)
+            Uri uri)
         {
-            Debug.Assert(uri.Scheme.StartsWith("ice+"));
-            string transportName = uri.Scheme.Substring(4); // i.e. chop-off "ice+"
+            Debug.Assert(uri.Scheme.StartsWith("ice+", StringComparison.InvariantCulture));
+            string transportName = uri.Scheme[4..]; // i.e. chop-off "ice+"
 
             ushort port;
             checked
@@ -183,8 +184,7 @@ namespace ZeroC.Ice
                                                port,
                                                options,
                                                communicator,
-                                               oaEndpoint,
-                                               uriString) ??
+                                               oaEndpoint) ??
                 UniversalEndpoint.Parse(transport, uri.DnsSafeHost, port, options, communicator, protocol);
 
             if (options.Count > 0)
@@ -208,11 +208,11 @@ namespace ZeroC.Ice
         {
             if (endpointOptions == null) // i.e. ice scheme
             {
-                Debug.Assert(uriString.StartsWith("ice:"));
+                Debug.Assert(uriString.StartsWith("ice:", StringComparison.InvariantCulture));
                 Debug.Assert(!pureEndpoints);
 
                 string body = uriString.Substring(4);
-                if (body.StartsWith("//"))
+                if (body.StartsWith("//", StringComparison.InvariantCulture))
                 {
                     throw new FormatException("the ice URI scheme cannot define a host or port");
                 }
@@ -337,7 +337,7 @@ namespace ZeroC.Ice
 
             try
             {
-                bool iceScheme = uriString.StartsWith("ice:");
+                bool iceScheme = uriString.StartsWith("ice:", StringComparison.InvariantCulture);
                 if (iceScheme && oaEndpoints)
                 {
                     throw new FormatException("an object adapter endpoint supports only ice+transport URIs");
@@ -356,21 +356,21 @@ namespace ZeroC.Ice
                 {
                     endpoints = new List<Endpoint>
                     {
-                        CreateEndpoint(communicator, oaEndpoints, endpointOptions, protocol, uri, uriString)
+                        CreateEndpoint(communicator, oaEndpoints, endpointOptions, protocol, uri)
                     };
 
                     if (altEndpoint != null)
                     {
                         foreach (string endpointStr in altEndpoint.Split(','))
                         {
-                            if (endpointStr.StartsWith("ice:"))
+                            if (endpointStr.StartsWith("ice:", StringComparison.InvariantCulture))
                             {
                                 throw new FormatException(
                                     $"invalid URI scheme for endpoint `{endpointStr}': must be empty or ice+transport");
                             }
 
                             string altUriString = endpointStr;
-                            if (!altUriString.StartsWith("ice+"))
+                            if (!altUriString.StartsWith("ice+", StringComparison.InvariantCulture))
                             {
                                 altUriString = $"{uri.Scheme}://{altUriString}";
                             }
@@ -396,8 +396,7 @@ namespace ZeroC.Ice
                                                          oaEndpoints,
                                                          endpointOptions,
                                                          protocol,
-                                                         endpointUri,
-                                                         endpointStr));
+                                                         endpointUri));
                         }
                     }
                 }

--- a/csharp/src/Ice/WSEndpoint.cs
+++ b/csharp/src/Ice/WSEndpoint.cs
@@ -132,8 +132,7 @@ namespace ZeroC.Ice
             ushort port,
             Dictionary<string, string> options,
             Communicator communicator,
-            bool oaEndpoint,
-            string _)
+            bool oaEndpoint)
         {
             Debug.Assert(transport == Transport.WS || transport == Transport.WSS);
 

--- a/csharp/src/iceboxnet/Server.cs
+++ b/csharp/src/iceboxnet/Server.cs
@@ -50,7 +50,7 @@ namespace ZeroC.IceBox
             foreach (KeyValuePair<string, string> pair in services)
             {
                 string name = pair.Key.Substring(prefix.Length);
-                argSeq.RemoveAll(v => v.StartsWith("--" + name));
+                argSeq.RemoveAll(v => v.StartsWith($"--{name}", StringComparison.InvariantCulture));
             }
 
             foreach (string arg in args)

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -331,7 +331,7 @@ namespace ZeroC.IceBox
                 Debug.Assert(_adminFacetFilter != null);
                 foreach (string p in _adminFacetFilter)
                 {
-                    if (p.StartsWith(prefix))
+                    if (p.StartsWith(prefix, StringComparison.InvariantCulture))
                     {
                         facetNames.Add(p.Substring(prefix.Length));
                     }
@@ -357,8 +357,9 @@ namespace ZeroC.IceBox
             if (_communicator.GetPropertyAsBool("IceBox.InheritProperties") ?? false)
             {
                 // Inherit all except Ice.Admin.xxx properties
-                properties = _communicator.GetProperties().Where(p => !p.Key.StartsWith("Ice.Admin.")).ToDictionary(
-                    p => p.Key, p => p.Value);
+                properties = _communicator.GetProperties().Where(
+                    p => !p.Key.StartsWith("Ice.Admin.", StringComparison.InvariantCulture)).ToDictionary(
+                        p => p.Key, p => p.Value);
             }
             else
             {
@@ -399,7 +400,7 @@ namespace ZeroC.IceBox
             {
                 foreach (string p in _communicator.FindAllAdminFacets().Keys)
                 {
-                    if (p.StartsWith(prefix))
+                    if (p.StartsWith(prefix, StringComparison.InvariantCulture))
                     {
                         _communicator.RemoveAdminFacet(p);
                     }
@@ -750,7 +751,9 @@ namespace ZeroC.IceBox
                 Debug.Assert(Args.Length > 0);
 
                 EntryPoint = Args[0];
-                Args = Args.Skip(1).Concat(serverArgs.Where(arg => arg.StartsWith($"--{service}."))).ToArray();
+                Args = Args.Skip(1).Concat(
+                    serverArgs.Where(
+                        arg => arg.StartsWith($"--{service}.", StringComparison.InvariantCulture))).ToArray();
             }
         }
     }

--- a/csharp/test/Directory.Build.props
+++ b/csharp/test/Directory.Build.props
@@ -3,6 +3,7 @@
     <Import Project="$(MSBuildThisFileDirectory)../msbuild/ice.test.props" />
     <PropertyGroup>
         <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net5</AppTargetFramework>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)../msbuild/CodeAnalysis.Test.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <Choose>
         <When Condition="'$(ICE_BIN_DIST)' == 'all'">

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -433,7 +433,8 @@ namespace ZeroC.Ice.Test.Metrics
 
             var invoke = (InvocationMetrics)view["Invocation"][0]!;
 
-            TestHelper.Assert(invoke.Id.IndexOf("[ice_ping]") > 0 && invoke.Current == 0 && invoke.Total == 5);
+            TestHelper.Assert(invoke.Id.IndexOf("[ice_ping]", StringComparison.InvariantCulture) > 0 &&
+                              invoke.Current == 0 && invoke.Total == 5);
             TestHelper.Assert(invoke.Children.Length == 2);
             TestHelper.Assert(invoke.Children[0]!.Total >= 2 && invoke.Children[1]!.Total >= 2);
             TestHelper.Assert((invoke.Children[0]!.Total + invoke.Children[1]!.Total) == 5);
@@ -443,7 +444,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             TestHelper.Assert(view["Dispatch"].Length == 1);
             TestHelper.Assert(view["Dispatch"][0]!.Current == 0 && view["Dispatch"][0]!.Total == 5);
-            TestHelper.Assert(view["Dispatch"][0]!.Id.IndexOf("[ice_ping]") > 0);
+            TestHelper.Assert(view["Dispatch"][0]!.Id.IndexOf("[ice_ping]", StringComparison.InvariantCulture) > 0);
 
             metrics.GetConnection().GoAwayAsync();
             metrics.Clone(connectionId: "Con1").GetConnection().GoAwayAsync();

--- a/csharp/test/Ice/plugin/BasePlugin.cs
+++ b/csharp/test/Ice/plugin/BasePlugin.cs
@@ -34,6 +34,7 @@ namespace ZeroC.Ice.Test.Plugin
         public abstract void Initialize(PluginInitializationContext context);
         public virtual async ValueTask DisposeAsync()
         {
+            GC.SuppressFinalize(this);
             if (Other != null)
             {
                 await Other.DisposeAsync();

--- a/csharp/test/Ice/plugin/PluginFactory.cs
+++ b/csharp/test/Ice/plugin/PluginFactory.cs
@@ -28,6 +28,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public ValueTask DisposeAsync()
             {
+                GC.SuppressFinalize(this);
                 _destroyed = true;
                 return new ValueTask(Task.CompletedTask);
             }

--- a/csharp/test/Ice/plugin/PluginOneFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginOneFailFactory.cs
@@ -32,6 +32,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public override ValueTask DisposeAsync()
             {
+                GC.SuppressFinalize(this);
                 TestHelper.Assert(_two != null && _two.isDestroyed());
 
                 // Not destroyed because initialize fails.

--- a/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
@@ -22,6 +22,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public override ValueTask DisposeAsync()
             {
+                GC.SuppressFinalize(this);
                 TestHelper.Assert(false);
                 return new ValueTask(Task.CompletedTask);
             }

--- a/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
@@ -32,6 +32,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public override ValueTask DisposeAsync()
             {
+                GC.SuppressFinalize(this);
                 TestHelper.Assert(_one != null && !_one.isDestroyed());
 
                 // Not destroyed because initialize fails.

--- a/csharp/test/Slice/escape/msbuild/client/CodeAnalysis.ruleset
+++ b/csharp/test/Slice/escape/msbuild/client/CodeAnalysis.ruleset
@@ -1,5 +1,5 @@
 ﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
-    <Include Path="..\..\..\..\..\msbuild\CodeAnalysis.ruleset" Action="Default" />
+    <Include Path="..\..\..\..\..\msbuild\CodeAnalysis.Test.ruleset" Action="Default" />
     <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
         <!-- We disable the following analyzer rules because this test doesn't use the C# normalized case -->
         <Rule Id="SA1304" Action="None" /> <!-- Non-private readonly fields should begin with upper-case letter -->


### PR DESCRIPTION
This PR splits the code analysis ruleset configuration into two files,  `CodeAnalysis.Base.ruleset` define the rules that are enabled for all projects, `CodeAnalysis.Test.ruleset` inherits the base rules and defines rules that apply only to test projects.

Update FxCopAnalyzers from 3.3.0 to 3.3.1

The previous setup with conditions in the ruleset wasn't working correctly, the analyzers were ignoring the conditions as a result some rules that should have been only disabled for tests were also disabled for sources.

- Add missing calls to `ConfigureAwait(false);` 
- Add `StringComparison.InvariantCulture`  where required, the default ==/Contains do ordinal comparison so those are fine but not so for `StartsWith`, `EndsWith`
- Remove `uriString` parameter from `Ice2EndpointParser` we were passing this down but not used anywhere, we can add it back when we require it.
- Don't use `_` as a parameter name, if you are overriding a method and don't use the parameter give it a name, if the method is not an override remove the unused parameter.
