### PR TITLE
npm: replace --no-optional with --omit=optional

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -21,4 +21,4 @@ lint: npminstall
 	$(NPM) run lint
 
 npminstall:
-	$(NPM) install --no-optional
+	$(NPM) install --omit=optional

--- a/js/msbuild/ice.proj
+++ b/js/msbuild/ice.proj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Target Name="Build">
-    <Exec Command="$(NPM) --no-optional install"
+    <Exec Command="$(NPM)--omit=optional install"
           WorkingDirectory="$(MSBuildThisFileDirectory).."
           StdOutEncoding="utf-8"
           StdErrEncoding="utf-8" />
@@ -19,7 +19,7 @@
   </Target>
 
   <Target Name="Clean">
-    <Exec Command="$(NPM) --no-optional install"
+    <Exec Command="$(NPM)--omit=optional install"
           WorkingDirectory="$(MSBuildThisFileDirectory).."
           StdOutEncoding="utf-8"
           StdErrEncoding="utf-8" />


### PR DESCRIPTION
`--no-optional` has been deprecated in favor of `--omit=optional`

Closes #1447
