### PR TITLE
Fix for JavaScript and TypeScript testsuite loading

### DIFF
--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3877,6 +3877,14 @@ class MatlabMapping(CppBasedClientMapping):
 class JavaScriptMixin():
 
     def loadTestSuites(self, tests, config, filters, rfilters):
+        # Exclude es5 directory, these are the same tests but transpiled with babel the JavaScript mapping
+        # use them when --es5 option is set.
+        rfilters += [re.compile("es5/*")]
+
+        # Exclude typescript directory when the mapping is not typescript otherwise we endup with duplicate entries
+        if self.name != "typescript":
+            rfilters += [re.compile("typescript/*")]
+
         Mapping.loadTestSuites(self, tests, config, filters, rfilters)
         self.getServerMapping().loadTestSuites(list(self.testsuites.keys()) + ["Ice/echo"], config)
 


### PR DESCRIPTION
This PR fix the discovery of JavaScript and TypeScript tests

previously I was getting duplicates for es5 tests and TypeScript 
```
*** [28/104] Running js/es5/Ice/acm tests ***
[ running client test - 03/30/22 19:43:33 ]
- Config: x64,Debug,es5
(node C:\Users\jose\source\repos\3.7.7\ice\js\test\es5\Common/run.js Client --Ice.Default.Host=127.0.0.1 --Ice.Warn.Connections=1 --Ice.Default.Protocol=tcp --Ice.IPv6=0 env={'NODE_PATH': 'C:\\Users\\jose\\source\\repos\\3.7.7\\ice\\js\\test\\es5\\Common;C:\\Users\\jose\\source\\repos\\3.7.7\\ice\\js\\test\\es5\\es5/Ice/acm'})
Traceback (most recent call last):
```