### PR TITLE
Fix for potential CFStream/NSStream deadlock with the iOS transports

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -92,6 +92,10 @@ These are the changes since Ice 3.7.6.
 - Added MSBuild target that copy the Ice DLL and PDB files to the projects output directory.
   The target can be enabled by setting MSbuild property `Ice_CopyDLLs` to `Yes` in the project.
 
+- The iOS transports were updated to ensure potential deadlocks are not
+  possible when using the CFStream/NSStream APIs. Such a deadlock could
+  be reproduced with the iAP transport implementation.
+
 ## Java Changes
 
 - Updated IceGrid GUI to include the registry instance name in the window title

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -314,10 +314,18 @@ IceObjC::StreamTransceiver::close()
 SocketOperation
 IceObjC::StreamTransceiver::write(Buffer& buf)
 {
-    IceUtil::Mutex::Lock sync(_mutex);
-    if(_error)
+    // Don't hold the lock which calling on the CFStream API to avoid deadlocks in case the CFStream API calls
+    // the stream notification callbacks with an internal lock held.
     {
-        checkErrorStatus(_writeStream.get(), 0, __FILE__, __LINE__);
+        IceUtil::Mutex::Lock sync(_mutex);
+        if(_error)
+        {
+            checkErrorStatus(_writeStream.get(), 0, __FILE__, __LINE__);
+        }
+        else if (_writeStreamRegistered)
+        {
+            return SocketOperationWrite;
+        }
     }
 
     size_t packetSize = static_cast<size_t>(buf.b.end() - buf.i);
@@ -355,10 +363,18 @@ IceObjC::StreamTransceiver::write(Buffer& buf)
 SocketOperation
 IceObjC::StreamTransceiver::read(Buffer& buf)
 {
-    IceUtil::Mutex::Lock sync(_mutex);
-    if(_error)
+    // Don't hold the lock which calling on the CFStream API to avoid deadlocks in case the CFStream API calls
+    // the stream notification callbacks with an internal lock held.
     {
-        checkErrorStatus(0, _readStream.get(), __FILE__, __LINE__);
+        IceUtil::Mutex::Lock sync(_mutex);
+        if (_error)
+        {
+            checkErrorStatus(0, _readStream.get(), __FILE__, __LINE__);
+        }
+        else if (_readStreamRegistered)
+        {
+            return SocketOperationRead;
+        }
     }
 
     size_t packetSize = static_cast<size_t>(buf.b.end() - buf.i);
@@ -493,23 +509,21 @@ void
 IceObjC::StreamTransceiver::checkErrorStatus(CFWriteStreamRef writeStream, CFReadStreamRef readStream,
                                              const char* file, int line)
 {
-    if((writeStream && (CFWriteStreamGetStatus(writeStream) == kCFStreamStatusAtEnd)) ||
-       (readStream && (CFReadStreamGetStatus(readStream) == kCFStreamStatusAtEnd)))
+    assert(writeStream || readStream);
+
+    CFStreamStatus status = writeStream ? CFWriteStreamGetStatus(writeStream) : CFReadStreamGetStatus(readStream);
+
+    if (status == kCFStreamStatusAtEnd || status == kCFStreamStatusClosed)
     {
         throw ConnectionLostException(file, line);
     }
 
-    UniqueRef<CFErrorRef> err;
-    if(writeStream && CFWriteStreamGetStatus(writeStream) == kCFStreamStatusError)
-    {
-        err.reset(CFWriteStreamCopyError(writeStream));
-    }
-    else if(readStream && CFReadStreamGetStatus(readStream) == kCFStreamStatusError)
-    {
-        err.reset(CFReadStreamCopyError(readStream));
-    }
+    assert(status == kCFStreamStatusError);
 
+    UniqueRef<CFErrorRef> err;
+    err.reset(writeStream ? CFWriteStreamCopyError(writeStream) : CFReadStreamCopyError(readStream));
     assert(err.get());
+
     CFStringRef domain = CFErrorGetDomain(err.get());
     if(CFStringCompare(domain, kCFErrorDomainPOSIX, 0) == kCFCompareEqualTo)
     {

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -314,7 +314,7 @@ IceObjC::StreamTransceiver::close()
 SocketOperation
 IceObjC::StreamTransceiver::write(Buffer& buf)
 {
-    // Don't hold the lock which calling on the CFStream API to avoid deadlocks in case the CFStream API calls
+    // Don't hold the lock while calling on the CFStream API to avoid deadlocks in case the CFStream API calls
     // the stream notification callbacks with an internal lock held.
     {
         IceUtil::Mutex::Lock sync(_mutex);
@@ -363,7 +363,7 @@ IceObjC::StreamTransceiver::write(Buffer& buf)
 SocketOperation
 IceObjC::StreamTransceiver::read(Buffer& buf)
 {
-    // Don't hold the lock which calling on the CFStream API to avoid deadlocks in case the CFStream API calls
+    // Don't hold the lock while calling on the CFStream API to avoid deadlocks in case the CFStream API calls
     // the stream notification callbacks with an internal lock held.
     {
         IceUtil::Mutex::Lock sync(_mutex);

--- a/cpp/src/IceIAP/Transceiver.mm
+++ b/cpp/src/IceIAP/Transceiver.mm
@@ -263,10 +263,18 @@ IceObjC::iAPTransceiver::close()
 SocketOperation
 IceObjC::iAPTransceiver::write(Buffer& buf)
 {
-    IceUtil::Mutex::Lock sync(_mutex);
-    if(_error)
+    // Don't hold the lock which calling on the NSStream API to avoid deadlocks in case the NSStream API calls
+    // the stream notification callbacks with an internal lock held.
     {
-        checkErrorStatus(_writeStream, __FILE__, __LINE__);
+        IceUtil::Mutex::Lock sync(_mutex);
+        if(_error)
+        {
+            checkErrorStatus(_writeStream, __FILE__, __LINE__);
+        }
+        else if(_writeStreamRegistered)
+        {
+            return SocketOperationWrite;
+        }
     }
 
     size_t packetSize = static_cast<size_t>(buf.b.end() - buf.i);
@@ -303,10 +311,18 @@ IceObjC::iAPTransceiver::write(Buffer& buf)
 SocketOperation
 IceObjC::iAPTransceiver::read(Buffer& buf)
 {
-    IceUtil::Mutex::Lock sync(_mutex);
-    if(_error)
+    // Don't hold the lock which calling on the NSStream API to avoid deadlocks in case the NSStream API calls
+    // the stream notification callbacks with an internal lock held.
     {
-        checkErrorStatus(_readStream, __FILE__, __LINE__);
+        IceUtil::Mutex::Lock sync(_mutex);
+        if(_error)
+        {
+            checkErrorStatus(_readStream, __FILE__, __LINE__);
+        }
+        else if(_readStreamRegistered)
+        {
+            return SocketOperationRead;
+        }
     }
 
     size_t packetSize = static_cast<size_t>(buf.b.end() - buf.i);
@@ -418,14 +434,15 @@ void
 IceObjC::iAPTransceiver::checkErrorStatus(NSStream* stream, const char* file, int line)
 {
     NSStreamStatus status = [stream streamStatus];
-    if(status == NSStreamStatusAtEnd)
+    if(status == NSStreamStatusAtEnd || status == NSStreamStatusClosed)
     {
         throw ConnectionLostException(file, line);
     }
 
     assert(status == NSStreamStatusError);
-
     NSError* err = [stream streamError];
+    assert(err != nil);
+
     NSString* domain = [err domain];
     if([domain compare:NSPOSIXErrorDomain] == NSOrderedSame)
     {

--- a/cpp/src/IceIAP/Transceiver.mm
+++ b/cpp/src/IceIAP/Transceiver.mm
@@ -263,7 +263,7 @@ IceObjC::iAPTransceiver::close()
 SocketOperation
 IceObjC::iAPTransceiver::write(Buffer& buf)
 {
-    // Don't hold the lock which calling on the NSStream API to avoid deadlocks in case the NSStream API calls
+    // Don't hold the lock while calling on the NSStream API to avoid deadlocks in case the NSStream API calls
     // the stream notification callbacks with an internal lock held.
     {
         IceUtil::Mutex::Lock sync(_mutex);
@@ -311,7 +311,7 @@ IceObjC::iAPTransceiver::write(Buffer& buf)
 SocketOperation
 IceObjC::iAPTransceiver::read(Buffer& buf)
 {
-    // Don't hold the lock which calling on the NSStream API to avoid deadlocks in case the NSStream API calls
+    // Don't hold the lock while calling on the NSStream API to avoid deadlocks in case the NSStream API calls
     // the stream notification callbacks with an internal lock held.
     {
         IceUtil::Mutex::Lock sync(_mutex);


### PR DESCRIPTION
This PR provides a potential fix for the iAP deadlock. A similar fix was applied to the iOS TCP transport as well since it's using the same underlying API (CFStream API).