### PR TITLE
Fixed communicator shutdown synchronization

### DIFF
--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -259,7 +259,7 @@ namespace ZeroC.Ice
             new ConcurrentDictionary<IRouterPrx, RouterInfo>();
         private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize =
             new Dictionary<Transport, BufWarnSizeInfo>();
-        private Task? _shutdownTask;
+        private SemaphoreSlim? _shutdownSemaphore;
         private TaskCompletionSource<object?>? _waitForShutdownCompletionSource;
 
         private readonly IDictionary<Transport, Ice1EndpointFactory> _ice1TransportRegistry =


### PR DESCRIPTION
This fix ensure the communicator lock isn't held while we loop over the adapters to dispose them.