### PR TITLE
Simplify async -> sync wrapping

### DIFF
--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -46,18 +46,7 @@ namespace ZeroC.Ice
         /// thread of a server, which will be completed once the shutdown process completes, and then the caller can
         /// do some cleanup work before calling <see cref="Dispose"/> to dispose the runtime and finally exists the
         /// application.</summary>
-        public void WaitForShutdown()
-        {
-            try
-            {
-                WaitForShutdownAsync().Wait();
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
-            }
-        }
+        public void WaitForShutdown() => WaitForShutdownAsync().GetAwaiter().GetResult();
 
         /// <summary>Returns a task that completes after the communicator has been shutdown. On the server side, the
         /// task returned by this operation completes once all executing operations have completed. On the client side,

--- a/csharp/src/Ice/Communicator-PluginManager.cs
+++ b/csharp/src/Ice/Communicator-PluginManager.cs
@@ -76,7 +76,7 @@ namespace ZeroC.Ice
                 {
                     try
                     {
-                        plugin.DisposeAsync().AsTask().Wait();
+                        plugin.DisposeAsync().GetResult();
                     }
                     catch
                     {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -975,7 +975,7 @@ namespace ZeroC.Ice
 
         /// <summary>Releases resources used by the communicator. This operation calls <see cref="ShutdownAsync"/>
         /// implicitly.</summary>
-        public void Dispose() => DisposeAsync().AsTask().Wait();
+        public void Dispose() => DisposeAsync().GetResult();
 
         /// <summary>Returns a facet of the Admin object.</summary>
         /// <param name="facet">The name of the Admin facet.</param>

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -212,18 +212,7 @@ namespace ZeroC.Ice
 
         /// <summary>Sends a ping frame.</summary>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        public void Ping(CancellationToken cancel = default)
-        {
-            try
-            {
-                PingAsync(cancel: cancel).Wait(cancel);
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
-            }
-        }
+        public void Ping(CancellationToken cancel = default) => PingAsync(cancel: cancel).GetAwaiter().GetResult();
 
         /// <summary>Sends an asynchronous ping frame.</summary>
         /// <param name="progress">Sent progress provider.</param>

--- a/csharp/src/Ice/ExceptionUtil.cs
+++ b/csharp/src/Ice/ExceptionUtil.cs
@@ -8,9 +8,8 @@ namespace ZeroC.Ice
 {
     internal static class ExceptionUtil
     {
-        /// <summary>Helper function to re throw an exception preserving the stack trace, use as:
-        /// <code>throw ExceptionUtil.Throw(ex.AggregateException);</code>
-        /// This prevent the compiler error of not all code path returning a value.</summary>
+        /// <summary>Rethrows an an exception while preserving its stack trace. This method does not return and
+        /// is typically called as <code>throw ExceptionUtil.Throw(ex);</code>.</summary>
         internal static Exception Throw(Exception ex)
         {
             ExceptionDispatchInfo.Throw(ex);

--- a/csharp/src/Ice/IObjectPrx.cs
+++ b/csharp/src/Ice/IObjectPrx.cs
@@ -355,13 +355,9 @@ namespace ZeroC.Ice
         {
             try
             {
-                IncomingResponseFrame response = Reference.InvokeAsync(this, request, oneway: false).Result;
+                IncomingResponseFrame response =
+                    Reference.InvokeAsync(this, request, oneway: false).GetAwaiter().GetResult();
                 return response.ReadReturnValue(this, reader);
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
             }
             finally
             {
@@ -378,16 +374,11 @@ namespace ZeroC.Ice
         {
             try
             {
-                IncomingResponseFrame response = Reference.InvokeAsync(this, request, oneway).Result;
+                IncomingResponseFrame response = Reference.InvokeAsync(this, request, oneway).GetAwaiter().GetResult();
                 if (!oneway)
                 {
                     response.ReadVoidReturnValue(this);
                 }
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
             }
             finally
             {

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -139,18 +139,8 @@ namespace ZeroC.Ice
         /// requests received through these endpoints. Activate also registers this object adapter with the locator (if
         /// set).</summary>
         /// <param name="interceptors">The dispatch interceptors to register with the object adapter.</param>
-        public void Activate(params DispatchInterceptor[] interceptors)
-        {
-            try
-            {
-                ActivateAsync(interceptors).Wait();
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
-            }
-        }
+        public void Activate(params DispatchInterceptor[] interceptors) =>
+            ActivateAsync(interceptors).GetAwaiter().GetResult();
 
         /// <summary>Activates all endpoints of this object adapter. After activation, the object adapter can dispatch
         /// requests received through these endpoints. ActivateAsync also registers this object adapter with the
@@ -193,7 +183,7 @@ namespace ZeroC.Ice
         }
 
         /// <summary>Releases resources used by the object adapter.</summary>
-        public void Dispose() => DisposeAsync().AsTask().Wait();
+        public void Dispose() => DisposeAsync().GetResult();
 
         /// <summary>Releases resources used by the object adapter.</summary>
         public async ValueTask DisposeAsync()

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -202,34 +202,29 @@ namespace ZeroC.Ice
 
         /// <summary>Returns the cached Connection for this proxy. If the proxy does not yet have an established
         /// connection, it does not attempt to create a connection.</summary>
+        /// <param name="proxy">The proxy.</param>
         /// <returns>The cached Connection for this proxy (null if the proxy does not have
         /// an established connection).</returns>
-        public static Connection? GetCachedConnection(this IObjectPrx prx) => prx.IceReference.GetCachedConnection();
+        public static Connection? GetCachedConnection(this IObjectPrx proxy) =>
+            proxy.IceReference.GetCachedConnection();
 
         /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
         /// it first attempts to create a connection.</summary>
+        /// <param name="proxy">The proxy.</param>
+        /// <param name="cancel">The cancellation token.</param>
         /// <returns>The Connection for this proxy.</returns>
-        public static Connection GetConnection(this IObjectPrx prx)
-        {
-            try
-            {
-                ValueTask<Connection> task = prx.GetConnectionAsync(cancel: default);
-                return task.IsCompleted ? task.Result : task.AsTask().Result;
-            }
-            catch (AggregateException ex)
-            {
-                Debug.Assert(ex.InnerException != null);
-                throw ExceptionUtil.Throw(ex.InnerException);
-            }
-        }
+        public static Connection GetConnection(this IObjectPrx proxy, CancellationToken cancel = default) =>
+            proxy.GetConnectionAsync(cancel).GetResult();
 
         /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
         /// it first attempts to create a connection.</summary>
+        /// <param name="proxy">The proxy.</param>
+        /// <param name="cancel">The cancellation token.</param>
         /// <returns>The Connection for this proxy.</returns>
         public static ValueTask<Connection> GetConnectionAsync(
-            this IObjectPrx prx,
+            this IObjectPrx proxy,
             CancellationToken cancel = default) =>
-            prx.IceReference.GetConnectionAsync(cancel);
+            proxy.IceReference.GetConnectionAsync(cancel);
 
         /// <summary>Forwards an incoming request to another Ice object represented by the <paramref name="proxy"/>
         /// parameter.</summary>

--- a/csharp/src/Ice/TaskExtensions.cs
+++ b/csharp/src/Ice/TaskExtensions.cs
@@ -18,23 +18,16 @@ namespace ZeroC.Ice
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="task">The value task.</param>
         /// <returns>The result.</returns>
-        internal static TResult GetResult<TResult>(this ValueTask<TResult> task)
+        internal static TResult GetResult<TResult>(this ValueTask<TResult> task) =>
+            task.IsCompleted ? task.Result : task.AsTask().GetAwaiter().GetResult();
+
+        /// <summary>Waits for a value task to complete.</summary>
+        /// <param name="task">The value task.</param>
+        internal static void GetResult(this ValueTask task)
         {
-            if (task.IsCompleted)
+            if (!task.IsCompleted)
             {
-                return task.Result;
-            }
-            else
-            {
-                try
-                {
-                    return task.AsTask().Result;
-                }
-                catch (AggregateException ex)
-                {
-                    Debug.Assert(ex.InnerException != null);
-                    throw ExceptionUtil.Throw(ex.InnerException);
-                }
+                task.AsTask().GetAwaiter().GetResult();
             }
         }
 

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -363,7 +363,7 @@ namespace ZeroC.IceBox
             {
                 try
                 {
-                    communicator.ShutdownAsync().Wait();
+                    communicator.ShutdownAsync().GetAwaiter().GetResult();
                 }
                 catch (CommunicatorDisposedException)
                 {

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -120,19 +120,10 @@ namespace ZeroC.Glacier2.Test.SessionHelper
             {
                 try
                 {
-                    throw exception;
-                }
-                catch (CommunicatorDisposedException)
-                {
+                    Assert(exception is CommunicatorDisposedException ||
+                           exception is FormatException ||
+                           exception is OperationCanceledException);
                     Console.Out.WriteLine("ok");
-                }
-                catch (FormatException)
-                {
-                    Console.Out.WriteLine("ok");
-                }
-                catch
-                {
-                    Assert(false);
                 }
                 finally
                 {


### PR DESCRIPTION
This PR simplifies the wrapping of Async methods by synchronous methods, and remove all use of `.Result` and `.Wait()` is src.

A separate / follow-up question is whether we should perform this wrapping at all.