### PR TITLE
Fix uninitialized memory issues 

### DIFF
--- a/php/src/php/Communicator.cpp
+++ b/php/src/php/Communicator.cpp
@@ -1190,7 +1190,7 @@ ZEND_FUNCTION(Ice_initialize)
     // Retrieve the arguments.
     //
 
-    zval* args = static_cast<zval*>(emalloc(ZEND_NUM_ARGS() * sizeof(zval)));
+    zval* args = static_cast<zval*>(ecalloc(1, ZEND_NUM_ARGS() * sizeof(zval)));
     AutoEfree autoArgs(args); // Call efree on return
     if(zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE)
     {

--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -317,7 +317,7 @@ IcePHP::OperationI::function()
 
         string fixed = fixIdent(name);
 
-        _zendFunction = static_cast<zend_internal_function*>(emalloc(sizeof(zend_internal_function)));
+        _zendFunction = static_cast<zend_internal_function*>(ecalloc(1, sizeof(zend_internal_function)));
         _zendFunction->type = ZEND_INTERNAL_FUNCTION;
         _zendFunction->function_name = zend_string_init(STRCAST(fixed.c_str()), static_cast<uint32_t>(fixed.length()), 0);
         _zendFunction->scope = proxyClassEntry;
@@ -730,7 +730,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
     //
     // Retrieve the arguments.
     //
-    zval* args = static_cast<zval*>(emalloc(ZEND_NUM_ARGS() * sizeof(zval)));
+    zval* args = static_cast<zval*>(ecalloc(1, ZEND_NUM_ARGS() * sizeof(zval)));
     AutoEfree autoArgs(args); // Call efree on return
     if(zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE)
     {

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -3260,7 +3260,7 @@ IcePHP::ReadObjectCallback::invoke(const Ice::ObjectPtr& p)
 zval*
 IcePHP::ExceptionInfo::unmarshal(Ice::InputStream* is, const CommunicatorInfoPtr& comm)
 {
-    zval* zv = static_cast<zval*>(emalloc(sizeof(zval)));
+    zval* zv = static_cast<zval*>(ecalloc(1, sizeof(zval)));
 
     if(object_init_ex(zv, zce) != SUCCESS)
     {
@@ -4025,7 +4025,7 @@ IcePHP::typesRequestInit(void)
     ICE_G(proxyInfoMap) = 0;
     ICE_G(exceptionInfoMap) = 0;
 
-    zval* unset = static_cast<zval*>(emalloc(sizeof(zval)));
+    zval* unset = static_cast<zval*>(ecalloc(1, sizeof(zval)));
     ZVAL_STRINGL(unset, STRCAST(_unsetGUID.c_str()), static_cast<int>(_unsetGUID.length()));
     ICE_G(unset) = unset;
 

--- a/php/src/php5/Communicator.cpp
+++ b/php/src/php5/Communicator.cpp
@@ -1121,7 +1121,7 @@ ZEND_FUNCTION(Ice_initialize)
     //
     // Retrieve the arguments.
     //
-    zval*** args = static_cast<zval***>(emalloc(ZEND_NUM_ARGS() * sizeof(zval**)));
+    zval*** args = static_cast<zval***>(ecalloc(1, ZEND_NUM_ARGS() * sizeof(zval**)));
     AutoEfree autoArgs(args); // Call efree on return
     if(zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE)
     {

--- a/php/src/php5/Operation.cpp
+++ b/php/src/php5/Operation.cpp
@@ -338,7 +338,7 @@ IcePHP::OperationI::function()
         }
 
         string fixed = fixIdent(name);
-        _zendFunction = static_cast<zend_internal_function*>(emalloc(sizeof(zend_internal_function)));
+        _zendFunction = static_cast<zend_internal_function*>(ecalloc(1, sizeof(zend_internal_function)));
         _zendFunction->type = ZEND_INTERNAL_FUNCTION;
         _zendFunction->function_name = estrndup(STRCAST(fixed.c_str()), static_cast<zend_uint>(fixed.length()));
         _zendFunction->scope = proxyClassEntry;
@@ -757,7 +757,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
     //
     // Retrieve the arguments.
     //
-    zval*** args = static_cast<zval***>(emalloc(ZEND_NUM_ARGS() * sizeof(zval**)));
+    zval*** args = static_cast<zval***>(ecalloc(1, ZEND_NUM_ARGS() * sizeof(zval**)));
     AutoEfree autoArgs(args); // Call efree on return
     if(zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE)
     {

--- a/php/src/php5/Util.cpp
+++ b/php/src/php5/Util.cpp
@@ -196,13 +196,13 @@ IcePHP::createWrapper(zend_class_entry* ce, size_t sz TSRMLS_DC)
 {
     zend_object* obj;
 
-    obj = static_cast<zend_object*>(emalloc(sz));
+    obj = static_cast<zend_object*>(ecalloc(1, sz));
 
     zend_object_std_init(obj, ce TSRMLS_CC);
 
 #if PHP_VERSION_ID < 50400
     zval* tmp;
-    obj->properties = static_cast<HashTable*>(emalloc(sizeof(HashTable)));
+    obj->properties = static_cast<HashTable*>(ecalloc(1, sizeof(HashTable)));
     zend_hash_init(obj->properties, 0, 0, dtor_wrapper, 0);
     zend_hash_copy(obj->properties, &ce->default_properties, (copy_ctor_func_t)zval_add_ref, &tmp, sizeof(zval*));
 #else


### PR DESCRIPTION
This PR contains a fix for #1420, we were using `emalloc` which doesn't initialize memory to 0, resulting in some random crashes, replaced with `ecalloc` that initializes the allocated memory to zero