### PR TITLE
PHP 8.0 Windows support

### DIFF
--- a/php/msbuild/ice.proj
+++ b/php/msbuild/ice.proj
@@ -14,6 +14,7 @@
         <CppDistTargets>c++98\slice2php;c++98\slice2html;c++98\icessl;c++98\icediscovery;c++98\icelocatordiscovery</CppDistTargets>
         <CppConfiguration Condition="'$(Configuration)' == 'NTS-Debug' or '$(Configuration)' == 'Debug'">Debug</CppConfiguration>
         <CppConfiguration Condition="'$(Configuration)' == 'NTS-Release' or '$(Configuration)' == 'Release'">Release</CppConfiguration>
+        <BuildWithPhpVersion Condition="'$(BuildWithPhpVersion)' == '' and '$(DefaultPlatformToolset)' == 'v142'">8.0</BuildWithPhpVersion>
         <BuildWithPhpVersion Condition="'$(BuildWithPhpVersion)' == '' and '$(DefaultPlatformToolset)' == 'v141'">7.2</BuildWithPhpVersion>
         <BuildWithPhpVersion Condition="'$(BuildWithPhpVersion)' == '' and '$(DefaultPlatformToolset)' == 'v140'">7.1</BuildWithPhpVersion>
         <PackageDirectory>zeroc.ice.php$(BuildWithPhpVersion)</PackageDirectory>

--- a/php/src/php/Communicator.cpp
+++ b/php/src/php/Communicator.cpp
@@ -358,6 +358,10 @@ ZEND_METHOD(Ice_Communicator, destroy)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_stringToProxy_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, str)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, stringToProxy)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
@@ -385,6 +389,10 @@ ZEND_METHOD(Ice_Communicator, stringToProxy)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_proxyToString_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, proxy)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, proxyToString)
 {
@@ -420,6 +428,10 @@ ZEND_METHOD(Ice_Communicator, proxyToString)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_propertyToProxy_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, property)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, propertyToProxy)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
@@ -447,6 +459,11 @@ ZEND_METHOD(Ice_Communicator, propertyToProxy)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_proxyToProperty_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, proxy)
+    ZEND_ARG_INFO(0, property)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, proxyToProperty)
 {
@@ -494,6 +511,10 @@ ZEND_METHOD(Ice_Communicator, proxyToProperty)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_stringToIdentity_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, str)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, stringToIdentity)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
@@ -521,6 +542,10 @@ ZEND_METHOD(Ice_Communicator, stringToIdentity)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_identityToString_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, identityToString)
 {
@@ -553,6 +578,11 @@ ZEND_METHOD(Ice_Communicator, identityToString)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_addObjectFactory_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, factory)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, addObjectFactory)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
@@ -581,6 +611,10 @@ ZEND_METHOD(Ice_Communicator, addObjectFactory)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_findObjectFactory_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, findObjectFactory)
 {
@@ -736,14 +770,17 @@ ZEND_METHOD(Ice_Communicator, getDefaultRouter)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_setDefaultRouter_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, router)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, setDefaultRouter)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
     assert(_this);
 
     zval* zv;
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O!"), &zv, proxyClassEntry) !=
-        SUCCESS)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O!"), &zv, proxyClassEntry) != SUCCESS)
     {
         RETURN_NULL();
     }
@@ -814,14 +851,17 @@ ZEND_METHOD(Ice_Communicator, getDefaultLocator)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_setDefaultLocator_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, locator)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Communicator, setDefaultLocator)
 {
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
     assert(_this);
 
     zval* zv;
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O!"), &zv, proxyClassEntry) !=
-        SUCCESS)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("O!"), &zv, proxyClassEntry) != SUCCESS)
     {
         RETURN_NULL();
     }
@@ -853,6 +893,10 @@ ZEND_METHOD(Ice_Communicator, setDefaultLocator)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_flushBatchRequests_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, compress)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, flushBatchRequests)
 {
@@ -888,6 +932,11 @@ ZEND_METHOD(Ice_ValueFactoryManager, __construct)
     runtimeError("value factory managers cannot be instantiated directly");
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ValueFactoryManager_add_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, factory)
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ValueFactoryManager, add)
 {
     ValueFactoryManagerPtr _this = Wrapper<ValueFactoryManagerPtr>::value(getThis());
@@ -899,8 +948,7 @@ ZEND_METHOD(Ice_ValueFactoryManager, add)
     zval* factory;
     char* id;
     size_t idLen;
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("Os!"), &factory, factoryClass, &id,
-                             &idLen) != SUCCESS)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("Os!"), &factory, factoryClass, &id, &idLen) != SUCCESS)
     {
         RETURN_NULL();
     }
@@ -923,6 +971,10 @@ ZEND_METHOD(Ice_ValueFactoryManager, add)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ValueFactoryManager_find_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ValueFactoryManager, find)
 {
@@ -1539,23 +1591,23 @@ static zend_function_entry _classMethods[] =
     ZEND_ME(Ice_Communicator, isShutdown, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, waitForShutdown, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, destroy, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, stringToProxy, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, proxyToString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, propertyToProxy, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, proxyToProperty, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, stringToIdentity, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, identityToString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, addObjectFactory, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, findObjectFactory, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, stringToProxy, Ice_Communicator_stringToProxy_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, proxyToString, Ice_Communicator_proxyToString_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, propertyToProxy, Ice_Communicator_propertyToProxy_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, proxyToProperty, Ice_Communicator_proxyToProperty_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, stringToIdentity, Ice_Communicator_stringToIdentity_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, identityToString, Ice_Communicator_identityToString_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, addObjectFactory, Ice_Communicator_addObjectFactory_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, findObjectFactory, Ice_Communicator_findObjectFactory_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getValueFactoryManager, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getImplicitContext, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getProperties, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getLogger, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getDefaultRouter, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, setDefaultRouter, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, setDefaultRouter, Ice_Communicator_setDefaultRouter_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Communicator, getDefaultLocator, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, setDefaultLocator, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Communicator, flushBatchRequests, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, setDefaultLocator, Ice_Communicator_setDefaultLocator_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Communicator, flushBatchRequests, Ice_Communicator_flushBatchRequests_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };
 
@@ -1569,8 +1621,8 @@ static zend_function_entry _vfmInterfaceMethods[] =
 static zend_function_entry _vfmClassMethods[] =
 {
     ZEND_ME(Ice_ValueFactoryManager, __construct, ice_void_arginfo, ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
-    ZEND_ME(Ice_ValueFactoryManager, add, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ValueFactoryManager, find, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ValueFactoryManager, add, Ice_ValueFactoryManager_add_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ValueFactoryManager, find, Ice_ValueFactoryManager_find_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };
 

--- a/php/src/php/Connection.cpp
+++ b/php/src/php/Connection.cpp
@@ -73,6 +73,10 @@ ZEND_METHOD(Ice_Connection, __toString)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Connection_close_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, mode)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Connection, close)
 {
     Ice::ConnectionPtr _this = Wrapper<Ice::ConnectionPtr>::value(getThis());
@@ -126,6 +130,10 @@ ZEND_METHOD(Ice_Connection, getEndpoint)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Connection_flushBatchRequests_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, compress)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Connection, flushBatchRequests)
 {
     zval* compress;
@@ -175,6 +183,12 @@ ZEND_METHOD(Ice_Connection, heartbeat)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Connection_setACM_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(3))
+    ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, close)
+    ZEND_ARG_INFO(0, heartbeat)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Connection, setACM)
 {
@@ -341,6 +355,11 @@ ZEND_METHOD(Ice_Connection, getInfo)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Connection_setBufferSize_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, rcvSize)
+    ZEND_ARG_INFO(0, sndSize)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Connection, setBufferSize)
 {
     Ice::ConnectionPtr _this = Wrapper<Ice::ConnectionPtr>::value(getThis());
@@ -460,17 +479,17 @@ static zend_function_entry _connectionClassMethods[] =
 {
     ZEND_ME(Ice_Connection, __construct, ice_void_arginfo, ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
     ZEND_ME(Ice_Connection, __toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Connection, close, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Connection, close, Ice_Connection_close_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, getEndpoint, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Connection, flushBatchRequests, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Connection, flushBatchRequests, Ice_Connection_flushBatchRequests_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, heartbeat, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Connection, setACM, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Connection, setACM, Ice_Connection_setACM_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, getACM, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, type, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, timeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, getInfo, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Connection, setBufferSize, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Connection, setBufferSize, Ice_Connection_setBufferSize_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Connection, throwException, ice_void_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };

--- a/php/src/php/Init.cpp
+++ b/php/src/php/Init.cpp
@@ -17,39 +17,158 @@ using namespace IcePHP;
 
 ZEND_DECLARE_MODULE_GLOBALS(ice)
 
-ZEND_BEGIN_ARG_INFO_EX(Ice_initialize_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(-1))
+ZEND_BEGIN_ARG_INFO_EX(Ice_initialize_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(0))
     ZEND_ARG_INFO(1, args)
     ZEND_ARG_INFO(1, properties)
     ZEND_ARG_INFO(1, initData)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(Ice_createProperties_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(-1))
-    ZEND_ARG_INFO(1, properties)
-    ZEND_ARG_INFO(0, defaultProperties)
+ZEND_BEGIN_ARG_INFO_EX(Ice_createProperties_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(0))
+    ZEND_ARG_INFO(0, args)
+    ZEND_ARG_INFO(0, defaults)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_declareClass_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineClass_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(7))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, compactId)
+    ZEND_ARG_INFO(0, preserve)
+    ZEND_ARG_INFO(0, interface)
+    ZEND_ARG_INFO(0, base)
+    ZEND_ARG_INFO(0, members)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineDictionary_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(3))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineEnum_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, enumerators)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineException_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(5))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, preserve)
+    ZEND_ARG_INFO(0, base)
+    ZEND_ARG_INFO(0, members)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineStruct_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(3))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, members)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_declareProxy_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineProxy_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(3))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, compactId)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineSequence_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, element)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineOperation_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(9))
+    ZEND_ARG_INFO(0, cls)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, mode)
+    ZEND_ARG_INFO(0, sendMode)
+    ZEND_ARG_INFO(0, format)
+    ZEND_ARG_INFO(0, inParams)
+    ZEND_ARG_INFO(0, outParams)
+    ZEND_ARG_INFO(0, returnType)
+    ZEND_ARG_INFO(0, exceptions)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_register_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, communicator)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, expires)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_unregister_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_find_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_getProperties_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(0))
+    ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_identityToString_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, mode)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_stringToIdentity_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_stringify_add_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, value)
+    ZEND_ARG_INFO(0, type)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_stringifyException_add_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, value)
+    ZEND_ARG_INFO(0, type)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_protocolVersionToString_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, protocolVersion)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_stringToProtocolVersion_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, str)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_encodingVersionToString_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, encodingVersion)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_stringToEncodingVersion_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, str)
 ZEND_END_ARG_INFO()
 
 #ifdef ICEPHP_USE_NAMESPACES
 #  define ICEPHP_COMMUNICATOR_FUNCTIONS \
     ZEND_NS_NAMED_FE("Ice", initialize, ZEND_FN(Ice_initialize), Ice_initialize_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", register, ZEND_FN(Ice_register), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", unregister, ZEND_FN(Ice_unregister), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", find, ZEND_FN(Ice_find), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", getProperties, ZEND_FN(Ice_getProperties), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", identityToString, ZEND_FN(Ice_identityToString), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", stringToIdentity, ZEND_FN(Ice_stringToIdentity), ice_void_arginfo)
+    ZEND_NS_NAMED_FE("Ice", register, ZEND_FN(Ice_register), Ice_register_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", unregister, ZEND_FN(Ice_unregister), Ice_unregister_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", find, ZEND_FN(Ice_find), Ice_find_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", getProperties, ZEND_FN(Ice_getProperties), Ice_getProperties_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", identityToString, ZEND_FN(Ice_identityToString), Ice_identityToString_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", stringToIdentity, ZEND_FN(Ice_stringToIdentity), Ice_stringToIdentity_arginfo)
 #else
 #  define ICEPHP_COMMUNICATOR_FUNCTIONS \
     ZEND_FE(Ice_initialize, Ice_initialize_arginfo) \
-    ZEND_FE(Ice_register, ice_void_arginfo) \
-    ZEND_FE(Ice_unregister, ice_void_arginfo) \
-    ZEND_FE(Ice_find, ice_void_arginfo) \
-    ZEND_FE(Ice_getProperties, ice_void_arginfo) \
-    ZEND_FE(Ice_identityToString, ice_void_arginfo) \
-    ZEND_FE(Ice_stringToIdentity, ice_void_arginfo)
+    ZEND_FE(Ice_register, Ice_register_arginfo) \
+    ZEND_FE(Ice_unregister, Ice_unregister_arginfo) \
+    ZEND_FE(Ice_find, Ice_find_arginfo) \
+    ZEND_FE(Ice_getProperties, Ice_getProperties_arginfo) \
+    ZEND_FE(Ice_identityToString, Ice_identityToString_arginfo) \
+    ZEND_FE(Ice_stringToIdentity, Ice_stringToIdentity_arginfo)
 #endif
 
 #define ICEPHP_OPERATION_FUNCTIONS \
-    ZEND_FE(IcePHP_defineOperation,  ice_void_arginfo)
+    ZEND_FE(IcePHP_defineOperation,  Ice_defineOperation_arginfo)
 
 #ifdef ICEPHP_USE_NAMESPACES
 #  define ICEPHP_PROPERTIES_FUNCTIONS \
@@ -60,17 +179,17 @@ ZEND_END_ARG_INFO()
 #endif
 
 #define ICEPHP_TYPE_FUNCTIONS \
-    ZEND_FE(IcePHP_defineEnum,          ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineStruct,        ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineSequence,      ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineDictionary,    ice_void_arginfo) \
-    ZEND_FE(IcePHP_declareProxy,        ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineProxy,         ice_void_arginfo) \
-    ZEND_FE(IcePHP_declareClass,        ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineClass,         ice_void_arginfo) \
-    ZEND_FE(IcePHP_defineException,     ice_void_arginfo) \
-    ZEND_FE(IcePHP_stringify,           ice_void_arginfo) \
-    ZEND_FE(IcePHP_stringifyException,  ice_void_arginfo)
+    ZEND_FE(IcePHP_defineEnum,          Ice_defineEnum_arginfo) \
+    ZEND_FE(IcePHP_defineStruct,        Ice_defineStruct_arginfo) \
+    ZEND_FE(IcePHP_defineSequence,      Ice_defineSequence_arginfo) \
+    ZEND_FE(IcePHP_defineDictionary,    Ice_defineDictionary_arginfo) \
+    ZEND_FE(IcePHP_declareProxy,        Ice_declareProxy_arginfo) \
+    ZEND_FE(IcePHP_defineProxy,         Ice_defineProxy_arginfo) \
+    ZEND_FE(IcePHP_declareClass,        Ice_declareClass_arginfo) \
+    ZEND_FE(IcePHP_defineClass,         Ice_defineClass_arginfo) \
+    ZEND_FE(IcePHP_defineException,     Ice_defineException_arginfo) \
+    ZEND_FE(IcePHP_stringify,           Ice_stringify_add_arginfo) \
+    ZEND_FE(IcePHP_stringifyException,  Ice_stringifyException_add_arginfo)
 
 #ifdef ICEPHP_USE_NAMESPACES
 #  define ICEPHP_UTIL_FUNCTIONS \
@@ -80,10 +199,10 @@ ZEND_END_ARG_INFO()
     ZEND_NS_NAMED_FE("Ice", currentProtocol, ZEND_FN(Ice_currentProtocol), ice_void_arginfo) \
     ZEND_NS_NAMED_FE("Ice", currentProtocolEncoding, ZEND_FN(Ice_currentProtocolEncoding), ice_void_arginfo) \
     ZEND_NS_NAMED_FE("Ice", currentEncoding, ZEND_FN(Ice_currentEncoding), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", protocolVersionToString, ZEND_FN(Ice_protocolVersionToString), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", stringToProtocolVersion, ZEND_FN(Ice_stringToProtocolVersion), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", encodingVersionToString, ZEND_FN(Ice_encodingVersionToString), ice_void_arginfo) \
-    ZEND_NS_NAMED_FE("Ice", stringToEncodingVersion, ZEND_FN(Ice_stringToEncodingVersion), ice_void_arginfo)
+    ZEND_NS_NAMED_FE("Ice", protocolVersionToString, ZEND_FN(Ice_protocolVersionToString), Ice_protocolVersionToString_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", stringToProtocolVersion, ZEND_FN(Ice_stringToProtocolVersion), Ice_stringToProtocolVersion_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", encodingVersionToString, ZEND_FN(Ice_encodingVersionToString), Ice_encodingVersionToString_arginfo) \
+    ZEND_NS_NAMED_FE("Ice", stringToEncodingVersion, ZEND_FN(Ice_stringToEncodingVersion), Ice_stringToEncodingVersion_arginfo)
 #else
 #  define ICEPHP_UTIL_FUNCTIONS \
     ZEND_FE(Ice_stringVersion, ice_void_arginfo) \
@@ -92,10 +211,10 @@ ZEND_END_ARG_INFO()
     ZEND_FE(Ice_currentProtocol, ice_void_arginfo) \
     ZEND_FE(Ice_currentProtocolEncoding, ice_void_arginfo) \
     ZEND_FE(Ice_currentEncoding, ice_void_arginfo) \
-    ZEND_FE(Ice_protocolVersionToString, ice_void_arginfo) \
-    ZEND_FE(Ice_stringToProtocolVersion, ice_void_arginfo) \
-    ZEND_FE(Ice_encodingVersionToString, ice_void_arginfo) \
-    ZEND_FE(Ice_stringToEncodingVersion, ice_void_arginfo)
+    ZEND_FE(Ice_protocolVersionToString, Ice_protocolVersionToString_arginfo) \
+    ZEND_FE(Ice_stringToProtocolVersion, Ice_stringToProtocolVersion_arginfo) \
+    ZEND_FE(Ice_encodingVersionToString, Ice_encodingVersionToString_arginfo) \
+    ZEND_FE(Ice_stringToEncodingVersion, Ice_stringToEncodingVersion_arginfo)
 #endif
 
 //

--- a/php/src/php/Logger.cpp
+++ b/php/src/php/Logger.cpp
@@ -49,6 +49,10 @@ ZEND_METHOD(Ice_Logger, __toString)
     RETURN_NULL();
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Logger_print_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Logger, print)
 {
     char* m;
@@ -73,6 +77,11 @@ ZEND_METHOD(Ice_Logger, print)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Logger_trace_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, category)
+    ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Logger, trace)
 {
@@ -102,6 +111,10 @@ ZEND_METHOD(Ice_Logger, trace)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Logger_warning_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Logger, warning)
 {
     char* m;
@@ -127,6 +140,10 @@ ZEND_METHOD(Ice_Logger, warning)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Logger_error_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Logger, error)
 {
     char* m;
@@ -151,6 +168,10 @@ ZEND_METHOD(Ice_Logger, error)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Logger_cloneWithPrefix_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, prefix)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Logger, cloneWithPrefix)
 {
@@ -241,11 +262,11 @@ static zend_function_entry _classMethods[] =
 {
     ZEND_ME(Ice_Logger, __construct, ice_void_arginfo, ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
     ZEND_ME(Ice_Logger, __toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Logger, print, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Logger, trace, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Logger, warning, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Logger, error, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Logger, cloneWithPrefix, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Logger, print, Ice_Logger_print_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Logger, trace, Ice_Logger_trace_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Logger, warning, Ice_Logger_warning_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Logger, error, Ice_Logger_error_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Logger, cloneWithPrefix, Ice_Logger_cloneWithPrefix_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };
 //

--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -383,7 +383,9 @@ IcePHP::OperationI::getArgInfo(zend_internal_arg_info& arg, const ParamInfoPtr& 
     {
         zend_internal_arg_info ai[] =
         {
-            ZEND_ARG_ARRAY_INFO((uint32_t)pass_by_ref, (uint32_t)0, (uint32_t)allow_null)
+            ZEND_ARG_ARRAY_INFO(static_cast<uint32_t>(pass_by_ref),
+                                static_cast<uint32_t>(0),
+                                static_cast<uint32_t>(allow_null))
         };
         arg = ai[0];
     }
@@ -391,7 +393,9 @@ IcePHP::OperationI::getArgInfo(zend_internal_arg_info& arg, const ParamInfoPtr& 
     {
         zend_internal_arg_info ai[] =
         {
-            ZEND_ARG_CALLABLE_INFO((uint32_t)pass_by_ref, (uint32_t)0, allow_null)
+            ZEND_ARG_CALLABLE_INFO(static_cast<uint32_t>(pass_by_ref),
+                                   static_cast<uint32_t>(0),
+                                   static_cast<uint32_t>(allow_null))
         };
         arg = ai[0];
     }

--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -383,7 +383,7 @@ IcePHP::OperationI::getArgInfo(zend_internal_arg_info& arg, const ParamInfoPtr& 
     {
         zend_internal_arg_info ai[] =
         {
-            ZEND_ARG_ARRAY_INFO(pass_by_ref, 0, allow_null)
+            ZEND_ARG_ARRAY_INFO((uint32_t)pass_by_ref, (uint32_t)0, (uint32_t)allow_null)
         };
         arg = ai[0];
     }
@@ -391,7 +391,7 @@ IcePHP::OperationI::getArgInfo(zend_internal_arg_info& arg, const ParamInfoPtr& 
     {
         zend_internal_arg_info ai[] =
         {
-            ZEND_ARG_CALLABLE_INFO(pass_by_ref, 0, allow_null)
+            ZEND_ARG_CALLABLE_INFO((uint32_t)pass_by_ref, (uint32_t)0, allow_null)
         };
         arg = ai[0];
     }

--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -174,7 +174,7 @@ IcePHP::ResultCallback::ResultCallback()
 
 IcePHP::ResultCallback::~ResultCallback()
 {
-    zval_ptr_dtor(&zv);
+
 }
 
 void

--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -174,7 +174,6 @@ IcePHP::ResultCallback::ResultCallback()
 
 IcePHP::ResultCallback::~ResultCallback()
 {
-
 }
 
 void
@@ -696,7 +695,6 @@ IcePHP::TypedInvocation::validateException(const ExceptionInfoPtr& info) const
             return true;
         }
     }
-
     return false;
 }
 

--- a/php/src/php/Properties.cpp
+++ b/php/src/php/Properties.cpp
@@ -70,6 +70,10 @@ ZEND_METHOD(Ice_Properties, __toString)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getProperty_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, getProperty)
 {
     char* name;
@@ -95,6 +99,11 @@ ZEND_METHOD(Ice_Properties, getProperty)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertyWithDefault_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, defaultValue)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Properties, getPropertyWithDefault)
 {
@@ -131,6 +140,10 @@ ZEND_METHOD(Ice_Properties, getPropertyWithDefault)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertyAsInt_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, getPropertyAsInt)
 {
     char* name;
@@ -156,6 +169,11 @@ ZEND_METHOD(Ice_Properties, getPropertyAsInt)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertyAsIntWithDefault_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, defaultValue)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
 {
@@ -185,6 +203,10 @@ ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertyAsList_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, getPropertyAsList)
 {
     char* name;
@@ -213,6 +235,14 @@ ZEND_METHOD(Ice_Properties, getPropertyAsList)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertyAsListWithDefault_arginfo,
+                       1,
+                       ZEND_RETURN_VALUE,
+                       static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, defaultValue)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Properties, getPropertyAsListWithDefault)
 {
@@ -250,6 +280,10 @@ ZEND_METHOD(Ice_Properties, getPropertyAsListWithDefault)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_getPropertiesForPrefix_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, prefix)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, getPropertiesForPrefix)
 {
     char* p;
@@ -283,6 +317,11 @@ ZEND_METHOD(Ice_Properties, getPropertiesForPrefix)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_setProperty_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Properties, setProperty)
 {
@@ -343,6 +382,11 @@ ZEND_METHOD(Ice_Properties, getCommandLineOptions)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_parseCommandLineOptions_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(2))
+    ZEND_ARG_INFO(0, prefix)
+    ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, parseCommandLineOptions)
 {
     char* p;
@@ -383,6 +427,13 @@ ZEND_METHOD(Ice_Properties, parseCommandLineOptions)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_parseIceCommandLineOptions_arginfo,
+                       1,
+                       ZEND_RETURN_VALUE,
+                       static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_Properties, parseIceCommandLineOptions)
 {
     zval* opts;
@@ -415,6 +466,10 @@ ZEND_METHOD(Ice_Properties, parseIceCommandLineOptions)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Properties_load_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, path)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Properties, load)
 {
@@ -524,7 +579,9 @@ ZEND_FUNCTION(Ice_createProperties)
     zval* arglist = 0;
     zval* defaultsObj = 0;
 
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("|a!O!"), &arglist, &defaultsObj,
+    if(zend_parse_parameters(ZEND_NUM_ARGS(),
+                             const_cast<char*>("|a!|O!"),
+                             &arglist, &defaultsObj,
                              propertiesClassEntry) == FAILURE)
     {
         RETURN_NULL();
@@ -601,18 +658,27 @@ static zend_function_entry _classMethods[] =
 {
     ZEND_ME(Ice_Properties, __construct, ice_void_arginfo, ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
     ZEND_ME(Ice_Properties, __toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getProperty, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertyWithDefault, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertyAsInt, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertyAsIntWithDefault, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertyAsList, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertyAsListWithDefault, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, getPropertiesForPrefix, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, setProperty, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, getProperty, Ice_Properties_getProperty_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, getPropertyWithDefault, Ice_Properties_getPropertyWithDefault_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, getPropertyAsInt, Ice_Properties_getPropertyAsInt_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties,
+            getPropertyAsIntWithDefault,
+            Ice_Properties_getPropertyAsIntWithDefault_arginfo,
+            ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, getPropertyAsList, Ice_Properties_getPropertyAsList_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties,
+            getPropertyAsListWithDefault,
+            Ice_Properties_getPropertyAsListWithDefault_arginfo,
+            ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, getPropertiesForPrefix, Ice_Properties_getPropertiesForPrefix_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, setProperty, Ice_Properties_setProperty_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Properties, getCommandLineOptions, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, parseCommandLineOptions, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, parseIceCommandLineOptions, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_Properties, load, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, parseCommandLineOptions, Ice_Properties_parseCommandLineOptions_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties,
+            parseIceCommandLineOptions,
+            Ice_Properties_parseIceCommandLineOptions_arginfo,
+            ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_Properties, load, Ice_Properties_load_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_Properties, clone, ice_void_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };

--- a/php/src/php/Proxy.cpp
+++ b/php/src/php/Proxy.cpp
@@ -148,6 +148,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getIdentity)
     createIdentity(return_value, _this->proxy->ice_getIdentity());
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_identity_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_identity)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -196,6 +200,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getContext)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_context_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, ctx)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_context)
 {
@@ -254,6 +262,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getFacet)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_facet_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, facet)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_facet)
 {
     char* name;
@@ -303,6 +315,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getAdapterId)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_adapterId_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_adapterId)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -345,7 +361,7 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEndpoints)
         Ice::EndpointSeq endpoints = _this->proxy->ice_getEndpoints();
 
         array_init(return_value);
-        uint idx = 0;
+        uint32_t idx = 0;
         for(Ice::EndpointSeq::const_iterator p = endpoints.begin(); p != endpoints.end(); ++p, ++idx)
         {
             zval elem;
@@ -363,6 +379,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEndpoints)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_endpoints_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, endpoints)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_endpoints)
 {
@@ -456,6 +476,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getConnectionId)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_locatorCacheTimeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, timeout)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_locatorCacheTimeout)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -503,6 +527,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isConnectionCached)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_connectionCached_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, cached)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_connectionCached)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -549,6 +577,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEndpointSelection)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_endpointSelection_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, selectionType)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_endpointSelection)
 {
@@ -604,6 +636,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isSecure)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_secure_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, secure)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_secure)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -652,6 +688,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEncodingVersion)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_encodingVersion_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, version)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_encodingVersion)
 {
@@ -706,6 +746,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isPreferSecure)
         RETURN_FALSE;
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_preferSecure_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, preferSecure)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_preferSecure)
 {
@@ -771,6 +815,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getRouter)
         RETURN_FALSE;
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_router_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, router)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_router)
 {
@@ -853,6 +901,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getLocator)
         RETURN_FALSE;
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_locator_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, locator)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_locator)
 {
@@ -1128,6 +1180,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isBatchDatagram)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_compress_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, compress)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_compress)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -1181,6 +1237,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getCompress)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_timeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, timeout)
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_ObjectPrx, ice_timeout)
 {
@@ -1236,6 +1296,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getTimeout)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_invocationTimeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, invocationTiemout)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_invocationTimeout)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -1282,6 +1346,10 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getInvocationTimeout)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_connectionId_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, connectionId)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_connectionId)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
@@ -1307,14 +1375,20 @@ ZEND_METHOD(Ice_ObjectPrx, ice_connectionId)
     }
 }
 
+ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_fixed_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, connection)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(Ice_ObjectPrx, ice_fixed)
 {
     ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis() TSRMLS_CC);
     assert(_this);
 
     zval* zcon;
-    if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, const_cast<char*>("O!"), &zcon, connectionClassEntry TSRMLS_CC) !=
-        SUCCESS)
+    if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+                             const_cast<char*>("O!"),
+                             &zcon,
+                             connectionClassEntry TSRMLS_CC) != SUCCESS)
     {
         RETURN_NULL();
     }
@@ -1431,6 +1505,12 @@ ZEND_METHOD(Ice_ObjectPrx, ice_flushBatchRequests)
         RETURN_NULL();
     }
 }
+
+ZEND_BEGIN_ARG_INFO_EX(Ice_Proxy_do_cast_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, facet)
+    ZEND_ARG_INFO(0, ctx)
+ZEND_END_ARG_INFO()
 
 static void
 do_cast(INTERNAL_FUNCTION_PARAMETERS, bool check)
@@ -1734,32 +1814,32 @@ static zend_function_entry _proxyMethods[] =
     ZEND_ME(Ice_ObjectPrx, ice_getCommunicator, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getIdentity, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_identity, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_identity, Ice_ObjectPrx_ice_identity_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getContext, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_context, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_context, Ice_ObjectPrx_ice_context_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getFacet, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_facet, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_facet, Ice_ObjectPrx_ice_facet_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getAdapterId, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_adapterId, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_adapterId, Ice_ObjectPrx_ice_adapterId_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getEndpoints, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_endpoints, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_endpoints, Ice_ObjectPrx_ice_endpoints_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getLocatorCacheTimeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getConnectionId, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_locatorCacheTimeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_locatorCacheTimeout, Ice_ObjectPrx_ice_locatorCacheTimeout_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isConnectionCached, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_connectionCached, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_connectionCached, Ice_ObjectPrx_ice_connectionCached_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getEndpointSelection, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_endpointSelection, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_endpointSelection, Ice_ObjectPrx_ice_endpointSelection_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isSecure, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_secure, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_secure, Ice_ObjectPrx_ice_secure_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getEncodingVersion, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_encodingVersion, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_encodingVersion, Ice_ObjectPrx_ice_encodingVersion_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isPreferSecure, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_preferSecure, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_preferSecure, Ice_ObjectPrx_ice_preferSecure_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getRouter, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_router, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_router, Ice_ObjectPrx_ice_router_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getLocator, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_locator, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_locator, Ice_ObjectPrx_ice_locator_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_twoway, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isTwoway, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_oneway, ice_void_arginfo, ZEND_ACC_PUBLIC)
@@ -1770,20 +1850,20 @@ static zend_function_entry _proxyMethods[] =
     ZEND_ME(Ice_ObjectPrx, ice_isDatagram, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_batchDatagram, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isBatchDatagram, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_compress, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_compress, Ice_ObjectPrx_ice_compress_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getCompress, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_timeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_timeout, Ice_ObjectPrx_ice_timeout_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getTimeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_invocationTimeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_invocationTimeout, Ice_ObjectPrx_ice_invocationTimeout_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getInvocationTimeout, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_connectionId, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_fixed, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_connectionId, Ice_ObjectPrx_ice_connectionId_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_fixed, Ice_ObjectPrx_ice_fixed_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_isFixed, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getConnection, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_getCachedConnection, ice_void_arginfo, ZEND_ACC_PUBLIC)
     ZEND_ME(Ice_ObjectPrx, ice_flushBatchRequests, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_uncheckedCast, ice_void_arginfo, ZEND_ACC_PUBLIC)
-    ZEND_ME(Ice_ObjectPrx, ice_checkedCast, ice_void_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_uncheckedCast, Ice_Proxy_do_cast_arginfo, ZEND_ACC_PUBLIC)
+    ZEND_ME(Ice_ObjectPrx, ice_checkedCast, Ice_Proxy_do_cast_arginfo, ZEND_ACC_PUBLIC)
     {0, 0, 0}
 };
 

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -2934,7 +2934,9 @@ void
 IcePHP::ObjectWriter::ice_preMarshal()
 {
     string name = "ice_premarshal"; // Must be lowercase.
-    if(zend_hash_str_exists(&Z_OBJCE_P(&_object)->function_table, STRCAST(name.c_str()), static_cast<uint>(name.size())))
+    if(zend_hash_str_exists(&Z_OBJCE_P(&_object)->function_table,
+                            STRCAST(name.c_str()),
+                            static_cast<uint32_t>(name.size())))
     {
         if(!invokeMethod(&_object, name))
         {

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -315,9 +315,6 @@ IcePHP::StreamUtil::setSlicedDataMember(zval* obj, const Ice::SlicedDataPtr& sli
 
     zval slices;
     array_init(&slices);
-#ifdef HT_ALLOW_COW_VIOLATION
-    HT_ALLOW_COW_VIOLATION(Z_ARRVAL(slices)); // Allow circular references.
-#endif
     AutoDestroy slicesDestroyer(&slices);
 
     addPropertyZval(&sd, STRCAST("slices"), &slices);
@@ -334,7 +331,9 @@ IcePHP::StreamUtil::setSlicedDataMember(zval* obj, const Ice::SlicedDataPtr& sli
         {
             throw AbortMarshaling();
         }
-
+#ifdef HT_ALLOW_COW_VIOLATION
+        HT_ALLOW_COW_VIOLATION(Z_ARRVAL(slices));
+#endif
         add_next_index_zval(&slices, &slice); // Steals a reference.
         Z_ADDREF_P(&slice);
 
@@ -1606,9 +1605,6 @@ IcePHP::SequenceInfo::unmarshal(Ice::InputStream* is, const UnmarshalCallbackPtr
 
     zval zv;
     array_init(&zv);
-#ifdef HT_ALLOW_COW_VIOLATION
-    HT_ALLOW_COW_VIOLATION(Z_ARRVAL(zv)); // Allow circular references.
-#endif
     AutoDestroy destroy(&zv);
 
     Ice::Int sz = is->readSize();
@@ -1627,6 +1623,9 @@ IcePHP::SequenceInfo::unmarshal(Ice::InputStream* is, const UnmarshalCallbackPtr
         // Add a temporary null value so that the foreach order is the
         // same as the index order.
         //
+#ifdef HT_ALLOW_COW_VIOLATION
+        HT_ALLOW_COW_VIOLATION(Z_ARRVAL(zv));
+#endif
         add_index_null(&zv, i);
         elementType->unmarshal(is, this, comm, &zv, cl, false);
     }
@@ -3221,6 +3220,12 @@ IcePHP::ReadObjectCallback::~ReadObjectCallback()
 void
 IcePHP::ReadObjectCallback::invoke(const Ice::ObjectPtr& p)
 {
+#ifdef HT_ALLOW_COW_VIOLATION
+    if(!ZVAL_IS_NULL(&_target))
+    {
+        HT_ALLOW_COW_VIOLATION(Z_ARRVAL(_target));
+    }
+#endif
     if(p)
     {
         ObjectReaderPtr reader = ObjectReaderPtr::dynamicCast(p);

--- a/php/src/php/Util.cpp
+++ b/php/src/php/Util.cpp
@@ -323,15 +323,15 @@ IcePHP::createStringMap(zval* zv, const map<string, string>& ctx)
 #if PHP_VERSION_ID >= 80000
         add_assoc_stringl_ex(zv,
                              const_cast<char*>(p->first.c_str()),
-                             static_cast<uint>(p->first.length()),
+                             static_cast<uint32_t>(p->first.length()),
                              const_cast<char*>(p->second.c_str()),
-                             static_cast<uint>(p->second.length()));
+                             static_cast<uint32_t>(p->second.length()));
 #else
         if(add_assoc_stringl_ex(zv,
                                 const_cast<char*>(p->first.c_str()),
-                                static_cast<uint>(p->first.length()),
+                                static_cast<uint32_t>(p->first.length()),
                                 const_cast<char*>(p->second.c_str()),
-                                static_cast<uint>(p->second.length())) == FAILURE)
+                                static_cast<uint32_t>(p->second.length())) == FAILURE)
         {
             return false;
         }
@@ -383,7 +383,7 @@ IcePHP::createStringArray(zval* zv, const Ice::StringSeq& seq)
     array_init(zv);
     for(Ice::StringSeq::const_iterator p = seq.begin(); p != seq.end(); ++p)
     {
-        if(add_next_index_stringl(zv, STRCAST(p->c_str()), static_cast<uint>(p->length())) == FAILURE)
+        if(add_next_index_stringl(zv, STRCAST(p->c_str()), static_cast<uint32_t>(p->length())) == FAILURE)
         {
             return false;
         }

--- a/php/src/php/msbuild/packages.config
+++ b/php/src/php/msbuild/packages.config
@@ -8,4 +8,6 @@
   <package id="php-7.3-ts" version="7.3.0" targetFramework="native" />
   <package id="php-8.0-nts" version="8.0.0" targetFramework="native" />
   <package id="php-8.0-ts" version="8.0.0" targetFramework="native" />
+  <package id="php-8.1-nts" version="8.1.0" targetFramework="native" />
+  <package id="php-8.1-ts" version="8.1.0" targetFramework="native" />
 </packages>

--- a/php/src/php/msbuild/packages.config
+++ b/php/src/php/msbuild/packages.config
@@ -6,4 +6,6 @@
   <package id="php-7.2-ts" version="7.2.8" targetFramework="native" />
   <package id="php-7.3-nts" version="7.3.0" targetFramework="native" />
   <package id="php-7.3-ts" version="7.3.0" targetFramework="native" />
+  <package id="php-8.0-nts" version="8.0.0" targetFramework="native" />
+  <package id="php-8.0-ts" version="8.0.0" targetFramework="native" />
 </packages>

--- a/php/src/php/msbuild/php_ice.vcxproj
+++ b/php/src/php/msbuild/php_ice.vcxproj
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\msbuild\packages\zeroc.ice.v140.3.7.7\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v140.3.7.7\build\native\zeroc.ice.v140.props') And '$(ICE_BIN_DIST)' == 'cpp'" />
+  <Import Project="..\..\..\msbuild\packages\zeroc.ice.v141.3.7.7\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v141.3.7.7\build\native\zeroc.ice.v141.props') And '$(ICE_BIN_DIST)' == 'cpp'" />
+  <Import Project="..\..\..\msbuild\packages\zeroc.ice.v142.3.7.7\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v142.3.7.7\build\native\zeroc.ice.v142.props') And '$(ICE_BIN_DIST)' == 'cpp'" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -244,12 +246,16 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\msbuild\packages\zeroc.ice.v140.3.7.7\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v140.3.7.7\build\native\zeroc.ice.v140.targets') And '$(ICE_BIN_DIST)' == 'cpp'" />
+    <Import Project="..\..\..\msbuild\packages\zeroc.ice.v141.3.7.7\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v141.3.7.7\build\native\zeroc.ice.v141.targets') And '$(ICE_BIN_DIST)' == 'cpp'" />
+    <Import Project="..\..\..\msbuild\packages\zeroc.ice.v142.3.7.7\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v142.3.7.7\build\native\zeroc.ice.v142.targets') And '$(ICE_BIN_DIST)' == 'cpp'" />
     <Import Project="..\..\..\msbuild\packages\php-7.1-nts.7.1.17\build\native\php-7.1-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.1-nts.7.1.17\build\native\php-7.1-nts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-7.1-ts.7.1.17\build\native\php-7.1-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.1-ts.7.1.17\build\native\php-7.1-ts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-7.2-nts.7.2.8\build\native\php-7.2-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.2-nts.7.2.8\build\native\php-7.2-nts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-7.2-ts.7.2.8\build\native\php-7.2-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.2-ts.7.2.8\build\native\php-7.2-ts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-7.3-nts.7.3.0\build\native\php-7.3-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.3-nts.7.3.0\build\native\php-7.3-nts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets')" />
+    <Import Project="..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets')" />
+    <Import Project="..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets')" />
   </ImportGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\cpp\msbuild\ice.sign.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -264,5 +270,7 @@
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-7.2-ts.7.2.8\build\native\php-7.2-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-7.2-ts.7.2.8\build\native\php-7.2-ts.targets'))" />
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-7.3-nts.7.3.0\build\native\php-7.3-nts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-7.3-nts.7.3.0\build\native\php-7.3-nts.targets'))" />
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets'))" />
   </Target>
 </Project>

--- a/php/src/php/msbuild/php_ice.vcxproj
+++ b/php/src/php/msbuild/php_ice.vcxproj
@@ -256,6 +256,8 @@
     <Import Project="..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets')" />
     <Import Project="..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets')" />
+    <Import Project="..\..\..\msbuild\packages\php-8.1-nts.8.1.0\build\native\php-8.1-nts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.1-nts.8.1.0\build\native\php-8.1-nts.targets')" />
+    <Import Project="..\..\..\msbuild\packages\php-8.1-ts.8.1.0\build\native\php-8.1-ts.targets" Condition="Exists('..\..\..\msbuild\packages\php-8.1-ts.8.1.0\build\native\php-8.1-ts.targets')" />
   </ImportGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\cpp\msbuild\ice.sign.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -272,5 +274,7 @@
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-7.3-ts.7.3.0\build\native\php-7.3-ts.targets'))" />
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.0-nts.8.0.0\build\native\php-8.0-nts.targets'))" />
     <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.0-ts.8.0.0\build\native\php-8.0-ts.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.1-nts.8.1.0\build\native\php-8.1-nts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.1-nts.8.1.0\build\native\php-8.1-nts.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\php-8.1-ts.8.1.0\build\native\php-8.1-ts.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\php-8.1-ts.8.1.0\build\native\php-8.1-ts.targets'))" />
   </Target>
 </Project>

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -268,7 +268,7 @@ if isinstance(platform, Windows):
     # Windows doesn't support all the mappings, we take them out here.
     if platform.getCompiler() not in ["v140", "v141"]:
         Mapping.disable("python")
-    if platform.getCompiler() not in ["v140", "v141"]:
+    if platform.getCompiler() not in ["v140", "v141", "v142"]:
         Mapping.disable("php")
 
 #

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3784,7 +3784,7 @@ class PhpMapping(CppBasedClientMapping):
         def usage(self):
             print("")
             print("PHP Mapping options:")
-            print("--php-version=[7.1|7.2|7.3]    PHP Version used for Windows builds")
+            print("--php-version=[7.1|7.2|7.3|8.0]    PHP Version used for Windows builds")
 
 
         def __init__(self, options=[]):
@@ -3803,7 +3803,8 @@ class PhpMapping(CppBasedClientMapping):
             nugetVersions = {
                 "7.1": "7.1.17",
                 "7.2": "7.2.8",
-                "7.3": "7.3.0"
+                "7.3": "7.3.0",
+                "8.0": "8.0.0"
             }
             nugetVersion = nugetVersions[current.config.phpVersion]
             threadSafe = current.driver.configs[self].buildConfig in ["Debug", "Release"]

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3784,7 +3784,7 @@ class PhpMapping(CppBasedClientMapping):
         def usage(self):
             print("")
             print("PHP Mapping options:")
-            print("--php-version=[7.1|7.2|7.3|8.0]    PHP Version used for Windows builds")
+            print("--php-version=[7.1|7.2|7.3|8.0|8.1]    PHP Version used for Windows builds")
 
 
         def __init__(self, options=[]):
@@ -3804,7 +3804,8 @@ class PhpMapping(CppBasedClientMapping):
                 "7.1": "7.1.17",
                 "7.2": "7.2.8",
                 "7.3": "7.3.0",
-                "8.0": "8.0.0"
+                "8.0": "8.0.0",
+                "8.1": "8.1.0"
             }
             nugetVersion = nugetVersions[current.config.phpVersion]
             threadSafe = current.driver.configs[self].buildConfig in ["Debug", "Release"]


### PR DESCRIPTION
This PR adds Windows support for PHP 8.0, and fixes some incorrect usages of ` ice_void_arginfo` used with methods that take parameters.