### PR TITLE
Minor fix for compatibility with OpenSSL < 1.1.0

### DIFF
--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -667,7 +667,6 @@ IceSSL::OpenSSL::Certificate::load(const std::string& file)
     {
         throw CertificateReadException(__FILE__, __LINE__, "error loading certificate:\n" + getSslErrors(false));
     }
-    BIO_free(cert);
     return ICE_MAKE_SHARED(OpenSSLCertificateI, x);
 }
 


### PR DESCRIPTION
This is a minor fix for compatibility with older OpenSSL versions that don't provide `X509_get_extension_flags`, `X509_get_key_usage` and `X509_get_extended_key_usage` methods.