### PR TITLE
Fix clang build (missing copy constructor)

### DIFF
--- a/cpp/src/IceStorm/Replica.h
+++ b/cpp/src/IceStorm/Replica.h
@@ -23,7 +23,7 @@ struct GroupNodeInfo
     //
 #if defined(__clang__) && defined(_LIBCPP_VERSION)
 #   ifdef ICE_CPP11_COMPILER
-    GroupNodeInfo(const GroupNodeInfo&);
+    GroupNodeInfo(const GroupNodeInfo&) = default;
 #   endif
     GroupNodeInfo& operator=(const GroupNodeInfo&);
 #endif


### PR DESCRIPTION
In 15a9edabe things were moved around, so that clang/libc++
builds have the copy constructor of GroupNodeInfo declared, but
(unlike the assignment operator in NodeI.cpp#L101, which might
not be needed to spelled out anymore these days) not defined,
which results in broken builds at link time.

Tested with clang v11.0.1.