### PR TITLE
Fix for Slice/errorDetection failure caused by the addition of the stream qualifier

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1100,7 +1100,7 @@ Slice::Container::lookupTypeNoBuiltin(const string& scoped, bool printError, boo
         {
             if (printError && !ignoreUndefined)
             {
-                _unit->error("`" + sc + "' is not defined");
+                _unit->error("type `" + sc + "' is not defined");
             }
             return TypeList();
         }

--- a/cpp/test/Slice/errorDetection/ConstDef.err
+++ b/cpp/test/Slice/errorDetection/ConstDef.err
@@ -1,4 +1,4 @@
-ConstDef.ice:68: `XXX' is not defined
+ConstDef.ice:68: type `XXX' is not defined
 ConstDef.ice:69: redefinition of constant `f11'
 ConstDef.ice:42: note: constant `f11' was originally defined here
 ConstDef.ice:70: constant `F10' differs only in capitalization from the constant named `f10'

--- a/cpp/test/Slice/errorDetection/IdentAsKeyword.err
+++ b/cpp/test/Slice/errorDetection/IdentAsKeyword.err
@@ -37,6 +37,8 @@ IdentAsKeyword.ice:55: keyword `long' cannot be used as enumerator
 IdentAsKeyword.ice:55: keyword `byte' cannot be used as enumerator
 IdentAsKeyword.ice:58: keyword `module' cannot be used as operation name
 IdentAsKeyword.ice:61: keyword `exception' cannot be used as operation name
-IdentAsKeyword.ice:64: syntax error
+IdentAsKeyword.ice:64: type `op' is not defined
 IdentAsKeyword.ice:67: keyword `byte' cannot be used as an identifier
 IdentAsKeyword.ice:70: keyword `byte' cannot be used as an identifier
+IdentAsKeyword.ice:73: syntax error
+IdentAsKeyword.ice:74: syntax error

--- a/cpp/test/Slice/errorDetection/IdentAsKeyword.ice
+++ b/cpp/test/Slice/errorDetection/IdentAsKeyword.ice
@@ -70,6 +70,9 @@ interface i8 { void op(double BYTE); }
 interface i9 { void op(out double byte); }
 interface i10 { void op(out double BYTE); }
 
+interface i11 { enum op(); }
+interface i12 { out enum op(); }
+
 interface \true {}     // OK, escaped keyword
 
 }

--- a/cpp/test/Slice/errorDetection/TypeAlias.err
+++ b/cpp/test/Slice/errorDetection/TypeAlias.err
@@ -1,11 +1,11 @@
-TypeAlias.ice:33: `foo' is not defined
+TypeAlias.ice:33: type `foo' is not defined
 TypeAlias.ice:33: unable to resolve underlying type
 TypeAlias.ice:34: `optintAlias': optional types cannot be type-aliased
 TypeAlias.ice:35: missing underlying type for typealias `missingType'
 TypeAlias.ice:38: `;' missing after type-alias
-TypeAlias.ice:39: `C1' is not defined
+TypeAlias.ice:39: type `C1' is not defined
 TypeAlias.ice:39: unable to resolve underlying type
-TypeAlias.ice:47: `C1' is not defined
+TypeAlias.ice:47: type `C1' is not defined
 TypeAlias.ice:47: unable to resolve underlying type
 TypeAlias.ice:56: redefinition of typealias `C0Alias'
 TypeAlias.ice:38: note: typealias `C0Alias' was originally defined here

--- a/cpp/test/Slice/errorDetection/Undefined.err
+++ b/cpp/test/Slice/errorDetection/Undefined.err
@@ -1,4 +1,4 @@
-Undefined.ice:8: `Foo' is not defined
-Undefined.ice:9: `Foo' is not defined
-Undefined.ice:10: `Foo' is not defined
-Undefined.ice:11: `Foo' is not defined
+Undefined.ice:8: type `Foo' is not defined
+Undefined.ice:9: type `Foo' is not defined
+Undefined.ice:10: type `Foo' is not defined
+Undefined.ice:11: type `Foo' is not defined


### PR DESCRIPTION
The `Slice/errorDetection` test fails since I added the support for the stream qualifier (which is handled like the out qualifier in the grammar). 

The operation definition `out op();` no longer generates a `syntax error` message but instead generates the error message `` `op' is not defined``. `out op` from the the operation definition is now interpreted as the `out` qualifier followed by the return type... so `op` is parsed as the return type and it errors because the type `op` can't be found. 

I tried to fix the grammar to catch the use of a keyword as the return type without much luck so instead I fixed the parser to be a little clearer and print the message ``type `op' is not defined`` in this case. I also fixed the error files to take into account this change.