### PR TITLE
Add editline support to icegridadmin and icestormadmin

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -94,6 +94,9 @@ Ice[iphonesimulator]_system_libs := $(Ice[iphoneos]_system_libs)
 IceSSL[iphonesimulator]_system_libs := $(IceSSL[iphoneos]_system_libs)
 IceIAP[iphonesimulator]_system_libs := $(IceIAP[iphoneos]_system_libs)
 
+icegridadmin[macosx]_system_libs := -ledit -lncurses
+icestormadmin[macosx]_system_libs := -ledit -lncurses
+
 Glacier2CryptPermissionsVerifier[macosx]_system_libs := $(IceSSL[macosx]_system_libs)
 Glacier2CryptPermissionsVerifier[iphoneos]_system_libs := $(IceSSL[iphoneos]_system_libs)
 Glacier2CryptPermissionsVerifier[iphonesimulator]_system_libs := $(IceSSL[iphonesimulator]_system_libs)

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -186,6 +186,9 @@ endif
 IceSSL_system_libs                              = -lssl -lcrypto
 Glacier2CryptPermissionsVerifier_system_libs    = -lcrypt
 
+icegridadmin_system_libs                        = -ledit
+icestormadmin_system_libs                       = -ledit
+
 #
 # On supported platforms and if Bluez and DBus are installed, we set the IceBT
 # system libraries. The build system checks for this variable to build or not

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -13,9 +13,8 @@
 #include <IceGrid/DescriptorHelper.h>
 #include <IceBox/IceBox.h>
 
-#ifdef HAVE_READLINE
-#   include <readline/readline.h>
-#   include <readline/history.h>
+#ifdef __APPLE__
+#    include <editline/readline.h>
 #endif
 
 #include <iterator>
@@ -2573,8 +2572,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
     }
     else
     {
-#ifdef HAVE_READLINE
-
+#ifdef __APPLE__
         const char* prompt = parser->getPrompt();
         char* line = readline(const_cast<char*>(prompt));
         if(!line)

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -13,7 +13,7 @@
 #include <IceGrid/DescriptorHelper.h>
 #include <IceBox/IceBox.h>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>
 #endif
 
@@ -2572,7 +2572,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
     }
     else
     {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__linux__)
         const char* prompt = parser->getPrompt();
         char* line = readline(const_cast<char*>(prompt));
         if(!line)

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -9,7 +9,7 @@
 #include <IceStorm/IceStormInternal.h>
 #include <algorithm>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>
 #endif
 
@@ -444,8 +444,8 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
     }
     else
     {
-#ifdef __APPLE__
 
+#if defined(__APPLE__) || defined(__linux__)
         const char* prompt = parser->getPrompt();
         char* line = readline(const_cast<char*>(prompt));
         if(!line)
@@ -473,9 +473,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
                 free(line);
             }
         }
-
 #else
-
         consoleOut << parser->getPrompt() << flush;
 
         string line;

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -9,9 +9,8 @@
 #include <IceStorm/IceStormInternal.h>
 #include <algorithm>
 
-#ifdef HAVE_READLINE
-#   include <readline/readline.h>
-#   include <readline/history.h>
+#ifdef __APPLE__
+#    include <editline/readline.h>
 #endif
 
 extern FILE* yyin;
@@ -445,7 +444,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
     }
     else
     {
-#ifdef HAVE_READLINE
+#ifdef __APPLE__
 
         const char* prompt = parser->getPrompt();
         char* line = readline(const_cast<char*>(prompt));


### PR DESCRIPTION
This PR adds support for editline (history) to icegridadmin and icestormadmin on macos.

It's likely we can do the same on some Linux distributions.