### PR TITLE
Remove Communicator.Dispose, IObjectPrx.GetConnection and more

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -208,10 +208,6 @@ namespace ZeroC.Ice
         /// <return><c>true</c> if the connection is active, <c>false</c> if it's closing or closed.</return>
         public bool IsActive => _state == ConnectionState.Active;
 
-        /// <summary>Sends a ping frame.</summary>
-        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-        public void Ping(CancellationToken cancel = default) => PingAsync(cancel: cancel).GetAwaiter().GetResult();
-
         /// <summary>Sends an asynchronous ping frame.</summary>
         /// <param name="progress">Sent progress provider.</param>
         /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -212,14 +212,6 @@ namespace ZeroC.Ice
         /// <param name="proxy">The proxy.</param>
         /// <param name="cancel">The cancellation token.</param>
         /// <returns>The Connection for this proxy.</returns>
-        public static Connection GetConnection(this IObjectPrx proxy, CancellationToken cancel = default) =>
-            proxy.GetConnectionAsync(cancel).GetResult();
-
-        /// <summary>Returns the Connection for this proxy. If the proxy does not yet have an established connection,
-        /// it first attempts to create a connection.</summary>
-        /// <param name="proxy">The proxy.</param>
-        /// <param name="cancel">The cancellation token.</param>
-        /// <returns>The Connection for this proxy.</returns>
         public static ValueTask<Connection> GetConnectionAsync(
             this IObjectPrx proxy,
             CancellationToken cancel = default) =>

--- a/csharp/src/Ice/TaskExtensions.cs
+++ b/csharp/src/Ice/TaskExtensions.cs
@@ -12,43 +12,6 @@ namespace ZeroC.Ice
     /// connection to be sent.</summary>
     public static class TaskExtensions
     {
-        /// <summary>Waits for a value task to complete and returns its result.</summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="task">The value task.</param>
-        /// <returns>The result.</returns>
-        internal static TResult GetResult<TResult>(this ValueTask<TResult> task) =>
-            task.IsCompleted ? task.Result : task.AsTask().GetAwaiter().GetResult();
-
-        /// <summary>Waits for a value task to complete.</summary>
-        /// <param name="task">The value task.</param>
-        internal static void GetResult(this ValueTask task)
-        {
-            if (!task.IsCompleted)
-            {
-                task.AsTask().GetAwaiter().GetResult();
-            }
-        }
-
-        /// <summary>Waits for the task to complete and allows the wait to be canceled.</summary>
-        /// <param name="task">The task to wait for.</param>
-        /// <param name="cancel">The cancellation token.</param>
-        internal static async ValueTask WaitAsync(this ValueTask task, CancellationToken cancel)
-        {
-            // Optimization: if the given task is already completed or the cancellation token is not cancelable,
-            // not need to wait for these two.
-            if (cancel.CanBeCanceled && !task.IsCompleted)
-            {
-                Task asTask = task.AsTask();
-                await Task.WhenAny(asTask, Task.Delay(-1, cancel)).ConfigureAwait(false);
-                cancel.ThrowIfCancellationRequested();
-                await asTask.ConfigureAwait(false);
-            }
-            else
-            {
-                await task.ConfigureAwait(false);
-            }
-        }
-
         /// <summary>Waits for the task to complete and allows the wait to be canceled.</summary>
         /// <param name="task">The task to wait for.</param>
         /// <param name="cancel">The cancellation token.</param>

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -162,15 +162,15 @@ namespace ZeroC.Ice.Test.ACM
             properties["Ice.IdleTimeout"] = $"{_clientIdleTimeout ?? 2}s";
             properties["Ice.KeepAlive"] = _clientKeepAlive?.ToString() ?? "0";
             _communicator = TestHelper.CreateCommunicator(properties);
-            _thread = new Thread(Run);
+            _thread = new Thread(() => RunAsync().Wait()); // TODO: fix
         }
 
         public void Start() => _thread!.Start();
 
-        public void Destroy()
+        public async Task DestroyAsync()
         {
-            _adapter!.Deactivate();
-            _communicator!.Dispose();
+            await _adapter!.DeactivateAsync();
+            await _communicator!.DestroyAsync();
         }
 
         public void Join()
@@ -190,7 +190,7 @@ namespace ZeroC.Ice.Test.ACM
             }
         }
 
-        public void Run()
+        public async Task RunAsync()
         {
             var proxy = ITestIntfPrx.Parse(_adapter!.GetTestIntf()!.ToString() ?? "", _communicator!);
             try
@@ -212,7 +212,7 @@ namespace ZeroC.Ice.Test.ACM
                         }
                     };
 
-                RunTestCase(_adapter, proxy);
+                await RunTestCaseAsync(_adapter, proxy);
             }
             catch (Exception ex)
             {
@@ -237,7 +237,7 @@ namespace ZeroC.Ice.Test.ACM
             }
         }
 
-        public abstract void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy);
+        public abstract Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy);
 
         public void SetClientParams(int idleTimeout, bool keepAlive)
         {
@@ -259,7 +259,7 @@ namespace ZeroC.Ice.Test.ACM
             // Faster ACM to make sure we receive enough ACM heartbeats
             public InvocationHeartbeatTest(IRemoteCommunicatorPrx com, TestHelper helper)
                 : base("invocation heartbeat", com, helper) => SetServerParams(2, false);
-            public override void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 proxy.Sleep(4);
 
@@ -268,6 +268,7 @@ namespace ZeroC.Ice.Test.ACM
                     TestHelper.Assert(Heartbeat >= 2);
                     TestHelper.Assert(!Closed);
                 }
+                return Task.CompletedTask;
             }
         }
 
@@ -277,7 +278,7 @@ namespace ZeroC.Ice.Test.ACM
             public CloseOnIdleTest(IRemoteCommunicatorPrx com, TestHelper helper)
                 : base("close on idle", com, helper) => SetClientParams(1, false);
 
-            public override void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 Connection connection = proxy.GetConnection()!;
                 WaitForClosed();
@@ -286,6 +287,7 @@ namespace ZeroC.Ice.Test.ACM
                     TestHelper.Assert(Heartbeat == 0);
                     TestHelper.Assert(!connection.IsActive);
                 }
+                return Task.CompletedTask;
             }
         }
 
@@ -295,7 +297,7 @@ namespace ZeroC.Ice.Test.ACM
             public HeartbeatOnIdleTest(IRemoteCommunicatorPrx com, TestHelper helper)
                 : base("heartbeat on idle", com, helper) => SetServerParams(1, true);
 
-            public override void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 Thread.Sleep(3000);
 
@@ -303,6 +305,7 @@ namespace ZeroC.Ice.Test.ACM
                 {
                     TestHelper.Assert(Heartbeat >= 3);
                 }
+                return Task.CompletedTask;
             }
         }
 
@@ -316,7 +319,7 @@ namespace ZeroC.Ice.Test.ACM
                 SetServerParams(10, false);
             }
 
-            public override void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 proxy.StartHeartbeatCount();
                 Connection con = proxy.GetConnection()!;
@@ -326,6 +329,7 @@ namespace ZeroC.Ice.Test.ACM
                 con.Ping();
                 con.Ping();
                 proxy.WaitForHeartbeatCount(5);
+                return Task.CompletedTask;
             }
         }
 
@@ -338,7 +342,7 @@ namespace ZeroC.Ice.Test.ACM
                 SetServerParams(60, false);
             }
 
-            public override void RunTestCase(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override async Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 Connection? con = proxy.GetCachedConnection();
                 TestHelper.Assert(con != null);
@@ -365,7 +369,7 @@ namespace ZeroC.Ice.Test.ACM
                 con.Closed += (sender, args) => t1.SetResult(null);
                 con.Closed += (sender, args) => t2.SetResult(null);
 
-                con.GoAwayAsync();
+                await con.GoAwayAsync();
                 TestHelper.Assert(t1.Task.Result == null);
                 TestHelper.Assert(t2.Task.Result == null);
 
@@ -383,7 +387,7 @@ namespace ZeroC.Ice.Test.ACM
                                                                     (50, "false"),
                                                                 })
                 {
-                    using var communicator = new Communicator(
+                    await using var communicator = new Communicator(
                         new Dictionary<string, string>(proxy.Communicator.GetProperties())
                         {
                             ["Ice.IdleTimeout"] = $"{idleTimeout}s",
@@ -398,7 +402,7 @@ namespace ZeroC.Ice.Test.ACM
             }
         }
 
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
             var com = IRemoteCommunicatorPrx.Parse(helper.GetTestProxy("communicator", 0), communicator);
@@ -429,14 +433,13 @@ namespace ZeroC.Ice.Test.ACM
             }
             foreach (TestCase test in tests)
             {
-                test.Destroy();
+                await test.DestroyAsync();
             }
 
             output.Write("shutting down... ");
             output.Flush();
             com.Shutdown();
             output.WriteLine("ok");
-            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -322,11 +322,11 @@ namespace ZeroC.Ice.Test.ACM
             {
                 proxy.StartHeartbeatCount();
                 Connection con = await proxy.GetConnectionAsync();
-                con.Ping();
-                con.Ping();
-                con.Ping();
-                con.Ping();
-                con.Ping();
+                await con.PingAsync();
+                await con.PingAsync();
+                await con.PingAsync();
+                await con.PingAsync();
+                await con.PingAsync();
                 proxy.WaitForHeartbeatCount(5);
             }
         }

--- a/csharp/test/Ice/acm/AllTests.cs
+++ b/csharp/test/Ice/acm/AllTests.cs
@@ -195,7 +195,7 @@ namespace ZeroC.Ice.Test.ACM
             var proxy = ITestIntfPrx.Parse(_adapter!.GetTestIntf()!.ToString() ?? "", _communicator!);
             try
             {
-                proxy.GetConnection().Closed += (sender, args) =>
+                (await proxy.GetConnectionAsync()).Closed += (sender, args) =>
                     {
                         lock (Mutex)
                         {
@@ -204,7 +204,7 @@ namespace ZeroC.Ice.Test.ACM
                         }
                     };
 
-                proxy.GetConnection().PingReceived += (sender, args) =>
+                (await proxy.GetConnectionAsync()).PingReceived += (sender, args) =>
                     {
                         lock (Mutex)
                         {
@@ -278,16 +278,15 @@ namespace ZeroC.Ice.Test.ACM
             public CloseOnIdleTest(IRemoteCommunicatorPrx com, TestHelper helper)
                 : base("close on idle", com, helper) => SetClientParams(1, false);
 
-            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override async Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
-                Connection connection = proxy.GetConnection()!;
+                Connection connection = await proxy.GetConnectionAsync();
                 WaitForClosed();
                 lock (Mutex)
                 {
                     TestHelper.Assert(Heartbeat == 0);
                     TestHelper.Assert(!connection.IsActive);
                 }
-                return Task.CompletedTask;
             }
         }
 
@@ -319,17 +318,16 @@ namespace ZeroC.Ice.Test.ACM
                 SetServerParams(10, false);
             }
 
-            public override Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
+            public override async Task RunTestCaseAsync(IRemoteObjectAdapterPrx adapter, ITestIntfPrx proxy)
             {
                 proxy.StartHeartbeatCount();
-                Connection con = proxy.GetConnection()!;
+                Connection con = await proxy.GetConnectionAsync();
                 con.Ping();
                 con.Ping();
                 con.Ping();
                 con.Ping();
                 con.Ping();
                 proxy.WaitForHeartbeatCount(5);
-                return Task.CompletedTask;
             }
         }
 
@@ -395,7 +393,7 @@ namespace ZeroC.Ice.Test.ACM
                         });
 
                     proxy = ITestIntfPrx.Parse(proxy.ToString()!, communicator);
-                    Connection? connection = proxy.GetConnection()!;
+                    Connection connection = await proxy.GetConnectionAsync();
                     TestHelper.Assert(connection.IdleTimeout == TimeSpan.FromSeconds(idleTimeout));
                     TestHelper.Assert(connection.KeepAlive == bool.Parse(keepAlive));
                 }

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -155,8 +155,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
             }
             output.WriteLine("ok");
 
-            Connection? connection = obj.GetConnection();
-            if (connection != null)
+            Connection connection = await obj.GetConnectionAsync();
             {
                 output.Write("testing object adapter with bi-dir connection... ");
                 output.Flush();

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -63,7 +63,7 @@ namespace ZeroC.Ice.Test.AdapterDeactivation
                 output.Flush();
                 for (int i = 0; i < 10; ++i)
                 {
-                    using var comm = new Communicator(communicator.GetProperties());
+                    await using var comm = new Communicator(communicator.GetProperties());
                     _ = IObjectPrx.Parse(helper.GetTestProxy("test", 0), communicator).IcePingAsync();
                 }
                 output.WriteLine("ok");

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -138,7 +138,7 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.ServerName"] = "127.0.0.1",
                     ["Ice.Admin.InstanceName"] = "Test"
                 };
-                using var com = new Communicator(properties);
+                await using var com = new Communicator(properties);
                 await com.ActivateAsync();
                 TestFacets(com, true, false);
             }
@@ -151,13 +151,13 @@ namespace ZeroC.Ice.Test.Admin
                     ["Ice.Admin.InstanceName"] = "Test",
                     ["Ice.Admin.Facets"] = "Properties"
                 };
-                using var com = new Communicator(properties);
+                await using var com = new Communicator(properties);
                 await com.ActivateAsync();
                 TestFacets(com, false, true);
             }
             {
                 // Test: Verify that the operations work correctly with the Admin object disabled.
-                using var com = new Communicator();
+                await using var com = new Communicator();
                 await com.ActivateAsync();
                 TestFacets(com, false, false);
             }
@@ -167,7 +167,7 @@ namespace ZeroC.Ice.Test.Admin
                 {
                     { "Ice.Admin.Enabled", "1" }
                 };
-                using var com = new Communicator(properties);
+                await using var com = new Communicator(properties);
                 await com.ActivateAsync();
                 TestHelper.Assert(com.GetAdminAsync().GetAwaiter().GetResult() == null);
                 var id = Identity.Parse("test-admin");
@@ -195,7 +195,7 @@ namespace ZeroC.Ice.Test.Admin
                     { "Ice.Admin.InstanceName", "Test" }
                 };
 
-                using var com = new Communicator(properties);
+                await using var com = new Communicator(properties);
                 TestFacets(com, true, false);
                 await com.ActivateAsync();
                 TestFacets(com, true, false);
@@ -220,7 +220,7 @@ namespace ZeroC.Ice.Test.Admin
                 TestHelper.Assert(obj != null);
                 IProcessPrx proc = obj.Clone(IProcessPrx.Factory, facet: "Process");
                 proc.Shutdown();
-                com.WaitForShutdown();
+                com.Shutdown();
                 com.Destroy();
             }
             output.WriteLine("ok");
@@ -615,7 +615,7 @@ namespace ZeroC.Ice.Test.Admin
                     obj.Clone(IObjectPrx.Factory, facet: "Process").CheckedCast(IProcessPrx.Factory);
                 TestHelper.Assert(proc != null);
                 proc.Shutdown();
-                com.WaitForShutdown();
+                com.Shutdown();
                 com.Destroy();
             }
             output.WriteLine("ok");

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -169,7 +169,7 @@ namespace ZeroC.Ice.Test.Admin
                 };
                 await using var com = new Communicator(properties);
                 await com.ActivateAsync();
-                TestHelper.Assert(com.GetAdminAsync().GetAwaiter().GetResult() == null);
+                TestHelper.Assert(await com.GetAdminAsync() == null);
                 var id = Identity.Parse("test-admin");
                 try
                 {
@@ -181,8 +181,8 @@ namespace ZeroC.Ice.Test.Admin
                 }
 
                 ObjectAdapter adapter = com.CreateObjectAdapter();
-                TestHelper.Assert(com.CreateAdminAsync(adapter, id).GetAwaiter().GetResult() != null);
-                TestHelper.Assert(com.GetAdminAsync().GetAwaiter().GetResult() != null);
+                TestHelper.Assert(await com.CreateAdminAsync(adapter, id) != null);
+                TestHelper.Assert(await com.GetAdminAsync() != null);
 
                 TestFacets(com, true, false);
             }

--- a/csharp/test/Ice/admin/Test.ice
+++ b/csharp/test/Ice/admin/Test.ice
@@ -27,9 +27,6 @@ interface RemoteCommunicator
     void error(string message);
 
     void shutdown();
-
-    void waitForShutdown();
-
     void destroy();
 }
 

--- a/csharp/test/Ice/alias/Server.cs
+++ b/csharp/test/Ice/alias/Server.cs
@@ -10,6 +10,7 @@ namespace ZeroC.Ice.Test.Alias
         public override async Task RunAsync(string[] args)
         {
             await using Communicator communicator = Initialize(ref args);
+            await communicator.ActivateAsync();
             communicator.SetProperty("TestAdapter.Endpoints", GetTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.CreateObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -519,7 +519,7 @@ namespace ZeroC.Ice.Test.AMI
                                 TestHelper.Assert(previous == expected);
                                 expected = j;
                             }
-                            await serialized.GetConnection().GoAwayAsync();
+                            await (await serialized.GetConnectionAsync()).GoAwayAsync();
                         }
                     }
 
@@ -534,7 +534,7 @@ namespace ZeroC.Ice.Test.AMI
                             {
                                 tasks[j] = serialized.IcePingAsync();
                             }
-                            _ = serialized.GetConnection().GoAwayAsync();
+                            _ = (await serialized.GetConnectionAsync()).GoAwayAsync();
                             for (int j = 0; j < tasks.Length; ++j)
                             {
                                 await tasks[j].ConfigureAwait(false);
@@ -573,7 +573,7 @@ namespace ZeroC.Ice.Test.AMI
                             {
                                 await tasks[j].ConfigureAwait(false);
                             }
-                            await serialized.GetConnection().GoAwayAsync();
+                            await (await serialized.GetConnectionAsync()).GoAwayAsync();
                         }
                     }
 
@@ -589,7 +589,7 @@ namespace ZeroC.Ice.Test.AMI
                             {
                                 tasks[j] = serializedOneway.IcePingAsync();
                             }
-                            _ = serializedOneway.GetConnection().GoAwayAsync();
+                            _ = (await serializedOneway.GetConnectionAsync()).GoAwayAsync();
                             for (int j = 0; j < tasks.Length; ++j)
                             {
                                 await tasks[j].ConfigureAwait(false);
@@ -799,7 +799,7 @@ namespace ZeroC.Ice.Test.AMI
                     // without waiting for the pending invocation to complete. There will be no retry and we expect the
                     // invocation to fail with ConnectionClosedException.
                     p = p.Clone(label: "CloseGracefully"); // Start with a new connection.
-                    Connection con = p.GetConnection();
+                    Connection con = await p.GetConnectionAsync();
                     var cb = new CallbackBase();
                     Task t = p.StartDispatchAsync(progress: new Progress(sentSynchronously => cb.Called()));
                     cb.Check(); // Ensure the request was sent before we close the connection.
@@ -817,7 +817,7 @@ namespace ZeroC.Ice.Test.AMI
 
                     // Remote case: the server closes the connection gracefully, which means the connection will not
                     // be closed until all pending dispatched requests have completed.
-                    con = p.GetConnection();
+                    con = await p.GetConnectionAsync();
                     cb = new CallbackBase();
                     con.Closed += (sender, args) => cb.Called();
                     t = p.SleepAsync(100);
@@ -833,7 +833,7 @@ namespace ZeroC.Ice.Test.AMI
                     // Local case: start an operation and then close the connection forcefully on the client side.
                     // There will be no retry and we expect the invocation to fail with ConnectionClosedLocallyException.
                     await p.IcePingAsync();
-                    Connection con = p.GetConnection();
+                    Connection con = await p.GetConnectionAsync();
                     var cb = new CallbackBase();
                     Task t = p.StartDispatchAsync(
                         progress: new Progress(sentSynchronously => cb.Called()));

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -98,7 +98,7 @@ namespace ZeroC.Ice.Test.AMI
             }
         }
 
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
 
@@ -295,7 +295,7 @@ namespace ZeroC.Ice.Test.AMI
 
                 Communicator ic = TestHelper.CreateCommunicator(communicator.GetProperties());
                 var p2 = ITestIntfPrx.Parse(p.ToString()!, ic);
-                ic.Dispose();
+                await ic.DisposeAsync();
 
                 try
                 {
@@ -698,14 +698,14 @@ namespace ZeroC.Ice.Test.AMI
                 // Set the value on the servant to 20 and sleep for 500ms. We send a large payload to fill up the
                 // send buffer and ensure other requests won't be sent.
                 serialized.Set(20);
-                serialized.SleepAsync(400);
+                _ = serialized.SleepAsync(400);
                 var payload = new byte[5 * 1024 * 1024];
-                serialized.OpWithPayloadAsync(payload);
-                serialized.OpWithPayloadAsync(payload);
-                serialized.OpWithPayloadAsync(payload);
-                serialized.OpWithPayloadAsync(payload);
-                serialized.OpWithPayloadAsync(payload);
-                serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
+                _ = serialized.OpWithPayloadAsync(payload);
 
                 // The send queue is blocked, we send 4 set requests and cancel 2 of them. We make sure that the
                 // requests are canceled and not sent by checking the response of set which sends the previous set
@@ -765,7 +765,7 @@ namespace ZeroC.Ice.Test.AMI
                         }
 
                         var cb = new ProgressCallback();
-                        p.CloseAsync(CloseMode.Gracefully, progress: cb);
+                        _ = p.CloseAsync(CloseMode.Gracefully, progress: cb);
 
                         if (!cb.Sent)
                         {
@@ -832,13 +832,13 @@ namespace ZeroC.Ice.Test.AMI
                 {
                     // Local case: start an operation and then close the connection forcefully on the client side.
                     // There will be no retry and we expect the invocation to fail with ConnectionClosedLocallyException.
-                    p.IcePing();
+                    await p.IcePingAsync();
                     Connection con = p.GetConnection();
                     var cb = new CallbackBase();
                     Task t = p.StartDispatchAsync(
                         progress: new Progress(sentSynchronously => cb.Called()));
                     cb.Check(); // Ensure the request was sent before we close the connection.
-                    con.AbortAsync();
+                    _ = con.AbortAsync();
                     try
                     {
                         t.Wait();
@@ -880,8 +880,7 @@ namespace ZeroC.Ice.Test.AMI
             }
             output.WriteLine("ok");
 
-            p.Shutdown();
-            return Task.CompletedTask;
+            await p.ShutdownAsync();
         }
     }
 }

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -463,14 +463,14 @@ namespace ZeroC.Ice.Test.Binding
 
                 foreach (Dictionary<string, string> p in serverProps)
                 {
-                    using var serverCommunicator = new Communicator(p);
+                    await using var serverCommunicator = new Communicator(p);
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapter("Adapter");
                     await oa.ActivateAsync();
 
                     IObjectPrx prx = oa.CreateProxy("dummy", IObjectPrx.Factory);
                     try
                     {
-                        using var clientCommunicator = new Communicator();
+                        await using var clientCommunicator = new Communicator();
                         prx = IObjectPrx.Parse(prx.ToString()!, clientCommunicator);
                         prx.IcePing();
                         TestHelper.Assert(false);
@@ -483,7 +483,7 @@ namespace ZeroC.Ice.Test.Binding
 
                 // Test IPv6 dual mode socket
                 {
-                    using var serverCommunicator = new Communicator();
+                    await using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::0");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
                     await oa.ActivateAsync();
@@ -502,7 +502,7 @@ namespace ZeroC.Ice.Test.Binding
 
                     try
                     {
-                        using var clientCommunicator = new Communicator();
+                        await using var clientCommunicator = new Communicator();
                         var prx = IObjectPrx.Parse(getProxy("dummy", "127.0.0.1"), clientCommunicator);
                         prx.IcePing();
                     }
@@ -514,7 +514,7 @@ namespace ZeroC.Ice.Test.Binding
 
                 // Test IPv6 only endpoints
                 {
-                    using var serverCommunicator = new Communicator();
+                    await using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::0") + (ice1 ? " --ipv6Only" : "?ipv6-only=true");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
                     await oa.ActivateAsync();
@@ -529,7 +529,7 @@ namespace ZeroC.Ice.Test.Binding
 
                     try
                     {
-                        using var clientCommunicator = new Communicator();
+                        await using var clientCommunicator = new Communicator();
                         var prx = IObjectPrx.Parse(getProxy("dummy", "127.0.0.1"), clientCommunicator);
                         prx.IcePing();
                         TestHelper.Assert(false);
@@ -542,7 +542,7 @@ namespace ZeroC.Ice.Test.Binding
 
                 // Listen on IPv4 loopback with IPv6 dual mode socket
                 {
-                    using var serverCommunicator = new Communicator();
+                    await using var serverCommunicator = new Communicator();
                     string endpoint = getEndpoint("::ffff:127.0.0.1");
                     ObjectAdapter oa = serverCommunicator.CreateObjectAdapterWithEndpoints(endpoint);
                     await oa.ActivateAsync();
@@ -562,7 +562,7 @@ namespace ZeroC.Ice.Test.Binding
 
                     try
                     {
-                        using var clientCommunicator = new Communicator();
+                        await using var clientCommunicator = new Communicator();
                         var prx = IObjectPrx.Parse(getProxy("dummy", "127.0.0.1"), clientCommunicator);
                         prx.IcePing();
                     }

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -54,7 +54,7 @@ namespace ZeroC.Ice.Test.Binding
                 ITestIntfPrx? test1 = adapter.GetTestIntf();
                 ITestIntfPrx? test2 = adapter.GetTestIntf();
                 TestHelper.Assert(test1 != null && test2 != null);
-                TestHelper.Assert(test1.GetConnection() == test2.GetConnection());
+                TestHelper.Assert(await test1.GetConnectionAsync() == await test2.GetConnectionAsync());
 
                 test1.IcePing();
                 test2.IcePing();
@@ -129,8 +129,7 @@ namespace ZeroC.Ice.Test.Binding
                                                                   preferExistingConnection: false);
                 TestHelper.Assert(!test1.CacheConnection && !test1.PreferExistingConnection);
                 TestHelper.Assert(!test2.CacheConnection && !test2.PreferExistingConnection);
-                TestHelper.Assert(test1.GetConnection() != null && test2.GetConnection() != null);
-                TestHelper.Assert(test1.GetConnection() == test2.GetConnection());
+                TestHelper.Assert(await test1.GetConnectionAsync() == await test2.GetConnectionAsync());
 
                 test1.IcePing();
 
@@ -139,7 +138,7 @@ namespace ZeroC.Ice.Test.Binding
                 var test3 = test1.Clone(ITestIntfPrx.Factory);
                 try
                 {
-                    TestHelper.Assert(test3.GetConnection() == test1.GetConnection());
+                    TestHelper.Assert(await test3.GetConnectionAsync() == await test1.GetConnectionAsync());
                     TestHelper.Assert(false);
                 }
                 catch (ConnectFailedException)
@@ -302,7 +301,7 @@ namespace ZeroC.Ice.Test.Binding
                     ITestIntfPrx testUDP = obj.Clone(invocationMode: InvocationMode.Datagram, preferNonSecure: NonSecure.Never);
                     try
                     {
-                        testUDP.GetConnection();
+                        await testUDP.GetConnectionAsync();
                         TestHelper.Assert(false);
                     }
                     catch (NoEndpointException)
@@ -311,7 +310,7 @@ namespace ZeroC.Ice.Test.Binding
                     }
 
                     testUDP = obj.Clone(invocationMode: InvocationMode.Datagram, preferNonSecure: NonSecure.Always);
-                    TestHelper.Assert(obj.GetConnection() != testUDP.GetConnection());
+                    TestHelper.Assert(await obj.GetConnectionAsync() != await testUDP.GetConnectionAsync());
                     try
                     {
                         testUDP.GetAdapterName();
@@ -340,21 +339,21 @@ namespace ZeroC.Ice.Test.Binding
                     for (int i = 0; i < 5; i++)
                     {
                         TestHelper.Assert(obj.GetAdapterName().Equals("Adapter82"));
-                        _ = obj.GetConnection().GoAwayAsync();
+                        _ = (await obj.GetConnectionAsync()).GoAwayAsync();
                     }
 
                     ITestIntfPrx testNonSecure = obj.Clone(preferNonSecure: NonSecure.Always);
                     // TODO: update when PreferNonSecure default is updated
                     ITestIntfPrx testSecure = obj.Clone(preferNonSecure: NonSecure.Never);
-                    TestHelper.Assert(obj.GetConnection() != testSecure.GetConnection());
-                    TestHelper.Assert(obj.GetConnection() == testNonSecure.GetConnection());
+                    TestHelper.Assert(await obj.GetConnectionAsync() != await testSecure.GetConnectionAsync());
+                    TestHelper.Assert(await obj.GetConnectionAsync() == await testNonSecure.GetConnectionAsync());
 
                     com.DeactivateObjectAdapter(adapters[1]);
 
                     for (int i = 0; i < 5; i++)
                     {
                         TestHelper.Assert(obj.GetAdapterName().Equals("Adapter81"));
-                        _ = obj.GetConnection().GoAwayAsync();
+                        _ = (await obj.GetConnectionAsync()).GoAwayAsync();
                     }
 
                     // TODO: ice1-only for now, because we send the client endpoints for use in OA configuration.
@@ -365,7 +364,7 @@ namespace ZeroC.Ice.Test.Binding
                         for (int i = 0; i < 5; i++)
                         {
                             TestHelper.Assert(obj.GetAdapterName().Equals("Adapter83"));
-                            _ = obj.GetConnection().GoAwayAsync();
+                            _ = (await obj.GetConnectionAsync()).GoAwayAsync();
                         }
                     }
 

--- a/csharp/test/Ice/discovery/AllTests.cs
+++ b/csharp/test/Ice/discovery/AllTests.cs
@@ -10,7 +10,7 @@ namespace ZeroC.Ice.Test.Discovery
 {
     public static class AllTests
     {
-        public static Task RunAsync(TestHelper helper, int num)
+        public static async Task RunAsync(TestHelper helper, int num)
         {
             TextWriter output = helper.Output;
             Communicator communicator = helper.Communicator;
@@ -273,7 +273,7 @@ namespace ZeroC.Ice.Test.Discovery
                 {
                     Dictionary<string, string> properties = communicator.GetProperties();
                     properties["Ice.Discovery.Lookup"] = $"udp -h {multicast} --interface unknown";
-                    using var comm = new Communicator(properties);
+                    await using var comm = new Communicator(properties);
                     TestHelper.Assert(comm.DefaultLocator != null);
                     try
                     {
@@ -294,7 +294,7 @@ namespace ZeroC.Ice.Test.Discovery
                         lookup += " --interface {intf}";
                     }
 
-                    using var comm = new Communicator(properties);
+                    await using var comm = new Communicator(properties);
                     TestHelper.Assert(comm.DefaultLocator != null);
                     IObjectPrx.Parse(ice1 ? "controller0@control0" : "ice:control0//controller0", comm).IcePing();
                 }
@@ -305,10 +305,9 @@ namespace ZeroC.Ice.Test.Discovery
             output.Flush();
             foreach (IControllerPrx prx in proxies)
             {
-                prx.Shutdown();
+                await prx.ShutdownAsync();
             }
             output.WriteLine("ok");
-            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -253,13 +253,13 @@ namespace ZeroC.Ice.Test.Exceptions
 
             output.WriteLine("ok");
 
-            if (thrower.GetConnection() is not ColocatedConnection)
+            if (await thrower.GetConnectionAsync() is not ColocatedConnection)
             {
                 output.Write("testing incoming frame max size...");
                 output.Flush();
                 if (thrower.Protocol == Protocol.Ice1)
                 {
-                    TestHelper.Assert(thrower.GetConnection().PeerIncomingFrameMaxSize == -1);
+                    TestHelper.Assert((await thrower.GetConnectionAsync()).PeerIncomingFrameMaxSize == -1);
                     try
                     {
                         thrower.SendAndReceive(Array.Empty<byte>());
@@ -322,7 +322,7 @@ namespace ZeroC.Ice.Test.Exceptions
                 }
                 else
                 {
-                    TestHelper.Assert(thrower.GetConnection().PeerIncomingFrameMaxSize == 10 * 1024);
+                    TestHelper.Assert((await thrower.GetConnectionAsync()).PeerIncomingFrameMaxSize == 10 * 1024);
                     try
                     {
                         // The response is too large
@@ -346,7 +346,7 @@ namespace ZeroC.Ice.Test.Exceptions
                     }
 
                     var thrower2 = IThrowerPrx.Parse(helper.GetTestProxy("thrower", 1), communicator);
-                    TestHelper.Assert(thrower2.GetConnection().PeerIncomingFrameMaxSize == int.MaxValue);
+                    TestHelper.Assert((await thrower2.GetConnectionAsync()).PeerIncomingFrameMaxSize == int.MaxValue);
                     try
                     {
                         // The response is too large
@@ -359,7 +359,7 @@ namespace ZeroC.Ice.Test.Exceptions
                     }
 
                     var thrower3 = IThrowerPrx.Parse(helper.GetTestProxy("thrower", 2), communicator);
-                    TestHelper.Assert(thrower3.GetConnection().PeerIncomingFrameMaxSize == 1024);
+                    TestHelper.Assert((await thrower3.GetConnectionAsync()).PeerIncomingFrameMaxSize == 1024);
                     try
                     {
                         // The request is too large
@@ -371,7 +371,7 @@ namespace ZeroC.Ice.Test.Exceptions
                     }
 
                     var forwarder = IThrowerPrx.Parse(helper.GetTestProxy("forwarder", 3), communicator);
-                    TestHelper.Assert(forwarder.GetConnection().PeerIncomingFrameMaxSize == int.MaxValue);
+                    TestHelper.Assert((await forwarder.GetConnectionAsync()).PeerIncomingFrameMaxSize == int.MaxValue);
                     try
                     {
                         forwarder.SendAndReceive(new byte[20 * 1024]);

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -141,7 +141,7 @@ namespace ZeroC.Ice.Test.Info
             output.Write("test connection endpoint information... ");
             output.Flush();
             {
-                Endpoint tcpEndpoint = testIntf.GetConnection()!.Endpoint;
+                Endpoint tcpEndpoint = (await testIntf.GetConnectionAsync()).Endpoint;
                 TestHelper.Assert(tcpEndpoint.Port == endpointPort);
 
                 TestHelper.Assert(tcpEndpoint["compress"] == null);
@@ -156,8 +156,8 @@ namespace ZeroC.Ice.Test.Info
                 if (ice1)
                 {
                     Endpoint udpEndpoint =
-                        testIntf.Clone(invocationMode: InvocationMode.Datagram,
-                                       preferNonSecure: NonSecure.Always).GetConnection()!.Endpoint;
+                        (await testIntf.Clone(invocationMode: InvocationMode.Datagram,
+                                       preferNonSecure: NonSecure.Always).GetConnectionAsync()).Endpoint;
                     TestHelper.Assert(udpEndpoint.Port == endpointPort);
                     TestHelper.Assert(udpEndpoint.Host == defaultHost);
                 }
@@ -167,7 +167,7 @@ namespace ZeroC.Ice.Test.Info
             output.Write("testing connection information... ");
             output.Flush();
             {
-                var connection = (IPConnection)testIntf.GetConnection()!;
+                var connection = (IPConnection)await testIntf.GetConnectionAsync();
 
                 TestHelper.Assert(!connection.IsIncoming);
                 TestHelper.Assert(connection.Adapter == null);
@@ -238,8 +238,9 @@ namespace ZeroC.Ice.Test.Info
 
                 if (ice1)
                 {
-                    connection = (IPConnection)testIntf.Clone(invocationMode: InvocationMode.Datagram,
-                                                              preferNonSecure: NonSecure.Always).GetConnection()!;
+                    connection = (IPConnection)await testIntf.Clone(
+                        invocationMode: InvocationMode.Datagram,
+                        preferNonSecure: NonSecure.Always).GetConnectionAsync();
 
                     var udpConnection = connection as UdpConnection;
                     TestHelper.Assert(udpConnection != null);

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -117,7 +117,7 @@ namespace ZeroC.Ice.Test.Interceptor
                         return response;
                     });
 
-                communicator.ActivateAsync().GetAwaiter().GetResult();
+                await communicator.ActivateAsync();
 
                 for (int i = 0; i < 10; ++i)
                 {
@@ -158,7 +158,7 @@ namespace ZeroC.Ice.Test.Interceptor
                     });
 
                 TestHelper.Assert(communicator.DefaultInvocationInterceptors.Count == 3);
-                communicator.ActivateAsync().GetAwaiter().GetResult();
+                await communicator.ActivateAsync();
                 TestHelper.Assert(communicator.DefaultInvocationInterceptors.Count == 4);
 
                 var prx1 = IMyObjectPrx.Parse(prx.ToString()!, communicator);
@@ -191,7 +191,7 @@ namespace ZeroC.Ice.Test.Interceptor
                         TestHelper.Assert(false);
                         return next(target, request, cancel);
                     });
-                communicator.ActivateAsync().GetAwaiter().GetResult();
+                await communicator.ActivateAsync();
 
                 var prx1 = IMyObjectPrx.Parse(prx.ToString()!, communicator);
                 try

--- a/csharp/test/Ice/interceptor/AllTests.cs
+++ b/csharp/test/Ice/interceptor/AllTests.cs
@@ -12,7 +12,7 @@ namespace ZeroC.Ice.Test.Interceptor
 {
     public static class AllTests
     {
-        public static IMyObjectPrx Run(TestHelper helper)
+        public static async Task<IMyObjectPrx> RunAsync(TestHelper helper)
         {
             bool ice2 = helper.Protocol == Protocol.Ice2;
             var prx = IMyObjectPrx.Parse(helper.GetTestProxy("test"), helper.Communicator!);
@@ -85,7 +85,7 @@ namespace ZeroC.Ice.Test.Interceptor
             {
                 var tasks = new List<Task>();
                 var invocationContext = new AsyncLocal<int>();
-                using var communicator = new Communicator(prx.Communicator.GetProperties());
+                await using var communicator = new Communicator(prx.Communicator.GetProperties());
 
                 communicator.DefaultInvocationInterceptors = ImmutableList.Create<InvocationInterceptor>(
                     (target, request, next, cancel) =>
@@ -134,7 +134,7 @@ namespace ZeroC.Ice.Test.Interceptor
                 int invocations = 0;
                 // An interceptor can stop the chain and directly return a response without calling next,
                 // the first invocation calls next and subsequent invocations reuse the first response.
-                using var communicator = new Communicator(prx.Communicator.GetProperties());
+                await using var communicator = new Communicator(prx.Communicator.GetProperties());
 
                 communicator.DefaultInvocationInterceptors = ImmutableList.Create<InvocationInterceptor>(
                     (target, request, next, cancel) =>
@@ -174,7 +174,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
             {
                 // throwing from an interceptor stops the interceptor chain
-                using var communicator = new Communicator(prx.Communicator.GetProperties());
+                await using var communicator = new Communicator(prx.Communicator.GetProperties());
                 communicator.DefaultInvocationInterceptors = ImmutableList.Create<InvocationInterceptor>(
                     (target, request, next, cancel) =>
                     {

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.Interceptor
 
             await communicator.ActivateAsync();
 
-            IMyObjectPrx prx = AllTests.Run(this);
+            IMyObjectPrx prx = await AllTests.RunAsync(this);
             await prx.ShutdownAsync();
         }
 

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -522,7 +522,7 @@ namespace ZeroC.Ice.Test.Location
             {
                 Dictionary<string, string> properties = communicator.GetProperties();
                 properties["Ice.BackgroundLocatorCacheUpdates"] = "1";
-                using Communicator ic = helper.Initialize(properties);
+                await using Communicator ic = helper.Initialize(properties);
 
                 RegisterAdapterEndpoints(
                     registry,

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -601,7 +601,7 @@ namespace ZeroC.Ice.Test.Location
                 output.Flush();
                 hello = IHelloPrx.Parse(ice1 ? "hello" : "ice:hello", communicator);
                 obj1.MigrateHello();
-                _ = hello.GetConnection().GoAwayAsync();
+                _ = (await hello.GetConnectionAsync()).GoAwayAsync();
                 hello.SayHello();
                 obj1.MigrateHello();
                 hello.SayHello();
@@ -664,17 +664,17 @@ namespace ZeroC.Ice.Test.Location
             {
                 helloPrx = IHelloPrx.Parse($"ice:{id}", communicator);
             }
-            TestHelper.Assert(helloPrx.GetConnection() is ColocatedConnection);
+            TestHelper.Assert(await helloPrx.GetConnectionAsync() is ColocatedConnection);
 
             // Ensure that calls on the indirect proxy (with adapter ID) is colocated
             helloPrx = adapter.CreateProxy(id, IObjectPrx.Factory).CheckedCast(IHelloPrx.Factory);
-            TestHelper.Assert(helloPrx != null && helloPrx.GetConnection() is ColocatedConnection);
+            TestHelper.Assert(helloPrx != null && await helloPrx.GetConnectionAsync() is ColocatedConnection);
 
             // Ensure that calls on the direct proxy is colocated
             helloPrx = adapter.CreateProxy(id, IObjectPrx.Factory).Clone(
                 endpoints: adapter.PublishedEndpoints,
                 location: ImmutableArray<string>.Empty).CheckedCast(IHelloPrx.Factory);
-            TestHelper.Assert(helloPrx != null && helloPrx.GetConnection() is ColocatedConnection);
+            TestHelper.Assert(helloPrx != null && await helloPrx.GetConnectionAsync() is ColocatedConnection);
 
             output.WriteLine("ok");
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -384,7 +384,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             TextWriter output = helper.Output;
 
-            IObjectPrx? admin = communicator.GetAdminAsync().GetAwaiter().GetResult();
+            IObjectPrx? admin = await communicator.GetAdminAsync();
             TestHelper.Assert(admin != null);
             var clientProps = admin.Clone(IPropertiesAdminPrx.Factory, facet: "Properties");
             var clientMetrics = admin.Clone(IMetricsAdminPrx.Factory, facet: "Metrics");

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Test;
 using ZeroC.IceMX;
 
@@ -364,7 +365,7 @@ namespace ZeroC.Ice.Test.Metrics
             return m;
         }
 
-        public static IMetricsPrx Run(TestHelper helper, CommunicatorObserver obsv, bool colocated)
+        public static async Task<IMetricsPrx> RunAsync(TestHelper helper, CommunicatorObserver obsv, bool colocated)
         {
             Communicator? communicator = helper.Communicator;
 
@@ -468,8 +469,8 @@ namespace ZeroC.Ice.Test.Metrics
             TestHelper.Assert(view["Dispatch"][0]!.Current == 0 && view["Dispatch"][0]!.Total == 5);
             TestHelper.Assert(view["Dispatch"][0]!.Id.IndexOf("[ice_ping]", StringComparison.InvariantCulture) > 0);
 
-            metrics.GetConnection().GoAwayAsync();
-            metrics.Clone(label: "Con1").GetConnection().GoAwayAsync();
+            _ = (await metrics.GetConnectionAsync()).GoAwayAsync();
+            _ = (await metrics.Clone(label: "Con1").GetConnectionAsync()).GoAwayAsync();
 
             WaitForCurrent(clientMetrics, "View", "Connection", 0);
             WaitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -578,7 +579,7 @@ namespace ZeroC.Ice.Test.Metrics
             map = ToMap(serverMetrics.GetMetricsView("View").ReturnValue["Connection"]!);
 
             TestHelper.Assert(map["active"].Current == 1);
-            metrics.GetConnection().GoAwayAsync();
+            _ = (await metrics.GetConnectionAsync()).GoAwayAsync();
 
             map = ToMap(clientMetrics.GetMetricsView("View").ReturnValue["Connection"]!);
             // The connection might already be closed so it can be 0 or 1
@@ -591,7 +592,7 @@ namespace ZeroC.Ice.Test.Metrics
 
             props["IceMX.Metrics.View.Map.Connection.GroupBy"] = "none";
             UpdateProps(clientProps, serverProps, update, props, "Connection");
-            metrics.GetConnection().GoAwayAsync();
+            _ = (await metrics.GetConnectionAsync()).GoAwayAsync();
 
             if (!colocated)
             {
@@ -663,7 +664,7 @@ namespace ZeroC.Ice.Test.Metrics
             TestAttribute(clientMetrics, clientProps, update, "Connection", "mcastHost", "", output);
             TestAttribute(clientMetrics, clientProps, update, "Connection", "mcastPort", "", output);
 
-            m.GetConnection().GoAwayAsync();
+            _ = (await m.GetConnectionAsync()).GoAwayAsync();
 
             WaitForCurrent(clientMetrics, "View", "Connection", 0);
             WaitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -686,7 +687,7 @@ namespace ZeroC.Ice.Test.Metrics
                 m1 = clientMetrics.GetMetricsView("View").ReturnValue["ConnectionEstablishment"][0]!;
                 TestHelper.Assert(m1.Current == 0 && m1.Total == 1 && m1.Id.Equals(hostAndPort));
 
-                metrics.GetConnection().GoAwayAsync();
+                _ = (await metrics.GetConnectionAsync()).GoAwayAsync();
 
                 ClearView(clientProps, serverProps, update);
                 TestHelper.Assert(clientMetrics.GetMetricsView("View").ReturnValue["ConnectionEstablishment"].Length == 0);
@@ -771,7 +772,7 @@ namespace ZeroC.Ice.Test.Metrics
                 try
                 {
                     prx.IcePing();
-                    prx.GetConnection().GoAwayAsync();
+                    _ = (await prx.GetConnectionAsync()).GoAwayAsync();
                 }
                 catch
                 {
@@ -826,9 +827,9 @@ namespace ZeroC.Ice.Test.Metrics
 
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "parent", "Communicator", c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "id",
-                            prx.GetConnection().Endpoint.ToString(), c, output);
+                            (await prx.GetConnectionAsync()).Endpoint.ToString(), c, output);
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpoint",
-                            prx.GetConnection().Endpoint.ToString(), c, output);
+                            (await prx.GetConnectionAsync()).Endpoint.ToString(), c, output);
 
                 TestAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointTransport", transportName,
                     c, output);

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -22,7 +22,7 @@ namespace ZeroC.Ice.Test.Metrics
             properties["Ice.InvocationMaxAttempts"] = "2";
 
             await using Communicator? communicator = Initialize(properties, observer: observer);
-            IMetricsPrx metrics = AllTests.Run(this, observer, colocated: false);
+            IMetricsPrx metrics = await AllTests.RunAsync(this, observer, colocated: false);
             await metrics.ShutdownAsync();
         }
 

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -27,7 +27,7 @@ namespace ZeroC.Ice.Test.Metrics
             adapter.Add("metrics", new Metrics());
             // Don't activate OA to ensure collocation is used.
 
-            IMetricsPrx metrics = AllTests.Run(this, observer, colocated: true);
+            IMetricsPrx metrics = await AllTests.RunAsync(this, observer, colocated: true);
             await metrics.ShutdownAsync();
         }
 

--- a/csharp/test/Ice/metrics/MetricsI.cs
+++ b/csharp/test/Ice/metrics/MetricsI.cs
@@ -2,38 +2,41 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ZeroC.Ice.Test.Metrics
 {
-    public sealed class Metrics : IMetrics
+    internal sealed class Metrics : IAsyncMetrics
     {
-        public void Op(Current current, CancellationToken cancel)
+        public ValueTask OpAsync(Current current, CancellationToken cancel) => default;
+
+        public ValueTask FailAsync(Current current, CancellationToken cancel)
         {
+            _ = current.Connection.AbortAsync();
+            return default;
         }
 
-        public void Fail(Current current, CancellationToken cancel) =>
-            current.Connection.AbortAsync();
-
-        public void OpWithUserException(Current current, CancellationToken cancel) =>
+        public ValueTask OpWithUserExceptionAsync(Current current, CancellationToken cancel) =>
             throw new UserEx("custom UserEx message");
 
-        public void OpWithRequestFailedException(Current current, CancellationToken cancel) =>
+        public ValueTask OpWithRequestFailedExceptionAsync(Current current, CancellationToken cancel) =>
             throw new ObjectNotExistException();
 
-        public void OpWithLocalException(Current current, CancellationToken cancel) =>
+        public ValueTask OpWithLocalExceptionAsync(Current current, CancellationToken cancel) =>
             throw new InvalidConfigurationException("fake");
 
-        public void OpWithUnknownException(Current current, CancellationToken cancel) =>
+        public ValueTask OpWithUnknownExceptionAsync(Current current, CancellationToken cancel) =>
             throw new ArgumentOutOfRangeException();
 
-        public void OpByteS(byte[] bs, Current current, CancellationToken cancel)
+        public ValueTask OpByteSAsync(byte[] bs, Current current, CancellationToken cancel) => default;
+
+        public ValueTask<IObjectPrx?> GetAdminAsync(Current current, CancellationToken cancel) =>
+            new(current.Communicator.GetAdminAsync(cancel: cancel));
+
+        public ValueTask ShutdownAsync(Current current, CancellationToken cancel)
         {
+            _ = current.Communicator.ShutdownAsync();
+            return default;
         }
-
-        public IObjectPrx? GetAdmin(Current current, CancellationToken cancel) =>
-            current.Communicator.GetAdminAsync(cancel: cancel).GetAwaiter().GetResult();
-
-        public void Shutdown(Current current, CancellationToken cancel) =>
-            current.Communicator.ShutdownAsync();
     }
 }

--- a/csharp/test/Ice/metrics/Test.ice
+++ b/csharp/test/Ice/metrics/Test.ice
@@ -31,7 +31,7 @@ interface Metrics
 
     void opByteS(ByteSeq bs);
 
-    Object* getAdmin();
+    Object? getAdmin();
 
     void shutdown();
 }

--- a/csharp/test/Ice/networkProxy/AllTests.cs
+++ b/csharp/test/Ice/networkProxy/AllTests.cs
@@ -8,7 +8,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
 {
     public static class AllTests
     {
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
 
@@ -29,7 +29,7 @@ namespace ZeroC.Ice.Test.NetworkProxy
             output.Write("testing connection information... ");
             output.Flush();
             {
-                var connection = (IPConnection)testPrx.GetConnection();
+                var connection = (IPConnection)await testPrx.GetConnectionAsync();
                 TestHelper.Assert(connection.RemoteEndpoint!.Port == proxyPort); // make sure we are connected to the proxy port.
             }
             output.WriteLine("ok");
@@ -54,7 +54,6 @@ namespace ZeroC.Ice.Test.NetworkProxy
                 }
             }
             output.WriteLine("ok");
-            return Task.CompletedTask;
         }
     }
 }

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1775,7 +1775,6 @@ namespace ZeroC.Ice.Test.Operations
                 }
             }
 
-            if (p.GetConnection() != null)
             {
                 communicator.CurrentContext["one"] = "ONE";
                 communicator.CurrentContext["two"] = "TWO";

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -1231,7 +1231,6 @@ namespace ZeroC.Ice.Test.Operations
             }
 
             // Test implicit context propagation with async task
-            if (p.GetConnection() != null)
             {
                 communicator.CurrentContext["one"] = "ONE";
                 communicator.CurrentContext["two"] = "TWO";

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -531,7 +531,7 @@ namespace ZeroC.Ice.Test.Proxy
             output.Flush();
             b1 = IObjectPrx.Parse(rf, communicator);
 
-            Connection connection = b1.GetConnection();
+            Connection connection = await b1.GetConnectionAsync();
             IObjectPrx b2 = connection.CreateProxy(Identity.Parse("fixed"), facet: "", IObjectPrx.Factory);
             if (connection.Protocol == Protocol.Ice1)
             {
@@ -973,9 +973,9 @@ namespace ZeroC.Ice.Test.Proxy
             TestHelper.Assert(endpts1[0].Equals(
                 IObjectPrx.Parse("ice+tcp://127.0.0.1:10000/foo", communicator).Endpoints[0]));
 
-            if (baseProxy.GetConnection() is IPConnection baseConnection)
+            if (await baseProxy.GetConnectionAsync() is IPConnection baseConnection)
             {
-                Connection baseConnection2 = baseProxy.Clone(label: "base2").GetConnection();
+                Connection baseConnection2 = await baseProxy.Clone(label: "base2").GetConnectionAsync();
                 compObj1 = compObj1.Clone(fixedConnection: baseConnection);
                 compObj2 = compObj2.Clone(fixedConnection: baseConnection2);
                 TestHelper.Assert(!compObj1.Equals(compObj2));
@@ -1085,7 +1085,7 @@ namespace ZeroC.Ice.Test.Proxy
                 // to marshal all relative proxies with the 2.0 encoding.
 
                 await using ObjectAdapter oa = communicator.CreateObjectAdapter(protocol: helper.Protocol);
-                cl.GetConnection().Adapter = oa;
+                (await cl.GetConnectionAsync()).Adapter = oa;
                 ICallbackPrx callback = oa.AddWithUUID(
                     new Callback((relativeTest, current, cancel) =>
                                  {
@@ -1106,7 +1106,7 @@ namespace ZeroC.Ice.Test.Proxy
             output.Write("testing ice_fixed... ");
             output.Flush();
             {
-                if (cl.GetConnection() is Connection connection2)
+                if (await cl.GetConnectionAsync() is Connection connection2)
                 {
                     TestHelper.Assert(!cl.IsFixed);
                     IMyClassPrx prx = cl.Clone(fixedConnection: connection2);
@@ -1123,10 +1123,10 @@ namespace ZeroC.Ice.Test.Proxy
                     };
                     TestHelper.Assert(cl.Clone(fixedConnection: connection2).Context.Count == 0);
                     TestHelper.Assert(cl.Clone(context: ctx, fixedConnection: connection2).Context.Count == 2);
-                    TestHelper.Assert(cl.Clone(fixedConnection: connection2).GetConnection() == connection2);
-                    TestHelper.Assert(cl.Clone(fixedConnection: connection2).Clone(fixedConnection: connection2).GetConnection() == connection2);
-                    Connection? fixedConnection = cl.Clone(label: "ice_fixed").GetConnection();
-                    TestHelper.Assert(cl.Clone(fixedConnection: connection2).Clone(fixedConnection: fixedConnection).GetConnection() == fixedConnection);
+                    TestHelper.Assert(await cl.Clone(fixedConnection: connection2).GetConnectionAsync() == connection2);
+                    TestHelper.Assert(await cl.Clone(fixedConnection: connection2).Clone(fixedConnection: connection2).GetConnectionAsync() == connection2);
+                    Connection? fixedConnection = await cl.Clone(label: "ice_fixed").GetConnectionAsync();
+                    TestHelper.Assert(await cl.Clone(fixedConnection: connection2).Clone(fixedConnection: fixedConnection).GetConnectionAsync() == fixedConnection);
                     try
                     {
                         cl.Clone(invocationMode: InvocationMode.Datagram, fixedConnection: connection2);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -1235,12 +1235,12 @@ namespace ZeroC.Ice.Test.Proxy
             output.Write("testing communicator default source address... ");
             output.Flush();
             {
-                using var comm1 = new Communicator(new Dictionary<string, string>()
+                await using var comm1 = new Communicator(new Dictionary<string, string>()
                     {
                         { "Ice.Default.SourceAddress", "192.168.1.40" }
                     });
 
-                using var comm2 = new Communicator();
+                await using var comm2 = new Communicator();
 
                 string[] proxyArray =
                     {
@@ -1261,12 +1261,12 @@ namespace ZeroC.Ice.Test.Proxy
             output.Write("testing communicator default invocation timeout... ");
             output.Flush();
             {
-                using var comm1 = new Communicator(new Dictionary<string, string>()
+                await using var comm1 = new Communicator(new Dictionary<string, string>()
                     {
                         { "Ice.Default.InvocationTimeout", "120s" }
                     });
 
-                using var comm2 = new Communicator();
+                await using var comm2 = new Communicator();
 
                 TestHelper.Assert(IObjectPrx.Parse("ice+tcp://localhost/identity", comm1).InvocationTimeout ==
                                   TimeSpan.FromSeconds(120));
@@ -1293,7 +1293,7 @@ namespace ZeroC.Ice.Test.Proxy
             {
                 try
                 {
-                    using var comm1 = new Communicator(new Dictionary<string, string>()
+                    await using var comm1 = new Communicator(new Dictionary<string, string>()
                     {
                         { "Ice.Default.InvocationTimeout", "0s" }
                     });

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -267,7 +267,7 @@ namespace ZeroC.Ice.Test.Retry
                     {
                         Dictionary<string, string> properties = communicator.GetProperties();
                         properties["Ice.RetryRequestMaxSize"] = "1024";
-                        using var communicator2 = new Communicator(properties);
+                        await using var communicator2 = new Communicator(properties);
                         var retry2 = IRetryPrx.Parse(helper.GetTestProxy("retry"), communicator2);
 
                         byte[] data = Enumerable.Range(0, 1024).Select(i => (byte)i).ToArray();
@@ -292,7 +292,7 @@ namespace ZeroC.Ice.Test.Retry
                     {
                         Dictionary<string, string> properties = communicator.GetProperties();
                         properties["Ice.RetryBufferMaxSize"] = "2048";
-                        using var communicator2 = new Communicator(properties);
+                        await using var communicator2 = new Communicator(properties);
                         var retry2 = IRetryPrx.Parse(helper.GetTestProxy("retry"), communicator2);
 
                         byte[] data = Enumerable.Range(0, 1024).Select(i => (byte)i).ToArray();

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -158,7 +158,7 @@ namespace ZeroC.Ice.Test.Retry
                 output.Flush();
                 var adapter = communicator.CreateObjectAdapter(protocol: ice1 ? Protocol.Ice1 : Protocol.Ice2);
                 var bidir = adapter.AddWithUUID(new Bidir(), IBidirPrx.Factory);
-                retry1.GetConnection().Adapter = adapter;
+                (await retry1.GetConnectionAsync()).Adapter = adapter;
                 retry1.OpBidirRetry(bidir);
 
                 output.WriteLine("ok");

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -771,7 +771,7 @@ namespace ZeroC.Ice.Test.Slicing.Exceptions
                 await using var adapter = communicator.CreateObjectAdapter(protocol: helper.Protocol);
                 IRelayPrx relay = adapter.AddWithUUID(new Relay(), IRelayPrx.Factory);
                 await adapter.ActivateAsync();
-                testPrx.GetConnection().Adapter = adapter;
+                (await testPrx.GetConnectionAsync()).Adapter = adapter;
 
                 try
                 {

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -71,7 +71,7 @@ namespace ZeroC.Ice.Test.Timeout
             output.Flush();
             {
                 timeout.IcePing(); // Makes sure a working connection is associated with the proxy
-                Connection? connection = timeout.GetConnection();
+                Connection connection = await timeout.GetConnectionAsync();
                 try
                 {
                     timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(100)).SleepAsync(1000).Wait();
@@ -82,7 +82,7 @@ namespace ZeroC.Ice.Test.Timeout
                 }
                 timeout.IcePing();
 
-                TestHelper.Assert(connection == timeout.GetConnection());
+                TestHelper.Assert(connection == await timeout.GetConnectionAsync());
                 try
                 {
                     timeout.Clone(invocationTimeout: TimeSpan.FromMilliseconds(1000)).SleepAsync(100).Wait();
@@ -91,7 +91,7 @@ namespace ZeroC.Ice.Test.Timeout
                 {
                     TestHelper.Assert(false);
                 }
-                TestHelper.Assert(connection == timeout.GetConnection());
+                TestHelper.Assert(connection == await timeout.GetConnectionAsync());
 
                 try
                 {
@@ -113,8 +113,8 @@ namespace ZeroC.Ice.Test.Timeout
 
                 var to = ITimeoutPrx.Parse(helper.GetTestProxy("timeout", 0), comm);
 
-                Connection? connection = to.GetConnection();
-                Connection? connection2 = timeout.GetConnection(); // No close timeout
+                Connection connection = await to.GetConnectionAsync();
+                Connection connection2 = await timeout.GetConnectionAsync(); // No close timeout
 
                 TestHelper.Assert(connection != null && connection2 != null);
 

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -10,14 +10,14 @@ namespace ZeroC.Ice.Test.Timeout
 {
     public static class AllTests
     {
-        public static Task RunAsync(TestHelper helper)
+        public static async Task RunAsync(TestHelper helper)
         {
             Communicator communicator = helper.Communicator;
 
             var controller = IControllerPrx.Parse(helper.GetTestProxy("controller", 1), communicator);
             try
             {
-                RunWithController(helper, controller);
+                await RunWithControllerAsync(helper, controller);
             }
             catch
             {
@@ -26,10 +26,9 @@ namespace ZeroC.Ice.Test.Timeout
                 controller.ResumeAdapter();
                 throw;
             }
-            return Task.CompletedTask;
         }
 
-        public static void RunWithController(TestHelper helper, IControllerPrx controller)
+        public static async Task RunWithControllerAsync(TestHelper helper, IControllerPrx controller)
         {
             Communicator communicator = helper.Communicator;
 
@@ -43,7 +42,7 @@ namespace ZeroC.Ice.Test.Timeout
             {
                 Dictionary<string, string> properties = communicator.GetProperties();
                 properties["Ice.ConnectTimeout"] = "100ms";
-                using var comm = new Communicator(properties);
+                await using var comm = new Communicator(properties);
 
                 var to = ITimeoutPrx.Parse(helper.GetTestProxy("timeout", 0), comm);
 
@@ -110,7 +109,7 @@ namespace ZeroC.Ice.Test.Timeout
             {
                 Dictionary<string, string> properties = communicator.GetProperties();
                 properties["Ice.CloseTimeout"] = "100ms";
-                using var comm = new Communicator(properties);
+                await using var comm = new Communicator(properties);
 
                 var to = ITimeoutPrx.Parse(helper.GetTestProxy("timeout", 0), comm);
 
@@ -127,11 +126,11 @@ namespace ZeroC.Ice.Test.Timeout
 
                 var semaphore = new System.Threading.SemaphoreSlim(0);
                 connection.Closed += (sender, args) => semaphore.Release();
-                connection.GoAwayAsync();
+                _ = connection.GoAwayAsync();
                 TestHelper.Assert(semaphore.Wait(500));
 
                 connection2.Closed += (sender, args) => semaphore.Release();
-                connection2.GoAwayAsync();
+                _ = connection2.GoAwayAsync();
                 TestHelper.Assert(!semaphore.Wait(500));
 
                 controller.ResumeAdapter();

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -126,7 +126,7 @@ namespace ZeroC.Ice.Test.UDP
                 // TransportException will be thrown when we try to send a larger packet.
                 TestHelper.Assert(seq.Length > 16384);
             }
-            _ = obj.GetConnection().GoAwayAsync();
+            _ = (await obj.GetConnectionAsync()).GoAwayAsync();
             communicator.SetProperty("Ice.UDP.SndSize", "64K");
             seq = new byte[50000];
             try
@@ -202,7 +202,7 @@ namespace ZeroC.Ice.Test.UDP
             {
                 Console.Out.Write("testing udp bi-dir connection... ");
                 Console.Out.Flush();
-                obj.GetConnection().Adapter = adapter;
+                (await obj.GetConnectionAsync()).Adapter = adapter;
                 nRetry = 5;
                 while (nRetry-- > 0)
                 {

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -51,7 +51,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 properties["AdapterForDiscoveryTest.Endpoints"] = $"{helper.Transport} -h 127.0.0.1";
 
                 {
-                    using var com = new Communicator(properties);
+                    await using var com = new Communicator(properties);
                     TestHelper.Assert(com.DefaultLocator != null);
                     IObjectPrx.Parse("test @ TestAdapter", com).IcePing();
                     IObjectPrx.Parse("test", com).IcePing();
@@ -83,7 +83,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     properties["Ice.LocatorDiscovery.InstanceName"] = "unknown";
                     properties["Ice.LocatorDiscovery.RetryCount"] = "1";
                     properties["Ice.LocatorDiscovery.Timeout"] = "100ms";
-                    using var com = new Communicator(properties);
+                    await using var com = new Communicator(properties);
                     TestHelper.Assert(com.DefaultLocator != null);
                     try
                     {
@@ -133,7 +133,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     properties = communicator.GetProperties();
                     properties["Ice.Default.Locator"] = "locatordiscovery";
                     properties["Ice.LocatorDiscovery.Lookup"] = $"udp -h {multicast} --interface unknown";
-                    using var com = new Communicator(properties);
+                    await using var com = new Communicator(properties);
                     TestHelper.Assert(com.DefaultLocator != null);
                     try
                     {
@@ -150,7 +150,7 @@ namespace ZeroC.IceGrid.Test.Simple
                     properties["Ice.Default.Locator"] = "locatordiscovery";
                     properties["Ice.LocatorDiscovery.RetryCount"] = "0";
                     properties["Ice.LocatorDiscovery.Lookup"] = $"udp -h {multicast} --interface unknown";
-                    using var com = new Communicator(properties);
+                    await using var com = new Communicator(properties);
                     TestHelper.Assert(com.DefaultLocator != null);
                     try
                     {
@@ -172,7 +172,7 @@ namespace ZeroC.IceGrid.Test.Simple
                         properties["Ice.LocatorDiscovery.Lookup"] =
                             $"udp -h {multicast} --interface unknown:udp -h {multicast} -p {port} --interface {intf}";
                     }
-                    using var com = new Communicator(properties);
+                    await using var com = new Communicator(properties);
                     TestHelper.Assert(com.DefaultLocator != null);
                     IObjectPrx.Parse("test @ TestAdapter", com).IcePing();
                 }

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -185,7 +185,7 @@ namespace ZeroC.IceGrid.Test.Simple
             Console.Out.WriteLine("ok");
         }
 
-        public static void RunWithDeploy(TestHelper helper)
+        public static async Task RunWithDeployAsync(TestHelper helper)
         {
             Communicator? communicator = helper.Communicator;
             TestHelper.Assert(communicator != null);
@@ -235,7 +235,7 @@ namespace ZeroC.IceGrid.Test.Simple
                 $"{communicator.DefaultLocator!.Identity.Category}/Registry", communicator);
             IAdminSessionPrx? session = registry.CreateAdminSession("foo", "bar");
             TestHelper.Assert(session != null);
-            Connection connection = session.GetConnection();
+            Connection connection = await session.GetConnectionAsync();
             connection.KeepAlive = true;
 
             IAdminPrx? admin = session.GetAdmin();

--- a/csharp/test/IceGrid/simple/Client.cs
+++ b/csharp/test/IceGrid/simple/Client.cs
@@ -14,7 +14,7 @@ namespace ZeroC.IceGrid.Test.Simple
             await using Communicator communicator = Initialize(ref args);
             if (args.Any(v => v.Equals("--with-deploy")))
             {
-                AllTests.RunWithDeploy(this);
+                await AllTests.RunWithDeployAsync(this);
             }
             else
             {

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -897,7 +897,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             IServerPrx server = fact.CreateServer(serverProperties, false);
                             try
                             {
-                                var tcpConnection = (TcpConnection)server.GetConnection();
+                                var tcpConnection = (TcpConnection)await server.GetConnectionAsync();
                                 TestHelper.Assert(tcpConnection.IsEncrypted);
                             }
                             catch (Exception ex)
@@ -945,7 +945,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     try
                     {
                         TestHelper.Assert(server != null);
-                        var tcpConnection = (TcpConnection)server.GetConnection();
+                        var tcpConnection = (TcpConnection)await server.GetConnectionAsync();
                         TestHelper.Assert(tcpConnection.IsEncrypted);
                         server.CheckCipher(tcpConnection.NegotiatedCipherSuite!.ToString()!);
                     }
@@ -1215,7 +1215,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     {
                         try
                         {
-                            _ = p.GetConnection();
+                            _ = await p.GetConnectionAsync();
                             break;
                         }
                         catch (Exception ex)

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -134,7 +134,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                 {
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -155,7 +155,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     // Supply our own certificate.
                     clientProperties = CreateProperties(defaultProperties);
                     clientProperties["IceSSL.CAs"] = caCert1File;
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ClientCertificates = new X509Certificate2Collection
@@ -186,7 +186,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     var cert0 = new X509Certificate2(Path.Combine(defaultDir, "c_rsa_ca1.p12"), "password");
                     var cert1 = new X509Certificate2(Path.Combine(defaultDir, "c_rsa_ca2.p12"), "password");
 
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ClientCertificates = new X509Certificate2Collection
@@ -221,7 +221,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // Supply our own CA certificate.
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ServerCertificateCertificateAuthorities = new X509Certificate2Collection()
@@ -247,7 +247,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                 {
                     // Initialization using TlsClientOptions and TlsServerOptions options
-                    using var clientCommunicator = new Communicator(ref args, CreateProperties(defaultProperties),
+                    await using var clientCommunicator = new Communicator(ref args, CreateProperties(defaultProperties),
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ClientCertificates = new X509Certificate2Collection()
@@ -260,7 +260,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                             }
                         });
 
-                    using var serverCommunicator = new Communicator(ref args, CreateProperties(defaultProperties),
+                    await using var serverCommunicator = new Communicator(ref args, CreateProperties(defaultProperties),
                         tlsServerOptions: new TlsServerOptions()
                         {
                             ServerCertificate = new X509Certificate2(
@@ -292,7 +292,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     bool serverCertificateValidationCallbackCalled = false;
 
                     clientProperties = CreateProperties(defaultProperties);
-                    using var clientCommunicator = new Communicator(ref args, clientProperties,
+                    await using var clientCommunicator = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ClientCertificateSelectionCallback =
@@ -306,7 +306,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         });
 
                     serverProperties = CreateProperties(defaultProperties);
-                    using var serverCommunicator = new Communicator(ref args, serverProperties,
+                    await using var serverCommunicator = new Communicator(ref args, serverProperties,
                         tlsServerOptions: new TlsServerOptions()
                         {
                             ServerCertificate = serverCertificate,
@@ -401,7 +401,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // The server doesn't request a certificate, but it still verifies the server's.
                     clientProperties = CreateProperties(defaultProperties, ca: "cacert1");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1");
                     IServerPrx server = fact.CreateServer(serverProperties, false);
@@ -419,7 +419,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                 {
                     // This should fail because the client does not supply a certificate and server request it.
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -442,7 +442,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // Test client has a certificate and server request it.
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -461,7 +461,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should fail because the client doesn't trust the server's CA.
                     clientProperties = CreateProperties(defaultProperties);
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1");
                     IServerPrx server = fact.CreateServer(serverProperties, false);
@@ -484,7 +484,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should fail because the server doesn't trust the client's CA.
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca2");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -507,7 +507,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should succeed because the self signed certificate used by the server is trusted.
                     clientProperties = CreateProperties(defaultProperties, ca: "cacert2");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "cacert2");
                     IServerPrx server = fact.CreateServer(serverProperties, false);
@@ -525,7 +525,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should fail because the self signed certificate used by the server is not trusted.
                     clientProperties = CreateProperties(defaultProperties);
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "cacert2");
                     IServerPrx server = fact.CreateServer(serverProperties, false);
@@ -561,7 +561,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // This must succeed, the target host matches the certificate DNS altName.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn1", "cacert1");
@@ -584,7 +584,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // This must fail, the target host does not match the certificate DNS altName.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn2", "cacert1");
@@ -605,7 +605,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // does not include a DNS altName.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn3", "cacert1");
@@ -626,7 +626,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // certificate does not include a DNS altName.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn4", "cacert1");
@@ -647,7 +647,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // a DNS altName that does not matches the target host
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn5", "cacert1");
@@ -718,7 +718,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // altName.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1_cn8", "cacert1");
@@ -742,7 +742,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         // Target host does not match the certificate DNS altName, connection should fail.
                         {
                             clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                            using var comm = new Communicator(ref args, clientProperties);
+                            await using var comm = new Communicator(ref args, clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(props, "s_rsa_ca1_cn2", "cacert1");
@@ -772,7 +772,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     var myCerts = new X509Certificate2Collection();
                     myCerts.Import(defaultDir + "/c_rsa_ca1.p12", "password", X509KeyStorageFlags.DefaultKeySet);
                     bool called = false;
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ClientCertificateSelectionCallback =
@@ -827,7 +827,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     {
                         {
                             clientProperties = CreateProperties(defaultProperties);
-                            using var comm = new Communicator(clientProperties);
+                            await using var comm = new Communicator(clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
 
@@ -890,7 +890,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                         {
                             // Now the client verifies the server certificate
                             clientProperties = CreateProperties(defaultProperties, ca: "cacert1");
-                            using var comm = new Communicator(clientProperties);
+                            await using var comm = new Communicator(clientProperties);
 
                             var fact = CreateServerFactoryPrx(factoryRef, comm);
                             serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1");
@@ -926,7 +926,7 @@ namespace ZeroC.IceSSL.Test.Configuration
 
                     bool invoked = false;
                     bool hadCert = false;
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
 #pragma warning disable CA5359 // Do Not Disable Certificate Validation
@@ -964,7 +964,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     bool invoked = false;
                     // Have the verifier return false. Close the connection explicitly to force a new connection to be
                     // established.
-                    using var comm = new Communicator(ref args, clientProperties,
+                    await using var comm = new Communicator(ref args, clientProperties,
                         tlsClientOptions: new TlsClientOptions()
                         {
                             ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
@@ -1005,7 +1005,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     // in common.
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
                     clientProperties["IceSSL.Protocols"] = "tls1_2";
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     serverProperties["IceSSL.Protocols"] = "tls1_3";
@@ -1028,7 +1028,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 }
                 {
                     // This should succeed.
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     serverProperties["IceSSL.Protocols"] = "tls1_2, tls1_3";
@@ -1042,7 +1042,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
                     clientProperties["IceSSL.Protocols"] = "tls1_2";
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     serverProperties["IceSSL.Protocols"] = "tls1_2";
@@ -1063,7 +1063,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should fail because the server's certificate is expired.
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacert1");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1_exp", "cacert1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -1086,7 +1086,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     // This should fail because the client's certificate is expired.
                     clientProperties["IceSSL.CertFile"] = "c_rsa_ca1_exp.p12";
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1", "cacert1");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -1114,7 +1114,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     Console.Out.Write("testing multiple CA certificates... ");
                     Console.Out.Flush();
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
-                    using var comm = new Communicator(ref args, clientProperties);
+                    await using var comm = new Communicator(ref args, clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca2");
                     store.Add(caCert1);
@@ -1139,7 +1139,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 Console.Out.Flush();
                 {
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1", "cacerts");
-                    using var comm = new Communicator(clientProperties);
+                    await using var comm = new Communicator(clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca2", "cacerts");
                     IServerPrx server = fact.CreateServer(serverProperties, true);
@@ -1161,7 +1161,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                 {
                     clientProperties = CreateProperties(defaultProperties, "c_rsa_ca1");
                     clientProperties["IceSSL.CAs"] = "cacert1.der";
-                    using var comm = new Communicator(clientProperties);
+                    await using var comm = new Communicator(clientProperties);
                     var fact = CreateServerFactoryPrx(factoryRef, comm);
                     serverProperties = CreateProperties(defaultProperties, "s_rsa_ca1");
                     serverProperties["IceSSL.CAs"] = "cacert1.der";
@@ -1208,7 +1208,7 @@ namespace ZeroC.IceSSL.Test.Configuration
                     clientProperties = CreateProperties(defaultProperties);
                     clientProperties["IceSSL.DefaultDir"] = "";
                     clientProperties["Ice.Override.Timeout"] = "5000"; // 5s timeout
-                    using var comm = new Communicator(clientProperties);
+                    await using var comm = new Communicator(clientProperties);
                     var p = IObjectPrx.Parse("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2", comm);
 
                     while (true)

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -58,7 +58,7 @@ namespace ZeroC.IceSSL.Test.Configuration
             }
         }
 
-        internal void Destroy() => _communicator.Dispose();
+        internal Task DestroyAsync() => _communicator.DestroyAsync();
 
         private readonly Communicator _communicator;
     }
@@ -101,14 +101,13 @@ namespace ZeroC.IceSSL.Test.Configuration
             return prx;
         }
 
-        public ValueTask DestroyServerAsync(IServerPrx? srv, Current current, CancellationToken cancel)
+        public async ValueTask DestroyServerAsync(IServerPrx? srv, Current current, CancellationToken cancel)
         {
             if (_servers.TryGetValue(srv!.Identity, out SSLServer? server))
             {
-                server.Destroy();
+                await server.DestroyAsync();
                 _servers.Remove(srv.Identity);
             }
-            return default;
         }
 
         public ValueTask ShutdownAsync(Current current, CancellationToken cancel)


### PR DESCRIPTION
This PR removes various sync "wrappers" in the Ice core.
