### PR TITLE
Udp multicast testing fixes

### DIFF
--- a/java-compat/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java-compat/test/src/main/java/test/Ice/udp/AllTests.java
@@ -194,7 +194,21 @@ public class AllTests
             while(nRetry-- > 0)
             {
                 replyI.reset();
-                objMcast.ping(reply);
+                try
+                {
+                    objMcast.ping(reply);
+                }
+                catch(Ice.SocketException ex)
+                {
+                    if(communicator.getProperties().getProperty("Ice.IPv6").equals("1"))
+                    {
+                        // Multicast IPv6 not supported on the platform. This occurs for example on macOS big_suir
+                        out.print("(not supported) ");
+                        ret = true;
+                        break;
+                    }
+                    throw ex;
+                }
                 ret = replyI.waitReply(numServers, 2000);
                 if(ret)
                 {

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -178,7 +178,21 @@ public class AllTests
             while(nRetry-- > 0)
             {
                 replyI.reset();
-                objMcast.ping(reply);
+                try
+                {
+                    objMcast.ping(reply);
+                }
+                catch(com.zeroc.Ice.SocketException ex)
+                {
+                    if(communicator.getProperties().getProperty("Ice.IPv6").equals("1"))
+                    {
+                        // Multicast IPv6 not supported on the platform. This occurs for example on macOS big_suir
+                        out.print("(not supported) ");
+                        ret = true;
+                        break;
+                    }
+                    throw ex;
+                }
                 ret = replyI.waitReply(numServers, 2000);
                 if(ret)
                 {

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -134,7 +134,13 @@ public func allTests(_ helper: TestHelper) throws {
 
     for _ in 0 ..< 5 {
         replyI.reset()
-        try objMcast.ping(reply)
+        do {
+            try objMcast.ping(reply)
+        } catch is Ice.SocketException where communicator.getProperties().getProperty("Ice.IPv6") == "1" {
+            out.write("(not supported) ")
+            ret = true
+            break
+        }
         ret = replyI.waitReply(expectedReplies: 5, timeout: 5000)
         if ret {
             break


### PR DESCRIPTION
This PR adds a workaround to the UDP tests to skip multicast IPv6 in platforms that don't support it (big_sur). I didn't test Swift @externl can you give it a try?