### PR TITLE
Replace WaitForShutdownAsync by ShutdownComplete property

### DIFF
--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -10,6 +10,13 @@ namespace ZeroC.Ice
 {
     public sealed partial class Communicator
     {
+        /// <summary>Returns a task that completes when the communicator's shutdown is complete: see
+        /// <see cref="ShutdownAsync"/>. This property can be retrieved before shutdown is initiated. A typical use-case
+        /// is to call <c>await communicator.ShutdownComplete;</c> in the Main method of a server to prevent the server
+        /// from exiting immediately. Once this task completes, the server can still make remote invocations since a
+        /// communicator that is shut down (but not disposed) remains usable for remote invocations.</summary>
+        public Task ShutdownComplete => _shutdownCompleteSource.Task;
+
         /// <summary>Shuts down this communicator's server functionality. This triggers the disposal of all object
         /// adapters. After this method returns, no new requests are processed. However, requests that have been started
         /// before ShutdownAsync was called might still be active until the returned task completes.</summary>
@@ -18,7 +25,6 @@ namespace ZeroC.Ice
             lock (_mutex)
             {
                 _shutdown = true;
-                _waitForShutdownCompletionSource ??= new TaskCompletionSource<object?>();
             }
 
             try
@@ -28,30 +34,8 @@ namespace ZeroC.Ice
             }
             finally
             {
-                _waitForShutdownCompletionSource.TrySetResult(null);
+                _shutdownCompleteSource.TrySetResult(null);
             }
-        }
-
-        /// <summary>Block the calling thread until the communicator has been shutdown. On the server side, the
-        /// operation completes once all executing operations have completed. On the client side, it completes once
-        /// <see cref="ShutdownAsync"/> has been called. A typical use of this method is to call it from the main
-        /// thread of a server, which will be completed once the shutdown process completes, and then the caller can
-        /// do some cleanup work before calling <see cref="Dispose"/> to dispose the runtime and finally exists the
-        /// application.</summary>
-        public void WaitForShutdown() => WaitForShutdownAsync().GetAwaiter().GetResult();
-
-        /// <summary>Returns a task that completes when the communicator is fully shut down: see
-        /// <see cref="ShutdownAsync"/>. A typical use of this method is to await the returned task from the main thread
-        /// of a server, and then perform some cleanup work before calling <see cref="DisposeAsync"/> on the
-        /// communicator. The application can make remote invocations using a communicator that is shut down but not
-        /// disposed.</summary>
-        public async Task WaitForShutdownAsync()
-        {
-            lock (_mutex)
-            {
-                _waitForShutdownCompletionSource ??= new TaskCompletionSource<object?>();
-            }
-            await _waitForShutdownCompletionSource.Task.ConfigureAwait(false);
         }
 
         /// <summary>Creates a new nameless object adapter. Such an object adapter has no configuration and can be

--- a/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
+++ b/csharp/src/Ice/Communicator-ObjectAdapterFactory.cs
@@ -37,6 +37,9 @@ namespace ZeroC.Ice
                 }
                 finally
                 {
+                    // The continuation is executed asynchronously (see _shutdownCompleteSource's construction). This
+                    // way, even if the continuation blocks waiting on ShutdownAsync to complete (with incorrect code
+                    // using Result or Wait()), ShutdownAsync will complete.
                     _shutdownCompleteSource.TrySetResult(null);
                 }
             }

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -272,7 +272,7 @@ namespace ZeroC.Ice
         private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize = new();
 
         private bool _shutdown;
-        private TaskCompletionSource<object?> _shutdownCompleteSource = new();
+        private readonly TaskCompletionSource<object?> _shutdownCompleteSource = new();
 
         /// <summary>Constructs a new communicator.</summary>
         /// <param name="properties">The properties of the new communicator.</param>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -270,9 +270,8 @@ namespace ZeroC.Ice
         private int _retryBufferSize;
         private readonly ConcurrentDictionary<IRouterPrx, RouterInfo> _routerInfoTable = new();
         private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize = new();
-
-        private bool _shutdown;
         private readonly TaskCompletionSource<object?> _shutdownCompleteSource = new();
+        private Lazy<Task>? _shutdownTask;
 
         /// <summary>Constructs a new communicator.</summary>
         /// <param name="properties">The properties of the new communicator.</param>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -270,7 +270,8 @@ namespace ZeroC.Ice
         private int _retryBufferSize;
         private readonly ConcurrentDictionary<IRouterPrx, RouterInfo> _routerInfoTable = new();
         private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize = new();
-        private readonly TaskCompletionSource<object?> _shutdownCompleteSource = new();
+        private readonly TaskCompletionSource<object?> _shutdownCompleteSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private Lazy<Task>? _shutdownTask;
 
         /// <summary>Constructs a new communicator.</summary>

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -216,24 +216,27 @@ namespace ZeroC.Ice
 
         private static string[] _emptyArgs = Array.Empty<string>();
 
+        private static readonly Dictionary<string, Assembly> _loadedAssemblies = new();
+
+        private static bool _oneOffDone;
+
+        private static bool _printProcessIdDone;
+
         private static readonly object _staticMutex = new object();
         private bool _activateCalled;
         private readonly Func<CancellationToken, Task>? _activateLocatorAsync;
-        private readonly HashSet<string> _adapterNamesInUse = new HashSet<string>();
-        private readonly List<ObjectAdapter> _adapters = new List<ObjectAdapter>();
+        private readonly HashSet<string> _adapterNamesInUse = new();
+        private readonly List<ObjectAdapter> _adapters = new();
         private ObjectAdapter? _adminAdapter;
         private readonly bool _adminEnabled;
-        private readonly HashSet<string> _adminFacetFilter = new HashSet<string>();
-        private readonly Dictionary<string, IObject> _adminFacets = new Dictionary<string, IObject>();
+        private readonly HashSet<string> _adminFacetFilter = new();
+        private readonly Dictionary<string, IObject> _adminFacets = new();
         private Identity _adminIdentity;
         private readonly bool _backgroundLocatorCacheUpdates;
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private readonly ConcurrentDictionary<string, Func<AnyClass>?> _classFactoryCache =
-            new ConcurrentDictionary<string, Func<AnyClass>?>();
-        private readonly ConcurrentDictionary<int, Func<AnyClass>?> _compactIdCache =
-            new ConcurrentDictionary<int, Func<AnyClass>?>();
-        private readonly ThreadLocal<SortedDictionary<string, string>> _currentContext
-            = new ThreadLocal<SortedDictionary<string, string>>();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private readonly ConcurrentDictionary<string, Func<AnyClass>?> _classFactoryCache = new();
+        private readonly ConcurrentDictionary<int, Func<AnyClass>?> _compactIdCache = new();
+        private readonly ThreadLocal<SortedDictionary<string, string>> _currentContext = new();
         private volatile ImmutableSortedDictionary<string, string> _defaultContext =
             ImmutableSortedDictionary<string, string>.Empty;
         private volatile ImmutableList<InvocationInterceptor> _defaultInvocationInterceptors =
@@ -243,38 +246,33 @@ namespace ZeroC.Ice
         private volatile ImmutableList<DispatchInterceptor> _defaultDispatchInterceptors =
             ImmutableList<DispatchInterceptor>.Empty;
         private Task? _destroyTask;
-        private static readonly Dictionary<string, Assembly> _loadedAssemblies = new Dictionary<string, Assembly>();
-        private readonly ConcurrentDictionary<ILocatorPrx, LocatorInfo> _locatorInfoMap =
-            new ConcurrentDictionary<ILocatorPrx, LocatorInfo>();
-
-        private volatile ILogger _logger;
-
-        private readonly object _mutex = new object();
-        private static bool _oneOffDone;
-        private static bool _printProcessIdDone;
-        private readonly ConcurrentDictionary<
-            string, Func<string?, RemoteExceptionOrigin?, RemoteException>?> _remoteExceptionFactoryCache = new();
-        private int _retryBufferSize;
-        private readonly ConcurrentDictionary<IRouterPrx, RouterInfo> _routerInfoTable =
-            new ConcurrentDictionary<IRouterPrx, RouterInfo>();
-        private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize =
-            new Dictionary<Transport, BufWarnSizeInfo>();
-        private bool _shutdown;
-        private TaskCompletionSource<object?>? _waitForShutdownCompletionSource;
 
         private readonly IDictionary<Transport, Ice1EndpointFactory> _ice1TransportRegistry =
             new ConcurrentDictionary<Transport, Ice1EndpointFactory>();
 
-        private readonly IDictionary<Transport, (Ice2EndpointFactory, Ice2EndpointParser)> _ice2TransportRegistry =
-            new ConcurrentDictionary<Transport, (Ice2EndpointFactory, Ice2EndpointParser)>();
-
         private readonly IDictionary<string, (Ice1EndpointParser, Transport)> _ice1TransportNameRegistry =
             new ConcurrentDictionary<string, (Ice1EndpointParser, Transport)>();
+
+        private readonly IDictionary<Transport, (Ice2EndpointFactory, Ice2EndpointParser)> _ice2TransportRegistry =
+            new ConcurrentDictionary<Transport, (Ice2EndpointFactory, Ice2EndpointParser)>();
 
         private readonly IDictionary<string, (Ice2EndpointParser, Transport)> _ice2TransportNameRegistry =
             new ConcurrentDictionary<string, (Ice2EndpointParser, Transport)>();
 
+        private readonly ConcurrentDictionary<ILocatorPrx, LocatorInfo> _locatorInfoMap = new();
+
+        private volatile ILogger _logger;
+        private readonly object _mutex = new object();
         private readonly List<(string Name, IPlugin Plugin)> _plugins = new();
+
+        private readonly ConcurrentDictionary<string, Func<string?, RemoteExceptionOrigin?, RemoteException>?> _remoteExceptionFactoryCache =
+            new();
+        private int _retryBufferSize;
+        private readonly ConcurrentDictionary<IRouterPrx, RouterInfo> _routerInfoTable = new();
+        private readonly Dictionary<Transport, BufWarnSizeInfo> _setBufWarnSize = new();
+
+        private bool _shutdown;
+        private TaskCompletionSource<object?> _shutdownCompleteSource = new();
 
         /// <summary>Constructs a new communicator.</summary>
         /// <param name="properties">The properties of the new communicator.</param>

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -175,7 +175,9 @@ namespace ZeroC.Ice
 
         private readonly RouterInfo? _routerInfo;
 
-        private readonly TaskCompletionSource<object?> _shutdownCompleteSource = new();
+        private readonly TaskCompletionSource<object?> _shutdownCompleteSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         private Lazy<Task>? _shutdownTask;
 
         /// <summary>Activates this object adapter. After activation, the object adapter can dispatch requests received
@@ -702,6 +704,9 @@ namespace ZeroC.Ice
                 }
                 finally
                 {
+                    // The continuation is executed asynchronously (see _shutdownCompleteSource's construction). This
+                    // way, even if the continuation blocks waiting on ShutdownAsync to complete (with incorrect code
+                    // using Result or Wait()), ShutdownAsync will complete.
                     _shutdownCompleteSource.TrySetResult(null);
                 }
             }

--- a/csharp/src/iceboxnet/ServiceManager.cs
+++ b/csharp/src/iceboxnet/ServiceManager.cs
@@ -227,7 +227,7 @@ namespace ZeroC.IceBox
                     Console.Out.WriteLine($"{bundleName} ready");
                 }
 
-                await _communicator.WaitForShutdownAsync();
+                await _communicator.ShutdownComplete;
             }
             catch (ObjectDisposedException)
             {

--- a/csharp/test/Glacier2/router/Server.cs
+++ b/csharp/test/Glacier2/router/Server.cs
@@ -31,7 +31,7 @@ namespace ZeroC.Glacier2.Test.Router
             // The test allows the prefixed userid.
             adapter.Add("_userid/callback", new Callback());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/acm/Server.cs
+++ b/csharp/test/Ice/acm/Server.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.ACM
 
             ServerReady();
             Communicator.SetProperty("Ice.PrintAdapterReady", "0");
-            await Communicator.WaitForShutdownAsync();
+            await Communicator.ShutdownComplete;
         }
 
         public static async Task<int> Main(string[] args)

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -41,9 +41,13 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
 
                 // Use a different port than the first adapter to avoid an "address already in use" error.
                 {
-                    await using var adapter = communicator.CreateObjectAdapterWithEndpoints(
+                    var adapter = communicator.CreateObjectAdapterWithEndpoints(
                         "TransientTestAdapter",
                         helper.GetTestEndpoint(2));
+
+                    TestHelper.Assert(!adapter.ShutdownComplete.IsCompleted);
+                    await adapter.DisposeAsync();
+                    TestHelper.Assert(adapter.ShutdownComplete.IsCompletedSuccessfully);
                 }
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/adapterDeactivation/Server.cs
+++ b/csharp/test/Ice/adapterDeactivation/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             await adapter.ActivateAsync();
 
             ServerReady();
-            await Communicator.WaitForShutdownAsync();
+            await Communicator.ShutdownComplete;
         }
 
         public static async Task<int> Main(string[] args)

--- a/csharp/test/Ice/admin/Server.cs
+++ b/csharp/test/Ice/admin/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Admin
             await adapter.ActivateAsync();
 
             ServerReady();
-            await Communicator.WaitForShutdownAsync();
+            await Communicator.ShutdownComplete;
         }
 
         public static async Task<int> Main(string[] args)

--- a/csharp/test/Ice/admin/TestI.cs
+++ b/csharp/test/Ice/admin/TestI.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.Admin
 
         // Note that we are executing in a thread of the *main* communicator, not the one that is being shut down.
         public void WaitForShutdown(Current current, CancellationToken cancel) =>
-            _communicator.WaitForShutdownAsync().Wait(cancel);
+            _communicator.ShutdownComplete.Wait(cancel);
 
         public void Destroy(Current current, CancellationToken cancel) => _communicator.Dispose();
 

--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.AMI
             await adapter2.ActivateAsync();
 
             ServerReady();
-            await Communicator.WaitForShutdownAsync();
+            await Communicator.ShutdownComplete;
         }
 
         public static async Task<int> Main(string[] args)

--- a/csharp/test/Ice/binding/Server.cs
+++ b/csharp/test/Ice/binding/Server.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Binding
             await adapter.ActivateAsync();
 
             ServerReady();
-            await Communicator.WaitForShutdownAsync();
+            await Communicator.ShutdownComplete;
         }
 
         public static async Task<int> Main(string[] args)

--- a/csharp/test/Ice/compress/Server.cs
+++ b/csharp/test/Ice/compress/Server.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Compress
 
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/dictMapping/Server.cs
+++ b/csharp/test/Ice/dictMapping/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.DictMapping
             adapter.Add("test", new MyClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/dictMapping/ServerAMD.cs
+++ b/csharp/test/Ice/dictMapping/ServerAMD.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.DictMapping
             adapter.Add("test", new AsyncMyClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/discovery/Server.cs
+++ b/csharp/test/Ice/discovery/Server.cs
@@ -30,7 +30,7 @@ namespace ZeroC.Ice.Test.Discovery
             adapter.Add($"faceted-controller{num}#abc", new Controller());
             await adapter.ActivateAsync();
 
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/echo/Server.cs
+++ b/csharp/test/Ice/echo/Server.cs
@@ -23,7 +23,7 @@ namespace ZeroC.Ice.Test.Echo
             adapter.AddDefault(blob);
             adapter.Add("__echo", new Echo());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/enums/Server.cs
+++ b/csharp/test/Ice/enums/Server.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Enums
             adapter.Add("test", new TestIntf());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/exceptions/Server.cs
+++ b/csharp/test/Ice/exceptions/Server.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.Exceptions
             await forwarderAdapter.ActivateAsync();
 
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -40,7 +40,7 @@ namespace ZeroC.Ice.Test.Exceptions
             await forwarderAdapter.ActivateAsync();
 
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Test;
+using ZeroC.Test;
 
 namespace ZeroC.Ice.Test.Exceptions
 {
@@ -10,20 +10,17 @@ namespace ZeroC.Ice.Test.Exceptions
     {
         public override async Task RunAsync(string[] args)
         {
-            Dictionary<string, string> properties = CreateTestProperties(ref args);
-            properties["Ice.Warn.Dispatch"] = "0";
-            properties["Ice.Warn.Connections"] = "0";
-            properties["Ice.IncomingFrameMaxSize"] = "10K";
-            using Communicator communicator = Initialize(properties);
-            communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
-            communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
-            communicator.SetProperty("TestAdapter2.IncomingFrameMaxSize", "0");
-            communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
-            communicator.SetProperty("TestAdapter3.IncomingFrameMaxSize", "1K");
+            await Communicator.ActivateAsync();
+            Dictionary<string, string> properties = Communicator.GetProperties();
+            Communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
+            Communicator.SetProperty("TestAdapter2.Endpoints", GetTestEndpoint(1));
+            Communicator.SetProperty("TestAdapter2.IncomingFrameMaxSize", "0");
+            Communicator.SetProperty("TestAdapter3.Endpoints", GetTestEndpoint(2));
+            Communicator.SetProperty("TestAdapter3.IncomingFrameMaxSize", "1K");
 
-            ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
-            ObjectAdapter adapter2 = communicator.CreateObjectAdapter("TestAdapter2");
-            ObjectAdapter adapter3 = communicator.CreateObjectAdapter("TestAdapter3");
+            ObjectAdapter adapter = Communicator.CreateObjectAdapter("TestAdapter");
+            ObjectAdapter adapter2 = Communicator.CreateObjectAdapter("TestAdapter2");
+            ObjectAdapter adapter3 = Communicator.CreateObjectAdapter("TestAdapter3");
             var obj = new AsyncThrower();
             ZeroC.Ice.IObjectPrx prx = adapter.Add("thrower", obj, ZeroC.Ice.IObjectPrx.Factory);
             adapter2.Add("thrower", obj);
@@ -40,9 +37,18 @@ namespace ZeroC.Ice.Test.Exceptions
             await forwarderAdapter.ActivateAsync();
 
             ServerReady();
-            await communicator.ShutdownComplete;
+            await Communicator.ShutdownComplete;
         }
 
-        public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);
+        public static async Task<int> Main(string[] args)
+        {
+            Dictionary<string, string> properties = CreateTestProperties(ref args);
+            properties["Ice.Warn.Dispatch"] = "0";
+            properties["Ice.Warn.Connections"] = "0";
+            properties["Ice.IncomingFrameMaxSize"] = "10K";
+
+            await using var communicator = CreateCommunicator(properties);
+            return await RunTestAsync<ServerAMD>(communicator, args);
+        }
     }
 }

--- a/csharp/test/Ice/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/exceptions/ServerAMD.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.Exceptions
             await adapter2.ActivateAsync();
             await adapter3.ActivateAsync();
 
-            using var communicator2 = new Communicator(properties);
+            await using var communicator2 = new Communicator(properties);
             communicator2.SetProperty("ForwarderAdapter.Endpoints", GetTestEndpoint(3));
             communicator2.SetProperty("ForwarderAdapter.IncomingFrameMaxSize", "0");
             ObjectAdapter forwarderAdapter = communicator2.CreateObjectAdapter("ForwarderAdapter");

--- a/csharp/test/Ice/facets/Server.cs
+++ b/csharp/test/Ice/facets/Server.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.Facets
             adapter.Add("d#facetGH", h);
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/faultTolerance/Server.cs
+++ b/csharp/test/Ice/faultTolerance/Server.cs
@@ -47,7 +47,7 @@ namespace ZeroC.Ice.Test.FaultTolerance
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/info/Server.cs
+++ b/csharp/test/Ice/info/Server.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Info
             adapter.Add("test", new TestIntf());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/inheritance/Server.cs
+++ b/csharp/test/Ice/inheritance/Server.cs
@@ -17,7 +17,7 @@ namespace ZeroC.Ice.Test.Inheritance
             adapter.Add("initial", initial);
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/interceptor/Server.cs
+++ b/csharp/test/Ice/interceptor/Server.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.Interceptor
             adapter.Add("test", new MyObject());
             await DispatchInterceptors.ActivateAsync(adapter);
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/interceptor/ServerAMD.cs
+++ b/csharp/test/Ice/interceptor/ServerAMD.cs
@@ -32,7 +32,7 @@ namespace ZeroC.Ice.Test.Interceptor
             adapter.Add("test", new AsyncMyObject());
             await DispatchInterceptors.ActivateAsync(adapter);
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/invoke/Server.cs
+++ b/csharp/test/Ice/invoke/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Invoke
             adapter.AddDefault(new BlobjectI());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/location/Server.cs
+++ b/csharp/test/Ice/location/Server.cs
@@ -30,7 +30,7 @@ namespace ZeroC.Ice.Test.Location
 
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/location/ServerManagerI.cs
+++ b/csharp/test/Ice/location/ServerManagerI.cs
@@ -25,7 +25,7 @@ namespace ZeroC.Ice.Test.Location
             foreach (Communicator c in _communicators)
             {
                 await c.ShutdownComplete;
-                c.Dispose();
+                await c.DisposeAsync();
             }
             _communicators.Clear();
 
@@ -90,15 +90,14 @@ namespace ZeroC.Ice.Test.Location
             }
         }
 
-        public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
+        public async ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {
             foreach (Communicator c in _communicators)
             {
-                c.Dispose();
+                await c.DisposeAsync();
             }
             _communicators.Clear();
             _ = current.Communicator.ShutdownAsync();
-            return default;
         }
     }
 }

--- a/csharp/test/Ice/location/ServerManagerI.cs
+++ b/csharp/test/Ice/location/ServerManagerI.cs
@@ -24,7 +24,7 @@ namespace ZeroC.Ice.Test.Location
         {
             foreach (Communicator c in _communicators)
             {
-                await c.WaitForShutdownAsync();
+                await c.ShutdownComplete;
                 c.Dispose();
             }
             _communicators.Clear();

--- a/csharp/test/Ice/metrics/Server.cs
+++ b/csharp/test/Ice/metrics/Server.cs
@@ -37,7 +37,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             controllerAdapter.Add("controller", new Controller(schedulerPair.ExclusiveScheduler));
             await controllerAdapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/namespacemd/Server.cs
+++ b/csharp/test/Ice/namespacemd/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.NamespaceMD
             adapter.Add("initial", new Initial());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/networkProxy/Server.cs
+++ b/csharp/test/Ice/networkProxy/Server.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("test", new TestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/objects/Server.cs
+++ b/csharp/test/Ice/objects/Server.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.Objects
             adapter.Add("uoet", uoet);
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/operations/Server.cs
+++ b/csharp/test/Ice/operations/Server.cs
@@ -20,7 +20,7 @@ namespace ZeroC.Ice.Test.Operations
             adapter.Add("test", new MyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/operations/ServerAMD.cs
+++ b/csharp/test/Ice/operations/ServerAMD.cs
@@ -19,7 +19,7 @@ namespace ZeroC.Ice.Test.Operations
             adapter.Add("test", new AsyncMyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/optional/Server.cs
+++ b/csharp/test/Ice/optional/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Optional
             adapter.Add("test", new Test());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/perf/Server.cs
+++ b/csharp/test/Ice/perf/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Perf
             adapter.Add("perf", new PerformanceI());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/protocolBridging/Server.cs
+++ b/csharp/test/Ice/protocolBridging/Server.cs
@@ -57,7 +57,7 @@ namespace ZeroC.Ice.Test.ProtocolBridging
             await adapterSame.ActivateAsync();
             await adapterOther.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/proxy/Server.cs
+++ b/csharp/test/Ice/proxy/Server.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.Proxy
             adapter.Add("test", new MyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/proxy/ServerAMD.cs
+++ b/csharp/test/Ice/proxy/ServerAMD.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.Proxy
             adapter.Add("test", new AsyncMyDerivedClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/retry/Server.cs
+++ b/csharp/test/Ice/retry/Server.cs
@@ -26,7 +26,7 @@ namespace ZeroC.Ice.Test.Retry
             adapter2.Add("replicated", new Replicated(false));
             await adapter2.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/scope/Server.cs
+++ b/csharp/test/Ice/scope/Server.cs
@@ -121,7 +121,7 @@ namespace ZeroC.Ice.Test.Scope
             adapter.Add("i4", new I4());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/seqMapping/Server.cs
+++ b/csharp/test/Ice/seqMapping/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.SeqMapping
             adapter.Add("test", new MyClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/seqMapping/ServerAMD.cs
+++ b/csharp/test/Ice/seqMapping/ServerAMD.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.SeqMapping
             adapter.Add("test", new AsyncMyClass());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/slicing/exceptions/Server.cs
+++ b/csharp/test/Ice/slicing/exceptions/Server.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/exceptions/ServerAMD.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new AsyncTestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/slicing/objects/Server.cs
+++ b/csharp/test/Ice/slicing/objects/Server.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new TestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/slicing/objects/ServerAMD.cs
+++ b/csharp/test/Ice/slicing/objects/ServerAMD.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Ice.Test.Slicing.Objects
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add("Test", new AsyncTestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/tagged/Server.cs
+++ b/csharp/test/Ice/tagged/Server.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Tagged
             adapter.Add("initial", new Initial());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/tagged/ServerAMD.cs
+++ b/csharp/test/Ice/tagged/ServerAMD.cs
@@ -16,7 +16,7 @@ namespace ZeroC.Ice.Test.Tagged
             adapter.Add("initial", new AsyncInitial());
             await adapter.ActivateAsync();
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<ServerAMD>(args);

--- a/csharp/test/Ice/threading/Server.cs
+++ b/csharp/test/Ice/threading/Server.cs
@@ -42,7 +42,7 @@ namespace ZeroC.Ice.Test.Threading
             ThreadPool.SetMaxThreads(20, 4);
 
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice.Test.Timeout
             await controllerAdapter.ActivateAsync();
 
             ServerReady();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -70,7 +70,7 @@ namespace ZeroC.Ice.Test.UDP
             mcastAdapter.Add("test", new TestIntf());
             await mcastAdapter.ActivateAsync();
 
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/IceGrid/simple/Server.cs
+++ b/csharp/test/IceGrid/simple/Server.cs
@@ -20,7 +20,7 @@ namespace ZeroC.IceGrid.Test.Simple
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");
             adapter.Add(communicator.GetProperty("Identity") ?? "test", new TestIntf());
             await adapter.ActivateAsync();
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/IceSSL/configuration/Server.cs
+++ b/csharp/test/IceSSL/configuration/Server.cs
@@ -23,7 +23,7 @@ namespace ZeroC.IceSSL.Test.Configuration
             adapter.Add("factory", new ServerFactory(args[0] + "/../certs"));
             await adapter.ActivateAsync();
 
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);

--- a/csharp/test/Slice/alias/Server.cs
+++ b/csharp/test/Slice/alias/Server.cs
@@ -18,7 +18,7 @@ namespace ZeroC.Slice.Test.Alias
             await adapter.ActivateAsync();
             ServerReady();
 
-            await communicator.WaitForShutdownAsync();
+            await communicator.ShutdownComplete;
         }
 
         public static Task<int> Main(string[] args) => TestDriver.RunTestAsync<Server>(args);


### PR DESCRIPTION
This PR replaces `Communicator.WaitForShutdownAsync` by a `ShutdownComplete` property, and adds `ObjectAdapter.ShutdownComplete` for consistency.

This PR also updates the shutdown implementation to use a "lazy" pattern:
```
            lock (_mutex)
            {
                _shutdownTask ??= new Lazy<Task>(() => PerformShutdownAsync());
            }
            return _shutdownTask.Value;
```

This pattern has several advantages:
 - the "body" executes immediately (synchronously) but outside the mutex lock
 - only one body executes
 - all the callers get the same task object