### PR TITLE
Rename global metadata to file metadata.

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -503,7 +503,7 @@ These are the changes since Ice 3.7.0.
 ## Java Changes
 
 - The java:package metadata can now be applied to modules. It can still
-  be used as global metadata, in which case it serves as the default
+  be used as file metadata, in which case it serves as the default
   directive unless overridden by module metadata.
 
 ## JavaScript Changes
@@ -528,7 +528,7 @@ These are the changes since Ice 3.7.0.
 ## Python Changes
 
 - The python:package metadata can now be applied to modules. It can still
-  be used as global metadata, in which case it serves as the default
+  be used as file metadata, in which case it serves as the default
   directive unless overridden by module metadata.
 
 - Fixed a bug that caused Python to crash on exit when the extension is
@@ -788,7 +788,7 @@ These are the changes since the Ice 3.6 release or snapshot described in
 - Replaced `Ice::NoObjectFactoryException` with `Ice::NoValueFactoryException`.
 
 - The Slice compiler options `--ice` and `--underscore` are now deprecated, and
-  replaced by the global Slice metadata `ice-prefix` and `underscore`.
+  replaced by the file Slice metadata `ice-prefix` and `underscore`.
 
 - Renamed local interface metadata `async` to `async-oneway`.
 
@@ -828,7 +828,7 @@ These are the changes since the Ice 3.6 release or snapshot described in
   https://github.com/zeroc-ice/freeze.
 
 - Added support for suppressing Slice warnings using the `[["suppress-warning"]]`
-  global metadata directive. If one or more categories are specified (for
+  file metadata directive. If one or more categories are specified (for
   example `"suppress-warning:invalid-metadata"` or
   `"suppress-warning:deprecated, invalid-metadata"`) only warnings matching these
   categories are suppressed, otherwise all warnings are suppressed.
@@ -854,7 +854,7 @@ These are the changes since the Ice 3.6 release or snapshot described in
   creates a `Communicator` in its constructor and destroys it in its destructor.
 
 - The `--dll-export` option of `slice2cpp` is now deprecated, and replaced by
-  the global Slice metadata `cpp:dll-export:SYMBOL`.
+  the file Slice metadata `cpp:dll-export:SYMBOL`.
 
 - The UDP and WS transports are no longer enabled by default with static builds
   of the Ice library. You need to register them explicitly with the
@@ -1003,7 +1003,7 @@ These are the changes since the Ice 3.6 release or snapshot described in
 - `Ice.HashMap` API has been aligned with the API of JavaScript `Map` type.
 
 - Added support to map Slice modules to JavaScript native modules this requires
-  using the global metadata `[["js:es6-module"]]`.
+  using the file metadata `[["js:es6-module"]]`.
 
 - The `["amd"]` metadata is now ignored in JavaScript. An operation can now be
   be dispatched asynchronously by just returning a JavaScript Promise object.
@@ -1034,7 +1034,7 @@ These are the changes since the Ice 3.6 release or snapshot described in
   trigger an assert on marshaling.
 
 - The `--dll-export` option of `slice2objc` is now deprecated, and replaced by
-  the global Slice metadata `objc:dll-export:SYMBOL`.
+  the file Slice metadata `objc:dll-export:SYMBOL`.
 
 - Added `objc:scoped` metadata for enums. The generated Objective-C enumerators
   for a "scoped enum" are prefixed with the enumeration's name. For example:

--- a/cpp/src/Slice/JavaUtil.cpp
+++ b/cpp/src/Slice/JavaUtil.cpp
@@ -139,7 +139,7 @@ public:
         static const string prefix = "java:";
 
         //
-        // Validate global metadata in the top-level file and all included files.
+        // Validate file metadata in the top-level file and all included files.
         //
         StringList files = p->allFiles();
 
@@ -166,7 +166,7 @@ public:
                     }
                     else
                     {
-                        dc->warning(InvalidMetaData, file, "",  "ignoring invalid global metadata `" + s + "'");
+                        dc->warning(InvalidMetaData, file, "",  "ignoring invalid file metadata `" + s + "'");
                         globalMetaData.remove(s);
                         continue;
                     }
@@ -953,7 +953,7 @@ Slice::JavaCompatGenerator::getPackagePrefix(const ContainedPtr& cont) const
     assert(m);
 
     //
-    // The java:package metadata can be defined as global metadata or applied to a top-level module.
+    // The java:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
     //
     static const string prefix = "java:package:";
@@ -3433,7 +3433,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
     assert(m);
 
     //
-    // The java:package metadata can be defined as global metadata or applied to a top-level module.
+    // The java:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
     //
     static const string prefix = "java:package:";

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -329,7 +329,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 else
                 {
                     warning(InvalidMetaData, "", "", string("invalid category `") + s +
-                            "' in global metadata suppress-warning");
+                            "' in file metadata suppress-warning");
                 }
             }
         }
@@ -2716,7 +2716,7 @@ Slice::Container::mergeModules()
             }
 
             //
-            // Compare the global metadata of the two modules being merged.
+            // Compare the file metadata of the two modules being merged.
             //
             DefinitionContextPtr dc2 = mod2->definitionContext();
             assert(dc2);
@@ -2725,7 +2725,7 @@ Slice::Container::mergeModules()
             metaData2.unique();
             if(!checkGlobalMetaData(metaData1, metaData2))
             {
-                unit()->warning(All, "global metadata mismatch for module `" + mod1->name() + "' in files " +
+                unit()->warning(All, "file metadata mismatch for module `" + mod1->name() + "' in files " +
                                 dc1->filename() + " and " + dc2->filename());
             }
 
@@ -3065,7 +3065,7 @@ bool
 Slice::Container::checkGlobalMetaData(const StringList& m1, const StringList& m2)
 {
     //
-    // Not all global metadata mismatches represent actual problems. We are only concerned about
+    // Not all file metadata mismatches represent actual problems. We are only concerned about
     // the prefixes listed below (also see bug 2766).
     //
     static const char* prefixes[] =
@@ -6546,12 +6546,12 @@ Slice::Unit::addGlobalMetaData(const StringList& metaData)
     assert(dc);
     if(dc->seenDefinition())
     {
-        error("global metadata must appear before any definitions");
+        error("file metadata must appear before any definitions");
     }
     else
     {
         //
-        // Append the global metadata to any existing metadata (e.g., default global metadata).
+        // Append the file metadata to any existing metadata (e.g., default file metadata).
         //
         StringList l = dc->getMetaData();
         copy(metaData.begin(), metaData.end(), back_inserter(l));

--- a/cpp/src/Slice/Python.cpp
+++ b/cpp/src/Slice/Python.cpp
@@ -685,7 +685,7 @@ Slice::Python::compile(const vector<string>& argv)
                         }
 
                         //
-                        // Check if the file contains the python:pkgdir global metadata.
+                        // Check if the file contains the python:pkgdir file metadata.
                         //
                         const string pkgdir = getPackageDirectory(icecpp->getFileName(), u);
 

--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -2852,7 +2852,7 @@ Slice::Python::getPackageDirectory(const string& file, const UnitPtr& ut)
     //
 
     //
-    // Check if the file contains the python:pkgdir global metadata.
+    // Check if the file contains the python:pkgdir file metadata.
     //
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
@@ -2877,7 +2877,7 @@ Slice::Python::getImportFileName(const string& file, const UnitPtr& ut, const ve
     //
 
     //
-    // Check if the file contains the python:pkgdir global metadata.
+    // Check if the file contains the python:pkgdir file metadata.
     //
     string pkgdir = getPackageDirectory(file, ut);
     if(!pkgdir.empty())
@@ -3034,7 +3034,7 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
     assert(m);
 
     //
-    // The python:package metadata can be defined as global metadata or applied to a top-level module.
+    // The python:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
     //
     static const string prefix = "python:package:";
@@ -3101,7 +3101,7 @@ Slice::Python::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
     static const string prefix = "python:";
 
     //
-    // Validate global metadata in the top-level file and all included files.
+    // Validate file metadata in the top-level file and all included files.
     //
     StringList files = p->allFiles();
     for(StringList::iterator q = files.begin(); q != files.end(); ++q)
@@ -3126,7 +3126,7 @@ Slice::Python::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     continue;
                 }
 
-                dc->warning(InvalidMetaData, file, "", "ignoring invalid global metadata `" + s + "'");
+                dc->warning(InvalidMetaData, file, "", "ignoring invalid file metadata `" + s + "'");
                 globalMetaData.remove(s);
             }
         }

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -2524,7 +2524,7 @@ int checkIdentifier(string& id)
     {
         DefinitionContextPtr dc = unit->currentDefinitionContext();
         assert(dc);
-        if(dc->findMetaData("underscore") != "underscore") // no 'underscore' global metadata
+        if(dc->findMetaData("underscore") != "underscore") // no 'underscore' file metadata
         {
             unit->error("illegal underscore in identifier `" + name + "'");
         }

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -646,7 +646,7 @@ int checkIdentifier(string& id)
     {
         DefinitionContextPtr dc = unit->currentDefinitionContext();
         assert(dc);
-        if(dc->findMetaData("underscore") != "underscore") // no 'underscore' global metadata
+        if(dc->findMetaData("underscore") != "underscore") // no 'underscore' file metadata
         {
             unit->error("illegal underscore in identifier `" + name + "'");
         }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -739,7 +739,7 @@ Slice::Gen::generate(const UnitPtr& p)
     string file = p->topLevelFile();
 
     //
-    // Give precedence to header-ext/source-ext global metadata.
+    // Give precedence to header-ext/source-ext file metadata.
     //
     string headerExtension = getHeaderExt(file, p);
     if(!headerExtension.empty())
@@ -987,7 +987,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 else
                 {
                     ostringstream ostr;
-                    ostr << "ignoring invalid global metadata `" << md << "'";
+                    ostr << "ignoring invalid file metadata `" << md << "'";
                     dc->warning(InvalidMetaData, file, -1, ostr.str());
                     globalMetaData.remove(md);
                 }
@@ -1001,7 +1001,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 else
                 {
                     ostringstream ostr;
-                    ostr << "ignoring invalid global metadata `" << md << "'";
+                    ostr << "ignoring invalid file metadata `" << md << "'";
                     dc->warning(InvalidMetaData, file, -1, ostr.str());
                     globalMetaData.remove(md);
                 }
@@ -5363,7 +5363,7 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
     static const string prefix = "cpp:";
 
     //
-    // Validate global metadata in the top-level file and all included files.
+    // Validate file metadata in the top-level file and all included files.
     // Note that these metadata can only be cpp:, never cpp98: or cpp11:
     //
     StringList files = p->allFiles();
@@ -5403,7 +5403,7 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     if(headerExtension > 1)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid global metadata `" << s
+                        ostr << "ignoring invalid file metadata `" << s
                              << "': directive can appear only once per file";
                         dc->warning(InvalidMetaData, file, -1, ostr.str());
                         globalMetaData.remove(s);
@@ -5416,7 +5416,7 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     if(sourceExtension > 1)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid global metadata `" << s
+                        ostr << "ignoring invalid file metadata `" << s
                              << "': directive can appear only once per file";
                         dc->warning(InvalidMetaData, file, -1, ostr.str());
                         globalMetaData.remove(s);
@@ -5429,7 +5429,7 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     if(dllExport > 1)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid global metadata `" << s
+                        ostr << "ignoring invalid file metadata `" << s
                              << "': directive can appear only once per file";
                         dc->warning(InvalidMetaData, file, -1, ostr.str());
 
@@ -5443,7 +5443,7 @@ Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                 }
 
                 ostringstream ostr;
-                ostr << "ignoring invalid global metadata `" << s << "'";
+                ostr << "ignoring invalid file metadata `" << s << "'";
                 dc->warning(InvalidMetaData, file, -1, ostr.str());
                 globalMetaData.remove(s);
             }
@@ -5856,7 +5856,7 @@ Slice::Gen::NormalizeMetaDataVisitor::normalize(const StringList& metaData)
     //             + transform "cpp98:" into "cpp:" in front
 
     //
-    // Note: global metadata like header-ext exists only in cpp:
+    // Note: file metadata like header-ext exists only in cpp:
     // form and are not processed at all
     //
 

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -41,14 +41,14 @@ private:
     void writeExtraHeaders(::IceUtilInternal::Output&);
 
     //
-    // Returns the header extension defined in the global metadata for a given file,
-    // or an empty string if no global metadata was found.
+    // Returns the header extension defined in the file metadata for a given file,
+    // or an empty string if no file metadata was found.
     //
     std::string getHeaderExt(const std::string& file, const UnitPtr& unit);
 
     //
-    // Returns the source extension defined in the global metadata for a given file,
-    // or an empty string if no global metadata was found.
+    // Returns the source extension defined in the file metadata for a given file,
+    // or an empty string if no file metadata was found.
     //
     std::string getSourceExt(const std::string& file, const UnitPtr& unit);
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -2458,7 +2458,7 @@ bool
 Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
 {
     //
-    // Validate global metadata in the top-level file and all included files.
+    // Validate file metadata in the top-level file and all included files.
     //
     StringList files = p->allFiles();
     for(StringList::iterator q = files.begin(); q != files.end(); ++q)
@@ -2488,7 +2488,7 @@ Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                 if(!(s.find(csTypeIdNsPrefix) == 0 && s.size() > csTypeIdNsPrefix.size()) &&
                    !(s.find(csAttributePrefix) == 0 && s.size() > csAttributePrefix.size()))
                 {
-                    dc->warning(InvalidMetaData, file, -1, "ignoring invalid global metadata `" + oldS + "'");
+                    dc->warning(InvalidMetaData, file, -1, "ignoring invalid file metadata `" + oldS + "'");
                     continue;
                 }
             }

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -76,7 +76,7 @@ usage(const string& n)
         "--impl                   Generate sample implementations.\n"
         "--impl-tie               Generate sample tie implementations. (Java Compat Only)\n"
         "--checksum CLASS         Generate checksums for Slice definitions into CLASS.\n"
-        "--meta META              Define global metadata directive META.\n"
+        "--meta META              Define file metadata directive META.\n"
         "--list-generated         Emit list of generated files in XML format.\n"
         "--ice                    Allow reserved Ice prefix in Slice identifiers\n"
         "                         deprecated: use instead [[\"ice-prefix\"]] metadata.\n"

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -714,12 +714,12 @@ Slice::Gen::generate(const UnitPtr& p)
     printGeneratedHeader(_jsout, _fileBase + ".ice");
 
     //
-    // Check for global "js:module:ice" metadata. If this is set then we are building Ice.
+    // Check for file "js:module:ice" metadata. If this is set then we are building Ice.
     //
     bool icejs = module == "ice";
 
     //
-    // Check for global "js:es6-module" metadata. If this is set we are using es6 module mapping
+    // Check for file "js:es6-module" metadata. If this is set we are using es6 module mapping
     //
     bool es6module = dc->findMetaData("js:es6-module") == "js:es6-module";
 

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -214,7 +214,7 @@ string
 Slice::JsGenerator::getModuleMetadata(const ContainedPtr& p)
 {
     //
-    // Check if the file contains the js:module global metadata.
+    // Check if the file contains the js:module file metadata.
     //
     DefinitionContextPtr dc = p->definitionContext();
     assert(dc);

--- a/cpp/src/slice2objc/ObjCUtil.cpp
+++ b/cpp/src/slice2objc/ObjCUtil.cpp
@@ -1054,7 +1054,7 @@ bool
 Slice::ObjCGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
 {
     //
-    // Validate global metadata in the top-level file and all included files.
+    // Validate file metadata in the top-level file and all included files.
     //
     StringList files = p->allFiles();
 
@@ -1080,7 +1080,7 @@ Slice::ObjCGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     if(headerDir > 1)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid global metadata `" << s
+                        ostr << "ignoring invalid file metadata `" << s
                              << "': directive can appear only once per file";
                         dc->warning(InvalidMetaData, file, -1, ostr.str());
                         globalMetaData.remove(s);
@@ -1093,7 +1093,7 @@ Slice::ObjCGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                     if(dllExport > 1)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid global metadata `" << s
+                        ostr << "ignoring invalid file metadata `" << s
                              << "': directive can appear only once per file";
                         dc->warning(InvalidMetaData, file, -1, ostr.str());
                         globalMetaData.remove(s);
@@ -1102,7 +1102,7 @@ Slice::ObjCGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
                 }
 
                 ostringstream ostr;
-                ostr << "ignoring invalid global metadata `" << s << "'";
+                ostr << "ignoring invalid file metadata `" << s << "'";
                 dc->warning(InvalidMetaData, file, -1, ostr.str());
 
                 globalMetaData.remove(s);

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
@@ -1,14 +1,14 @@
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:header-ext:hh': directive can appear only once per file
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:source-ext:cc': directive can appear only once per file
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:dll-export:Test': directive can appear only once per file
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:header-ext'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:header-ext:'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:source-ext'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:source-ext:'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:dll-export'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:dll-export:'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:include'
-WarningInvalidMetaData.ice: warning: ignoring invalid global metadata `cpp:include:'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:header-ext:hh': directive can appear only once per file
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:source-ext:cc': directive can appear only once per file
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:dll-export:Test': directive can appear only once per file
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:header-ext'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:header-ext:'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:source-ext'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:source-ext:'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:dll-export'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:dll-export:'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:include'
+WarningInvalidMetaData.ice: warning: ignoring invalid file metadata `cpp:include:'
 WarningInvalidMetaData.ice:32: warning: ignoring metadata `cpp:noexcept' for non local interface
 WarningInvalidMetaData.ice:35: warning: ignoring invalid metadata `cpp:type:std::list< ::std::string>' for operation with void return type
 WarningInvalidMetaData.ice:38: warning: ignoring invalid metadata `cpp:view-type:std::experimental::string_view' for operation with void return type

--- a/man/man1/slice2java.1
+++ b/man/man1/slice2java.1
@@ -125,10 +125,10 @@ the compiler.
 .TP
 .BR \-\-meta " " META\fR
 .br
-Define the global metadata directive META. Using this option is equivalent to
-defining the global metadata META in each named Slice file, as well as in any
-file included by a named Slice file. Global metadata specified with --meta
-overrides any corresponding global metadata directive in the files being
+Define the file metadata directive META. Using this option is equivalent to
+defining the file metadata META in each named Slice file, as well as in any
+file included by a named Slice file. File metadata specified with --meta
+overrides any corresponding file metadata directive in the files being
 compiled.
 
 .TP


### PR DESCRIPTION
Fixes #828.

I didn't rename variable names and other symbols. Only error messages, comments and test files.