### PR TITLE
Suppress BinaryFormatter-related code for .NET 8.0

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2973,6 +2973,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     if(!dataMembers.empty())
     {
         _out << sp;
+        _out << nl << "#if !NET8_0_OR_GREATER";
         emitGeneratedCodeAttribute();
         _out << nl << "public override void GetObjectData(global::System.Runtime.Serialization.SerializationInfo info, "
              << "global::System.Runtime.Serialization.StreamingContext context)";
@@ -2984,6 +2985,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         }
         _out << sp << nl << "base.GetObjectData(info, context);";
         _out << eb;
+        _out << nl << "#endif";
     }
 
     _out << sp << nl << "#endregion"; // Object members

--- a/csharp/BUILDING.md
+++ b/csharp/BUILDING.md
@@ -45,6 +45,13 @@ To build all Ice assemblies and the associated test suite, run:
 msbuild msbuild\ice.proj
 ```
 
+> Depending on your Visual Studio environment, you may need to specify the platform.
+> For example:
+>
+> ```shell
+> msbuild msbuild\ice.proj /p:Platform=x64
+> ```
+
 Upon completion, the Ice assemblies for the .NET Framework 4.5 and .NET Standard 2.0 are placed
 in the `lib\net45` and `lib\netstandard2.0` folders respectively.
 

--- a/csharp/msbuild/ice.common.props
+++ b/csharp/msbuild/ice.common.props
@@ -16,6 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DefineConstants>TRACE</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <DefineConstants Condition="'$(TargetFrameworkVersion)' == 'v4.5.1'">NET45;$(DefineConstants)</DefineConstants>

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -87,7 +87,10 @@ namespace Ice
                 mo1.ioopd.Value.Add(5, communicator.stringToProxy("test"));
 
                 mo1.bos = new bool[] { false, true, false };
+
+                #if !NET8_0_OR_GREATER // See #1549
                 mo1.ser = new Test.SerializableClass(56);
+                #endif
 
                 test(mo1.a.Value ==(byte)15);
                 test(mo1.b.Value);
@@ -121,7 +124,12 @@ namespace Ice
                 test(mo1.ioopd.Value[5].Equals(communicator.stringToProxy("test")));
 
                 test(ArraysEqual(mo1.bos.Value, new bool[] { false, true, false }));
+
+                #if NET8_0_OR_GREATER
+                test(!mo1.ser.HasValue);
+                #else
                 test(mo1.ser.Value.Equals(new Test.SerializableClass(56)));
+                #endif
 
                 output.WriteLine("ok");
 
@@ -170,7 +178,12 @@ namespace Ice
 
                 test(!mo4.ser.HasValue);
 
+                #if NET8_0_OR_GREATER
+                bool supportsCsharpSerializable = false;
+                #else
                 bool supportsCsharpSerializable = initial.supportsCsharpSerializable();
+                #endif
+
                 if(!supportsCsharpSerializable)
                 {
                     mo1.ser = Ice.Util.None;

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -401,7 +401,11 @@ namespace Ice
 
             public override bool supportsCsharpSerializable(Ice.Current current)
             {
+                #if NET8_0_OR_GREATER
+                return false;
+                #else
                 return true;
+                #endif
             }
 
             public override bool supportsCppStringView(Ice.Current current)

--- a/csharp/test/Ice/seqMapping/Twoways.cs
+++ b/csharp/test/Ice/seqMapping/Twoways.cs
@@ -1238,6 +1238,7 @@ namespace Ice
                     }
                 }
 
+                #if !NET8_0_OR_GREATER // See #1549
                 {
                     Serialize.Small i = null;
                     Serialize.Small o;
@@ -1345,6 +1346,7 @@ namespace Ice
                         // OK, talking to non-C# server.
                     }
                 }
+                #endif
             }
         }
     }

--- a/csharp/test/Ice/seqMapping/TwowaysAMI.cs
+++ b/csharp/test/Ice/seqMapping/TwowaysAMI.cs
@@ -885,6 +885,7 @@ namespace Ice
                     callback.called();
                 }
 
+                #if !NET8_0_OR_GREATER // See #1549
                 public void opSerialSmallCSharpNullI(Ice.AsyncResult result)
                 {
                     try
@@ -980,6 +981,7 @@ namespace Ice
                         // OK, talking to non-C# server.
                     }
                 }
+                #endif
 
                 public virtual void check()
                 {
@@ -1843,6 +1845,7 @@ namespace Ice
                     cb.check();
                 }
 
+                #if !NET8_0_OR_GREATER // See #1549
                 {
                     Serialize.Small i = null;
 
@@ -1889,6 +1892,7 @@ namespace Ice
                     p.begin_opSerialStructCSharp(i, null, cb.opSerialStructCSharpI, i);
                     cb.check();
                 }
+                #endif
             }
         }
     }

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -176,10 +176,11 @@ namespace Ice
                     new StreamingContext(StreamingContextStates.All, communicator));
                 using(MemoryStream mem = new MemoryStream())
                 {
-
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                     bin.Serialize(mem, o);
                     mem.Seek(0, 0);
                     return(T)bin.Deserialize(mem);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 }
 #endif
             }

--- a/csharp/test/Ice/serialize/AllTests.cs
+++ b/csharp/test/Ice/serialize/AllTests.cs
@@ -167,16 +167,21 @@ namespace Ice
 
             private static T inOut<T>(T o, Ice.Communicator communicator)
             {
+#if NET8_0_OR_GREATER
+                // .NET 8.0 and greater removed support for BinaryFormatter
+                // See also #1549.
+                return o;
+#else
                 BinaryFormatter bin = new BinaryFormatter(null,
                     new StreamingContext(StreamingContextStates.All, communicator));
                 using(MemoryStream mem = new MemoryStream())
                 {
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
+
                     bin.Serialize(mem, o);
                     mem.Seek(0, 0);
                     return(T)bin.Deserialize(mem);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 }
+#endif
             }
         }
     }

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -366,6 +366,7 @@ namespace Ice
                     test(Compare(arr2S, arrS));
                 }
 
+                #if !NET8_0_OR_GREATER // See #1549
                 {
                     Serialize.Small small = new Serialize.Small();
                     small.i = 99;
@@ -376,6 +377,7 @@ namespace Ice
                     var small2 =(Serialize.Small)inS.readSerializable();
                     test(small2.i == 99);
                 }
+                #endif
 
                 {
                     short[] arr = { 0x01, 0x11, 0x12, 0x22 };


### PR DESCRIPTION
Fixes #1548 

I also added:
```
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
```

Not sure why this wasn't set already.