### PR TITLE
Fix Glacier2 permissions verifier builds

### DIFF
--- a/cpp/msbuild/ice.v143.sln
+++ b/cpp/msbuild/ice.v143.sln
@@ -244,7 +244,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "C++98", "C++98", "{2DC2B270
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "C++11", "C++11", "{F48CC091-6F26-4EC8-A2FB-485975E7C908}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glacier2router", "..\src\Glacier2\msbuild\glacier2router.vcxproj", "{541CF1D6-95FD-4499-AB02-75CCCEE660B0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glacier2router++11", "..\src\Glacier2\msbuild\glacier2router.vcxproj", "{541CF1D6-95FD-4499-AB02-75CCCEE660B0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2940A3C2-A9BA-44AA-AF65-00479C783407} = {2940A3C2-A9BA-44AA-AF65-00479C783407}
 		{3AB9772C-6113-4F1C-90FB-5368E7486C11} = {3AB9772C-6113-4F1C-90FB-5368E7486C11}
@@ -280,6 +280,11 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ice2slice", "..\src\ice2slice\msbuild\ice2slice.vcxproj", "{773EA63E-40AE-45B8-82B4-82B54CF309F8}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glacier2cryptpermissionsverifier", "..\src\Glacier2CryptPermissionsVerifier\msbuild\glacier2cryptpermissionsverifier\glacier2cryptpermissionsverifier.vcxproj", "{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C7223CC8-0AAA-470B-ACB3-12B9DE75525C} = {C7223CC8-0AAA-470B-ACB3-12B9DE75525C}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glacier2cryptpermissionsverifier++11", "..\src\Glacier2CryptPermissionsVerifier\msbuild\glacier2cryptpermissionsverifier++11\glacier2cryptpermissionsverifier++11.vcxproj", "{BF2077E4-D837-486B-9356-24FA5F659808}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2940A3C2-A9BA-44AA-AF65-00479C783407} = {2940A3C2-A9BA-44AA-AF65-00479C783407}
 	EndProjectSection
@@ -692,6 +697,14 @@ Global
 		{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3}.Release|Win32.Build.0 = Release|Win32
 		{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3}.Release|x64.ActiveCfg = Release|x64
 		{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3}.Release|x64.Build.0 = Release|x64
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Debug|Win32.Build.0 = Debug|Win32
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Debug|x64.ActiveCfg = Debug|x64
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Debug|x64.Build.0 = Debug|x64
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Release|Win32.ActiveCfg = Release|Win32
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Release|Win32.Build.0 = Release|Win32
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Release|x64.ActiveCfg = Release|x64
+		{BF2077E4-D837-486B-9356-24FA5F659808}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -746,7 +759,8 @@ Global
 		{D0DC2305-37FE-4D03-BE05-AC8912678DC8} = {F48CC091-6F26-4EC8-A2FB-485975E7C908}
 		{0D08F6B8-39C0-413B-84CE-D73230BCC740} = {2DC2B270-B7AE-48CF-8FB0-41A55A9747E9}
 		{773EA63E-40AE-45B8-82B4-82B54CF309F8} = {2DC2B270-B7AE-48CF-8FB0-41A55A9747E9}
-		{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3} = {F48CC091-6F26-4EC8-A2FB-485975E7C908}
+		{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3} = {2DC2B270-B7AE-48CF-8FB0-41A55A9747E9}
+		{BF2077E4-D837-486B-9356-24FA5F659808} = {F48CC091-6F26-4EC8-A2FB-485975E7C908}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AAB39BE9-A7ED-4C54-80FE-D63A173ABB06}

--- a/cpp/src/Glacier2CryptPermissionsVerifier/msbuild/glacier2cryptpermissionsverifier++11/glacier2cryptpermissionsverifier++11.vcxproj
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/msbuild/glacier2cryptpermissionsverifier++11/glacier2cryptpermissionsverifier++11.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{519CB7EF-8E49-4BC1-B3DB-181BEF5AC3B3}</ProjectGuid>
+    <ProjectGuid>{BF2077E4-D837-486B-9356-24FA5F659808}</ProjectGuid>
     <RootNamespace>Glacier2CryptPermissionsVerifier</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\ice.cpp98.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\ice.cpp11.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/cpp/src/Glacier2CryptPermissionsVerifier/msbuild/glacier2cryptpermissionsverifier++11/glacier2cryptpermissionsverifier++11.vcxproj.filters
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/msbuild/glacier2cryptpermissionsverifier++11/glacier2cryptpermissionsverifier++11.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{a7b5adff-15af-48c2-9491-a6fbe9b5ed99}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{7bcfbb57-99ea-410a-be73-9059546f3b4d}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{6c7fbad5-7deb-4d8b-b0c7-4452a2cb7ed0}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\CryptPermissionsVerifierI.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\CryptPermissionsVerifier.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR fixes the Glacier2 permissions verifier build. We need to build both C++11 and C++98 versions for now.