### PR TITLE
Fix macOS build settings

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -26,6 +26,9 @@ iphonesimulator_ldflags         = $(iphonesimulator_cppflags)
 iphonesimulator_configs         = %xcodesdk
 iphonesimulator_targetdir       = $(if $(filter %/build,$5),/iphonesimulator)
 
+MCPP_HOME                      ?= $(shell brew --prefix mcpp)
+LMDB_HOME                      ?= $(shell brew --prefix lmdb)
+
 # If building objects for a shared library, enable fPIC
 shared_cppflags = $(if $(filter-out program,$($1_target)),-fPIC) -fvisibility=hidden
 


### PR DESCRIPTION
This PR fixes the default value of MCPP_HOME and LMDB_HOME on macOS so that it works with both m1 and x86_64 builds out of the box