### PR TITLE
Fix for Windows 11 .NET 4.5 IceSSL/configuration test failure

### DIFF
--- a/csharp/src/IceSSL/TransceiverI.cs
+++ b/csharp/src/IceSSL/TransceiverI.cs
@@ -445,7 +445,7 @@ namespace IceSSL
             catch (System.ComponentModel.Win32Exception ex)
             {
                 // This error code correspond to SChannel SEC_E_ALGORITHM_MISMATCH. The client and server cannot
-                // communicate, because they do not possess a common algorithm.
+                // communicate, because they can't agree on a common algorithm.
                 if (ex.NativeErrorCode == -2146893007)
                 {
                     throw new Ice.ConnectionLostException(ex);

--- a/csharp/src/IceSSL/TransceiverI.cs
+++ b/csharp/src/IceSSL/TransceiverI.cs
@@ -444,6 +444,8 @@ namespace IceSSL
 #if NET45
             catch (System.ComponentModel.Win32Exception ex)
             {
+                // This error code correspond to SChannel SEC_E_ALGORITHM_MISMATCH. The client and server cannot
+                // communicate, because they do not possess a common algorithm.
                 if (ex.NativeErrorCode == -2146893007)
                 {
                     throw new Ice.ConnectionLostException(ex);

--- a/csharp/src/IceSSL/TransceiverI.cs
+++ b/csharp/src/IceSSL/TransceiverI.cs
@@ -441,7 +441,17 @@ namespace IceSSL
                 e.reason = ex.Message;
                 throw e;
             }
-            catch(Exception ex)
+#if NET45
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                if (ex.NativeErrorCode == -2146893007)
+                {
+                    throw new Ice.ConnectionLostException(ex);
+                }
+                throw new Ice.SyscallException(ex);
+            }
+#endif
+            catch (Exception ex)
             {
                 throw new Ice.SyscallException(ex);
             }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -1360,28 +1360,6 @@ public class AllTests
                 }
                 fact.destroyServer(server);
                 comm.destroy();
-
-                //
-                // This should success because the client and the server enables SSLv3
-                //
-                comm = Ice.Util.initialize(ref args, initData);
-                fact = Test.ServerFactoryPrxHelper.checkedCast(comm.stringToProxy(factoryRef));
-                test(fact != null);
-                d = createServerProps(defaultProperties, "s_rsa_ca1", "cacert1");
-                d["IceSSL.VerifyPeer"] = "2";
-                d["IceSSL.Protocols"] = "ssl3, tls1_0, tls1_1, tls1_2";
-                server = fact.createServer(d);
-                try
-                {
-                    server.ice_ping();
-                }
-                catch(Ice.LocalException ex)
-                {
-                    Console.WriteLine(ex.ToString());
-                    test(false);
-                }
-                fact.destroyServer(server);
-                comm.destroy();
             }
 #endif
             Console.Out.WriteLine("ok");


### PR DESCRIPTION
This PR fixes a failure with Windows 11 and .NET 4.5 IceSSL/configuration test

```
testing protocols... Ice.SyscallException
    error = 0
   at Ice.ObjectPrxHelperBase.ice_ping(OptionalContext context) in C:\Users\vagrant\workspace\ice\3.7\csharp\src\Ice\Proxy.cs:line 1036
   at AllTests.allTests(TestHelper helper, String testDir) in C:\Users\vagrant\workspace\ice\3.7\csharp\test\IceSSL\configuration\AllTests.cs:line 1349
Caused by: System.ComponentModel.Win32Exception: The client and server cannot communicate, because they do not possess a common algorithm
   at System.Net.SSPIWrapper.AcquireCredentialsHandle(SSPIInterface SecModule, String package, CredentialUse intent, SecureCredential scc)
   at System.Net.Security.SecureChannel.AcquireCredentialsHandle(CredentialUse credUsage, SecureCredential& secureCredential)
   at System.Net.Security.SecureChannel.AcquireCredentialsHandle(CredentialUse credUsage, X509Certificate2 selectedCert, Flags flags)
   at System.Net.Security.SecureChannel.AcquireClientCredentials(Byte[]& thumbPrint)
   at System.Net.Security.SecureChannel.GenerateToken(Byte[] input, Int32 offset, Int32 count, Byte[]& output)
   at System.Net.Security.SecureChannel.NextMessage(Byte[] incoming, Int32 offset, Int32 count)
   at System.Net.Security.SslState.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessAuthentication(LazyAsyncResult lazyResult)
   at System.Net.Security.SslStream.BeginAuthenticateAsClient(String targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, Boolean checkCertificateRevocation, AsyncCallback asyncCallback, Object asyncState)
   at System.Net.Security.SslStream.<>c__DisplayClass32_0.<AuthenticateAsClientAsync>b__0(AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl(Func`3 beginMethod, Func`2 endFunction, Action`1 endAction, Object state, TaskCreationOptions creationOptions)
   at System.Net.Security.SslStream.AuthenticateAsClientAsync(String targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, Boolean checkCertificateRevocation)
   at IceSSL.TransceiverI.startAuthenticate(AsyncCallback callback, Object state) in C:\Users\vagrant\workspace\ice\3.7\csharp\src\IceSSL\TransceiverI.cs:line 399
```