### PR TITLE
Copy dlls

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -87,6 +87,9 @@ These are the changes since Ice 3.7.6.
   retrieving the values of the "Key Usage" and "Extended Key Usage" extensions of an X509
   certificate.
 
+- Added MSBuild target that copy the Ice DLL and PDB files to the projects output directory.
+  The target can be enabled by setting MSbuild property `Ice_CopyDLLs` to `Yes` in the project.
+
 ## Java Changes
 
 - Updated IceGrid GUI to include the registry instance name in the window title

--- a/cpp/msbuild/zeroc.ice.v100.targets
+++ b/cpp/msbuild/zeroc.ice.v100.targets
@@ -27,4 +27,12 @@
                Condition="'$(IceNugetPackageVersion)' != '3.7.6'" />
     </Target>
 
+    <Target Name="Ice_CopyDLLs_v100" AfterTargets="Build" Condition="'$(PlatformToolset)' == 'v100' and '$(Ice_CopyDLLs)' == 'Yes'">
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+    </Target>
 </Project>

--- a/cpp/msbuild/zeroc.ice.v120.targets
+++ b/cpp/msbuild/zeroc.ice.v120.targets
@@ -22,4 +22,13 @@
         <Error Text="Detected invalid Ice NuGet package version '$(IceNugetPackageVersion)' expected '3.7.6'"
                Condition="'$(IceNugetPackageVersion)' != '3.7.6'" />
     </Target>
+
+    <Target Name="Ice_CopyDLLs_v120" AfterTargets="Build" Condition="'$(PlatformToolset)' == 'v120' and '$(Ice_CopyDLLs)' == 'Yes'">
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+    </Target>
 </Project>

--- a/cpp/msbuild/zeroc.ice.v140.targets
+++ b/cpp/msbuild/zeroc.ice.v140.targets
@@ -22,4 +22,13 @@
         <Error Text="Detected invalid Ice NuGet package version '$(IceNugetPackageVersion)' expected '3.7.6'"
                Condition="'$(IceNugetPackageVersion)' != '3.7.6'" />
     </Target>
+
+    <Target Name="Ice_CopyDLLs_v140" AfterTargets="Build" Condition="'$(PlatformToolset)' == 'v140' and '$(Ice_CopyDLLs)' == 'Yes'">
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+    </Target>
 </Project>

--- a/cpp/msbuild/zeroc.ice.v141.targets
+++ b/cpp/msbuild/zeroc.ice.v141.targets
@@ -22,4 +22,13 @@
         <Error Text="Detected invalid Ice NuGet package version '$(IceNugetPackageVersion)' expected '3.7.6'"
                Condition="'$(IceNugetPackageVersion)' != '3.7.6'" />
     </Target>
+
+    <Target Name="Ice_CopyDLLs_v141" AfterTargets="Build" Condition="'$(PlatformToolset)' == 'v141' and '$(Ice_CopyDLLs)' == 'Yes'">
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+    </Target>
 </Project>

--- a/cpp/msbuild/zeroc.ice.v142.targets
+++ b/cpp/msbuild/zeroc.ice.v142.targets
@@ -27,7 +27,6 @@
         <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
               DestinationFolder="$(OutDir)"
               SkipUnchangedFiles="true"/>
-
         <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
               DestinationFolder="$(OutDir)"
               SkipUnchangedFiles="true"/>

--- a/cpp/msbuild/zeroc.ice.v142.targets
+++ b/cpp/msbuild/zeroc.ice.v142.targets
@@ -23,4 +23,13 @@
                Condition="'$(IceNugetPackageVersion)' != '3.7.6'" />
     </Target>
 
+    <Target Name="Ice_CopyDLLs_v142" AfterTargets="Build" Condition="'$(PlatformToolset)' == 'v142' and '$(Ice_CopyDLLs)' == 'Yes'">
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.dll"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)\bin\$(Platform)\$(Configuration)\*.pdb"
+              DestinationFolder="$(OutDir)"
+              SkipUnchangedFiles="true"/>
+    </Target>
 </Project>


### PR DESCRIPTION
Add MSBuild target that Copy DLL and PDB files to the project output directory.  The target is disabled by default and it can be enabled by setting MSBuild property `Ice_CopyDLLs` to `yes`