### PR TITLE
Avoid clear locator cache during invocation retries

### DIFF
--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -442,8 +442,7 @@ namespace ZeroC.Ice
                     else
                     {
                         // Cache the resolved location
-                        TimeSpan insertionTime = Time.Elapsed;
-                        _locationCache[(location, protocol)] = (insertionTime, endpoints);
+                        _locationCache[(location, protocol)] = (Time.Elapsed, endpoints);
                         return endpoints;
                     }
                 }

--- a/csharp/src/Ice/LocatorInfo.cs
+++ b/csharp/src/Ice/LocatorInfo.cs
@@ -135,7 +135,7 @@ namespace ZeroC.Ice
                 bool expired = CheckExpired(endpointsAge, reference.LocatorCacheTimeout);
                 if (endpoints.Count == 0 ||
                     (!_background && expired) ||
-                    endpointsAge > endpointsMaxAge ||
+                    endpointsAge >= endpointsMaxAge ||
                     (reference.IsWellKnown && locationAge <= endpointsAge))
                 {
                     try

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1464,7 +1464,6 @@ namespace ZeroC.Ice
                             {
                                 endpointsMaxAge = endpointsAge;
                                 endpoints = null;
-                                break;
                             }
                             else
                             {

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1460,8 +1460,10 @@ namespace ZeroC.Ice
                         // Ignore the exception unless this is the last endpoint.
                         if (ReferenceEquals(endpoint, last))
                         {
-                            if (IsIndirect && endpointsMaxAge == TimeSpan.MaxValue)
+                            if (IsIndirect && endpointsAge != TimeSpan.Zero && endpointsMaxAge == TimeSpan.MaxValue)
                             {
+                                // If the first lookup for an indirect reference returns an endpoint from the cache, set
+                                // endpointsMaxAge to force a new locator lookup for a fresher endpoint.
                                 endpointsMaxAge = endpointsAge;
                                 endpoints = null;
                             }

--- a/csharp/src/Ice/Reference.cs
+++ b/csharp/src/Ice/Reference.cs
@@ -1331,7 +1331,8 @@ namespace ZeroC.Ice
             }
         }
 
-        private async ValueTask<(List<Endpoint> Endpoints, bool Cached)> ComputeEndpointsAsync(
+        private async ValueTask<(List<Endpoint> Endpoints, TimeSpan EndpointsAge)> ComputeEndpointsAsync(
+            TimeSpan endpointsMaxAge,
             CancellationToken cancel)
         {
             Debug.Assert(!IsFixed);
@@ -1340,7 +1341,7 @@ namespace ZeroC.Ice
             if (InvocationMode != InvocationMode.Datagram &&
                 Communicator.GetColocatedEndpoint(this) is Endpoint colocatedEndpoint)
             {
-                return (new List<Endpoint>() { colocatedEndpoint }, false);
+                return (new List<Endpoint>() { colocatedEndpoint }, TimeSpan.Zero);
             }
 
             IReadOnlyList<Endpoint>? endpoints = ImmutableArray<Endpoint>.Empty;
@@ -1350,7 +1351,7 @@ namespace ZeroC.Ice
                 endpoints = await RouterInfo.GetClientEndpointsAsync(cancel).ConfigureAwait(false);
             }
 
-            bool cached = false;
+            TimeSpan endpointsAge = TimeSpan.Zero;
             if (endpoints.Count == 0)
             {
                 // Get the proxy's endpoint or query the locator to get endpoints
@@ -1360,13 +1361,15 @@ namespace ZeroC.Ice
                 }
                 else if (LocatorInfo != null)
                 {
-                    (endpoints, cached) =
-                        await LocatorInfo.ResolveIndirectReferenceAsync(this, cancel).ConfigureAwait(false);
+                    (endpoints, endpointsAge) =
+                        await LocatorInfo.ResolveIndirectReferenceAsync(this,
+                                                                        endpointsMaxAge,
+                                                                        cancel).ConfigureAwait(false);
                 }
             }
 
             // Apply overrides and filter endpoints
-            List<Endpoint> filteredEndpoints = endpoints.Where(endpoint =>
+            var filteredEndpoints = endpoints.Where(endpoint =>
             {
                 // Filter out opaque and universal endpoints
                 if (endpoint is OpaqueEndpoint || endpoint is UniversalEndpoint)
@@ -1400,7 +1403,7 @@ namespace ZeroC.Ice
             {
                 filteredEndpoints = Communicator.OrderEndpointsByTransportFailures(filteredEndpoints);
             }
-            return (filteredEndpoints, cached);
+            return (filteredEndpoints, endpointsAge);
         }
         internal Connection? GetCachedConnection() => _connection;
 
@@ -1415,12 +1418,13 @@ namespace ZeroC.Ice
                 cancel,
                 Communicator.CancellationToken);
             cancel = linkedCancellationSource.Token;
-            bool cached;
+            TimeSpan endpointsAge = TimeSpan.Zero;
+            TimeSpan endpointsMaxAge = Timeout.InfiniteTimeSpan;
             List<Endpoint>? endpoints = null;
             if ((connection == null || (!IsFixed && !connection.IsActive)) && PreferExistingConnection)
             {
                 // No cached connection, so now check if there is an existing connection that we can reuse.
-                (endpoints, cached) = await ComputeEndpointsAsync(cancel).ConfigureAwait(false);
+                (endpoints, endpointsAge) = await ComputeEndpointsAsync(endpointsMaxAge, cancel).ConfigureAwait(false);
                 connection = Communicator.GetConnection(endpoints, PreferNonSecure, Label);
                 if (CacheConnection)
                 {
@@ -1428,11 +1432,11 @@ namespace ZeroC.Ice
                 }
             }
 
-            if (connection == null)
+            while (connection == null && endpointsMaxAge == Timeout.InfiniteTimeSpan)
             {
                 if (endpoints == null)
                 {
-                    (endpoints, cached) = await ComputeEndpointsAsync(cancel).ConfigureAwait(false);
+                    (endpoints, endpointsAge) = await ComputeEndpointsAsync(endpointsMaxAge, cancel).ConfigureAwait(false);
                 }
 
                 Endpoint last = endpoints[^1];
@@ -1453,10 +1457,16 @@ namespace ZeroC.Ice
                     catch
                     {
                         // Ignore the exception unless this is the last endpoint.
-                        // TODO retry with non cached endpoints
                         if (ReferenceEquals(endpoint, last))
                         {
-                            throw;
+                            if (IsIndirect && endpointsAge != TimeSpan.Zero)
+                            {
+                                endpointsMaxAge = endpointsAge;
+                            }
+                            else
+                            {
+                                throw;
+                            }
                         }
                     }
                 }
@@ -1746,13 +1756,14 @@ namespace ZeroC.Ice
             CancellationToken cancel)
         {
             Connection? connection = _connection;
-            bool cached = false;
+            TimeSpan endpointsMaxAge = Timeout.InfiniteTimeSpan;
+            TimeSpan endpointsAge = TimeSpan.Zero;
             List<Endpoint>? endpoints = null;
 
             if ((connection == null || (!IsFixed && !connection.IsActive)) && PreferExistingConnection)
             {
                 // No cached connection, so now check if there is an existing connection that we can reuse.
-                (endpoints, cached) = await ComputeEndpointsAsync(cancel).ConfigureAwait(false);
+                (endpoints, endpointsAge) = await ComputeEndpointsAsync(endpointsMaxAge, cancel).ConfigureAwait(false);
                 connection = Communicator.GetConnection(endpoints, PreferNonSecure, Label);
                 if (CacheConnection)
                 {
@@ -1779,15 +1790,16 @@ namespace ZeroC.Ice
                     {
                         if (endpoints == null)
                         {
+                            Debug.Assert(nextEndpoint == 0);
                             // ComputeEndpointsAsync throws if it can't figure out the endpoints
-                            // TODO ComputeEndpointsAsync should return a integer indicating the locator cache version,
-                            // -1 indicates the locator was not contacted.
-                            (endpoints, cached) = await ComputeEndpointsAsync(cancel).ConfigureAwait(false);
+                            (endpoints, endpointsAge) = await ComputeEndpointsAsync(endpointsMaxAge,
+                                                                                    cancel).ConfigureAwait(false);
                             if (excludedEndpoints != null)
                             {
                                 endpoints = endpoints.Except(excludedEndpoints).ToList();
                                 if (endpoints.Count == 0)
                                 {
+                                    endpoints = null;
                                     throw new NoEndpointException();
                                 }
                             }
@@ -1859,7 +1871,7 @@ namespace ZeroC.Ice
                     }
                     observer?.RemoteException();
                 }
-                catch (NoEndpointException ex) when (!cached)
+                catch (NoEndpointException ex) when (endpointsAge == TimeSpan.Zero)
                 {
                     // If we get NoEndpointException while using non cached endpoints, either all endpoints
                     // have been excluded or the proxy has no endpoints. we cannot retry, return here to
@@ -1887,28 +1899,26 @@ namespace ZeroC.Ice
 
                 // With the retry-policy OtherReplica we add the current endpoint to the list of excluded
                 // endpoints this prevents the endpoints to be tried again during the current retry sequence.
-                if (retryPolicy == RetryPolicy.OtherReplica)
+                if (retryPolicy == RetryPolicy.OtherReplica &&
+                    (endpoints?[nextEndpoint] ?? connection?.Endpoint) is Endpoint endpoint)
                 {
-                    if ((endpoints?[nextEndpoint] ?? connection?.Endpoint) is Endpoint endpoint)
-                    {
-                        excludedEndpoints ??= new();
-                        excludedEndpoints.Add(endpoint);
-                    }
+                    excludedEndpoints ??= new();
+                    excludedEndpoints.Add(endpoint);
                 }
 
                 if (endpoints != null && (connection == null || retryPolicy == RetryPolicy.OtherReplica))
                 {
                     // If connection establishment failed or if the endpoint was excluded, try the next endpoint
                     nextEndpoint = ++nextEndpoint % endpoints.Count;
-
                     if (nextEndpoint == 0)
                     {
                         // nextendpoint == 0 indicates that we already tried all the endpoints.
-                        if (cached)
+                        if (endpointsAge != TimeSpan.Zero)
                         {
-                            // If we were using cached endpoints, we clear the endpoints to trigger a new endpoint
-                            // lookup.
+                            // If we were using cached endpoints, we clear the endpoints, and set endpointsMaxAge to
+                            // request a fresher endpoint.
                             endpoints = null;
+                            endpointsMaxAge = endpointsAge;
                         }
                         else
                         {
@@ -1981,11 +1991,12 @@ namespace ZeroC.Ice
 
                     observer?.Retried();
 
-                    // TODO remove this when we implement the locator cache serial, that will retrieve a fresh endpoint
-                    // based on the previous serial.
-                    if (cached && IsIndirect)
+                    // If an indirect reference is using a endpoint from the cache, set endpointsMaxAge to force
+                    // a new locator lookup.
+                    if (IsIndirect && endpointsAge != TimeSpan.Zero)
                     {
-                        LocatorInfo?.ClearCache(this);
+                        endpointsMaxAge = endpointsAge;
+                        endpoints = null;
                     }
 
                     if (!IsFixed && connection != null)
@@ -2001,7 +2012,7 @@ namespace ZeroC.Ice
             observer?.Failed(exception?.GetType().FullName ?? "System.Exception");
             Debug.Assert(response != null || exception != null);
             Debug.Assert(response == null || response.ResultType == ResultType.Failure);
-            return response ?? throw exception!;
+            return response ?? throw ExceptionUtil.Throw(exception!);
 
             void TraceRetry(string message, int attempt = 0, RetryPolicy? policy = null, Exception? exception = null)
             {

--- a/csharp/test/Ice/discovery/AllTests.cs
+++ b/csharp/test/Ice/discovery/AllTests.cs
@@ -128,13 +128,7 @@ namespace ZeroC.Ice.Test.Discovery
 
                 proxies[1].AddObject("oa", "object");
                 IObjectPrx.Parse(ice1 ? "object @ oa2" : "ice:oa2//object", communicator).IcePing();
-
-                if (ice1)
-                {
-                    // TODO: this currently does not work with ice2 because the previous object (in oa1) is still in
-                    // the cache and we don't retry on ONE.
-                    IObjectPrx.Parse("object", communicator).IcePing();
-                }
+                IObjectPrx.Parse(ice1 ? "object" : "ice:object", communicator).IcePing();
                 proxies[1].RemoveObject("oa", "object");
 
                 try

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -252,7 +252,7 @@ namespace ZeroC.Ice.Test.Location
             IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(2)).IcePing(); // 2s timeout
             TestHelper.Assert(count == locator.GetRequestCount());
-            System.Threading.Thread.Sleep(1300); // 1300ms
+            Thread.Sleep(1300); // 1300ms
             IObjectPrx.Parse(ice1 ? "test" : "ice:test", communicator)
                 .Clone(locatorCacheTimeout: TimeSpan.FromSeconds(1)).IcePing(); // 1s timeout
             count += 2;

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -187,7 +187,7 @@ namespace ZeroC.Ice.Test.Retry
                 try
                 {
                     // No retries before timeout kicks-in
-                    retry1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(500)).OpAfterDelay(2, 600);
+                    retry1.Clone(invocationTimeout: TimeSpan.FromMilliseconds(400)).OpAfterDelay(2, 600);
                     TestHelper.Assert(false);
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
This PR reworks the computation of indirect endpoints to allow requesting a fresh endpoint without clearing the cache