### PR TITLE
Set default value for python optional parameters

### DIFF
--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -808,7 +808,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             string inParamsDecl;
 
             // Find the last required parameter, all optional parameters after the last required parameter will use
-            // Ice.Uset as the default.
+            // Ice.Unset as the default.
             ParamDeclPtr lastRequiredParameter;
             for(ParamDeclList::const_iterator q = paramList.begin(); q != paramList.end(); ++q)
             {

--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -807,7 +807,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             string inParams;
             string inParamsDecl;
 
-            // Find the last required parameter, all optional paramteres after the last required parameter will use
+            // Find the last required parameter, all optional parameters after the last required parameter will use
             // Ice.Uset as the default.
             ParamDeclPtr lastRequiredParameter;
             for(ParamDeclList::const_iterator q = paramList.begin(); q != paramList.end(); ++q)

--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -805,7 +805,20 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             TypePtr ret = (*oli)->returnType();
             ParamDeclList paramList = (*oli)->parameters();
             string inParams;
+            string inParamsDecl;
 
+            // Find the last required parameter, all optional paramteres after the last required parameter will use
+            // Ice.Uset as the default.
+            ParamDeclPtr lastRequiredParameter;
+            for(ParamDeclList::const_iterator q = paramList.begin(); q != paramList.end(); ++q)
+            {
+                if(!(*q)->isOutParam() && !(*q)->optional())
+                {
+                    lastRequiredParameter = *q;
+                }
+            }
+
+            bool afterLastRequiredParameter = lastRequiredParameter == ICE_NULLPTR;
             for(ParamDeclList::const_iterator q = paramList.begin(); q != paramList.end(); ++q)
             {
                 if(!(*q)->isOutParam())
@@ -813,17 +826,29 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
                     if(!inParams.empty())
                     {
                         inParams.append(", ");
+                        inParamsDecl.append(", ");
                     }
-                    inParams.append(fixIdent((*q)->name()));
+                    string param = fixIdent((*q)->name());
+                    inParams.append(param);
+                    if(afterLastRequiredParameter)
+                    {
+                        param += "=Ice.Unset";
+                    }
+                    inParamsDecl.append(param);
+
+                    if(*q == lastRequiredParameter)
+                    {
+                        afterLastRequiredParameter = true;
+                    }
                 }
             }
 
             _out << sp;
             writeDocstring(*oli, DocSync, false);
             _out << nl << "def " << fixedOpName << "(self";
-            if(!inParams.empty())
+            if(!inParamsDecl.empty())
             {
-                _out << ", " << inParams;
+                _out << ", " << inParamsDecl;
             }
             const string contextParamName = getEscapedParamName(*oli, "context");
             _out << ", " << contextParamName << "=None):";

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -754,7 +754,7 @@ def allTests(helper, communicator):
         test(p2 is Ice.Unset)
         test(p3 == 3)
     except Ice.OperationNotExistException:
-        # Expected for language mappings that don't implement this operations when running cross tests
+        # Expected for language mappings that don't implement these operations when running cross tests
         pass
     print("ok")
 

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -738,6 +738,24 @@ def allTests(helper, communicator):
     (p2, p3) = f.result()
     test(p2[1].a == 58 and p3[1].a == 58);
 
+    try:
+        (p1, p2, p3) = initial.opRequiredAfterOptional(1, 2, 3)
+        test(p1 == 1)
+        test(p2 == 2)
+        test(p3 == 3)
+
+        (p1, p2, p3) = initial.opOptionalAfterRequired(1)
+        test(p1 == 1)
+        test(p2 is Ice.Unset)
+        test(p3 is Ice.Unset)
+
+        (p1, p2, p3) = initial.opOptionalAfterRequired(1, p3=3)
+        test(p1 == 1)
+        test(p2 is Ice.Unset)
+        test(p3 == 3)
+    except Ice.OperationNotExistException:
+        # Expected for language mappings that don't implement this operations when running cross tests
+        pass
     print("ok")
 
     sys.stdout.write("testing exception optionals... ")

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -166,6 +166,12 @@ class InitialI(Test.Initial):
     def opMG2(self, p1, current):
         return Test.Initial.OpMG2MarshaledResult((p1, p1), current)
 
+    def opRequiredAfterOptional(self, p1, p2, p3, current):
+        return (p1, p2, p3)
+
+    def opOptionalAfterRequired(self, p1, p2, p3, current):
+        return (p1, p2, p3)
+
     def supportsRequiredParams(self, current=None):
         return False
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -172,6 +172,12 @@ class InitialI(Test.Initial):
     def opMG2(self, p1, current):
         return Ice.Future.completed(Test.Initial.OpMG2MarshaledResult((p1, p1), current))
 
+    def opRequiredAfterOptional(self, p1, p2, p3, current):
+        return Ice.Future.completed((p1, p2, p3))
+
+    def opOptionalAfterRequired(self, p1, p2, p3, current):
+        return Ice.Future.completed((p1, p2, p3))
+
     def supportsRequiredParams(self, current=None):
         return Ice.Future.completed(False)
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -275,6 +275,10 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
+    void opRequiredAfterOptional(int p1, optional(1) int p2, int p3, out int p4, out optional(2) int p5, out int p6);
+    void opOptionalAfterRequired(int p1, optional(1) int p2, optional(2) int p3, out int p4, out optional(3) int p5,
+                                 out optional(4) int p6);
+
     void sendOptionalClass(bool req, optional(1) OneOptional o);
 
     void returnOptionalClass(bool req, out optional(1) OneOptional o);


### PR DESCRIPTION
This PR updates the python mapping to use `Ice.Unset` as the default value for optional parameters that come after all required parameters.