### PR TITLE
New CompressionFormat and compress(args)

### DIFF
--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -845,9 +845,9 @@ Slice::getBitSequenceSize(const MemberList& members)
 namespace
 {
 
-bool opCompress(const OperationPtr& op, bool params)
+bool opCompress(const OperationPtr& op, bool args)
 {
-    string direction = params ? "params" : "return";
+    string direction = args ? "args" : "return";
     string prefix = "compress:";
     string compress = op->findMetadataWithPrefix(prefix);
 
@@ -862,7 +862,7 @@ bool opCompress(const OperationPtr& op, bool params)
 
 }
 
-bool Slice::opCompressParams(const OperationPtr& op)
+bool Slice::opCompressArgs(const OperationPtr& op)
 {
     return opCompress(op, true);
 }

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -96,8 +96,8 @@ MemberList getClassTypeMembers(const MemberList& members);
 // Returns the size of the bit sequence used to encode the optional elements in this member list.
 size_t getBitSequenceSize(const MemberList&);
 
-// Returns true if the compress:params metadata is set for the operation
-bool opCompressParams(const OperationPtr& op);
+// Returns true if the compress:args metadata is set for the operation
+bool opCompressArgs(const OperationPtr& op);
 
 // Returns true if the compress:return metadata is set for the operation
 bool opCompressReturn(const OperationPtr& op);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2309,7 +2309,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << nl << "proxy,"
                      << nl << "\"" << operation->name() << "\","
                      << nl << "idempotent: " << (operation->isIdempotent() ? "true" : "false") << ","
-                     << nl << "compress: " << (opCompressParams(operation) ? "true" : "false") << ","
+                     << nl << "compress: " << (opCompressArgs(operation) ? "true" : "false") << ","
                      << nl << "format: " << opFormatTypeToString(operation) << ","
                      << nl << "context,"
                      << nl << (inValue ? "in " : "") << "args,"

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -38,7 +38,7 @@ namespace ZeroC.Ice
         private readonly int _maxSize;
 
         /// <summary>Decompresses the encapsulation payload if it is compressed. Compressed encapsulations are only
-        /// supported with 2.0 encoding.</summary>
+        /// supported with the 2.0 encoding.</summary>
         public void DecompressPayload()
         {
             if (PayloadCompressionFormat == CompressionFormat.Decompressed)
@@ -47,15 +47,14 @@ namespace ZeroC.Ice
             }
             else if (PayloadCompressionFormat != CompressionFormat.GZip)
             {
-                throw new NotSupportedException(
-                    $"cannot decompress a payload compressed with compression format {PayloadCompressionFormat}");
+                throw new NotSupportedException($"cannot decompress compression format `{PayloadCompressionFormat}'");
             }
             else
             {
                 int encapsulationOffset = this is IncomingResponseFrame ? 1 : 0;
 
                 ReadOnlySpan<byte> buffer = Payload.Slice(encapsulationOffset);
-                (int size, int sizeLength, Encoding _) = buffer.ReadEncapsulationHeader(Protocol.GetEncoding());
+                (int _, int sizeLength, Encoding _) = buffer.ReadEncapsulationHeader(Protocol.GetEncoding());
 
                 // Read the decompressed size that is written after the compression status byte when the payload is
                 // compressed +3 corresponds to (Encoding 2 bytes, Compression status 1 byte)

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
                 int encapsulationOffset = this is IncomingResponseFrame ? 1 : 0;
 
                 ReadOnlySpan<byte> buffer = Payload.Slice(encapsulationOffset);
-                (int _, int sizeLength, Encoding _) = buffer.ReadEncapsulationHeader(Protocol.GetEncoding());
+                int sizeLength = Protocol == Protocol.Ice1 ? 4 : buffer[0].ReadSizeLength20();
 
                 // Read the decompressed size that is written after the compression status byte when the payload is
                 // compressed +3 corresponds to (Encoding 2 bytes, Compression status 1 byte)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -234,7 +234,7 @@ namespace ZeroC.Ice
 
             if (istr.Pos + size - 2 != data.Count) // - 2 for the encoding encoded on 2 bytes
             {
-                // The payload holds an encapsulation and the encapsulation must use up the full buffer,=.
+                // The payload holds an encapsulation and the encapsulation must use up the full buffer.
                 throw new InvalidDataException($"invalid request encapsulation size: {size}");
             }
 

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -66,7 +66,7 @@ namespace ZeroC.Ice
         /// unknown tagged arguments.</summary>
         public void ReadEmptyArgs()
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -86,7 +86,7 @@ namespace ZeroC.Ice
         /// <returns>The request arguments.</returns>
         public T ReadArgs<T>(Connection connection, InputStreamReader<T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -104,7 +104,7 @@ namespace ZeroC.Ice
         /// <returns>The request argument.</returns>
         public T ReadArgs<T>(Func<SocketStream, T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -129,7 +129,7 @@ namespace ZeroC.Ice
         /// <returns>The request arguments.</returns>
         public T ReadArgs<T>(Connection connection, InputStreamReaderWithStreamable<T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -227,20 +227,21 @@ namespace ZeroC.Ice
                 throw new InvalidDataException("received request with empty operation name");
             }
 
-            (int size, int sizeLength, Encoding encoding) =
-                data.Slice(istr.Pos).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+            Payload = data.Slice(istr.Pos);
 
-            Payload = data.Slice(istr.Pos, size + sizeLength); // the payload is the encapsulation
+            int size;
+            (size, PayloadEncoding) = istr.ReadEncapsulationHeader();
 
-            if (protocol == Protocol.Ice1 && size + 4 + istr.Pos != data.Count)
+            if (istr.Pos + size - 2 != data.Count) // - 2 for the encoding encoded on 2 bytes
             {
-                // The payload holds an encapsulation and the encapsulation must use up the full buffer with ice1.
-                // "4" corresponds to fixed-length size with the 1.1 encoding.
+                // The payload holds an encapsulation and the encapsulation must use up the full buffer,=.
                 throw new InvalidDataException($"invalid request encapsulation size: {size}");
             }
 
-            PayloadEncoding = encoding;
-            HasCompressedPayload = PayloadEncoding == Encoding.V20 && Payload[sizeLength + 2] != 0;
+            if (PayloadEncoding == Encoding.V20)
+            {
+                PayloadCompressionFormat = istr.ReadCompressionFormat();
+            }
         }
 
         /// <summary>Constructs an incoming request frame from an outgoing request frame. Used for colocated calls.
@@ -267,7 +268,7 @@ namespace ZeroC.Ice
             PayloadEncoding = request.PayloadEncoding;
 
             Payload = request.Payload.AsArraySegment();
-            HasCompressedPayload = request.HasCompressedPayload;
+            PayloadCompressionFormat = request.PayloadCompressionFormat;
         }
     }
 }

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -51,7 +51,7 @@ namespace ZeroC.Ice
         /// <returns>The frame return value.</returns>
         public T ReadReturnValue<T>(IObjectPrx proxy, InputStreamReader<T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -81,7 +81,7 @@ namespace ZeroC.Ice
         /// <returns>The frame return value.</returns>
         public T ReadReturnValue<T>(IObjectPrx proxy, InputStreamReaderWithStreamable<T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -123,7 +123,7 @@ namespace ZeroC.Ice
         /// <returns>The frame return value.</returns>
         public T ReadReturnValue<T>(IObjectPrx proxy, Func<SocketStream, T> reader)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -157,7 +157,7 @@ namespace ZeroC.Ice
         /// </param>
         public void ReadVoidReturnValue(IObjectPrx proxy)
         {
-            if (HasCompressedPayload)
+            if (PayloadCompressionFormat != CompressionFormat.Decompressed)
             {
                 DecompressPayload();
             }
@@ -251,7 +251,10 @@ namespace ZeroC.Ice
                         } bytes encapsulation but expected {Payload.Count - 1 - sizeLength} bytes");
                 }
 
-                HasCompressedPayload = PayloadEncoding == Encoding.V20 && Payload[1 + sizeLength + 2] != 0;
+                if (PayloadEncoding == Encoding.V20)
+                {
+                    PayloadCompressionFormat = Payload[1 + sizeLength + 2].AsCompressionFormat();
+                }
             }
         }
 
@@ -267,7 +270,7 @@ namespace ZeroC.Ice
             }
 
             PayloadEncoding = response.PayloadEncoding;
-            HasCompressedPayload = response.HasCompressedPayload;
+            PayloadCompressionFormat = response.PayloadCompressionFormat;
             Payload = response.Payload.AsArraySegment();
         }
 

--- a/csharp/src/Ice/OutgoingFrame.cs
+++ b/csharp/src/Ice/OutgoingFrame.cs
@@ -113,7 +113,7 @@ namespace ZeroC.Ice
                 }
                 else if (format != CompressionFormat.GZip)
                 {
-                    throw new NotSupportedException($"cannot compress payload with compression format {format}");
+                    throw new NotSupportedException($"cannot compress with compression format `{format}'");
                 }
 
                 int encapsulationOffset = this is OutgoingResponseFrame ? 1 : 0;

--- a/csharp/test/Ice/compress/AllTests.cs
+++ b/csharp/test/Ice/compress/AllTests.cs
@@ -16,9 +16,9 @@ namespace ZeroC.Ice.Test.Compress
             for (int size = 1024; size <= 4096; size *= 2)
             {
                 byte[] p1 = Enumerable.Range(0, size).Select(i => (byte)i).ToArray();
-                prx1.OpCompressParams(size, p1);
+                prx1.OpCompressArgs(size, p1);
 
-                byte[] p2 = prx1.OpCompressParamsAndReturn(p1);
+                byte[] p2 = prx1.OpCompressArgsAndReturn(p1);
                 TestHelper.Assert(p1.SequenceEqual(p2));
 
                 p2 = prx1.OpCompressReturn(size);
@@ -38,9 +38,9 @@ namespace ZeroC.Ice.Test.Compress
             for (int size = 2; size < 1024; size *= 2)
             {
                 byte[] p1 = Enumerable.Range(0, size).Select(i => (byte)i).ToArray();
-                prx2.OpCompressParams(size, p1);
+                prx2.OpCompressArgs(size, p1);
 
-                byte[] p2 = prx2.OpCompressParamsAndReturn(p1);
+                byte[] p2 = prx2.OpCompressArgsAndReturn(p1);
                 TestHelper.Assert(p1.SequenceEqual(p2));
 
                 p2 = prx2.OpCompressReturn(size);

--- a/csharp/test/Ice/compress/Test.ice
+++ b/csharp/test/Ice/compress/Test.ice
@@ -18,9 +18,9 @@ exception MyException
 
 interface TestIntf
 {
-    [compress(params)] void opCompressParams(int size, ByteSeq p1);
+    [compress(args)] void opCompressArgs(int size, ByteSeq p1);
     [compress(return)] ByteSeq opCompressReturn(int size);
-    [compress(params, return)] ByteSeq opCompressParamsAndReturn(ByteSeq p1);
+    [compress(args, return)] ByteSeq opCompressArgsAndReturn(ByteSeq p1);
 
     void opWithUserException(int size);
 

--- a/csharp/test/Ice/compress/TestI.cs
+++ b/csharp/test/Ice/compress/TestI.cs
@@ -63,6 +63,16 @@ namespace ZeroC.Ice.Test.Compress
 
             if (response.PayloadEncoding == Encoding.V20 && current.Operation == "opWithUserException")
             {
+                try
+                {
+                    response.CompressPayload((CompressionFormat)2);
+                    TestHelper.Assert(false);
+                }
+                catch (NotSupportedException)
+                {
+                    // expected.
+                }
+
                 response.CompressPayload();
             }
             return response;

--- a/csharp/test/Ice/compress/TestI.cs
+++ b/csharp/test/Ice/compress/TestI.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Compress
             Current current,
             CancellationToken cancel)
         {
-            if (current.Operation == "opCompressParams" || current.Operation == "opCompressParamsAndReturn")
+            if (current.Operation == "opCompressArgs" || current.Operation == "opCompressArgsAndReturn")
             {
                 if (request.PayloadEncoding == Encoding.V20)
                 {
@@ -37,7 +37,7 @@ namespace ZeroC.Ice.Test.Compress
                 }
             }
             OutgoingResponseFrame response = await _servant.DispatchAsync(request, current, cancel);
-            if (current.Operation == "opCompressReturn" || current.Operation == "opCompressParamsAndReturn")
+            if (current.Operation == "opCompressReturn" || current.Operation == "opCompressArgsAndReturn")
             {
                 if (response.PayloadEncoding == Encoding.V20)
                 {
@@ -81,7 +81,7 @@ namespace ZeroC.Ice.Test.Compress
 
     public sealed class TestIntf : ITestIntf
     {
-        public void OpCompressParams(int size, byte[] p1, Current current, CancellationToken cancel)
+        public void OpCompressArgs(int size, byte[] p1, Current current, CancellationToken cancel)
         {
             TestHelper.Assert(size == p1.Length);
             for (int i = 0; i < size; ++i)
@@ -90,7 +90,7 @@ namespace ZeroC.Ice.Test.Compress
             }
         }
 
-        public ReadOnlyMemory<byte> OpCompressParamsAndReturn(byte[] p1, Current current, CancellationToken cancel) =>
+        public ReadOnlyMemory<byte> OpCompressArgsAndReturn(byte[] p1, Current current, CancellationToken cancel) =>
             p1;
 
         public ReadOnlyMemory<byte> OpCompressReturn(int size, Current current, CancellationToken cancel) =>

--- a/slice/Ice/Encoding.ice
+++ b/slice/Ice/Encoding.ice
@@ -26,4 +26,17 @@ module Ice
         /// The minor version number of this version of the Ice encoding.
         byte minor;
     }
+
+#ifdef __SLICE2CS__
+    /// With the 2.0 encoding, the payload of an encapsulation (and by extension the payload of a protocol frame)
+    /// may be compressed. CompressionFormat describes the format of such a payload.
+    unchecked enum CompressionFormat : byte
+    {
+        /// The payload is not compressed and can be read directly.
+        Decompressed = 0,
+
+        /// The payload is compressed using the gzip format.
+        GZip = 1,
+    }
+#endif
 }


### PR DESCRIPTION
This PR introduces a new CompressionFormat enumeration to keep track of the (compression) format of 2.0 encapsulation payloads (default = 0 = Decompressed).

It also renames params to args in the compress metadata, for consistency with Frame API (WithArgs etc.).