### PR TITLE
OpenSSL 3.0 build

### DIFF
--- a/cpp/src/Ice/SHA1.cpp
+++ b/cpp/src/Ice/SHA1.cpp
@@ -12,6 +12,8 @@
 #      include <CommonCrypto/CommonDigest.h>
 #   else
 #      include <openssl/sha.h>
+#      // Ignore OpenSSL 3.0 deprecation warning
+#      pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #   endif
 #endif
 

--- a/cpp/src/Ice/Thread.cpp
+++ b/cpp/src/Ice/Thread.cpp
@@ -714,9 +714,9 @@ IceUtil::Thread::start(size_t stackSize, bool realtimeScheduling, int priority)
     }
     if(stackSize > 0)
     {
-        if(stackSize < PTHREAD_STACK_MIN)
+        if(stackSize < (size_t)PTHREAD_STACK_MIN)
         {
-            stackSize = PTHREAD_STACK_MIN;
+            stackSize = (size_t)PTHREAD_STACK_MIN;
         }
 #ifdef __APPLE__
         if(stackSize % 4096 > 0)

--- a/cpp/src/IceSSL/OpenSSLEngine.cpp
+++ b/cpp/src/IceSSL/OpenSSLEngine.cpp
@@ -28,6 +28,9 @@
 
 #ifdef _MSC_VER
 #   pragma warning(disable:4127) // conditional expression is constant
+#elif defined(__GNUC__)
+#  // Ignore OpenSSL 3.0 deprecation warning
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 using namespace std;

--- a/cpp/src/IceSSL/OpenSSLUtil.cpp
+++ b/cpp/src/IceSSL/OpenSSLUtil.cpp
@@ -10,6 +10,8 @@
 //
 #if defined(__GNUC__)
 #  pragma GCC diagnostic ignored "-Wold-style-cast"
+#  // Ignore OpenSSL 3.0 deprecation warning
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 using namespace std;


### PR DESCRIPTION
Fix for OpenSSL 3.0 builds see #1319, I disable the deprecation warnings and test with Ubuntu 22.04 and 3.0 packages from this PPA https://launchpad.net/~schopin/+archive/ubuntu/openssl-3.0.0