### PR TITLE
Use custom trace listener with tests to abort upon failure

### DIFF
--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -26,6 +26,49 @@ namespace Test
 
     public abstract class TestHelper
     {
+        // A custom trace listener that allways aborts the application upon failure.
+        internal class TestTraceListener : DefaultTraceListener
+        {
+            public override void Fail(string message)
+            {
+                Fail(message, null);
+            }
+
+            public override void Fail(string message, string detailMessage)
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("failed:");
+                if (message != null && message.Length > 0)
+                {
+                    sb.Append(message);
+                }
+                sb.Append("\n");
+                if (detailMessage != null && detailMessage.Length > 0)
+                {
+                    sb.Append("details:").Append(detailMessage).Append("\n");
+                }
+                try
+                {
+                    sb.Append(new StackTrace(fNeedFileInfo: true).ToString());
+                }
+                catch
+                {
+                }
+
+                Console.WriteLine(sb.ToString());
+                Environment.Exit(1);
+            }
+        }
+
+        static TestHelper()
+        {
+            // Replace the default trace listeneter that is responsible of displaying the retry/abort dialog
+            // with our custom trace listener that alwways abort upon failure.
+            // see https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.defaulttracelistener?view=net-5.0#remarks
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new TestTraceListener());
+        }
+
         public abstract void run(string[] args);
 
         public string getTestEndpoint(int num = 0, string protocol = "")

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -26,7 +26,7 @@ namespace Test
 
     public abstract class TestHelper
     {
-        // A custom trace listener that allways aborts the application upon failure.
+        // A custom trace listener that always aborts the application upon failure.
         internal class TestTraceListener : DefaultTraceListener
         {
             public override void Fail(string message)

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -64,8 +64,8 @@ namespace Test
         static TestHelper()
         {
             // Replace the default trace listeneter that is responsible of displaying the retry/abort dialog
-            // with our custom trace listener that alwways abort upon failure.
-            // see https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.defaulttracelistener?view=net-5.0#remarks
+            // with our custom trace listener that alwways aborts upon failure.
+            // see: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.defaulttracelistener?view=net-5.0#remarks
             Trace.Listeners.Clear();
             Trace.Listeners.Add(new TestTraceListener());
         }

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -40,6 +40,7 @@ namespace Test
                 sb.Append("failed:");
                 if (message != null && message.Length > 0)
                 {
+                    sb.Append(" ");
                     sb.Append(message);
                 }
                 sb.Append("\n");

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -36,21 +36,19 @@ namespace Test
 
             public override void Fail(string message, string detailMessage)
             {
-                StringBuilder sb = new StringBuilder();
-                sb.Append("failed:");
+                var sb = new StringBuilder();
+                sb.Append("failed:\n");
                 if (message != null && message.Length > 0)
                 {
-                    sb.Append(" ");
-                    sb.Append(message);
+                    sb.Append("message: ").Append(message).Append('\n');
                 }
-                sb.Append("\n");
                 if (detailMessage != null && detailMessage.Length > 0)
                 {
-                    sb.Append("details:").Append(detailMessage).Append("\n");
+                    sb.Append("details: ").Append(detailMessage).Append('\n');
                 }
                 try
                 {
-                    sb.Append(new StackTrace(fNeedFileInfo: true).ToString());
+                    sb.Append(new StackTrace(fNeedFileInfo: true).ToString()).Append('\n');
                 }
                 catch
                 {
@@ -63,8 +61,8 @@ namespace Test
 
         static TestHelper()
         {
-            // Replace the default trace listeneter that is responsible of displaying the retry/abort dialog
-            // with our custom trace listener that alwways aborts upon failure.
+            // Replace the default trace listener that is responsible of displaying the retry/abort dialog
+            // with our custom trace listener that always aborts upon failure.
             // see: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.defaulttracelistener?view=net-5.0#remarks
             Trace.Listeners.Clear();
             Trace.Listeners.Add(new TestTraceListener());


### PR DESCRIPTION
This small PR replaces the default C# trace listener in tests with a custom trace listener that always aborts the application upon failure, this avoids displaying the retry/abort dialog that will make the CI build hangs upon failures.