### PR TITLE
Better handling of undefined values

### DIFF
--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -2278,7 +2278,7 @@ class EncapsEncoder10 extends EncapsEncoder
         //
         // Object references are encoded as a negative integer in 1.0.
         //
-        if(v !== null)
+        if(v !== null && v !== undefined)
         {
             this._stream.writeInt(-this.registerValue(v));
         }
@@ -2450,7 +2450,7 @@ class EncapsEncoder11 extends EncapsEncoder
     writeValue(v)
     {
         Debug.assert(v !== undefined);
-        if(v === null)
+        if(v === null || v === undefined)
         {
             this._stream.writeSize(0);
         }
@@ -3078,7 +3078,7 @@ class OutputStream
 
     writeBlob(v)
     {
-        if(v === null)
+        if(v === null || v === undefined)
         {
             return;
         }
@@ -3121,7 +3121,7 @@ class OutputStream
 
     writeByteSeq(v)
     {
-        if(v === null || v.length === 0)
+        if(v === null || v === undefined || v.length === 0)
         {
             this.writeSize(0);
         }
@@ -3181,7 +3181,7 @@ class OutputStream
 
     writeString(v)
     {
-        if(v === null || v.length === 0)
+        if(v === null || v === undefined || v.length === 0)
         {
             this.writeSize(0);
         }
@@ -3193,14 +3193,14 @@ class OutputStream
 
     writeProxy(v)
     {
-        if(v !== null)
-        {
-            v._write(this);
-        }
-        else
+        if(v === null || v === undefined)
         {
             const ident = new Ice.Identity();
             ident._write(this);
+        }
+        else
+        {
+            v._write(this);
         }
     }
 

--- a/js/src/Ice/StreamHelpers.js
+++ b/js/src/Ice/StreamHelpers.js
@@ -108,7 +108,7 @@ class SequenceHelper
 {
     write(os, v)
     {
-        if(v === null || v.length === 0)
+        if(v === null || v === undefined || v.length === 0)
         {
             os.writeSize(0);
         }
@@ -219,7 +219,7 @@ class DictionaryHelper
 {
     write(os, v)
     {
-        if(v === null || v.size === 0)
+        if(v === null || v == undefined || v.size === 0)
         {
             os.writeSize(0);
         }


### PR DESCRIPTION
This PR fixes JavaScript OutputStream to better handling undefined values, in general, we treat undefined as not set optional value and null as an empty string or collection, this is not required in the methods that write nonoptional values, allowing these methods to accept undefined with the same semantic as null makes the code more flexible. 