### PR TITLE
Read encapsulation header cleanup

### DIFF
--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -179,19 +179,6 @@ namespace ZeroC.Ice
 
         internal static int ReadSizeLength20(this byte b) => b.ReadVarLongLength();
 
-        internal static (long Value, int ValueLength) ReadVarLong(this ReadOnlySpan<byte> buffer)
-        {
-            long value = (buffer[0] & 0x03) switch
-            {
-                0 => buffer[0] >> 2,
-                1 => BitConverter.ToInt16(buffer) >> 2,
-                2 => BitConverter.ToInt32(buffer) >> 2,
-                _ => BitConverter.ToInt64(buffer) >> 2
-            };
-
-            return (value, buffer[0].ReadVarLongLength());
-        }
-
         // Applies to all var type: varlong, varulong etc.
         internal static int ReadVarLongLength(this byte b) => 1 << (b & 0x03);
 

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -149,37 +149,6 @@ namespace ZeroC.Ice
         internal static ReadOnlySpan<T> AsReadOnlySpan<T>(this ArraySegment<T> segment, int start, int length) =>
             segment.AsSpan(start, length);
 
-        internal static (int Size, int SizeLength, Encoding Encoding) ReadEncapsulationHeader(
-            this ReadOnlySpan<byte> buffer,
-            Encoding encoding)
-        {
-            int sizeLength;
-            int size;
-
-            if (encoding == Encoding.V11)
-            {
-                sizeLength = 4;
-                size = buffer.ReadInt() - sizeLength; // Remove the size length which is included with the 1.1 encoding.
-                if (size < 0)
-                {
-                    throw new InvalidDataException(
-                        $"the 1.1 encapsulation's size ({size + sizeLength}) is too small");
-                }
-            }
-            else
-            {
-                (size, sizeLength) = buffer.ReadSize20();
-            }
-
-            if (sizeLength + size > buffer.Length)
-            {
-                throw new InvalidDataException(
-                    $"the encapsulation's size ({size}) extends beyond the end of the buffer");
-            }
-
-            return (size, sizeLength, new Encoding(buffer[sizeLength], buffer[sizeLength + 1]));
-        }
-
         internal static int ReadInt(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt32(buffer);
         internal static long ReadLong(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt64(buffer);
         internal static short ReadShort(this ReadOnlySpan<byte> buffer) => BitConverter.ToInt16(buffer);

--- a/csharp/src/Ice/ByteBufferExtensions.cs
+++ b/csharp/src/Ice/ByteBufferExtensions.cs
@@ -161,22 +161,6 @@ namespace ZeroC.Ice
         internal static string ReadString(this ReadOnlySpan<byte> buffer) =>
             buffer.IsEmpty ? "" : _utf8.GetString(buffer);
 
-        private static (int Size, int SizeLength) ReadSize11(this ReadOnlySpan<byte> buffer)
-        {
-            byte b = buffer[0];
-            if (b < 255)
-            {
-                return (b, 1);
-            }
-
-            int size = buffer.Slice(1, 4).ReadInt();
-            if (size < 0)
-            {
-                throw new InvalidDataException($"read invalid size: {size}");
-            }
-            return (size, 5);
-        }
-
         internal static (int Size, int SizeLength) ReadSize20(this ReadOnlySpan<byte> buffer)
         {
             ulong size = (buffer[0] & 0x03) switch
@@ -208,6 +192,7 @@ namespace ZeroC.Ice
             return (value, buffer[0].ReadVarLongLength());
         }
 
+        // Applies to all var type: varlong, varulong etc.
         internal static int ReadVarLongLength(this byte b) => 1 << (b & 0x03);
 
         internal static (ulong Value, int ValueLength) ReadVarULong(this ReadOnlySpan<byte> buffer)

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
                 int encapsulationOffset = this is IncomingResponseFrame ? 1 : 0;
 
                 ReadOnlySpan<byte> buffer = Payload.Slice(encapsulationOffset);
-                int sizeLength = Protocol == Protocol.Ice1 ? 4 : buffer[0].ReadSizeLength20();
+                int sizeLength = Protocol == Protocol.Ice2 buffer[0].ReadSizeLength20() : 4;
 
                 // Read the decompressed size that is written after the compression status byte when the payload is
                 // compressed +3 corresponds to (Encoding 2 bytes, Compression status 1 byte)

--- a/csharp/src/Ice/IncomingFrame.cs
+++ b/csharp/src/Ice/IncomingFrame.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice
                 int encapsulationOffset = this is IncomingResponseFrame ? 1 : 0;
 
                 ReadOnlySpan<byte> buffer = Payload.Slice(encapsulationOffset);
-                int sizeLength = Protocol == Protocol.Ice2 buffer[0].ReadSizeLength20() : 4;
+                int sizeLength = Protocol == Protocol.Ice2 ? buffer[0].ReadSizeLength20() : 4;
 
                 // Read the decompressed size that is written after the compression status byte when the payload is
                 // compressed +3 corresponds to (Encoding 2 bytes, Compression status 1 byte)

--- a/csharp/src/Ice/IncomingRequestFrame.cs
+++ b/csharp/src/Ice/IncomingRequestFrame.cs
@@ -229,15 +229,7 @@ namespace ZeroC.Ice
 
             Payload = data.Slice(istr.Pos);
 
-            int size;
-            (size, PayloadEncoding) = istr.ReadEncapsulationHeader();
-
-            if (istr.Pos + size - 2 != data.Count) // - 2 for the encoding encoded on 2 bytes
-            {
-                // The payload holds an encapsulation and the encapsulation must use up the full buffer.
-                throw new InvalidDataException($"invalid request encapsulation size: {size}");
-            }
-
+            PayloadEncoding = istr.ReadEncapsulationHeader(checkFullBuffer: true).Encoding;
             if (PayloadEncoding == Encoding.V20)
             {
                 PayloadCompressionFormat = istr.ReadCompressionFormat();

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -198,15 +198,14 @@ namespace ZeroC.Ice
         {
             SocketStream = socketStream;
 
-            bool hasEncapsulation = false;
+            var istr = new InputStream(data, Protocol.GetEncoding());
 
+            bool hasEncapsulation = false;
             if (Protocol == Protocol.Ice1)
             {
-                Payload = data;
+                Payload = data; // there is no response frame header with ice1
 
-                ReplyStatus replyStatus = Payload[0].AsReplyStatus();
-
-                if ((byte)replyStatus <= (byte)ReplyStatus.UserException)
+                if ((byte)istr.ReadReplyStatus() <= (byte)ReplyStatus.UserException)
                 {
                     hasEncapsulation = true;
                 }
@@ -218,7 +217,6 @@ namespace ZeroC.Ice
             else
             {
                 Debug.Assert(Protocol == Protocol.Ice2);
-                var istr = new InputStream(data, Protocol.GetEncoding());
                 int headerSize = istr.ReadSize();
                 int startPos = istr.Pos;
                 BinaryContext = istr.ReadBinaryContext();
@@ -230,21 +228,22 @@ namespace ZeroC.Ice
                 }
 
                 Payload = data.Slice(istr.Pos);
-
-                _ = Payload[0].AsResultType(); // just to check the value
+                _ = istr.ReadResultType(); // just to check the value
                 hasEncapsulation = true;
             }
 
-            // Read encapsulation header, in particular the payload encoding.
             if (hasEncapsulation)
             {
+                // Read encapsulation header, in particular the payload encoding.
+
+                int startPos = istr.Pos;
                 int size;
-                int sizeLength;
+                (size, PayloadEncoding) = istr.ReadEncapsulationHeader();
 
-                (size, sizeLength, PayloadEncoding) =
-                    Payload.Slice(1).AsReadOnlySpan().ReadEncapsulationHeader(Protocol.GetEncoding());
+                int sizeLength = istr.Pos - startPos - 2; // - 2 is for the 2 bytes of the encoding.
 
-                if (Payload.Count - 1 != size + sizeLength)
+                // The encapsulation starts at Payload[1], hence - 1.
+                if (size != Payload.Count - 1 - sizeLength)
                 {
                     throw new InvalidDataException(
                         @$"received {Protocol.GetName()} response frame with a {size
@@ -253,7 +252,7 @@ namespace ZeroC.Ice
 
                 if (PayloadEncoding == Encoding.V20)
                 {
-                    PayloadCompressionFormat = Payload[1 + sizeLength + 2].AsCompressionFormat();
+                    PayloadCompressionFormat = istr.ReadCompressionFormat();
                 }
             }
         }

--- a/csharp/src/Ice/IncomingResponseFrame.cs
+++ b/csharp/src/Ice/IncomingResponseFrame.cs
@@ -236,19 +236,7 @@ namespace ZeroC.Ice
             {
                 // Read encapsulation header, in particular the payload encoding.
 
-                int startPos = istr.Pos;
-                int size;
-                (size, PayloadEncoding) = istr.ReadEncapsulationHeader();
-
-                int sizeLength = istr.Pos - startPos - 2; // - 2 is for the 2 bytes of the encoding.
-
-                // The encapsulation starts at Payload[1], hence - 1.
-                if (size != Payload.Count - 1 - sizeLength)
-                {
-                    throw new InvalidDataException(
-                        @$"received {Protocol.GetName()} response frame with a {size
-                        } bytes encapsulation but expected {Payload.Count - 1 - sizeLength} bytes");
-                }
+                PayloadEncoding = istr.ReadEncapsulationHeader(checkFullBuffer: true).Encoding;
 
                 if (PayloadEncoding == Encoding.V20)
                 {

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1082,7 +1082,7 @@ namespace ZeroC.Ice
             if (OldEncoding)
             {
                 size = ReadInt();
-                if (size < 0)
+                if (size < 4)
                 {
                     throw new InvalidDataException($"the 1.1 encapsulation's size ({size}) is too small");
                 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1020,26 +1020,19 @@ namespace ZeroC.Ice
 
             if (startEncapsulation)
             {
-                (int size, Encoding encapsEncoding) = ReadEncapsulationHeader();
-
                 // When startEncapsulation is true, the buffer must extend until the end of the encapsulation - it
                 // cannot include extra bytes.
-                if (Pos + size - 2 != _buffer.Length)
-                {
-                    throw new InvalidDataException(
-                        $"{_buffer.Length - Pos - size - 2} bytes left in buffer after the encapsulation");
-                }
+                Encoding = ReadEncapsulationHeader(checkFullBuffer: true).Encoding;
+                Encoding.CheckSupported();
 
                 // We slice the provided buffer to the encapsulation (minus its header).
                 _buffer = buffer.Slice(Pos);
                 Pos = 0;
-                Encoding = encapsEncoding;
-                Encoding.CheckSupported();
 
-                if (encapsEncoding == Encoding.V20)
+                if (Encoding == Encoding.V20)
                 {
-                    byte compressionStatus = ReadByte();
-                    if (compressionStatus != 0)
+                    CompressionFormat compressionFormat = this.ReadCompressionFormat();
+                    if (compressionFormat != CompressionFormat.Decompressed)
                     {
                         throw new InvalidDataException("the buffer encapsulation is compressed");
                     }
@@ -1078,26 +1071,37 @@ namespace ZeroC.Ice
         }
 
         /// <summary>Reads an encapsulation header from the stream.</summary>
-        /// <returns>The encapsulation header read from the stream.</returns>
-        internal (int Size, Encoding Encoding) ReadEncapsulationHeader()
+        /// <param name="checkFullBuffer">When true, the encapsulation is expected to consume all the bytes of the
+        /// current buffer. When false, bytes can remain in the buffer after the encapsulation.</param>
+        /// <returns>The encapsulation header read from the stream. The size does not include the bytes to the size
+        /// length; it does however include the two byte for the encoding.</returns>
+        internal (int Size, Encoding Encoding) ReadEncapsulationHeader(bool checkFullBuffer)
         {
             int size;
 
             if (OldEncoding)
             {
-                size = ReadInt() - 4; // remove the size length which is included with the 1.1 encoding.
+                size = ReadInt();
                 if (size < 0)
                 {
-                    // add back size length to print the value that was read.
-                    throw new InvalidDataException($"the 1.1 encapsulation's size ({size + 4}) is too small");
+                    throw new InvalidDataException($"the 1.1 encapsulation's size ({size}) is too small");
                 }
+                size -= 4; // remove the size length which is included with the 1.1 encoding
             }
             else
             {
                 size = ReadSize20();
             }
 
-            if (Pos + size > _buffer.Length)
+            if (checkFullBuffer)
+            {
+                if (size != _buffer.Length - Pos)
+                {
+                    throw new InvalidDataException(
+                        $"expected an encapsulation size of {_buffer.Length - Pos} bytes, but read {size}");
+                }
+            }
+            else if (size > _buffer.Length - Pos)
             {
                 throw new InvalidDataException(
                     $"the encapsulation's size ({size}) extends beyond the end of the buffer");
@@ -1118,7 +1122,7 @@ namespace ZeroC.Ice
             if (protocol == Protocol.Ice1 || OldEncoding)
             {
                 Transport transport = this.ReadTransport();
-                (int size, Encoding encoding) = ReadEncapsulationHeader();
+                (int size, Encoding encoding) = ReadEncapsulationHeader(checkFullBuffer: false);
 
                 Ice1EndpointFactory? ice1Factory = protocol == Protocol.Ice1 && encoding.IsSupported ?
                     Communicator.FindIce1EndpointFactory(transport) : null;


### PR DESCRIPTION
This PR removes the static ReadEncapsulationHeader and moves encapsulation-size checks to InputStream.ReadEncapsulationHeader.