### PR TITLE
Stream bug fixes

### DIFF
--- a/csharp/src/Ice/ColocatedStream.cs
+++ b/csharp/src/Ice/ColocatedStream.cs
@@ -44,9 +44,9 @@ namespace ZeroC.Ice
                     }
                     else if (buffer.Length < _receiveSegment.Count)
                     {
-                        _receiveSegment.Slice(0, buffer.Length).AsMemory().CopyTo(buffer);
+                        _receiveSegment[0..buffer.Length].AsMemory().CopyTo(buffer);
                         received += buffer.Length;
-                        _receiveSegment = _receiveSegment.Slice(buffer.Length);
+                        _receiveSegment = _receiveSegment[buffer.Length..];
                         buffer = buffer[buffer.Length..];
                     }
                     else
@@ -134,7 +134,7 @@ namespace ZeroC.Ice
                 else
                 {
                     Debug.Assert(expectedFrameType == data[0][0]);
-                    (int size, int sizeLength) = data[0].Slice(1).AsReadOnlySpan().ReadSize20();
+                    (int size, int sizeLength) = data[0][1..].AsReadOnlySpan().ReadSize20();
                     return data[0].Slice(1 + sizeLength, size);
                 }
             }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -308,6 +308,10 @@ namespace ZeroC.Ice
                                                                exception.Message,
                                                                cancel).ConfigureAwait(false);
 
+                    // Make sure to yield to release the mutex. It's important to not hold the mutex because the
+                    // loop below waits for AbortAsync to be called and AbortAsync requires to lock the mutex.
+                    await Task.Yield();
+
                     // Wait for the peer to close the connection.
                     while (true)
                     {

--- a/csharp/src/Ice/MultiStreamSocket.cs
+++ b/csharp/src/Ice/MultiStreamSocket.cs
@@ -557,9 +557,9 @@ namespace ZeroC.Ice
             {
                 var istr = new InputStream(data, encoding);
                 s.Append("\nlast bidirectional stream ID = ");
-                s.Append(istr.ReadVarLong());
+                s.Append(istr.ReadVarULong());
                 s.Append("\nlast unidirectional stream ID = ");
-                s.Append(istr.ReadVarLong());
+                s.Append(istr.ReadVarULong());
                 s.Append("\nmessage from peer = ");
                 s.Append(istr.ReadString());
             }

--- a/csharp/src/Ice/MultiStreamSocket.cs
+++ b/csharp/src/Ice/MultiStreamSocket.cs
@@ -61,12 +61,12 @@ namespace ZeroC.Ice
         internal int OutgoingStreamCount => Thread.VolatileRead(ref _outgoingStreamCount);
 
         private int _incomingStreamCount;
-        // The mutex provides thread-safety for the _observer and LastActivity data members.
+        // The mutex provides thread-safety for the _observer, _streamsAborted and LastActivity data members.
         private readonly object _mutex = new();
         private IConnectionObserver? _observer;
         private int _outgoingStreamCount;
         private readonly ConcurrentDictionary<long, SocketStream> _streams = new();
-        private volatile bool _streamsAborted;
+        private bool _streamsAborted;
         private volatile TaskCompletionSource? _streamsEmptySource;
 
         /// <summary>Aborts the socket.</summary>
@@ -122,15 +122,11 @@ namespace ZeroC.Ice
         /// unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            // Dispose of the control streams. It's possible that non-control streams are still left in the dictionary
-            // if they are being created and added while this socket is being disposed. AddStream will remove them
-            // from the dictionary and throw in this case once it checks for _streamsAborted.
+            // Dispose of the control streams.
             foreach (SocketStream stream in _streams.Values)
             {
-                if (stream.IsControl)
-                {
-                    stream.Dispose();
-                }
+                Debug.Assert(stream.IsControl);
+                stream.Dispose();
             }
         }
 
@@ -219,9 +215,15 @@ namespace ZeroC.Ice
             Abort();
 
             // Consider the abort as graceful if the streams were already aborted.
-            bool graceful = _streamsAborted;
+            bool graceful;
+            lock (_mutex)
+            {
+                graceful = _streamsAborted;
+            }
 
-            // Abort the streams if not already done and wait for all the streams to be completed.
+            // Abort the streams if not already done and wait for all the streams to be completed. It's important to
+            // call this again even if has already been called previously by graceful connection closure. Not all the
+            // streams might have been aborted and at this point we want to make sure all the streams are aborted.
             AbortStreams(exception);
 
             await WaitForEmptyStreamsAsync().ConfigureAwait(false);
@@ -252,8 +254,12 @@ namespace ZeroC.Ice
 
         internal virtual (long, long) AbortStreams(Exception exception, Func<SocketStream, bool>? predicate = null)
         {
-            // Set the _streamsAborted flag to prevent addition of new streams to the _streams collection.
-            _streamsAborted = true;
+            lock (_mutex)
+            {
+                // Set the _streamsAborted flag to prevent addition of new streams by AddStream. No more streams will
+                // be added to _streams once this flag is true.
+                _streamsAborted = true;
+            }
 
             // Cancel the streams based on the given predicate. Control streams are not canceled since they are
             // still needed for sending and receiving GoAway frames.
@@ -282,20 +288,18 @@ namespace ZeroC.Ice
 
         internal void AddStream(long id, SocketStream stream, bool control)
         {
-            _streams[id] = stream;
+            lock (_mutex)
+            {
+                if (_streamsAborted)
+                {
+                    throw new ConnectionClosedException(isClosedByPeer: false, RetryPolicy.AfterDelay(TimeSpan.Zero));
+                }
+                _streams[id] = stream;
+            }
 
             if (!control)
             {
                 Interlocked.Increment(ref stream.IsIncoming ? ref _incomingStreamCount : ref _outgoingStreamCount);
-            }
-
-            // If the socket streams are aborted, we remove the stream from the dictionary and throw. It's important
-            // to do this check after adding the stream to the dictionary since AbortStreams sets this flag before
-            // looping over the streams to abort them.
-            if (_streamsAborted)
-            {
-                RemoveStream(id);
-                throw new ConnectionClosedException(isClosedByPeer: false, RetryPolicy.AfterDelay(TimeSpan.Zero));
             }
         }
 
@@ -452,6 +456,14 @@ namespace ZeroC.Ice
             {
                 s.Append("\nstream ID = ");
                 s.Append(streamId);
+                s.Append((streamId % 4) switch
+                {
+                    0 => " (client-initiated, bidirectional)",
+                    1 => " (server-initiated, bidirectional)",
+                    2 => " (client-initiated, unidirectional)",
+                    3 => " (server-initiated, unidirectional)",
+                    _ => throw new InvalidArgumentException(nameof(streamId))
+                });
             }
             else if (frameType == "Request" || frameType == "Response")
             {
@@ -550,20 +562,23 @@ namespace ZeroC.Ice
                 s.Append("\nnumber of requests = ");
                 s.Append(data.AsReadOnlySpan().ReadInt());
             }
-            else if (protocol == Protocol.Ice2 && frameType == "GoAway")
+            else if (frameType == "GoAway")
             {
-                var istr = new InputStream(data, encoding);
-                s.Append("\nlast bidirectional stream ID = ");
-                s.Append(istr.ReadVarULong());
-                s.Append("\nlast unidirectional stream ID = ");
-                s.Append(istr.ReadVarULong());
-                s.Append("\nmessage from peer = ");
-                s.Append(istr.ReadString());
-            }
-            else
-            {
-                s.Append("\nlast request ID = ");
-                s.Append((int)(LastResponseStreamId >> 2) + 1);
+                if (protocol == Protocol.Ice2)
+                {
+                    var istr = new InputStream(data, encoding);
+                    s.Append("\nlast bidirectional stream ID = ");
+                    s.Append(istr.ReadVarULong());
+                    s.Append("\nlast unidirectional stream ID = ");
+                    s.Append(istr.ReadVarULong());
+                    s.Append("\nmessage from peer = ");
+                    s.Append(istr.ReadString());
+                }
+                else
+                {
+                    s.Append("\nlast request ID = ");
+                    s.Append((int)(LastResponseStreamId >> 2) + 1);
+                }
             }
 
             s.Append('\n');

--- a/csharp/src/Ice/MultiStreamSocket.cs
+++ b/csharp/src/Ice/MultiStreamSocket.cs
@@ -222,10 +222,7 @@ namespace ZeroC.Ice
             bool graceful = _streamsAborted;
 
             // Abort the streams if not already done and wait for all the streams to be completed.
-            if (!_streamsAborted)
-            {
-                AbortStreams(exception);
-            }
+            AbortStreams(exception);
 
             await WaitForEmptyStreamsAsync().ConfigureAwait(false);
 

--- a/csharp/src/Ice/SlicSocket.cs
+++ b/csharp/src/Ice/SlicSocket.cs
@@ -463,11 +463,9 @@ namespace ZeroC.Ice
 
         internal void ReleaseFlowControlCredit(SlicStream stream)
         {
-            if (stream.IsControl)
-            {
-                // Credit isn't acquired for control streams.
-            }
-            else if (stream.IsIncoming)
+            Debug.Assert(!stream.IsControl);
+
+            if (stream.IsIncoming)
             {
                 if (stream.IsBidirectional)
                 {

--- a/csharp/src/Ice/SlicSocket.cs
+++ b/csharp/src/Ice/SlicSocket.cs
@@ -543,7 +543,7 @@ namespace ZeroC.Ice
             }
 
             // Once we acquired the send semaphore, the sending is no longer cancellable. We can't interrupt a
-            // a send on the underlying socket and we want to make sure that once a stream is started, the peer
+            // send on the underlying socket and we want to make sure that once a stream is started, the peer
             // will always receive at least one stream frame.
 
             try

--- a/csharp/src/Ice/SlicSocket.cs
+++ b/csharp/src/Ice/SlicSocket.cs
@@ -28,13 +28,10 @@ namespace ZeroC.Ice
         private long _lastUnidirectionalId;
         private readonly int _maxBidirectionalStreams;
         private readonly int _maxUnidirectionalStreams;
-        // The mutex is used to protect the next stream IDs and the send queue. It's also used to ensure the
-        // stream ID assignment and the sending of the first packet are atomic.
-        private readonly object _mutex = new();
         private long _nextBidirectionalId;
         private long _nextUnidirectionalId;
         private readonly ManualResetValueTaskCompletionSource<int> _receiveStreamCompletionTaskSource = new();
-        private Task _sendTask = Task.CompletedTask;
+        private readonly AsyncSemaphore _sendSemaphore = new AsyncSemaphore(1);
         private readonly BufferedReceiveOverSingleStreamSocket _socket;
         private int _unidirectionalStreamCount;
         private AsyncSemaphore? _unidirectionalStreamSemaphore;
@@ -417,7 +414,7 @@ namespace ZeroC.Ice
             _receiveStreamCompletionTaskSource.SetResult(frameSize - frameOffset);
         }
 
-        internal Task PrepareAndSendFrameAsync(
+        internal async Task PrepareAndSendFrameAsync(
             SlicDefinitions.FrameType type,
             Action<OutputStream>? writer = null,
             long? streamId = null,
@@ -441,14 +438,24 @@ namespace ZeroC.Ice
                 TraceTransportFrame("sending ", type, frameSize, streamId);
             }
 
-            return SendFrameAsync(data, cancel);
+            // Wait for other packets to be sent.
+            await _sendSemaphore.WaitAsync(cancel).ConfigureAwait(false);
+
+            try
+            {
+                await SendPacketAsync(data).ConfigureAwait(false);
+            }
+            finally
+            {
+                _sendSemaphore.Release();
+            }
         }
 
         internal async ValueTask ReceiveDataAsync(Memory<byte> buffer, CancellationToken cancel)
         {
             for (int offset = 0; offset != buffer.Length;)
             {
-                int received = await _socket.ReceiveAsync(buffer.Slice(offset), cancel).ConfigureAwait(false);
+                int received = await _socket.ReceiveAsync(buffer[offset..], cancel).ConfigureAwait(false);
                 offset += received;
                 Received(received);
             }
@@ -471,7 +478,7 @@ namespace ZeroC.Ice
                     Interlocked.Decrement(ref _unidirectionalStreamCount);
                 }
             }
-            else if (stream.IsStarted)
+            else
             {
                 if (stream.IsBidirectional)
                 {
@@ -484,76 +491,66 @@ namespace ZeroC.Ice
             }
         }
 
-        internal Task SendFrameAsync(IList<ArraySegment<byte>> buffer, CancellationToken cancel)
+        internal async ValueTask SendPacketAsync(IList<ArraySegment<byte>> buffer)
         {
-            cancel.ThrowIfCancellationRequested();
-
-            // Synchronization is required here because this might be called concurrently by the connection code
-            lock (_mutex)
-            {
-                ValueTask sendTask = QueueAsync(buffer, cancel);
-                _sendTask = sendTask.IsCompletedSuccessfully ? Task.CompletedTask : sendTask.AsTask();
-                return _sendTask;
-            }
-
-            async ValueTask QueueAsync(IList<ArraySegment<byte>> buffer, CancellationToken cancel)
-            {
-                try
-                {
-                    // Wait for the previous send to complete
-                    await _sendTask.WaitAsync(cancel).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Ignore if it got canceled.
-                }
-
-                // If the send got cancelled, throw to notify the stream of the cancellation. This isn't a fatal
-                // connection error, the next pending frame will be sent.
-                cancel.ThrowIfCancellationRequested();
-
-                // Perform the write
-                int sent = await _socket.SendAsync(buffer, CancellationToken.None).ConfigureAwait(false);
-                Debug.Assert(sent == buffer.GetByteCount());
-                Sent(sent);
-            }
+            // Perform the write
+            int sent = await _socket.SendAsync(buffer, CancellationToken.None).ConfigureAwait(false);
+            Debug.Assert(sent == buffer.GetByteCount());
+            Sent(sent);
         }
 
-        internal async Task SendStreamPacketAsync(
+        internal async ValueTask SendStreamFrameAsync(
             SlicStream stream,
             int packetSize,
             bool fin,
             IList<ArraySegment<byte>> buffer,
             CancellationToken cancel)
         {
-            if (stream.IsStarted)
+            if (stream.IsStarted || stream.IsControl)
             {
-                await stream.SendPacketAsync(packetSize, fin, buffer, cancel).ConfigureAwait(false);
+                // Wait for queued packets to be sent. If this is canceled, the caller is responsible for
+                // ensuring that the flow control credit is released. If it's an incoming stream, the
+                // flow control is released by SlicStream.Dispose(). For outgoing streams, the flow
+                // control will be released once the peer send the StreamLast frame after receiving the
+                // stream reset frame.
+                await _sendSemaphore.WaitAsync(cancel).ConfigureAwait(false);
             }
             else
             {
+                // If the outgoing stream isn't started, we need to acquire flow control credit to ensure
+                // we don't open more streams than the peer allows. The semaphore provides FIFO guarantee
+                // to ensure that the sending of requests is serialized.
                 Debug.Assert(!stream.IsIncoming);
-
-                if (!stream.IsControl)
+                if (stream.IsBidirectional)
                 {
-                    // If the outgoing stream isn't started, it's the first send call. We need to acquire flow
-                    // control credit to ensure we don't open more streams than the peer allows. The semaphore
-                    // provides FIFO guarantee to ensure that the sending of requests is serialized.
-                    if (stream.IsBidirectional)
-                    {
-                        await _bidirectionalStreamSemaphore!.WaitAsync(cancel).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await _unidirectionalStreamSemaphore!.WaitAsync(cancel).ConfigureAwait(false);
-                    }
+                    await _bidirectionalStreamSemaphore!.WaitAsync(cancel).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _unidirectionalStreamSemaphore!.WaitAsync(cancel).ConfigureAwait(false);
                 }
 
-                // Ensure we allocate and queue for sending the first packet atomically to ensure the receiver
-                // won't receive stream frames with out-of-order stream IDs. The ID assignment will throw if
-                // the connection is being closed and no new streams can be created.
-                Task task;
-                lock (_mutex)
+                // Wait for queued packets to be sent.
+                try
+                {
+                    await _sendSemaphore.WaitAsync(cancel).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // The stream isn't started so we're responsible for releasing the flow control we just acquired
+                    // above. No stream reset will be sent to the peer for streams which are not started.
+                    stream.ReleaseFlowControlCredit();
+                    throw;
+                }
+            }
+
+            // Once we acquired the send semaphore, the sending is no longer cancellable. We can't interrupt a
+            // a send on the underlying socket and we want to make sure that once a stream is started, the peer
+            // will always receive at least one stream frame.
+
+            try
+            {
+                if (!stream.IsStarted)
                 {
                     // Allocate a new ID according to the Quic numbering scheme.
                     if (stream.IsBidirectional)
@@ -566,9 +563,61 @@ namespace ZeroC.Ice
                         stream.Id = _nextUnidirectionalId;
                         _nextUnidirectionalId += 4;
                     }
-                    task = stream.SendPacketAsync(packetSize, fin, buffer, cancel);
                 }
-                await task.ConfigureAwait(false);
+
+                // The incoming bidirectional stream is considered completed once no more data will be written on
+                // the stream. It's important to release the flow control credit here before the peer receives the
+                // last stream frame to prevent a race where the peer could start a new stream before the credit
+                // counter is released. If the credit is already released, this indicates that the stream got reset.
+                // In this case, we return since an empty stream last frame has been sent already.
+                if (stream.IsIncoming && fin && !stream.ReleaseFlowControlCredit())
+                {
+                    return;
+                }
+
+                // The given buffer includes space for the Slic header, we subtract the header size from the given
+                // frame size.
+                Debug.Assert(packetSize >= SlicDefinitions.FrameHeader.Length);
+                packetSize -= SlicDefinitions.FrameHeader.Length;
+
+                // Compute how much space the size and stream ID require to figure out the start of the Slic header.
+                int sizeLength = OutputStream.GetVarLongLength(packetSize);
+                int streamIdLength = OutputStream.GetVarLongLength(stream.Id);
+                packetSize += streamIdLength;
+
+                SlicDefinitions.FrameType frameType =
+                    fin ? SlicDefinitions.FrameType.StreamLast : SlicDefinitions.FrameType.Stream;
+
+                // Write the Slic frame header (frameType - byte, frameSize - varint, streamId - varlong). Since
+                // we might not need the full space reserved for the header, we modify the send buffer to ensure
+                // the first element points at the start of the Slic header. We'll restore the send buffer once
+                // the send is complete (it's important for the tracing code which might rely on the encoded
+                // data).
+                ArraySegment<byte> previous = buffer[0];
+                ArraySegment<byte> headerData =
+                    buffer[0].Slice(SlicDefinitions.FrameHeader.Length - sizeLength - streamIdLength - 1);
+                headerData[0] = (byte)frameType;
+                headerData.AsSpan(1, sizeLength).WriteFixedLengthSize20(packetSize);
+                headerData.AsSpan(1 + sizeLength, streamIdLength).WriteFixedLengthVarLong(stream.Id);
+                buffer[0] = headerData;
+
+                if (Endpoint.Communicator.TraceLevels.Transport > 2)
+                {
+                    TraceTransportFrame("sending ", frameType, packetSize, stream.Id);
+                }
+
+                try
+                {
+                    await SendPacketAsync(buffer).ConfigureAwait(false);
+                }
+                finally
+                {
+                    buffer[0] = previous; // Restore the original value of the send buffer.
+                }
+            }
+            finally
+            {
+                _sendSemaphore.Release();
             }
         }
 

--- a/csharp/src/Ice/SlicSocket.cs
+++ b/csharp/src/Ice/SlicSocket.cs
@@ -170,8 +170,8 @@ namespace ZeroC.Ice
                             }
                             catch
                             {
-                                // Ignore, the socket no longer accepts new streams because it's being
-                                // closed or the stream has been disposed shortly after being constructed.
+                                // Ignore, the socket no longer accepts new streams because it's being closed or the
+                                // stream has been disposed shortly after being constructed.
                                 stream?.Dispose();
                             }
 

--- a/csharp/src/Ice/SlicStream.cs
+++ b/csharp/src/Ice/SlicStream.cs
@@ -94,9 +94,8 @@ namespace ZeroC.Ice
             return size;
         }
 
-        protected override async ValueTask ResetAsync(long errorCode)
-        {
-            await _socket.PrepareAndSendFrameAsync(
+        protected override ValueTask ResetAsync(long errorCode) =>
+            new(_socket.PrepareAndSendFrameAsync(
                 SlicDefinitions.FrameType.StreamReset,
                 ostr =>
                 {
@@ -105,8 +104,7 @@ namespace ZeroC.Ice
                         new StreamResetBody((ulong)errorCode).IceWrite(ostr);
                     }
                 },
-                Id).ConfigureAwait(false);
-        }
+                Id));
 
         protected override async ValueTask SendAsync(
             IList<ArraySegment<byte>> buffer,

--- a/csharp/src/Ice/SlicStream.cs
+++ b/csharp/src/Ice/SlicStream.cs
@@ -26,21 +26,16 @@ namespace ZeroC.Ice
             base.Dispose(disposing);
             if (disposing)
             {
-                if (IsSignaled)
+                try
                 {
-                    // If the stream is signaled, it was canceled or discarded. We get the information for the frame
-                    // to receive in order to consume it below.
-                    try
-                    {
-                        ValueTask<(int, bool)> valueTask = WaitSignalAsync(CancellationToken.None);
-                        Debug.Assert(valueTask.IsCompleted);
-                        (_receivedSize, _receivedEndOfStream) = valueTask.Result;
-                        _receivedOffset = 0;
-                    }
-                    catch
-                    {
-                        // Ignore, the stream got aborted and there's nothing to consume.
-                    }
+                    ValueTask<(int, bool)> valueTask = WaitSignalAsync(CancellationToken.None);
+                    Debug.Assert(valueTask.IsCompleted);
+                    (_receivedSize, _receivedEndOfStream) = valueTask.Result;
+                    _receivedOffset = 0;
+                }
+                catch
+                {
+                    // Ignore, there's nothing to consume.
                 }
 
                 // If there's still data pending to be receive for the stream, we notify the socket that

--- a/csharp/src/Ice/SlicStream.cs
+++ b/csharp/src/Ice/SlicStream.cs
@@ -51,9 +51,10 @@ namespace ZeroC.Ice
                     _socket.FinishedReceivedStreamData(Id, _receivedOffset, _receivedSize, _receivedEndOfStream);
                 }
 
-                // Only release incoming streams on Dispose. Slic outgoing streams are released when the StreamLast
-                // frame is received and it can be received after the stream is disposed (e.g.: for oneway requests
-                // we dispose of the stream as soon as the request is sent and before receiving the StreamLast frame).
+                // Only release the flow control credit for incoming streams on Dispose. Flow control for Slic outgoing
+                // streams are released when the StreamLast frame is received and it can be received after the stream
+                // is disposed (e.g.: for oneway requests we dispose the stream as soon as the request is sent and
+                // before receiving the StreamLast frame).
                 if (IsIncoming)
                 {
                     ReleaseFlowControlCredit(notifyPeer: true);
@@ -117,11 +118,12 @@ namespace ZeroC.Ice
 
             int size = buffer.GetByteCount();
 
-            // If the protocol buffer is larger than the configure Slic packet size, send it over multiple Slic packets.
+            // If the protocol buffer is larger than the configured Slic packet size, send the buffer with multiple
+            // Slic stream frames.
             int packetMaxSize = _socket.Endpoint.Communicator.SlicPacketMaxSize;
             if (size > packetMaxSize)
             {
-                // The send buffer for the Slic packet.
+                // The send buffer for the Slic stream frame.
                 var sendBuffer = new List<ArraySegment<byte>>(buffer.Count);
 
                 // The amount of data sent so far.
@@ -137,13 +139,13 @@ namespace ZeroC.Ice
                     int sendSize = 0;
                     if (offset > 0)
                     {
-                        // If it's not the first Slic packet, we re-use the space reserved for Slic header in the first
-                        // segment of the protocol buffer.
+                        // If it's not the first Slic stream frame, we re-use the space reserved for the Slic header in
+                        // the first segment of the protocol buffer.
                         sendBuffer.Add(buffer[0].Slice(0, Header.Length));
                         sendSize += sendBuffer[0].Count;
                     }
 
-                    // Append data until we reach the Slic packet size or the end of the protocol buffer.
+                    // Append data until we reach the Slic packet size or the end of the buffer to send.
                     bool lastBuffer = false;
                     for (int i = start.Segment; i < buffer.Count; ++i)
                     {
@@ -163,19 +165,19 @@ namespace ZeroC.Ice
                         }
                     }
 
-                    // Send the Slic packet.
+                    // Send the Slic stream frame.
                     offset += sendSize;
-                    await _socket.SendStreamPacketAsync(this,
-                                                        sendSize,
-                                                        lastBuffer && fin,
-                                                        sendBuffer,
-                                                        cancel).ConfigureAwait(false);
+                    await _socket.SendStreamFrameAsync(this,
+                                                       sendSize,
+                                                       lastBuffer && fin,
+                                                       sendBuffer,
+                                                       cancel).ConfigureAwait(false);
                 }
             }
             else
             {
-                // If the protocol buffer is small enough to fit in a single Slic packet, send it directly.
-                await _socket.SendStreamPacketAsync(this, size, fin, buffer, cancel).ConfigureAwait(false);
+                // If the buffer to send is small enough to fit in a single Slic stream frame, send it directly.
+                await _socket.SendStreamFrameAsync(this, size, fin, buffer, cancel).ConfigureAwait(false);
             }
         }
 
@@ -209,65 +211,7 @@ namespace ZeroC.Ice
             }
         }
 
-        /// <summary>Send a Slic packet. The first segment of the given buffer always contain space reserved for
-        /// the Slic header.</summary>
-        internal async Task SendPacketAsync(
-            int packetSize,
-            bool fin,
-            IList<ArraySegment<byte>> buffer,
-            CancellationToken cancel)
-        {
-            // The incoming bidirectional stream is considered completed once no more data will be written on
-            // the stream. It's important to release the flow control credit here before the peer receives the
-            // last stream frame to prevent a race where the peer could start a new stream before the credit
-            // counter is released. If the credit is already released, this indicates that the stream got reset.
-            // In this case, we return since an empty stream last frame has been sent already.
-            if (IsIncoming && fin && !ReleaseFlowControlCredit())
-            {
-                return;
-            }
-
-            // The given buffer includes space for the Slic header, we subtract the header size from the given
-            // frame size.
-            Debug.Assert(packetSize >= Header.Length);
-            packetSize -= Header.Length;
-
-            // Compute how much space the size and stream ID require to figure out the start of the Slic header.
-            int sizeLength = OutputStream.GetVarLongLength(packetSize);
-            int streamIdLength = OutputStream.GetVarLongLength(Id);
-            packetSize += streamIdLength;
-
-            SlicDefinitions.FrameType frameType =
-                fin ? SlicDefinitions.FrameType.StreamLast : SlicDefinitions.FrameType.Stream;
-
-            // Write the Slic frame header (frameType - byte, frameSize - varint, streamId - varlong). Since
-            // we might not need the full space reserved for the header, we modify the send buffer to ensure
-            // the first element points at the start of the Slic header. We'll restore the send buffer once
-            // the send is complete (it's important for the tracing code which might rely on the encoded
-            // data).
-            ArraySegment<byte> previous = buffer[0];
-            ArraySegment<byte> headerData = buffer[0].Slice(Header.Length - sizeLength - streamIdLength - 1);
-            headerData[0] = (byte)frameType;
-            headerData.AsSpan(1, sizeLength).WriteFixedLengthSize20(packetSize);
-            headerData.AsSpan(1 + sizeLength, streamIdLength).WriteFixedLengthVarLong(Id);
-            buffer[0] = headerData;
-
-            if (_socket.Endpoint.Communicator.TraceLevels.Transport > 2)
-            {
-                _socket.TraceTransportFrame("sending ", frameType, packetSize, Id);
-            }
-
-            try
-            {
-                await _socket.SendFrameAsync(buffer, cancel).ConfigureAwait(false);
-            }
-            finally
-            {
-                buffer[0] = previous; // Restore the original value of the send buffer.
-            }
-        }
-
-        private bool ReleaseFlowControlCredit(bool notifyPeer = false)
+        internal bool ReleaseFlowControlCredit(bool notifyPeer = false)
         {
             // If the flow control credit is not already released, releases it now.
             if (Interlocked.CompareExchange(ref _flowControlCreditReleased, 1, 0) == 0)
@@ -278,7 +222,7 @@ namespace ZeroC.Ice
                 {
                     // It's important to decrement the stream count before sending the StreamLast frame to prevent
                     // a race where the peer could start a new stream before the counter is decremented.
-                    _socket.PrepareAndSendFrameAsync(SlicDefinitions.FrameType.StreamLast, streamId: Id);
+                    _ = _socket.PrepareAndSendFrameAsync(SlicDefinitions.FrameType.StreamLast, streamId: Id);
                 }
                 return true;
             }

--- a/csharp/src/Ice/SocketStream.cs
+++ b/csharp/src/Ice/SocketStream.cs
@@ -450,6 +450,8 @@ namespace ZeroC.Ice
             }
             catch (OperationCanceledException)
             {
+                // If the stream is not started, there's no need to send a stream reset frame. The stream ID wasn't
+                // allocated and the peer doesn't know about this stream.
                 if (IsStarted && _socket.Endpoint.Protocol != Protocol.Ice1)
                 {
                     await ResetAsync((long)StreamResetErrorCode.RequestCanceled).ConfigureAwait(false);

--- a/csharp/src/Ice/SocketStream.cs
+++ b/csharp/src/Ice/SocketStream.cs
@@ -93,6 +93,8 @@ namespace ZeroC.Ice
             Task.Run(async () =>
                 {
                     // We use the same default buffer size as System.IO.Stream.CopyToAsync()
+                    // TODO: Should this depend on the transport packet size? (Slic default packet size is 32KB for
+                    // example).
                     int bufferSize = 81920;
                     if (ioStream.CanSeek)
                     {

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -1002,30 +1002,18 @@ namespace ZeroC.Ice.Test.Operations
         public void OpSendStream1(Stream p1, Current current, CancellationToken cancel) =>
             CompareStreams(File.OpenRead("AllTests.cs"), p1);
 
-        /// <param name="current">The Current object for the dispatch.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         public void OpSendStream2(string p1, Stream p2, Current current, CancellationToken cancel) =>
             CompareStreams(File.OpenRead(p1), p2);
 
-        /// <param name="current">The Current object for the dispatch.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         public Stream OpGetStream1(Current current, CancellationToken cancel) =>
             File.OpenRead("AllTests.cs");
 
-        /// <param name="current">The Current object for the dispatch.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        /// <returns>Named tuple with the following fields:</returns>
         public (string R1, Stream R2) OpGetStream2(Current current, CancellationToken cancel) =>
             ("AllTests.cs", File.OpenRead("AllTests.cs"));
 
-        /// <param name="current">The Current object for the dispatch.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
         public Stream OpSendAndGetStream1(Stream p1, Current current, CancellationToken cancel) =>
             p1;
 
-        /// <param name="current">The Current object for the dispatch.</param>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        /// <returns>Named tuple with the following fields:</returns>
         public (string R1, Stream R2) OpSendAndGetStream2(
             string p1,
             Stream p2,


### PR DESCRIPTION
This PR provides a number of minor fixes to the transport stream code:
- colocation now copies the data when streaming a System.IO.Stream object
- tracing shows the stream type with the stream ID
- Slic now uses an async semaphore to serialize the sending of frames

It also fixes some race conditions discovered with testing.