### PR TITLE
Remove unnecessary escape characters.

### DIFF
--- a/slice/Ice/Current.ice
+++ b/slice/Ice/Current.ice
@@ -73,7 +73,7 @@ enum OperationMode
      * <p class="Deprecated"><code>Nonmutating</code> is deprecated; Use the
      * <code>idempotent</code> keyword instead. For C++, to retain the mapping
      * of <code>nonmutating</code> operations to C++ <code>const</code>
-     * member functions, use the <code>\["cpp:const"]</code> metadata
+     * member functions, use the <code>["cpp:const"]</code> metadata
      * directive.
      */
     \Nonmutating,

--- a/slice/Ice/Properties.ice
+++ b/slice/Ice/Properties.ice
@@ -35,7 +35,7 @@ module Ice
  * A property set used to configure Ice and Ice applications.
  * Properties are key/value pairs, with both keys and values
  * being strings. By convention, property keys should have the form
- * <em>application-name</em>\[.<em>category</em>\[.<em>sub-category</em>]].<em>name</em>.
+ * <em>application-name</em>[.<em>category</em>[.<em>sub-category</em>]].<em>name</em>.
  *
  **/
 local interface Properties
@@ -111,7 +111,7 @@ local interface Properties
      * whitespace and commas if they are enclosed in single or double
      * quotes. If quotes are mismatched, an empty list is returned.
      * Within single quotes or double quotes, you can escape the
-     * quote in question with \, e.g. O'Reilly can be written as
+     * quote in question with a backslash, e.g. O'Reilly can be written as
      * O'Reilly, "O'Reilly" or 'O\'Reilly'.
      *
      * @param key The property key.
@@ -131,7 +131,7 @@ local interface Properties
      * whitespace and commas if they are enclosed in single or double
      * quotes. If quotes are mismatched, the default list is returned.
      * Within single quotes or double quotes, you can escape the
-     * quote in question with \, e.g. O'Reilly can be written as
+     * quote in question with a backslash, e.g. O'Reilly can be written as
      * O'Reilly, "O'Reilly" or 'O\'Reilly'.
      *
      * @param key The property key.


### PR DESCRIPTION
This PR fixes #1560 by removing the invalid escape sequences.

The escaped commas seem like an accident, it's trying to show a literal backslash, but is getting picked up as an escape sequence.

The escaped square brackets were just a hold-over from our old syntax for links:  https://github.com/zeroc-ice/ice/commit/7c9cc22c22d9be5491667e16fcea50eab5367fcd
Nowadays we use the newer `@link` tag syntax, and `slice2html` will emit a warning if it sees this old syntax.

This PR removes the brackets, so this means running `slice2html` on these files will produce warnings.