### PR TITLE
Fix python install_dir for compatiblity with debian packaging

### DIFF
--- a/python/config/install_dir
+++ b/python/config/install_dir
@@ -11,6 +11,13 @@ if len(sys.argv) != 2:
    sys.exit(1)
 
 prefix = sys.argv[1]
+libdir = os.path.join(prefix, "lib", "python{}.{}".format(sys.version_info.major, sys.version_info.minor))
+
+for dir in site.getsitepackages():
+    if dir.startswith(libdir):
+       print(dir)
+       sys.exit(0)
+
 libdir = os.path.join(prefix, "lib")
 
 for dir in site.getsitepackages():


### PR DESCRIPTION
A minor fix to install_dir python script for compatibility with our Debian python packaging.

See https://github.com/zeroc-ice/ice-debian-packaging/blob/dfce343b1e0be6eeb58e401b287c81ae6f02b7d3/debian/rules#L54C1-L55C1