### PR TITLE
Clear locator cache upon remote exception

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -545,8 +545,8 @@ namespace ZeroC.Ice
                 {
                     if (stream.IsBidirectional)
                     {
-                        var exception = new ObjectNotExistException();
-                        response = new OutgoingResponseFrame(request, exception);
+                        response = new OutgoingResponseFrame(request,
+                                                             new ObjectNotExistException(RetryPolicy.OtherReplica));
                         await stream.SendResponseFrameAsync(response, true, cancel).ConfigureAwait(false);
                     }
                     return;

--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -156,14 +156,7 @@ namespace ZeroC.Ice
                         reference.RouterInfo.ClearCache(reference);
                         return RetryPolicy.AfterDelay(TimeSpan.Zero);
                     }
-                    else if (reference.IsIndirect)
-                    {
-                        if (reference.IsWellKnown)
-                        {
-                            reference.LocatorInfo?.ClearCache(reference);
-                        }
-                        return RetryPolicy.AfterDelay(TimeSpan.Zero);
-                    }
+                    return RetryPolicy.OtherReplica;
                 }
             }
             return RetryPolicy.NoRetry;

--- a/csharp/src/Ice/LoggerAdmin.cs
+++ b/csharp/src/Ice/LoggerAdmin.cs
@@ -133,7 +133,7 @@ namespace ZeroC.Ice
             {
                 if (_destroyed)
                 {
-                    throw new ObjectNotExistException();
+                    throw new ObjectNotExistException(RetryPolicy.OtherReplica);
                 }
 
                 _sendLogCommunicator ??= CreateSendLogCommunicator(current.Adapter.Communicator, _logger.LocalLogger);

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -841,8 +841,7 @@ namespace ZeroC.Ice
                 IObject? servant = Find(current.Identity, current.Facet);
                 if (servant == null)
                 {
-                    throw new ObjectNotExistException(
-                        ReplicaGroupId.Length == 0 ? RetryPolicy.NoRetry : RetryPolicy.OtherReplica);
+                    throw new ObjectNotExistException(RetryPolicy.OtherReplica);
                 }
 
                 // TODO: support input streamable data if Current.EndOfStream == false and output streamable data.

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -915,7 +915,7 @@ namespace ZeroC.Ice.Test.Metrics
             else
             {
                 // We marshal the full ONE.
-                TestHelper.Assert(dm1.Size == 51 && dm1.ReplySize == 203);
+                TestHelper.Assert(dm1.Size == 51 && dm1.ReplySize == 209);
             }
 
             dm1 = (DispatchMetrics)map["opWithUnknownException"];
@@ -1109,7 +1109,7 @@ namespace ZeroC.Ice.Test.Metrics
             CheckFailure(clientMetrics, "Invocation", im1.Id, "System.Exception", 2, output);
 
             im1 = (InvocationMetrics)map["opWithRequestFailedException"];
-            TestHelper.Assert(im1.Current <= 1 && im1.Total == 2 && im1.Retry == 0);
+            TestHelper.Assert(im1.Current <= 1 && im1.Total == 2 && im1.Retry == 2);
             // System exceptions raised by the servant are reported as remote exceptions only with ice2, both as
             // a failure and remote exceptions with ice1.
             TestHelper.Assert(im1.Failures == 2 && im1.UserException == 2);

--- a/csharp/test/Ice/metrics/MetricsAMDI.cs
+++ b/csharp/test/Ice/metrics/MetricsAMDI.cs
@@ -20,7 +20,7 @@ namespace ZeroC.Ice.Test.Metrics
             throw new UserEx("custom UserEx message");
 
         public ValueTask OpWithRequestFailedExceptionAsync(Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ObjectNotExistException(RetryPolicy.OtherReplica);
 
         public ValueTask OpWithLocalExceptionAsync(Current current, CancellationToken cancel) =>
             throw new InvalidConfigurationException("fake");

--- a/csharp/test/Ice/metrics/MetricsI.cs
+++ b/csharp/test/Ice/metrics/MetricsI.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Metrics
             throw new UserEx("custom UserEx message");
 
         public void OpWithRequestFailedException(Current current, CancellationToken cancel) =>
-            throw new ObjectNotExistException();
+            throw new ObjectNotExistException(RetryPolicy.OtherReplica);
 
         public void OpWithLocalException(Current current, CancellationToken cancel) =>
             throw new InvalidConfigurationException("fake");


### PR DESCRIPTION
This small PR fixes retry code to clear the locator cache upon a remote exception when using an indirect reference, the cache is at most cleared once per retry sequence, this is a simpler rule that the behavior proposed with https://github.com/zeroc-ice/ice/pull/1129 that require a new retry policy.