### PR TITLE
Add per proxy invocation interceptors

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -145,7 +145,7 @@ namespace ZeroC.Ice
         /// </param>
         /// <returns>A proxy that matches the given identity and uses this connection.</returns>
         public T CreateProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx =>
-            factory(new Reference(_communicator, this, identity, invocationInterceptors: null));
+            factory(new Reference(_communicator, this, identity));
 
         /// <summary>This event is raised when the connection is closed. If the subscriber needs more information about
         /// the closure, it can call Connection.ThrowException. The connection object is passed as the event sender

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -145,7 +145,7 @@ namespace ZeroC.Ice
         /// </param>
         /// <returns>A proxy that matches the given identity and uses this connection.</returns>
         public T CreateProxy<T>(Identity identity, ProxyFactory<T> factory) where T : class, IObjectPrx =>
-            factory(new Reference(_communicator, this, identity));
+            factory(new Reference(_communicator, this, identity, invocationInterceptors: null));
 
         /// <summary>This event is raised when the connection is closed. If the subscriber needs more information about
         /// the closure, it can call Connection.ThrowException. The connection object is passed as the event sender

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -506,7 +506,7 @@ namespace ZeroC.Ice
                                                 _publishedEndpoints : ImmutableArray<Endpoint>.Empty,
                                              facet,
                                              identity,
-                                             invocationInterceptors: null,
+                                             invocationInterceptors: ImmutableArray<InvocationInterceptor>.Empty,
                                              _invocationMode,
                                              location,
                                              protocol));
@@ -1059,15 +1059,16 @@ namespace ZeroC.Ice
             {
                 if (Protocol == Protocol.Ice1)
                 {
-                    IObjectPrx proxy = IObjectPrx.Factory(new Reference(Communicator,
-                                                                        Protocol.GetEncoding(),
-                                                                        endpoints,
-                                                                        facet: "",
-                                                                        new Identity("dummy", ""),
-                                                                        invocationInterceptors: null,
-                                                                        invocationMode: default,
-                                                                        location: ImmutableArray<string>.Empty,
-                                                                        protocol: endpoints[0].Protocol));
+                    IObjectPrx proxy = IObjectPrx.Factory(
+                        new Reference(Communicator,
+                                      Protocol.GetEncoding(),
+                                      endpoints,
+                                      facet: "",
+                                      new Identity("dummy", ""),
+                                      invocationInterceptors: ImmutableArray<InvocationInterceptor>.Empty,
+                                      invocationMode: default,
+                                      location: ImmutableArray<string>.Empty,
+                                      protocol: endpoints[0].Protocol));
                     if (ReplicaGroupId.Length > 0)
                     {
                         await locatorRegistry.SetReplicatedAdapterDirectProxyAsync(

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -506,6 +506,7 @@ namespace ZeroC.Ice
                                                 _publishedEndpoints : ImmutableArray<Endpoint>.Empty,
                                              facet,
                                              identity,
+                                             invocationInterceptors: null,
                                              _invocationMode,
                                              location,
                                              protocol));
@@ -1063,6 +1064,7 @@ namespace ZeroC.Ice
                                                                         endpoints,
                                                                         facet: "",
                                                                         new Identity("dummy", ""),
+                                                                        invocationInterceptors: null,
                                                                         invocationMode: default,
                                                                         location: ImmutableArray<string>.Empty,
                                                                         protocol: endpoints[0].Protocol));

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -51,6 +51,8 @@ namespace ZeroC.Ice
         /// proxy. You can clone a non-fixed proxy into a fixed proxy but not vice-versa.</param>
         /// <param name="identity">The identity of the clone.</param>
         /// <param name="identityAndFacet">A relative URI string [category/]identity[#facet].</param>
+        /// <param name="invocationInterceptors">A collection of <see cref="InvocationInterceptor"/> that will be
+        /// executed with each invocation</param>
         /// <param name="invocationMode">The invocation mode of the clone (optional). Applies only to ice1 proxies.
         /// </param>
         /// <param name="invocationTimeout">The invocation timeout of the clone (optional).</param>
@@ -76,6 +78,7 @@ namespace ZeroC.Ice
             Connection? fixedConnection = null,
             Identity? identity = null,
             string? identityAndFacet = null,
+            IEnumerable<InvocationInterceptor>? invocationInterceptors = null,
             InvocationMode? invocationMode = null,
             TimeSpan? invocationTimeout = null,
             IEnumerable<string>? location = null,
@@ -95,6 +98,7 @@ namespace ZeroC.Ice
                                            fixedConnection,
                                            identity,
                                            identityAndFacet,
+                                           invocationInterceptors,
                                            invocationMode,
                                            invocationTimeout,
                                            location,
@@ -119,6 +123,8 @@ namespace ZeroC.Ice
         /// <param name="endpoints">The endpoints of the clone (optional).</param>
         /// <param name="fixedConnection">The connection of the clone (optional). When specified, the clone is a fixed
         /// proxy. You can clone a non-fixed proxy into a fixed proxy but not vice-versa.</param>
+        /// <param name="invocationInterceptors">A collection of <see cref="InvocationInterceptor"/> that will be
+        /// executed with each invocation</param>
         /// <param name="invocationMode">The invocation mode of the clone (optional). Applies only to ice1 proxies.
         /// </param>
         /// <param name="invocationTimeout">The invocation timeout of the clone (optional).</param>
@@ -140,6 +146,7 @@ namespace ZeroC.Ice
             Encoding? encoding = null,
             IEnumerable<Endpoint>? endpoints = null,
             Connection? fixedConnection = null,
+            IEnumerable<InvocationInterceptor>? invocationInterceptors = null,
             InvocationMode? invocationMode = null,
             TimeSpan? invocationTimeout = null,
             IEnumerable<string>? location = null,
@@ -160,6 +167,7 @@ namespace ZeroC.Ice
                                                      fixedConnection,
                                                      identity: null,
                                                      identityAndFacet: null,
+                                                     invocationInterceptors,
                                                      invocationMode,
                                                      invocationTimeout,
                                                      location,

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -48,7 +48,7 @@ namespace ZeroC.Ice
         internal Protocol Protocol { get; }
         internal RouterInfo? RouterInfo { get; }
         private int _hashCode;
-        private IReadOnlyList<InvocationInterceptor> _invocationInterceptors;
+        private readonly IReadOnlyList<InvocationInterceptor> _invocationInterceptors;
 
         private volatile Connection? _connection; // readonly when IsFixed is true
 
@@ -590,8 +590,8 @@ namespace ZeroC.Ice
             bool oneway,
             IProgress<bool>? progress = null)
         {
-            IReadOnlyList<InvocationInterceptor> referenceInterceptors = proxy.IceReference._invocationInterceptors;
-            IReadOnlyList<InvocationInterceptor> communicatorInterceptos = proxy.Communicator.InvocationInterceptors;
+            IReadOnlyList<InvocationInterceptor> proxyInterceptors = proxy.IceReference._invocationInterceptors;
+            IReadOnlyList<InvocationInterceptor> communicatorInterceptors = proxy.Communicator.InvocationInterceptors;
 
             switch (proxy.InvocationMode)
             {
@@ -620,13 +620,13 @@ namespace ZeroC.Ice
             {
                 cancel.ThrowIfCancellationRequested();
                 InvocationInterceptor? interceptor = null;
-                if (i < referenceInterceptors.Count)
+                if (i < proxyInterceptors.Count)
                 {
-                    interceptor = referenceInterceptors[i];
+                    interceptor = proxyInterceptors[i];
                 }
-                else if (i - referenceInterceptors.Count < communicatorInterceptos.Count)
+                else if (i - proxyInterceptors.Count < communicatorInterceptors.Count)
                 {
-                    interceptor = communicatorInterceptos[i - referenceInterceptors.Count];
+                    interceptor = communicatorInterceptors[i - proxyInterceptors.Count];
                 }
 
                 if (interceptor != null)

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -636,7 +636,7 @@ namespace ZeroC.Ice
                         proxy,
                         request,
                         (target, request, cancel) =>
-                            InvokeWithInterceptorsAsync(target, request, oneway, ++i, progress, cancel),
+                            InvokeWithInterceptorsAsync(target, request, oneway, i + 1, progress, cancel),
                         cancel);
                 }
                 else

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -331,7 +331,30 @@ namespace ZeroC.Ice.Test.Interceptor
                         });
                     context = prx.Op2();
                     TestHelper.Assert(context["context1"] == "plug-in");
-                    TestHelper.Assert(context["context2"] == "proxy");
+                    TestHelper.Assert(context["context2"] == "plug-in");
+                    TestHelper.Assert(context["context3"] == "proxy");
+
+                    // Calling next twice doesn't change the result
+                    prx = prx.Clone(invocationInterceptors: new InvocationInterceptor[]
+                        {
+                            (target, request, next, cancel) =>
+                            {
+                                request.ContextOverride["context2"] = "proxy";
+                                request.ContextOverride["context3"] = "proxy";
+                                _ = next(target, request, cancel);
+                                return next(target, request, cancel);
+                            }
+                        });
+                    context = prx.Op2();
+                    TestHelper.Assert(context["context1"] == "plug-in");
+                    TestHelper.Assert(context["context2"] == "plug-in");
+                    TestHelper.Assert(context["context3"] == "proxy");
+
+                    // Cloning the proxy preserve its interceptors
+                    prx = prx.Clone(invocationTimeout: TimeSpan.FromSeconds(10));
+                    context = prx.Op2();
+                    TestHelper.Assert(context["context1"] == "plug-in");
+                    TestHelper.Assert(context["context2"] == "plug-in");
                     TestHelper.Assert(context["context3"] == "proxy");
                 }
                 output.WriteLine("ok");

--- a/csharp/test/Ice/interceptor/InvocationPlugin.cs
+++ b/csharp/test/Ice/interceptor/InvocationPlugin.cs
@@ -19,6 +19,8 @@ namespace ZeroC.Ice.Test.Interceptor
                     {
                         if (request.Protocol == Protocol.Ice2)
                         {
+                            request.ContextOverride["context1"] = "plug-in";
+                            request.ContextOverride["context2"] = "plug-in";
                             request.ContextOverride["InvocationPlugin"] = "1";
                         }
                         IncomingResponseFrame response = await next(target, request, cancel);

--- a/csharp/test/Ice/interceptor/Test.ice
+++ b/csharp/test/Ice/interceptor/Test.ice
@@ -6,6 +6,8 @@
 
 [[suppress-warning(reserved-identifier)]]
 
+#include <Ice/Context.ice>
+
 module ZeroC::Ice::Test::Interceptor
 {
 
@@ -38,6 +40,8 @@ interface MyObject
     void opWithBinaryContext(Token token);
 
     void op1();
+
+    Ice::Context op2();
 
     void shutdown();
 }

--- a/csharp/test/Ice/interceptor/Test.ice
+++ b/csharp/test/Ice/interceptor/Test.ice
@@ -43,6 +43,8 @@ interface MyObject
 
     Ice::Context op2();
 
+    int op3();
+
     void shutdown();
 }
 

--- a/csharp/test/Ice/interceptor/TestAMDI.cs
+++ b/csharp/test/Ice/interceptor/TestAMDI.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Test;
 
 namespace ZeroC.Ice.Test.Interceptor
 {
@@ -23,6 +25,10 @@ namespace ZeroC.Ice.Test.Interceptor
             throw new ObjectNotExistException();
         public ValueTask Op1Async(Current current, CancellationToken cancel) => new ValueTask();
         public ValueTask OpWithBinaryContextAsync(Token token, Current current, CancellationToken cancel) => default;
+
+        public ValueTask<IReadOnlyDictionary<string, string>> Op2Async(Current current, CancellationToken cancel) =>
+            new ValueTask<IReadOnlyDictionary<string, string>>(current.Context);
+
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {
             current.Communicator.ShutdownAsync();

--- a/csharp/test/Ice/interceptor/TestAMDI.cs
+++ b/csharp/test/Ice/interceptor/TestAMDI.cs
@@ -9,6 +9,8 @@ namespace ZeroC.Ice.Test.Interceptor
 {
     public sealed class AsyncMyObject : IAsyncMyObject
     {
+        private int _i;
+
         public ValueTask<int> AddAsync(int x, int y, Current current, CancellationToken cancel) =>
             new ValueTask<int>(x + y);
         public ValueTask<int> AddWithRetryAsync(int x, int y, Current current, CancellationToken cancel)
@@ -28,6 +30,8 @@ namespace ZeroC.Ice.Test.Interceptor
 
         public ValueTask<IReadOnlyDictionary<string, string>> Op2Async(Current current, CancellationToken cancel) =>
             new ValueTask<IReadOnlyDictionary<string, string>>(current.Context);
+
+        public ValueTask<int> Op3Async(Current current, CancellationToken cancel) => new ValueTask<int>(_i++);
 
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {

--- a/csharp/test/Ice/interceptor/TestI.cs
+++ b/csharp/test/Ice/interceptor/TestI.cs
@@ -8,6 +8,7 @@ namespace ZeroC.Ice.Test.Interceptor
 {
     public class MyObject : IMyObject
     {
+        private int _i;
         public int Add(int x, int y, Current current, CancellationToken cancel) => x + y;
 
         public int AddWithRetry(int x, int y, Current current, CancellationToken cancel)
@@ -33,6 +34,8 @@ namespace ZeroC.Ice.Test.Interceptor
         }
 
         public IReadOnlyDictionary<string, string> Op2(Current current, CancellationToken cancel) => current.Context;
+
+        public int Op3(Current current, CancellationToken cancel) => _i++;
 
         public void Shutdown(Current current, CancellationToken cancel) => current.Communicator.ShutdownAsync();
     }

--- a/csharp/test/Ice/interceptor/TestI.cs
+++ b/csharp/test/Ice/interceptor/TestI.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Collections.Generic;
 using System.Threading;
 using Test;
 
@@ -30,6 +31,8 @@ namespace ZeroC.Ice.Test.Interceptor
         public void OpWithBinaryContext(Token token, Current current, CancellationToken cancel)
         {
         }
+
+        public IReadOnlyDictionary<string, string> Op2(Current current, CancellationToken cancel) => current.Context;
 
         public void Shutdown(Current current, CancellationToken cancel) => current.Communicator.ShutdownAsync();
     }


### PR DESCRIPTION
This PR adds per proxy invocation interceptors, the per proxy interceptors run after the communicator interceptors, the current implementation allows to set the interceptors using invocationInterceptors: Clone parameter but we can consider setting this with the proxy factory methods too.

I think per proxy invocation interceptors can be useful to attach additional behavior to a specific proxy, and it doesn't make the implementation more complex.   