### PR TITLE
Simplify Locator::resolveLocation

### DIFF
--- a/csharp/src/Ice/Discovery/Locator.cs
+++ b/csharp/src/Ice/Discovery/Locator.cs
@@ -95,7 +95,7 @@ namespace ZeroC.Ice.Discovery
 
             using var replyServant = new ResolveAdapterIdReply(_replyAdapter);
 
-            IReadOnlyList<EndpointData> endpoints = await InvokeAsync(
+            return await InvokeAsync(
                 (lookup, dummyReply) =>
                 {
                     IResolveAdapterIdReplyPrx reply =
@@ -107,8 +107,6 @@ namespace ZeroC.Ice.Discovery
                                                         cancel: cancel);
                 },
                 replyServant).ConfigureAwait(false);
-
-            return endpoints;
         }
 
         public async ValueTask<(IEnumerable<EndpointData>, IEnumerable<string>)> ResolveWellKnownProxyAsync(

--- a/csharp/src/Ice/Discovery/Locator.cs
+++ b/csharp/src/Ice/Discovery/Locator.cs
@@ -76,7 +76,7 @@ namespace ZeroC.Ice.Discovery
         public ValueTask<ILocatorRegistryPrx?> GetRegistryAsync(Current current, CancellationToken cancel) =>
             new (_registry);
 
-        public async ValueTask<(IEnumerable<EndpointData>, IEnumerable<string>)> ResolveLocationAsync(
+        public async ValueTask<IEnumerable<EndpointData>> ResolveLocationAsync(
             string[] location,
             Current current,
             CancellationToken cancel)
@@ -84,6 +84,11 @@ namespace ZeroC.Ice.Discovery
             if (location.Length == 0)
             {
                 throw new InvalidArgumentException("location cannot be empty", nameof(location));
+            }
+            else if (location.Length > 1)
+            {
+                // Ice discovery supports only single-segment locations.
+                return ImmutableArray<EndpointData>.Empty;
             }
 
             string adapterId = location[0];
@@ -103,14 +108,7 @@ namespace ZeroC.Ice.Discovery
                 },
                 replyServant).ConfigureAwait(false);
 
-            if (endpoints.Count > 0)
-            {
-                return (endpoints, location[1..]);
-            }
-            else
-            {
-                return (endpoints, ImmutableArray<string>.Empty);
-            }
+            return endpoints;
         }
 
         public async ValueTask<(IEnumerable<EndpointData>, IEnumerable<string>)> ResolveWellKnownProxyAsync(

--- a/csharp/src/Ice/LocatorDiscovery/Locator.cs
+++ b/csharp/src/Ice/LocatorDiscovery/Locator.cs
@@ -91,23 +91,22 @@ namespace ZeroC.Ice.LocatorDiscovery
                                 locator?.GetRegistryAsync(current.Context, cancel: cancel) ??
                                     Task.FromResult<ILocatorRegistryPrx?>(null));
 
-        public ValueTask<(IEnumerable<EndpointData>, IEnumerable<string>)> ResolveLocationAsync(
+        public ValueTask<IEnumerable<EndpointData>> ResolveLocationAsync(
             string[] location,
             Current current,
             CancellationToken cancel) =>
-            ForwardRequestAsync<(IEnumerable<EndpointData>, IEnumerable<string>)>(
+            ForwardRequestAsync<IEnumerable<EndpointData>>(
                 async locator =>
                 {
                     if (locator != null)
                     {
-                        return await locator.ResolveLocationAsync(
-                            location,
-                            current.Context,
-                            cancel: cancel).ConfigureAwait(false);
+                        return await locator.ResolveLocationAsync(location,
+                                                                  current.Context,
+                                                                  cancel: cancel).ConfigureAwait(false);
                     }
                     else
                     {
-                        return (ImmutableArray<EndpointData>.Empty, ImmutableArray<string>.Empty);
+                        return ImmutableArray<EndpointData>.Empty;
                     }
                 });
 

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -26,11 +26,11 @@ namespace ZeroC.Ice
 
         private readonly bool _background;
 
-        private readonly ConcurrentDictionary<(Location, Protocol), (TimeSpan InsertionTime, EndpointList Endpoints, Location Location)> _locationCache =
+        private readonly ConcurrentDictionary<(Location, Protocol), (TimeSpan InsertionTime, EndpointList Endpoints)> _locationCache =
             new (_locationComparer);
 
-        private readonly Dictionary<(Location, Protocol), Task<(EndpointList, Location)>> _locationRequests =
-             new (_locationComparer);
+        private readonly Dictionary<(Location, Protocol), Task<EndpointList>> _locationRequests =
+            new (_locationComparer);
 
         private ILocatorRegistryPrx? _locatorRegistry;
 
@@ -65,8 +65,7 @@ namespace ZeroC.Ice
                         {
                             Trace("removed well-known proxy with endpoints from locator cache",
                                   reference,
-                                  entry.Endpoints,
-                                  entry.Location);
+                                  entry.Endpoints);
                         }
                     }
                     else
@@ -90,26 +89,25 @@ namespace ZeroC.Ice
         }
 
         /// <summary>Resolves an indirect reference using the locator proxy or cache.</summary>
-        internal async ValueTask<(EndpointList Endpoints, Location Location, bool Cached)> ResolveIndirectReferenceAsync(
+        internal async ValueTask<(EndpointList Endpoints, bool Cached)> ResolveIndirectReferenceAsync(
             Reference reference,
             CancellationToken cancel)
         {
             Debug.Assert(reference.IsIndirect);
 
             EndpointList endpoints = ImmutableArray<Endpoint>.Empty;
-            Location newLocation = ImmutableArray<string>.Empty;
             bool cached = false;
 
-            Location locationToResolve = reference.Location;
+            Location location = reference.Location;
 
             if (reference.IsWellKnown)
             {
                 // First, we check the cache.
-                (endpoints, newLocation, cached) = GetResolvedWellKnownProxyFromCache(reference,
-                                                                                      reference.LocatorCacheTimeout);
+                (endpoints, location, cached) = GetResolvedWellKnownProxyFromCache(reference,
+                                                                                   reference.LocatorCacheTimeout);
                 if (!cached)
                 {
-                    if (_background && (endpoints.Count > 0 || newLocation.Count > 0))
+                    if (_background && (endpoints.Count > 0 || location.Count > 0))
                     {
                         // Entry is returned from the cache but TTL was reached, if backgrounds updates are configured,
                         // we make a new resolution to refresh the cache but use the stale info to not block the caller.
@@ -117,20 +115,21 @@ namespace ZeroC.Ice
                     }
                     else
                     {
-                        (endpoints, newLocation) =
+                        (endpoints, location) =
                             await ResolveWellKnownProxyAsync(reference, cancel).ConfigureAwait(false);
                     }
                 }
-
-                locationToResolve = endpoints.Count == 0 ? newLocation : ImmutableArray<string>.Empty;
             }
 
-            if (locationToResolve.Count > 0)
+            if (location.Count > 0)
             {
+                Debug.Assert(endpoints.Count == 0);
+
                 bool cachedLocation;
 
-                (endpoints, newLocation, cachedLocation) =
-                    GetResolvedLocationFromCache(locationToResolve, reference.Protocol, reference.LocatorCacheTimeout);
+                (endpoints, cachedLocation) = GetResolvedLocationFromCache(location,
+                                                                           reference.Protocol,
+                                                                           reference.LocatorCacheTimeout);
 
                 if (!cachedLocation)
                 {
@@ -139,7 +138,7 @@ namespace ZeroC.Ice
                         // Endpoints are returned from the cache but TTL was reached, if backgrounds updates
                         // are configured, we obtain new endpoints but continue using the stale endpoints to
                         // not block the caller.
-                        _ = ResolveLocationAsync(locationToResolve,
+                        _ = ResolveLocationAsync(location,
                                                  reference.Protocol,
                                                  reference.Communicator,
                                                  cancel: default);
@@ -148,11 +147,10 @@ namespace ZeroC.Ice
                     {
                         try
                         {
-                            (endpoints, newLocation) =
-                                await ResolveLocationAsync(locationToResolve,
-                                                           reference.Protocol,
-                                                           reference.Communicator,
-                                                           cancel).ConfigureAwait(false);
+                            endpoints = await ResolveLocationAsync(location,
+                                                                   reference.Protocol,
+                                                                   reference.Communicator,
+                                                                   cancel).ConfigureAwait(false);
                         }
                         finally
                         {
@@ -180,17 +178,15 @@ namespace ZeroC.Ice
                         Trace(cached ? $"found entry for well-known proxy in locator cache" :
                                   $"resolved well-known proxy using locator, adding to locator cache",
                               reference,
-                              endpoints,
-                              newLocation);
+                              endpoints);
                     }
                     else
                     {
                         Trace(cached ? $"found entry for location in locator cache" :
                                   $"resolved location using locator, adding to locator cache",
-                              locationToResolve,
+                              location,
                               reference.Protocol,
                               endpoints,
-                              newLocation,
                               reference.Communicator);
                     }
                 }
@@ -213,7 +209,7 @@ namespace ZeroC.Ice
                 }
             }
 
-            return (endpoints, newLocation, cached);
+            return (endpoints, cached);
         }
 
         internal async ValueTask<ILocatorRegistryPrx?> GetLocatorRegistryAsync()
@@ -236,7 +232,6 @@ namespace ZeroC.Ice
             Location location,
             Protocol protocol,
             EndpointList endpoints,
-            Location newLocation,
             Communicator communicator)
         {
             var sb = new System.Text.StringBuilder(msg);
@@ -246,26 +241,16 @@ namespace ZeroC.Ice
             sb.Append(protocol.GetName());
             sb.Append("\nendpoints = ");
             sb.AppendEndpointList(endpoints);
-            if (protocol != Protocol.Ice1)
-            {
-                sb.Append("\nnew location = ");
-                sb.Append(newLocation.ToLocationString());
-            }
             communicator.Logger.Trace(TraceLevels.LocatorCategory, sb.ToString());
         }
 
-        private static void Trace(string msg, Reference wellKnownProxy, EndpointList endpoints, Location location)
+        private static void Trace(string msg, Reference wellKnownProxy, EndpointList endpoints)
         {
             var sb = new System.Text.StringBuilder(msg);
             sb.Append("\nwell-known proxy = ");
             sb.Append(wellKnownProxy);
             sb.Append("\nendpoints = ");
             sb.AppendEndpointList(endpoints);
-            if (wellKnownProxy.Protocol != Protocol.Ice1)
-            {
-                sb.Append("\nlocation = ");
-                sb.Append(location.ToLocationString());
-            }
             wellKnownProxy.Communicator.Logger.Trace(TraceLevels.LocatorCategory, sb.ToString());
         }
 
@@ -277,15 +262,6 @@ namespace ZeroC.Ice
             sb.Append("\nlocation = ");
             sb.Append(location.ToLocationString());
             wellKnownProxy.Communicator.Logger.Trace(TraceLevels.LocatorCategory, sb.ToString());
-        }
-
-        private static void TraceInvalid(Location location, Location newLocation, Communicator communicator)
-        {
-            var sb = new System.Text.StringBuilder("locator returned only a location when resolving location ");
-            sb.Append(location.ToLocationString());
-            sb.Append("\n received = ");
-            sb.Append(newLocation.ToLocationString());
-            communicator.Logger.Trace(TraceLevels.LocatorCategory, sb.ToString());
         }
 
         private static void TraceInvalid(Location location, Reference invalidReference)
@@ -308,9 +284,7 @@ namespace ZeroC.Ice
 
         private void ClearCache(Location location, Protocol protocol, Communicator communicator)
         {
-            if (_locationCache.TryRemove(
-                (location, protocol),
-                out (TimeSpan _, EndpointList Endpoints, Location Location) entry))
+            if (_locationCache.TryRemove((location, protocol), out (TimeSpan _, EndpointList Endpoints) entry))
             {
                 if (communicator.TraceLevels.Locator >= 2)
                 {
@@ -318,26 +292,25 @@ namespace ZeroC.Ice
                           location,
                           protocol,
                           entry.Endpoints,
-                          entry.Location,
                           communicator);
                 }
             }
         }
 
-        private (EndpointList Endpoints, Location Location, bool Cached) GetResolvedLocationFromCache(
+        private (EndpointList Endpoints, bool Cached) GetResolvedLocationFromCache(
             Location location,
             Protocol protocol,
             TimeSpan ttl)
         {
             if (ttl != TimeSpan.Zero && _locationCache.TryGetValue(
                 (location, protocol),
-                out (TimeSpan InsertionTime, EndpointList Endpoints, Location Location) entry))
+                out (TimeSpan InsertionTime, EndpointList Endpoints) entry))
             {
-                return (entry.Endpoints, entry.Location, CheckTTL(entry.InsertionTime, ttl));
+                return (entry.Endpoints, CheckTTL(entry.InsertionTime, ttl));
             }
             else
             {
-                return (ImmutableArray<Endpoint>.Empty, ImmutableArray<string>.Empty, false);
+                return (ImmutableArray<Endpoint>.Empty, false);
             }
         }
 
@@ -358,7 +331,7 @@ namespace ZeroC.Ice
             }
         }
 
-        private async Task<(EndpointList, Location)> ResolveLocationAsync(
+        private async Task<EndpointList> ResolveLocationAsync(
             Location location,
             Protocol protocol,
             Communicator communicator,
@@ -370,7 +343,7 @@ namespace ZeroC.Ice
                     $"resolving location\nlocation = {location.ToLocationString()}");
             }
 
-            Task<(EndpointList, Location)>? task;
+            Task<EndpointList>? task;
             lock (_mutex)
             {
                 if (!_locationRequests.TryGetValue((location, protocol), out task))
@@ -391,7 +364,7 @@ namespace ZeroC.Ice
 
             return await task.WaitAsync(cancel).ConfigureAwait(false);
 
-            async Task<(EndpointList, Location)> PerformResolveLocationAsync(
+            async Task<EndpointList> PerformResolveLocationAsync(
                 Location location,
                 Protocol protocol,
                 Communicator communicator)
@@ -401,7 +374,6 @@ namespace ZeroC.Ice
                 try
                 {
                     EndpointList endpoints = ImmutableArray<Endpoint>.Empty;
-                    Location newLocation = ImmutableArray<string>.Empty;
 
                     if (protocol == Protocol.Ice1)
                     {
@@ -436,7 +408,7 @@ namespace ZeroC.Ice
                         EndpointData[] dataArray;
 
                         // This will throw OperationNotExistException if it's an old Locator, and that's fine.
-                        (dataArray, newLocation) = await Locator.ResolveLocationAsync(
+                        dataArray = await Locator.ResolveLocationAsync(
                             location,
                             cancel: CancellationToken.None).ConfigureAwait(false);
 
@@ -444,23 +416,18 @@ namespace ZeroC.Ice
                         {
                             endpoints = dataArray.ToEndpointList(communicator);
                         }
-                        else if (newLocation.Count > 0)
-                        {
-                            TraceInvalid(location, newLocation, communicator);
-                            newLocation = ImmutableArray<string>.Empty;
-                        }
                     }
 
                     if (endpoints.Count == 0)
                     {
                         ClearCache(location, protocol, communicator);
-                        return (endpoints, newLocation);
+                        return endpoints;
                     }
                     else
                     {
                         // Cache the resolved location
-                        _locationCache[(location, protocol)] = (Time.Elapsed, endpoints, newLocation);
-                        return (endpoints, newLocation);
+                        _locationCache[(location, protocol)] = (Time.Elapsed, endpoints);
+                        return endpoints;
                     }
                 }
                 catch (Exception exception)
@@ -559,7 +526,16 @@ namespace ZeroC.Ice
                             reference.Facet,
                             cancel: CancellationToken.None).ConfigureAwait(false);
 
-                        endpoints = dataArray.ToEndpointList(reference.Communicator);
+                        if (dataArray.Length > 0)
+                        {
+                            endpoints = dataArray.ToEndpointList(reference.Communicator);
+                            location = ImmutableArray<string>.Empty; // always wipe-out / ignore location
+                        }
+                        else
+                        {
+                            endpoints = ImmutableArray<Endpoint>.Empty;
+                            // and keep returned location
+                        }
                     }
 
                     if (endpoints.Count == 0 && location.Count == 0)
@@ -569,6 +545,8 @@ namespace ZeroC.Ice
                     }
                     else
                     {
+                        Debug.Assert(endpoints.Count == 0 || location.Count == 0);
+
                         _wellKnownProxyCache[(reference.Identity, reference.Facet, reference.Protocol)] =
                             (Time.Elapsed, endpoints, location);
                         return (endpoints, location);

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1332,8 +1332,7 @@ namespace ZeroC.Ice
                     }
                     else if (LocatorInfo != null)
                     {
-                        // TODO: cache and send the new location with requests
-                        (endpoints, _, cached) =
+                        (endpoints, cached) =
                             await LocatorInfo.ResolveIndirectReferenceAsync(this, cancel).ConfigureAwait(false);
                     }
                 }

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -705,12 +705,10 @@ namespace ZeroC.Ice.Test.Location
             }
             else
             {
-                (EndpointData[] dataArray, string[] newLocation) =
-                    locator.ResolveLocation(ImmutableArray.Create(adapterId));
+                EndpointData[] dataArray = locator.ResolveLocation(ImmutableArray.Create(adapterId));
 
                 return dataArray.Length > 0 ?
-                    locator.Clone(endpoints: dataArray.ToEndpointList(locator.Communicator), location: newLocation) :
-                        null;
+                    locator.Clone(endpoints: dataArray.ToEndpointList(locator.Communicator)) : null;
             }
         }
 

--- a/csharp/test/Ice/location/ServerLocator.cs
+++ b/csharp/test/Ice/location/ServerLocator.cs
@@ -42,17 +42,14 @@ namespace ZeroC.Ice.Test.Location
 
         public int GetRequestCount(Current current, CancellationToken cancel) => _requestCount;
 
-        public (IEnumerable<EndpointData>, IEnumerable<string>) ResolveLocation(
-            string[] location,
-            Current current,
-            CancellationToken cancel)
+        public IEnumerable<EndpointData> ResolveLocation(string[] location, Current current, CancellationToken cancel)
         {
             ++_requestCount;
             // We add a small delay to make sure locator request queuing gets tested when
             // running the test on a fast machine
             System.Threading.Thread.Sleep(1);
 
-            return (_registry.GetIce2Adapter(location[0]), location[1..]);
+            return _registry.GetIce2Adapter(location[0]);
         }
 
         public (IEnumerable<EndpointData>, IEnumerable<string>) ResolveWellKnownProxy(

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -79,16 +79,15 @@ module Ice
         /// Resolves the location of a proxy that uses the ice2 protocol.
         /// @param location The location to resolve.
         /// @return A sequence of one or more endpoints when the location can be resolved, and an empty sequence of
-        /// endpoints when the location cannot be resolved. When the location can be resolved, this operation also
-        /// returns a new location which is typically location[1..].
-        idempotent (EndpointDataSeq endpoints, StringSeq newLocation) resolveLocation(StringSeq location);
+        /// endpoints when the location cannot be resolved.
+        idempotent EndpointDataSeq resolveLocation(StringSeq location);
 
-        /// Locates the well-known object with the given identity and facet. This object must be reachable using the
+        /// Resolves the well-known object with the given identity and facet. This object must be reachable using the
         /// ice2 protocol.
         /// @param identity The identity of the well-known Ice object.
         /// @param facet The facet of the well-known Ice object.
-        /// @return A sequence of one or more endpoints and/or a non-empty location if the Locator could resolve the
-        /// identity and facet. Otherwise, an empty sequence of endpoints and an empty location.
+        /// @return If the locator can locate the well-known object, either a sequence of one or more endpoints or
+        /// a non-empty location. Otherwise, an empty sequence of endpoints and an empty location.
         idempotent (EndpointDataSeq endpoints, StringSeq location) resolveWellKnownProxy(
             Identity identity,
             string facet);


### PR DESCRIPTION
This PR simplifies `Locator::resolveLocation` to return only endpoints.

Returning a "resolved location" is not particularly useful because we can't send this resolved location with the request (at least not easily).

I also kept resolveWellKnownProxy unchanged, with the same semantics as findObjectById, i.e. it can return a location or endpoints (but not both).