### PR TITLE
Ensure we don't reuse a connection for a different endpoint

### DIFF
--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -250,17 +250,19 @@ namespace ZeroC.Ice
                             Connection connection = completedTask.Result;
                             foreach ((IConnector connector, Endpoint endpoint) in connectors)
                             {
-                                // If the connection was established for another endpoint but to the same connector,
-                                // we ensure to also associate the connection with this endpoint.
-                                if (connection.Connector.Equals(connector) && !connection.Endpoints.Contains(endpoint))
+                                if (connection.Connector.Equals(connector))
                                 {
                                     Debug.Assert(connection.ConnectionId == connectionId);
-                                    connection.Endpoints.Add(endpoint);
-                                    _connectionsByEndpoint.Add((endpoint, connectionId), connection);
-                                    break;
+                                    // If the connection was established for another endpoint but to the same connector,
+                                    // we ensure to also associate the connection with this endpoint.
+                                    if (!connection.Endpoints.Contains(endpoint))
+                                    {
+                                        connection.Endpoints.Add(endpoint);
+                                        _connectionsByEndpoint.Add((endpoint, connectionId), connection);
+                                    }
+                                    return connection;
                                 }
                             }
-                            return connection;
                         }
                     }
                     connectTasks.Remove(completedTask);

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -3,29 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Binding
 {
     public static class AllTests
     {
-        private static string GetAdapterNameWithAMI(ITestIntfPrx testIntf) => testIntf.GetAdapterNameAsync().Result;
-
-        private static void Shuffle(ref List<IRemoteObjectAdapterPrx> array)
-        {
-            for (int i = 0; i < array.Count - 1; ++i)
-            {
-                int r = _rand.Next(array.Count - i) + i;
-                TestHelper.Assert(r >= i && r < array.Count);
-                if (r != i)
-                {
-                    IRemoteObjectAdapterPrx tmp = array[i];
-                    array[i] = array[r];
-                    array[r] = tmp;
-                }
-            }
-        }
-
         private static ITestIntfPrx CreateTestIntfPrx(List<IRemoteObjectAdapterPrx> adapters)
         {
             var endpoints = new List<Endpoint>();
@@ -230,6 +214,40 @@ namespace ZeroC.Ice.Test.Binding
 
                     Deactivate(com, adapters);
                 }
+            }
+            output.WriteLine("ok");
+
+            output.Write("testing connection reuse with multiple endpoints... ");
+            output.Flush();
+            {
+                var adapters1 = new List<IRemoteObjectAdapterPrx>
+                {
+                    com.CreateObjectAdapter("Adapter81", testTransport)!,
+                    com.CreateObjectAdapter("Adapter82", testTransport)!,
+                    com.CreateObjectAdapter("Adapter83", testTransport)!
+                };
+
+                var adapters2 = new List<IRemoteObjectAdapterPrx>
+                {
+                    adapters1[0],
+                    com.CreateObjectAdapter("Adapter84", testTransport)!,
+                    com.CreateObjectAdapter("Adapter85", testTransport)!
+                };
+
+                ITestIntfPrx obj1 = CreateTestIntfPrx(adapters1);
+                ITestIntfPrx obj2 = CreateTestIntfPrx(adapters2);
+
+                com.DeactivateObjectAdapter(adapters1[0]);
+
+                Task<string> t1 = obj1.GetAdapterNameAsync();
+                Task<string> t2 = obj2.GetAdapterNameAsync();
+                string adapter1 = t1.Result;
+                string adapter2 = t2.Result;
+                TestHelper.Assert(adapter1 == "Adapter82", $"Adpter name: {adapter1}");
+                TestHelper.Assert(adapter2 == "Adapter84", $"Adpter name: {adapter2}");
+
+                Deactivate(com, adapters1);
+                Deactivate(com, adapters2);
             }
             output.WriteLine("ok");
 
@@ -523,7 +541,5 @@ namespace ZeroC.Ice.Test.Binding
 
             com.Shutdown();
         }
-
-        private static readonly Random _rand = new Random(unchecked((int)DateTime.Now.Ticks));
     }
 }

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -241,10 +241,35 @@ namespace ZeroC.Ice.Test.Binding
 
                 Task<string> t1 = obj1.GetAdapterNameAsync();
                 Task<string> t2 = obj2.GetAdapterNameAsync();
-                string adapter1 = t1.Result;
-                string adapter2 = t2.Result;
-                TestHelper.Assert(adapter1 == "Adapter82", $"Adpter name: {adapter1}");
-                TestHelper.Assert(adapter2 == "Adapter84", $"Adpter name: {adapter2}");
+                TestHelper.Assert(t1.Result == "Adapter82");
+                TestHelper.Assert(t2.Result == "Adapter84");
+
+                Deactivate(com, adapters1);
+                Deactivate(com, adapters2);
+            }
+
+            {
+                var adapters1 = new List<IRemoteObjectAdapterPrx>
+                {
+                    com.CreateObjectAdapter("Adapter91", testTransport)!,
+                    com.CreateObjectAdapter("Adapter92", testTransport)!,
+                    com.CreateObjectAdapter("Adapter93", testTransport)!
+                };
+
+                var adapters2 = new List<IRemoteObjectAdapterPrx>
+                {
+                    adapters1[0],
+                    com.CreateObjectAdapter("Adapter94", testTransport)!,
+                    com.CreateObjectAdapter("Adapter95", testTransport)!
+                };
+
+                ITestIntfPrx obj1 = CreateTestIntfPrx(adapters1);
+                ITestIntfPrx obj2 = CreateTestIntfPrx(adapters2);
+
+                Task<string> t1 = obj1.GetAdapterNameAsync();
+                Task<string> t2 = obj2.GetAdapterNameAsync();
+                TestHelper.Assert(t1.Result == "Adapter91");
+                TestHelper.Assert(t2.Result == "Adapter91");
 
                 Deactivate(com, adapters1);
                 Deactivate(com, adapters2);


### PR DESCRIPTION
This PR fixes a connection reuse issue that can result in a reference using a connection to an endpoint that doesn't belong to it.