### PR TITLE
Cpp mode check

### DIFF
--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -97,7 +97,7 @@ endif
 # the cpp11 name to the target directory if building outside the build
 # directory.
 #
-cpp11_cppflags          = -DICE_CPP11_MAPPING -std=c++11
+cpp11_cppflags          = -DICE_CPP11_MAPPING $(if $(shell $(CC) -E config/cplusplus_check.cpp 2> /dev/null),,-std=c++11)
 cpp11_ldflags           = $(cpp11_cppflags)
 cpp11_targetname        = $(if $(or $(filter-out $($1_target),program),$(filter $(bindir)%,$($4_targetdir))),++11)
 cpp11_targetdir         = $(if $(filter %/build,$5),cpp11)

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -97,7 +97,10 @@ endif
 # the cpp11 name to the target directory if building outside the build
 # directory.
 #
-cpp11_cppflags          = -DICE_CPP11_MAPPING $(if $(shell $(CC) -E config/cplusplus_check.cpp 2> /dev/null),,-std=c++11)
+cpp11_cppflags          = -DICE_CPP11_MAPPING
+ifneq ("OK", $(shell $(CC) -E config/cplusplus_check.cpp 2> /dev/null && echo "OK"))
+cpp11_cppflags          := $(cpp11_cppflags) -std=c++11
+endif
 cpp11_ldflags           = $(cpp11_cppflags)
 cpp11_targetname        = $(if $(or $(filter-out $($1_target),program),$(filter $(bindir)%,$($4_targetdir))),++11)
 cpp11_targetdir         = $(if $(filter %/build,$5),cpp11)

--- a/cpp/config/cplusplus_check.cpp
+++ b/cpp/config/cplusplus_check.cpp
@@ -1,0 +1,9 @@
+// This file is used to check if the C++ compiler version is greater than 199711L (c++98)
+// in which case we don't have to set -std=c++11 when building the C++11 mapping
+int main()
+{
+#if !defined(__cplusplus) || (__cplusplus == 199711L)
+#    error "c++98 mode"
+#endif
+    return 0;
+}


### PR DESCRIPTION
This PR updates Make build to not set `-std=c++11` when the default mode is `c++11` or greater.