### PR TITLE
Remove RefreshPublishedEndpoints

### DIFF
--- a/csharp/src/Ice/ColocatedEndpoint.cs
+++ b/csharp/src/Ice/ColocatedEndpoint.cs
@@ -43,7 +43,8 @@ namespace ZeroC.Ice
         {
         }
 
-        protected internal override Endpoint GetPublishedEndpoint(string serverName) => this;
+        protected internal override Endpoint GetPublishedEndpoint(string serverName) =>
+            throw new NotSupportedException("cannot create published endpoint for colocated endpoint");
 
         internal ColocatedEndpoint(ObjectAdapter adapter)
             : base(new EndpointData(Transport.Colocated, host: adapter.Name, port: 0, Array.Empty<string>()),

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -550,9 +550,6 @@ namespace ZeroC.Ice
             _acceptor = endpoint.Acceptor(this, _adapter);
             Endpoint = _acceptor.Endpoint;
 
-            // If Endpoint is an IP endpoint, it must have an IP address, not a DNS name.
-            Debug.Assert((Endpoint as IPEndpoint)?.Address != IPAddress.None);
-
             if (_communicator.TraceLevels.Transport >= 1)
             {
                 _communicator.Logger.Trace(TraceLevels.TransportCategory,

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -548,6 +549,9 @@ namespace ZeroC.Ice
             _adapter = adapter;
             _acceptor = endpoint.Acceptor(this, _adapter);
             Endpoint = _acceptor.Endpoint;
+
+            // If Endpoint is an IP endpoint, it must have an IP address, not a DNS name.
+            Debug.Assert((Endpoint as IPEndpoint)?.Address != IPAddress.None);
 
             if (_communicator.TraceLevels.Transport >= 1)
             {

--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -475,9 +475,7 @@ namespace ZeroC.Ice
 
     internal abstract class IncomingConnectionFactory : IAsyncDisposable
     {
-        internal abstract Endpoint PublishedEndpoint { get; }
-
-        private protected abstract Endpoint Endpoint { get; }
+        internal abstract Endpoint Endpoint { get; }
 
         public abstract ValueTask DisposeAsync();
 
@@ -491,8 +489,7 @@ namespace ZeroC.Ice
     // IncomingConnectionFactory for acceptor based transports.
     internal sealed class AcceptorIncomingConnectionFactory : IncomingConnectionFactory, IConnectionManager
     {
-        internal override Endpoint PublishedEndpoint { get; }
-        private protected override Endpoint Endpoint { get; }
+        internal override Endpoint Endpoint { get; }
 
         private readonly IAcceptor _acceptor;
         private Task? _acceptTask;
@@ -545,14 +542,12 @@ namespace ZeroC.Ice
 
         public override string ToString() => _acceptor.ToString()!;
 
-        internal AcceptorIncomingConnectionFactory(ObjectAdapter adapter, Endpoint endpoint, string serverName)
+        internal AcceptorIncomingConnectionFactory(ObjectAdapter adapter, Endpoint endpoint)
         {
             _communicator = adapter.Communicator;
             _adapter = adapter;
             _acceptor = endpoint.Acceptor(this, _adapter);
-
             Endpoint = _acceptor.Endpoint;
-            PublishedEndpoint = Endpoint.GetPublishedEndpoint(serverName);
 
             if (_communicator.TraceLevels.Transport >= 1)
             {
@@ -651,8 +646,7 @@ namespace ZeroC.Ice
     // IncomingConnectionFactory for datagram based transports
     internal sealed class DatagramIncomingConnectionFactory : IncomingConnectionFactory
     {
-        internal override Endpoint PublishedEndpoint { get; }
-        private protected override Endpoint Endpoint { get; }
+        internal override Endpoint Endpoint { get; }
 
         private readonly Connection _connection;
 
@@ -665,11 +659,10 @@ namespace ZeroC.Ice
 
         public override string ToString() => _connection.ToString()!;
 
-        internal DatagramIncomingConnectionFactory(ObjectAdapter adapter, Endpoint endpoint, string serverName)
+        internal DatagramIncomingConnectionFactory(ObjectAdapter adapter, Endpoint endpoint)
         {
             _connection = endpoint.CreateDatagramServerConnection(adapter);
             Endpoint = _connection.Endpoint;
-            PublishedEndpoint = Endpoint.GetPublishedEndpoint(serverName);
             _ = _connection.InitializeAsync();
         }
 

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -162,25 +162,6 @@ namespace ZeroC.Ice
             return await GetAddressesAsync(host, port, ipVersion, cancel).ConfigureAwait(false);
         }
 
-        internal static IPEndPoint GetAddressForServerEndpoint(string host, int port, int ipVersion)
-        {
-            // TODO: Fix this method to be asynchronous.
-
-            Debug.Assert(host.Length > 0);
-
-            try
-            {
-                // Get the addresses for the given host and return the first one
-                ValueTask<IEnumerable<IPEndPoint>> task = GetAddressesAsync(host, port, ipVersion);
-                return (task.IsCompleted ? task.Result : task.AsTask().Result).First();
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
-            }
-        }
-
         internal static List<string> GetHostsForEndpointExpand(string host, int ipVersion, bool includeLoopback)
         {
             var hosts = new List<string>();

--- a/csharp/src/Ice/TcpAcceptor.cs
+++ b/csharp/src/Ice/TcpAcceptor.cs
@@ -100,13 +100,11 @@ namespace ZeroC.Ice
 
         internal TcpAcceptor(TcpEndpoint endpoint, IConnectionManager manager, ObjectAdapter adapter)
         {
+            Debug.Assert(endpoint.Address != IPAddress.None); // not a DNS name
+
             _manager = manager;
             _adapter = adapter;
-
-            _addr = Network.GetAddressForServerEndpoint(endpoint.Host,
-                                                        endpoint.Port,
-                                                        Network.EnableBoth);
-
+            _addr = new IPEndPoint(endpoint.Address, endpoint.Port);
             _socket = Network.CreateServerSocket(endpoint, _addr.AddressFamily);
 
             try

--- a/csharp/src/Ice/TcpEndpoint.cs
+++ b/csharp/src/Ice/TcpEndpoint.cs
@@ -33,8 +33,12 @@ namespace ZeroC.Ice
 
         private int _hashCode;
 
-        public override IAcceptor Acceptor(IConnectionManager manager, ObjectAdapter adapter) =>
-            new TcpAcceptor(this, manager, adapter);
+        // TODO: should not be public
+        public override IAcceptor Acceptor(IConnectionManager manager, ObjectAdapter adapter)
+        {
+            Debug.Assert(Address != IPAddress.None); // i.e. not a DNS name
+            return new TcpAcceptor(this, manager, adapter);
+        }
 
         public override Connection CreateDatagramServerConnection(ObjectAdapter adapter) =>
             throw new InvalidOperationException();

--- a/csharp/src/Ice/UdpEndpoint.cs
+++ b/csharp/src/Ice/UdpEndpoint.cs
@@ -38,6 +38,8 @@ namespace ZeroC.Ice
 
         public override Connection CreateDatagramServerConnection(ObjectAdapter adapter)
         {
+            Debug.Assert(Address != IPAddress.None); // i.e. not a DNS name
+
             var socket = new UdpSocket(this, Communicator);
             try
             {

--- a/csharp/src/Ice/UdpSocket.cs
+++ b/csharp/src/Ice/UdpSocket.cs
@@ -297,8 +297,10 @@ namespace ZeroC.Ice
         // Only for use by UdpEndpoint.
         internal UdpSocket(UdpEndpoint endpoint, Communicator communicator)
         {
+            Debug.Assert(endpoint.Address != IPAddress.None); // not a DNS name
+
             _communicator = communicator;
-            _addr = Network.GetAddressForServerEndpoint(endpoint.Host, endpoint.Port, Network.EnableBoth);
+            _addr = new IPEndPoint(endpoint.Address, endpoint.Port);
             _multicastInterface = endpoint.MulticastInterface;
             _incoming = true;
 

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -156,23 +156,6 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 TestHelper.Assert(adapter.CreateProxy(new Identity("dummy", ""), IObjectPrx.Factory).Endpoints.
                     SequenceEqual(prx.Endpoints));
                 TestHelper.Assert(adapter.PublishedEndpoints.SequenceEqual(prx.Endpoints));
-                adapter.RefreshPublishedEndpoints();
-                TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
-                TestHelper.Assert(adapter.PublishedEndpoints[0] == endpt);
-                communicator.SetProperty("PAdapter.PublishedEndpoints",
-                    ice1 ? "tcp -h localhost -p 12345 -t 20000" : "ice+tcp://localhost:12345");
-                adapter.RefreshPublishedEndpoints();
-                TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
-
-                if (ice1)
-                {
-                    TestHelper.Assert(
-                        adapter.PublishedEndpoints[0].ToString() == "tcp -h localhost -p 12345 -t 20000");
-                }
-                else
-                {
-                    TestHelper.Assert(adapter.PublishedEndpoints[0].ToString() == "ice+tcp://localhost:12345");
-                }
             }
             output.WriteLine("ok");
 
@@ -207,18 +190,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                     {
                         TestHelper.Assert(endpointsStr == "ice+tcp://localhost:23456");
                     }
-                    adapter.RefreshPublishedEndpoints();
-                    TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
 
-                    if (ice1)
-                    {
-                        TestHelper.Assert(
-                            adapter.PublishedEndpoints[0].ToString() == "tcp -h localhost -p 23457 -t 60000");
-                    }
-                    else
-                    {
-                        TestHelper.Assert(adapter.PublishedEndpoints[0].ToString() == "ice+tcp://localhost:23457");
-                    }
                     try
                     {
                         adapter.SetPublishedEndpoints(router.Endpoints);

--- a/csharp/test/Ice/adapterDeactivation/Servant.cs
+++ b/csharp/test/Ice/adapterDeactivation/Servant.cs
@@ -10,13 +10,11 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
 {
     public sealed class Router : IRouter
     {
-        private int _nextPort = 23456;
-
         public (IObjectPrx?, bool?) GetClientProxy(Current current, CancellationToken cancel) => (null, false);
 
         public IObjectPrx GetServerProxy(Current current, CancellationToken cancel) =>
             IObjectPrx.Parse(TestHelper.GetTestProtocol(current.Communicator.GetProperties()) == Protocol.Ice1 ?
-                $"dummy:tcp -h localhost -p {_nextPort++}" : $"ice+tcp://localhost:{_nextPort++}/dummy",
+                $"dummy:tcp -h localhost -p 23456" : $"ice+tcp://localhost:23456/dummy",
                 current.Communicator);
 
         public IEnumerable<IObjectPrx?> AddProxies(IObjectPrx?[] proxies, Current current, CancellationToken cancel) =>

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -75,7 +75,7 @@ namespace ZeroC.Ice.Test.Info
             output.Write("test object adapter endpoint information... ");
             output.Flush();
             {
-                string serverName = "testhost";
+                string serverName = helper.Host;
 
                 communicator.SetProperty("TestAdapter.Endpoints",
                     $"tcp -h \"{helper.Host}\" -p 0 -t 15000");

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -83,7 +83,7 @@ namespace ZeroC.Ice.Test.Info
                 communicator.SetProperty("TestAdapter.ServerName", serverName);
                 adapter = communicator.CreateObjectAdapter("TestAdapter");
 
-                IReadOnlyList<Endpoint> endpoints = adapter.GetEndpoints();
+                IReadOnlyList<Endpoint> endpoints = adapter.Endpoints;
                 TestHelper.Assert(endpoints.Count == 1);
                 IReadOnlyList<Endpoint> publishedEndpoints = adapter.PublishedEndpoints;
                 TestHelper.Assert(endpoints.SequenceEqual(publishedEndpoints));
@@ -104,7 +104,7 @@ namespace ZeroC.Ice.Test.Info
                 communicator.SetProperty("TestAdapter.PublishedEndpoints", helper.GetTestEndpoint(1));
                 adapter = communicator.CreateObjectAdapter("TestAdapter");
 
-                endpoints = adapter.GetEndpoints();
+                endpoints = adapter.Endpoints;
                 TestHelper.Assert(endpoints.Count >= 1);
                 publishedEndpoints = adapter.PublishedEndpoints;
                 TestHelper.Assert(publishedEndpoints.Count == 1);


### PR DESCRIPTION
This PR removes `RefreshPublishedEndpoints` on ObjectAdapter as its main use case (recomputing default published endpoints when listening on 0.0.0.0) was removed by #1158.
It also simplifies various published endpoints related code.

We should also consider removing:
- the setter of ObjectAdapter.Locator, and possibly replace it by a parameter to `CreateObjectAdapter`
- `SetPublishedEndpoints` and `SetPublishedEndpointsAsync` - the use-case for these methods in not obvious to me. I believe they don't work with IceGrid since IceGrid does not accept re-registration of an object adapter endpoints.