### PR TITLE
Fix python version check

### DIFF
--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -16,7 +16,6 @@ PYTHON              ?= python3
 -include        $(lang_srcdir)/config/Make.rules.$(os)
 
 # PYTHON must be set to a value that has a corresponding PYTHON-config
-python-version := $(shell $(PYTHON) -c "import sys; print(\"{0}.{1}\".format(sys.version_info[0], sys.version_info[1]))")
 python-config := $(PYTHON)-config
 
 ifeq ($(os),Linux)

--- a/python/python/Makefile
+++ b/python/python/Makefile
@@ -32,7 +32,7 @@ install:: | $(DESTDIR)$(install_pythondir)/Ice
 	$(E) "Installing generated code"
 	$(Q)$(INSTALL) -m 644 Ice/__init__.py $(DESTDIR)$(install_pythondir)/Ice
 # Ice/Future requires python >= 3.5
-ifeq ($(shell $(PYTHON) -c "print(1 if $(python-version) >= 3.5 else 0)"),1)
+ifeq ($(shell $(PYTHON) -c "import sys; print(1 if sys.version_info[:2] >= (3, 5) else 0)"),1)
 	$(Q)$(MKDIR) -p -m 755 $(DESTDIR)$(install_pythondir)/Ice/Py3
 	$(Q)$(INSTALL) -m 644 Ice/Py3/IceFuture.py $(DESTDIR)$(install_pythondir)/Ice/Py3/
 endif


### PR DESCRIPTION
We got this error with the python Debian package build with python 3.10 
```
  File "/home/ubuntu/workspace/ice-dist/3.7/dist-utils/build/ice/builds/ice-g++-default/python/test/TestHelper.py", line 5, in <module>
    import Ice
  File "/usr/lib/python3/dist-packages/Ice/__init__.py", line 78, in <module>
    from Ice.Py3.IceFuture import FutureBase, wrap_future
ModuleNotFoundError: No module named 'Ice.Py3'
Traceback (most recent call last):
  File "/home/ubuntu/workspace/ice-dist/3.7/dist-utils/build/ice/builds/ice-g++-default/python/test/TestHelper.py", line 5, in <module>
    import Ice
  File "/usr/lib/python3/dist-packages/Ice/__init__.py", line 78, in <module>
    from Ice.Py3.IceFuture import FutureBase, wrap_future
ModuleNotFoundError: No module named 'Ice.Py3'
```

That was caused by a bogus version comparison in the Makefile