### PR TITLE
Make router ice1-only

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1296,7 +1296,7 @@ namespace ZeroC.Ice
         internal RouterInfo? GetRouterInfo(IRouterPrx? router)
         {
             // Returns router info for a given router. Automatically creates the router info if it doesn't exist yet.
-            if (router != null)
+            if (router?.Protocol == Protocol.Ice1)
             {
                 // The router cannot be routed.
                 return _routerInfoTable.GetOrAdd(router.Clone(clearRouter: true), key => new RouterInfo(key));

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -1296,7 +1296,7 @@ namespace ZeroC.Ice
         internal RouterInfo? GetRouterInfo(IRouterPrx? router)
         {
             // Returns router info for a given router. Automatically creates the router info if it doesn't exist yet.
-            if (router?.Protocol == Protocol.Ice1)
+            if (router != null)
             {
                 // The router cannot be routed.
                 return _routerInfoTable.GetOrAdd(router.Clone(clearRouter: true), key => new RouterInfo(key));

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -684,7 +684,6 @@ namespace ZeroC.Ice
             AcceptNonSecure = communicator.AcceptNonSecure;
 
             _publishedEndpoints = Array.Empty<Endpoint>();
-            _routerInfo = null;
 
             AdapterId = "";
             ReplicaGroupId = "";
@@ -707,7 +706,6 @@ namespace ZeroC.Ice
             TaskScheduler = scheduler;
 
             _publishedEndpoints = Array.Empty<Endpoint>();
-            _routerInfo = null;
 
             (bool noProps, List<string> unknownProps) = FilterProperties();
 
@@ -742,18 +740,27 @@ namespace ZeroC.Ice
 
             try
             {
+                if (router != null && router.Protocol != Protocol.Ice1)
+                {
+                    throw new ArgumentException($"{nameof(router)} must be an ice1 proxy", nameof(router));
+                }
+
                 router ??= Communicator.GetPropertyAsProxy($"{Name}.Router", IRouterPrx.Factory);
 
                 if (router != null)
                 {
                     Protocol = router.Protocol;
+                    if (Protocol != Protocol.Ice1)
+                    {
+                        throw new InvalidConfigurationException($"{Name}.Router must be an ice1 proxy");
+                    }
                     _routerInfo = Communicator.GetRouterInfo(router);
                     Debug.Assert(_routerInfo != null);
 
                     // Make sure this router is not already registered with another adapter.
                     if (_routerInfo.Adapter != null)
                     {
-                        throw new ArgumentException($"router `{router}' already registered with an object adapter",
+                        throw new ArgumentException($"router `{router}' is already registered with an object adapter",
                             nameof(router));
                     }
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -202,6 +202,16 @@ namespace ZeroC.Ice
                 property = $"{propertyPrefix}.Router";
                 if (communicator.GetPropertyAsProxy(property, IRouterPrx.Factory) is IRouterPrx router)
                 {
+                    if (protocol != Protocol.Ice1)
+                    {
+                        throw new InvalidConfigurationException(
+                            $"`{property}={communicator.GetProperty(property)}': only an ice1 proxy can have a router");
+                    }
+                    if (router.Protocol != Protocol.Ice1)
+                    {
+                        throw new InvalidConfigurationException(@$"`{property}={communicator.GetProperty(property)
+                            }': a router proxy must use the ice1 protocol");
+                    }
                     if (propertyPrefix.EndsWith(".Router", StringComparison.Ordinal))
                     {
                         throw new InvalidConfigurationException(
@@ -229,7 +239,7 @@ namespace ZeroC.Ice
                                  preferNonSecure: preferNonSecure ?? communicator.DefaultPreferNonSecure,
                                  protocol: protocol,
                                  relative: relative,
-                                 routerInfo: routerInfo ?? communicator.GetRouterInfo(communicator.DefaultRouter));
+                                 routerInfo: communicator.GetRouterInfo(communicator.DefaultRouter));
         }
 
         /// <inheritdoc/>
@@ -1319,11 +1329,18 @@ namespace ZeroC.Ice
                 {
                     throw new ArgumentException($"cannot set both {nameof(locator)} and {nameof(clearLocator)}");
                 }
+                if (Protocol != Protocol.Ice1 && router != null)
+                {
+                    throw new ArgumentException("only an ice1 proxy can have a router", nameof(router));
+                }
                 if (router != null && clearRouter)
                 {
                     throw new ArgumentException($"cannot set both {nameof(router)} and {nameof(clearRouter)}");
                 }
-
+                if (router != null && router.Protocol != Protocol.Ice1)
+                {
+                    throw new ArgumentException($"{nameof(router)} must be an ice1 proxy", nameof(router));
+                }
                 if (locatorCacheTimeout != null &&
                     locatorCacheTimeout < TimeSpan.Zero && locatorCacheTimeout != Timeout.InfiniteTimeSpan)
                 {

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -239,7 +239,8 @@ namespace ZeroC.Ice
                                  preferNonSecure: preferNonSecure ?? communicator.DefaultPreferNonSecure,
                                  protocol: protocol,
                                  relative: relative,
-                                 routerInfo: communicator.GetRouterInfo(communicator.DefaultRouter));
+                                 routerInfo: protocol == Protocol.Ice1 ?
+                                    routerInfo ?? communicator.GetRouterInfo(communicator.DefaultRouter) : null);
         }
 
         /// <inheritdoc/>
@@ -1150,7 +1151,8 @@ namespace ZeroC.Ice
                    preferNonSecure: communicator.DefaultPreferNonSecure,
                    protocol: protocol,
                    relative: false,
-                   routerInfo: communicator.GetRouterInfo(communicator.DefaultRouter))
+                   routerInfo: protocol == Protocol.Ice1 ?
+                    communicator.GetRouterInfo(communicator.DefaultRouter) : null)
         {
         }
 

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -192,6 +192,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
 
             output.Write("testing object adapter with router... ");
             output.Flush();
+            if (ice1)
             {
                 var routerId = new Identity("router", "");
                 IRouterPrx router = obj.Clone(IRouterPrx.Factory, connectionId: "rc", identity: routerId);
@@ -199,26 +200,12 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                     using var adapter = communicator.CreateObjectAdapterWithRouter(router);
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
                     string endpointsStr = adapter.PublishedEndpoints[0].ToString();
-                    if (ice1)
-                    {
-                        TestHelper.Assert(endpointsStr == "tcp -h localhost -p 23456 -t 60000");
-                    }
-                    else
-                    {
-                        TestHelper.Assert(endpointsStr == "ice+tcp://localhost:23456");
-                    }
+                    TestHelper.Assert(endpointsStr == "tcp -h localhost -p 23456 -t 60000");
                     adapter.RefreshPublishedEndpoints();
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
 
-                    if (ice1)
-                    {
-                        TestHelper.Assert(
-                            adapter.PublishedEndpoints[0].ToString() == "tcp -h localhost -p 23457 -t 60000");
-                    }
-                    else
-                    {
-                        TestHelper.Assert(adapter.PublishedEndpoints[0].ToString() == "ice+tcp://localhost:23457");
-                    }
+                    TestHelper.Assert(
+                        adapter.PublishedEndpoints[0].ToString() == "tcp -h localhost -p 23457 -t 60000");
                     try
                     {
                         adapter.SetPublishedEndpoints(router.Endpoints);
@@ -250,6 +237,19 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 }
                 catch (ConnectFailedException)
                 {
+                }
+            }
+            else
+            {
+                try
+                {
+                    using var adapter = communicator.CreateObjectAdapterWithRouter(
+                        obj.Clone(IRouterPrx.Factory, connectionId: "rc", identity: new Identity("router", "")));
+                    TestHelper.Assert(false);
+                }
+                catch (ArgumentException)
+                {
+                    // expected.
                 }
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -63,18 +63,22 @@ namespace ZeroC.Ice.Test.Location
             base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
             TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Locator!, communicator.DefaultLocator!));
 
-            // TODO: We also test ice_router/ice_getRouter(perhaps we should add a test/Ice/router test?)
-            TestHelper.Assert(base1.Router == null);
-            var anotherRouter = IRouterPrx.Parse(ice1 ? "anotherRouter" : "ice:anotherRouter", communicator);
-            base1 = base1.Clone(router: anotherRouter);
-            TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, anotherRouter));
-            var router = IRouterPrx.Parse(ice1 ? "dummyrouter" : "ice:dummyrouter", communicator);
-            communicator.DefaultRouter = router;
-            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
-            TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, communicator.DefaultRouter!));
-            communicator.DefaultRouter = null;
-            base1 = IObjectPrx.Parse(ice1 ? "test @ TestAdapter" : "ice:TestAdapter//test", communicator);
-            TestHelper.Assert(base1.Router == null);
+            if (ice1)
+            {
+                // TODO: We also test ice_router/ice_getRouter(perhaps we should add a test/Ice/router test?)
+                TestHelper.Assert(base1.Router == null);
+                var anotherRouter = IRouterPrx.Parse("anotherRouter", communicator);
+                base1 = base1.Clone(router: anotherRouter);
+                TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, anotherRouter));
+                var router = IRouterPrx.Parse("dummyrouter", communicator);
+                communicator.DefaultRouter = router;
+                base1 = IObjectPrx.Parse("test @ TestAdapter", communicator);
+                TestHelper.Assert(ProxyComparer.Identity.Equals(base1.Router!, communicator.DefaultRouter!));
+                communicator.DefaultRouter = null;
+                base1 = IObjectPrx.Parse("test @ TestAdapter", communicator);
+                TestHelper.Assert(base1.Router == null);
+            }
+
             output.WriteLine("ok");
 
             output.Write("starting server... ");


### PR DESCRIPTION
This PR makes the router mechanism ice1-only, that is, all router proxies when configured on proxies or object adapters must be ice1 proxies, and only ice1 proxies and ice1 object adapters can have routers.