### PR TITLE
Remove unused declarations in slice2java

### DIFF
--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -57,13 +57,6 @@ protected:
     // op is provided only when we want to check for the java:UserException metadata
     //
     void writeThrowsClause(const std::string&, const ExceptionList&, const OperationPtr& op = 0);
-
-    //
-    // Generate code to compute a hash code for a type.
-    //
-    void writeHashCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, int&,
-                       const std::list<std::string>& = std::list<std::string>());
-
     //
     // Marshal/unmarshal a data member.
     //

--- a/cpp/src/slice2java/GenCompat.h
+++ b/cpp/src/slice2java/GenCompat.h
@@ -65,20 +65,11 @@ protected:
     void writeThrowsClause(const std::string&, const ExceptionList&, const OperationPtr& op = 0);
 
     //
-    // Generate code to compute a hash code for a type.
-    //
-    void writeHashCode(::IceUtilInternal::Output&, const TypePtr&, const std::string&, int&,
-                       const std::list<std::string>& = std::list<std::string>());
-
-    //
     // Marshal/unmarshal a data member.
     //
     void writeMarshalDataMember(::IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, int&, bool = false);
     void writeUnmarshalDataMember(::IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, int&,
                                   bool, int&, bool = false);
-    void writeStreamMarshalDataMember(::IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, int&);
-    void writeStreamUnmarshalDataMember(::IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, int&,
-                                        bool, int&);
 
     //
     // Generate a patcher class.

--- a/cpp/src/slice2java/msbuild/slice2java.vcxproj
+++ b/cpp/src/slice2java/msbuild/slice2java.vcxproj
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Gen.h" />
+    <ClInclude Include="..\GenCompat.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\IceUtil\msbuild\iceutil\iceutil.vcxproj">

--- a/cpp/src/slice2java/msbuild/slice2java.vcxproj.filters
+++ b/cpp/src/slice2java/msbuild/slice2java.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClInclude Include="..\Gen.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\GenCompat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
These methods are declared but not implemented, or used. Seems like a leftover from a previous version.