### PR TITLE
Dynamic properties removal

### DIFF
--- a/php/lib/Ice_no_ns.php
+++ b/php/lib/Ice_no_ns.php
@@ -41,6 +41,8 @@ abstract class Ice_Exception extends Exception
 
 abstract class Ice_UserException extends Ice_Exception
 {
+    public $_ice_slicedData;
+
     public function __construct($message = '')
     {
         parent::__construct($message);
@@ -57,6 +59,8 @@ abstract class Ice_LocalException extends Ice_Exception
 
 class Ice_Value
 {
+    public $_ice_slicedData;
+
     public static function ice_staticId()
     {
         return "::Ice::Object";
@@ -69,19 +73,14 @@ class Ice_Value
 
     public function ice_getSlicedData()
     {
-        if(property_exists($this, '_ice_slicedData'))
-        {
-            return $this->_ice_slicedData;
-        }
-        else
-        {
-            return null;
-        }
+        return $this->_ice_slicedData;
     }
 }
 
 class Ice_InterfaceByValue extends Ice_Value
 {
+    public $id;
+
     public function __construct($id)
     {
         $this->id =$id;
@@ -125,6 +124,8 @@ $Ice__t_ObjectProxySeq = IcePHP_defineSequence('::Ice::ObjectProxySeq', $Ice__t_
 
 class Ice_UnknownSlicedValue extends Ice_Value
 {
+    public $unknownTypeId;
+
     public function __construct()
     {
     }

--- a/php/lib/Ice_ns.php
+++ b/php/lib/Ice_ns.php
@@ -45,6 +45,8 @@ namespace Ice
 
     abstract class UserException extends Exception
     {
+        public $_ice_slicedData;
+
         public function __construct($message = '')
         {
             parent::__construct($message);
@@ -61,7 +63,7 @@ namespace Ice
 
     class Value
     {
-        public $_ice_slicedData = null;
+        public $_ice_slicedData;
 
         public static function ice_staticId()
         {

--- a/php/lib/Ice_ns.php
+++ b/php/lib/Ice_ns.php
@@ -61,6 +61,8 @@ namespace Ice
 
     class Value
     {
+        public $_ice_slicedData = null;
+
         public static function ice_staticId()
         {
             return "::Ice::Object";
@@ -73,19 +75,14 @@ namespace Ice
 
         public function ice_getSlicedData()
         {
-            if(property_exists($this, '_ice_slicedData'))
-            {
-                return $this->_ice_slicedData;
-            }
-            else
-            {
-                return null;
-            }
+            return $this->_ice_slicedData;
         }
     }
 
     class InterfaceByValue extends Value
     {
+        public $id;
+
         public function __construct($id)
         {
             $this->id =$id;
@@ -129,6 +126,8 @@ namespace Ice
 
     class UnknownSlicedValue extends Value
     {
+        public $unknownTypeId;
+
         public function __construct()
         {
         }

--- a/php/src/php/Connection.cpp
+++ b/php/src/php/Connection.cpp
@@ -591,6 +591,8 @@ IcePHP::connectionInit(void)
                                ZEND_ACC_PUBLIC);
     zend_declare_property_string(connectionInfoClassEntry, STRCAST("adapterName"), sizeof("adapterName") - 1,
                                  STRCAST(""), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(connectionInfoClassEntry, STRCAST("underlying"), sizeof("underlying") - 1,
+                               ZEND_ACC_PUBLIC);
 
     //
     // Register the IPConnectionInfo class.
@@ -621,6 +623,10 @@ IcePHP::connectionInit(void)
 #endif
     ce.create_object = handleConnectionInfoAlloc;
     tcpConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, ipConnectionInfoClassEntry);
+    zend_declare_property_long(tcpConnectionInfoClassEntry, STRCAST("rcvSize"), sizeof("rcvSize") - 1, 0,
+                               ZEND_ACC_PUBLIC);
+    zend_declare_property_long(tcpConnectionInfoClassEntry, STRCAST("sndSize"), sizeof("sndSize") - 1, 0,
+                               ZEND_ACC_PUBLIC);
 
     //
     // Register the UDPConnectionInfo class.

--- a/php/src/php/Endpoint.cpp
+++ b/php/src/php/Endpoint.cpp
@@ -299,6 +299,8 @@ IcePHP::endpointInit(void)
                                ZEND_ACC_PUBLIC);
     zend_declare_property_bool(endpointInfoClassEntry, STRCAST("compress"), sizeof("compress") - 1, 0,
                                ZEND_ACC_PUBLIC);
+    zend_declare_property_null(endpointInfoClassEntry, STRCAST("underlying"), sizeof("underlying") - 1,
+                               ZEND_ACC_PUBLIC);
 
     //
     // Define the IPEndpointInfo class.

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -420,7 +420,7 @@ IcePHP::StreamUtil::getSlicedDataMember(zval* obj, ObjectMap* objectMap)
     Ice::SlicedDataPtr slicedData;
 
     string name = "_ice_slicedData";
-    zval* sd = zend_hash_str_find(Z_OBJPROP_P(obj), STRCAST(name.c_str()), name.size());
+    zval* sd = zend_hash_str_find_ind(Z_OBJPROP_P(obj), STRCAST(name.c_str()), name.size());
     if(sd)
     {
         if(Z_TYPE_P(sd) != IS_NULL)

--- a/php/test/Ice/slicing/objects/Client.php
+++ b/php/test/Ice/slicing/objects/Client.php
@@ -539,7 +539,6 @@ function allTests($helper)
         $d3->sb = "D3.sb";
         $d3->pb = $d3;
         $d3->sd3 = "D3.sd3";
-        $d3->pd1 = null;
         $d3->pd3 = $d11;
 
         $d12 = $NS ? eval("return new Test\\D1;") : eval("return new Test_D1;");
@@ -598,7 +597,6 @@ function allTests($helper)
             $ss2d3->sb = "D3.sb";
             $ss2d3->sd3 = "D3.sd3";
             $ss2d3->pb = $ss2b;
-            $ss2d3->pd1 = null;
 
             $ss1d1->pd1 = $ss2b;
             $ss1d3->pd3 = $ss2d1;


### PR DESCRIPTION
Avoid the use of dynamic properties deprecated in PHP 8.2. Fixes #1422