### PR TITLE
Add new Communicator.DestroyAsync method

### DIFF
--- a/csharp/src/Ice/Communicator-OutgoingConnectionFactory.cs
+++ b/csharp/src/Ice/Communicator-OutgoingConnectionFactory.cs
@@ -34,7 +34,7 @@ namespace ZeroC.Ice
             {
                 lock (_mutex)
                 {
-                    if (_disposeTask != null)
+                    if (_destroyTask != null)
                     {
                         throw new CommunicatorDisposedException();
                     }
@@ -104,7 +104,7 @@ namespace ZeroC.Ice
                                                                         cancel).ConfigureAwait(false);
                     lock (_mutex)
                     {
-                        if (_disposeTask != null)
+                        if (_destroyTask != null)
                         {
                             // If the communicator has been disposed return the connection here and avoid adding the
                             // connection to the outgoing connections map, the connection will be disposed from the
@@ -160,7 +160,7 @@ namespace ZeroC.Ice
                     lock (_mutex)
                     {
                         // Don't modify the pending connections map after the communicator was disposed.
-                        if (_disposeTask == null)
+                        if (_destroyTask == null)
                         {
                             _pendingOutgoingConnections.Remove((endpoint, label));
                         }
@@ -236,7 +236,7 @@ namespace ZeroC.Ice
             // such connections, so that callbacks from the router can be received over such connections.
             lock (_mutex)
             {
-                if (_disposeTask != null)
+                if (_destroyTask != null)
                 {
                     throw new CommunicatorDisposedException();
                 }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -847,7 +847,7 @@ namespace ZeroC.Ice
         }
 
         /// <summary>Releases all resources used by this communicator. This method calls <see cref="ShutdownAsync"/>
-        /// implicitly, and be called multiple times.</summary>
+        /// implicitly, and can be called multiple times.</summary>
         /// <returns>A task that completes when the destruction is complete.</returns>
         public Task DestroyAsync()
         {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -194,7 +194,7 @@ namespace ZeroC.Ice
 
         internal TimeSpan IdleTimeout { get; }
         internal int IncomingFrameMaxSize { get; }
-        internal bool IsDisposed => _disposeTask != null;
+        internal bool IsDisposed => _destroyTask != null;
         internal bool KeepAlive { get; }
         internal int MaxBidirectionalStreams { get; }
         internal int MaxUnidirectionalStreams { get; }
@@ -254,7 +254,7 @@ namespace ZeroC.Ice
         private volatile IRouterPrx? _defaultRouter;
         private volatile ImmutableList<DispatchInterceptor> _defaultDispatchInterceptors =
             ImmutableList<DispatchInterceptor>.Empty;
-        private Task? _disposeTask;
+        private Task? _destroyTask;
         private static readonly Dictionary<string, Assembly> _loadedAssemblies = new Dictionary<string, Assembly>();
         private readonly ConcurrentDictionary<ILocatorPrx, LocatorInfo> _locatorInfoMap =
             new ConcurrentDictionary<ILocatorPrx, LocatorInfo>();
@@ -857,24 +857,25 @@ namespace ZeroC.Ice
             return adminAdapter.CreateProxy(adminIdentity, IObjectPrx.Factory);
         }
 
-        /// <summary>Releases resources used by the communicator. This method calls <see cref="ShutdownAsync"/>
+        /// <summary>Releases all resources used by this communicator. This method calls <see cref="ShutdownAsync"/>
         /// implicitly, and be called multiple times.</summary>
-        public ValueTask DisposeAsync()
+        /// <returns>A task that completes when the destruction is complete.</returns>
+        public Task DestroyAsync()
         {
             lock (_mutex)
             {
-                _disposeTask ??= PerformDisposeAsync();
-                return new(_disposeTask);
+                _destroyTask ??= PerformDestroyAsync();
+                return _destroyTask;
             }
 
-            async Task PerformDisposeAsync()
+            async Task PerformDestroyAsync()
             {
                 // Cancel operations that are waiting and using the communicator's cancellation token
                 _cancellationTokenSource.Cancel();
 
                 // Shutdown and destroy all the incoming and outgoing Ice connections and wait for the connections to be
                 // finished.
-                CommunicatorDisposedException disposedException = new();
+                var disposedException = new CommunicatorDisposedException();
                 IEnumerable<Task> closeTasks =
                     _outgoingConnections.Values.SelectMany(connections => connections).Select(
                         connection => connection.GoAwayAsync(disposedException)).Append(ShutdownAsync());
@@ -950,6 +951,11 @@ namespace ZeroC.Ice
         /// <summary>Releases resources used by the communicator. This operation calls <see cref="ShutdownAsync"/>
         /// implicitly.</summary>
         public void Dispose() => DisposeAsync().GetResult();
+
+        /// <summary>An alias for <see cref="DestroyAsync"/>, except this method returns a <see cref="ValueTask"/>.
+        /// </summary>
+        /// <returns>A value task constructed using the task returned by DestroyAsync.</returns>
+        public ValueTask DisposeAsync() => new(DestroyAsync());
 
         /// <summary>Returns a facet of the Admin object.</summary>
         /// <param name="facet">The name of the Admin facet.</param>

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -52,7 +52,7 @@ namespace ZeroC.Ice.Test.ACM
         public ITestIntfPrx GetTestIntf(Current current, CancellationToken cancel) => _testIntf;
 
         public void Deactivate(Current current, CancellationToken cancel) =>
-            _adapter.Communicator.DisposeAsync().AsTask();
+            _adapter.Communicator.DestroyAsync();
     }
 
     public class TestIntf : ITestIntf


### PR DESCRIPTION
DisposeAsync is now an alias for DestroyAsync. 

DestroyAsync returns a Task, while DisposeAsync returns a ValueTask.

The main reason for this alias is consistency with ShutdownAsync, which returns a Task, and can be used as follows for console events:
```
// Initiates shutdown of the communicator.
Console.CancelKeyPress += (sender, eventArgs) => communicator.ShutdownAsync();
```

With DestroyAsync, we can write the same:
```
// Initiates destruction of the communicator.
Console.CancelKeyPress += (sender, eventArgs) => communicator.DestroyAsync();
```

whereas with DisposeAsync, we would need a more confusing and inconsistent:
```
// Initiates destruction of the communicator.
// AsTask() is correct and avoids a warning.
Console.CancelKeyPress += (sender, eventArgs) => communicator.DisposeAsync().AsTask();
```

or

```
// Initiates destruction of the communicator.
Console.CancelKeyPress += async (sender, eventArgs) => await communicator.DisposeAsync();
```
