### PR TITLE
Fix hang risk warnings in test suite

### DIFF
--- a/swift/.swiftformat
+++ b/swift/.swiftformat
@@ -1,1 +1,2 @@
 --commas "inline"
+--disable wrapMultilineStatementBraces

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -20,7 +20,7 @@ public extension Connection {
                                                     if let sentCB = sentCB {
                                                         sentCB($0)
                                                     }
-            })
+                                                })
         }
     }
 
@@ -145,6 +145,7 @@ class ConnectionI: LocalObject<ICEConnection>, Connection {
     func getInfo() throws -> ConnectionInfo {
         // swiftlint:disable force_cast
         return try handle.getInfo() as! ConnectionInfo
+        // swiftlint:enable force_cast
     }
 
     func setBufferSize(rcvSize: Int32, sndSize: Int32) throws {

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -12,7 +12,7 @@ import IceImpl
 // should check `factoriesRegistered' to ensure lazzy initinialization occurrs before
 // the factories are used.
 //
-internal let factoriesRegistered: Bool = {
+let factoriesRegistered: Bool = {
     ICEUtil.registerFactories(exception: ExceptionFactory.self,
                               connectionInfo: ConnectionInfoFactory.self,
                               endpointInfo: EndpointInfoFactory.self,
@@ -159,6 +159,7 @@ private func initializeImpl(args: [String],
         } else {
             // swiftlint:disable force_cast
             return (communicator, remArgs as! [String])
+            // swiftlint:enable force_cast
         }
     }
 }
@@ -222,6 +223,7 @@ public func createProperties(_ args: inout [String], defaults: Properties? = nil
 
         // swiftlint:disable force_cast
         args = remArgs as! [String]
+        // swiftlint:enable force_cast
         return PropertiesI(handle: propertiesHandle)
     }
 }

--- a/swift/src/Ice/LocalExceptionFactory.swift
+++ b/swift/src/Ice/LocalExceptionFactory.swift
@@ -200,6 +200,7 @@ class ExceptionFactory: ICEExceptionFactory {
     static func badMagicException(_ reason: String, badMagic: Data, file: String, line: Int) -> Error {
         // swiftlint:disable force_cast
         return BadMagicException(reason: reason, badMagic: badMagic, file: file, line: line)
+        // swiftlint:enable force_cast
     }
 
     static func unsupportedProtocolException(_ reason: String,

--- a/swift/src/Ice/LocalObject.swift
+++ b/swift/src/Ice/LocalObject.swift
@@ -28,6 +28,7 @@ extension ICELocalObject {
             precondition(swiftClass is LocalObjectClass)
             // swiftlint:disable force_cast
             return swiftClass as! LocalObjectClass
+            // swiftlint:enable force_cast
         }
 
         return initializer()

--- a/swift/src/Ice/LoggerWrapper.swift
+++ b/swift/src/Ice/LoggerWrapper.swift
@@ -62,5 +62,6 @@ class ObjcLoggerWrapper: LocalObject<ICELogger>, Logger {
     func cloneWithPrefix(_ prefix: String) -> Logger {
         // swiftlint:disable force_cast
         return ObjcLoggerWrapper(handle: handle.cloneWithPrefix(prefix) as! ICELogger)
+        // swiftlint:enable force_cast
     }
 }

--- a/swift/test/Ice/acm/AllTests.swift
+++ b/swift/test/Ice/acm/AllTests.swift
@@ -157,7 +157,7 @@ class TestCase {
         _closed = false
         _semaphore = DispatchSemaphore(value: 0)
 
-        _queue = DispatchQueue(label: name)
+        _queue = DispatchQueue(label: name, qos: .background)
         _group = DispatchGroup()
     }
 

--- a/swift/test/Ice/acm/AllTests.swift
+++ b/swift/test/Ice/acm/AllTests.swift
@@ -250,13 +250,13 @@ class TestCase {
         }
 
         if _semaphore.wait(timeout: .now() + Double(30)) == .timedOut {
-            precondition(false) // Waited for more than 30s for close, something's wrong.
+            preconditionFailure() // Waited for more than 30s for close, something's wrong.
         }
         precondition(_closed)
     }
 
     func runTestCase(adapter _: RemoteObjectAdapterPrx, proxy _: TestIntfPrx) throws {
-        precondition(false, "Abstract Method")
+        preconditionFailure("Abstract Method")
     }
 
     func setClientACM(timeout: Int32, close: Int32, heartbeat: Int32) {
@@ -531,7 +531,7 @@ class SetACMTest: TestCase {
         }.wait()
 
         con.setHeartbeatCallback { _ in
-            precondition(false)
+            preconditionFailure()
         }
     }
 }

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -385,7 +385,7 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) throws {
                 do {
                     try con.setCloseCallback { _ in seal.fulfill(()) }
                 } catch {
-                    precondition(false)
+                    preconditionFailure()
                 }
             }
             let r = p.sleepAsync(100)

--- a/swift/test/Ice/hold/TestI.swift
+++ b/swift/test/Ice/hold/TestI.swift
@@ -30,7 +30,7 @@ class HoldI: Hold {
                 do {
                     try self.putOnHold(seconds: 0, current: current)
                 } catch is Ice.ObjectAdapterDeactivatedException {} catch {
-                    precondition(false)
+                    preconditionFailure()
                 }
             }
         }
@@ -46,7 +46,7 @@ class HoldI: Hold {
                 // This shouldn't occur. The test ensures all the waitForHold timers are
                 // finished before shutting down the communicator.
                 //
-                precondition(false)
+                preconditionFailure()
             }
         }
     }

--- a/swift/test/Ice/timeout/TestI.swift
+++ b/swift/test/Ice/timeout/TestI.swift
@@ -31,7 +31,7 @@ class ControllerI: Controller {
                     do {
                         try self._adapter.activate()
                     } catch {
-                        precondition(false)
+                        preconditionFailure()
                     }
                 }
             }

--- a/swift/test/Ice/udp/TestI.swift
+++ b/swift/test/Ice/udp/TestI.swift
@@ -9,7 +9,7 @@ class TestIntfI: TestIntf {
         do {
             try reply!.reply()
         } catch {
-            precondition(false)
+            preconditionFailure()
         }
     }
 
@@ -17,7 +17,7 @@ class TestIntfI: TestIntf {
         do {
             try reply!.reply()
         } catch {
-            precondition(false)
+            preconditionFailure()
         }
     }
 
@@ -37,7 +37,7 @@ class TestIntfI: TestIntf {
             try uncheckedCast(prx: current.con!.createProxy(reply),
                               type: PingReplyPrx.self).reply()
         } catch {
-            precondition(false)
+            preconditionFailure()
         }
     }
 

--- a/swift/test/TestDriver/iOS/ControllerI.swift
+++ b/swift/test/TestDriver/iOS/ControllerI.swift
@@ -49,8 +49,8 @@ class ProcessControllerI: CommonProcessController {
         _ipv4 = ipv4
         _ipv6 = ipv6
 
-        _serverDispatchQueue = DispatchQueue(label: "Server", qos: .userInitiated)
-        _clientDispatchQueue = DispatchQueue(label: "Client", qos: .userInitiated)
+        _serverDispatchQueue = DispatchQueue(label: "Server", qos: .background)
+        _clientDispatchQueue = DispatchQueue(label: "Client", qos: .background)
     }
 
     func start(testsuite: String,


### PR DESCRIPTION
This PR fixes #1547, there are also a few minor fixes for Swiftlint warnings.

For the hang warnings see https://developer.apple.com/documentation/xcode/diagnosing-performance-issues-early