### PR TITLE
Fxcop warnings

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2571,11 +2571,13 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
              << p->scoped() << "\";";
 
         _out << sp;
+        emitGeneratedCodeAttribute();
         _out << nl << "public static new string ice_staticId()";
         _out << sb;
         _out << nl << "return _id;";
         _out << eb;
 
+        emitGeneratedCodeAttribute();
         _out << nl << "public override string ice_id()";
         _out << sb;
         _out << nl << "return _id;";


### PR DESCRIPTION
This PR reverts the changes make to use pragmas instead of SuppressMessage attribute as pragma attributes don't work with old FxCopCmd.

The PR also adds missing generated code attribute on some members that were causing warnings with the old FxCop. 

The attached slice2cs contains a binary build with these changes.

[slice2cs.zip](https://github.com/zeroc-ice/ice/files/5694770/slice2cs.zip)
 