### PR TITLE
Suppress generated IEquatable for struct with sequence or dictionary member

### DIFF
--- a/csharp/src/Ice/Discovery/Locator.cs
+++ b/csharp/src/Ice/Discovery/Locator.cs
@@ -439,7 +439,7 @@ namespace ZeroC.Ice.Discovery
     internal sealed class ResolveAdapterIdReply : ReplyServant<IReadOnlyList<EndpointData>>, IResolveAdapterIdReply
     {
         private readonly object _mutex = new();
-        private readonly HashSet<EndpointData> _endpointDataSet = new(EndpointDataComparer.Instance);
+        private readonly HashSet<EndpointData> _endpointDataSet = new();
 
         public void FoundAdapterId(
             EndpointData[] endpoints,
@@ -490,31 +490,6 @@ namespace ZeroC.Ice.Discovery
         internal ResolveWellKnownProxyReply(ObjectAdapter replyAdapter)
             : base(emptyResult: "", replyAdapter)
         {
-        }
-    }
-
-    // Temporary helper class
-    internal sealed class EndpointDataComparer : IEqualityComparer<EndpointData>
-    {
-        internal static readonly EndpointDataComparer Instance = new();
-
-        public bool Equals(EndpointData x, EndpointData y) =>
-            x.Transport == y.Transport &&
-            x.Host == y.Host &&
-            x.Port == y.Port &&
-            x.Options.SequenceEqual(y.Options);
-
-        public int GetHashCode(EndpointData obj)
-        {
-            var hash = new HashCode();
-            hash.Add(obj.Transport);
-            hash.Add(obj.Host);
-            hash.Add(obj.Port);
-            foreach (string s in obj.Options)
-            {
-                hash.Add(s);
-            }
-            return hash.ToHashCode();
         }
     }
 }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -119,26 +119,10 @@ namespace ZeroC.Ice
             other is Endpoint endpoint &&
                 Communicator == endpoint.Communicator &&
                 Protocol == endpoint.Protocol &&
-                Transport == endpoint.Transport &&
-                Host == endpoint.Host &&
-                Port == endpoint.Port &&
-                Data.Options.SequenceEqual(endpoint.Data.Options);
+                Data == endpoint.Data;
 
         /// <inheritdoc/>
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Communicator);
-            hash.Add(Protocol);
-            hash.Add(Transport);
-            hash.Add(Host);
-            hash.Add(Port);
-            foreach (string s in Data.Options)
-            {
-                hash.Add(s);
-            }
-            return hash.ToHashCode();
-        }
+        public override int GetHashCode() => HashCode.Combine(Communicator, Protocol, Data);
 
         /// <summary>Converts the endpoint into a string. The format of this string depends on the protocol: either
         /// ice1 format (for ice1) or URI format (for ice2 and up).</summary>
@@ -220,6 +204,46 @@ namespace ZeroC.Ice
             Communicator = communicator;
             Data = data;
             Protocol = protocol;
+        }
+    }
+
+    // Extends EndpointData with the correct Equals and GetHashCode implementation.
+    public readonly partial struct EndpointData : IEquatable<EndpointData>
+    {
+        /// <summary>The equality operator == returns true if its operands are equal, false otherwise.</summary>
+        /// <param name="lhs">The left hand side operand.</param>
+        /// <param name="rhs">The right hand side operand.</param>
+        /// <returns><c>true</c> if the operands are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(EndpointData lhs, EndpointData rhs) => lhs.Equals(rhs);
+
+        /// <summary>The inequality operator != returns true if its operands are not equal, false otherwise.</summary>
+        /// <param name="lhs">The left hand side operand.</param>
+        /// <param name="rhs">The right hand side operand.</param>
+        /// <returns><c>true</c> if the operands are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(EndpointData lhs, EndpointData rhs) => !lhs.Equals(rhs);
+
+        /// <inheritdoc/>
+        public readonly bool Equals(EndpointData other) =>
+            Transport == other.Transport &&
+            Host == other.Host &&
+            Port == other.Port &&
+            Options.SequenceEqual(other.Options);
+
+        /// <inheritdoc/>
+        public readonly override bool Equals(object? other) => other is EndpointData value && Equals(value);
+
+        /// <inheritdoc/>
+        public readonly override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Transport);
+            hash.Add(Host);
+            hash.Add(Port);
+            foreach (string option in Options)
+            {
+                hash.Add(option);
+            }
+            return hash.ToHashCode();
         }
     }
 

--- a/csharp/src/Ice/ProxyComparer.cs
+++ b/csharp/src/Ice/ProxyComparer.cs
@@ -1,20 +1,21 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 
 namespace ZeroC.Ice
 {
     /// <summary>Represents an <see cref="IObjectPrx">object proxy</see>comparison operation based on all or only some
     /// of the proxy properties. The <see cref="EqualityComparer{T}.Default"/> property delegates to the implementation
-    /// of <see cref="System.IEquatable{T}"/> provided by IObjectPrx.</summary>
+    /// of <see cref="IEquatable{T}"/> provided by IObjectPrx.</summary>
     public abstract class ProxyComparer : EqualityComparer<IObjectPrx>
     {
-        /// <summary>Gets a <see cref="ProxyComparer"/> that compare proxies based only on the proxies' object
+        /// <summary>Gets a <see cref="ProxyComparer"/> that compares proxies based only on the proxies' object
         /// identity.</summary>
         public static ProxyComparer Identity { get; } = new IdentityComparer();
 
-        /// <summary>Gets a <see cref="ProxyComparer"/> that compare proxies, based only on the proxies' object
-        /// identity and facet.</summary>
+        /// <summary>Gets a <see cref="ProxyComparer"/> that compares proxies based only on the proxies' object identity
+        /// and facet.</summary>
         public static ProxyComparer IdentityAndFacet { get; } = new IdentityAndFacetComparer();
 
         private class IdentityComparer : ProxyComparer
@@ -33,13 +34,13 @@ namespace ZeroC.Ice
                     return false;
                 }
 
-                return lhs.Identity.Equals(rhs.Identity);
+                return lhs.Identity == rhs.Identity;
             }
         }
 
         private class IdentityAndFacetComparer : ProxyComparer
         {
-            public override int GetHashCode(IObjectPrx obj) => System.HashCode.Combine(obj.Identity, obj.Facet);
+            public override int GetHashCode(IObjectPrx obj) => HashCode.Combine(obj.Identity, obj.Facet);
 
             public override bool Equals(IObjectPrx? lhs, IObjectPrx? rhs)
             {
@@ -53,7 +54,7 @@ namespace ZeroC.Ice
                     return false;
                 }
 
-                return lhs.Identity.Equals(rhs.Identity) && lhs.Facet.Equals(rhs.Facet);
+                return lhs.Identity == rhs.Identity && lhs.Facet == rhs.Facet;
             }
         }
     }

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -178,7 +178,6 @@ namespace ZeroC.Ice.Test.Optional
             output.Write("testing struct with optional data members... ");
             var myStruct = new MyStruct(test, null, new string?[] { "foo", null, "bar" });
             MyStruct myStructResult = test.OpMyStruct(myStruct);
-            TestHelper.Assert(myStruct != myStructResult); // the proxies and arrays can't be identical
             TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
                 myStructResult.X == myStruct.X &&
                 myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));


### PR DESCRIPTION
This is helpful / necessary to allow application-code to provide a correct implementation for Equals and GetHashCode in a partial struct. For sequences, the Equals implementation can for example use SequenceEqual from Linq.

This PR uses this feature to provide correct Equals / GetHashCode to EndpointData.