### PR TITLE
Clarifications for Android testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,5 @@ Carthage
 .project
 .settings
 *.dep
-
-
 # Android Tets
 **/android/**/raw/*.bks

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ Carthage
 .project
 .settings
 *.dep
+
+
+# Android Tets
+**/android/**/raw/*.bks

--- a/java-compat/README.md
+++ b/java-compat/README.md
@@ -176,18 +176,12 @@ for the Ice test suite controller.
 Building any Ice application for Android requires Android Studio and the Android
 SDK build tools. We tested with the following components:
 
-- Android Studio Chipmunk
-- Android SDK 30
+- Android Studio Electric Eel
+- Android SDK 33
 
 Ice requires at minimum API level 21:
 
 - Android 5 (API21)
-
-If you want to target a later version of the Android API level for the test
-suite, edit `test/android/controller/gradle.properties` and change the
-following variables:
-
-*NOTE: Do not use Android Studio to modify the project's settings.*
 
 ### Building the Android Test Controller
 
@@ -198,6 +192,9 @@ for instructions, then follow these steps:
 2. Select "Open an existing Android Studio project"
 3. Navigate to and select the "android" subdirectory
 4. Click OK and wait for the project to open and build
+
+To build the tests against the Ice binary distribution you must set `ICE_BIN_DIST` environment
+variable to `all` before starting Android Studio.
 
 ## Running the Android Tests
 

--- a/java-compat/test/android/controller/build.gradle
+++ b/java-compat/test/android/controller/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'gradle.plugin.com.zeroc.gradle.ice-builder:slice:1.5.0'
     }
 }

--- a/java/README.md
+++ b/java/README.md
@@ -219,8 +219,8 @@ the Ice test suite controller.
 Building any Ice application for Android requires Android Studio and the Android
 SDK build tools. We tested with the following components:
 
-- Android Studio Chipmunk
-- Android SDK 30
+- Android Studio Electric Eel
+- Android SDK 33
 
 Using Ice's Java mapping with Java 8 requires at minimum API level 24:
 
@@ -235,6 +235,9 @@ for instructions, then follow these steps:
 2. Select "Open an existing Android Studio project"
 3. Navigate to and select the "java/test/android/controller" subdirectory
 4. Click OK and wait for the project to open and build
+
+To build the tests against the Ice binary distribution you must set `ICE_BIN_DIST` environment
+variable to `all` before starting Android Studio.
 
 ### Running the Android Test Suite
 

--- a/java/test/android/controller/build.gradle
+++ b/java/test/android/controller/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'gradle.plugin.com.zeroc.gradle.ice-builder:slice:1.5.0'
     }
 }


### PR DESCRIPTION
I spent some time figuring out why the test controller wasn't resolving JARs from the dev repositories. It turns out we need to run Android Studio with `ICE_BIN_DIST` set to `all`.

I have also updated:
* The README to mention the Android Studio we are using for testing.
* The projects to use the latest android gradle tools.
* The .gitignore to ignore the bks certificates that are copied over to the test directory during the build.