### PR TITLE
Add devcontainer configuration for C++ development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+USER vscode
+WORKDIR /home/vscode
+
+# Install necessary packages
+RUN set -eux \
+    && wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && sudo dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && sudo apt update \
+    && sudo apt-get install -y libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev libmcpp-dev libssl-dev libsystemd-dev \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo apt-get clean
+
+# Set environment variables
+ENV PATH=/home/vscode/.cargo/bin:$PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,3 @@ RUN set -eux \
     && sudo apt-get install -y libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev libmcpp-dev libssl-dev libsystemd-dev \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean
-
-# Set environment variables
-ENV PATH=/home/vscode/.cargo/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    // Use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    // Configure tool-specific properties
+    "customizations": {
+        "vscode": {
+            /* spell-checker:disable */
+            "extensions": [
+                "davidson.vscode-markdownlint",
+                "editorconfig.editorconfig",
+                "ms-azuretools.vscode-docker",
+                "streetsidesoftware.code-spell-checker",
+                "zerocinc.slice"
+            ]
+            /* spell-checker:enable */
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a devcontainer configuration that can be used for C++ development with Debian 12 image.