### PR TITLE
Suppress doc warning when importing Ruby headers

### DIFF
--- a/ruby/src/IceRuby/Config.h
+++ b/ruby/src/IceRuby/Config.h
@@ -51,7 +51,7 @@
 // BUGFIX: Workaround unused parameter in ruby.h header file
 //
 #if defined(__clang__)
-// BUFIX: Workaround clang 13 warnings during ruby macro expansion, it is important to put this before the push/pop
+// BUGFIX: Workaround clang 13 warnings during ruby macro expansion, it is important to put this before the push/pop
 // directives to keep the warnings ignored in the source files where macros are expanded.
 #   if __clang_major__ >= 13
 #       pragma clang diagnostic ignored "-Wcompound-token-split-by-macro"
@@ -64,6 +64,7 @@
 #   pragma clang diagnostic ignored "-Wconversion"
 
 // Silence warnings regarding missing deprecation attributes in ruby headers
+#   pragma clang diagnostic ignored "-Wdocumentation"
 #   pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
 #elif defined(__GNUC__)
 #   pragma GCC diagnostic push
@@ -74,6 +75,10 @@
 #endif
 
 #include <ruby.h>
+
+#ifdef HAVE_RUBY_ENCODING_H
+#  include <ruby/encoding.h>
+#endif
 
 #if defined(__clang__)
 #   pragma clang diagnostic pop

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -7,10 +7,6 @@
 #include <Ice/Protocol.h>
 #include <stdarg.h>
 
-#ifdef HAVE_RUBY_ENCODING_H
-#  include <ruby/encoding.h>
-#endif
-
 using namespace std;
 using namespace IceRuby;
 


### PR DESCRIPTION
Closes #1373
