### PR TITLE
Simplified TestHelper

### DIFF
--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using TestNew;
 
 namespace ZeroC.Ice.Test.ACM
 {
@@ -161,7 +161,7 @@ namespace ZeroC.Ice.Test.ACM
             Dictionary<string, string> properties = _com.Communicator.GetProperties();
             properties["Ice.IdleTimeout"] = $"{_clientIdleTimeout ?? 2}s";
             properties["Ice.KeepAlive"] = _clientKeepAlive?.ToString() ?? "0";
-            _communicator = _helper.Initialize(properties);
+            _communicator = TestHelper.CreateCommunicator(properties);
             _thread = new Thread(Run);
         }
 
@@ -398,10 +398,9 @@ namespace ZeroC.Ice.Test.ACM
             }
         }
 
-        public static void Run(TestHelper helper)
+        public static Task RunAsync(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator;
-            TestHelper.Assert(communicator != null);
+            Communicator communicator = helper.Communicator;
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
 
             TextWriter output = helper.Output;
@@ -437,6 +436,7 @@ namespace ZeroC.Ice.Test.ACM
             output.Flush();
             com.Shutdown();
             output.WriteLine("ok");
+            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using TestNew;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.ACM
 {

--- a/csharp/test/Ice/acm/Client.cs
+++ b/csharp/test/Ice/acm/Client.cs
@@ -1,18 +1,18 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using TestNew;
 
 namespace ZeroC.Ice.Test.ACM
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args)
-        {
-            await using Communicator communicator = Initialize(ref args);
-            AllTests.Run(this);
-        }
+        public override async Task RunAsync(string[] args) => await AllTests.RunAsync(this);
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Client>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/acm/Client.cs
+++ b/csharp/test/Ice/acm/Client.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using TestNew;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.ACM
 {

--- a/csharp/test/Ice/acm/Client.cs
+++ b/csharp/test/Ice/acm/Client.cs
@@ -7,7 +7,7 @@ namespace ZeroC.Ice.Test.ACM
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args) => await AllTests.RunAsync(this);
+        public override Task RunAsync(string[] args) => AllTests.RunAsync(this);
 
         public static async Task<int> Main(string[] args)
         {

--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using TestNew;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.ACM
 {

--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using TestNew;
 
 namespace ZeroC.Ice.Test.ACM
 {
@@ -9,17 +9,20 @@ namespace ZeroC.Ice.Test.ACM
     {
         public override async Task RunAsync(string[] args)
         {
-            await using Communicator communicator = Initialize(ref args);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());
             await adapter.ActivateAsync();
             ServerReady();
-            communicator.SetProperty("Ice.PrintAdapterReady", "0");
-            await communicator.WaitForShutdownAsync();
+            Communicator.SetProperty("Ice.PrintAdapterReady", "0");
+            await Communicator.WaitForShutdownAsync();
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Server>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using TestNew;
 
 namespace ZeroC.Ice.Test.ACM
 {

--- a/csharp/test/Ice/acm/TestI.cs
+++ b/csharp/test/Ice/acm/TestI.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using TestNew;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.ACM
 {

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -8,7 +8,271 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using ZeroC.Ice;
+using ZeroC.Ice.Instrumentation;
 
+// The new version of the Test helper classes. Will be renamed Test once all the tests have migrated to TestNew.
+namespace ZeroC.Test
+{
+    public abstract class TestHelper
+    {
+        private TextWriter? _writer;
+
+        public ushort BasePort => GetTestBasePort(Communicator.GetProperties());
+
+        public Communicator Communicator { get; private init; } = null!;
+
+        public ZeroC.Ice.Encoding Encoding => GetTestEncoding(Communicator.GetProperties());
+
+        public string Host => GetTestHost(Communicator.GetProperties());
+
+        public Protocol Protocol => GetTestProtocol(Communicator.GetProperties());
+
+        public string Transport => GetTestTransport(Communicator.GetProperties());
+
+        public TextWriter Output
+        {
+            get => _writer ?? Console.Out;
+            set => _writer = value;
+        }
+
+        public static void Assert([DoesNotReturnIf(false)] bool b, string message = "")
+        {
+            if (!b)
+            {
+                Debug.Assert(false, message);
+                throw new Exception(message);
+            }
+        }
+
+        public static Communicator CreateCommunicator(
+            ref string[] args,
+            Dictionary<string, string>? defaults = null,
+            ICommunicatorObserver? observer = null) =>
+            CreateCommunicator(CreateTestProperties(ref args, defaults), observer);
+
+        public static Communicator CreateCommunicator(
+            Dictionary<string, string> properties,
+            ICommunicatorObserver? observer = null)
+        {
+            var tlsServerOptions = new TlsServerOptions();
+            if (properties.TryGetValue("Test.Transport", out string? value))
+            {
+                // When running test with WSS, disable client authentication for browser compatibility
+                tlsServerOptions.RequireClientCertificate = value == "ssl";
+            }
+
+            return new Communicator(properties, tlsServerOptions: tlsServerOptions, observer: observer);
+        }
+
+        public string GetTestEndpoint(
+            int num = 0,
+            string transport = "",
+            bool ephemeral = false) =>
+            GetTestEndpoint(Communicator.GetProperties(), num, transport, ephemeral);
+
+        public static string GetTestEndpoint(
+            Dictionary<string, string> properties,
+            int num = 0,
+            string transport = "",
+            bool ephemeral = false)
+        {
+            if (transport.Length == 0)
+            {
+                transport = GetTestTransport(properties);
+            }
+
+            string host = GetTestHost(properties);
+            string port = ephemeral ? "0" : $"{GetTestBasePort(properties) + num}";
+
+            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
+            {
+                var sb = new StringBuilder("ice+");
+                sb.Append(transport);
+                sb.Append("://");
+
+                if (host.Contains(':'))
+                {
+                    sb.Append('[');
+                    sb.Append(host);
+                    sb.Append(']');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
+                sb.Append(':');
+                sb.Append(port);
+                return sb.ToString();
+            }
+            else
+            {
+                var sb = new StringBuilder(transport);
+                sb.Append(" -h ");
+                if (host.Contains(':'))
+                {
+                    sb.Append('"');
+                    sb.Append(host);
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
+                sb.Append(" -p ");
+                sb.Append(port);
+                return sb.ToString();
+            }
+        }
+
+        public static string GetTestProxy(
+            string identity,
+            Dictionary<string, string> properties,
+            int num = 0,
+            string? transport = null)
+        {
+            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
+            {
+                var sb = new StringBuilder("ice+");
+                sb.Append(transport ?? GetTestTransport(properties));
+                sb.Append("://");
+                string host = GetTestHost(properties);
+                if (host.Contains(':'))
+                {
+                    sb.Append('[');
+                    sb.Append(host);
+                    sb.Append(']');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
+                sb.Append(':');
+                sb.Append(GetTestBasePort(properties) + num);
+                sb.Append('/');
+                sb.Append(identity);
+                return sb.ToString();
+            }
+            else // i.e. ice1
+            {
+                var sb = new StringBuilder(identity);
+                sb.Append(':');
+                sb.Append(transport ?? GetTestTransport(properties));
+                sb.Append(" -h ");
+                string host = GetTestHost(properties);
+                if (host.Contains(':'))
+                {
+                    sb.Append('"');
+                    sb.Append(host);
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append(host);
+                }
+                sb.Append(" -p ");
+                sb.Append(GetTestBasePort(properties) + num);
+                return sb.ToString();
+            }
+        }
+
+        public static string GetTestHost(Dictionary<string, string> properties)
+        {
+            if (!properties.TryGetValue("Test.Host", out string? host))
+            {
+                host = "127.0.0.1";
+            }
+            return host;
+        }
+
+        public static Protocol GetTestProtocol(Dictionary<string, string> properties)
+        {
+            if (!properties.TryGetValue("Test.Protocol", out string? value))
+            {
+                return Protocol.Ice2;
+            }
+            try
+            {
+                return ProtocolExtensions.Parse(value);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidConfigurationException($"invalid value for for Test.Protocol: `{value}'", ex);
+            }
+        }
+
+        public static ZeroC.Ice.Encoding GetTestEncoding(Dictionary<string, string> properties) =>
+            GetTestProtocol(properties).GetEncoding();
+
+        public static string GetTestTransport(Dictionary<string, string> properties)
+        {
+            if (properties.TryGetValue("Test.Transport", out string? transport))
+            {
+                if (GetTestProtocol(properties) == Protocol.Ice1)
+                {
+                    return transport;
+                }
+                return transport switch
+                {
+                    "wss" => "ws",
+                    "ssl" => "tcp",
+                    _ => transport,
+                };
+            }
+            else
+            {
+                return "tcp";
+            }
+        }
+
+        public static ushort GetTestBasePort(Dictionary<string, string> properties)
+        {
+            ushort basePort = 12010;
+            if (properties.TryGetValue("Test.BasePort", out string? value))
+            {
+                basePort = ushort.Parse(value);
+            }
+            return basePort;
+        }
+
+        public static Dictionary<string, string> CreateTestProperties(
+            ref string[] args,
+            Dictionary<string, string>? defaults = null)
+        {
+            var properties =
+                defaults == null ? new Dictionary<string, string>() : new Dictionary<string, string>(defaults);
+            properties.ParseIceArgs(ref args);
+            properties.ParseArgs(ref args, "Test");
+            return properties;
+        }
+
+        public string GetTestProxy(string identity, int num = 0, string? transport = null) =>
+            GetTestProxy(identity, Communicator.GetProperties(), num, transport);
+
+        public abstract Task RunAsync(string[] args);
+
+        public static async Task<int> RunTestAsync<T>(Communicator communicator, string[] args)
+            where T : TestHelper, new()
+        {
+            try
+            {
+                var helper = new T() { Communicator = communicator };
+                await helper.RunAsync(args);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return 1;
+            }
+        }
+
+        public virtual void ServerReady()
+        {
+        }
+    }
+}
+
+// Old namespace, remove once all the tests use ZeroC.Test.
 namespace Test
 {
     public interface IControllerHelper
@@ -240,12 +504,12 @@ namespace Test
 
         public Communicator Initialize(ref string[] args,
             Dictionary<string, string>? defaults = null,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null) =>
+            ICommunicatorObserver? observer = null) =>
             Initialize(CreateTestProperties(ref args, defaults), observer);
 
         public Communicator Initialize(
             Dictionary<string, string> properties,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
+            ICommunicatorObserver? observer = null)
         {
             var tlsServerOptions = new TlsServerOptions();
             if (properties.TryGetValue("Test.Transport", out string? value))
@@ -281,263 +545,6 @@ namespace Test
                 status = 1;
             }
             return status;
-        }
-    }
-}
-
-// The new version of the Test helper classes. Will be renamed Test once all the tests have migrated to TestNew.
-namespace TestNew
-{
-    public abstract class TestHelper
-    {
-        private TextWriter? _writer;
-
-        public ushort BasePort => GetTestBasePort(Communicator.GetProperties());
-
-        public Communicator Communicator { get; private init; } = null!;
-
-        public ZeroC.Ice.Encoding Encoding => GetTestEncoding(Communicator.GetProperties());
-
-        public string Host => GetTestHost(Communicator.GetProperties());
-
-        public Protocol Protocol => GetTestProtocol(Communicator.GetProperties());
-
-        public string Transport => GetTestTransport(Communicator.GetProperties());
-
-        public TextWriter Output
-        {
-            get => _writer ?? Console.Out;
-            set => _writer = value;
-        }
-
-        public static void Assert([DoesNotReturnIf(false)] bool b, string message = "")
-        {
-            if (!b)
-            {
-                Debug.Assert(false, message);
-                throw new Exception(message);
-            }
-        }
-
-        public static Communicator CreateCommunicator(
-            ref string[] args,
-            Dictionary<string, string>? defaults = null,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null) =>
-            CreateCommunicator(CreateTestProperties(ref args, defaults), observer);
-
-        public static Communicator CreateCommunicator(
-            Dictionary<string, string> properties,
-            ZeroC.Ice.Instrumentation.ICommunicatorObserver? observer = null)
-        {
-            var tlsServerOptions = new TlsServerOptions();
-            if (properties.TryGetValue("Test.Transport", out string? value))
-            {
-                // When running test with WSS, disable client authentication for browser compatibility
-                tlsServerOptions.RequireClientCertificate = value == "ssl";
-            }
-
-            return new Communicator(properties, tlsServerOptions: tlsServerOptions, observer: observer);
-        }
-
-        public string GetTestEndpoint(int num = 0, string transport = "", bool ephemeral = false) =>
-            GetTestEndpoint(Communicator.GetProperties(), num, transport, ephemeral);
-
-        public static string GetTestEndpoint(
-            Dictionary<string, string> properties, int num = 0, string transport = "", bool ephemeral = false)
-        {
-            if (transport.Length == 0)
-            {
-                transport = GetTestTransport(properties);
-            }
-
-            string host = GetTestHost(properties);
-            string port = ephemeral ? "0" : $"{GetTestBasePort(properties) + num}";
-
-            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
-            {
-                var sb = new StringBuilder("ice+");
-                sb.Append(transport);
-                sb.Append("://");
-
-                if (host.Contains(':'))
-                {
-                    sb.Append('[');
-                    sb.Append(host);
-                    sb.Append(']');
-                }
-                else
-                {
-                    sb.Append(host);
-                }
-                sb.Append(':');
-                sb.Append(port);
-                return sb.ToString();
-            }
-            else
-            {
-                var sb = new StringBuilder(transport);
-                sb.Append(" -h ");
-                if (host.Contains(':'))
-                {
-                    sb.Append('"');
-                    sb.Append(host);
-                    sb.Append('"');
-                }
-                else
-                {
-                    sb.Append(host);
-                }
-                sb.Append(" -p ");
-                sb.Append(port);
-                return sb.ToString();
-            }
-        }
-
-        public static string GetTestProxy(
-            string identity,
-            Dictionary<string, string> properties,
-            int num = 0,
-            string? transport = null)
-        {
-            if (GetTestProtocol(properties) == Protocol.Ice2 && transport != "udp")
-            {
-                var sb = new StringBuilder("ice+");
-                sb.Append(transport ?? GetTestTransport(properties));
-                sb.Append("://");
-                string host = GetTestHost(properties);
-                if (host.Contains(':'))
-                {
-                    sb.Append('[');
-                    sb.Append(host);
-                    sb.Append(']');
-                }
-                else
-                {
-                    sb.Append(host);
-                }
-                sb.Append(':');
-                sb.Append(GetTestBasePort(properties) + num);
-                sb.Append('/');
-                sb.Append(identity);
-                return sb.ToString();
-            }
-            else // i.e. ice1
-            {
-                var sb = new StringBuilder(identity);
-                sb.Append(':');
-                sb.Append(transport ?? GetTestTransport(properties));
-                sb.Append(" -h ");
-                string host = GetTestHost(properties);
-                if (host.Contains(':'))
-                {
-                    sb.Append('"');
-                    sb.Append(host);
-                    sb.Append('"');
-                }
-                else
-                {
-                    sb.Append(host);
-                }
-                sb.Append(" -p ");
-                sb.Append(GetTestBasePort(properties) + num);
-                return sb.ToString();
-            }
-        }
-
-        public static string GetTestHost(Dictionary<string, string> properties)
-        {
-            if (!properties.TryGetValue("Test.Host", out string? host))
-            {
-                host = "127.0.0.1";
-            }
-            return host;
-        }
-
-        public static Protocol GetTestProtocol(Dictionary<string, string> properties)
-        {
-            if (!properties.TryGetValue("Test.Protocol", out string? value))
-            {
-                return Protocol.Ice2;
-            }
-            try
-            {
-                return ProtocolExtensions.Parse(value);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidConfigurationException(
-                    $"invalid value for for Test.Protocol: `{value}'", ex);
-            }
-        }
-
-        public static ZeroC.Ice.Encoding GetTestEncoding(Dictionary<string, string> properties)
-            => ProtocolExtensions.GetEncoding(GetTestProtocol(properties));
-
-        public static string GetTestTransport(Dictionary<string, string> properties)
-        {
-            if (properties.TryGetValue("Test.Transport", out string? transport))
-            {
-                if (GetTestProtocol(properties) == Protocol.Ice1)
-                {
-                    return transport;
-                }
-                return transport switch
-                {
-                    "wss" => "ws",
-                    "ssl" => "tcp",
-                    _ => transport,
-                };
-            }
-            else
-            {
-                return "tcp";
-            }
-        }
-
-        public static ushort GetTestBasePort(Dictionary<string, string> properties)
-        {
-            ushort basePort = 12010;
-            if (properties.TryGetValue("Test.BasePort", out string? value))
-            {
-                basePort = ushort.Parse(value);
-            }
-            return basePort;
-        }
-
-        public static Dictionary<string, string> CreateTestProperties(
-            ref string[] args,
-            Dictionary<string, string>? defaults = null)
-        {
-            var properties =
-                defaults == null ? new Dictionary<string, string>() : new Dictionary<string, string>(defaults);
-            properties.ParseIceArgs(ref args);
-            properties.ParseArgs(ref args, "Test");
-            return properties;
-        }
-
-        public string GetTestProxy(string identity, int num = 0, string? transport = null) =>
-            GetTestProxy(identity, Communicator.GetProperties(), num, transport);
-
-        public abstract Task RunAsync(string[] args);
-
-        public static async Task<int> RunTestAsync<T>(Communicator communicator, string[] args)
-            where T : TestHelper, new()
-        {
-            try
-            {
-                var helper = new T() { Communicator = communicator };
-                await helper.RunAsync(args);
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-                return 1;
-            }
-        }
-
-        public virtual void ServerReady()
-        {
         }
     }
 }

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -336,8 +336,7 @@ namespace TestNew
                 tlsServerOptions.RequireClientCertificate = value == "ssl";
             }
 
-            var communicator = new Communicator(properties, tlsServerOptions: tlsServerOptions, observer: observer);
-            return communicator;
+            return new Communicator(properties, tlsServerOptions: tlsServerOptions, observer: observer);
         }
 
         public string GetTestEndpoint(int num = 0, string transport = "", bool ephemeral = false) =>
@@ -540,7 +539,5 @@ namespace TestNew
         public virtual void ServerReady()
         {
         }
-
-        protected TestHelper() => Communicator = null!; // Set by RunTestAsync immediately after construction.
     }
 }


### PR DESCRIPTION
This PR adds a simplified version of TestHelper in namespace TestNew (a temporary name), and updates the Ice/acm test to use this new TestHelper.