### PR TITLE
g++11 build fixes

### DIFF
--- a/cpp/include/IceUtil/MutexPtrLock.h
+++ b/cpp/include/IceUtil/MutexPtrLock.h
@@ -16,7 +16,7 @@ class MutexPtrLock
 {
 public:
 
-    MutexPtrLock<T>(const T* mutex) :
+    MutexPtrLock(T* mutex) :
         _mutex(mutex),
         _acquired(false)
     {
@@ -27,7 +27,7 @@ public:
         }
     }
 
-    ~MutexPtrLock<T>()
+    ~MutexPtrLock()
     {
         if(_mutex && _acquired)
         {
@@ -66,8 +66,8 @@ private:
 
     // Not implemented; prevents accidental use.
     //
-    MutexPtrLock<T>(const MutexPtrLock<T>&);
-    MutexPtrLock<T>& operator=(const MutexPtrLock<T>&);
+    MutexPtrLock(const MutexPtrLock<T>&);
+    MutexPtrLock& operator=(const MutexPtrLock<T>&);
 
     const T* _mutex;
     mutable bool _acquired;

--- a/cpp/src/Slice/CPlusPlusUtil.cpp
+++ b/cpp/src/Slice/CPlusPlusUtil.cpp
@@ -1196,8 +1196,8 @@ lookupKwd(const string& name)
         "decltype", "default", "delete", "do", "double", "dynamic_cast",
         "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend",
         "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq",
-        "operator", "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast", "return",
-        "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch",
+        "operator", "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast", "requires",
+        "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch",
         "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename",
         "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
     };

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -959,57 +959,57 @@ vector<string>
 Slice::Gen::RequireVisitor::writeRequires(const UnitPtr& p)
 {
     vector<string> seenModules;
-    map<string, list<string> > requires;
+    map<string, list<string>> jsRequires;
     if(_icejs)
     {
-        requires["Ice"] = list<string>();
+        jsRequires["Ice"] = list<string>();
 
         //
         // Generate require() statements for all of the run-time code needed by the generated code.
         //
         if(_seenClass || _seenObjectSeq || _seenObjectDict)
         {
-            requires["Ice"].push_back("Ice/Object");
-            requires["Ice"].push_back("Ice/Value");
+            jsRequires["Ice"].push_back("Ice/Object");
+            jsRequires["Ice"].push_back("Ice/Value");
         }
         if(_seenClass)
         {
-            requires["Ice"].push_back("Ice/ObjectPrx");
+            jsRequires["Ice"].push_back("Ice/ObjectPrx");
         }
         if(_seenOperation)
         {
-            requires["Ice"].push_back("Ice/Operation");
+            jsRequires["Ice"].push_back("Ice/Operation");
         }
         if(_seenStruct)
         {
-            requires["Ice"].push_back("Ice/Struct");
+            jsRequires["Ice"].push_back("Ice/Struct");
         }
 
         if(_seenLocalException || _seenUserException)
         {
-            requires["Ice"].push_back("Ice/Exception");
+            jsRequires["Ice"].push_back("Ice/Exception");
         }
 
         if(_seenEnum)
         {
-            requires["Ice"].push_back("Ice/EnumBase");
+            jsRequires["Ice"].push_back("Ice/EnumBase");
         }
 
         if(_seenCompactId)
         {
-            requires["Ice"].push_back("Ice/CompactIdRegistry");
+            jsRequires["Ice"].push_back("Ice/CompactIdRegistry");
         }
 
-        requires["Ice"].push_back("Ice/Long");
-        requires["Ice"].push_back("Ice/HashMap");
-        requires["Ice"].push_back("Ice/HashUtil");
-        requires["Ice"].push_back("Ice/ArrayUtil");
-        requires["Ice"].push_back("Ice/StreamHelpers");
+        jsRequires["Ice"].push_back("Ice/Long");
+        jsRequires["Ice"].push_back("Ice/HashMap");
+        jsRequires["Ice"].push_back("Ice/HashUtil");
+        jsRequires["Ice"].push_back("Ice/ArrayUtil");
+        jsRequires["Ice"].push_back("Ice/StreamHelpers");
     }
     else
     {
-        requires["Ice"] = list<string>();
-        requires["Ice"].push_back("ice");
+        jsRequires["Ice"] = list<string>();
+        jsRequires["Ice"].push_back("ice");
     }
 
     StringList includes = p->includeFiles();
@@ -1133,19 +1133,19 @@ Slice::Gen::RequireVisitor::writeRequires(const UnitPtr& p)
             {
                 if(!_icejs && iceBuiltinModule(*j))
                 {
-                    if(requires.find(*j) == requires.end())
+                    if(jsRequires.find(*j) == jsRequires.end())
                     {
-                        requires[*j] = list<string>();
-                        requires[*j].push_back("ice");
+                        jsRequires[*j] = list<string>();
+                        jsRequires[*j].push_back("ice");
                     }
                 }
                 else
                 {
-                    if(requires.find(*j) == requires.end())
+                    if(jsRequires.find(*j) == jsRequires.end())
                     {
-                        requires[*j] = list<string>();
+                        jsRequires[*j] = list<string>();
                     }
-                    requires[*j].push_back(changeInclude(*i, _includePaths));
+                    jsRequires[*j].push_back(changeInclude(*i, _includePaths));
                 }
             }
         }
@@ -1167,7 +1167,7 @@ Slice::Gen::RequireVisitor::writeRequires(const UnitPtr& p)
             _out << nl << "const _ModuleRegistry = require(\"../Ice/ModuleRegistry\").Ice._ModuleRegistry;";
         }
 
-        for(map<string, list<string> >::const_iterator i = requires.begin(); i != requires.end(); ++i)
+        for(map<string, list<string> >::const_iterator i = jsRequires.begin(); i != jsRequires.end(); ++i)
         {
             if(!_icejs && i->first == "Ice")
             {

--- a/cpp/test/Ice/interceptor/MyObjectI.cpp
+++ b/cpp/test/Ice/interceptor/MyObjectI.cpp
@@ -6,6 +6,7 @@
 #include <MyObjectI.h>
 #include <TestHelper.h>
 #include <IceUtil/IceUtil.h>
+#include <thread>
 
 using namespace IceUtil;
 using namespace std;

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -114,8 +114,7 @@ public:
 // This section of the test is present to ensure that the C++ types
 // are named correctly. It is not expected to run.
 //
-void
-testtypes()
+void testtypes(const Ice::CommunicatorPtr& communicator)
 {
 #ifdef ICE_CPP11_MAPPING
     _cpp_and::_cpp_continue a = _cpp_and::_cpp_continue::_cpp_asm;
@@ -138,12 +137,14 @@ testtypes()
     c->_cpp_else = "";
 #endif
 
-    _cpp_and::breakPrxPtr d;
+    _cpp_and::breakPrxPtr d = ICE_UNCHECKED_CAST(_cpp_and::breakPrx,
+                                                 communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
     int d2;
     d->_cpp_case(0, d2);
     _cpp_and::breakPtr d1 = ICE_MAKE_SHARED(breakI);
 
-    _cpp_and::charPrxPtr e;
+    _cpp_and::charPrxPtr e =ICE_UNCHECKED_CAST(_cpp_and::charPrx,
+                                               communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010");
     e->_cpp_explicit();
     _cpp_and::charPtr e1 = ICE_MAKE_SHARED(charI);
 

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -137,14 +137,14 @@ void testtypes(const Ice::CommunicatorPtr& communicator)
     c->_cpp_else = "";
 #endif
 
-    _cpp_and::breakPrxPtr d = ICE_UNCHECKED_CAST(_cpp_and::breakPrx,
-                                                 communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
+    _cpp_and::breakPrxPtr d =
+        ICE_UNCHECKED_CAST(_cpp_and::breakPrx, communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
     int d2;
     d->_cpp_case(0, d2);
     _cpp_and::breakPtr d1 = ICE_MAKE_SHARED(breakI);
 
-    _cpp_and::charPrxPtr e =ICE_UNCHECKED_CAST(_cpp_and::charPrx,
-                                               communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010");
+    _cpp_and::charPrxPtr e =
+        ICE_UNCHECKED_CAST(_cpp_and::charPrx, communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
     e->_cpp_explicit();
     _cpp_and::charPtr e1 = ICE_MAKE_SHARED(charI);
 


### PR DESCRIPTION
This PR fixes a few build error detected when building with G++ 11 in C++20 mode

One remaining issue is the setting of `-std=c++11` in https://github.com/zeroc-ice/ice/blob/af5c1bf7528db71a312baa71cd2bc3fb32f05215/cpp/config/Make.rules#L100

G++11 default is C++20 mode and we force C++11 mode with this setting, the source distribution still build but it causes failures in some tests like

```
test/Ice/ami/AllTests.cpp:2165:56: error: no match for 'operator!=' (operand types are 'std::thread::id' and 'std::thread::id')
 2165 |                              (!sentSynchronously && id != this_thread::get_id()));
      |                                                     ~~ ^~ ~~~~~~~~~~~~~~~~~~~~~
      |                                                     |                        |
      |                                                     std::thread::id          std::thread::id
```

This operation is supposed to be synthesized in C++20 mode, and the headers included with G++11 don't include it, but because we build in C++11 mode it is not synthesized and the build fails.