### PR TITLE
Move InvokeAsync to Reference

### DIFF
--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -345,7 +345,7 @@ namespace ZeroC.Ice
         {
             try
             {
-                IncomingResponseFrame response = this.InvokeAsync(request, oneway: false).Result;
+                IncomingResponseFrame response = Reference.InvokeAsync(this, request, oneway: false).Result;
                 return response.ReadReturnValue(Communicator, reader);
             }
             catch (AggregateException ex)
@@ -368,7 +368,7 @@ namespace ZeroC.Ice
         {
             try
             {
-                IncomingResponseFrame response = this.InvokeAsync(request, oneway).Result;
+                IncomingResponseFrame response = Reference.InvokeAsync(this, request, oneway).Result;
                 if (!oneway)
                 {
                     response.ReadVoidReturnValue(Communicator);
@@ -401,7 +401,7 @@ namespace ZeroC.Ice
             Task<IncomingResponseFrame> responseTask;
             try
             {
-                responseTask = this.InvokeAsync(request, oneway: false, progress);
+                responseTask = Reference.InvokeAsync(this, request, oneway: false, progress);
             }
             catch
             {
@@ -439,7 +439,7 @@ namespace ZeroC.Ice
             Task<IncomingResponseFrame> responseTask;
             try
             {
-                responseTask = this.InvokeAsync(request, oneway, progress);
+                responseTask = Reference.InvokeAsync(this, request, oneway, progress);
             }
             catch
             {

--- a/csharp/src/Ice/LocatorDiscovery/Locator.cs
+++ b/csharp/src/Ice/LocatorDiscovery/Locator.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice.LocatorDiscovery
             {
                 return await ForwardRequestAsync(
                     locator =>
-                    locator?.ForwardAsync(current.IsOneway, request, cancel: cancel).AsTask() ??
+                    locator?.ForwardAsync(request, current.IsOneway, cancel: cancel).AsTask() ??
                         // In the unlikely event locator is now null (e.g. after a failed attempt), we use the
                         // "transcoding dispatch method" which will in turn return null/empty with a null locator.
                         // See comments below.

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -5,11 +5,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
-using ZeroC.Ice.Instrumentation;
 
 namespace ZeroC.Ice
 {
@@ -213,355 +210,39 @@ namespace ZeroC.Ice
         /// automatically bridges between these two protocols. When proxy's protocol is ice1, the resulting outgoing
         /// request frame is never compressed.</remarks>
         /// <param name="proxy">The proxy for the target Ice object.</param>
+        /// <param name="request">The incoming request frame to forward to proxy's target.</param>
         /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
         /// two-way request.</param>
-        /// <param name="request">The incoming request frame to forward to proxy's target.</param>
         /// <param name="progress">Sent progress provider.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         /// <returns>A task holding the response frame.</returns>
         public static async ValueTask<OutgoingResponseFrame> ForwardAsync(
             this IObjectPrx proxy,
-            bool oneway,
             IncomingRequestFrame request,
+            bool oneway,
             IProgress<bool>? progress = null,
             CancellationToken cancel = default)
         {
             var forwardedRequest = new OutgoingRequestFrame(proxy, request, cancel: cancel);
             IncomingResponseFrame response =
-                await proxy.InvokeAsync(forwardedRequest, oneway, progress).ConfigureAwait(false);
+                await Reference.InvokeAsync(proxy, forwardedRequest, oneway, progress).ConfigureAwait(false);
             return new OutgoingResponseFrame(request, response);
         }
 
+        /// <summary>Invokes a request on a proxy.</summary>
+        /// <remarks>request.CancellationToken holds the cancellation token.</remarks>
+        /// <param name="proxy">The proxy for the target Ice object.</param>
+        /// <param name="request">The request frame.</param>
+        /// <param name="oneway">When true, the request is sent as a oneway request. When false, it is sent as a
+        /// two-way request.</param>
+        /// <param name="progress">Sent progress provider.</param>
+        /// <returns>A task holding the response frame.</returns>
         public static Task<IncomingResponseFrame> InvokeAsync(
             this IObjectPrx proxy,
             OutgoingRequestFrame request,
             bool oneway = false,
-            IProgress<bool>? progress = null)
-        {
-            switch (proxy.InvocationMode)
-            {
-                case InvocationMode.BatchOneway:
-                case InvocationMode.BatchDatagram:
-                    Debug.Assert(false); // not implemented
-                    return default;
-                case InvocationMode.Datagram when !oneway:
-                    throw new InvalidOperationException("cannot make two-way call on a datagram proxy");
-                default:
-                    return InvokeWithInterceptorsAsync(proxy,
-                                                       request,
-                                                       oneway,
-                                                       0,
-                                                       progress,
-                                                       request.CancellationToken);
-            }
-
-            Task<IncomingResponseFrame> InvokeWithInterceptorsAsync(
-                IObjectPrx proxy,
-                OutgoingRequestFrame request,
-                bool oneway,
-                int i,
-                IProgress<bool>? progress,
-                CancellationToken cancel)
-            {
-                cancel.ThrowIfCancellationRequested();
-                if (i < proxy.Communicator.InvocationInterceptors.Count)
-                {
-                    // Call the next interceptor in the chain
-                    InvocationInterceptor interceptor = proxy.Communicator.InvocationInterceptors[i++];
-                    return interceptor(
-                        proxy,
-                        request,
-                        (target, request, cancel) =>
-                            InvokeWithInterceptorsAsync(target, request, oneway, i, progress, cancel),
-                        cancel);
-                }
-                else
-                {
-                    // After we went down the interceptor chain make the invocation.
-                    return PerformInvokeAsync(request, oneway, progress, cancel);
-                }
-            }
-
-            async Task<IncomingResponseFrame> PerformInvokeAsync(
-                OutgoingRequestFrame request,
-                bool oneway,
-                IProgress<bool>? progress,
-                CancellationToken cancel)
-            {
-                request.Finish();
-                Reference reference = proxy.IceReference;
-
-                IInvocationObserver? observer = ObserverHelper.GetInvocationObserver(proxy,
-                                                                                     request.Operation,
-                                                                                     request.Context);
-                int attempt = 1;
-                // If the request size is greater than Ice.RetryRequestSizeMax or the size of the request
-                // would increase the buffer retry size beyond Ice.RetryBufferSizeMax we release the request
-                // after it was sent to avoid holding too much memory and we wont retry in case of a failure.
-                int requestSize = request.Size;
-                bool releaseRequestAfterSent =
-                    requestSize > reference.Communicator.RetryRequestSizeMax ||
-                    !reference.Communicator.IncRetryBufferSize(requestSize);
-                try
-                {
-                    IncomingResponseFrame? response = null;
-                    Exception? lastException = null;
-                    List<IConnector>? excludedConnectors = null;
-                    IConnector? connector = null;
-                    while (true)
-                    {
-                        Connection? connection = null;
-                        bool sent = false;
-                        RetryPolicy retryPolicy = RetryPolicy.NoRetry;
-                        IChildInvocationObserver? childObserver = null;
-                        try
-                        {
-                            // Get the connection, this will eventually establish a connection if needed.
-                            connection = await reference.GetConnectionAsync(
-                                excludedConnectors ?? (IReadOnlyList<IConnector>)ImmutableList<IConnector>.Empty,
-                                cancel).ConfigureAwait(false);
-                            connector = connection.Connector;
-                            cancel.ThrowIfCancellationRequested();
-
-                            // Create the outgoing stream.
-                            using TransceiverStream stream = connection.CreateStream(!oneway);
-
-                            childObserver = observer?.GetChildInvocationObserver(connection, request.Size);
-                            childObserver?.Attach();
-
-                            // TODO: support for streaming data, fin should be false if there's data to stream.
-                            bool fin = true;
-
-                            // Send the request and wait for the sending to complete.
-                            await stream.SendRequestFrameAsync(request, fin, cancel).ConfigureAwait(false);
-
-                            // The request is sent, notify the progress callback.
-                            // TODO: Get rid of the sentSynchronously parameter which is always false now?
-                            if (progress != null)
-                            {
-                                progress.Report(false);
-                                progress = null; // Only call the progress callback once (TODO: revisit this?)
-                            }
-                            if (releaseRequestAfterSent)
-                            {
-                                // TODO release the request
-                            }
-                            sent = true;
-                            lastException = null;
-
-                            if (oneway)
-                            {
-                                return IncomingResponseFrame.WithVoidReturnValue(request.Protocol, request.Encoding);
-                            }
-
-                            // TODO: the synchronous boolean is no longer used. It was used to allow the reception
-                            // of the response frame to be ran synchronously from the IO thread. Supporting this
-                            // might still be possible depending on the underlying transport but it would be quite
-                            // complex. So get rid of the synchronous boolean and simplify the proxy generated code?
-
-                            // Wait for the reception of the response.
-                            (response, fin) = await stream.ReceiveResponseFrameAsync(cancel).ConfigureAwait(false);
-
-                            if (childObserver != null)
-                            {
-                                // Detach now to not count as a remote failure the 1.1 system exception which might
-                                // be raised below.
-                                childObserver.Reply(response.Size);
-                                childObserver.Detach();
-                                childObserver = null;
-                            }
-
-                            if (!fin)
-                            {
-                                // TODO: handle received stream data.
-                            }
-
-                            // If success, just return the response!
-                            if (response.ResultType == ResultType.Success)
-                            {
-                                return response;
-                            }
-
-                            // Get the retry policy.
-                            observer?.RemoteException();
-                            if (response.Encoding == Encoding.V11)
-                            {
-                                retryPolicy = Ice1Definitions.GetRetryPolicy(response, reference);
-                            }
-                            else if (response.BinaryContext.TryGetValue((int)BinaryContext.RetryPolicy,
-                                                                        out ReadOnlyMemory<byte> value))
-                            {
-                                retryPolicy = value.Read(istr => new RetryPolicy(istr));
-                            }
-                        }
-                        catch (NoEndpointException ex)
-                        {
-                            // The reference has no endpoints or the previous retry policy asked to retry on a
-                            // different replica but no more replicas are available (in this case, we throw
-                            // the previous exception instead of the NoEndpointException).
-                            if (response == null && lastException == null)
-                            {
-                                lastException = ex;
-                            }
-                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
-                        }
-                        catch (TransportException ex)
-                        {
-                            var closedException = ex as ConnectionClosedException;
-                            connector ??= ex.Connector;
-                            if (connector != null && closedException == null)
-                            {
-                                reference.Communicator.OutgoingConnectionFactory.AddTransportFailure(connector);
-                            }
-
-                            lastException = ex;
-                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
-
-                            // Retry transport exceptions if the request is idempotent, was not sent or if the
-                            // connection was gracefully closed by the peer (in which case it's safe to retry).
-                            if ((closedException?.IsClosedByPeer ?? false) || request.IsIdempotent || !sent)
-                            {
-                                retryPolicy = ex.RetryPolicy;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            lastException = ex;
-                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
-                        }
-                        finally
-                        {
-                            childObserver?.Detach();
-                        }
-
-                        if (sent && releaseRequestAfterSent)
-                        {
-                            if (reference.Communicator.TraceLevels.Retry >= 1)
-                            {
-                                TraceRetry("request failed with retryable exception but the request is not retryable " +
-                                           "because\n" + (requestSize > reference.Communicator.RetryRequestSizeMax ?
-                                           "the request size exceeds Ice.RetryRequestSizeMax, " :
-                                           "the retry buffer size would exceed Ice.RetryBufferSizeMax, ") +
-                                           "passing exception through to the application",
-                                           attempt,
-                                           retryPolicy,
-                                           lastException);
-                            }
-                            break; // We cannot retry, get out of the loop
-                        }
-                        else if (retryPolicy == RetryPolicy.NoRetry)
-                        {
-                            break; // We cannot retry, get out of the loop
-                        }
-                        else if (++attempt > reference.Communicator.RetryMaxAttempts)
-                        {
-                            if (reference.Communicator.TraceLevels.Retry >= 1)
-                            {
-                                TraceRetry("request failed with retryable exception but it was the final attempt,\n" +
-                                           "passing exception through to the application",
-                                           attempt,
-                                           retryPolicy,
-                                           lastException);
-                            }
-                            break; // We cannot retry, get out of the loop
-                        }
-                        else
-                        {
-                            Debug.Assert(attempt <= reference.Communicator.RetryMaxAttempts &&
-                                         retryPolicy != RetryPolicy.NoRetry);
-                            if (retryPolicy == RetryPolicy.OtherReplica)
-                            {
-                                Debug.Assert(connector != null);
-                                excludedConnectors ??= new List<IConnector>();
-                                excludedConnectors.Add(connector);
-                                if (reference.Communicator.TraceLevels.Retry >= 1)
-                                {
-                                    reference.Communicator.Logger.Trace(TraceLevels.RetryCategory,
-                                                                        $"excluding connector\n{connector}");
-                                }
-                            }
-
-                            if (reference.IsConnectionCached && connection != null)
-                            {
-                                reference.ClearConnection(connection);
-                            }
-
-                            if (reference.Communicator.TraceLevels.Retry >= 1)
-                            {
-                                TraceRetry("retrying request because of retryable exception",
-                                           attempt,
-                                           retryPolicy,
-                                           lastException);
-                            }
-
-                            if (retryPolicy.Retryable == Retryable.AfterDelay && retryPolicy.Delay != TimeSpan.Zero)
-                            {
-                                // The delay task can be canceled either by the user code using the provided
-                                // cancellation token or if the communicator is destroyed.
-                                using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(
-                                    cancel,
-                                    proxy.Communicator.CancellationToken);
-                                await Task.Delay(retryPolicy.Delay, tokenSource.Token).ConfigureAwait(false);
-                            }
-
-                            observer?.Retried();
-                        }
-                    }
-
-                    // No more retries or can't retry, throw the exception and return the remote exception
-                    if (lastException != null)
-                    {
-                        observer?.Failed(lastException.GetType().FullName ?? "System.Exception");
-                        throw ExceptionUtil.Throw(lastException);
-                    }
-                    else
-                    {
-                        observer?.Failed("System.Exception"); // TODO cleanup observer logic
-                        Debug.Assert(response != null && response.ResultType == ResultType.Failure);
-                        return response;
-                    }
-                }
-                finally
-                {
-                    if (!releaseRequestAfterSent)
-                    {
-                        reference.Communicator.DecRetryBufferSize(requestSize);
-                    }
-                    // TODO release the request memory if not already done after sent.
-                    // TODO: Use IDisposable for observers, this will allow using "using".
-                    observer?.Detach();
-                }
-            }
-
-            void TraceRetry(string message, int attempt, RetryPolicy policy, Exception? exception = null)
-            {
-                var sb = new StringBuilder();
-                sb.Append(message);
-                sb.Append("\nproxy = ");
-                sb.Append(proxy);
-                sb.Append("\noperation = ");
-                sb.Append(request.Operation);
-                if (attempt <= proxy.Communicator.RetryMaxAttempts)
-                {
-                    sb.Append("\nrequest attempt = ");
-                    sb.Append(attempt);
-                    sb.Append('/');
-                    sb.Append(proxy.Communicator.RetryMaxAttempts);
-                }
-                sb.Append("\nretry policy = ");
-                sb.Append(policy);
-                if (exception != null)
-                {
-                    sb.Append("\nexception = ");
-                    sb.Append(exception);
-                }
-                else
-                {
-                    sb.Append("\nexception = remote exception");
-                }
-                proxy.Communicator.Logger.Trace(TraceLevels.RetryCategory, sb.ToString());
-            }
-        }
+            IProgress<bool>? progress = null) =>
+            Reference.InvokeAsync(proxy, request, oneway, progress);
 
         /// <summary>Produces a string representation of a location.</summary>
         /// <param name="location">The location.</param>

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using ZeroC.Ice.Instrumentation;
+
 namespace ZeroC.Ice
 {
     /// <summary>Reference is an Ice-internal but publicly visible class. Each Ice proxy has a single Reference.
@@ -571,6 +573,337 @@ namespace ZeroC.Ice
             }
         }
 
+        internal static Task<IncomingResponseFrame> InvokeAsync(
+            IObjectPrx proxy,
+            OutgoingRequestFrame request,
+            bool oneway,
+            IProgress<bool>? progress = null)
+        {
+            switch (proxy.InvocationMode)
+            {
+                case InvocationMode.BatchOneway:
+                case InvocationMode.BatchDatagram:
+                    Debug.Assert(false); // not implemented
+                    return default;
+                case InvocationMode.Datagram when !oneway:
+                    throw new InvalidOperationException("cannot make two-way call on a datagram proxy");
+                default:
+                    return InvokeWithInterceptorsAsync(proxy,
+                                                       request,
+                                                       oneway,
+                                                       0,
+                                                       progress,
+                                                       request.CancellationToken);
+            }
+
+            Task<IncomingResponseFrame> InvokeWithInterceptorsAsync(
+                IObjectPrx proxy,
+                OutgoingRequestFrame request,
+                bool oneway,
+                int i,
+                IProgress<bool>? progress,
+                CancellationToken cancel)
+            {
+                cancel.ThrowIfCancellationRequested();
+                if (i < proxy.Communicator.InvocationInterceptors.Count)
+                {
+                    // Call the next interceptor in the chain
+                    InvocationInterceptor interceptor = proxy.Communicator.InvocationInterceptors[i++];
+                    return interceptor(
+                        proxy,
+                        request,
+                        (target, request, cancel) =>
+                            InvokeWithInterceptorsAsync(target, request, oneway, i, progress, cancel),
+                        cancel);
+                }
+                else
+                {
+                    // After we went down the interceptor chain make the invocation.
+                    return PerformInvokeAsync(request, oneway, progress, cancel);
+                }
+            }
+
+            async Task<IncomingResponseFrame> PerformInvokeAsync(
+                OutgoingRequestFrame request,
+                bool oneway,
+                IProgress<bool>? progress,
+                CancellationToken cancel)
+            {
+                request.Finish();
+                Reference reference = proxy.IceReference;
+
+                IInvocationObserver? observer = ObserverHelper.GetInvocationObserver(proxy,
+                                                                                     request.Operation,
+                                                                                     request.Context);
+                int attempt = 1;
+                // If the request size is greater than Ice.RetryRequestSizeMax or the size of the request
+                // would increase the buffer retry size beyond Ice.RetryBufferSizeMax we release the request
+                // after it was sent to avoid holding too much memory and we wont retry in case of a failure.
+                int requestSize = request.Size;
+                bool releaseRequestAfterSent =
+                    requestSize > reference.Communicator.RetryRequestSizeMax ||
+                    !reference.Communicator.IncRetryBufferSize(requestSize);
+                try
+                {
+                    IncomingResponseFrame? response = null;
+                    Exception? lastException = null;
+                    List<IConnector>? excludedConnectors = null;
+                    IConnector? connector = null;
+                    while (true)
+                    {
+                        Connection? connection = null;
+                        bool sent = false;
+                        RetryPolicy retryPolicy = RetryPolicy.NoRetry;
+                        IChildInvocationObserver? childObserver = null;
+                        try
+                        {
+                            // Get the connection, this will eventually establish a connection if needed.
+                            connection = await reference.GetConnectionAsync(
+                                excludedConnectors ?? (IReadOnlyList<IConnector>)ImmutableList<IConnector>.Empty,
+                                cancel).ConfigureAwait(false);
+                            connector = connection.Connector;
+                            cancel.ThrowIfCancellationRequested();
+
+                            // Create the outgoing stream.
+                            using TransceiverStream stream = connection.CreateStream(!oneway);
+
+                            childObserver = observer?.GetChildInvocationObserver(connection, request.Size);
+                            childObserver?.Attach();
+
+                            // TODO: support for streaming data, fin should be false if there's data to stream.
+                            bool fin = true;
+
+                            // Send the request and wait for the sending to complete.
+                            await stream.SendRequestFrameAsync(request, fin, cancel).ConfigureAwait(false);
+
+                            // The request is sent, notify the progress callback.
+                            // TODO: Get rid of the sentSynchronously parameter which is always false now?
+                            if (progress != null)
+                            {
+                                progress.Report(false);
+                                progress = null; // Only call the progress callback once (TODO: revisit this?)
+                            }
+                            if (releaseRequestAfterSent)
+                            {
+                                // TODO release the request
+                            }
+                            sent = true;
+                            lastException = null;
+
+                            if (oneway)
+                            {
+                                return IncomingResponseFrame.WithVoidReturnValue(request.Protocol, request.Encoding);
+                            }
+
+                            // TODO: the synchronous boolean is no longer used. It was used to allow the reception
+                            // of the response frame to be ran synchronously from the IO thread. Supporting this
+                            // might still be possible depending on the underlying transport but it would be quite
+                            // complex. So get rid of the synchronous boolean and simplify the proxy generated code?
+
+                            // Wait for the reception of the response.
+                            (response, fin) = await stream.ReceiveResponseFrameAsync(cancel).ConfigureAwait(false);
+
+                            if (childObserver != null)
+                            {
+                                // Detach now to not count as a remote failure the 1.1 system exception which might
+                                // be raised below.
+                                childObserver.Reply(response.Size);
+                                childObserver.Detach();
+                                childObserver = null;
+                            }
+
+                            if (!fin)
+                            {
+                                // TODO: handle received stream data.
+                            }
+
+                            // If success, just return the response!
+                            if (response.ResultType == ResultType.Success)
+                            {
+                                return response;
+                            }
+
+                            // Get the retry policy.
+                            observer?.RemoteException();
+                            if (response.Encoding == Encoding.V11)
+                            {
+                                retryPolicy = Ice1Definitions.GetRetryPolicy(response, reference);
+                            }
+                            else if (response.BinaryContext.TryGetValue((int)BinaryContext.RetryPolicy,
+                                                                        out ReadOnlyMemory<byte> value))
+                            {
+                                retryPolicy = value.Read(istr => new RetryPolicy(istr));
+                            }
+                        }
+                        catch (NoEndpointException ex)
+                        {
+                            // The reference has no endpoints or the previous retry policy asked to retry on a
+                            // different replica but no more replicas are available (in this case, we throw
+                            // the previous exception instead of the NoEndpointException).
+                            if (response == null && lastException == null)
+                            {
+                                lastException = ex;
+                            }
+                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
+                        }
+                        catch (TransportException ex)
+                        {
+                            var closedException = ex as ConnectionClosedException;
+                            connector ??= ex.Connector;
+                            if (connector != null && closedException == null)
+                            {
+                                reference.Communicator.OutgoingConnectionFactory.AddTransportFailure(connector);
+                            }
+
+                            lastException = ex;
+                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
+
+                            // Retry transport exceptions if the request is idempotent, was not sent or if the
+                            // connection was gracefully closed by the peer (in which case it's safe to retry).
+                            if ((closedException?.IsClosedByPeer ?? false) || request.IsIdempotent || !sent)
+                            {
+                                retryPolicy = ex.RetryPolicy;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            lastException = ex;
+                            childObserver?.Failed(ex.GetType().FullName ?? "System.Exception");
+                        }
+                        finally
+                        {
+                            childObserver?.Detach();
+                        }
+
+                        if (sent && releaseRequestAfterSent)
+                        {
+                            if (reference.Communicator.TraceLevels.Retry >= 1)
+                            {
+                                TraceRetry("request failed with retryable exception but the request is not retryable " +
+                                           "because\n" + (requestSize > reference.Communicator.RetryRequestSizeMax ?
+                                           "the request size exceeds Ice.RetryRequestSizeMax, " :
+                                           "the retry buffer size would exceed Ice.RetryBufferSizeMax, ") +
+                                           "passing exception through to the application",
+                                           attempt,
+                                           retryPolicy,
+                                           lastException);
+                            }
+                            break; // We cannot retry, get out of the loop
+                        }
+                        else if (retryPolicy == RetryPolicy.NoRetry)
+                        {
+                            break; // We cannot retry, get out of the loop
+                        }
+                        else if (++attempt > reference.Communicator.RetryMaxAttempts)
+                        {
+                            if (reference.Communicator.TraceLevels.Retry >= 1)
+                            {
+                                TraceRetry("request failed with retryable exception but it was the final attempt,\n" +
+                                           "passing exception through to the application",
+                                           attempt,
+                                           retryPolicy,
+                                           lastException);
+                            }
+                            break; // We cannot retry, get out of the loop
+                        }
+                        else
+                        {
+                            Debug.Assert(attempt <= reference.Communicator.RetryMaxAttempts &&
+                                         retryPolicy != RetryPolicy.NoRetry);
+                            if (retryPolicy == RetryPolicy.OtherReplica)
+                            {
+                                Debug.Assert(connector != null);
+                                excludedConnectors ??= new List<IConnector>();
+                                excludedConnectors.Add(connector);
+                                if (reference.Communicator.TraceLevels.Retry >= 1)
+                                {
+                                    reference.Communicator.Logger.Trace(TraceLevels.RetryCategory,
+                                                                        $"excluding connector\n{connector}");
+                                }
+                            }
+
+                            if (reference.IsConnectionCached && connection != null)
+                            {
+                                reference.ClearConnection(connection);
+                            }
+
+                            if (reference.Communicator.TraceLevels.Retry >= 1)
+                            {
+                                TraceRetry("retrying request because of retryable exception",
+                                           attempt,
+                                           retryPolicy,
+                                           lastException);
+                            }
+
+                            if (retryPolicy.Retryable == Retryable.AfterDelay && retryPolicy.Delay != TimeSpan.Zero)
+                            {
+                                // The delay task can be canceled either by the user code using the provided
+                                // cancellation token or if the communicator is destroyed.
+                                using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                                    cancel,
+                                    proxy.Communicator.CancellationToken);
+                                await Task.Delay(retryPolicy.Delay, tokenSource.Token).ConfigureAwait(false);
+                            }
+
+                            observer?.Retried();
+                        }
+                    }
+
+                    // No more retries or can't retry, throw the exception and return the remote exception
+                    if (lastException != null)
+                    {
+                        observer?.Failed(lastException.GetType().FullName ?? "System.Exception");
+                        throw ExceptionUtil.Throw(lastException);
+                    }
+                    else
+                    {
+                        observer?.Failed("System.Exception"); // TODO cleanup observer logic
+                        Debug.Assert(response != null && response.ResultType == ResultType.Failure);
+                        return response;
+                    }
+                }
+                finally
+                {
+                    if (!releaseRequestAfterSent)
+                    {
+                        reference.Communicator.DecRetryBufferSize(requestSize);
+                    }
+                    // TODO release the request memory if not already done after sent.
+                    // TODO: Use IDisposable for observers, this will allow using "using".
+                    observer?.Detach();
+                }
+            }
+
+            void TraceRetry(string message, int attempt, RetryPolicy policy, Exception? exception = null)
+            {
+                var sb = new StringBuilder();
+                sb.Append(message);
+                sb.Append("\nproxy = ");
+                sb.Append(proxy);
+                sb.Append("\noperation = ");
+                sb.Append(request.Operation);
+                if (attempt <= proxy.Communicator.RetryMaxAttempts)
+                {
+                    sb.Append("\nrequest attempt = ");
+                    sb.Append(attempt);
+                    sb.Append('/');
+                    sb.Append(proxy.Communicator.RetryMaxAttempts);
+                }
+                sb.Append("\nretry policy = ");
+                sb.Append(policy);
+                if (exception != null)
+                {
+                    sb.Append("\nexception = ");
+                    sb.Append(exception);
+                }
+                else
+                {
+                    sb.Append("\nexception = remote exception");
+                }
+                proxy.Communicator.Logger.Trace(TraceLevels.RetryCategory, sb.ToString());
+            }
+        }
+
         /// <summary>Reads a reference from the input stream.</summary>
         /// <param name="istr">The input stream to read from.</param>
         /// <returns>The reference read from the stream (can be null).</returns>
@@ -713,7 +1046,7 @@ namespace ZeroC.Ice
         {
         }
 
-        internal void ClearConnection(Connection connection)
+        private void ClearConnection(Connection connection)
         {
             Debug.Assert(!IsFixed);
             Interlocked.CompareExchange(ref _connection, null, connection);

--- a/csharp/test/Ice/echo/BlobjectI.cs
+++ b/csharp/test/Ice/echo/BlobjectI.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Echo
                 IObjectPrx.Factory,
                 facet: current.Facet,
                 oneway: current.IsOneway);
-            return proxy.ForwardAsync(current.IsOneway, request, cancel: cancel);
+            return proxy.ForwardAsync(request, current.IsOneway, cancel: cancel);
         }
     }
 }

--- a/csharp/test/Ice/protocolBridging/TestI.cs
+++ b/csharp/test/Ice/protocolBridging/TestI.cs
@@ -36,7 +36,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
                 request.Context["Intercepted"] = "1";
             }
 
-            return _target.ForwardAsync(current.IsOneway, request, cancel: cancel);
+            return _target.ForwardAsync(request, current.IsOneway, cancel: cancel);
         }
 
         internal Forwarder(IObjectPrx target) => _target = target;


### PR DESCRIPTION
This PR moves InvokeAsync from Proxy to Reference, and updates the signature of ForwardAsync. There is no change at all in InvokeAsync.

Reference is a better home for InvokeAsync as it holds the actual implementation of all untyped proxy methods (and holds all fields).



