### PR TITLE
Fixed reference retry fixes

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -98,7 +98,7 @@ namespace ZeroC.Ice
         public Protocol Protocol => Endpoint.Protocol;
 
         // The connector from which the connection was created. This is used by the outgoing connection factory.
-        internal IConnector Connector => _connector!;
+        internal IConnector? Connector => _connector;
 
         // The endpoints which are associated with this connection. This is populated by the outgoing connection
         // factory when an endpoint resolves to the same connector as this connection's connector. Two endpoints

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -68,10 +68,7 @@ namespace ZeroC.Ice
             }
         }
 
-        internal OutgoingConnectionFactory(Communicator communicator)
-        {
-            _communicator = communicator;
-        }
+        internal OutgoingConnectionFactory(Communicator communicator) => _communicator = communicator;
 
         internal void AddTransportFailure(IConnector connector) => _transportFailures[connector] = DateTime.Now;
 

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -60,6 +60,7 @@ namespace ZeroC.Ice
         {
             lock (_mutex)
             {
+                Debug.Assert(connection.Connector != null);
                 _connectionsByConnector.Remove((connection.Connector, connection.ConnectionId), connection);
                 foreach (Endpoint endpoint in connection.Endpoints)
                 {
@@ -242,6 +243,7 @@ namespace ZeroC.Ice
                             Connection connection = completedTask.Result;
                             foreach ((IConnector connector, Endpoint endpoint) in connectors)
                             {
+                                Debug.Assert(connection.Connector != null);
                                 if (connection.Connector.Equals(connector))
                                 {
                                     Debug.Assert(connection.ConnectionId == connectionId);

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -471,6 +471,12 @@ namespace ZeroC.Ice
                                          retryPolicy != RetryPolicy.NoRetry);
                             if (retryPolicy == RetryPolicy.OtherReplica)
                             {
+                                if (reference.IsFixed)
+                                {
+                                    // A fixed reference implies there are no more replicas
+                                    break;
+                                }
+
                                 Debug.Assert(connector != null);
                                 excludedConnectors ??= new List<IConnector>();
                                 excludedConnectors.Add(connector);

--- a/csharp/test/Ice/retry/RetryI.cs
+++ b/csharp/test/Ice/retry/RetryI.cs
@@ -52,7 +52,8 @@ namespace ZeroC.Ice.Test.Retry
             {
             }
 
-            // With Ice1 the exception is not retryable, with Ice2 we can retry using the existing connection.
+            // With Ice1 the exception is not retryable, with Ice2 we can retry using the existing connection
+            // because the exception uses the AfterDelay retry policy.
             try
             {
                 bidir.AfterDelay(2, cancel: CancellationToken.None);

--- a/csharp/test/Ice/retry/RetryI.cs
+++ b/csharp/test/Ice/retry/RetryI.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using Test;
 
 namespace ZeroC.Ice.Test.Retry
 {
@@ -37,6 +38,30 @@ namespace ZeroC.Ice.Test.Retry
             int counter = _counter;
             _counter = 0;
             return counter;
+        }
+
+        public void OpBidirRetry(IBidirPrx bidir, Current current, CancellationToken cancel)
+        {
+            bidir = bidir.Clone(fixedConnection: current.Connection);
+            try
+            {
+                bidir.OtherReplica(cancel: CancellationToken.None);
+                TestHelper.Assert(false);
+            }
+            catch (ObjectNotExistException)
+            {
+            }
+
+            // With Ice1 the exception is not retryable, with Ice2 we can retry using the existing connection.
+            try
+            {
+                bidir.AfterDelay(2, cancel: CancellationToken.None);
+                TestHelper.Assert(current.Protocol == Protocol.Ice2);
+            }
+            catch (ObjectNotExistException)
+            {
+                TestHelper.Assert(current.Protocol == Protocol.Ice1);
+            }
         }
 
         public void OpNotIdempotent(Current current, CancellationToken cancel) =>

--- a/csharp/test/Ice/retry/Test.ice
+++ b/csharp/test/Ice/retry/Test.ice
@@ -15,6 +15,12 @@ exception SystemFailure
 
 sequence<byte> ByteSeq;
 
+interface Bidir
+{
+    void otherReplica();
+    void afterDelay(int n);
+}
+
 interface Retry
 {
     void op(bool kill);
@@ -23,6 +29,7 @@ interface Retry
     void opNotIdempotent();
     void opSystemException();
     int opAfterDelay(int retries, int delay);
+    void opBidirRetry(Bidir prx);
 
     idempotent void sleep(int delay);
 


### PR DESCRIPTION
This tiny PR adds a test case for retries with fixed references, an exception that carries an AfterDelay policy can be retried over the same connection, exceptions that carry OtherReplica policy cannot be retried because a fixed connection implies a single replica.