### PR TITLE
Add Communicator.ActivateAsync

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -297,6 +297,7 @@ generated from the section label.
         <property name="ACM.Server" class="acm"/>
         <property name="AcceptNonSecure" />
         <property name="Admin" class="objectadapter" />
+        <!-- TODO: Remove Admin.DelayCreation -->
         <property name="Admin.DelayCreation" />
         <property name="Admin.Enabled" />
         <property name="Admin.Facets" />
@@ -359,6 +360,7 @@ generated from the section label.
         <property name="IdleTimeout"/>
         <property name="ImplicitContext" />
         <property name="IncomingFrameMaxSize" />
+        <!-- TODO: Remove InitPlugins -->
         <property name="InitPlugins" />
         <property name="InvocationMaxAttempts" />
         <!-- TODO: Remove IPv4 -->

--- a/csharp/src/Ice/Communicator-PluginManager.cs
+++ b/csharp/src/Ice/Communicator-PluginManager.cs
@@ -163,15 +163,10 @@ namespace ZeroC.Ice
                 }
             }
 
-            // Loads and activates the plug-ins defined in the property set with the prefix "Ice.Plugin.". These
-            // properties should have the following format:
+            // Loads the plug-ins defined in the property set with the prefix "Ice.Plugin.". These properties should
+            // have the following format:
             //
             // Ice.Plugin.name[.<language>]=entry_point [args]
-            //
-            // The code below is different from the Java/C++ algorithm because C# must support full assembly names such
-            // as:
-            //
-            // Ice.Plugin.Logger=logger, Version=0.0.0.0, Culture=neutral:LoginPluginFactory
             //
             // If the Ice.PluginLoadOrder property is defined, load the specified plug-ins in the specified order, then
             // load any remaining plug-ins.

--- a/csharp/src/Ice/Communicator-PluginManager.cs
+++ b/csharp/src/Ice/Communicator-PluginManager.cs
@@ -22,11 +22,9 @@ namespace ZeroC.Ice
 
     public sealed partial class Communicator
     {
-        private static readonly List<string> _loadOnInitialization = new List<string>();
-        private static readonly Dictionary<string, IPluginFactory> _pluginFactories =
-            new Dictionary<string, IPluginFactory>();
-
-        private readonly List<(string Name, IPlugin Plugin)> _plugins = new List<(string Name, IPlugin Plugin)>();
+        private static readonly List<string> _loadOnInitialization = new();
+        private static readonly Dictionary<string, IPluginFactory> _pluginFactories = new();
+        private readonly List<(string Name, IPlugin Plugin)> _plugins = new();
 
         /// <summary>Manually registers a plug-in factory.</summary>
         /// <param name="name">The name assigned to the plug-in.</param>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -137,7 +137,7 @@ namespace ZeroC.Ice
         public ILogger Logger { get; internal set; }
 
         /// <summary>Gets the communicator observer used by the Ice run-time or null if a communicator observer
-        /// was not set during communicator initialization.</summary>
+        /// was not set during communicator construction.</summary>
         public Instrumentation.ICommunicatorObserver? Observer { get; }
 
         /// <summary>The output mode or format for ToString on Ice proxies when the protocol is ice1. See
@@ -203,6 +203,7 @@ namespace ZeroC.Ice
             "Context\\..*"
         };
         private static readonly object _staticMutex = new object();
+        private volatile bool _activateCalled;
         private readonly Func<CancellationToken, Task>? _activateLocatorAsync;
         private readonly HashSet<string> _adapterNamesInUse = new HashSet<string>();
         private readonly List<ObjectAdapter> _adapters = new List<ObjectAdapter>();
@@ -748,9 +749,6 @@ namespace ZeroC.Ice
                         _printProcessIdDone = true;
                     }
                 }
-
-                // TODO: temporary!
-                InitializeAsync().GetAwaiter().GetResult();
             }
             catch
             {
@@ -759,28 +757,27 @@ namespace ZeroC.Ice
             }
         }
 
-        // TODO: temporarily private
-        private async Task InitializeAsync(CancellationToken cancel = default)
+        /// <summary>Activates the plugins and built-in locator implementation of this communicator, if any. Also
+        /// creates and activates the Ice.Admin object and its object adapter, if enabled. It is recommended to always
+        /// activate a communicator even though this activation may not do anything.</summary>
+        /// <param name="cancel">The cancellation token.</param>
+        /// <returns>A task that completes when the activation completes.</returns>
+        public async Task ActivateAsync(CancellationToken cancel = default)
         {
-            // An application can set Ice.InitPlugins=0 if it wants to postpone initialization until after it has
-            // interacted directly with the plug-ins.
-            if (GetPropertyAsBool("Ice.InitPlugins") ?? true)
+            if (_activateCalled)
             {
-                await InitializePluginsAsync(cancel).ConfigureAwait(false);
+                throw new InvalidOperationException("ActivateAsync was already called on this communicator");
             }
+            _activateCalled = true;
+
+            await ActivatePluginsAsync(cancel).ConfigureAwait(false);
 
             if (_activateLocatorAsync != null)
             {
                 await _activateLocatorAsync(cancel).ConfigureAwait(false);
             }
 
-            // This must be done last as this call creates the Ice.Admin object adapter and eventually registers a
-            // process proxy with the Ice locator (allowing remote clients to invoke on Ice.Admin facets as soon as
-            // it's registered).
-            if (!(GetPropertyAsBool("Ice.Admin.DelayCreation") ?? false))
-            {
-                _ = await GetAdminAsync(cancel).ConfigureAwait(false);
-            }
+            _ = await GetAdminAsync(cancel).ConfigureAwait(false);
         }
 
         /// <summary>Adds an admin facet to the communicator.</summary>
@@ -1108,11 +1105,11 @@ namespace ZeroC.Ice
             }
         }
 
-        // Add one or more dispatch interceptors, only to use by PluginInitializationContext
+        // Add one or more dispatch interceptors, only to use by PluginActivationContext
         internal void AddDispatchInterceptor(DispatchInterceptor[] interceptors) =>
             _dispatchInterceptors.AddRange(interceptors);
 
-        // Add one or more invocation interceptors, only to use by PluginInitializationContext
+        // Add one or more invocation interceptors, only to use by PluginActivationContext
         internal void AddInvocationInterceptor(InvocationInterceptor[] interceptors) =>
             _invocationInterceptors.AddRange(interceptors);
 

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -203,7 +203,7 @@ namespace ZeroC.Ice
             "Context\\..*"
         };
         private static readonly object _staticMutex = new object();
-        private volatile bool _activateCalled;
+        private bool _activateCalled;
         private readonly Func<CancellationToken, Task>? _activateLocatorAsync;
         private readonly HashSet<string> _adapterNamesInUse = new HashSet<string>();
         private readonly List<ObjectAdapter> _adapters = new List<ObjectAdapter>();
@@ -764,11 +764,14 @@ namespace ZeroC.Ice
         /// <returns>A task that completes when the activation completes.</returns>
         public async Task ActivateAsync(CancellationToken cancel = default)
         {
-            if (_activateCalled)
+            lock (_mutex)
             {
-                throw new InvalidOperationException("ActivateAsync was already called on this communicator");
+                if (_activateCalled)
+                {
+                    throw new InvalidOperationException("ActivateAsync was already called on this communicator");
+                }
+                _activateCalled = true;
             }
-            _activateCalled = true;
 
             await ActivatePluginsAsync(cancel).ConfigureAwait(false);
 

--- a/csharp/src/Ice/IPlugin.cs
+++ b/csharp/src/Ice/IPlugin.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice
 {
-    /// <summary>A communicator plug-in, a plug-in generally adds a feature to a communicator, such as support for a
-    /// protocol. The communicator loads its plug-ins in two stages: the first stage creates the plug-ins, and the
-    /// second stage invokes Plugin#initialize on each one.</summary>
+    /// <summary>A plug-in adds a feature to a communicator, such as support for a transport. The plugins are created
+    /// when the communicator is constructed, and are later activated asynchronously when the communicator is
+    /// activated asynchronously.</summary>
     public interface IPlugin : IAsyncDisposable
     {
-        /// <summary>Perform any necessary initialization steps.</summary>
-        /// <param name="context">The plug-in initialization context enables the registration of invocation and dispatch
-        /// interceptors, it can also be use to set the communicator logger.</param>
+        /// <summary>Performs any necessary activation steps.</summary>
+        /// <param name="context">The plug-in activation context allows the registration of invocation and dispatch
+        /// interceptors, and can be used to set the communicator logger.</param>
         /// <param name="cancel">The cancellation token.</param>
-        /// <returns>A task that completes once the initialization completes.</returns>
-        Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel);
+        /// <returns>A task that completes once the activation completes.</returns>
+        Task ActivateAsync(PluginActivationContext context, CancellationToken cancel);
     }
 }

--- a/csharp/src/Ice/PluginActivationContext.cs
+++ b/csharp/src/Ice/PluginActivationContext.cs
@@ -4,11 +4,10 @@ using System;
 
 namespace ZeroC.Ice
 {
-    /// <summary>The plug-in initialization context is passed to plug-ins during initialization allowing plug-ins to
-    /// set the Communicator's logger, or add dispatch and invocation interceptors.</summary>
-    public sealed class PluginInitializationContext : IDisposable
+    /// <summary>The activation context is passed to plug-ins during activation.</summary>
+    public sealed class PluginActivationContext : IDisposable
     {
-        /// <summary>The communicator that is in the process of being initialized.</summary>
+        /// <summary>The communicator that is in the process of being activated.</summary>
         public Communicator Communicator { get; }
 
         private volatile bool _disposed;
@@ -21,7 +20,7 @@ namespace ZeroC.Ice
             {
                 if (_disposed)
                 {
-                    throw new ObjectDisposedException($"{typeof(PluginInitializationContext).FullName}");
+                    throw new ObjectDisposedException($"{typeof(PluginActivationContext).FullName}");
                 }
                 Communicator.Logger = value;
             }
@@ -33,7 +32,7 @@ namespace ZeroC.Ice
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException($"{typeof(PluginInitializationContext).FullName}");
+                throw new ObjectDisposedException($"{typeof(PluginActivationContext).FullName}");
             }
             Communicator.AddDispatchInterceptor(interceptor);
         }
@@ -44,13 +43,13 @@ namespace ZeroC.Ice
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException($"{typeof(PluginInitializationContext).FullName}");
+                throw new ObjectDisposedException($"{typeof(PluginActivationContext).FullName}");
             }
             Communicator.AddInvocationInterceptor(interceptor);
         }
 
         public void Dispose() => _disposed = true;
 
-        internal PluginInitializationContext(Communicator communicator) => Communicator = communicator;
+        internal PluginActivationContext(Communicator communicator) => Communicator = communicator;
     }
 }

--- a/csharp/src/iceboxnet/Server.cs
+++ b/csharp/src/iceboxnet/Server.cs
@@ -12,11 +12,7 @@ namespace ZeroC.IceBox
         {
             try
             {
-                using var communicator = new Ice.Communicator(ref args,
-                                                              new Dictionary<string, string>()
-                                                              {
-                                                                  { "Ice.Admin.DelayCreation", "1" }
-                                                              });
+                using var communicator = new Ice.Communicator(ref args);
 
                 Console.CancelKeyPress += async (sender, eventArgs) =>
                 {

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -276,9 +276,11 @@ namespace ZeroC.IceBox
                     StartService(s.Name, s.EntryPoint, s.Args);
                 }
 
-                // Start Admin (if enabled)
+                // Add Admin facet
                 _communicator.AddAdminFacet("IceBox.ServiceManager", this);
-                _ = await _communicator.GetAdminAsync().ConfigureAwait(false);
+
+                // We can now activate the main communicator.
+                await _communicator.ActivateAsync().ConfigureAwait(false);
 
                 // We may want to notify external scripts that the services have started and that IceBox is "ready".
                 // This is done by defining the property IceBox.PrintServicesReady=bundleName, bundleName is whatever

--- a/csharp/test/Glacier2/router/Server.cs
+++ b/csharp/test/Glacier2/router/Server.cs
@@ -15,6 +15,7 @@ namespace ZeroC.Glacier2.Test.Router
             properties["Test.Protocol"] = "ice1";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("CallbackAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("CallbackAdapter");
 

--- a/csharp/test/Glacier2/sessionHelper/Server.cs
+++ b/csharp/test/Glacier2/sessionHelper/Server.cs
@@ -14,6 +14,7 @@ namespace ZeroC.Glacier2.Test.SessionHelper
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Test.Protocol"] = "ice1";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("DeactivatedAdapter.Endpoints", GetTestEndpoint(1));
             communicator.CreateObjectAdapter("DeactivatedAdapter");
 

--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.ACM
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());

--- a/csharp/test/Ice/adapterDeactivation/Collocated.cs
+++ b/csharp/test/Ice/adapterDeactivation/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/adapterDeactivation/Server.cs
+++ b/csharp/test/Ice/adapterDeactivation/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.AddDefault(new Servant());

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -138,6 +138,7 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.Admin.InstanceName"] = "Test"
                 };
                 using var com = new Communicator(properties);
+                com.ActivateAsync().GetAwaiter().GetResult();
                 TestFacets(com, true, false);
             }
             {
@@ -150,11 +151,13 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.Admin.Facets"] = "Properties"
                 };
                 using var com = new Communicator(properties);
+                com.ActivateAsync().GetAwaiter().GetResult();
                 TestFacets(com, false, true);
             }
             {
                 // Test: Verify that the operations work correctly with the Admin object disabled.
                 using var com = new Communicator();
+                com.ActivateAsync().GetAwaiter().GetResult();
                 TestFacets(com, false, false);
             }
             {
@@ -164,6 +167,7 @@ namespace ZeroC.Ice.Test.Admin
                     { "Ice.Admin.Enabled", "1" }
                 };
                 using var com = new Communicator(properties);
+                com.ActivateAsync().GetAwaiter().GetResult();
                 TestHelper.Assert(com.GetAdminAsync().GetAwaiter().GetResult() == null);
                 var id = Identity.Parse("test-admin");
                 try
@@ -187,13 +191,12 @@ namespace ZeroC.Ice.Test.Admin
                 {
                     { "Ice.Admin.Endpoints", ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0" },
                     { "Ice.ServerName", "127.0.0.1" },
-                    { "Ice.Admin.InstanceName", "Test" },
-                    { "Ice.Admin.DelayCreation", "1" }
+                    { "Ice.Admin.InstanceName", "Test" }
                 };
 
                 using var com = new Communicator(properties);
                 TestFacets(com, true, false);
-                com.GetAdminAsync().GetAwaiter().GetResult();
+                com.ActivateAsync().GetAwaiter().GetResult();
                 TestFacets(com, true, false);
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/admin/Client.cs
+++ b/csharp/test/Ice/admin/Client.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Admin
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             AllTests.Run(this);
         }
 

--- a/csharp/test/Ice/admin/Server.cs
+++ b/csharp/test/Ice/admin/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Admin
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("factory", new RemoteCommunicatorFactoryI());

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -21,6 +21,7 @@ namespace ZeroC.Ice.Test.AMI
             properties["Ice.Warn.Connections"] = "0";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
 
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -19,6 +19,7 @@ namespace ZeroC.Ice.Test.AMI
             properties["Ice.TCP.RcvSize"] = "50K";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
 

--- a/csharp/test/Ice/binding/Server.cs
+++ b/csharp/test/Ice/binding/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Binding
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.ServerIdleTime"] = "30";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());

--- a/csharp/test/Ice/compress/Server.cs
+++ b/csharp/test/Ice/compress/Server.cs
@@ -15,6 +15,7 @@ namespace ZeroC.Ice.Test.Compress
                 {
                     ["Ice.CompressionMinSize"] = "1K"
                 });
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test-1", new Interceptor(new TestIntf(), compressed: true));

--- a/csharp/test/Ice/dictMapping/Server.cs
+++ b/csharp/test/Ice/dictMapping/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.DictMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyClass());

--- a/csharp/test/Ice/dictMapping/ServerAMD.cs
+++ b/csharp/test/Ice/dictMapping/ServerAMD.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.DictMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new AsyncMyClass());

--- a/csharp/test/Ice/discovery/Client.cs
+++ b/csharp/test/Ice/discovery/Client.cs
@@ -11,6 +11,8 @@ namespace ZeroC.Ice.Test.Discovery
         public override async Task RunAsync(string[] args)
         {
             await using Ice.Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
+
             int num;
             try
             {

--- a/csharp/test/Ice/discovery/Server.cs
+++ b/csharp/test/Ice/discovery/Server.cs
@@ -11,6 +11,8 @@ namespace ZeroC.Ice.Test.Discovery
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
+
             int num = 0;
             try
             {

--- a/csharp/test/Ice/enums/Server.cs
+++ b/csharp/test/Ice/enums/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Enums
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.ServerIdleTime"] = "30";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -15,6 +15,7 @@ namespace ZeroC.Ice.Test.Exceptions
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.IncomingFrameMaxSize"] = "10K";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("thrower", new Thrower());

--- a/csharp/test/Ice/exceptions/Server.cs
+++ b/csharp/test/Ice/exceptions/Server.cs
@@ -14,7 +14,8 @@ namespace ZeroC.Ice.Test.Exceptions
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.IncomingFrameMaxSize"] = "10K";
-            using Communicator communicator = Initialize(properties);
+            await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
             communicator.SetProperty("TestAdapter2.IncomingFrameMaxSize", "0");
@@ -32,7 +33,8 @@ namespace ZeroC.Ice.Test.Exceptions
             await adapter2.ActivateAsync();
             await adapter3.ActivateAsync();
 
-            using var communicator2 = new Communicator(properties);
+            await using var communicator2 = new Communicator(properties);
+            await communicator2.ActivateAsync();
             communicator2.SetProperty("ForwarderAdapter.Endpoints", GetTestEndpoint(3));
             communicator2.SetProperty("ForwarderAdapter.IncomingFrameMaxSize", "0");
             ObjectAdapter forwarderAdapter = communicator2.CreateObjectAdapter("ForwarderAdapter");

--- a/csharp/test/Ice/facets/Collocated.cs
+++ b/csharp/test/Ice/facets/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Facets
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             var d = new D();

--- a/csharp/test/Ice/facets/Server.cs
+++ b/csharp/test/Ice/facets/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Facets
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             var d = new D();

--- a/csharp/test/Ice/faultTolerance/Server.cs
+++ b/csharp/test/Ice/faultTolerance/Server.cs
@@ -42,6 +42,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
             }
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(port));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());

--- a/csharp/test/Ice/info/Server.cs
+++ b/csharp/test/Ice/info/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Info
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             if (Protocol == Protocol.Ice1)
             {
                 communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0) + ":" + GetTestEndpoint(0, "udp"));

--- a/csharp/test/Ice/inheritance/Collocated.cs
+++ b/csharp/test/Ice/inheritance/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Inheritance
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new InitialI(adapter));

--- a/csharp/test/Ice/inheritance/Server.cs
+++ b/csharp/test/Ice/inheritance/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Inheritance
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             var initial = new InitialI(adapter);

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -117,6 +117,7 @@ namespace ZeroC.Ice.Test.Interceptor
                             return response;
                         }
                     });
+                communicator.ActivateAsync().GetAwaiter().GetResult();
 
                 for (int i = 0; i < 10; ++i)
                 {
@@ -160,6 +161,7 @@ namespace ZeroC.Ice.Test.Interceptor
                             return next(target, request, cancel);
                         }
                     });
+                communicator.ActivateAsync().GetAwaiter().GetResult();
 
                 var prx1 = IMyObjectPrx.Parse(prx.ToString()!, communicator);
                 prx1.Op1(new Dictionary<string, string> { { "local-user", "10" } });
@@ -190,6 +192,7 @@ namespace ZeroC.Ice.Test.Interceptor
                             return next(target, request, cancel);
                         }
                     });
+                communicator.ActivateAsync().GetAwaiter().GetResult();
 
                 var prx1 = IMyObjectPrx.Parse(prx.ToString()!, communicator);
                 try

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -21,9 +21,12 @@ namespace ZeroC.Ice.Test.Interceptor
                 {
                     {
                         "Ice.Plugin.InvocationPlugin",
-                        $"{pluginPath }:ZeroC.Ice.Test.Interceptor.InvocationPluginFactory"
+                        $"{pluginPath}:ZeroC.Ice.Test.Interceptor.InvocationPluginFactory"
                     }
                 });
+
+            await communicator.ActivateAsync();
+
             IMyObjectPrx prx = AllTests.Run(this);
             await prx.ShutdownAsync();
         }

--- a/csharp/test/Ice/interceptor/DispatchPlugin.cs
+++ b/csharp/test/Ice/interceptor/DispatchPlugin.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
         internal class Plugin : IPlugin
         {
-            public Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 context.AddDispatchInterceptor(
                     async (request, current, next, cancel) =>

--- a/csharp/test/Ice/interceptor/InvocationPlugin.cs
+++ b/csharp/test/Ice/interceptor/InvocationPlugin.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
         internal class Plugin : IPlugin
         {
-            public Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 context.AddInvocationInterceptor(
                     async (target, request, next, cancel) =>

--- a/csharp/test/Ice/interceptor/Server.cs
+++ b/csharp/test/Ice/interceptor/Server.cs
@@ -21,9 +21,12 @@ namespace ZeroC.Ice.Test.Interceptor
                 {
                     {
                         "Ice.Plugin.DispatchPlugin",
-                        $"{pluginPath }:ZeroC.Ice.Test.Interceptor.DispatchPluginFactory"
+                        $"{pluginPath}:ZeroC.Ice.Test.Interceptor.DispatchPluginFactory"
                     }
                 });
+
+            await communicator.ActivateAsync();
+
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyObject());

--- a/csharp/test/Ice/interceptor/ServerAMD.cs
+++ b/csharp/test/Ice/interceptor/ServerAMD.cs
@@ -24,6 +24,9 @@ namespace ZeroC.Ice.Test.Interceptor
                         $"{pluginPath }:ZeroC.Ice.Test.Interceptor.DispatchPluginFactory"
                     }
                 });
+
+            await communicator.ActivateAsync();
+
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new AsyncMyObject());

--- a/csharp/test/Ice/invoke/Server.cs
+++ b/csharp/test/Ice/invoke/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Invoke
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.AddDefault(new BlobjectI());

--- a/csharp/test/Ice/location/Server.cs
+++ b/csharp/test/Ice/location/Server.cs
@@ -15,6 +15,7 @@ namespace ZeroC.Ice.Test.Location
             Dictionary<string, string> properties = CreateTestProperties(ref args);
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("ServerManagerAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("ServerManagerAdapter");
 

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -17,7 +17,6 @@ namespace ZeroC.Ice.Test.Metrics
 
             properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "client";
-            properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.ConnectTimeout"] = "3s";
 

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -17,7 +17,6 @@ namespace ZeroC.Ice.Test.Metrics
 
             properties["Ice.Admin.Endpoints"] = ice1 ? "tcp -h 127.0.0.1" : "ice+tcp://127.0.0.1:0";
             properties["Ice.Admin.InstanceName"] = "colocated";
-            properties["Ice.Admin.DelayCreation"] = "1";
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.Warn.Dispatch"] = "0";
 

--- a/csharp/test/Ice/namespacemd/Server.cs
+++ b/csharp/test/Ice/namespacemd/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.NamespaceMD
         public override async Task RunAsync(string[] args)
         {
             await using var communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new Initial());

--- a/csharp/test/Ice/networkProxy/Server.cs
+++ b/csharp/test/Ice/networkProxy/Server.cs
@@ -17,6 +17,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());

--- a/csharp/test/Ice/objects/Collocated.cs
+++ b/csharp/test/Ice/objects/Collocated.cs
@@ -12,6 +12,7 @@ namespace ZeroC.Ice.Test.Objects
             var properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new Initial(adapter));

--- a/csharp/test/Ice/objects/Server.cs
+++ b/csharp/test/Ice/objects/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Objects
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new Initial(adapter));

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Operations
         public override async Task RunAsync(string[] args)
         {
             await using Communicator? communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.AdapterId", "test");
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/operations/Server.cs
+++ b/csharp/test/Ice/operations/Server.cs
@@ -14,6 +14,7 @@ namespace ZeroC.Ice.Test.Operations
             // We don't want connection warnings because of the timeout test.
             properties["Ice.Warn.Connections"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyDerivedClass());

--- a/csharp/test/Ice/operations/ServerAMD.cs
+++ b/csharp/test/Ice/operations/ServerAMD.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Operations
             // We don't want connection warnings because of the timeout test.
             properties["Ice.Warn.Connections"] = "0";
             await using var communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new AsyncMyDerivedClass());

--- a/csharp/test/Ice/optional/Server.cs
+++ b/csharp/test/Ice/optional/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Optional
         public override async Task RunAsync(string[] args)
         {
             await using var communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new Test());

--- a/csharp/test/Ice/perf/Collocated.cs
+++ b/csharp/test/Ice/perf/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Perf
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter? adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("perf", new PerformanceI());

--- a/csharp/test/Ice/perf/Server.cs
+++ b/csharp/test/Ice/perf/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Perf
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("perf", new PerformanceI());

--- a/csharp/test/Ice/plugin/BasePlugin.cs
+++ b/csharp/test/Ice/plugin/BasePlugin.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.Plugin
 
         public bool IsDestroyed() => Destroyed;
 
-        public abstract Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel);
+        public abstract Task ActivateAsync(PluginActivationContext context, CancellationToken cancel);
         public virtual async ValueTask DisposeAsync()
         {
             GC.SuppressFinalize(this);

--- a/csharp/test/Ice/plugin/BasePluginFail.cs
+++ b/csharp/test/Ice/plugin/BasePluginFail.cs
@@ -25,7 +25,7 @@ namespace ZeroC.Ice.Test.Plugin
 
         public bool isDestroyed() => _destroyed;
 
-        public abstract Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel);
+        public abstract Task ActivateAsync(PluginActivationContext context, CancellationToken cancel);
         public abstract ValueTask DisposeAsync();
     }
 }

--- a/csharp/test/Ice/plugin/Client.cs
+++ b/csharp/test/Ice/plugin/Client.cs
@@ -29,6 +29,7 @@ namespace ZeroC.Ice.Test.Plugin
                         $"{pluginPath }:ZeroC.Ice.Test.Plugin.PluginFactory 'C:\\Program Files\\' --DatabasePath 'C:\\Program Files\\Application\\db'"
                     }
                 });
+                await communicator.ActivateAsync();
                 Console.WriteLine("ok");
             }
 
@@ -37,12 +38,13 @@ namespace ZeroC.Ice.Test.Plugin
                 Console.Out.Flush();
                 try
                 {
-                    Initialize(new Dictionary<string, string>()
+                    await using Communicator communicator = Initialize(new Dictionary<string, string>()
                     {
                         {
                             "Ice.Plugin.Test", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginInitializeFailFactory"
                         }
                     });
+                    await communicator.ActivateAsync();
                     Assert(false);
                 }
                 catch
@@ -56,13 +58,14 @@ namespace ZeroC.Ice.Test.Plugin
                 Console.Write("testing plug-in load order... ");
                 Console.Out.Flush();
 
-                using Communicator communicator = Initialize(new Dictionary<string, string>()
+                await using Communicator communicator = Initialize(new Dictionary<string, string>()
                 {
                     { "Ice.Plugin.PluginOne", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginOneFactory" },
                     { "Ice.Plugin.PluginTwo", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginTwoFactory" },
                     { "Ice.Plugin.PluginThree", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginThreeFactory" },
                     { "Ice.PluginLoadOrder", "PluginOne, PluginTwo" } // Exclude PluginThree
                 });
+                await communicator.ActivateAsync();
                 Console.WriteLine("ok");
             }
 
@@ -72,12 +75,11 @@ namespace ZeroC.Ice.Test.Plugin
 
                 MyPlugin p4;
                 {
-                    using Communicator communicator = Initialize(new Dictionary<string, string>()
+                    await using Communicator communicator = Initialize(new Dictionary<string, string>()
                     {
                         { "Ice.Plugin.PluginOne", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginOneFactory" },
                         { "Ice.Plugin.PluginTwo", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginTwoFactory" },
                         { "Ice.Plugin.PluginThree", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginThreeFactory" },
-                        { "Ice.InitPlugins", "0"}
                     });
 
                     Assert(communicator.GetPlugin("PluginOne") != null);
@@ -88,7 +90,7 @@ namespace ZeroC.Ice.Test.Plugin
                     communicator.AddPlugin("PluginFour", p4);
                     Assert(communicator.GetPlugin("PluginFour") != null);
 
-                    communicator.InitializePluginsAsync().GetAwaiter().GetResult();
+                    await communicator.ActivateAsync();
 
                     Assert(p4.IsInitialized());
                 }
@@ -101,13 +103,14 @@ namespace ZeroC.Ice.Test.Plugin
                 Console.Out.Flush();
                 try
                 {
-                    Initialize(new Dictionary<string, string>()
+                    await using Communicator communicator = Initialize(new Dictionary<string, string>()
                     {
                         { "Ice.Plugin.PluginOneFail", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginOneFailFactory" },
                         { "Ice.Plugin.PluginTwoFail", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginTwoFailFactory" },
                         { "Ice.Plugin.PluginThreeFail", $"{pluginPath}:ZeroC.Ice.Test.Plugin.PluginThreeFailFactory" },
                         { "Ice.PluginLoadOrder", "PluginOneFail, PluginTwoFail, PluginThreeFail"}
                     });
+                    await communicator.ActivateAsync();
                 }
                 catch
                 {
@@ -126,7 +129,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public bool IsDestroyed() => _destroyed;
 
-            public Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 _initialized = true;
                 return Task.CompletedTask;

--- a/csharp/test/Ice/plugin/PluginFactory.cs
+++ b/csharp/test/Ice/plugin/PluginFactory.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Plugin
 
             public Plugin(string[] args) => _args = args;
 
-            public Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 _initialized = true;
                 TestHelper.Assert(_args.Length == 3);

--- a/csharp/test/Ice/plugin/PluginInitializeFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginInitializeFailFactory.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.Plugin
 
         internal class PluginInitializeFail : IPlugin
         {
-            public Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel) =>
+            public Task ActivateAsync(PluginActivationContext context, CancellationToken cancel) =>
                 throw new PluginInitializeFailException();
 
             public ValueTask DisposeAsync()

--- a/csharp/test/Ice/plugin/PluginOneFactory.cs
+++ b/csharp/test/Ice/plugin/PluginOneFactory.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 var other = (BasePlugin?)Communicator.GetPlugin("PluginTwo");
                 TestHelper.Assert(other != null);

--- a/csharp/test/Ice/plugin/PluginOneFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginOneFailFactory.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 var two = (BasePluginFail?)_communicator.GetPlugin("PluginTwoFail");
                 TestHelper.Assert(two != null);

--- a/csharp/test/Ice/plugin/PluginThreeFactory.cs
+++ b/csharp/test/Ice/plugin/PluginThreeFactory.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 var other = (BasePlugin?)Communicator.GetPlugin("PluginTwo");
                 TestHelper.Assert(other != null);

--- a/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel) =>
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel) =>
                 throw new PluginInitializeFailException();
 
             public override ValueTask DisposeAsync()

--- a/csharp/test/Ice/plugin/PluginTwoFactory.cs
+++ b/csharp/test/Ice/plugin/PluginTwoFactory.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 var other = (BasePlugin?)Communicator.GetPlugin("PluginOne");
                 TestHelper.Assert(other != null);

--- a/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Plugin
             {
             }
 
-            public override Task InitializeAsync(PluginInitializationContext context, CancellationToken cancel)
+            public override Task ActivateAsync(PluginActivationContext context, CancellationToken cancel)
             {
                 var one = (BasePluginFail?)_communicator.GetPlugin("PluginOneFail");
                 TestHelper.Assert(one != null);

--- a/csharp/test/Ice/protocolBridging/Server.cs
+++ b/csharp/test/Ice/protocolBridging/Server.cs
@@ -11,6 +11,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapterForwarder.Endpoints", GetTestEndpoint(0));
 
             var ice1Endpoint = TestHelper.GetTestEndpoint(

--- a/csharp/test/Ice/proxy/Collocated.cs
+++ b/csharp/test/Ice/proxy/Collocated.cs
@@ -14,6 +14,7 @@ namespace ZeroC.Ice.Test.Proxy
             properties["Ice.Warn.Dispatch"] = "0";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyDerivedClass());

--- a/csharp/test/Ice/proxy/Server.cs
+++ b/csharp/test/Ice/proxy/Server.cs
@@ -16,6 +16,7 @@ namespace ZeroC.Ice.Test.Proxy
             properties["Ice.Warn.Dispatch"] = "0";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyDerivedClass());

--- a/csharp/test/Ice/proxy/ServerAMD.cs
+++ b/csharp/test/Ice/proxy/ServerAMD.cs
@@ -16,6 +16,7 @@ namespace ZeroC.Ice.Test.Proxy
             properties["Ice.Warn.Dispatch"] = "0";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new AsyncMyDerivedClass());

--- a/csharp/test/Ice/retry/Collocated.cs
+++ b/csharp/test/Ice/retry/Collocated.cs
@@ -17,6 +17,7 @@ namespace ZeroC.Ice.Test.Retry
             // This test kills connections, so we don't want warnings.
             properties["Ice.Warn.Connections"] = "0";
             await using Communicator communicator = Initialize(properties, observer: observer);
+            await communicator.ActivateAsync();
 
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.CreateObjectAdapter("TestAdapter").Add("retry", new Retry());

--- a/csharp/test/Ice/retry/Server.cs
+++ b/csharp/test/Ice/retry/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Retry
             properties["Ice.Warn.Dispatch"] = "0";
             properties["Ice.Warn.Connections"] = "0";
             await using var communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter1.Endpoints", GetTestEndpoint(0));
             var adapter1 = communicator.CreateObjectAdapter("TestAdapter1");
             adapter1.Add("retry", new Retry());

--- a/csharp/test/Ice/scope/Server.cs
+++ b/csharp/test/Ice/scope/Server.cs
@@ -112,6 +112,7 @@ namespace ZeroC.Ice.Test.Scope
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("i1", new I1());

--- a/csharp/test/Ice/seqMapping/Collocated.cs
+++ b/csharp/test/Ice/seqMapping/Collocated.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.SeqMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyClass());

--- a/csharp/test/Ice/seqMapping/Server.cs
+++ b/csharp/test/Ice/seqMapping/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.SeqMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyClass());

--- a/csharp/test/Ice/seqMapping/ServerAMD.cs
+++ b/csharp/test/Ice/seqMapping/ServerAMD.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.SeqMapping
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             var adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new AsyncMyClass());

--- a/csharp/test/Ice/slicing/exceptions/Server.cs
+++ b/csharp/test/Ice/slicing/exceptions/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());

--- a/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new AsyncTestIntf());

--- a/csharp/test/Ice/slicing/objects/Server.cs
+++ b/csharp/test/Ice/slicing/objects/Server.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());

--- a/csharp/test/Ice/slicing/objects/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/objects/ServerAMD.cs
@@ -13,6 +13,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             Dictionary<string, string>? properties = CreateTestProperties(ref args);
             properties["Ice.Warn.Dispatch"] = "0";
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new AsyncTestIntf());

--- a/csharp/test/Ice/tagged/Server.cs
+++ b/csharp/test/Ice/tagged/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Tagged
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new Initial());

--- a/csharp/test/Ice/tagged/ServerAMD.cs
+++ b/csharp/test/Ice/tagged/ServerAMD.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Tagged
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("initial", new AsyncInitial());

--- a/csharp/test/Ice/threading/Collocated.cs
+++ b/csharp/test/Ice/threading/Collocated.cs
@@ -11,6 +11,7 @@ namespace ZeroC.Ice.Test.Threading
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
 
             ObjectAdapter adapter1 = communicator.CreateObjectAdapterWithEndpoints("TestAdapter", GetTestEndpoint(0));
             adapter1.Add("test", new TestIntf(TaskScheduler.Default));

--- a/csharp/test/Ice/threading/Server.cs
+++ b/csharp/test/Ice/threading/Server.cs
@@ -11,6 +11,7 @@ namespace ZeroC.Ice.Test.Threading
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
 
             ObjectAdapter? adapter = communicator.CreateObjectAdapterWithEndpoints("TestAdapter", GetTestEndpoint(0));
             adapter.Add("test", new TestIntf(TaskScheduler.Default));

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -25,6 +25,7 @@ namespace ZeroC.Ice.Test.Timeout
             properties["Ice.TCP.RcvSize"] = "50K";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             communicator.SetProperty("ControllerAdapter.Endpoints", GetTestEndpoint(1));
 

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -17,6 +17,7 @@ namespace ZeroC.Ice.Test.UDP
             properties["Ice.UDP.RcvSize"] = "16K";
 
             await using Communicator communicator = Initialize(properties);
+            await communicator.ActivateAsync();
             int num = 0;
             try
             {

--- a/csharp/test/IceGrid/simple/Server.cs
+++ b/csharp/test/IceGrid/simple/Server.cs
@@ -15,6 +15,8 @@ namespace ZeroC.IceGrid.Test.Simple
             properties.ParseArgs(ref args, "TestAdapter");
 
             await using Communicator communicator = Initialize(ref args, properties);
+            await communicator.ActivateAsync();
+
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add(communicator.GetProperty("Identity") ?? "test", new TestIntf());
             await adapter.ActivateAsync();

--- a/csharp/test/IceSSL/configuration/Server.cs
+++ b/csharp/test/IceSSL/configuration/Server.cs
@@ -11,6 +11,7 @@ namespace ZeroC.IceSSL.Test.Configuration
         public override async Task RunAsync(string[] args)
         {
             await using Ice.Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             if (args.Length < 1)
             {
                 throw new ArgumentException("Usage: server testdir");


### PR DESCRIPTION
This PR splits communicator creation in two phases:
- construction, which is naturally synchronous
- asynchronous activation, by calling ActivateAsync on the communicator object

This PR also renames IPlugin's InitializeAsync to ActivateAsync for consistency.

With the PR, the following configuration properties are no longer used:
- Ice.InitPlugins (since plug-in activation is now always explicit with ActivateAsync)
- Ice.Admin.DelayCreation (since Admin creation is always delayed until ActivateAsync)
