### PR TITLE
Allow to build Python extension with recent Visual Studio versions

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -18,7 +18,7 @@ pip install <URL of Ice source distribution for Python>
 
 ## Building with Visual Studio 2015 and MSBuild (Python 3.10 for Windows)
 
-You can  build an Ice for Python extension that links with the Ice C++ DLLs using Visual Studio and MSBuild.
+You can build an Ice for Python extension that links with the Ice C++ DLLs using Visual Studio and MSBuild.
 
 First, open a Visual Studio 2015 command prompt:
 

--- a/python/README.md
+++ b/python/README.md
@@ -4,7 +4,7 @@ This document describes how to build and install Ice for Python from source.
 You can also download and install a [binary distribution][1].
 
 * [Building with Pip](#building-with-pip)
-* [Building with Visual Studio 2015 and MSBuild (Python 3\.7 for Windows)](#building-with-visual-studio-2015-and-msbuild-python-37-for-windows)
+* [Building with Visual Studio 2015 and MSBuild (Python 3\.10 for Windows)](#building-with-visual-studio-2015-and-msbuild-python-310-for-windows)
 * [Building on Linux or macOS](#building-on-linux-or-macos)
 * [Configuring your Environment for Python](#configuring-your-environment-for-python)
 * [Running the Python Tests](#running-the-python-tests)
@@ -16,10 +16,9 @@ You can build the Ice for Python extension from source using `pip`:
 pip install <URL of Ice source distribution for Python>
 ```
 
-## Building with Visual Studio 2015 and MSBuild (Python 3.7 for Windows)
+## Building with Visual Studio 2015 and MSBuild (Python 3.10 for Windows)
 
-You can  build an Ice for Python 3.7 extension that links with the Ice C++
-DLLs using Visual Studio and MSBuild.
+You can  build an Ice for Python extension that links with the Ice C++ DLLs using Visual Studio and MSBuild.
 
 First, open a Visual Studio 2015 command prompt:
 
@@ -84,7 +83,7 @@ msbuild msbuild\ice.proj /p:Configuration=Release /p:Platform=x64 /p:PythonHome=
 
 ## Building on Linux or macOS
 
-Ice for Python supports Python versions 2.7 and 3.7. Note however that
+Ice for Python supports Python versions 2.7 and 3.10. Note however that
 your Python installation must have been built with a C++ compiler that is
 compatible with the compiler used to build Ice for C++.
 

--- a/python/modules/IcePy/msbuild/icepy.vcxproj
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj
@@ -173,6 +173,8 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\msbuild\packages\mcpp.v140.2.7.2.17\build\native\mcpp.v140.targets" Condition="Exists('..\..\..\msbuild\packages\mcpp.v140.2.7.2.17\build\native\mcpp.v140.targets')" />
     <Import Project="..\..\..\msbuild\packages\mcpp.v141.2.7.2.17\build\native\mcpp.v141.targets" Condition="Exists('..\..\..\msbuild\packages\mcpp.v141.2.7.2.17\build\native\mcpp.v141.targets')" />
+    <Import Project="..\..\..\msbuild\packages\mcpp.v142.2.7.2.17\build\native\mcpp.v142.targets" Condition="Exists('..\..\..\msbuild\packages\mcpp.v142.2.7.2.17\build\native\mcpp.v142.targets')" />
+    <Import Project="..\..\..\msbuild\packages\mcpp.v143.2.7.2.17\build\native\mcpp.v143.targets" Condition="Exists('..\..\..\msbuild\packages\mcpp.v143.2.7.2.17\build\native\mcpp.v143.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -180,6 +182,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\msbuild\packages\mcpp.v140.2.7.2.17\build\native\mcpp.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\mcpp.v140.2.7.2.17\build\native\mcpp.v140.targets'))" />
     <Error Condition="!Exists('..\..\..\msbuild\packages\mcpp.v141.2.7.2.17\build\native\mcpp.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\mcpp.v141.2.7.2.17\build\native\mcpp.v141.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\mcpp.v142.2.7.2.17\build\native\mcpp.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\mcpp.v142.2.7.2.17\build\native\mcpp.v142.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\mcpp.v143.2.7.2.17\build\native\mcpp.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\mcpp.v143.2.7.2.17\build\native\mcpp.v143.targets'))" />
   </Target>
 
   <PropertyGroup>

--- a/python/modules/IcePy/msbuild/packages.config
+++ b/python/modules/IcePy/msbuild/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="mcpp.v140" version="2.7.2.17" targetFramework="native" />
   <package id="mcpp.v141" version="2.7.2.17" targetFramework="native" />
+  <package id="mcpp.v142" version="2.7.2.17" targetFramework="native" />
+  <package id="mcpp.v143" version="2.7.2.17" targetFramework="native" />
 </packages>

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -266,7 +266,7 @@ for m in filter(lambda x: os.path.isdir(os.path.join(toplevel, x)), os.listdir(t
 
 if isinstance(platform, Windows):
     # Windows doesn't support all the mappings, we take them out here.
-    if platform.getCompiler() not in ["v140", "v141", "v142" "v143"]:
+    if platform.getCompiler() not in ["v140", "v141", "v142", "v143"]:
         Mapping.disable("python")
     if platform.getCompiler() not in ["v140", "v141", "v142"]:
         Mapping.disable("php")

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -266,7 +266,7 @@ for m in filter(lambda x: os.path.isdir(os.path.join(toplevel, x)), os.listdir(t
 
 if isinstance(platform, Windows):
     # Windows doesn't support all the mappings, we take them out here.
-    if platform.getCompiler() not in ["v140", "v141"]:
+    if platform.getCompiler() not in ["v140", "v141", "v142" "v143"]:
         Mapping.disable("python")
     if platform.getCompiler() not in ["v140", "v141", "v142"]:
         Mapping.disable("php")


### PR DESCRIPTION
This PR updates the Windows Python build to work with recent Visual Studio versions (2022 and 2019)