### PR TITLE
Update generated struct Equals and GetHashCode

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1578,7 +1578,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
             }
             else if(StructPtr::dynamicCast(cont))
             {
-                if(s.substr(csPrefix.size()) == "readonly")
+                if (s == "cs:readonly" || s == "cs:custom-equals")
                 {
                     newLocalMetadata.push_back(s);
                     continue;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1921,7 +1921,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                 _out << lhs << " == " << rhs << " ||";
                 _out.inc();
                 _out << nl << "(" << lhs << " != null && " << rhs << " != null && ";
-                _out << "global::ZeroC.Ice.DictionaryExtensions.DictionaryEqual(" << lhs << ", " << rhs << ")";
+                _out << "ZeroC.Ice.DictionaryExtensions.DictionaryEqual(" << lhs << ", " << rhs << ")";
                 _out << ")";
                 if (dataMembers.size() > 1)
                 {
@@ -1958,14 +1958,14 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
             {
                 _out << nl << "if (" << obj << " != null)";
                 _out << sb;
-                _out << nl << "hash.Add(global::ZeroC.Ice.EnumerableExtensions.GetSequenceHashCode(" << obj << "));";
+                _out << nl << "hash.Add(ZeroC.Ice.EnumerableExtensions.GetSequenceHashCode(" << obj << "));";
                 _out << eb;
             }
             else if (DictionaryPtr::dynamicCast(mType))
             {
                 _out << nl << "if (" << obj << " != null)";
                 _out << sb;
-                _out << nl << "hash.Add(global::ZeroC.Ice.DictionaryExtensions.GetDictionaryHashCode(" << obj << "));";
+                _out << nl << "hash.Add(ZeroC.Ice.DictionaryExtensions.GetDictionaryHashCode(" << obj << "));";
                 _out << eb;
             }
             else

--- a/csharp/src/Ice/DictionaryExtensions.cs
+++ b/csharp/src/Ice/DictionaryExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ZeroC.Ice
 {
-    internal static class DictionaryExtensions
+    public static class DictionaryExtensions
     {
         /// <summary>Compares two dictionaries for equality. Enumerable.SequenceEqual provides the equivalent
         /// functionality for sequences.</summary>
@@ -12,7 +12,7 @@ namespace ZeroC.Ice
         /// <param name="rhs">The second dictionary to compare.</param>
         /// <returns>True if the two dictionaries have the exact same entries using the value's default equality
         /// comparison; otherwise, false.</returns>
-        internal static bool DictionaryEqual<TKey, TValue>(
+        public static bool DictionaryEqual<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue>? lhs,
             IReadOnlyDictionary<TKey, TValue>? rhs) where TKey : notnull
         {
@@ -40,7 +40,7 @@ namespace ZeroC.Ice
         /// <summary>Computes the hash code for a dictionary.</summary>
         /// <param name="dict">The dictionary.</param>
         /// <returns>A hash code computed using the dictionary's entries.</returns>
-        internal static int GetDictionaryHashCode<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict)
+        public static int GetDictionaryHashCode<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict)
             where TKey : notnull
         {
             var hash = new System.HashCode();

--- a/csharp/src/Ice/Discovery/Locator.cs
+++ b/csharp/src/Ice/Discovery/Locator.cs
@@ -439,7 +439,7 @@ namespace ZeroC.Ice.Discovery
     internal sealed class ResolveAdapterIdReply : ReplyServant<IReadOnlyList<EndpointData>>, IResolveAdapterIdReply
     {
         private readonly object _mutex = new();
-        private readonly HashSet<EndpointData> _endpointDataSet = new(EndpointDataComparer.Instance);
+        private readonly HashSet<EndpointData> _endpointDataSet = new();
 
         public void FoundAdapterId(
             EndpointData[] endpoints,
@@ -490,31 +490,6 @@ namespace ZeroC.Ice.Discovery
         internal ResolveWellKnownProxyReply(ObjectAdapter replyAdapter)
             : base(emptyResult: "", replyAdapter)
         {
-        }
-    }
-
-    // Temporary helper class
-    internal sealed class EndpointDataComparer : IEqualityComparer<EndpointData>
-    {
-        internal static readonly EndpointDataComparer Instance = new();
-
-        public bool Equals(EndpointData x, EndpointData y) =>
-            x.Transport == y.Transport &&
-            x.Host == y.Host &&
-            x.Port == y.Port &&
-            x.Options.SequenceEqual(y.Options);
-
-        public int GetHashCode(EndpointData obj)
-        {
-            var hash = new HashCode();
-            hash.Add(obj.Transport);
-            hash.Add(obj.Host);
-            hash.Add(obj.Port);
-            foreach (string s in obj.Options)
-            {
-                hash.Add(s);
-            }
-            return hash.ToHashCode();
         }
     }
 }

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -207,46 +207,6 @@ namespace ZeroC.Ice
         }
     }
 
-    // Extends EndpointData with the correct Equals and GetHashCode implementation.
-    public readonly partial struct EndpointData : IEquatable<EndpointData>
-    {
-        /// <summary>The equality operator == returns true if its operands are equal, false otherwise.</summary>
-        /// <param name="lhs">The left hand side operand.</param>
-        /// <param name="rhs">The right hand side operand.</param>
-        /// <returns><c>true</c> if the operands are equal, otherwise <c>false</c>.</returns>
-        public static bool operator ==(EndpointData lhs, EndpointData rhs) => lhs.Equals(rhs);
-
-        /// <summary>The inequality operator != returns true if its operands are not equal, false otherwise.</summary>
-        /// <param name="lhs">The left hand side operand.</param>
-        /// <param name="rhs">The right hand side operand.</param>
-        /// <returns><c>true</c> if the operands are not equal, otherwise <c>false</c>.</returns>
-        public static bool operator !=(EndpointData lhs, EndpointData rhs) => !lhs.Equals(rhs);
-
-        /// <inheritdoc/>
-        public readonly bool Equals(EndpointData other) =>
-            Transport == other.Transport &&
-            Host == other.Host &&
-            Port == other.Port &&
-            Options.SequenceEqual(other.Options);
-
-        /// <inheritdoc/>
-        public readonly override bool Equals(object? other) => other is EndpointData value && Equals(value);
-
-        /// <inheritdoc/>
-        public readonly override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Transport);
-            hash.Add(Host);
-            hash.Add(Port);
-            foreach (string option in Options)
-            {
-                hash.Add(option);
-            }
-            return hash.ToHashCode();
-        }
-    }
-
     public static class EndpointExtensions
     {
         /// <summary>Creates an endpoint from an <see cref="EndpointData"/> struct.</summary>

--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -119,26 +119,10 @@ namespace ZeroC.Ice
             other is Endpoint endpoint &&
                 Communicator == endpoint.Communicator &&
                 Protocol == endpoint.Protocol &&
-                Transport == endpoint.Transport &&
-                Host == endpoint.Host &&
-                Port == endpoint.Port &&
-                Data.Options.SequenceEqual(endpoint.Data.Options);
+                Data == endpoint.Data;
 
         /// <inheritdoc/>
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(Communicator);
-            hash.Add(Protocol);
-            hash.Add(Transport);
-            hash.Add(Host);
-            hash.Add(Port);
-            foreach (string s in Data.Options)
-            {
-                hash.Add(s);
-            }
-            return hash.ToHashCode();
-        }
+        public override int GetHashCode() => HashCode.Combine(Communicator, Protocol, Data);
 
         /// <summary>Converts the endpoint into a string. The format of this string depends on the protocol: either
         /// ice1 format (for ice1) or URI format (for ice2 and up).</summary>
@@ -220,6 +204,46 @@ namespace ZeroC.Ice
             Communicator = communicator;
             Data = data;
             Protocol = protocol;
+        }
+    }
+
+    // Extends EndpointData with the correct Equals and GetHashCode implementation.
+    public readonly partial struct EndpointData : IEquatable<EndpointData>
+    {
+        /// <summary>The equality operator == returns true if its operands are equal, false otherwise.</summary>
+        /// <param name="lhs">The left hand side operand.</param>
+        /// <param name="rhs">The right hand side operand.</param>
+        /// <returns><c>true</c> if the operands are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(EndpointData lhs, EndpointData rhs) => lhs.Equals(rhs);
+
+        /// <summary>The inequality operator != returns true if its operands are not equal, false otherwise.</summary>
+        /// <param name="lhs">The left hand side operand.</param>
+        /// <param name="rhs">The right hand side operand.</param>
+        /// <returns><c>true</c> if the operands are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(EndpointData lhs, EndpointData rhs) => !lhs.Equals(rhs);
+
+        /// <inheritdoc/>
+        public readonly bool Equals(EndpointData other) =>
+            Transport == other.Transport &&
+            Host == other.Host &&
+            Port == other.Port &&
+            Options.SequenceEqual(other.Options);
+
+        /// <inheritdoc/>
+        public readonly override bool Equals(object? other) => other is EndpointData value && Equals(value);
+
+        /// <inheritdoc/>
+        public readonly override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Transport);
+            hash.Add(Host);
+            hash.Add(Port);
+            foreach (string option in Options)
+            {
+                hash.Add(option);
+            }
+            return hash.ToHashCode();
         }
     }
 

--- a/csharp/src/Ice/EnumerableExtensions.cs
+++ b/csharp/src/Ice/EnumerableExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace ZeroC.Ice
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>Computes the hash code for a sequence.</summary>
+        /// <param name="sequence">The sequence.</param>
+        /// <returns>A hash code computed using the sequence's elements.</returns>
+        public static int GetSequenceHashCode<T>(this IEnumerable<T> sequence)
+        {
+            var hash = new HashCode();
+            foreach (T element in sequence)
+            {
+                hash.Add(element);
+            }
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -580,16 +580,8 @@ namespace ZeroC.Ice
                 (Location Location, Protocol Protocol) rhs) =>
                 lhs.Location.SequenceEqual(rhs.Location) && lhs.Protocol == rhs.Protocol;
 
-            public int GetHashCode((Location Location, Protocol Protocol) obj)
-            {
-                var hash = new HashCode();
-                foreach (string s in obj.Location)
-                {
-                    hash.Add(s);
-                }
-                hash.Add(obj.Protocol);
-                return hash.ToHashCode();
-            }
+            public int GetHashCode((Location Location, Protocol Protocol) obj) =>
+                HashCode.Combine(obj.Location.GetSequenceHashCode(), obj.Protocol);
         }
     }
 }

--- a/csharp/src/Ice/OpaqueEndpoint.cs
+++ b/csharp/src/Ice/OpaqueEndpoint.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,7 +61,11 @@ namespace ZeroC.Ice
             }
             else
             {
-                int hashCode = HashCode.Combine(base.GetHashCode(), ValueEncoding, Value);
+                int hashCode = HashCode.Combine(
+                    base.GetHashCode(),
+                    ValueEncoding,
+                    MemoryMarshal.ToEnumerable(Value).GetSequenceHashCode());
+
                 if (hashCode == 0)
                 {
                     hashCode = 1;

--- a/csharp/src/Ice/ProxyComparer.cs
+++ b/csharp/src/Ice/ProxyComparer.cs
@@ -1,20 +1,21 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 
 namespace ZeroC.Ice
 {
     /// <summary>Represents an <see cref="IObjectPrx">object proxy</see>comparison operation based on all or only some
     /// of the proxy properties. The <see cref="EqualityComparer{T}.Default"/> property delegates to the implementation
-    /// of <see cref="System.IEquatable{T}"/> provided by IObjectPrx.</summary>
+    /// of <see cref="IEquatable{T}"/> provided by IObjectPrx.</summary>
     public abstract class ProxyComparer : EqualityComparer<IObjectPrx>
     {
-        /// <summary>Gets a <see cref="ProxyComparer"/> that compare proxies based only on the proxies' object
+        /// <summary>Gets a <see cref="ProxyComparer"/> that compares proxies based only on the proxies' object
         /// identity.</summary>
         public static ProxyComparer Identity { get; } = new IdentityComparer();
 
-        /// <summary>Gets a <see cref="ProxyComparer"/> that compare proxies, based only on the proxies' object
-        /// identity and facet.</summary>
+        /// <summary>Gets a <see cref="ProxyComparer"/> that compares proxies based only on the proxies' object identity
+        /// and facet.</summary>
         public static ProxyComparer IdentityAndFacet { get; } = new IdentityAndFacetComparer();
 
         private class IdentityComparer : ProxyComparer
@@ -33,13 +34,13 @@ namespace ZeroC.Ice
                     return false;
                 }
 
-                return lhs.Identity.Equals(rhs.Identity);
+                return lhs.Identity == rhs.Identity;
             }
         }
 
         private class IdentityAndFacetComparer : ProxyComparer
         {
-            public override int GetHashCode(IObjectPrx obj) => System.HashCode.Combine(obj.Identity, obj.Facet);
+            public override int GetHashCode(IObjectPrx obj) => HashCode.Combine(obj.Identity, obj.Facet);
 
             public override bool Equals(IObjectPrx? lhs, IObjectPrx? rhs)
             {
@@ -53,7 +54,7 @@ namespace ZeroC.Ice
                     return false;
                 }
 
-                return lhs.Identity.Equals(rhs.Identity) && lhs.Facet.Equals(rhs.Facet);
+                return lhs.Identity == rhs.Identity && lhs.Facet == rhs.Facet;
             }
         }
     }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -347,10 +347,7 @@ namespace ZeroC.Ice
                 hash.Add(Encoding);
                 hash.Add(Facet);
                 hash.Add(Identity);
-                foreach (InvocationInterceptor interceptor in _invocationInterceptors)
-                {
-                    hash.Add(interceptor);
-                }
+                hash.Add(_invocationInterceptors.GetSequenceHashCode());
                 hash.Add(InvocationMode);
                 hash.Add(InvocationTimeout);
                 hash.Add(Protocol);
@@ -362,25 +359,13 @@ namespace ZeroC.Ice
                 else
                 {
                     hash.Add(ConnectionId);
-                    foreach (Endpoint e in Endpoints)
-                    {
-                        hash.Add(e);
-                    }
+                    hash.Add(Endpoints.GetSequenceHashCode());
                     hash.Add(IsConnectionCached);
-                    foreach (string s in Location)
-                    {
-                        hash.Add(s);
-                    }
+                    hash.Add(Location.GetSequenceHashCode());
                     hash.Add(LocatorCacheTimeout);
-                    if (LocatorInfo != null)
-                    {
-                        hash.Add(LocatorInfo);
-                    }
+                    hash.Add(LocatorInfo);
                     hash.Add(PreferNonSecure);
-                    if (RouterInfo != null)
-                    {
-                        hash.Add(RouterInfo);
-                    }
+                    hash.Add(RouterInfo);
                 }
 
                 int hashCode = hash.ToHashCode();

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -178,14 +178,10 @@ namespace ZeroC.Ice.Test.Optional
             output.Write("testing struct with optional data members... ");
             var myStruct = new MyStruct(test, null, new string?[] { "foo", null, "bar" });
             MyStruct myStructResult = test.OpMyStruct(myStruct);
-            TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
-                myStructResult.X == myStruct.X &&
-                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));
+            TestHelper.Assert(myStruct == myStructResult);
 
             myStructResult = test.OpOptMyStruct(myStruct)!.Value;
-            TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
-                myStructResult.X == myStruct.X &&
-                myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));
+            TestHelper.Assert(myStruct == myStructResult);
 
             TestHelper.Assert(test.OpOptMyStruct(null) == null);
             output.WriteLine("ok");

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -178,7 +178,6 @@ namespace ZeroC.Ice.Test.Optional
             output.Write("testing struct with optional data members... ");
             var myStruct = new MyStruct(test, null, new string?[] { "foo", null, "bar" });
             MyStruct myStructResult = test.OpMyStruct(myStruct);
-            TestHelper.Assert(myStruct != myStructResult); // the proxies and arrays can't be identical
             TestHelper.Assert(myStructResult.Proxy!.Equals(myStruct.Proxy) &&
                 myStructResult.X == myStruct.X &&
                 myStructResult.StringSeq!.SequenceEqual(myStruct.StringSeq!));

--- a/csharp/test/Slice/structure/Client.cs
+++ b/csharp/test/Slice/structure/Client.cs
@@ -8,11 +8,18 @@ using ZeroC.Ice;
 
 namespace ZeroC.Slice.Test.Structure
 {
+    // Use reference equality for IntList
+    public partial struct S3
+    {
+        public readonly bool Equals(S3 other) => S == other.S && IntList == other.IntList;
+        public readonly override int GetHashCode() => HashCode.Combine(S, IntList);
+    }
+
     public class Client : TestHelper
     {
         private static void Run(Communicator communicator)
         {
-            Console.Out.Write("testing equals() for Slice structures... ");
+            Console.Out.Write("testing Equals() for Slice structures... ");
             Console.Out.Flush();
 
             // Define some default values.
@@ -28,8 +35,15 @@ namespace ZeroC.Slice.Test.Structure
             _ = new S2(true, 98, 99, 100, 101, 1.0f, 2.0, "string", def_ss, def_il, def_sd, def_s, def_cls, def_prx);
 
             // Compare default-constructed structures.
-            Assert(new S2().Equals(new S2()));
+            Assert(new S2() == new S2());
 
+            var s3 = new S3("foo", new int[] { 4, 7, 10 });
+            var s3Copy = s3;
+            Assert(s3 == s3Copy);
+            Assert(s3.GetHashCode() == s3Copy.GetHashCode());
+            s3Copy.IntList = new int[] { 4, 7, 10 }; // same values, different object
+            Assert(s3 != s3Copy);
+            Assert(s3.GetHashCode() != s3Copy.GetHashCode()); // can be the same, just unlikely
             Console.Out.WriteLine("ok");
         }
 

--- a/csharp/test/Slice/structure/Test.ice
+++ b/csharp/test/Slice/structure/Test.ice
@@ -2,41 +2,43 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[[3.7]]
-
 module ZeroC::Slice::Test::Structure
 {
+    sequence<string> StringSeq;
+    sequence<int> IntList;
+    dictionary<string, string> StringDict;
 
-sequence<string> StringSeq;
-sequence<int> IntList;
-dictionary<string, string> StringDict;
+    class C
+    {
+        int i;
+    }
 
-class C
-{
-    int i;
-}
+    struct S1
+    {
+        string name;
+    }
 
-struct S1
-{
-    string name;
-}
+    struct S2
+    {
+        bool bo;
+        byte by;
+        short sh;
+        int i;
+        long l;
+        float? f;
+        double d;
+        string str;
+        StringSeq ss;
+        IntList il;
+        StringDict sd;
+        S1 s;
+        C cls;
+        Object? prx;
+    }
 
-struct S2
-{
-    bool bo;
-    byte by;
-    short sh;
-    int i;
-    long l;
-    float f;
-    double d;
-    string str;
-    StringSeq ss;
-    IntList il;
-    StringDict sd;
-    S1 s;
-    C cls;
-    Object* prx;
-}
-
+    [cs:custom-equals] struct S3
+    {
+        string s;
+        IntList intList;
+    }
 }


### PR DESCRIPTION
This PR updates the implementation of Equals and GetHashCode in generated structs: it's now a deep comparison for sequence and dictionary, using Linq.SequenceEqual and other helper methods.

This PR also adds a new struct metadata, `[cs:custom-equals]`, which allows users to provide their own custom Equals and GetHashCode in custom implementation in a partial struct.
