### PR TITLE
Communicator shutdown update

### DIFF
--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice
 
             try
             {
-                // _adapters can only be updated when _shutdown is false
+                // _adapters can only be updated when _shutdown is false so no need to lock _mutex.
                 await Task.WhenAll(_adapters.Select(adapter => adapter.ShutdownAsync())).ConfigureAwait(false);
             }
             finally

--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice
             try
             {
                 // _adapters can only be updated when _shutdown is false
-                await Task.WhenAll(_adapters.Select(adapter => adapter.DisposeAsync().AsTask())).ConfigureAwait(false);
+                await Task.WhenAll(_adapters.Select(adapter => adapter.ShutdownAsync())).ConfigureAwait(false);
             }
             finally
             {

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -259,7 +259,7 @@ namespace ZeroC.Ice
             new ConcurrentDictionary<IRouterPrx, RouterInfo>();
         private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize =
             new Dictionary<Transport, BufWarnSizeInfo>();
-        private SemaphoreSlim? _shutdownSemaphore;
+        private bool _shutdown;
         private TaskCompletionSource<object?>? _waitForShutdownCompletionSource;
 
         private readonly IDictionary<Transport, Ice1EndpointFactory> _ice1TransportRegistry =

--- a/csharp/src/Ice/IncomingConnectionFactory.cs
+++ b/csharp/src/Ice/IncomingConnectionFactory.cs
@@ -98,7 +98,7 @@ namespace ZeroC.Ice
                 _acceptor.Dispose();
             }
 
-            // The connection set is immutable once _disposed = true
+            // The connection set is immutable once _shutdown is true
             var exception = new ObjectDisposedException($"{typeof(ObjectAdapter).FullName}:{_adapter.Name}");
             IEnumerable<Task> tasks = _connections.Select(connection => connection.GoAwayAsync(exception));
 

--- a/csharp/src/Ice/IncomingConnectionFactory.cs
+++ b/csharp/src/Ice/IncomingConnectionFactory.cs
@@ -8,15 +8,14 @@ using System.Threading.Tasks;
 
 namespace ZeroC.Ice
 {
-    internal abstract class IncomingConnectionFactory : IAsyncDisposable
+    internal abstract class IncomingConnectionFactory
     {
         internal abstract Endpoint Endpoint { get; }
-
-        public abstract ValueTask DisposeAsync();
-
         internal abstract void Activate();
 
         internal bool IsLocal(Endpoint endpoint) => endpoint.IsLocal(Endpoint);
+
+        internal abstract Task ShutdownAsync();
 
         internal abstract void UpdateConnectionObservers();
     }
@@ -33,47 +32,6 @@ namespace ZeroC.Ice
         private readonly HashSet<Connection> _connections = new();
         private bool _disposed;
         private readonly object _mutex = new();
-
-        public override async ValueTask DisposeAsync()
-        {
-            if (_communicator.TraceLevels.Transport >= 1)
-            {
-                _communicator.Logger.Trace(TraceLevels.TransportCategory,
-                    $"stopping to accept {Endpoint.TransportName} connections at {_acceptor}");
-            }
-
-            // Dispose of the acceptor and close the connections. It's important to perform this synchronously without
-            // any await in between to guarantee that once Communicator.ShutdownAsync returns the communicator no
-            // longer accepts any requests.
-
-            lock (_mutex)
-            {
-                _disposed = true;
-                _acceptor.Dispose();
-            }
-
-            // The connection set is immutable once _disposed = true
-            var exception = new ObjectDisposedException($"{typeof(ObjectAdapter).FullName}:{_adapter.Name}");
-            IEnumerable<Task> tasks = _connections.Select(connection => connection.GoAwayAsync(exception));
-
-            // Wait for AcceptAsync and the connection closure to return.
-            if (_acceptTask != null)
-            {
-                await _acceptTask.ConfigureAwait(false);
-            }
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-        }
-
-        public void Remove(Connection connection)
-        {
-            lock (_mutex)
-            {
-                if (!_disposed)
-                {
-                    _connections.Remove(connection);
-                }
-            }
-        }
 
         public override string ToString() => _acceptor.ToString()!;
 
@@ -109,6 +67,47 @@ namespace ZeroC.Ice
                                                     TaskCreationOptions.None,
                                                     _adapter.TaskScheduler ?? TaskScheduler.Default);
             }
+        }
+
+        internal void Remove(Connection connection)
+        {
+            lock (_mutex)
+            {
+                if (!_disposed)
+                {
+                    _connections.Remove(connection);
+                }
+            }
+        }
+
+        internal override async Task ShutdownAsync()
+        {
+            if (_communicator.TraceLevels.Transport >= 1)
+            {
+                _communicator.Logger.Trace(TraceLevels.TransportCategory,
+                    $"stopping to accept {Endpoint.TransportName} connections at {_acceptor}");
+            }
+
+            // Dispose of the acceptor and close the connections. It's important to perform this synchronously without
+            // any await in between to guarantee that once Communicator.ShutdownAsync returns the communicator no
+            // longer accepts any requests.
+
+            lock (_mutex)
+            {
+                _disposed = true;
+                _acceptor.Dispose();
+            }
+
+            // The connection set is immutable once _disposed = true
+            var exception = new ObjectDisposedException($"{typeof(ObjectAdapter).FullName}:{_adapter.Name}");
+            IEnumerable<Task> tasks = _connections.Select(connection => connection.GoAwayAsync(exception));
+
+            // Wait for AcceptAsync and the connection closure to return.
+            if (_acceptTask != null)
+            {
+                await _acceptTask.ConfigureAwait(false);
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         internal override void UpdateConnectionObservers()
@@ -187,13 +186,6 @@ namespace ZeroC.Ice
 
         private readonly Connection _connection;
 
-        public override async ValueTask DisposeAsync()
-        {
-            var exception =
-                new ObjectDisposedException($"{typeof(ObjectAdapter).FullName}:{_connection.Adapter!.Name}");
-            await _connection.GoAwayAsync(exception).ConfigureAwait(false);
-        }
-
         public override string ToString() => _connection.ToString()!;
 
         internal DatagramIncomingConnectionFactory(ObjectAdapter adapter, Endpoint endpoint)
@@ -205,6 +197,13 @@ namespace ZeroC.Ice
 
         internal override void Activate()
         {
+        }
+
+        internal override Task ShutdownAsync()
+        {
+            var exception =
+                new ObjectDisposedException($"{typeof(ObjectAdapter).FullName}:{_connection.Adapter!.Name}");
+            return _connection.GoAwayAsync(exception);
         }
 
         internal override void UpdateConnectionObservers() => _connection.UpdateObserver();


### PR DESCRIPTION
This is a small update to the Communicator's ShutdownAsync implementation, using a flag (_shutdown) as suggested by @bentoi.

