### PR TITLE
IceUtil: Define ICE_LITTLE_ENDIAN if _M_ARM64 is

### DIFF
--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -41,6 +41,7 @@
       defined(__ARMEL__)   || \
       defined(_M_ARM_FP)   || \
       defined(__arm64)     || \
+      defined(_M_ARM64)    || \
       defined(__MIPSEL__)
 
 #   define ICE_LITTLE_ENDIAN


### PR DESCRIPTION
_M_ARM64 is defined by MSVC when the target architecture is ARM64.

https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros