### PR TITLE
Update C++ builds to use -std=c++17

### DIFF
--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -845,7 +845,7 @@ endef
 define create-translator-project
 $1_programs     := $(notdir $1)
 $1_dependencies := Slice IceUtil
-$1_cppflags     := -I$1 -std=c++17
+$1_cppflags     := -I$1
 $1_targetdir    := $(call bindir,$1)
 
 #

--- a/config/Make.rules
+++ b/config/Make.rules
@@ -114,6 +114,9 @@ soversion               = 37
 #
 compatversion           = $(version)
 
+# We assume Make.rules.$(os) defines cppflags.
+cppflags                += -std=c++17
+
 ifneq ($(filter all cpp obj%c,$(ICE_BIN_DIST)),)
 # NOTE: on macOS, if ICE_HOME isn't set we build against /usr/local/opt/ice because the
 # XCode SDK is not accessible through /usr/local

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -98,15 +98,6 @@ endif
 # directory.
 #
 cpp11_cppflags          = -DICE_CPP11_MAPPING
-ifneq ($(shell $(CC) -E config/cplusplus_check.cpp 1> /dev/null 2>&1; echo $$?),0)
-ifeq ($(os),Darwin)
-# With Xcode 14.3 C++17 deprecations apply when building with -std=c++11, we pass -std=c++17
-# to enable C++17 mode conditional code.
-cpp11_cppflags          := $(cpp11_cppflags) -std=c++17
-else
-cpp11_cppflags          := $(cpp11_cppflags) -std=c++11
-endif
-endif
 cpp11_ldflags           = $(cpp11_cppflags)
 cpp11_targetname        = $(if $(or $(filter-out $($1_target),program),$(filter $(bindir)%,$($4_targetdir))),++11)
 cpp11_targetdir         = $(if $(filter %/build,$5),cpp11)

--- a/cpp/src/Slice/Makefile.mk
+++ b/cpp/src/Slice/Makefile.mk
@@ -6,7 +6,6 @@ $(project)_libraries    := Slice
 
 Slice_targetdir         := $(libdir)
 Slice_libs              := mcpp
-Slice_cppflags          := -std=c++17
 
 # Always enable the static configuration for the Slice library and never
 # install it


### PR DESCRIPTION
This PR updates the C++ builds to use -std=c++17 all the time for gmake builds.

It's a draft PR as some code (IceDB and more) is currently not compatible with -std=c++17.