### PR TITLE
Don't leak operation return values

### DIFF
--- a/php/src/php/Operation.cpp
+++ b/php/src/php/Operation.cpp
@@ -174,6 +174,7 @@ IcePHP::ResultCallback::ResultCallback()
 
 IcePHP::ResultCallback::~ResultCallback()
 {
+    zval_ptr_dtor(&zv);
 }
 
 void
@@ -623,12 +624,12 @@ IcePHP::TypedInvocation::unmarshalResults(int argc, zval* args, zval* ret,
         //
         zval* arg = Z_REFVAL_P(&args[i]);
         zval_ptr_dtor(arg);
-        ZVAL_DUP(arg, &(*q)->zv);
+        ZVAL_COPY(arg, &(*q)->zv);
     }
 
     if(_op->returnType)
     {
-        ZVAL_DUP(ret, &retCallback->zv);
+        ZVAL_COPY(ret, &retCallback->zv);
     }
 }
 

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -2845,8 +2845,19 @@ IcePHP::ProxyInfo::print(zval* zv, IceUtilInternal::Output& out, PrintObjectHist
 void
 IcePHP::ProxyInfo::destroy()
 {
-    const_cast<ProxyInfoPtr&>(base) = 0;
+    const_cast<OperationMap&>(operations).clear();
+
+    for(ProxyInfoList::const_iterator p = interfaces.begin(); p != interfaces.end(); ++p)
+    {
+        (*p)->destroy();
+    }
     const_cast<ProxyInfoList&>(interfaces).clear();
+
+    if (base)
+    {
+        const_cast<ProxyInfoPtr&>(base)->destroy();
+        const_cast<ProxyInfoPtr&>(base) = 0;
+    }
 }
 
 bool


### PR DESCRIPTION
This PR fix the leaking of the operation return type, we identified this leak with the Ice/inheritance test. It turns out that the unmarshaled value was copied but never destructed.