### PR TITLE
Workaround JS frameworks that don't support Symbol.species with Promises

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -72,6 +72,11 @@ These are the changes since Ice 3.7.4.
   The property `Ice.AcceptClassCycles` can be set to a value greater than `0`
   to change this behavior.
 
+## JS Changes
+
+- Add default constructor for Promise derived objects, this works around problems with
+  JavaScript frameworks that don't support Symbol.species with their Promise implementations.
+
 # Changes in Ice 3.7.4
 
 These are the changes since Ice 3.7.3.

--- a/js/src/Ice/AsyncResultBase.js
+++ b/js/src/Ice/AsyncResultBase.js
@@ -10,7 +10,7 @@ class AsyncResultBase extends Ice.Promise
     {
         super();
         this._communicator = communicator;
-        this._instance = communicator !== null ? communicator.instance : null;
+        this._instance = communicator ? communicator.instance : null;
         this._operation = op;
         this._connection = connection;
         this._proxy = proxy;

--- a/js/src/Ice/OutgoingAsync.js
+++ b/js/src/Ice/OutgoingAsync.js
@@ -55,7 +55,14 @@ class ProxyOutgoingAsyncBase extends OutgoingAsyncBase
 {
     constructor(prx, operation)
     {
-        super(prx.ice_getCommunicator(), operation, null, prx, null);
+        if (prx)
+        {
+            super(prx.ice_getCommunicator(), operation, null, prx, null);
+        }
+        else
+        {
+            super();
+        }
         this._mode = null;
         this._cnt = 0;
         this._sent = false;
@@ -190,8 +197,11 @@ class OutgoingAsync extends ProxyOutgoingAsyncBase
     constructor(prx, operation, completed)
     {
         super(prx, operation);
-        this._encoding = Protocol.getCompatibleEncoding(this._proxy._getReference().getEncoding());
-        this._completed = completed;
+        if (prx)
+        {
+            this._encoding = Protocol.getCompatibleEncoding(this._proxy._getReference().getEncoding());
+            this._completed = completed;
+        }
     }
 
     prepare(op, mode, ctx)

--- a/js/src/Ice/Promise.js
+++ b/js/src/Ice/Promise.js
@@ -16,7 +16,7 @@ class P extends Promise
                 res = resolve;
                 rej = reject;
 
-                if(cb !== undefined)
+                if(cb)
                 {
                     cb(resolve, reject);
                 }


### PR DESCRIPTION
This PR fixes the types derived from Promise so that it is safe to construct them with a `null` argument. Frameworks that don't use `Symbol.species` to construct the Promise objects can end-up calling the constructor of one of these derived types directly resulting in exceptions from Ice JavaScript run-time.

This was the case with Angular, the issue was fixed in https://github.com/angular/angular/issues/34105

This workaround allows Ice.js to work with older Angular versions.

[ice-3.7.4.zip](https://github.com/zeroc-ice/ice/files/5607743/ice-3.7.4.zip)