### PR TITLE
Removed CheckSendSize from SingleStreamSocket

### DIFF
--- a/csharp/src/Ice/BZip2.cs
+++ b/csharp/src/Ice/BZip2.cs
@@ -190,11 +190,6 @@ namespace ZeroC.Ice
                 compressedHeader[9] = 2;
                 compressedHeader.AsSpan(10, 4).WriteInt(compressedSize);
 
-                // Write the compression status and size of the compressed stream into the header of the decompressed
-                // stream -- we need this to trace requests correctly.
-                headerSegment[9] = 2;
-                headerSegment.AsSpan(10, 4).WriteInt(compressedSize);
-
                 // Add the size of the decompressed stream before the frame body.
                 compressedHeader.AsSpan(headerSize, 4).WriteInt(size);
 

--- a/csharp/src/Ice/Ice1NetworkSocket.cs
+++ b/csharp/src/Ice/Ice1NetworkSocket.cs
@@ -294,11 +294,11 @@ namespace ZeroC.Ice
                                                     ex.InnerException is SocketException socketException &&
                                                     socketException.SocketErrorCode == SocketError.MessageSize)
                 {
-                    // If the send failed because the datagram was too large, ignore and continue sending.
+                    // If the previous send failed because the datagram was too large, ignore and continue sending.
                 }
                 catch (OperationCanceledException)
                 {
-                    // Ignore if it got canceled.
+                    // Ignore if the previous send got canceled.
                 }
 
                 // If the send got cancelled, throw to notify the connection of the cancellation. This isn't a fatal

--- a/csharp/src/Ice/Ice1NetworkSocket.cs
+++ b/csharp/src/Ice/Ice1NetworkSocket.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -289,7 +290,9 @@ namespace ZeroC.Ice
                     // Wait for the previous send to complete
                     await _sendTask.ConfigureAwait(false);
                 }
-                catch (DatagramLimitException)
+                catch (TransportException ex) when (Endpoint.IsDatagram &&
+                                                    ex.InnerException is SocketException socketException &&
+                                                    socketException.SocketErrorCode == SocketError.MessageSize)
                 {
                     // If the send failed because the datagram was too large, ignore and continue sending.
                 }

--- a/csharp/src/Ice/Ice1NetworkSocketStream.cs
+++ b/csharp/src/Ice/Ice1NetworkSocketStream.cs
@@ -113,22 +113,18 @@ namespace ZeroC.Ice
                 }
 
                 ArraySegment<byte> header;
+                header = buffer[0];
                 if (compressed != null)
                 {
                     buffer = compressed;
-                    header = buffer[0];
-                    size = buffer.GetByteCount();
                 }
-                else // Message not compressed, request compressed response, if any.
+                else
                 {
-                    header = buffer[0];
+                    // Message not compressed, request compressed response, if any.
                     header[9] = 1; // Write the compression status
                 }
                 compressionStatus = header[9];
             }
-
-            // Ensure the frame isn't bigger than what we can send with the transport.
-            _socket.Underlying.CheckSendSize(size);
 
             await _socket.SendFrameAsync(buffer, CancellationToken.None).ConfigureAwait(false);
 

--- a/csharp/src/Ice/Ice1NetworkSocketStream.cs
+++ b/csharp/src/Ice/Ice1NetworkSocketStream.cs
@@ -112,18 +112,19 @@ namespace ZeroC.Ice
                                                 _socket.Endpoint.Communicator.CompressionLevel);
                 }
 
-                ArraySegment<byte> header;
-                header = buffer[0];
                 if (compressed != null)
                 {
+                    // Message compressed, get the compression status and ensure we send the compressed message.
                     buffer = compressed;
+                    compressionStatus = buffer[0][9];
                 }
                 else
                 {
-                    // Message not compressed, request compressed response, if any.
-                    header[9] = 1; // Write the compression status
+                    // Message not compressed, request compressed response, if any and write the compression status.
+                    compressionStatus = 1;
+                    ArraySegment<byte> header = buffer[0];
+                    header[9] = compressionStatus; // Write the compression status
                 }
-                compressionStatus = header[9];
             }
 
             await _socket.SendFrameAsync(buffer, CancellationToken.None).ConfigureAwait(false);

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -296,21 +296,6 @@ namespace ZeroC.Ice
         }
     }
 
-    /// <summary>This exception reports that a datagram exceeds the configured send or receive buffer size, or exceeds
-    /// the maximum payload size of a UDP packet (65507 bytes).</summary>
-    // TODO: eliminate this exception
-    public class DatagramLimitException : TransportException
-    {
-        /// <summary>Constructs a new instance of the <see cref="DatagramLimitException"/> class with a specified
-        /// error message.</summary>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="retryPolicy">The exception retry policy.</param>
-        public DatagramLimitException(string message, RetryPolicy retryPolicy = default)
-            : base(message, retryPolicy, null)
-        {
-        }
-    }
-
     /// <summary>This exception reports that data (bytes) received by Ice are not in an expected format.</summary>
     public class InvalidDataException : Exception
     {

--- a/csharp/src/Ice/MultiStreamSocket.cs
+++ b/csharp/src/Ice/MultiStreamSocket.cs
@@ -222,6 +222,7 @@ namespace ZeroC.Ice
             {
                 AbortStreams(exception);
             }
+
             await WaitForEmptyStreamsAsync().ConfigureAwait(false);
 
             lock (_mutex)
@@ -293,7 +294,7 @@ namespace ZeroC.Ice
 
         internal void CheckStreamsEmpty()
         {
-            if (_streams.Count <= 2)
+            if (_incomingStreamCount == 0 && _outgoingStreamCount == 0)
             {
                 _streamsEmptySource?.TrySetResult();
             }
@@ -561,7 +562,7 @@ namespace ZeroC.Ice
 
         internal async ValueTask WaitForEmptyStreamsAsync()
         {
-            if (_streams.Count > 2)
+            if (_incomingStreamCount > 0 || _outgoingStreamCount > 0)
             {
                 // Create a task completion source to wait for the streams to complete.
                 _streamsEmptySource ??= new TaskCompletionSource();

--- a/csharp/src/Ice/WSSocket.cs
+++ b/csharp/src/Ice/WSSocket.cs
@@ -63,8 +63,6 @@ namespace ZeroC.Ice
         private readonly IList<ArraySegment<byte>> _sendBuffer;
         private Task _sendTask = Task.CompletedTask;
 
-        public override void CheckSendSize(int size) => _underlying.CheckSendSize(size);
-
         public override async ValueTask CloseAsync(Exception exception, CancellationToken cancel)
         {
             byte[] payload = new byte[2];

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -122,7 +122,7 @@ namespace ZeroC.Ice.Test.UDP
             catch (TransportException)
             {
                 // The server's Ice.UDP.RcvSize property is set to 16384, which means that
-                // TransportException will be throw when try to send a packet bigger than that.
+                // TransportException will be thrown when we try to send a larger packet.
                 TestHelper.Assert(seq.Length > 16384);
             }
             obj.GetConnection().GoAwayAsync();

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -119,10 +119,10 @@ namespace ZeroC.Ice.Test.UDP
                     replyI.WaitReply(1, TimeSpan.FromSeconds(10));
                 }
             }
-            catch (DatagramLimitException)
+            catch (TransportException)
             {
                 // The server's Ice.UDP.RcvSize property is set to 16384, which means that
-                // DatagramLimitException will be throw when try to send a packet bigger than that.
+                // TransportException will be throw when try to send a packet bigger than that.
                 TestHelper.Assert(seq.Length > 16384);
             }
             obj.GetConnection().GoAwayAsync();
@@ -138,7 +138,7 @@ namespace ZeroC.Ice.Test.UDP
                 // delivered.
                 TestHelper.Assert(!b);
             }
-            catch (DatagramLimitException)
+            catch (TransportException)
             {
             }
             catch (Exception ex)

--- a/csharp/test/Ice/udp/TestIntfI.cs
+++ b/csharp/test/Ice/udp/TestIntfI.cs
@@ -48,16 +48,16 @@ namespace ZeroC.Ice.Test.UDP
                     byte[] seq = new byte[64 * 1024];
                     current.Connection.CreateProxy(id, "", ITestIntfPrx.Factory).SendByteSeq(seq, null, cancel: cancel);
                 }
-                catch (DatagramLimitException)
+                catch (TransportException)
                 {
                     // Expected.
                 }
 
                 current.Connection.CreateProxy(id, "", IPingReplyPrx.Factory).Reply(cancel: cancel);
             }
-            catch
+            catch (System.Exception ex)
             {
-                TestHelper.Assert(false);
+                TestHelper.Assert(false, ex.ToString());
             }
         }
 


### PR DESCRIPTION
I got rid of the explicit check for datagram size and DatagramLimitException. The sending of a datagram which is too large will now raise a TransportException with an associated C# socket exception.