### PR TITLE
Fix Cleanup of IceStorm DB Files

### DIFF
--- a/scripts/IceStormUtil.py
+++ b/scripts/IceStormUtil.py
@@ -27,8 +27,8 @@ class IceStorm(ProcessFromBinDir, Server):
 
     def setup(self, current):
         # Create the database directory
+        self.dbdir = os.path.join(current.testsuite.getPath(), "{0}-{1}.db".format(self.instanceName, self.replica))
         if self.createDb:
-            self.dbdir = os.path.join(current.testsuite.getPath(), "{0}-{1}.db".format(self.instanceName, self.replica))
             if os.path.exists(self.dbdir):
                 shutil.rmtree(self.dbdir)
             os.mkdir(self.dbdir)


### PR DESCRIPTION
The 'dbbir' variable was only initialized when 'createDb' is set to true. This resulted in files being left behind in the IceStorm/persistence test when using two instances, as shown in the following code snippet:

```python
icestorm1 = IceStorm(createDb=True, cleanDb=False)
icestorm2 = IceStorm(createDb=False, cleanDb=True)
```

Fix #1498