### PR TITLE
Remove Dispose and Activate on ObjectAdapter

### DIFF
--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -205,7 +205,7 @@ namespace ZeroC.Glacier2
             {
                 Debug.Assert(_adapter == null);
                 _adapter = _communicator.CreateObjectAdapterWithRouter(router);
-                _adapter.Activate();
+                _adapter.ActivateAsync().GetAwaiter().GetResult();
             }
 
             string category = router.GetCategoryForClient();

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice
     /// <summary>The object adapter provides an up-call interface from the Ice run time to the implementation of Ice
     /// objects. The object adapter is responsible for receiving requests from endpoints, and for mapping between
     /// servants, identities, and proxies.</summary>
-    public sealed class ObjectAdapter : IDisposable, IAsyncDisposable
+    public sealed class ObjectAdapter : IAsyncDisposable
     {
         /// <summary>Indicates under what circumstances the object adapter accepts non-secure incoming connections. This
         /// property corresponds to the object adapter's AcceptNonSecure property. If not set then the value of
@@ -332,9 +332,6 @@ namespace ZeroC.Ice
                 }
             }
         }
-
-        /// <summary>Releases resources used by the object adapter.</summary>
-        public void Dispose() => DisposeAsync().GetResult();
 
         /// <summary>Releases resources used by the object adapter.</summary>
         public async ValueTask DisposeAsync()

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -172,11 +172,6 @@ namespace ZeroC.Ice
 
         private readonly RouterInfo? _routerInfo;
 
-        /// <summary>Activates all endpoints of this object adapter. After activation, the object adapter can dispatch
-        /// requests received through these endpoints. Activate also registers this object adapter with the locator (if
-        /// set).</summary>
-        public void Activate() => ActivateAsync().GetAwaiter().GetResult();
-
         /// <summary>Activates this object adapter. After activation, the object adapter can dispatch requests received
         /// through its endpoints. Also registers this object adapter with the locator (if set).</summary>
         /// <param name="cancel">The cancellation token.</param>

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -182,7 +182,7 @@ namespace ZeroC.Glacier2.Test.Router
                 Console.Out.Flush();
                 communicator.SetProperty("Ice.PrintAdapterReady", "0");
                 adapter = communicator.CreateObjectAdapterWithRouter("CallbackReceiverAdapter", router);
-                adapter.Activate();
+                await adapter.ActivateAsync();
                 Console.Out.WriteLine("ok");
             }
 

--- a/csharp/test/Ice/acm/Test.ice
+++ b/csharp/test/Ice/acm/Test.ice
@@ -24,7 +24,7 @@ interface RemoteObjectAdapter
 
 interface RemoteCommunicator
 {
-    RemoteObjectAdapter* createObjectAdapter(int idleTimeout, bool keepAlive);
+    RemoteObjectAdapter createObjectAdapter(int idleTimeout, bool keepAlive);
     void shutdown();
 }
 

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -173,7 +173,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 IRouterPrx router = obj.Clone(IRouterPrx.Factory, label: "rc", identity: routerId);
                 {
                     await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
                     string endpointsStr = adapter.PublishedEndpoints[0].ToString();
                     TestHelper.Assert(endpointsStr == "tcp -h localhost -p 23456 -t 60000");
@@ -184,7 +184,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                     routerId = new Identity("test", "");
                     router = obj.Clone(IRouterPrx.Factory, identity: routerId);
                     await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                     TestHelper.Assert(false);
                 }
                 catch (OperationNotExistException)
@@ -196,7 +196,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 {
                     router = IRouterPrx.Parse(helper.GetTestProxy("test", 1), communicator);
                     await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                     TestHelper.Assert(false);
                 }
                 catch (ConnectFailedException)

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -10,7 +10,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
 {
     public static class AllTests
     {
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
 
@@ -25,7 +25,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 output.Write("creating/destroying/recreating object adapter... ");
                 output.Flush();
                 {
-                    using var adapter = communicator.CreateObjectAdapterWithEndpoints(
+                    await using var adapter = communicator.CreateObjectAdapterWithEndpoints(
                         "TransientTestAdapter",
                         helper.GetTestEndpoint(1));
                     try
@@ -41,7 +41,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
 
                 // Use a different port than the first adapter to avoid an "address already in use" error.
                 {
-                    using var adapter = communicator.CreateObjectAdapterWithEndpoints(
+                    await using var adapter = communicator.CreateObjectAdapterWithEndpoints(
                         "TransientTestAdapter",
                         helper.GetTestEndpoint(2));
                 }
@@ -60,7 +60,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 for (int i = 0; i < 10; ++i)
                 {
                     using var comm = new Communicator(communicator.GetProperties());
-                    IObjectPrx.Parse(helper.GetTestProxy("test", 0), communicator).IcePingAsync();
+                    _ = IObjectPrx.Parse(helper.GetTestProxy("test", 0), communicator).IcePingAsync();
                 }
                 output.WriteLine("ok");
             }
@@ -108,7 +108,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                         "DAdapter.Endpoints",
                         ice1 ? "tcp -h \"::0\" -p 0" : "ice+tcp://[::0]:0");
 
-                    using var adapter = communicator.CreateObjectAdapter("DAdapter");
+                    await using var adapter = communicator.CreateObjectAdapter("DAdapter");
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
                     Endpoint publishedEndpoint = adapter.PublishedEndpoints[0];
                     TestHelper.Assert(publishedEndpoint.Host == testHost);
@@ -119,7 +119,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                         ice1 ? $"{helper.GetTestEndpoint(1)}:{helper.GetTestEndpoint(2)}" :
                             $"{helper.GetTestEndpoint(1)}?alt-endpoint={helper.GetTestEndpoint(2)}");
 
-                    using var adapter = communicator.CreateObjectAdapter("DAdapter");
+                    await using var adapter = communicator.CreateObjectAdapter("DAdapter");
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 2);
                     Endpoint publishedEndpoint0 = adapter.PublishedEndpoints[0];
                     TestHelper.Assert(publishedEndpoint0.Host == testHost);
@@ -136,7 +136,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             {
                 communicator.SetProperty("PAdapter.PublishedEndpoints",
                     ice1 ? "tcp -h localhost -p 12345 -t 30000" : "ice+tcp://localhost:12345");
-                using var adapter = communicator.CreateObjectAdapter("PAdapter");
+                await using var adapter = communicator.CreateObjectAdapter("PAdapter");
                 TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
                 Endpoint? endpt = adapter.PublishedEndpoints[0];
                 TestHelper.Assert(endpt != null);
@@ -159,7 +159,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 ObjectAdapter adapter = communicator.CreateObjectAdapter();
                 connection.Adapter = adapter;
                 connection.Adapter = null;
-                adapter.Dispose();
+                await adapter.DisposeAsync();
                 // Setting a deactivated adapter on a connection no longer raise ObjectAdapterDeactivatedException
                 connection.Adapter = adapter;
                 output.WriteLine("ok");
@@ -172,7 +172,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 var routerId = new Identity("router", "");
                 IRouterPrx router = obj.Clone(IRouterPrx.Factory, label: "rc", identity: routerId);
                 {
-                    using var adapter = communicator.CreateObjectAdapterWithRouter(router);
+                    await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
                     adapter.Activate();
                     TestHelper.Assert(adapter.PublishedEndpoints.Count == 1);
                     string endpointsStr = adapter.PublishedEndpoints[0].ToString();
@@ -183,7 +183,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 {
                     routerId = new Identity("test", "");
                     router = obj.Clone(IRouterPrx.Factory, identity: routerId);
-                    using var adapter = communicator.CreateObjectAdapterWithRouter(router);
+                    await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
                     adapter.Activate();
                     TestHelper.Assert(false);
                 }
@@ -195,7 +195,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 try
                 {
                     router = IRouterPrx.Parse(helper.GetTestProxy("test", 1), communicator);
-                    using var adapter = communicator.CreateObjectAdapterWithRouter(router);
+                    await using var adapter = communicator.CreateObjectAdapterWithRouter(router);
                     adapter.Activate();
                     TestHelper.Assert(false);
                 }
@@ -207,7 +207,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             {
                 try
                 {
-                    using var adapter = communicator.CreateObjectAdapterWithRouter(
+                    await using var adapter = communicator.CreateObjectAdapterWithRouter(
                         obj.Clone(IRouterPrx.Factory, label: "rc", identity: new Identity("router", "")));
 
                     TestHelper.Assert(false);
@@ -222,8 +222,8 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             output.Write("testing object adapter creation with port in use... ");
             output.Flush();
             {
-                using var adapter1 = communicator.CreateObjectAdapterWithEndpoints("Adpt1",
-                                                                                   helper.GetTestEndpoint(10));
+                await using var adapter1 = communicator.CreateObjectAdapterWithEndpoints("Adpt1",
+                                                                                         helper.GetTestEndpoint(10));
                 try
                 {
                     communicator.CreateObjectAdapterWithEndpoints("Adpt2", helper.GetTestEndpoint(10));
@@ -252,7 +252,6 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             {
                 output.WriteLine("ok");
             }
-            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -121,7 +121,7 @@ namespace ZeroC.Ice.Test.Admin
             }
         }
 
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
 
@@ -139,7 +139,7 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.Admin.InstanceName"] = "Test"
                 };
                 using var com = new Communicator(properties);
-                com.ActivateAsync().GetAwaiter().GetResult();
+                await com.ActivateAsync();
                 TestFacets(com, true, false);
             }
             {
@@ -152,13 +152,13 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.Admin.Facets"] = "Properties"
                 };
                 using var com = new Communicator(properties);
-                com.ActivateAsync().GetAwaiter().GetResult();
+                await com.ActivateAsync();
                 TestFacets(com, false, true);
             }
             {
                 // Test: Verify that the operations work correctly with the Admin object disabled.
                 using var com = new Communicator();
-                com.ActivateAsync().GetAwaiter().GetResult();
+                await com.ActivateAsync();
                 TestFacets(com, false, false);
             }
             {
@@ -168,12 +168,12 @@ namespace ZeroC.Ice.Test.Admin
                     { "Ice.Admin.Enabled", "1" }
                 };
                 using var com = new Communicator(properties);
-                com.ActivateAsync().GetAwaiter().GetResult();
+                await com.ActivateAsync();
                 TestHelper.Assert(com.GetAdminAsync().GetAwaiter().GetResult() == null);
                 var id = Identity.Parse("test-admin");
                 try
                 {
-                    _ = com.CreateAdminAsync(null, id).GetAwaiter().GetResult();
+                    _ = await com.CreateAdminAsync(null, id);
                     TestHelper.Assert(false);
                 }
                 catch (InvalidConfigurationException)
@@ -197,7 +197,7 @@ namespace ZeroC.Ice.Test.Admin
 
                 using var com = new Communicator(properties);
                 TestFacets(com, true, false);
-                com.ActivateAsync().GetAwaiter().GetResult();
+                await com.ActivateAsync();
                 TestFacets(com, true, false);
             }
             output.WriteLine("ok");
@@ -374,7 +374,7 @@ namespace ZeroC.Ice.Test.Admin
 
                 IRemoteLoggerPrx myProxy = adapter.AddWithUUID(remoteLogger, IRemoteLoggerPrx.Factory);
 
-                adapter.Activate();
+                await adapter.ActivateAsync();
 
                 // No filtering
                 (logMessages, prefix) = logger.GetLog(Array.Empty<LogMessageType>(), Array.Empty<string>(), -1);
@@ -621,7 +621,6 @@ namespace ZeroC.Ice.Test.Admin
             output.WriteLine("ok");
 
             factory.Shutdown();
-            return Task.CompletedTask;
         }
 
         private class RemoteLogger : IRemoteLogger

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -465,7 +465,7 @@ namespace ZeroC.Ice.Test.Binding
                 {
                     using var serverCommunicator = new Communicator(p);
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapter("Adapter");
-                    oa.Activate();
+                    await oa.ActivateAsync();
 
                     IObjectPrx prx = oa.CreateProxy("dummy", IObjectPrx.Factory);
                     try
@@ -486,7 +486,7 @@ namespace ZeroC.Ice.Test.Binding
                     using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::0");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
-                    oa.Activate();
+                    await oa.ActivateAsync();
 
                     try
                     {
@@ -517,7 +517,7 @@ namespace ZeroC.Ice.Test.Binding
                     using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::0") + (ice1 ? " --ipv6Only" : "?ipv6-only=true");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
-                    oa.Activate();
+                    await oa.ActivateAsync();
 
                     // 0.0.0.0 can still be bound if ::0 is IPv6 only
                     {
@@ -545,7 +545,7 @@ namespace ZeroC.Ice.Test.Binding
                     using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::ffff:127.0.0.1");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
-                    oa.Activate();
+                    await oa.ActivateAsync();
 
                     try
                     {

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -33,7 +33,7 @@ namespace ZeroC.Ice.Test.Binding
             }
         }
 
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
             bool ice1 = helper.Protocol == Protocol.Ice1;
@@ -340,7 +340,7 @@ namespace ZeroC.Ice.Test.Binding
                     for (int i = 0; i < 5; i++)
                     {
                         TestHelper.Assert(obj.GetAdapterName().Equals("Adapter82"));
-                        obj.GetConnection().GoAwayAsync();
+                        _ = obj.GetConnection().GoAwayAsync();
                     }
 
                     ITestIntfPrx testNonSecure = obj.Clone(preferNonSecure: NonSecure.Always);
@@ -354,7 +354,7 @@ namespace ZeroC.Ice.Test.Binding
                     for (int i = 0; i < 5; i++)
                     {
                         TestHelper.Assert(obj.GetAdapterName().Equals("Adapter81"));
-                        obj.GetConnection().GoAwayAsync();
+                        _ = obj.GetConnection().GoAwayAsync();
                     }
 
                     // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
@@ -365,7 +365,7 @@ namespace ZeroC.Ice.Test.Binding
                         for (int i = 0; i < 5; i++)
                         {
                             TestHelper.Assert(obj.GetAdapterName().Equals("Adapter83"));
-                            obj.GetConnection().GoAwayAsync();
+                            _ = obj.GetConnection().GoAwayAsync();
                         }
                     }
 
@@ -490,9 +490,9 @@ namespace ZeroC.Ice.Test.Binding
 
                     try
                     {
-                        using ObjectAdapter ipv4OA =
+                        await using ObjectAdapter ipv4OA =
                             serverCommunicator.CreateObjectAdapterWithEndpoints(getEndpoint("0.0.0.0"));
-                        ipv4OA.Activate();
+                        await ipv4OA.ActivateAsync();
                         TestHelper.Assert(false);
                     }
                     catch (TransportException)
@@ -522,8 +522,9 @@ namespace ZeroC.Ice.Test.Binding
                     // 0.0.0.0 can still be bound if ::0 is IPv6 only
                     {
                         string ipv4Endpoint = getEndpoint("0.0.0.0");
-                        using ObjectAdapter ipv4OA = serverCommunicator.CreateObjectAdapterWithEndpoints(ipv4Endpoint);
-                        ipv4OA.Activate();
+                        await using ObjectAdapter ipv4OA =
+                            serverCommunicator.CreateObjectAdapterWithEndpoints(ipv4Endpoint);
+                        await ipv4OA.ActivateAsync();
                     }
 
                     try
@@ -549,8 +550,9 @@ namespace ZeroC.Ice.Test.Binding
                     try
                     {
                         string ipv4Endpoint = getEndpoint("127.0.0.1");
-                        using ObjectAdapter ipv4OA = serverCommunicator.CreateObjectAdapterWithEndpoints(ipv4Endpoint);
-                        ipv4OA.Activate();
+                        await using ObjectAdapter ipv4OA =
+                            serverCommunicator.CreateObjectAdapterWithEndpoints(ipv4Endpoint);
+                        await ipv4OA.ActivateAsync();
                         TestHelper.Assert(false);
                     }
                     catch (TransportException)
@@ -574,7 +576,6 @@ namespace ZeroC.Ice.Test.Binding
             }
 
             com.Shutdown();
-            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
+++ b/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
@@ -2,10 +2,11 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Binding
 {
-    public class RemoteObjectAdapter : IRemoteObjectAdapter
+    public class RemoteObjectAdapter : IAsyncRemoteObjectAdapter
     {
         private readonly ObjectAdapter _adapter;
         private readonly ITestIntfPrx _testIntf;
@@ -14,20 +15,12 @@ namespace ZeroC.Ice.Test.Binding
         {
             _adapter = adapter;
             _testIntf = _adapter.Add("test", new TestIntf(), ITestIntfPrx.Factory);
-            _adapter.Activate();
         }
 
-        public ITestIntfPrx GetTestIntf(Current current, CancellationToken cancel) => _testIntf;
+        public ValueTask<ITestIntfPrx> GetTestIntfAsync(Current current, CancellationToken cancel) =>
+            new(_testIntf);
 
-        public void Deactivate(Current current, CancellationToken cancel)
-        {
-            try
-            {
-                _adapter.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-        }
+        public async ValueTask DeactivateAsync(Current current, CancellationToken cancel) =>
+            await _adapter.DisposeAsync();
     }
 }

--- a/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
+++ b/csharp/test/Ice/binding/RemoteObjectAdapterI.cs
@@ -20,7 +20,6 @@ namespace ZeroC.Ice.Test.Binding
         public ValueTask<ITestIntfPrx> GetTestIntfAsync(Current current, CancellationToken cancel) =>
             new(_testIntf);
 
-        public async ValueTask DeactivateAsync(Current current, CancellationToken cancel) =>
-            await _adapter.DisposeAsync();
+        public ValueTask DeactivateAsync(Current current, CancellationToken cancel) => _adapter.DisposeAsync();
     }
 }

--- a/csharp/test/Ice/binding/Test.ice
+++ b/csharp/test/Ice/binding/Test.ice
@@ -16,7 +16,7 @@ interface TestIntf
 
 interface RemoteObjectAdapter
 {
-    TestIntf* getTestIntf();
+    TestIntf getTestIntf();
 
     void deactivate();
 }
@@ -26,7 +26,7 @@ interface RemoteCommunicator
     RemoteObjectAdapter createObjectAdapter(string name, string transport);
     RemoteObjectAdapter createObjectAdapterWithEndpoints(string name, string endpoints);
 
-    void deactivateObjectAdapter(RemoteObjectAdapter* adapter);
+    void deactivateObjectAdapter(RemoteObjectAdapter adapter);
 
     void shutdown();
 }

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.DefaultServant
 {
     public static class AllTests
     {
-        public static void Run(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             TextWriter output = helper.Output;
             Communicator? communicator = helper.Communicator;
@@ -16,7 +17,7 @@ namespace ZeroC.Ice.Test.DefaultServant
 
             ObjectAdapter oa = communicator.CreateObjectAdapterWithEndpoints("MyOA",
                 helper.GetTestEndpoint(ephemeral: true));
-            oa.Activate();
+            await oa.ActivateAsync();
 
             output.Write("testing single category... ");
             output.Flush();

--- a/csharp/test/Ice/defaultServant/Client.cs
+++ b/csharp/test/Ice/defaultServant/Client.cs
@@ -10,7 +10,7 @@ namespace ZeroC.Ice.Test.DefaultServant
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -9,7 +9,7 @@ namespace ZeroC.Ice.Test.Exceptions
 {
     public static class AllTests
     {
-        public static async ValueTask<IThrowerPrx> RunAsync(TestHelper helper)
+        public static async Task<IThrowerPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Exceptions
 {
     public static class AllTests
     {
-        public static IThrowerPrx Run(TestHelper helper)
+        public static async ValueTask<IThrowerPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -52,14 +53,14 @@ namespace ZeroC.Ice.Test.Exceptions
                 {
                     // Expected
                 }
-                first.Dispose();
+                await first.DisposeAsync();
                 output.WriteLine("ok");
             }
 
             {
                 output.Write("testing servant registration exceptions... ");
                 communicator.SetProperty("TestAdapter1.Endpoints", helper.GetTestEndpoint(ephemeral: true));
-                ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter1");
+                await using ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter1");
                 var obj = new Empty();
                 adapter.Add("x", obj);
                 try
@@ -82,7 +83,6 @@ namespace ZeroC.Ice.Test.Exceptions
 
                 adapter.Remove("x");
                 adapter.Remove("x"); // as of Ice 4.0, Remove succeeds with multiple removals
-                adapter.Dispose();
                 output.WriteLine("ok");
             }
 

--- a/csharp/test/Ice/exceptions/Client.cs
+++ b/csharp/test/Ice/exceptions/Client.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.Exceptions
             properties["Ice.IncomingFrameMaxSize"] = "10K";
             await using Communicator communicator = Initialize(properties);
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            IThrowerPrx thrower = AllTests.Run(this);
+            IThrowerPrx thrower = await AllTests.RunAsync(this);
             await thrower.ShutdownAsync();
         }
 

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Exceptions
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("thrower", new Thrower());
-            AllTests.Run(this);
+            _ = await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Collocated>(args);

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Facets
 {
     public static class AllTests
     {
-        public static IGPrx Run(TestHelper helper)
+        public static async ValueTask<IGPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -55,7 +56,7 @@ namespace ZeroC.Ice.Test.Facets
             adapter.Remove("d#facetABCD"); // multiple Remove are fine as of Ice 4.0
             output.WriteLine("ok");
 
-            adapter.Dispose();
+            await adapter.DisposeAsync();
 
             var prx = IObjectPrx.Parse(helper.GetTestProxy("d", 0), communicator);
             IDPrx? d;

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -9,7 +9,7 @@ namespace ZeroC.Ice.Test.Facets
 {
     public static class AllTests
     {
-        public static async ValueTask<IGPrx> RunAsync(TestHelper helper)
+        public static async Task<IGPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);

--- a/csharp/test/Ice/facets/Client.cs
+++ b/csharp/test/Ice/facets/Client.cs
@@ -10,7 +10,8 @@ namespace ZeroC.Ice.Test.Facets
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            AllTests.Run(this).Shutdown();
+            IGPrx prx = await AllTests.RunAsync(this);
+            await prx.ShutdownAsync();
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/facets/Collocated.cs
+++ b/csharp/test/Ice/facets/Collocated.cs
@@ -18,7 +18,8 @@ namespace ZeroC.Ice.Test.Facets
             adapter.Add("d#facetABCD", d);
             adapter.Add("d#facetEF", new F());
             adapter.Add("d#facetGH", new H(communicator));
-            AllTests.Run(this);
+
+            _ = await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Collocated>(args);

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -5,13 +5,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Info
 {
     public static class AllTests
     {
-        public static void Run(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -95,7 +96,7 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(tcpEndpoint.Host == serverName);
                 TestHelper.Assert(tcpEndpoint.Port > 0);
                 TestHelper.Assert(tcpEndpoint["timeout"] is string value && int.Parse(value) == 15000);
-                adapter.Dispose();
+                await adapter.DisposeAsync();
 
                 int port = helper.BasePort + 1;
 
@@ -118,7 +119,7 @@ namespace ZeroC.Ice.Test.Info
                 TestHelper.Assert(tcpEndpoint.Host == "127.0.0.1");
                 TestHelper.Assert(tcpEndpoint.Port == port);
 
-                adapter.Dispose();
+                await adapter.DisposeAsync();
             }
             output.WriteLine("ok");
 
@@ -257,9 +258,7 @@ namespace ZeroC.Ice.Test.Info
             output.WriteLine("ok");
 
             testIntf.Shutdown();
-
-            communicator.ShutdownAsync();
-            communicator.WaitForShutdownAsync();
+            await communicator.ShutdownAsync();
         }
     }
 }

--- a/csharp/test/Ice/info/Client.cs
+++ b/csharp/test/Ice/info/Client.cs
@@ -10,7 +10,7 @@ namespace ZeroC.Ice.Test.Info
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -11,7 +11,7 @@ namespace ZeroC.Ice.Test.Location
 {
     public static class AllTests
     {
-        public static void Run(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -601,7 +601,7 @@ namespace ZeroC.Ice.Test.Location
                 output.Flush();
                 hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
                 obj1.MigrateHello();
-                hello.GetConnection().GoAwayAsync();
+                _ = hello.GetConnection().GoAwayAsync();
                 hello.SayHello();
                 obj1.MigrateHello();
                 hello.SayHello();
@@ -652,7 +652,7 @@ namespace ZeroC.Ice.Test.Location
 
             var id = new Identity(Guid.NewGuid().ToString(), "");
             adapter.Add(id, new Hello());
-            adapter.Activate();
+            await adapter.ActivateAsync();
 
             // Ensure that calls on the well-known proxy is collocated.
             IHelloPrx? helloPrx;

--- a/csharp/test/Ice/location/Client.cs
+++ b/csharp/test/Ice/location/Client.cs
@@ -13,7 +13,7 @@ namespace ZeroC.Ice.Test.Location
             Dictionary<string, string> properties = CreateTestProperties(ref args);
             properties["Ice.Default.Locator"] = GetTestProxy("locator", properties, 0);
             await using Communicator communicator = Initialize(properties);
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Proxy
 {
     public static class AllTests
     {
-        public static async ValueTask<IMyClassPrx> RunAsync(TestHelper helper)
+        public static async Task<IMyClassPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -5,13 +5,14 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Proxy
 {
     public static class AllTests
     {
-        public static IMyClassPrx Run(TestHelper helper)
+        public static async ValueTask<IMyClassPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -1083,7 +1084,7 @@ namespace ZeroC.Ice.Test.Proxy
                 // The Clone(encoding: Encoding.V20) are only for ice1; with ice2, it's the default encoding. We need
                 // to marshal all relative proxies with the 2.0 encoding.
 
-                using ObjectAdapter oa = communicator.CreateObjectAdapter(protocol: helper.Protocol);
+                await using ObjectAdapter oa = communicator.CreateObjectAdapter(protocol: helper.Protocol);
                 cl.GetConnection().Adapter = oa;
                 ICallbackPrx callback = oa.AddWithUUID(
                     new Callback((relativeTest, current, cancel) =>
@@ -1224,12 +1225,10 @@ namespace ZeroC.Ice.Test.Proxy
             output.Flush();
             {
                 var com = new Communicator();
-                com.ShutdownAsync();
-                com.WaitForShutdownAsync();
-                com.Dispose();
-                com.ShutdownAsync();
-                com.WaitForShutdownAsync();
-                com.Dispose();
+                await com.ShutdownAsync();
+                await com.DisposeAsync();
+                await com.ShutdownAsync();
+                await com.DisposeAsync();
             }
             output.WriteLine("ok");
 

--- a/csharp/test/Ice/proxy/Client.cs
+++ b/csharp/test/Ice/proxy/Client.cs
@@ -10,7 +10,8 @@ namespace ZeroC.Ice.Test.Proxy
         public override async Task RunAsync(string[] args)
         {
             await using Communicator? communicator = Initialize(ref args);
-            AllTests.Run(this).Shutdown();
+            IMyClassPrx prx = await AllTests.RunAsync(this);
+            await prx.ShutdownAsync();
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Client>(args);

--- a/csharp/test/Ice/proxy/Collocated.cs
+++ b/csharp/test/Ice/proxy/Collocated.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Proxy
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new MyDerivedClass());
             // Don't activate OA to ensure collocation is used.
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Collocated>(args);

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.Slicing.Exceptions
@@ -34,7 +35,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                 throw new ClientPrivateException("ClientPrivate");
         }
 
-        public static ITestIntfPrx Run(TestHelper helper)
+        public static async Task<ITestIntfPrx> RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -767,9 +768,9 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                     TestHelper.Assert(slices[0].TypeId!.Equals("::ZeroC::Ice::Test::Slicing::Exceptions::SPreserved2"));
                 }
 
-                ObjectAdapter adapter = communicator.CreateObjectAdapter(protocol: helper.Protocol);
+                await using var adapter = communicator.CreateObjectAdapter(protocol: helper.Protocol);
                 IRelayPrx relay = adapter.AddWithUUID(new Relay(), IRelayPrx.Factory);
-                adapter.Activate();
+                await adapter.ActivateAsync();
                 testPrx.GetConnection().Adapter = adapter;
 
                 try
@@ -871,8 +872,6 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                 {
                     TestHelper.Assert(false);
                 }
-
-                adapter.Dispose();
             }
             output.WriteLine("ok");
 

--- a/csharp/test/Ice/slicing/exceptions/Client.cs
+++ b/csharp/test/Ice/slicing/exceptions/Client.cs
@@ -10,7 +10,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
-            ITestIntfPrx test = AllTests.Run(this);
+            ITestIntfPrx test = await AllTests.RunAsync(this);
             await test.ShutdownAsync();
         }
 

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -51,7 +51,7 @@ namespace ZeroC.Ice.Test.Timeout
 
             ObjectAdapter controllerAdapter = communicator.CreateObjectAdapter("ControllerAdapter");
             controllerAdapter.Add("controller", new Controller(schedulerPair.ExclusiveScheduler));
-            controllerAdapter.Activate();
+            await controllerAdapter.ActivateAsync();
 
             ServerReady();
             await communicator.WaitForShutdownAsync();

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Test;
 
 namespace ZeroC.Ice.Test.UDP
@@ -58,7 +59,7 @@ namespace ZeroC.Ice.Test.UDP
             private int _replies;
         }
 
-        public static void Run(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -68,7 +69,7 @@ namespace ZeroC.Ice.Test.UDP
             var replyI = new PingReplyI();
             IPingReplyPrx reply = adapter.AddWithUUID(replyI, IPingReplyPrx.Factory)
                 .Clone(invocationMode: InvocationMode.Datagram, preferNonSecure: NonSecure.Always);
-            adapter.Activate();
+            await adapter.ActivateAsync();
 
             Console.Out.Write("testing udp... ");
             Console.Out.Flush();
@@ -125,7 +126,7 @@ namespace ZeroC.Ice.Test.UDP
                 // TransportException will be thrown when we try to send a larger packet.
                 TestHelper.Assert(seq.Length > 16384);
             }
-            obj.GetConnection().GoAwayAsync();
+            _ = obj.GetConnection().GoAwayAsync();
             communicator.SetProperty("Ice.UDP.SndSize", "64K");
             seq = new byte[50000];
             try

--- a/csharp/test/Ice/udp/Client.cs
+++ b/csharp/test/Ice/udp/Client.cs
@@ -15,7 +15,7 @@ namespace ZeroC.Ice.Test.UDP
             properties["Ice.Warn.Connections"] = "0";
             properties["Ice.UDP.SndSize"] = "16K";
             await using Communicator communicator = Initialize(properties);
-            AllTests.Run(this);
+            await AllTests.RunAsync(this);
 
             int num;
             try

--- a/csharp/test/IceBox/configuration/TestServiceI.cs
+++ b/csharp/test/IceBox/configuration/TestServiceI.cs
@@ -10,7 +10,7 @@ namespace ZeroC.IceBox.Test.Configuration
         {
             ObjectAdapter adapter = communicator.CreateObjectAdapter(name + "OA");
             adapter.Add("test", new TestIntf(args));
-            adapter.Activate();
+            adapter.ActivateAsync().GetAwaiter().GetResult(); // TODO: temporary
         }
 
         public void Stop()

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Test;
 using ZeroC.Ice;
 
@@ -9,7 +10,7 @@ namespace ZeroC.IceGrid.Test.Simple
 {
     public static class AllTests
     {
-        public static void Run(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -75,7 +76,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     TestHelper.Assert(iceGridLocator.GetLocalQuery() != null);
 
                     ObjectAdapter adapter = com.CreateObjectAdapter("AdapterForDiscoveryTest");
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                 }
                 // Now, ensure that locator discovery correctly handles failure to find a locator.
                 {
@@ -113,8 +114,8 @@ namespace ZeroC.IceGrid.Test.Simple
                     {
                     }
 
-                    using ObjectAdapter adapter = com.CreateObjectAdapter("AdapterForDiscoveryTest");
-                    adapter.Activate();
+                    await using ObjectAdapter adapter = com.CreateObjectAdapter("AdapterForDiscoveryTest");
+                    await adapter.ActivateAsync();
                 }
 
                 string multicast;

--- a/csharp/test/IceGrid/simple/Client.cs
+++ b/csharp/test/IceGrid/simple/Client.cs
@@ -18,7 +18,7 @@ namespace ZeroC.IceGrid.Test.Simple
             }
             else
             {
-                AllTests.Run(this);
+                await AllTests.RunAsync(this);
             }
         }
 

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -75,7 +75,7 @@ namespace ZeroC.IceSSL.Test.Configuration
         CreateServerFactoryPrx(string factoryRef, Communicator communicator) =>
             IServerFactoryPrx.Parse(factoryRef, communicator).Clone(preferNonSecure: NonSecure.Always);
 
-        public static IServerFactoryPrx Run(TestHelper helper, string testDir)
+        public static async Task<IServerFactoryPrx> RunAsync(TestHelper helper, string testDir)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -276,7 +276,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                             "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+tcp://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
                     prx.IcePing();
                 }
@@ -322,7 +322,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     ObjectAdapter adapter = serverCommunicator.CreateObjectAdapterWithEndpoints(
                         "MyAdapter", ice1 ? $"ssl -h {host}" : $"ice+tcp://{host}:0");
                     IObjectPrx? prx = adapter.AddWithUUID(new Blobject(), IObjectPrx.Factory);
-                    adapter.Activate();
+                    await adapter.ActivateAsync();
                     prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
                     prx.IcePing();
                     TestHelper.Assert(clientCertificateValidationCallbackCalled);

--- a/csharp/test/IceSSL/configuration/Client.cs
+++ b/csharp/test/IceSSL/configuration/Client.cs
@@ -21,7 +21,7 @@ namespace ZeroC.IceSSL.Test.Configuration
             }
 
             IServerFactoryPrx factory;
-            factory = AllTests.Run(this, args[0]);
+            factory = await AllTests.RunAsync(this, args[0]);
             await factory.ShutdownAsync();
         }
 


### PR DESCRIPTION
This PR removes these two sync "helper" methods. You should only call (and await) the Async methods.