### PR TITLE
Add IceSSL::getHost

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -78,10 +78,9 @@ These are the changes since Ice 3.7.5.
   failure from `IceSSL::ConnectionInfo`. To get the description of a `IceSSL::TrustError` pass it to
   `IceSSL::getTrustErrorDescription`.
 
-- Added `IceSSL::getHost` function to allow retrieving the host that was used to create a SSL connection from
-  the `IceSSL::ConnectionInfo` object. The returned host correpspond to the `Edndpoint::host` member of the endpoint
+- Added `IceSSL::getHost` function to allow retrieving the host that was used to create an SSL connection from
+  the `IceSSL::ConnectionInfo` object. The returned host corresponds to the `Endpoint::host` member of the endpoint
   that was used to create the connection.
-
 # Changes in Ice 3.7.5
 
 These are the changes since Ice 3.7.4.

--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -78,6 +78,10 @@ These are the changes since Ice 3.7.5.
   failure from `IceSSL::ConnectionInfo`. To get the description of a `IceSSL::TrustError` pass it to
   `IceSSL::getTrustErrorDescription`.
 
+- Added `IceSSL::getHost` function to allow retrieving the host that was used to create a SSL connection from
+  the `IceSSL::ConnectionInfo` object. The returned host correpspond to the `Edndpoint::host` member of the endpoint
+  that was used to create the connection.
+
 # Changes in Ice 3.7.5
 
 These are the changes since Ice 3.7.4.

--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -81,6 +81,7 @@ These are the changes since Ice 3.7.5.
 - Added `IceSSL::getHost` function to allow retrieving the host that was used to create an SSL connection from
   the `IceSSL::ConnectionInfo` object. The returned host corresponds to the `Endpoint::host` member of the endpoint
   that was used to create the connection.
+
 # Changes in Ice 3.7.5
 
 These are the changes since Ice 3.7.4.

--- a/cpp/include/IceSSL/Plugin.h
+++ b/cpp/include/IceSSL/Plugin.h
@@ -87,6 +87,7 @@ enum TrustError
 
 ICESSL_API TrustError getTrustError(const IceSSL::ConnectionInfoPtr&);
 ICESSL_API std::string getTrustErrorDescription(TrustError);
+ICESSL_API std::string getHost(const IceSSL::ConnectionInfoPtr&);
 
 /**
  * Thrown if the certificate cannot be read.

--- a/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
@@ -932,6 +932,7 @@ OpenSSL::TransceiverI::getInfo() const
     info->certs = _certs;
     info->verified = _verified;
     info->errorCode = _trustError;
+    info->host = _incoming ? "" : _host;
     return info;
 }
 

--- a/cpp/src/IceSSL/PluginI.cpp
+++ b/cpp/src/IceSSL/PluginI.cpp
@@ -237,3 +237,10 @@ IceSSL::getTrustErrorDescription(TrustError error)
     assert(false);
     return "unknown failure";
 }
+
+std::string
+IceSSL::getHost(const IceSSL::ConnectionInfoPtr& info)
+{
+    ExtendedConnectionInfoPtr extendedInfo = ICE_DYNAMIC_CAST(ExtendedConnectionInfo, info);
+    return extendedInfo ? extendedInfo->host : "";
+}

--- a/cpp/src/IceSSL/PluginI.h
+++ b/cpp/src/IceSSL/PluginI.h
@@ -18,6 +18,7 @@ class ExtendedConnectionInfo : public ConnectionInfo
 public:
 
     TrustError errorCode;
+    std::string host;
 };
 ICE_DEFINE_PTR(ExtendedConnectionInfoPtr, ExtendedConnectionInfo);
 

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -1106,6 +1106,7 @@ SChannel::TransceiverI::getInfo() const
     info->certs = _certs;
     info->verified = _verified;
     info->errorCode = _trustError;
+    info->host = _incoming ? "" : _host;
     return info;
 }
 

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
@@ -593,6 +593,7 @@ IceSSL::SecureTransport::TransceiverI::getInfo() const
     info->certs = _certs;
     info->verified = _verified;
     info->errorCode = _trustError;
+    info->host = _incoming ? "" : _host;
     return info;
 }
 

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -1241,6 +1241,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->verified);
+            test(getHost(info) == "localhost");
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
 
             fact->destroyServer(server);
@@ -1262,6 +1263,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1290,6 +1292,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             {
                 test(info->verified);
             }
+            test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1311,6 +1314,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1332,6 +1336,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1356,6 +1361,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+            test(getHost(info) == "127.0.0.1");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1376,6 +1382,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getHost(info) == "127.0.0.1");
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1401,6 +1408,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
             test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getHost(info) == "127.0.0.1");
             fact->destroyServer(server);
             comm->destroy();
         }
@@ -4100,6 +4108,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
                         ICE_DYNAMIC_CAST(Ice::WSConnectionInfo, p->ice_getConnection()->getInfo());
                     IceSSL::ConnectionInfoPtr sslInfo = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, wsinfo->underlying);
                     test(sslInfo->verified);
+                    test(getHost(sslInfo) == "zeroc.com");
                     break;
                 }
                 catch(const Ice::LocalException& ex)


### PR DESCRIPTION
This PR adds a new function `IceSSL::getHost` that allows retrieving the host that was used to create a SSL connection from the `SSLConnectionInfo`