### PR TITLE
Adjust version for gcc ignored diagnostic pragmas

### DIFF
--- a/php/src/php/Config.h
+++ b/php/src/php/Config.h
@@ -48,7 +48,7 @@ extern "C"
 #   pragma GCC diagnostic warning "-Wnarrowing"
 #endif
 
-#if defined(__GNUC__) && ((__GNUC__ >= 8))
+#if defined(__GNUC__) && ((__GNUC__ >= 4))
 #   pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #   pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif


### PR DESCRIPTION
Compiling with gcc-4.8.5 on CentOS-7 required this change.