### PR TITLE
Retry loop fixes

### DIFF
--- a/csharp/src/Ice/Ice1Definitions.cs
+++ b/csharp/src/Ice/Ice1Definitions.cs
@@ -162,7 +162,7 @@ namespace ZeroC.Ice
                         {
                             reference.LocatorInfo?.ClearCache(reference);
                         }
-                        return RetryPolicy.AfterDelay(TimeSpan.Zero);
+                        return RetryPolicy.OtherReplica;
                     }
                 }
             }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -576,8 +576,7 @@ namespace ZeroC.Ice
                 IObject? servant = Find(current.Identity, current.Facet);
                 if (servant == null)
                 {
-                    throw new ObjectNotExistException(
-                        ReplicaGroupId.Length == 0 ? RetryPolicy.NoRetry : RetryPolicy.OtherReplica);
+                    throw new ObjectNotExistException(RetryPolicy.OtherReplica);
                 }
 
                 // TODO: support input streamable data if Current.EndOfStream == false and output streamable data.

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1744,6 +1744,18 @@ namespace ZeroC.Ice
                         {
                             _connection = connection;
                         }
+
+                        if (RouterInfo != null)
+                        {
+                            await RouterInfo.AddProxyAsync(IObjectPrx.Factory(this)).ConfigureAwait(false);
+
+                            // Set the object adapter for this router (if any) on the new connection, so that callbacks from
+                            // the router can be received over this new connection.
+                            if (RouterInfo.Adapter != null)
+                            {
+                                connection.Adapter = RouterInfo.Adapter;
+                            }
+                        }
                     }
 
                     cancel.ThrowIfCancellationRequested();

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1740,10 +1740,6 @@ namespace ZeroC.Ice
                                                                      PreferNonSecure,
                                                                      Label,
                                                                      cancel).ConfigureAwait(false);
-                        if (CacheConnection)
-                        {
-                            _connection = connection;
-                        }
 
                         if (RouterInfo != null)
                         {
@@ -1755,6 +1751,11 @@ namespace ZeroC.Ice
                             {
                                 connection.Adapter = RouterInfo.Adapter;
                             }
+                        }
+
+                        if (CacheConnection)
+                        {
+                            _connection = connection;
                         }
                     }
 

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1844,14 +1844,10 @@ namespace ZeroC.Ice
                     }
                 }
 
-                if (endpoints != null)
+                if (endpoints != null && (connection == null || retryPolicy == RetryPolicy.OtherReplica))
                 {
-                    if (connection == null || retryPolicy == RetryPolicy.OtherReplica)
-                    {
-                        // If connection establishment failed or if the endpoint was excluded, try the next
-                        // endpoint
-                        nextEndpoint = ++nextEndpoint % endpoints.Count;
-                    }
+                    // If connection establishment failed or if the endpoint was excluded, try the next endpoint
+                    nextEndpoint = ++nextEndpoint % endpoints.Count;
 
                     if (nextEndpoint == 0)
                     {
@@ -1861,7 +1857,6 @@ namespace ZeroC.Ice
                             // If we were using cached endpoints, we clear the endpoints to trigger a new endpoint
                             // lookup.
                             endpoints = null;
-                            nextEndpoint = 0;
                         }
                         else
                         {
@@ -1879,7 +1874,7 @@ namespace ZeroC.Ice
 
                 // Check if we can retry, we cannot retry if we have consumed all attempts, the current retry
                 // policy doesn't allow retries, the request was already released, there are no more endpoints
-                // or a fixed reference receives an exception with OtherReplica retry.
+                // or a fixed reference receives an exception with OtherReplica retry policy.
 
                 if (attempt == Communicator.InvocationMaxAttempts ||
                     retryPolicy == RetryPolicy.NoRetry ||
@@ -1919,8 +1914,8 @@ namespace ZeroC.Ice
 
                     if (connection != null || triedAllEndpoints)
                     {
-                        // Only count an attempt if the connection was established or if all the endpoints were
-                        // tried at least once. This ensures that we don't end up into an infinite loop for connection
+                        // Only count an attempt if the connection was established or if all the endpoints were tried
+                        // at least once. This ensures that we don't end up into an infinite loop for connection
                         // establishment failures which don't result in endpoint exclusion.
                         attempt++;
                     }


### PR DESCRIPTION
This PR fixes issues introduced with previous retry loop updates

* Add AddProxyAsync that was accidentally removed
* The retry policy for ObjectNotExists exception should be always OtherReplica except for Ice1 router "ice_add_proxy"
* The assumption that nextEndpoint==0 means that we tried all endpoints was not correct, https://github.com/zeroc-ice/ice/blob/abc0ed7a0f6bd1b59251edb504c8c475ad5ef679/csharp/src/Ice/Reference.cs#L1846

If you get an exception with `AfterDelay` policy from the first endpoint, `nextEndpoint` remains 0 but can be other endpoints that have not been tried 