### PR TITLE
Remove Constructed class

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -2590,7 +2590,7 @@ yyreduce:
     }
     else
     {
-        st = cont->createStruct(IceUtil::generateUUID()); // Dummy
+        st = cont->createStruct(IceUtil::generateUUID(), Dummy);
         assert(st);
         unit->pushContainer(st);
     }

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -828,7 +828,7 @@ struct_def
     }
     else
     {
-        st = cont->createStruct(IceUtil::generateUUID()); // Dummy
+        st = cont->createStruct(IceUtil::generateUUID(), Dummy);
         assert(st);
         unit->pushContainer(st);
     }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2431,23 +2431,6 @@ Slice::Module::hasOnlySubModules() const
 }
 
 // ----------------------------------------------------------------------
-// Constructed
-// ----------------------------------------------------------------------
-
-string
-Slice::Constructed::typeId() const
-{
-    return scoped();
-}
-
-Slice::Constructed::Constructed(const ContainerPtr& container, const string& name) :
-    SyntaxTreeBase(container->unit()),
-    Type(container->unit()),
-    Contained(container, name)
-{
-}
-
-// ----------------------------------------------------------------------
 // ClassDecl
 // ----------------------------------------------------------------------
 
@@ -2462,6 +2445,12 @@ ClassDefPtr
 Slice::ClassDecl::definition() const
 {
     return _definition;
+}
+
+string
+Slice::ClassDecl::typeId() const
+{
+    return scoped();
 }
 
 bool
@@ -2509,8 +2498,7 @@ Slice::ClassDecl::visit(ParserVisitor* visitor, bool)
 Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
-    Contained(container, name),
-    Constructed(container, name)
+    Contained(container, name)
 {
 }
 
@@ -2693,6 +2681,12 @@ Slice::InterfaceDecl::definition() const
     return _definition;
 }
 
+string
+Slice::InterfaceDecl::typeId() const
+{
+    return scoped();
+}
+
 bool
 Slice::InterfaceDecl::uses(const ContainedPtr&) const
 {
@@ -2771,8 +2765,7 @@ Slice::InterfaceDecl::checkBasesAreLegal(const string& name, const InterfaceList
 Slice::InterfaceDecl::InterfaceDecl(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
-    Contained(container, name),
-    Constructed(container, name)
+    Contained(container, name)
 {
 }
 
@@ -3336,6 +3329,12 @@ Slice::Struct::createDataMember(const string& name, const TypePtr& type, bool ta
                                                  defaultLiteral);
 }
 
+string
+Slice::Struct::typeId() const
+{
+    return scoped();
+}
+
 bool
 Slice::Struct::usesClasses() const
 {
@@ -3407,8 +3406,7 @@ Slice::Struct::Struct(const ContainerPtr& container, const string& name) :
     Container(container->unit()),
     Contained(container, name),
     DataMemberContainer(container, name),
-    Type(container->unit()),
-    Constructed(container, name)
+    Type(container->unit())
 {
 }
 
@@ -3426,6 +3424,12 @@ StringList
 Slice::Sequence::typeMetadata() const
 {
     return _typeMetadata;
+}
+
+string
+Slice::Sequence::typeId() const
+{
+    return scoped();
 }
 
 bool
@@ -3476,7 +3480,6 @@ Slice::Sequence::Sequence(const ContainerPtr& container, const string& name, con
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
     Contained(container, name),
-    Constructed(container, name),
     _type(type),
     _typeMetadata(typeMetadata)
 {
@@ -3508,6 +3511,12 @@ StringList
 Slice::Dictionary::valueMetadata() const
 {
     return _valueMetadata;
+}
+
+string
+Slice::Dictionary::typeId() const
+{
+    return scoped();
 }
 
 bool
@@ -3637,7 +3646,6 @@ Slice::Dictionary::Dictionary(const ContainerPtr& container, const string& name,
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
     Contained(container, name),
-    Constructed(container, name),
     _keyType(keyType),
     _valueType(valueType),
     _keyMetadata(keyMetadata),
@@ -3715,6 +3723,12 @@ Slice::Enum::contents() const
     return result;
 }
 
+string
+Slice::Enum::typeId() const
+{
+    return scoped();
+}
+
 bool
 Slice::Enum::uses(const ContainedPtr&) const
 {
@@ -3783,7 +3797,6 @@ Slice::Enum::Enum(const ContainerPtr& container, const string& name, bool unchec
     Container(container->unit()),
     Type(container->unit()),
     Contained(container, name),
-    Constructed(container, name),
     _unchecked(unchecked),
     _underlying(nullptr),
     _explicitValue(false),

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2496,8 +2496,8 @@ Slice::ClassDecl::visit(ParserVisitor* visitor, bool)
 
 Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
-    Type(container->unit()),
-    Contained(container, name)
+    Contained(container, name),
+    Type(container->unit())
 {
 }
 
@@ -2763,8 +2763,8 @@ Slice::InterfaceDecl::checkBasesAreLegal(const string& name, const InterfaceList
 
 Slice::InterfaceDecl::InterfaceDecl(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
-    Type(container->unit()),
-    Contained(container, name)
+    Contained(container, name),
+    Type(container->unit())
 {
 }
 
@@ -3477,8 +3477,8 @@ Slice::Sequence::visit(ParserVisitor* visitor, bool)
 Slice::Sequence::Sequence(const ContainerPtr& container, const string& name, const TypePtr& type,
                           const StringList& typeMetadata) :
     SyntaxTreeBase(container->unit()),
-    Type(container->unit()),
     Contained(container, name),
+    Type(container->unit()),
     _type(type),
     _typeMetadata(typeMetadata)
 {
@@ -3643,8 +3643,8 @@ Slice::Dictionary::Dictionary(const ContainerPtr& container, const string& name,
                               const StringList& keyMetadata, const TypePtr& valueType,
                               const StringList& valueMetadata) :
     SyntaxTreeBase(container->unit()),
-    Type(container->unit()),
     Contained(container, name),
+    Type(container->unit()),
     _keyType(keyType),
     _valueType(valueType),
     _keyMetadata(keyMetadata),
@@ -3794,8 +3794,8 @@ Slice::Enum::initUnderlying(const TypePtr& type)
 Slice::Enum::Enum(const ContainerPtr& container, const string& name, bool unchecked) :
     SyntaxTreeBase(container->unit()),
     Container(container->unit()),
-    Type(container->unit()),
     Contained(container, name),
+    Type(container->unit()),
     _unchecked(unchecked),
     _underlying(nullptr),
     _explicitValue(false),

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2396,12 +2396,14 @@ Slice::Module::hasNonClassTypes() const
                 return true;
             }
         }
-        else
+        else if (!ClassDeclPtr::dynamicCast(content) && !ClassDefPtr::dynamicCast(content) &&
+                 TypePtr::dynamicCast(content))
+         {
+            return true;
+        }
+        else if(ExceptionPtr::dynamicCast(content) || ConstPtr::dynamicCast(content))
         {
-            if (!ClassDeclPtr::dynamicCast(content) && !ClassDefPtr::dynamicCast(content))
-            {
-                return true;
-            }
+            return true;
         }
     }
     return false;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2388,25 +2388,23 @@ Slice::Module::hasOnlyInterfaces() const
 }
 
 bool
-Slice::Module::hasOtherConstructedOrExceptions() const
+Slice::Module::hasNonClassTypes() const
 {
     for (const auto& content : _contents)
     {
-        if (!ClassDeclPtr::dynamicCast(content) && !ClassDefPtr::dynamicCast(content)
-            && ConstructedPtr::dynamicCast(content))
+        if (auto submodule = ModulePtr::dynamicCast(content))
         {
-            return true;
+            if (submodule->hasNonClassTypes())
+            {
+                return true;
+            }
         }
-
-        if (ExceptionPtr::dynamicCast(content) || ConstPtr::dynamicCast(content))
+        else
         {
-            return true;
-        }
-
-        ModulePtr submodule = ModulePtr::dynamicCast(content);
-        if (submodule && submodule->hasOtherConstructedOrExceptions())
-        {
-            return true;
+            if (!ClassDeclPtr::dynamicCast(content) && !ClassDefPtr::dynamicCast(content))
+            {
+                return true;
+            }
         }
     }
     return false;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1295,20 +1295,6 @@ Slice::Container::thisScope() const
     return "::";
 }
 
-void
-Slice::Container::containerRecDependencies(set<ConstructedPtr>& dependencies)
-{
-    for (const auto& content : contents())
-    {
-        ConstructedPtr constructed = ConstructedPtr::dynamicCast(content);
-        if (constructed && dependencies.find(constructed) != dependencies.end())
-        {
-            dependencies.insert(constructed);
-            constructed->recDependencies(dependencies);
-        }
-    }
-}
-
 bool
 Slice::Container::checkIntroduced(const string& scoped, ContainedPtr namedThing)
 {
@@ -2456,14 +2442,6 @@ Slice::Constructed::typeId() const
     return scoped();
 }
 
-ConstructedList
-Slice::Constructed::dependencies()
-{
-    set<ConstructedPtr> resultSet;
-    recDependencies(resultSet);
-    return ConstructedList(resultSet.begin(), resultSet.end());
-}
-
 Slice::Constructed::Constructed(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
     Type(container->unit()),
@@ -2528,20 +2506,6 @@ void
 Slice::ClassDecl::visit(ParserVisitor* visitor, bool)
 {
     visitor->visitClassDecl(this);
-}
-
-void
-Slice::ClassDecl::recDependencies(set<ConstructedPtr>& dependencies)
-{
-    if (_definition)
-    {
-        _definition->containerRecDependencies(dependencies);
-        ClassDefPtr base = _definition->base();
-        if (base)
-        {
-            base->declaration()->recDependencies(dependencies);
-        }
-    }
 }
 
 Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name) :
@@ -2771,19 +2735,6 @@ void
 Slice::InterfaceDecl::visit(ParserVisitor* visitor, bool)
 {
     visitor->visitInterfaceDecl(this);
-}
-
-void
-Slice::InterfaceDecl::recDependencies(set<ConstructedPtr>& dependencies)
-{
-    if (_definition)
-    {
-        _definition->containerRecDependencies(dependencies);
-        for (auto& base : _definition->bases())
-        {
-            base->declaration()->recDependencies(dependencies);
-        }
-    }
 }
 
 void
@@ -3453,12 +3404,6 @@ Slice::Struct::visit(ParserVisitor* visitor, bool all)
     }
 }
 
-void
-Slice::Struct::recDependencies(set<ConstructedPtr>& dependencies)
-{
-    containerRecDependencies(dependencies);
-}
-
 Slice::Struct::Struct(const ContainerPtr& container, const string& name) :
     SyntaxTreeBase(container->unit()),
     Container(container->unit()),
@@ -3526,17 +3471,6 @@ void
 Slice::Sequence::visit(ParserVisitor* visitor, bool)
 {
     visitor->visitSequence(this);
-}
-
-void
-Slice::Sequence::recDependencies(set<ConstructedPtr>& dependencies)
-{
-    ConstructedPtr constructed = ConstructedPtr::dynamicCast(_type);
-    if (constructed && dependencies.find(constructed) != dependencies.end())
-    {
-        dependencies.insert(constructed);
-        constructed->recDependencies(dependencies);
-    }
 }
 
 Slice::Sequence::Sequence(const ContainerPtr& container, const string& name, const TypePtr& type,
@@ -3634,28 +3568,6 @@ void
 Slice::Dictionary::visit(ParserVisitor* visitor, bool)
 {
     visitor->visitDictionary(this);
-}
-
-void
-Slice::Dictionary::recDependencies(set<ConstructedPtr>& dependencies)
-{
-    {
-        ConstructedPtr constructed = ConstructedPtr::dynamicCast(_keyType);
-        if (constructed && dependencies.find(constructed) != dependencies.end())
-        {
-            dependencies.insert(constructed);
-            constructed->recDependencies(dependencies);
-        }
-    }
-
-    {
-        ConstructedPtr constructed = ConstructedPtr::dynamicCast(_valueType);
-        if (constructed && dependencies.find(constructed) != dependencies.end())
-        {
-            dependencies.insert(constructed);
-            constructed->recDependencies(dependencies);
-        }
-    }
 }
 
 //
@@ -3845,12 +3757,6 @@ void
 Slice::Enum::visit(ParserVisitor* visitor, bool)
 {
     visitor->visitEnum(this);
-}
-
-void
-Slice::Enum::recDependencies(set<ConstructedPtr>&)
-{
-    // An Enum does not have any dependencies.
 }
 
 void

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2065,7 +2065,7 @@ Slice::Module::createStruct(const string& name, NodeType nt)
 }
 
 SequencePtr
-Slice::Module::createSequence(const string& name, const TypePtr& type, const StringList& metadata, NodeType nt)
+Slice::Module::createSequence(const string& name, const TypePtr& type, const StringList& metadata)
 {
     _unit->checkType(type);
     if (!checkForRedefinition(this, name, "sequence"))
@@ -2074,7 +2074,7 @@ Slice::Module::createSequence(const string& name, const TypePtr& type, const Str
     }
 
     checkIdentifier(name); // Don't return here -- we create the sequence anyway.
-    if (nt == Real && _name == "")
+    if (_name == "")
     {
         _unit->error("`" + name + "': a sequence can only be defined at module scope");
     }
@@ -2086,7 +2086,7 @@ Slice::Module::createSequence(const string& name, const TypePtr& type, const Str
 
 DictionaryPtr
 Slice::Module::createDictionary(const string& name, const TypePtr& keyType, const StringList& keyMetadata,
-                                const TypePtr& valueType, const StringList& valueMetadata, NodeType nt)
+                                const TypePtr& valueType, const StringList& valueMetadata)
 {
     _unit->checkType(keyType);
     _unit->checkType(valueType);
@@ -2096,23 +2096,20 @@ Slice::Module::createDictionary(const string& name, const TypePtr& keyType, cons
     }
 
     checkIdentifier(name); // Don't return here -- we create the dictionary anyway.
-    if (nt == Real)
+    if (_name == "")
     {
-        if (_name == "")
-        {
-            _unit->error("`" + name + "': a dictionary can only be defined at module scope");
-        }
+        _unit->error("`" + name + "': a dictionary can only be defined at module scope");
+    }
 
-        bool containsSequence = false;
-        if (!Dictionary::legalKeyType(keyType, containsSequence))
-        {
-            _unit->error("dictionary `" + name + "' uses an illegal key type");
-            return nullptr;
-        }
-        if (containsSequence)
-        {
-            _unit->warning(Deprecated, "use of sequences in dictionary keys has been deprecated");
-        }
+    bool containsSequence = false;
+    if (!Dictionary::legalKeyType(keyType, containsSequence))
+    {
+        _unit->error("dictionary `" + name + "' uses an illegal key type");
+        return nullptr;
+    }
+    if (containsSequence)
+    {
+        _unit->warning(Deprecated, "use of sequences in dictionary keys has been deprecated");
     }
 
     DictionaryPtr p = new Dictionary(this, name, keyType, keyMetadata, valueType, valueMetadata);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -70,7 +70,6 @@ class Contained;
 class Container;
 class DataMemberContainer;
 class Module;
-class Constructed;
 class ClassDecl;
 class ClassDef;
 class InterfaceDecl;
@@ -98,7 +97,6 @@ typedef ::IceUtil::Handle<Contained> ContainedPtr;
 typedef ::IceUtil::Handle<Container> ContainerPtr;
 typedef ::IceUtil::Handle<DataMemberContainer> DataMemberContainerPtr;
 typedef ::IceUtil::Handle<Module> ModulePtr;
-typedef ::IceUtil::Handle<Constructed> ConstructedPtr;
 typedef ::IceUtil::Handle<ClassDecl> ClassDeclPtr;
 typedef ::IceUtil::Handle<ClassDef> ClassDefPtr;
 typedef ::IceUtil::Handle<InterfaceDecl> InterfaceDeclPtr;
@@ -546,30 +544,16 @@ protected:
 };
 
 // ----------------------------------------------------------------------
-// Constructed
-// ----------------------------------------------------------------------
-
-class Constructed : public virtual Type, public virtual Contained
-{
-public:
-
-    std::string typeId() const override;
-
-protected:
-
-    Constructed(const ContainerPtr&, const std::string&);
-};
-
-// ----------------------------------------------------------------------
 // ClassDecl
 // ----------------------------------------------------------------------
 
-class ClassDecl : public virtual Constructed
+class ClassDecl : public virtual Contained, public virtual Type
 {
 public:
 
     void destroy() override;
     ClassDefPtr definition() const;
+    std::string typeId() const override;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     bool isClassType() const override { return true; }
@@ -631,12 +615,13 @@ protected:
 // InterfaceDecl
 // ----------------------------------------------------------------------
 
-class InterfaceDecl : public virtual Constructed
+class InterfaceDecl : public virtual Contained, public virtual Type
 {
 public:
 
     void destroy() override;
     InterfaceDefPtr definition() const;
+    std::string typeId() const override;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     bool isInterfaceType() const override { return true; }
@@ -806,7 +791,6 @@ private:
 // Exception
 // ----------------------------------------------------------------------
 
-// No inheritance from Constructed, as this is not a Type
 class Exception : public virtual DataMemberContainer, public virtual Contained
 {
 public:
@@ -838,11 +822,12 @@ protected:
 // Struct
 // ----------------------------------------------------------------------
 
-class Struct : public virtual DataMemberContainer, public virtual Constructed
+class Struct : public virtual DataMemberContainer, public virtual Contained, public virtual Type
 {
 public:
     MemberPtr createDataMember(const std::string&, const TypePtr&, bool, int, const SyntaxTreeBasePtr& = nullptr,
                                const std::string& = "", const std::string& = "") override;
+    std::string typeId() const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;
     std::string getTagFormat() const override;
@@ -862,12 +847,13 @@ protected:
 // Sequence
 // ----------------------------------------------------------------------
 
-class Sequence : public virtual Constructed
+class Sequence : public virtual Contained, public virtual Type
 {
 public:
 
     TypePtr type() const;
     StringList typeMetadata() const;
+    std::string typeId() const override;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;
@@ -891,7 +877,7 @@ protected:
 // Dictionary
 // ----------------------------------------------------------------------
 
-class Dictionary : public virtual Constructed
+class Dictionary : public virtual Contained, public virtual Type
 {
 public:
 
@@ -899,6 +885,7 @@ public:
     TypePtr valueType() const;
     StringList keyMetadata() const;
     StringList valueMetadata() const;
+    std::string typeId() const override;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;
@@ -927,7 +914,7 @@ protected:
 // Enum
 // ----------------------------------------------------------------------
 
-class Enum : public virtual Container, public virtual Constructed
+class Enum : public virtual Container, public virtual Contained, public virtual Type
 {
 public:
 
@@ -949,6 +936,7 @@ public:
     std::int64_t minValue() const;
     std::int64_t maxValue() const;
     ContainedList contents() const override;
+    std::string typeId() const override;
     bool uses(const ContainedPtr&) const override;
     bool usesClasses() const override;
     size_t minWireSize() const override;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -513,9 +513,9 @@ public:
     InterfaceDeclPtr createInterfaceDecl(const std::string&);
     ExceptionPtr createException(const std::string&, const ExceptionPtr&, NodeType = Real);
     StructPtr createStruct(const std::string&, NodeType = Real);
-    SequencePtr createSequence(const std::string&, const TypePtr&, const StringList&, NodeType = Real);
+    SequencePtr createSequence(const std::string&, const TypePtr&, const StringList&);
     DictionaryPtr createDictionary(const std::string&, const TypePtr&, const StringList&, const TypePtr&,
-                                   const StringList&, NodeType = Real);
+                                   const StringList&);
     EnumPtr createEnum(const std::string&, bool, NodeType = Real);
     ConstPtr createConst(const std::string, const TypePtr&, const StringList&, const SyntaxTreeBasePtr&,
                          const std::string&, const std::string&, NodeType = Real);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -533,8 +533,8 @@ public:
     bool hasInterfaceDefs() const;
     bool hasOnlyClassDecls() const;
     bool hasOnlyInterfaces() const;
-    bool hasOtherConstructedOrExceptions() const; // Exceptions or constructed types other than classes.
     bool hasOnlySubModules() const;
+    bool hasNonClassTypes() const;
 
 protected:
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -120,7 +120,6 @@ typedef std::set<std::string> StringSet;
 typedef std::list<std::string> StringList;
 typedef std::list<ContainedPtr> ContainedList;
 typedef std::list<ModulePtr> ModuleList;
-typedef std::list<ConstructedPtr> ConstructedList;
 typedef std::list<ClassDefPtr> ClassList;
 typedef std::list<InterfaceDefPtr> InterfaceList;
 typedef std::list<ExceptionPtr> ExceptionList;
@@ -459,7 +458,6 @@ public:
     virtual ContainedList contents() const = 0;
     bool hasContentsWithMetadata(const std::string&) const;
     std::string thisScope() const;
-    void containerRecDependencies(std::set<ConstructedPtr>&); // Internal operation, don't use directly.
 
     bool checkIntroduced(const std::string&, ContainedPtr = nullptr);
 
@@ -556,9 +554,6 @@ class Constructed : public virtual Type, public virtual Contained
 public:
 
     std::string typeId() const override;
-    bool isVariableLength() const override = 0;
-    ConstructedList dependencies();
-    virtual void recDependencies(std::set<ConstructedPtr>&) = 0; // Internal operation, don't use directly.
 
 protected:
 
@@ -583,7 +578,6 @@ public:
     bool isVariableLength() const override;
     void visit(ParserVisitor*, bool) override;
     std::string kindOf() const override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
 protected:
 
@@ -651,7 +645,6 @@ public:
     bool isVariableLength() const override;
     void visit(ParserVisitor*, bool) override;
     std::string kindOf() const override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
     static void checkBasesAreLegal(const std::string&, const InterfaceList&, const UnitPtr&);
 
@@ -856,7 +849,6 @@ public:
     bool isVariableLength() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
 protected:
 
@@ -883,7 +875,6 @@ public:
     bool isVariableLength() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
 protected:
 
@@ -915,7 +906,6 @@ public:
     bool isVariableLength() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
     static bool legalKeyType(const TypePtr&, bool&);
 
@@ -966,7 +956,6 @@ public:
     bool isVariableLength() const override;
     std::string kindOf() const override;
     void visit(ParserVisitor*, bool) override;
-    void recDependencies(std::set<ConstructedPtr>&) override; // Internal operation, don't use directly.
 
     // Sets the underlying type shortly after construction and before any enumerator is added.
     void initUnderlying(const TypePtr&);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1581,7 +1581,7 @@ Slice::Gen::TypesVisitor::TypesVisitor(Output& h, Output& c, const string& dllEx
 bool
 Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
-    if(!p->hasOtherConstructedOrExceptions())
+    if(!p->hasNonClassTypes())
     {
         return false;
     }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -873,9 +873,9 @@ Slice::CsGenerator::writeUnmarshalCode(
     }
     else
     {
-        auto constructed = ConstructedPtr::dynamicCast(underlying);
-        assert(constructed);
-        out << helperName(underlying, scope) << ".Read" << constructed->name() << "(istr)";
+        auto contained = ContainedPtr::dynamicCast(underlying);
+        assert(contained);
+        out << helperName(underlying, scope) << ".Read" << contained->name() << "(istr)";
     }
 
     if (optional)

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1600,9 +1600,8 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(Output& out,
         return;
     }
 
-    ConstructedPtr constructed = ConstructedPtr::dynamicCast(type);
+    assert (ContainedPtr::dynamicCast(type));
     StructPtr st = StructPtr::dynamicCast(type);
-    assert(constructed);
     if(marshal)
     {
         if(isTaggedParam)


### PR DESCRIPTION
This PR removed the Constructed class from the parser, since it's mostly dead code, and implementing type-aliases was much easier without it. After this PR, I'll open one for adding type-aliases. Felt better to keep them separate.

Previously we had Constructed for managing Slice dependencies, but we use other logic for this now, leaving the dependency code in Constructed unused.

Other changes:
- Everything directly inherits from Contained & Type now (the previous base classes for Constructed)
- Everything has to implement it's own `typeid` instead of using the default that was in Constructed (trivial change)
- Renames `hasOtherConstructedOrExceptions` to `hasNonClassTypes` (same logic, just better name)
- Cleans up some places where weren't using NodeTypes correctly.