### PR TITLE
Fix System CAs tests

### DIFF
--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -4043,15 +4043,8 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, false);
             initData.properties->setProperty("IceSSL.DefaultDir", "");
-            initData.properties->setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties->setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties->setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
-#   ifdef _WIN32
-            //
-            // BUGFIX: SChannel TLS 1.2 bug that affects Windows versions prior to Windows 10
-            // can cause SSL handshake errors when connecting to the remote zeroc server.
-            //
-            initData.properties->setProperty("IceSSL.Protocols", "TLS1_0,TLS1_1");
-#   endif
             CommunicatorPtr comm = initialize(initData);
             Ice::ObjectPrxPtr p = comm->stringToProxy("Glacier2/router:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
             while(true)
@@ -4092,16 +4085,9 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, false);
             initData.properties->setProperty("IceSSL.DefaultDir", "");
-            initData.properties->setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties->setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties->setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             initData.properties->setProperty("IceSSL.UsePlatformCAs", "1");
-#   ifdef _WIN32
-            //
-            // BUGFIX: SChannel TLS 1.2 bug that affects Windows versions prior to Windows 10
-            // can cause SSL handshake errors when connecting to the remote zeroc server.
-            //
-            initData.properties->setProperty("IceSSL.Protocols", "TLS1_0,TLS1_1");
-#   endif
             CommunicatorPtr comm = initialize(initData);
             Ice::ObjectPrxPtr p = comm->stringToProxy("Glacier2/router:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
             while(true)

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -2443,16 +2443,8 @@ public class AllTests
 
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.DefaultDir", "");
-                initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+                initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
                 initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
-                if(IceInternal.AssemblyUtil.isWindows)
-                {
-                    //
-                    // BUGFIX: SChannel TLS 1.2 bug that affects Windows versions prior to Windows 10
-                    // can cause SSL handshake errors when connecting to the remote zeroc server.
-                    //
-                    initData.properties.setProperty("IceSSL.Protocols", "TLS1_0,TLS1_1");
-                }
                 Ice.Communicator comm = Ice.Util.initialize(initData);
                 Ice.ObjectPrx p = comm.stringToProxy("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
                 while(true)
@@ -2492,17 +2484,9 @@ public class AllTests
                 retryCount = 0;
                 initData = createClientProps(defaultProperties);
                 initData.properties.setProperty("IceSSL.DefaultDir", "");
-                initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+                initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
                 initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
                 initData.properties.setProperty("IceSSL.UsePlatformCAs", "1");
-                if(IceInternal.AssemblyUtil.isWindows)
-                {
-                    //
-                    // BUGFIX: SChannel TLS 1.2 bug that affects Windows versions prior to Windows 10
-                    // can cause SSL handshake errors when connecting to the remote zeroc server.
-                    //
-                    initData.properties.setProperty("IceSSL.Protocols", "TLS1_0,TLS1_1");
-                }
                 comm = Ice.Util.initialize(initData);
                 p = comm.stringToProxy("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
                 while(true)

--- a/java-compat/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java-compat/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -2097,7 +2097,7 @@ public class AllTests
             int retryCount = 0;
 
             initData = createClientProps(defaultProperties, defaultDir, defaultHost);
-            initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             Ice.Communicator comm = Ice.Util.initialize(initData);
             Ice.ObjectPrx p = comm.stringToProxy("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
@@ -2143,7 +2143,7 @@ public class AllTests
             comm.destroy();
 
             initData = createClientProps(defaultProperties, defaultDir, defaultHost);
-            initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             initData.properties.setProperty("IceSSL.UsePlatformCAs", "1");
             comm = Ice.Util.initialize(initData);

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -2097,7 +2097,7 @@ public class AllTests
             int retryCount = 0;
 
             initData = createClientProps(defaultProperties);
-            initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             com.zeroc.Ice.Communicator comm = Util.initialize(initData);
             com.zeroc.Ice.ObjectPrx p = comm.stringToProxy("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
@@ -2144,7 +2144,7 @@ public class AllTests
 
             retryCount = 0;
             initData = createClientProps(defaultProperties);
-            initData.properties.setProperty("IceSSL.VerifyDepthMax", "4");
+            initData.properties.setProperty("IceSSL.VerifyDepthMax", "5");
             initData.properties.setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             initData.properties.setProperty("IceSSL.UsePlatformCAs", "1");
             comm = Util.initialize(initData);


### PR DESCRIPTION
There were two issues encountered during the testing of System.CAs:

1. For compatibility purposes, we were using "TLS1_0,TLS1_1" on Windows. However, these TLS versions are now unsupported by the CloudFront server we are testing against.
2. The certificate chain length exceeded the limit defined by the test.
