### PR TITLE
Binary compatibility

### DIFF
--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -329,7 +329,12 @@ public:
 protected:
 
     Object() {} // This class is abstract.
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-dtor"
     virtual ~Object() {}
+#   pragma clang diagnostic pop
+#endif
 
 protected:
 

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -329,10 +329,6 @@ public:
 protected:
 
     Object() {} // This class is abstract.
-#ifdef ICE_CPP11_COMPILER
-    Object(const Object&) = default;
-    Object& operator=(const Object&) = default;
-#endif
     virtual ~Object() {}
 
 protected:

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -608,12 +608,12 @@ Ice::InputStream::read(pair<const Short*, const Short*>& v, IceUtil::ScopedArray
         v.second = reinterpret_cast<Short*>(i);
 #else
 #  ifdef ICE_CPP11_MAPPING
-        auto result = new short[sz];
+        auto result = new short[static_cast<size_t>(sz)];
         _deleters.push_back([result] { delete[] result; });
         v.first = result;
         v.second = result + sz;
 #  else
-        result.reset(new Short[sz]);
+        result.reset(new Short[static_cast<size_t>(sz)]);
         v.first = result.get();
         v.second = result.get() + sz;
 #   endif
@@ -691,12 +691,12 @@ Ice::InputStream::read(pair<const Int*, const Int*>& v, ::IceUtil::ScopedArray<I
 #else
 
 #  ifdef ICE_CPP11_MAPPING
-        auto result = new int[sz];
+        auto result = new int[static_cast<size_t>(sz)];
         _deleters.push_back([result] { delete[] result; });
         v.first = result;
         v.second = result + sz;
 #  else
-        result.reset(new Int[sz]);
+        result.reset(new Int[static_cast<size_t>(sz)]);
         v.first = result.get();
         v.second = result.get() + sz;
 #  endif
@@ -812,12 +812,12 @@ Ice::InputStream::read(pair<const Long*, const Long*>& v, IceUtil::ScopedArray<L
 #else
 
 #  ifdef ICE_CPP11_MAPPING
-        auto result = new long long[sz];
+        auto result = new long long[static_cast<size_t>(sz)];
         _deleters.push_back([result] { delete[] result; });
         v.first = result;
         v.second = result + sz;
 #  else
-        result.reset(new Long[sz]);
+        result.reset(new Long[static_cast<size_t>(sz)]);
         v.first = result.get();
         v.second = result.get() + sz;
 #  endif
@@ -925,12 +925,12 @@ Ice::InputStream::read(pair<const Float*, const Float*>& v, IceUtil::ScopedArray
 #else
 
 #  ifdef ICE_CPP11_MAPPING
-        auto result = new float[sz];
+        auto result = new float[static_cast<size_t>(sz)];
         _deleters.push_back([result] { delete[] result; });
         v.first = result;
         v.second = result + sz;
 #  else
-        result.reset(new Float[sz]);
+        result.reset(new Float[static_cast<size_t>(sz)]);
         v.first = result.get();
         v.second = result.get() + sz;
 #  endif
@@ -1046,12 +1046,12 @@ Ice::InputStream::read(pair<const Double*, const Double*>& v, IceUtil::ScopedArr
 #else
 
 #  ifdef ICE_CPP11_MAPPING
-        auto result = new double[sz];
+        auto result = new double[static_cast<size_t>(sz)];
         _deleters.push_back([result] { delete[] result; });
         v.first = result;
         v.second = result + sz;
 #  else
-        result.reset(new Double[sz]);
+        result.reset(new Double[static_cast<size_t>(sz)]);
         v.first = result.get();
         v.second = result.get() + sz;
 #  endif

--- a/cpp/src/IceDB/IceDB.cpp
+++ b/cpp/src/IceDB/IceDB.cpp
@@ -322,6 +322,10 @@ DbiBase::DbiBase() :
 {
 }
 
+DbiBase::~DbiBase()
+{
+}
+
 void
 DbiBase::clear(const ReadWriteTxn& txn)
 {

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -214,6 +214,8 @@ public:
     void clear(const ReadWriteTxn&);
     MDB_dbi mdbi() const;
 
+    virtual ~DbiBase();
+
 protected:
 
     DbiBase(const Txn&, const std::string&, unsigned int, MDB_cmp_func*);

--- a/cpp/src/IceGrid/DescriptorHelper.h
+++ b/cpp/src/IceGrid/DescriptorHelper.h
@@ -85,6 +85,7 @@ public:
 
     CommunicatorHelper(const CommunicatorDescriptorPtr&, bool = false);
     CommunicatorHelper() : _ignoreProps(false) { }
+    virtual ~CommunicatorHelper() { }
 
     virtual bool operator==(const CommunicatorHelper&) const;
     virtual bool operator!=(const CommunicatorHelper&) const;
@@ -271,6 +272,7 @@ class NodeHelper
 public:
 
     NodeHelper(const std::string&, const NodeDescriptor&, const Resolver&, bool);
+    virtual ~NodeHelper() { }
 
     virtual bool operator==(const NodeHelper&) const;
     virtual bool operator!=(const NodeHelper&) const;

--- a/cpp/src/IceStorm/Replica.h
+++ b/cpp/src/IceStorm/Replica.h
@@ -22,6 +22,9 @@ struct GroupNodeInfo
     // COMPILER FIX: Clang using libc++ requires to define operator=
     //
 #if defined(__clang__) && defined(_LIBCPP_VERSION)
+#   ifdef ICE_CPP11_COMPILER
+    GroupNodeInfo(const GroupNodeInfo&);
+#   endif
     GroupNodeInfo& operator=(const GroupNodeInfo&);
 #endif
     const int id;

--- a/cpp/src/IceStorm/Replica.h
+++ b/cpp/src/IceStorm/Replica.h
@@ -22,9 +22,6 @@ struct GroupNodeInfo
     // COMPILER FIX: Clang using libc++ requires to define operator=
     //
 #if defined(__clang__) && defined(_LIBCPP_VERSION)
-#ifdef ICE_CPP11_COMPILER
-    GroupNodeInfo(const GroupNodeInfo&) = default;
-#endif
     GroupNodeInfo& operator=(const GroupNodeInfo&);
 #endif
     const int id;


### PR DESCRIPTION
This PR includes a few minor fixes to restore binary compatibility with 3.7.5, there is also a minor fix for InputStream compiler warnings when building with clang in C++20 mode