### PR TITLE
Switched some C# tests to the new TestHelper

### DIFF
--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -11,9 +11,11 @@ namespace ZeroC.Ice.Test.ACM
         {
             await Communicator.ActivateAsync();
             Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+
             ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());
             await adapter.ActivateAsync();
+
             ServerReady();
             Communicator.SetProperty("Ice.PrintAdapterReady", "0");
             await Communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -3,16 +3,17 @@
 using System;
 using System.IO;
 using System.Linq;
-using Test;
+using System.Threading.Tasks;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {
     public static class AllTests
     {
-        public static ITestIntfPrx Run(TestHelper helper)
+        public static Task RunAsync(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator;
-            TestHelper.Assert(communicator != null);
+            Communicator communicator = helper.Communicator;
+
             bool ice1 = TestHelper.GetTestProtocol(communicator.GetProperties()) == Protocol.Ice1;
             TextWriter output = helper.Output;
             output.Write("testing stringToProxy... ");
@@ -251,7 +252,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             {
                 output.WriteLine("ok");
             }
-            return obj;
+            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/adapterDeactivation/Client.cs
+++ b/csharp/test/Ice/adapterDeactivation/Client.cs
@@ -1,18 +1,18 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args)
-        {
-            await using Communicator communicator = Initialize(ref args);
-            AllTests.Run(this);
-        }
+        public override Task RunAsync(string[] args) => AllTests.RunAsync(this);
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Client>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/adapterDeactivation/Collocated.cs
+++ b/csharp/test/Ice/adapterDeactivation/Collocated.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {
@@ -9,16 +9,19 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
     {
         public override async Task RunAsync(string[] args)
         {
-            await using Communicator communicator = Initialize(ref args);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
 
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.AddDefault(new Servant());
 
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Collocated>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Collocated>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/adapterDeactivation/Servant.cs
+++ b/csharp/test/Ice/adapterDeactivation/Servant.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {

--- a/csharp/test/Ice/adapterDeactivation/Server.cs
+++ b/csharp/test/Ice/adapterDeactivation/Server.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {
@@ -9,16 +9,21 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
     {
         public override async Task RunAsync(string[] args)
         {
-            await using Communicator communicator = Initialize(ref args);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.AddDefault(new Servant());
             await adapter.ActivateAsync();
+
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await Communicator.WaitForShutdownAsync();
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Server>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/adapterDeactivation/TestI.cs
+++ b/csharp/test/Ice/adapterDeactivation/TestI.cs
@@ -2,7 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AdapterDeactivation
 {

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -4,7 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using Test;
+using System.Threading.Tasks;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Admin
 {
@@ -120,10 +121,10 @@ namespace ZeroC.Ice.Test.Admin
             }
         }
 
-        public static void Run(TestHelper helper)
+        public static Task RunAsync(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator;
-            TestHelper.Assert(communicator != null);
+            Communicator communicator = helper.Communicator;
+
             TextWriter output = helper.Output;
             bool ice1 = helper.Protocol == Protocol.Ice1;
 
@@ -620,6 +621,7 @@ namespace ZeroC.Ice.Test.Admin
             output.WriteLine("ok");
 
             factory.Shutdown();
+            return Task.CompletedTask;
         }
 
         private class RemoteLogger : IRemoteLogger

--- a/csharp/test/Ice/admin/Client.cs
+++ b/csharp/test/Ice/admin/Client.cs
@@ -1,19 +1,19 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Admin
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args)
-        {
-            await using Communicator communicator = Initialize(ref args);
-            await communicator.ActivateAsync();
-            AllTests.Run(this);
-        }
+        public override Task RunAsync(string[] args) => AllTests.RunAsync(this);
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            await communicator.ActivateAsync();
+            return await RunTestAsync<Client>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/admin/Server.cs
+++ b/csharp/test/Ice/admin/Server.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Admin
 {
@@ -9,16 +9,21 @@ namespace ZeroC.Ice.Test.Admin
     {
         public override async Task RunAsync(string[] args)
         {
-            await using Communicator communicator = Initialize(ref args);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("factory", new RemoteCommunicatorFactoryI());
             await adapter.ActivateAsync();
+
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await Communicator.WaitForShutdownAsync();
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            await using var communicator = CreateCommunicator(ref args);
+            return await RunTestAsync<Server>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Admin
 {

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AMI
 {
@@ -98,10 +98,10 @@ namespace ZeroC.Ice.Test.AMI
             }
         }
 
-        public static void Run(TestHelper helper)
+        public static Task RunAsync(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator;
-            TestHelper.Assert(communicator != null);
+            Communicator communicator = helper.Communicator;
+
             bool ice1 = helper.Protocol == Protocol.Ice1;
 
             var p = ITestIntfPrx.Parse(helper.GetTestProxy("test", 0), communicator);
@@ -293,7 +293,7 @@ namespace ZeroC.Ice.Test.AMI
                     TestHelper.Assert(ex.InnerException is NoEndpointException);
                 }
 
-                Communicator ic = helper.Initialize(communicator.GetProperties());
+                Communicator ic = TestHelper.CreateCommunicator(communicator.GetProperties());
                 var p2 = ITestIntfPrx.Parse(p.ToString()!, ic);
                 ic.Dispose();
 
@@ -881,6 +881,7 @@ namespace ZeroC.Ice.Test.AMI
             output.WriteLine("ok");
 
             p.Shutdown();
+            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/ami/Client.cs
+++ b/csharp/test/Ice/ami/Client.cs
@@ -1,25 +1,26 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AMI
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args)
+        public override Task RunAsync(string[] args) => AllTests.RunAsync(this);
+
+        public static async Task<int> Main(string[] args)
         {
-            System.Collections.Generic.Dictionary<string, string> properties = CreateTestProperties(ref args);
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Warn.AMICallback"] = "0";
             properties["Ice.Warn.Connections"] = "0";
-
             // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
             // of data.
             properties["Ice.TCP.SndSize"] = "50K";
-            await using Communicator communicator = Initialize(properties);
-            AllTests.Run(this);
-        }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<Client>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AMI
 {
@@ -10,34 +10,35 @@ namespace ZeroC.Ice.Test.AMI
     {
         public override async Task RunAsync(string[] args)
         {
-            Dictionary<string, string>? properties = CreateTestProperties(ref args);
+            await Communicator.ActivateAsync();
 
-            properties["Ice.Warn.AMICallback"] = "0";
-            // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
-            // of data.
-            properties["Ice.TCP.SndSize"] = "50K";
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            Communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
 
-            // This test kills connections, so we don't want warnings.
-            properties["Ice.Warn.Connections"] = "0";
-
-            await using Communicator communicator = Initialize(properties);
-            await communicator.ActivateAsync();
-
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());
             adapter.Add("test2", new TestIntf2());
             // Don't activate OA to ensure collocation is used.
 
-            ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2", serializeDispatch: true);
+            ObjectAdapter adapter2 = Communicator.CreateObjectAdapter("TestAdapter2", serializeDispatch: true);
             adapter2.Add("serialized", new TestIntf());
             // Don't activate OA to ensure collocation is used.
 
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Collocated>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
+            properties["Ice.Warn.AMICallback"] = "0";
+            // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount
+            // of data.
+            properties["Ice.TCP.SndSize"] = "50K";
+            // This test kills connections, so we don't want warnings.
+            properties["Ice.Warn.Connections"] = "0";
+
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<Collocated>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -1,7 +1,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AMI
 {
@@ -9,36 +10,36 @@ namespace ZeroC.Ice.Test.AMI
     {
         public override async Task RunAsync(string[] args)
         {
-            System.Collections.Generic.Dictionary<string, string> properties = CreateTestProperties(ref args);
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            Communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
 
-            // This test kills connections, so we don't want warnings.
-            properties["Ice.Warn.Connections"] = "0";
-
-            // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given amount
-            // of data.
-            properties["Ice.TCP.RcvSize"] = "50K";
-
-            // The client sends large payloads to block in send()
-            properties["Ice.IncomingFrameMaxSize"] = "15M";
-
-            await using Communicator communicator = Initialize(properties);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());
             adapter.Add("test2", new TestIntf2());
             await adapter.ActivateAsync();
 
-            ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2", serializeDispatch: true);
+            ObjectAdapter adapter2 = Communicator.CreateObjectAdapter("TestAdapter2", serializeDispatch: true);
             adapter2.Add("serialized", new TestIntf());
             await adapter2.ActivateAsync();
 
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await Communicator.WaitForShutdownAsync();
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
+            // This test kills connections, so we don't want warnings.
+            properties["Ice.Warn.Connections"] = "0";
+            // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given amount
+            // of data.
+            properties["Ice.TCP.RcvSize"] = "50K";
+            // The client sends large payloads to block in send()
+            properties["Ice.IncomingFrameMaxSize"] = "15M";
+
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<Server>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -2,7 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.AMI
 {

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Binding
 {
@@ -33,11 +33,11 @@ namespace ZeroC.Ice.Test.Binding
             }
         }
 
-        public static void Run(TestHelper helper)
+        public static Task RunAsync(TestHelper helper)
         {
-            Communicator? communicator = helper.Communicator;
+            Communicator communicator = helper.Communicator;
             bool ice1 = helper.Protocol == Protocol.Ice1;
-            TestHelper.Assert(communicator != null);
+
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
             string testTransport = helper.Transport;
 
@@ -574,6 +574,7 @@ namespace ZeroC.Ice.Test.Binding
             }
 
             com.Shutdown();
+            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/binding/Client.cs
+++ b/csharp/test/Ice/binding/Client.cs
@@ -2,25 +2,24 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Binding
 {
     public class Client : TestHelper
     {
-        public override async Task RunAsync(string[] args)
+        public override Task RunAsync(string[] args) => AllTests.RunAsync(this);
+
+        public static async Task<int> Main(string[] args)
         {
             Dictionary<string, string> properties = CreateTestProperties(ref args);
-
             // Under out-of-FDs conditions, the server might close the connection after it accepted it and
             // sent the connection validation message (the failure typically occurs when calling StartRead on
             // the transport).
             properties["Ice.Warn.Connections"] = "0";
 
-            await using Communicator communicator = Initialize(properties);
-            AllTests.Run(this);
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<Client>(communicator, args);
         }
-
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);
     }
 }

--- a/csharp/test/Ice/binding/RemoteCommunicatorI.cs
+++ b/csharp/test/Ice/binding/RemoteCommunicatorI.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 using System.Threading;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Binding
 {

--- a/csharp/test/Ice/binding/Server.cs
+++ b/csharp/test/Ice/binding/Server.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Binding
 {
@@ -10,18 +10,23 @@ namespace ZeroC.Ice.Test.Binding
     {
         public override async Task RunAsync(string[] args)
         {
-            Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.ServerIdleTime"] = "30";
-            await using Communicator communicator = Initialize(properties);
-            await communicator.ActivateAsync();
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
+            await Communicator.ActivateAsync();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("communicator", new RemoteCommunicator());
             await adapter.ActivateAsync();
+
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await Communicator.WaitForShutdownAsync();
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
+            properties["Ice.ServerIdleTime"] = "30";
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<Server>(communicator, args);
+        }
     }
 }


### PR DESCRIPTION
This PR switches the `adapterDeactivation`, `admin`, `ami`, and `binding` tests to use the new TestHelper class, and also attempts to make them more consistent in their style and structure.