### PR TITLE
C++ 20 msvc fixes

### DIFF
--- a/cpp/include/Ice/Functional.h
+++ b/cpp/include/Ice/Functional.h
@@ -7,7 +7,7 @@
 
 #include <IceUtil/Config.h>
 
-#ifndef ICE_CPP11_COMPILER
+#if !defined(ICE_CPP11_MAPPING) && (ICE_CPLUSPLUS < 201703L)
 
 #include <IceUtil/Functional.h>
 #include <Ice/Handle.h>

--- a/cpp/include/Ice/Functional.h
+++ b/cpp/include/Ice/Functional.h
@@ -5,7 +5,9 @@
 #ifndef ICE_FUNCTIONAL_H
 #define ICE_FUNCTIONAL_H
 
-#ifndef ICE_CPP11_MAPPING
+#include <IceUtil/Config.h>
+
+#ifndef ICE_CPP11_COMPILER
 
 #include <IceUtil/Functional.h>
 #include <Ice/Handle.h>

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -3168,11 +3168,7 @@ ICE_API bool proxyIdentityAndFacetEqual(const ObjectPrx& lhs, const ObjectPrx& r
  * compares less than the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#ifdef ICE_CPP11_COMPILER
 struct ProxyIdentityLess
-#else
-struct ProxyIdentityLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
-#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3185,11 +3181,7 @@ struct ProxyIdentityLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
  * compares equal to the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#ifdef ICE_CPP11_COMPILER
 struct ProxyIdentityEqual
-#else
-struct ProxyIdentityEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
-#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3202,11 +3194,7 @@ struct ProxyIdentityEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
  * and facet in lhs compare less than the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#ifdef ICE_CPP11_COMPILER
 struct ProxyIdentityAndFacetLess
-#else
-struct ProxyIdentityAndFacetLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
-#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3219,11 +3207,7 @@ struct ProxyIdentityAndFacetLess : std::binary_function<bool, ObjectPrx&, Object
  * and facet in lhs compare equal to the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#ifdef ICE_CPP11_COMPILER
 struct ProxyIdentityAndFacetEqual
-#else
-struct ProxyIdentityAndFacetEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
-#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -3168,7 +3168,11 @@ ICE_API bool proxyIdentityAndFacetEqual(const ObjectPrx& lhs, const ObjectPrx& r
  * compares less than the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
+#ifdef ICE_CPP11_COMPILER
+struct ProxyIdentityLess
+#else
 struct ProxyIdentityLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3181,7 +3185,11 @@ struct ProxyIdentityLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
  * compares equal to the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
+#ifdef ICE_CPP11_COMPILER
+struct ProxyIdentityEqual
+#else
 struct ProxyIdentityEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3194,7 +3202,11 @@ struct ProxyIdentityEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
  * and facet in lhs compare less than the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
+#ifdef ICE_CPP11_COMPILER
+struct ProxyIdentityAndFacetLess
+#else
 struct ProxyIdentityAndFacetLess : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3207,7 +3219,11 @@ struct ProxyIdentityAndFacetLess : std::binary_function<bool, ObjectPrx&, Object
  * and facet in lhs compare equal to the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
+#ifdef ICE_CPP11_COMPILER
+struct ProxyIdentityAndFacetEqual
+#else
 struct ProxyIdentityAndFacetEqual : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -1477,10 +1477,10 @@ ICE_API bool proxyIdentityAndFacetEqual(const ::std::shared_ptr<ObjectPrx>& lhs,
  * compares less than the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#if (ICE_CPLUSPLUS >= 201703L)
+
 struct ProxyIdentityLess
-#else
-struct ProxyIdentityLess : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
 #endif
 {
     bool operator()(const ::std::shared_ptr<ObjectPrx>& lhs, const ::std::shared_ptr<ObjectPrx>& rhs) const
@@ -1494,10 +1494,9 @@ struct ProxyIdentityLess : std::binary_function<bool, ::std::shared_ptr<ObjectPr
  * compares equal to the identity in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#if (ICE_CPLUSPLUS >= 201703L)
 struct ProxyIdentityEqual
-#else
-struct ProxyIdentityEqual : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
 #endif
 {
     bool operator()(const ::std::shared_ptr<ObjectPrx>& lhs, const ::std::shared_ptr<ObjectPrx>& rhs) const
@@ -1511,10 +1510,9 @@ struct ProxyIdentityEqual : std::binary_function<bool, ::std::shared_ptr<ObjectP
  * and facet in lhs compare less than the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#if (ICE_CPLUSPLUS >= 201703L)
 struct ProxyIdentityAndFacetLess
-#else
-struct ProxyIdentityAndFacetLess : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
 #endif
 {
     bool operator()(const ::std::shared_ptr<ObjectPrx>& lhs, const ::std::shared_ptr<ObjectPrx>& rhs) const
@@ -1528,10 +1526,9 @@ struct ProxyIdentityAndFacetLess : std::binary_function<bool, ::std::shared_ptr<
  * and facet in lhs compare equal to the identity and facet in rhs, false otherwise.
  * \headerfile Ice/Ice.h
  */
-#if (ICE_CPLUSPLUS >= 201703L)
 struct ProxyIdentityAndFacetEqual
-#else
-struct ProxyIdentityAndFacetEqual : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ::std::shared_ptr<ObjectPrx>&, ::std::shared_ptr<ObjectPrx>&>
 #endif
 {
     bool operator()(const ::std::shared_ptr<ObjectPrx>& lhs, const ::std::shared_ptr<ObjectPrx>& rhs) const
@@ -3169,6 +3166,9 @@ ICE_API bool proxyIdentityAndFacetEqual(const ObjectPrx& lhs, const ObjectPrx& r
  * \headerfile Ice/Ice.h
  */
 struct ProxyIdentityLess
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3182,6 +3182,9 @@ struct ProxyIdentityLess
  * \headerfile Ice/Ice.h
  */
 struct ProxyIdentityEqual
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3195,6 +3198,9 @@ struct ProxyIdentityEqual
  * \headerfile Ice/Ice.h
  */
 struct ProxyIdentityAndFacetLess
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {
@@ -3208,6 +3214,9 @@ struct ProxyIdentityAndFacetLess
  * \headerfile Ice/Ice.h
  */
 struct ProxyIdentityAndFacetEqual
+#if (ICE_CPLUSPLUS < 201703L)
+    : std::binary_function<bool, ObjectPrx&, ObjectPrx&>
+#endif
 {
     bool operator()(const ObjectPrx& lhs, const ObjectPrx& rhs) const
     {

--- a/cpp/include/IceUtil/Functional.h
+++ b/cpp/include/IceUtil/Functional.h
@@ -7,7 +7,7 @@
 
 #include <IceUtil/Config.h>
 
-#ifndef ICE_CPP11_COMPILER
+#if !defined(ICE_CPP11_MAPPING) && (ICE_CPLUSPLUS < 201703L)
 
 #include <IceUtil/Handle.h>
 #include <functional>

--- a/cpp/include/IceUtil/Functional.h
+++ b/cpp/include/IceUtil/Functional.h
@@ -5,7 +5,9 @@
 #ifndef ICE_UTIL_FUNCTIONAL_H
 #define ICE_UTIL_FUNCTIONAL_H
 
-#ifndef ICE_CPP11_MAPPING
+#include <IceUtil/Config.h>
+
+#ifndef ICE_CPP11_COMPILER
 
 #include <IceUtil/Handle.h>
 #include <functional>

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -48,7 +48,7 @@ IceUtil::Shared* IceInternal::upCast(IncomingConnectionFactory* p) { return p; }
 namespace
 {
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
 template <typename Map> void
 remove(Map& m, const typename Map::key_type& k, const typename Map::mapped_type& v)
 {
@@ -463,9 +463,9 @@ IceInternal::OutgoingConnectionFactory::findConnection(const vector<EndpointIPtr
     assert(!endpoints.empty());
     for(vector<EndpointIPtr>::const_iterator p = endpoints.begin(); p != endpoints.end(); ++p)
     {
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
         auto connection = find(_connectionsByEndpoint, *p,
-                               [](const ConnectionIPtr& conn)
+                               [](const auto& conn)
                                {
                                    return conn->isActiveOrHolding();
                                });
@@ -501,9 +501,9 @@ IceInternal::OutgoingConnectionFactory::findConnection(const vector<ConnectorInf
             continue;
         }
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
         auto connection = find(_connections, p->connector,
-                               [](const ConnectionIPtr& conn)
+                               [](const auto& conn)
                                {
                                    return conn->isActiveOrHolding();
                                });

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -133,8 +133,8 @@ IceInternal::LocatorManager::destroy()
 {
     IceUtil::Mutex::Lock sync(*this);
 
-#ifdef ICE_CPP11_MAPPING
-    for_each(_table.begin(), _table.end(), [](pair<shared_ptr<Ice::LocatorPrx>, LocatorInfoPtr> it){ it.second->destroy(); });
+#ifdef ICE_CPP11_COMPILER
+    for_each(_table.begin(), _table.end(), [](const auto& it){ it.second->destroy(); });
 #else
     for_each(_table.begin(), _table.end(), Ice::secondVoidMemFun<const LocatorPrx, LocatorInfo>(&LocatorInfo::destroy));
 #endif
@@ -773,7 +773,7 @@ IceInternal::LocatorInfo::trace(const string& msg, const ReferencePtr& ref, cons
 
     const char* sep = endpoints.size() > 1 ? ":" : "";
     ostringstream o;
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     transform(endpoints.begin(), endpoints.end(), ostream_iterator<string>(o, sep),
               [](const EndpointPtr& endpoint)
               {

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -46,8 +46,8 @@ IceInternal::ObjectAdapterFactory::shutdown()
     // Deactivate outside the thread synchronization, to avoid
     // deadlocks.
     //
-#ifdef ICE_CPP11_MAPPING
-    for_each(adapters.begin(), adapters.end(), [](const ObjectAdapterIPtr& adapter) { adapter->deactivate(); });
+#ifdef ICE_CPP11_COMPILER
+    for_each(adapters.begin(), adapters.end(), [](const auto& adapter) { adapter->deactivate(); });
 #else
     for_each(adapters.begin(), adapters.end(), IceUtil::voidMemFun(&ObjectAdapter::deactivate));
 #endif
@@ -75,8 +75,8 @@ IceInternal::ObjectAdapterFactory::waitForShutdown()
     //
     // Now we wait for deactivation of each object adapter.
     //
-#ifdef ICE_CPP11_MAPPING
-    for_each(adapters.begin(), adapters.end(), [](const ObjectAdapterIPtr& adapter) { adapter->waitForDeactivate(); });
+#ifdef ICE_CPP11_COMPILER
+    for_each(adapters.begin(), adapters.end(), [](const auto& adapter) { adapter->waitForDeactivate(); });
 #else
     for_each(adapters.begin(), adapters.end(), IceUtil::voidMemFun(&ObjectAdapter::waitForDeactivate));
 #endif
@@ -108,8 +108,8 @@ IceInternal::ObjectAdapterFactory::destroy()
     //
     // Now we destroy each object adapter.
     //
-#ifdef ICE_CPP11_MAPPING
-    for_each(adapters.begin(), adapters.end(), [](const ObjectAdapterIPtr& adapter) { adapter->destroy(); });
+#ifdef ICE_CPP11_COMPILER
+    for_each(adapters.begin(), adapters.end(), [](const auto& adapter) { adapter->destroy(); });
 #else
     for_each(adapters.begin(), adapters.end(), IceUtil::voidMemFun(&ObjectAdapter::destroy));
 #endif
@@ -128,7 +128,7 @@ IceInternal::ObjectAdapterFactory::updateObservers(void (ObjectAdapterI::*fn)())
         IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
         adapters = _adapters;
     }
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(adapters.begin(), adapters.end(),
         [fn](const ObjectAdapterIPtr& adapter)
         {

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -98,9 +98,9 @@ Ice::ObjectAdapterI::activate()
         //
         if(_state != StateUninitialized)
         {
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
             for_each(_incomingConnectionFactories.begin(), _incomingConnectionFactories.end(),
-                [](const IncomingConnectionFactoryPtr& factory)
+                [](const auto& factory)
                 {
                     factory->activate();
                 });
@@ -159,9 +159,9 @@ Ice::ObjectAdapterI::activate()
         IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
         assert(_state == StateActivating);
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
             for_each(_incomingConnectionFactories.begin(), _incomingConnectionFactories.end(),
-                [](const IncomingConnectionFactoryPtr& factory)
+                [](const auto& factory)
                 {
                     factory->activate();
                 });
@@ -182,9 +182,9 @@ Ice::ObjectAdapterI::hold()
     checkForDeactivation();
     _state = StateHeld;
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(_incomingConnectionFactories.begin(), _incomingConnectionFactories.end(),
-        [](const IncomingConnectionFactoryPtr& factory)
+        [](const auto& factory)
         {
             factory->hold();
         });
@@ -206,9 +206,9 @@ Ice::ObjectAdapterI::waitForHold()
         incomingConnectionFactories = _incomingConnectionFactories;
     }
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(incomingConnectionFactories.begin(), incomingConnectionFactories.end(),
-        [](const IncomingConnectionFactoryPtr& factory)
+        [](const auto& factory)
         {
             factory->waitUntilHolding();
         });
@@ -269,9 +269,9 @@ Ice::ObjectAdapterI::deactivate() ICE_NOEXCEPT
         //
     }
 
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(_incomingConnectionFactories.begin(), _incomingConnectionFactories.end(),
-        [](const IncomingConnectionFactoryPtr& factory)
+        [](const auto& factory)
         {
             factory->destroy();
         });
@@ -317,9 +317,9 @@ Ice::ObjectAdapterI::waitForDeactivate() ICE_NOEXCEPT
     // Now we wait until all incoming connection factories are
     // finished.
     //
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(incomingConnectionFactories.begin(), incomingConnectionFactories.end(),
-        [](const IncomingConnectionFactoryPtr& factory)
+        [](const auto& factory)
         {
             factory->waitUntilFinished();
         });
@@ -639,8 +639,8 @@ Ice::ObjectAdapterI::getEndpoints() const ICE_NOEXCEPT
     EndpointSeq endpoints;
     transform(_incomingConnectionFactories.begin(), _incomingConnectionFactories.end(),
             back_inserter(endpoints),
-#ifdef ICE_CPP11_MAPPING
-            [](const IncomingConnectionFactoryPtr& factory)
+#ifdef ICE_CPP11_COMPILER
+            [](const auto& factory)
             {
                 return factory->endpoint();
             });
@@ -831,9 +831,9 @@ Ice::ObjectAdapterI::updateConnectionObservers()
         IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(*this);
         f = _incomingConnectionFactories;
     }
-#ifdef ICE_CPP11_MAPPING
+#ifdef ICE_CPP11_COMPILER
     for_each(f.begin(), f.end(),
-        [](const IncomingConnectionFactoryPtr& factory)
+        [](const auto& factory)
         {
             factory->updateConnectionObservers();
         });

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -25,8 +25,8 @@ void
 IceInternal::RouterManager::destroy()
 {
     IceUtil::Mutex::Lock sync(*this);
-#ifdef ICE_CPP11_MAPPING
-    for_each(_table.begin(), _table.end(), [](const pair<shared_ptr<RouterPrx>, RouterInfoPtr> it){ it.second->destroy(); });
+#ifdef ICE_CPP11_COMPILER
+    for_each(_table.begin(), _table.end(), [](const auto& it){ it.second->destroy(); });
 #else
     for_each(_table.begin(), _table.end(), Ice::secondVoidMemFun<const RouterPrx, RouterInfo>(&RouterInfo::destroy));
 #endif

--- a/cpp/src/IceGrid/AdapterCache.cpp
+++ b/cpp/src/IceGrid/AdapterCache.cpp
@@ -20,7 +20,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+struct ReplicaLoadComp
+#else
 struct ReplicaLoadComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEntryPtr&, bool>
+#endif
 {
     bool operator()(const pair<float, ServerAdapterEntryPtr>& lhs, const pair<float, ServerAdapterEntryPtr>& rhs)
     {
@@ -28,7 +32,11 @@ struct ReplicaLoadComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEn
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct ReplicaPriorityComp
+#else
 struct ReplicaPriorityComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEntryPtr&, bool>
+#endif
 {
     bool operator()(const ServerAdapterEntryPtr& lhs, const ServerAdapterEntryPtr& rhs)
     {
@@ -36,8 +44,12 @@ struct ReplicaPriorityComp : binary_function<ServerAdapterEntryPtr&, ServerAdapt
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct TransformToReplicaLoad
+#else
 struct TransformToReplicaLoad :
         public unary_function<const ServerAdapterEntryPtr&, pair<float, ServerAdapterEntryPtr> >
+#endif
 {
 public:
 
@@ -52,7 +64,11 @@ public:
     LoadSample _loadSample;
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct TransformToReplica
+#else
 struct TransformToReplica : public unary_function<const pair<string, ServerAdapterEntryPtr>&, ServerAdapterEntryPtr>
+#endif
 {
     ServerAdapterEntryPtr
     operator()(const pair<float, ServerAdapterEntryPtr>& value)

--- a/cpp/src/IceGrid/AdapterCache.cpp
+++ b/cpp/src/IceGrid/AdapterCache.cpp
@@ -20,11 +20,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
 struct ReplicaLoadComp
-#else
-struct ReplicaLoadComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEntryPtr&, bool>
-#endif
 {
     bool operator()(const pair<float, ServerAdapterEntryPtr>& lhs, const pair<float, ServerAdapterEntryPtr>& rhs)
     {
@@ -32,11 +28,7 @@ struct ReplicaLoadComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEn
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct ReplicaPriorityComp
-#else
-struct ReplicaPriorityComp : binary_function<ServerAdapterEntryPtr&, ServerAdapterEntryPtr&, bool>
-#endif
 {
     bool operator()(const ServerAdapterEntryPtr& lhs, const ServerAdapterEntryPtr& rhs)
     {
@@ -44,12 +36,7 @@ struct ReplicaPriorityComp : binary_function<ServerAdapterEntryPtr&, ServerAdapt
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct TransformToReplicaLoad
-#else
-struct TransformToReplicaLoad :
-        public unary_function<const ServerAdapterEntryPtr&, pair<float, ServerAdapterEntryPtr> >
-#endif
 {
 public:
 
@@ -64,11 +51,7 @@ public:
     LoadSample _loadSample;
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct TransformToReplica
-#else
-struct TransformToReplica : public unary_function<const pair<string, ServerAdapterEntryPtr>&, ServerAdapterEntryPtr>
-#endif
 {
     ServerAdapterEntryPtr
     operator()(const pair<float, ServerAdapterEntryPtr>& value)

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -16,11 +16,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
 struct AllocatableObjectEntryCI
-#else
-struct AllocatableObjectEntryCI : binary_function<AllocatableObjectEntryPtr&, AllocatableObjectEntryPtr&, bool>
-#endif
 {
 
     bool

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -16,7 +16,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+struct AllocatableObjectEntryCI
+#else
 struct AllocatableObjectEntryCI : binary_function<AllocatableObjectEntryPtr&, AllocatableObjectEntryPtr&, bool>
+#endif
 {
 
     bool

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -43,11 +43,7 @@ const string internalObjectsDbName = "internal-objects";
 const string internalObjectsByTypeDbName = "internal-objectsByType";
 const string serialsDbName = "serials";
 
-#ifdef ICE_CPP11_COMPILER
 struct ObjectLoadCI
-#else
-struct ObjectLoadCI : binary_function<pair<Ice::ObjectPrx, float>&, pair<Ice::ObjectPrx, float>&, bool>
-#endif
 {
     bool operator()(const pair<Ice::ObjectPrx, float>& lhs, const pair<Ice::ObjectPrx, float>& rhs)
     {

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -23,7 +23,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+struct GetReplicaGroupId
+#else
 struct GetReplicaGroupId : unary_function<const ReplicaGroupDescriptor&, const string&>
+#endif
 {
     const string&
     operator()(const ReplicaGroupDescriptor& desc)
@@ -32,7 +36,11 @@ struct GetReplicaGroupId : unary_function<const ReplicaGroupDescriptor&, const s
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct GetAdapterId
+#else
 struct GetAdapterId : unary_function<const AdapterDescriptor&, const string&>
+#endif
 {
     const string&
     operator()(const AdapterDescriptor& desc)
@@ -41,7 +49,11 @@ struct GetAdapterId : unary_function<const AdapterDescriptor&, const string&>
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct GetObjectId
+#else
 struct GetObjectId : unary_function<const ObjectDescriptor&, const Ice::Identity&>
+#endif
 {
     const Ice::Identity&
     operator()(const ObjectDescriptor& desc)
@@ -76,7 +88,11 @@ isSeqEqual(const Seq& lseq, const Seq& rseq, GetKeyFunc func, EqFunc eq = equal_
     return true;
 }
 
+#ifdef  ICE_CPP11_COMPILER
+struct TemplateDescriptorEqual
+#else
 struct TemplateDescriptorEqual : std::binary_function<TemplateDescriptor&, TemplateDescriptor&, bool>
+#endif
 {
     bool
     operator()(const TemplateDescriptor& lhs, const TemplateDescriptor& rhs)
@@ -120,7 +136,11 @@ struct TemplateDescriptorEqual : std::binary_function<TemplateDescriptor&, Templ
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct ObjectDescriptorEq
+#else
 struct ObjectDescriptorEq : std::binary_function<const ObjectDescriptor&, const ObjectDescriptor&, bool>
+#endif
 {
     bool
     operator()(const ObjectDescriptor& lhs, const ObjectDescriptor& rhs)
@@ -141,7 +161,11 @@ struct ObjectDescriptorEq : std::binary_function<const ObjectDescriptor&, const 
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct AdapterEq
+#else
 struct AdapterEq : std::binary_function<const AdapterDescriptor&, const AdapterDescriptor&, bool>
+#endif
 {
     bool
     operator()(const AdapterDescriptor& lhs, const AdapterDescriptor& rhs)
@@ -186,7 +210,11 @@ struct AdapterEq : std::binary_function<const AdapterDescriptor&, const AdapterD
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct ReplicaGroupEq
+#else
 struct ReplicaGroupEq : std::binary_function<const ReplicaGroupDescriptor&, const ReplicaGroupDescriptor&, bool>
+#endif
 {
     bool
     operator()(const ReplicaGroupDescriptor& lhs, const ReplicaGroupDescriptor& rhs)

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -23,11 +23,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
 struct GetReplicaGroupId
-#else
-struct GetReplicaGroupId : unary_function<const ReplicaGroupDescriptor&, const string&>
-#endif
 {
     const string&
     operator()(const ReplicaGroupDescriptor& desc)
@@ -36,11 +32,7 @@ struct GetReplicaGroupId : unary_function<const ReplicaGroupDescriptor&, const s
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct GetAdapterId
-#else
-struct GetAdapterId : unary_function<const AdapterDescriptor&, const string&>
-#endif
 {
     const string&
     operator()(const AdapterDescriptor& desc)
@@ -49,11 +41,7 @@ struct GetAdapterId : unary_function<const AdapterDescriptor&, const string&>
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct GetObjectId
-#else
-struct GetObjectId : unary_function<const ObjectDescriptor&, const Ice::Identity&>
-#endif
 {
     const Ice::Identity&
     operator()(const ObjectDescriptor& desc)
@@ -88,11 +76,7 @@ isSeqEqual(const Seq& lseq, const Seq& rseq, GetKeyFunc func, EqFunc eq = equal_
     return true;
 }
 
-#ifdef  ICE_CPP11_COMPILER
 struct TemplateDescriptorEqual
-#else
-struct TemplateDescriptorEqual : std::binary_function<TemplateDescriptor&, TemplateDescriptor&, bool>
-#endif
 {
     bool
     operator()(const TemplateDescriptor& lhs, const TemplateDescriptor& rhs)
@@ -136,11 +120,7 @@ struct TemplateDescriptorEqual : std::binary_function<TemplateDescriptor&, Templ
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct ObjectDescriptorEq
-#else
-struct ObjectDescriptorEq : std::binary_function<const ObjectDescriptor&, const ObjectDescriptor&, bool>
-#endif
 {
     bool
     operator()(const ObjectDescriptor& lhs, const ObjectDescriptor& rhs)
@@ -161,11 +141,7 @@ struct ObjectDescriptorEq : std::binary_function<const ObjectDescriptor&, const 
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct AdapterEq
-#else
-struct AdapterEq : std::binary_function<const AdapterDescriptor&, const AdapterDescriptor&, bool>
-#endif
 {
     bool
     operator()(const AdapterDescriptor& lhs, const AdapterDescriptor& rhs)
@@ -210,11 +186,7 @@ struct AdapterEq : std::binary_function<const AdapterDescriptor&, const AdapterD
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct ReplicaGroupEq
-#else
-struct ReplicaGroupEq : std::binary_function<const ReplicaGroupDescriptor&, const ReplicaGroupDescriptor&, bool>
-#endif
 {
     bool
     operator()(const ReplicaGroupDescriptor& lhs, const ReplicaGroupDescriptor& rhs)

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -19,11 +19,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
 struct ToInternalServerDescriptor
-#else
-struct ToInternalServerDescriptor : std::unary_function<CommunicatorDescriptorPtr&, void>
-#endif
 {
     ToInternalServerDescriptor(const InternalServerDescriptorPtr& descriptor, const InternalNodeInfoPtr& node,
                                int iceVersion) :

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -19,7 +19,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+struct ToInternalServerDescriptor
+#else
 struct ToInternalServerDescriptor : std::unary_function<CommunicatorDescriptorPtr&, void>
+#endif
 {
     ToInternalServerDescriptor(const InternalServerDescriptorPtr& descriptor, const InternalNodeInfoPtr& node,
                                int iceVersion) :

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -884,8 +884,11 @@ NodeI::checkConsistency(const NodeSessionPrx& session)
         }
         sort(servers.begin(), servers.end());
     }
-
+#ifdef ICE_CPP11_COMPILER
+    for_each(commands.begin(), commands.end(), [](const auto& it) { it->execute(); });
+#else
     for_each(commands.begin(), commands.end(), IceUtil::voidMemFun(&ServerCommand::execute));
+#endif
 }
 
 void

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -368,8 +368,11 @@ NodeSessionI::destroyImpl(bool shutdown)
     }
 
     ServerEntrySeq servers = _database->getNode(_info->name)->getServers();
+#ifdef ICE_CPP11_COMPILER
+    for_each(servers.begin(), servers.end(), [](const auto& it) {it->unsync(); });
+#else
     for_each(servers.begin(), servers.end(), IceUtil::voidMemFun(&ServerEntry::unsync));
-
+#endif
     //
     // If the registry isn't being shutdown we remove the node
     // internal proxy from the database.

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -373,6 +373,7 @@ NodeSessionI::destroyImpl(bool shutdown)
 #else
     for_each(servers.begin(), servers.end(), IceUtil::voidMemFun(&ServerEntry::unsync));
 #endif
+
     //
     // If the registry isn't being shutdown we remove the node
     // internal proxy from the database.

--- a/cpp/src/IceGrid/ObjectCache.cpp
+++ b/cpp/src/IceGrid/ObjectCache.cpp
@@ -17,11 +17,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
 struct ObjectEntryCI
-#else
-struct ObjectEntryCI : binary_function<ObjectEntryPtr&, ObjectEntryPtr&, bool>
-#endif
 {
 
     bool
@@ -31,11 +27,7 @@ struct ObjectEntryCI : binary_function<ObjectEntryPtr&, ObjectEntryPtr&, bool>
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct ObjectLoadCI
-#else
-struct ObjectLoadCI : binary_function<pair<Ice::ObjectPrx, float>&, pair<Ice::ObjectPrx, float>&, bool>
-#endif
 {
     bool operator()(const pair<Ice::ObjectPrx, float>& lhs, const pair<Ice::ObjectPrx, float>& rhs)
     {

--- a/cpp/src/IceGrid/ObjectCache.cpp
+++ b/cpp/src/IceGrid/ObjectCache.cpp
@@ -17,7 +17,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+struct ObjectEntryCI
+#else
 struct ObjectEntryCI : binary_function<ObjectEntryPtr&, ObjectEntryPtr&, bool>
+#endif
 {
 
     bool
@@ -27,7 +31,11 @@ struct ObjectEntryCI : binary_function<ObjectEntryPtr&, ObjectEntryPtr&, bool>
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct ObjectLoadCI
+#else
 struct ObjectLoadCI : binary_function<pair<Ice::ObjectPrx, float>&, pair<Ice::ObjectPrx, float>&, bool>
+#endif
 {
     bool operator()(const pair<Ice::ObjectPrx, float>& lhs, const pair<Ice::ObjectPrx, float>& rhs)
     {

--- a/cpp/src/IceGrid/ServerCache.cpp
+++ b/cpp/src/IceGrid/ServerCache.cpp
@@ -21,7 +21,11 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
+#ifdef ICE_CPP11_COMPILER
+    struct AddCommunicator
+#else
     struct AddCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
+#endif
     {
         AddCommunicator(ServerCache& serverCache, const ServerEntryPtr& entry, const string& application) :
             _serverCache(serverCache), _entry(entry), _application(application)
@@ -45,7 +49,11 @@ namespace IceGrid
         const string _application;
     };
 
+#ifdef ICE_CPP11_COMPILER
+    struct RemoveCommunicator
+#else
     struct RemoveCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
+#endif
     {
         RemoveCommunicator(ServerCache& serverCache, const ServerEntryPtr& entry) :
             _serverCache(serverCache), _entry(entry)

--- a/cpp/src/IceGrid/ServerCache.cpp
+++ b/cpp/src/IceGrid/ServerCache.cpp
@@ -21,11 +21,7 @@ using namespace IceGrid;
 namespace IceGrid
 {
 
-#ifdef ICE_CPP11_COMPILER
     struct AddCommunicator
-#else
-    struct AddCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
-#endif
     {
         AddCommunicator(ServerCache& serverCache, const ServerEntryPtr& entry, const string& application) :
             _serverCache(serverCache), _entry(entry), _application(application)
@@ -49,11 +45,7 @@ namespace IceGrid
         const string _application;
     };
 
-#ifdef ICE_CPP11_COMPILER
     struct RemoveCommunicator
-#else
-    struct RemoveCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
-#endif
     {
         RemoveCommunicator(ServerCache& serverCache, const ServerEntryPtr& entry) :
             _serverCache(serverCache), _entry(entry)

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -367,11 +367,7 @@ private:
 };
 typedef IceUtil::Handle<ResetPropertiesCB> ResetPropertiesCBPtr;
 
-#ifdef ICE_CPP11_COMPILER
 struct EnvironmentEval
-#else
-struct EnvironmentEval : std::unary_function<string, string>
-#endif
 {
 
     string

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -367,7 +367,11 @@ private:
 };
 typedef IceUtil::Handle<ResetPropertiesCB> ResetPropertiesCBPtr;
 
+#ifdef ICE_CPP11_COMPILER
+struct EnvironmentEval
+#else
 struct EnvironmentEval : std::unary_function<string, string>
+#endif
 {
 
     string

--- a/cpp/src/IceGrid/Util.h
+++ b/cpp/src/IceGrid/Util.h
@@ -39,7 +39,11 @@ void setupThreadPool(const Ice::PropertiesPtr&, const std::string&, int, int = 0
 int getMMVersion(const std::string&);
 
 template<class Function>
+#ifdef  ICE_CPP11_COMPILER
+struct ForEachCommunicator
+#else
 struct ForEachCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
+#endif
 {
     ForEachCommunicator(Function f) : _function(f)
     {
@@ -131,7 +135,11 @@ inline forEachCommunicator(Function function)
 }
 
 template<class T, class A>
+#ifdef ICE_CPP11_COMPILER
+struct ObjFunc
+#else
 struct ObjFunc : std::unary_function<A, void>
+#endif
 {
     T& _obj;
     typedef void (T::*MemberFN)(A);

--- a/cpp/src/IceGrid/Util.h
+++ b/cpp/src/IceGrid/Util.h
@@ -39,11 +39,7 @@ void setupThreadPool(const Ice::PropertiesPtr&, const std::string&, int, int = 0
 int getMMVersion(const std::string&);
 
 template<class Function>
-#ifdef  ICE_CPP11_COMPILER
 struct ForEachCommunicator
-#else
-struct ForEachCommunicator : std::unary_function<CommunicatorDescriptorPtr&, void>
-#endif
 {
     ForEachCommunicator(Function f) : _function(f)
     {
@@ -135,11 +131,7 @@ inline forEachCommunicator(Function function)
 }
 
 template<class T, class A>
-#ifdef ICE_CPP11_COMPILER
 struct ObjFunc
-#else
-struct ObjFunc : std::unary_function<A, void>
-#endif
 {
     T& _obj;
     typedef void (T::*MemberFN)(A);

--- a/cpp/src/IcePatch2/Calc.cpp
+++ b/cpp/src/IcePatch2/Calc.cpp
@@ -15,7 +15,11 @@ using namespace IceInternal;
 using namespace IcePatch2;
 using namespace IcePatch2Internal;
 
+#ifdef ICE_CPP11_COMPILER
+struct FileInfoPathLess
+#else
 struct FileInfoPathLess: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
+#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)
@@ -24,7 +28,11 @@ struct FileInfoPathLess: public binary_function<const LargeFileInfo&, const Larg
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct IFileInfoPathEqual
+#else
 struct IFileInfoPathEqual: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
+#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)
@@ -46,7 +54,11 @@ struct IFileInfoPathEqual: public binary_function<const LargeFileInfo&, const La
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct IFileInfoPathLess
+#else
 struct IFileInfoPathLess: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
+#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)

--- a/cpp/src/IcePatch2/Calc.cpp
+++ b/cpp/src/IcePatch2/Calc.cpp
@@ -15,11 +15,7 @@ using namespace IceInternal;
 using namespace IcePatch2;
 using namespace IcePatch2Internal;
 
-#ifdef ICE_CPP11_COMPILER
 struct FileInfoPathLess
-#else
-struct FileInfoPathLess: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
-#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)
@@ -28,11 +24,7 @@ struct FileInfoPathLess: public binary_function<const LargeFileInfo&, const Larg
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct IFileInfoPathEqual
-#else
-struct IFileInfoPathEqual: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
-#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)
@@ -54,11 +46,7 @@ struct IFileInfoPathEqual: public binary_function<const LargeFileInfo&, const La
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct IFileInfoPathLess
-#else
-struct IFileInfoPathLess: public binary_function<const LargeFileInfo&, const LargeFileInfo&, bool>
-#endif
 {
     bool
     operator()(const LargeFileInfo& lhs, const LargeFileInfo& rhs)

--- a/cpp/src/IcePatch2Lib/Util.h
+++ b/cpp/src/IcePatch2Lib/Util.h
@@ -46,11 +46,7 @@ ICEPATCH2_API void decompressFile(const std::string&);
 
 ICEPATCH2_API void setFileFlags(const std::string&, const IcePatch2::LargeFileInfo&);
 
-#ifdef ICE_CPP11_COMPILER
 struct FileInfoEqual
-#else
-struct FileInfoEqual : public std::binary_function<const IcePatch2::LargeFileInfo&, const IcePatch2::LargeFileInfo&, bool>
-#endif
 {
     bool
     operator()(const IcePatch2::LargeFileInfo& lhs, const IcePatch2::LargeFileInfo& rhs)
@@ -82,11 +78,7 @@ struct FileInfoEqual : public std::binary_function<const IcePatch2::LargeFileInf
     }
 };
 
-#ifdef ICE_CPP11_COMPILER
 struct FileInfoWithoutFlagsLess
-#else
-struct FileInfoWithoutFlagsLess : public std::binary_function<const IcePatch2::LargeFileInfo&, const IcePatch2::LargeFileInfo&, bool>
-#endif
 {
     bool
     operator()(const IcePatch2::LargeFileInfo& lhs, const IcePatch2::LargeFileInfo& rhs)

--- a/cpp/src/IcePatch2Lib/Util.h
+++ b/cpp/src/IcePatch2Lib/Util.h
@@ -46,7 +46,11 @@ ICEPATCH2_API void decompressFile(const std::string&);
 
 ICEPATCH2_API void setFileFlags(const std::string&, const IcePatch2::LargeFileInfo&);
 
+#ifdef ICE_CPP11_COMPILER
+struct FileInfoEqual
+#else
 struct FileInfoEqual : public std::binary_function<const IcePatch2::LargeFileInfo&, const IcePatch2::LargeFileInfo&, bool>
+#endif
 {
     bool
     operator()(const IcePatch2::LargeFileInfo& lhs, const IcePatch2::LargeFileInfo& rhs)
@@ -78,7 +82,11 @@ struct FileInfoEqual : public std::binary_function<const IcePatch2::LargeFileInf
     }
 };
 
+#ifdef ICE_CPP11_COMPILER
+struct FileInfoWithoutFlagsLess
+#else
 struct FileInfoWithoutFlagsLess : public std::binary_function<const IcePatch2::LargeFileInfo&, const IcePatch2::LargeFileInfo&, bool>
+#endif
 {
     bool
     operator()(const IcePatch2::LargeFileInfo& lhs, const IcePatch2::LargeFileInfo& rhs)

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -2,6 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(_MSC_VER) && (_MSVC_LANG >= 201703L)
+    // TODO codecvt was deprecated in C++17 and cause build failures with VC++ compiler
+    // we should replace this code with MultiByteToWideChar() and WideCharToMultiByte()
+#   define  _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+#endif
+
 #include <IceUtil/StringConverter.h>
 #include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/Mutex.h>

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1107,7 +1107,11 @@ Slice::Contained::Contained(const ContainerPtr& container, const string& name) :
 void
 Slice::Container::destroy()
 {
+#ifdef ICE_CPP11_COMPILER
+    for_each(_contents.begin(), _contents.end(), [](const auto& it) { it->destroy();  });
+#else
     for_each(_contents.begin(), _contents.end(), ::IceUtil::voidMemFun(&SyntaxTreeBase::destroy));
+#endif
     _contents.clear();
     _introducedMap.clear();
     SyntaxTreeBase::destroy();

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -181,7 +181,11 @@ struct OptionalDef
 // CICompare -- function object to do case-insensitive string comparison.
 // ----------------------------------------------------------------------
 
+#ifdef ICE_CPP11_COMPILER
+class CICompare
+#else
 class CICompare : public std::binary_function<std::string, std::string, bool>
+#endif
 {
 public:
 
@@ -197,7 +201,11 @@ bool cICompare(const std::string&, const std::string&);
 // most-derived to least-derived order.
 // ----------------------------------------------------------------------
 
+#ifdef ICE_CPP11_COMPILER
+class DerivedToBaseCompare
+#else
 class DerivedToBaseCompare : public std::binary_function<std::string, std::string, bool>
+#endif
 {
 public:
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -181,11 +181,7 @@ struct OptionalDef
 // CICompare -- function object to do case-insensitive string comparison.
 // ----------------------------------------------------------------------
 
-#ifdef ICE_CPP11_COMPILER
 class CICompare
-#else
-class CICompare : public std::binary_function<std::string, std::string, bool>
-#endif
 {
 public:
 
@@ -201,11 +197,7 @@ bool cICompare(const std::string&, const std::string&);
 // most-derived to least-derived order.
 // ----------------------------------------------------------------------
 
-#ifdef ICE_CPP11_COMPILER
 class DerivedToBaseCompare
-#else
-class DerivedToBaseCompare : public std::binary_function<std::string, std::string, bool>
-#endif
 {
 public:
 

--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -949,7 +949,11 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         //
         ClassList allBases = p->allBases();
         StringList ids;
+#ifdef ICE_CPP11_COMPILER
+        transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
         transform(allBases.begin(), allBases.end(), back_inserter(ids), IceUtil::constMemFun(&Contained::scoped));
+#endif
         StringList other;
         other.push_back(scoped);
         other.push_back("::Ice::Object");

--- a/cpp/src/iceserviceinstall/ServiceInstaller.cpp
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.cpp
@@ -706,8 +706,14 @@ IceServiceInstaller::addLog(const string& log) const
     // We don't support to use a string converter with this tool, so don't need to
     // use string converters in calls to stringToWstring.
     //
-    LONG res = RegCreateKeyExW(HKEY_LOCAL_MACHINE, stringToWstring(createLog(log)).c_str(), 0, L"REG_SZ",
-                               REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, 0, &key, &disposition);
+    LONG res = RegCreateKeyExW(HKEY_LOCAL_MACHINE,
+                               stringToWstring(createLog(log)).c_str(),
+                               0,
+                               const_cast<wchar_t*>(L"REG_SZ"),
+                               REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
+                               0,
+                               &key,
+                               &disposition);
 
     if(res != ERROR_SUCCESS)
     {
@@ -748,8 +754,15 @@ IceServiceInstaller::addSource(const string& source, const string& log, const st
     //
     HKEY key = 0;
     DWORD disposition = 0;
-    LONG res = RegCreateKeyExW(HKEY_LOCAL_MACHINE, stringToWstring(createSource(source, log)).c_str(),
-                               0, L"REG_SZ", REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, 0, &key, &disposition);
+    LONG res = RegCreateKeyExW(HKEY_LOCAL_MACHINE,
+                               stringToWstring(createSource(source, log)).c_str(),
+                               0,
+                               const_cast<wchar_t*>(L"REG_SZ"),
+                               REG_OPTION_NON_VOLATILE,
+                               KEY_ALL_ACCESS,
+                               0,
+                               &key,
+                               &disposition);
     if(res != ERROR_SUCCESS)
     {
         throw runtime_error("Could not create Event Log source in registry: " + IceUtilInternal::errorToString(res));

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -3077,7 +3077,11 @@ Slice::Gen::ObjectVisitor::visitClassDefStart(const ClassDefPtr& p)
 
         ClassList allBases = p->allBases();
         StringList ids;
+#ifdef ICE_CPP11_COMPILER
+        transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
         transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
         StringList other;
         other.push_back(p->scoped());
         other.push_back("::Ice::Object");
@@ -3217,9 +3221,12 @@ Slice::Gen::ObjectVisitor::visitClassDefEnd(const ClassDefPtr& p)
         if(!allOps.empty())
         {
             StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+            transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name(); });
+#else
             transform(allOps.begin(), allOps.end(), back_inserter(allOpNames),
                       ::IceUtil::constMemFun(&Contained::name));
-
+#endif
             allOpNames.push_back("ice_id");
             allOpNames.push_back("ice_ids");
             allOpNames.push_back("ice_isA");
@@ -6163,7 +6170,11 @@ Slice::Gen::Cpp11DeclVisitor::visitClassDefStart(const ClassDefPtr& p)
 
         ClassList allBases = p->allBases();
         StringList ids;
+#ifdef ICE_CPP11_COMPILER
+        transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
         transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
         StringList other;
         other.push_back(p->scoped());
         other.push_back("::Ice::Object");
@@ -6184,7 +6195,11 @@ Slice::Gen::Cpp11DeclVisitor::visitClassDefStart(const ClassDefPtr& p)
         C << eb << ';';
 
         StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+        transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name(); });
+#else
         transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), ::IceUtil::constMemFun(&Contained::name));
+#endif
         allOpNames.push_back("ice_id");
         allOpNames.push_back("ice_ids");
         allOpNames.push_back("ice_isA");
@@ -7978,7 +7993,11 @@ Slice::Gen::Cpp11InterfaceVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(p->scoped());
     other.push_back("::Ice::Object");
@@ -8076,7 +8095,11 @@ Slice::Gen::Cpp11InterfaceVisitor::visitClassDefEnd(const ClassDefPtr& p)
     if(!allOps.empty())
     {
         StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+        transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name(); });
+#else
         transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), ::IceUtil::constMemFun(&Contained::name));
+#endif
         allOpNames.push_back("ice_id");
         allOpNames.push_back("ice_ids");
         allOpNames.push_back("ice_isA");

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -393,7 +393,11 @@ Slice::CsVisitor::writeDispatch(const ClassDefPtr& p)
     StringList ids;
     ClassList bases = p->bases();
     bool hasBaseClass = !bases.empty() && !bases.front()->isInterface();
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped();  });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(p->scoped());
     other.push_back("::Ice::Object");
@@ -646,7 +650,11 @@ Slice::CsVisitor::writeDispatch(const ClassDefPtr& p)
     if(!allOps.empty() || (!p->isInterface() && !hasBaseClass))
     {
         StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+        transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name();  });
+#else
         transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), constMemFun(&Contained::name));
+#endif
         allOpNames.push_back("ice_id");
         allOpNames.push_back("ice_ids");
         allOpNames.push_back("ice_isA");
@@ -762,7 +770,11 @@ Slice::CsVisitor::writeMarshaling(const ClassDefPtr& p)
     StringList ids;
     ClassList bases = p->bases();
 
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped();  });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(p->scoped());
     other.push_back("::Ice::Value");
@@ -4883,7 +4895,11 @@ Slice::Gen::HelperVisitor::visitClassDefStart(const ClassDefPtr& p)
     string scoped = p->scoped();
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped();  });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(p->scoped());
     other.push_back("::Ice::Object");

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1145,7 +1145,11 @@ Slice::JavaVisitor::writeDispatch(Output& out, const ClassDefPtr& p)
 
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(scoped);
     other.push_back("::Ice::Object");
@@ -1388,7 +1392,11 @@ Slice::JavaVisitor::writeDispatch(Output& out, const ClassDefPtr& p)
     if(!allOps.empty())
     {
         StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+        transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name(); });
+#else
         transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), constMemFun(&Contained::name));
+#endif
         allOpNames.push_back("ice_id");
         allOpNames.push_back("ice_ids");
         allOpNames.push_back("ice_isA");

--- a/cpp/src/slice2java/GenCompat.cpp
+++ b/cpp/src/slice2java/GenCompat.cpp
@@ -1107,7 +1107,11 @@ Slice::JavaCompatVisitor::writeDispatchAndMarshalling(Output& out, const ClassDe
 
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(scoped);
     other.push_back("::Ice::Object");
@@ -1539,7 +1543,11 @@ Slice::JavaCompatVisitor::writeDispatchAndMarshalling(Output& out, const ClassDe
     if(!allOps.empty())
     {
         StringList allOpNames;
+#ifdef ICE_CPP11_COMPILER
+        transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), [](const auto& it) { return it->name(); });
+#else
         transform(allOps.begin(), allOps.end(), back_inserter(allOpNames), constMemFun(&Contained::name));
+#endif
         allOpNames.push_back("ice_id");
         allOpNames.push_back("ice_ids");
         allOpNames.push_back("ice_isA");
@@ -4879,7 +4887,11 @@ Slice::GenCompat::HelperVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(scoped);
     other.push_back("::Ice::Object");

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1330,7 +1330,11 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     ClassList allBases = p->allBases();
     StringList ids;
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
     StringList other;
     other.push_back(scoped);
     other.push_back("::Ice::Object");

--- a/cpp/src/slice2objc/Gen.cpp
+++ b/cpp/src/slice2objc/Gen.cpp
@@ -212,7 +212,11 @@ Slice::ObjCVisitor::writeDispatchAndMarshalling(const ClassDefPtr& p)
     ClassList allBases = p->allBases();
     StringList ids;
 
+#ifdef ICE_CPP11_COMPILER
+    transform(allBases.begin(), allBases.end(), back_inserter(ids), [](const auto& it) { return it->scoped(); });
+#else
     transform(allBases.begin(), allBases.end(), back_inserter(ids), ::IceUtil::constMemFun(&Contained::scoped));
+#endif
 
     StringList other;
     other.push_back(p->scoped());

--- a/cpp/src/slice2rb/Main.cpp
+++ b/cpp/src/slice2rb/Main.cpp
@@ -24,12 +24,12 @@ int main(int argc, char* argv[])
     }
     catch(const std::exception& ex)
     {
-        consoleErr << argv[0] << ": error:" << ex.what() << endl;
+        consoleErr << args[0] << ": error:" << ex.what() << endl;
         return EXIT_FAILURE;
     }
     catch(...)
     {
-        consoleErr << argv[0] << ": error:" << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:" << "unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }


### PR DESCRIPTION
This PR fixes C++ build to support MSVC using C++ 20 mode, there were mainly two problems:

- Codectv utf8/utf32 conversions are deprecated as C++17, and we disable the warnings for now
- std::binary_function and std::unary_function were removed in C++ 17