### PR TITLE
Java8

### DIFF
--- a/java/src/IceGridGUI/build.gradle
+++ b/java/src/IceGridGUI/build.gradle
@@ -81,7 +81,8 @@ jar {
 
 project.ext.libJars = []
 
-project.ext.jarBuilder = icegridguiProguard.toBoolean() ? "proguard-jar.gradle" : "plain-jar.gradle"
+project.ext.jarBuilder = icegridguiProguard.toBoolean() &&
+    JavaVersion.current() > JavaVersion.VERSION_1_8 ? "proguard-jar.gradle" : "plain-jar.gradle"
 
 apply from: jarBuilder
 

--- a/java/src/IceGridGUI/build.gradle
+++ b/java/src/IceGridGUI/build.gradle
@@ -81,8 +81,8 @@ jar {
 
 project.ext.libJars = []
 
-project.ext.jarBuilder = icegridguiProguard.toBoolean() &&
-    JavaVersion.current() > JavaVersion.VERSION_1_8 ? "proguard-jar.gradle" : "plain-jar.gradle"
+project.ext.jarBuilder = icegridguiProguard.toBoolean() && JavaVersion.current() > JavaVersion.VERSION_1_8 ?
+    "proguard-jar.gradle" : "plain-jar.gradle"
 
 apply from: jarBuilder
 


### PR DESCRIPTION
The new Proguard version `com.guardsquare:proguard-gradle:7.2.0-beta2` doesn't work with Java 8, The old Proguard versions including `net.sf.proguard:proguard-gradle:6.1.1`, that we use before,  doesn't work with Gradle 7.3 that we have to use to support Java 17, this makes building the IceGrid GUI Proguard jar with Java 8 inflexible.

So for Java 8 build we always build the plain-jar, the Proguard JAR build with Java 11 or Java 17 still works with Java 8