### PR TITLE
Add php5 flag to slice2php

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -10,12 +10,13 @@ particular aspect of Ice.
 
 - [Changes in Ice 3.7.9](#changes-in-ice-379)
   - [C++ Changes](#c-changes)
+  - [PHP Changes](#php-changes)
 - [Changes in Ice 3.7.8](#changes-in-ice-378)
   - [C++ Changes](#c-changes-1)
   - [JavaScript Changes](#javascript-changes)
   - [MATLAB Changes](#matlab-changes)
+  - [PHP Changes](#php-changes-1)
   - [Python Changes](#python-changes)
-  - [PHP Changes](#php-changes)
 - [Changes in Ice 3.7.7](#changes-in-ice-377)
   - [C++ Changes](#c-changes-2)
   - [Java Changes](#java-changes)
@@ -30,7 +31,7 @@ particular aspect of Ice.
   - [C++ Changes](#c-changes-4)
   - [C# Changes](#c-changes-5)
   - [JavaScript Changes](#javascript-changes-2)
-  - [PHP Changes](#php-changes-1)
+  - [PHP Changes](#php-changes-2)
   - [Python Changes](#python-changes-1)
   - [Ruby Changes](#ruby-changes)
   - [Swift Changes](#swift-changes-1)
@@ -59,7 +60,7 @@ particular aspect of Ice.
   - [JavaScript Changes](#javascript-changes-5)
   - [MATLAB Changes](#matlab-changes-3)
   - [Objective-C Changes](#objective-c-changes)
-  - [PHP Changes](#php-changes-2)
+  - [PHP Changes](#php-changes-3)
   - [Python Changes](#python-changes-4)
 - [Changes in Ice 3.7.1](#changes-in-ice-371)
   - [General Changes](#general-changes-5)
@@ -69,7 +70,7 @@ particular aspect of Ice.
   - [JavaScript Changes](#javascript-changes-6)
   - [MATLAB Changes](#matlab-changes-4)
   - [Objective-C Changes](#objective-c-changes-1)
-  - [PHP Changes](#php-changes-3)
+  - [PHP Changes](#php-changes-4)
   - [Python Changes](#python-changes-5)
   - [Ruby Changes](#ruby-changes-2)
 - [Changes in Ice 3.7.0](#changes-in-ice-370)
@@ -79,10 +80,9 @@ particular aspect of Ice.
   - [Java Changes](#java-changes-5)
   - [JavaScript Changes](#javascript-changes-7)
   - [Objective-C Changes](#objective-c-changes-2)
-  - [PHP Changes](#php-changes-4)
+  - [PHP Changes](#php-changes-5)
   - [Python Changes](#python-changes-6)
   - [Ruby Changes](#ruby-changes-3)
-
 
 # Changes in Ice 3.7.9
 
@@ -92,6 +92,13 @@ These are the changes since Ice 3.7.8.
 
 - Fixed an IceSSL bug where the OpenSSL error description was not correctly included with the `Ice::ProtocolException`
   thrown when a read failure occurred. OpenSSL versions previous to `1.1.1e` are not affected.
+
+## PHP Changes
+
+- Added support for PHP 8.2.
+
+- `slice2php` will now generate code compatible with PHP >= 7 by default. To generate PHP 5 compatible code, use the
+  new `--php5` flag.
 
 # Changes in Ice 3.7.8
 

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -809,7 +809,6 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     else
     {
         _out << sp << nl << "public function __toString(): string";
-
     }
 
     _out << sb;

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -68,7 +68,7 @@ class CodeVisitor : public ParserVisitor
 {
 public:
 
-    CodeVisitor(IceUtilInternal::Output&, bool);
+    CodeVisitor(IceUtilInternal::Output&, bool, bool);
 
     virtual void visitClassDecl(const ClassDeclPtr&);
     virtual bool visitClassDefStart(const ClassDefPtr&);
@@ -83,10 +83,6 @@ private:
 
     void startNamespace(const ContainedPtr&);
     void endNamespace();
-
-    void writeClassDef(const ClassDefPtr&, bool);
-    void writeException(const ExceptionPtr&, bool);
-    void writeStruct(const StructPtr&, bool);
 
     //
     // Return the PHP name for the given Slice type. When using namespaces,
@@ -146,14 +142,16 @@ private:
     bool _ns; // Using namespaces?
     list<string> _moduleStack; // TODO: Necessary?
     set<string> _classHistory; // TODO: Necessary?
+    bool _php5; // Generate PHP5 compatible code
 };
 
 //
 // CodeVisitor implementation.
 //
-CodeVisitor::CodeVisitor(Output& out, bool ns) :
+CodeVisitor::CodeVisitor(Output& out, bool ns, bool php5) :
     _out(out),
-    _ns(ns)
+    _ns(ns),
+    _php5(php5)
 {
 }
 
@@ -196,32 +194,6 @@ bool
 CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     string scoped = p->scoped();
-
-    startNamespace(p);
-
-    _out << sp << nl << "if (PHP_VERSION_ID < 80200)";
-    _out << sb;
-    writeClassDef(p, false);
-    _out << eb;
-    _out << nl << "else";
-    _out << sb;
-    writeClassDef(p, true);
-    _out << eb;
-
-    endNamespace();
-
-    if(_classHistory.count(scoped) == 0)
-    {
-        _classHistory.insert(scoped); // Avoid redundant declarations.
-    }
-
-    return false;
-}
-
-void
-CodeVisitor::writeClassDef(const ClassDefPtr& p, bool returnTypeDeclaration)
-{
-    string scoped = p->scoped();
     string name = getName(p);
     string type = getTypeVar(p);
     string abs = getAbsolute(p, _ns);
@@ -234,6 +206,8 @@ CodeVisitor::writeClassDef(const ClassDefPtr& p, bool returnTypeDeclaration)
     DataMemberList members = p->dataMembers();
     bool isInterface = p->isInterface();
     bool isAbstract = isInterface || p->allOperations().size() > 0; // Don't use isAbstract() - see bug 3739
+
+    startNamespace(p);
 
     _out << sp << nl << "global " << type << ';';
     if(!p->isLocal() && isAbstract)
@@ -386,13 +360,13 @@ CodeVisitor::writeClassDef(const ClassDefPtr& p, bool returnTypeDeclaration)
         //
         // __toString
         //
-        if (returnTypeDeclaration)
+        if (_php5)
         {
-            _out << sp << nl << "public function __toString(): string";
+            _out << sp << nl << "public function __toString()";
         }
         else
         {
-            _out << sp << nl << "public function __toString()";
+            _out << sp << nl << "public function __toString(): string";
         }
 
         _out << sb;
@@ -739,34 +713,26 @@ CodeVisitor::writeClassDef(const ClassDefPtr& p, bool returnTypeDeclaration)
             }
         }
     }
+
+    endNamespace();
+
+    if(_classHistory.count(scoped) == 0)
+    {
+        _classHistory.insert(scoped); // Avoid redundant declarations.
+    }
+
+    return false;
 }
 
 bool
 CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    startNamespace(p);
-
-    _out << sp << nl << "if (PHP_VERSION_ID < 80200)";
-    _out << sb;
-    writeException(p, false);
-    _out << eb;
-    _out << nl << "else";
-    _out << sb;
-    writeException(p, true);
-    _out << eb;
-
-    endNamespace();
-
-    return false;
-}
-
-void
-CodeVisitor::writeException(const ExceptionPtr &p, bool returnTypeDeclaration)
-{
     string scoped = p->scoped();
     string name = getName(p);
     string type = getTypeVar(p);
     string abs = getAbsolute(p, _ns);
+
+    startNamespace(p);
 
     _out << sp << nl << "global " << type << ';';
     _out << nl << "class " << name << " extends ";
@@ -836,13 +802,14 @@ CodeVisitor::writeException(const ExceptionPtr &p, bool returnTypeDeclaration)
     //
     // __toString
     //
-    if (returnTypeDeclaration)
+    if (_php5)
     {
-        _out << sp << nl << "public function __toString(): string";
+        _out << sp << nl << "public function __toString()";
     }
     else
     {
-        _out << sp << nl << "public function __toString()";
+        _out << sp << nl << "public function __toString(): string";
+
     }
 
     _out << sb;
@@ -917,29 +884,14 @@ CodeVisitor::writeException(const ExceptionPtr &p, bool returnTypeDeclaration)
         _out << "null";
     }
     _out << ");";
-}
-
-bool
-CodeVisitor::visitStructStart(const StructPtr& p)
-{
-    startNamespace(p);
-
-    _out << sp << nl << "if (PHP_VERSION_ID < 80200)";
-    _out << sb;
-    writeStruct(p, false);
-    _out << eb;
-    _out << nl << "else";
-    _out << sb;
-    writeStruct(p, true);
-    _out << eb;
 
     endNamespace();
 
     return false;
 }
 
-void
-CodeVisitor::writeStruct(const StructPtr& p, bool returnTypeDeclaration)
+bool
+CodeVisitor::visitStructStart(const StructPtr& p)
 {
     string scoped = p->scoped();
     string name = getName(p);
@@ -958,6 +910,8 @@ CodeVisitor::writeStruct(const StructPtr& p, bool returnTypeDeclaration)
         }
     }
 
+    startNamespace(p);
+
     _out << sp << nl << "global " << type << ';';
 
     _out << nl << "class " << name;
@@ -975,13 +929,13 @@ CodeVisitor::writeStruct(const StructPtr& p, bool returnTypeDeclaration)
     //
     // __toString
     //
-    if (returnTypeDeclaration)
+    if (_php5)
     {
-        _out << sp << nl << "public function __toString(): string";
+        _out << sp << nl << "public function __toString()";
     }
     else
     {
-        _out << sp << nl << "public function __toString()";
+        _out << sp << nl << "public function __toString(): string";
     }
     _out << sb;
     _out << nl << "global " << type << ';';
@@ -1034,6 +988,10 @@ CodeVisitor::writeStruct(const StructPtr& p, bool returnTypeDeclaration)
         _out.dec();
     }
     _out << "));";
+
+    endNamespace();
+
+    return false;
 }
 
 void
@@ -1553,7 +1511,7 @@ CodeVisitor::collectExceptionMembers(const ExceptionPtr& p, MemberInfoList& allM
 }
 
 static void
-generate(const UnitPtr& un, bool all, bool checksum, bool ns, const vector<string>& includePaths, Output& out)
+generate(const UnitPtr& un, bool all, bool checksum, bool ns, bool php5, const vector<string>& includePaths, Output& out)
 {
     if(!all)
     {
@@ -1584,7 +1542,7 @@ generate(const UnitPtr& un, bool all, bool checksum, bool ns, const vector<strin
         }
     }
 
-    CodeVisitor codeVisitor(out, ns);
+    CodeVisitor codeVisitor(out, ns, php5);
     un->visit(&codeVisitor, false);
 
     if(checksum)
@@ -1714,6 +1672,7 @@ usage(const string& n)
         "                         deprecated: use instead [[\"ice-prefix\"]] metadata.\n"
         "--underscore             Allow underscores in Slice identifiers\n"
         "                         deprecated: use instead [[\"underscore\"]] metadata.\n"
+        "--php5                   Generate PHP5 compatible code.\n"
         ;
 }
 
@@ -1738,6 +1697,7 @@ compile(const vector<string>& argv)
     opts.addOpt("", "all");
     opts.addOpt("", "checksum");
     opts.addOpt("n", "no-namespace");
+    opts.addOpt("", "php5");
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
@@ -1808,6 +1768,8 @@ compile(const vector<string>& argv)
     bool checksum = opts.isSet("checksum");
 
     bool ns = !opts.isSet("no-namespace");
+
+    bool php5 = opts.isSet("php5");
 
     if(args.empty())
     {
@@ -1960,7 +1922,7 @@ compile(const vector<string>& argv)
                         //
                         // Generate the PHP mapping.
                         //
-                        generate(u, all, checksum, ns, includePaths, out);
+                        generate(u, all, checksum, ns, php5, includePaths, out);
 
                         out << "?>\n";
                         out.close();

--- a/man/man1/slice2php.1
+++ b/man/man1/slice2php.1
@@ -101,6 +101,11 @@ Generate code without support for PHP namespaces (deprecated).
 .br
 Generate checksums for Slice definitions.
 
+.TP
+.BR \-\-php5 " " CLASS\fR
+.br
+Generate PHP5 compatible code.
+
 .SH SEE ALSO
 
 .BR slice2cpp (1),

--- a/php/Makefile
+++ b/php/Makefile
@@ -24,7 +24,7 @@ ifeq ($(filter all php,$(ICE_BIN_DIST)),)
 # Load Makefile.mk fragments
 #
 ifeq ($(filter tests,$(MAKECMDGOALS)),)
-    ifeq ($(shell [ $$($(PHP_CONFIG) --vernum) -lt 70000 ] && echo 0),0)
+    ifeq ($(php_major_version),5)
         include $(lang_srcdir)/src/php5/Makefile.mk
     else
         include $(lang_srcdir)/src/php/Makefile.mk

--- a/php/config/Make.rules
+++ b/php/config/Make.rules
@@ -18,12 +18,14 @@ USE_NAMESPACES  ?= yes
 # Don't change anything below this line!
 # ----------------------------------------------------------------------
 
+php_major_version       = $(firstword $(subst ., ,$(shell $(PHP_CONFIG) --version)))
+
 ifneq ($(USE_NAMESPACES),yes)
 slice2php_flags         = --no-namespace
 endif
 
-ifeq ($(shell [ $$($(PHP_CONFIG) --vernum) -lt 70000 ] && echo 0),0)
-    slice2php_flags = $(slice2php_flags) --php5
+ifeq ($(php_major_version),5)
+slice2php_flags         += --php5
 endif
 
 #

--- a/php/config/Make.rules
+++ b/php/config/Make.rules
@@ -22,6 +22,10 @@ ifneq ($(USE_NAMESPACES),yes)
 slice2php_flags         = --no-namespace
 endif
 
+ifeq ($(shell [ $$($(PHP_CONFIG) --vernum) -lt 70000 ] && echo 0),0)
+    slice2php_flags = $(slice2php_flags) --php5
+endif
+
 #
 # $(call make-php-test-project,$1=testdir)
 #


### PR DESCRIPTION
This PR adds support for a new `--php5` flag to `slice2php`. 