### PR TITLE
Remove`underscore` and `ice-prefix` Metadata

### DIFF
--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/DBTypes.ice
+++ b/cpp/src/IceStorm/DBTypes.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <IceStorm/SubscriberRecord.ice>
 #include <IceStorm/LLURecord.ice>

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <IceStorm/IceStorm.ice>
 #include <IceStorm/Election.ice>

--- a/cpp/src/IceStorm/LLURecord.ice
+++ b/cpp/src/IceStorm/LLURecord.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/LinkRecord.ice
+++ b/cpp/src/IceStorm/LinkRecord.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStormInternal.ice>

--- a/cpp/src/IceStorm/SubscriberRecord.ice
+++ b/cpp/src/IceStorm/SubscriberRecord.ice
@@ -4,7 +4,7 @@
 
 #pragma once
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 #include <Ice/Identity.ice>
 #include <IceStorm/IceStorm.ice>

--- a/cpp/src/icegriddb/DBTypes.ice
+++ b/cpp/src/icegriddb/DBTypes.ice
@@ -6,7 +6,7 @@
 
 #include <IceGrid/Admin.ice>
 
-[["ice-prefix", "cpp:header-ext:h"]]
+[["cpp:header-ext:h"]]
 
 module IceGrid
 {

--- a/cpp/test/Slice/errorDetection/IdentAsKeywordUnderscore.err
+++ b/cpp/test/Slice/errorDetection/IdentAsKeywordUnderscore.err
@@ -1,76 +1,76 @@
-IdentAsKeywordUnderscore.ice:10: syntax error
-IdentAsKeywordUnderscore.ice:12: `Void': an exception can be defined only at module scope
-IdentAsKeywordUnderscore.ice:13: keyword `int' cannot be used as exception name
-IdentAsKeywordUnderscore.ice:13: `int': an exception can be defined only at module scope
-IdentAsKeywordUnderscore.ice:15: `OUT': a structure can be defined only at module scope
-IdentAsKeywordUnderscore.ice:16: keyword `double' cannot be used as struct name
-IdentAsKeywordUnderscore.ice:16: `double': a structure can be defined only at module scope
-IdentAsKeywordUnderscore.ice:18: `s1': a structure can be defined only at module scope
-IdentAsKeywordUnderscore.ice:19: `s2': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:8: syntax error
+IdentAsKeywordUnderscore.ice:10: `Void': an exception can be defined only at module scope
+IdentAsKeywordUnderscore.ice:11: keyword `int' cannot be used as exception name
+IdentAsKeywordUnderscore.ice:11: `int': an exception can be defined only at module scope
+IdentAsKeywordUnderscore.ice:13: `OUT': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:14: keyword `double' cannot be used as struct name
+IdentAsKeywordUnderscore.ice:14: `double': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:16: `s1': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:17: `s2': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:17: keyword `byte' cannot be used as data member name
+IdentAsKeywordUnderscore.ice:18: `s3': a structure can be defined only at module scope
+IdentAsKeywordUnderscore.ice:19: `s4': a structure can be defined only at module scope
 IdentAsKeywordUnderscore.ice:19: keyword `byte' cannot be used as data member name
-IdentAsKeywordUnderscore.ice:20: `s3': a structure can be defined only at module scope
-IdentAsKeywordUnderscore.ice:21: `s4': a structure can be defined only at module scope
-IdentAsKeywordUnderscore.ice:21: keyword `byte' cannot be used as data member name
-IdentAsKeywordUnderscore.ice:23: `inTERface': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:24: keyword `interface' cannot be used as class name
-IdentAsKeywordUnderscore.ice:24: `interface': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:26: `MOdule': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:27: keyword `module' cannot be used as class name
-IdentAsKeywordUnderscore.ice:27: `module': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:29: `C': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:30: `C': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:30: keyword `extends' cannot be used as data member name
-IdentAsKeywordUnderscore.ice:31: `D': a class can be defined only at module scope
-IdentAsKeywordUnderscore.ice:31: keyword `extends' cannot be used as data member name
-IdentAsKeywordUnderscore.ice:36: keyword `Object' cannot be used as interface name
-IdentAsKeywordUnderscore.ice:36: `Object': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:37: `object': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:38: keyword `long' cannot be used as interface name
-IdentAsKeywordUnderscore.ice:38: `long': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:40: `impLEments': a sequence can be defined only at module scope
-IdentAsKeywordUnderscore.ice:41: sequence `implements' differs only in capitalization from sequence `impLEments'
-IdentAsKeywordUnderscore.ice:41: keyword `implements' cannot be used as sequence name
-IdentAsKeywordUnderscore.ice:42: `short': a sequence can be defined only at module scope
-IdentAsKeywordUnderscore.ice:42: keyword `short' cannot be used as sequence name
-IdentAsKeywordUnderscore.ice:44: syntax error
-IdentAsKeywordUnderscore.ice:45: `moDule' is not defined
-IdentAsKeywordUnderscore.ice:47: `throws': a dictionary can be defined only at module scope
-IdentAsKeywordUnderscore.ice:47: keyword `throws' cannot be used as dictionary name
-IdentAsKeywordUnderscore.ice:48: dictionary `thRows' differs only in capitalization from dictionary `throws'
-IdentAsKeywordUnderscore.ice:51: syntax error
-IdentAsKeywordUnderscore.ice:52: `MODULE' is not defined
-IdentAsKeywordUnderscore.ice:54: syntax error
-IdentAsKeywordUnderscore.ice:55: `d4': a dictionary can be defined only at module scope
-IdentAsKeywordUnderscore.ice:57: syntax error
-IdentAsKeywordUnderscore.ice:58: `VOID' is an exception, which cannot be used as a type
-IdentAsKeywordUnderscore.ice:63: `e1': an enumeration can be defined only at module scope
-IdentAsKeywordUnderscore.ice:63: keyword `long' cannot be used as enumerator
-IdentAsKeywordUnderscore.ice:63: keyword `byte' cannot be used as enumerator
-IdentAsKeywordUnderscore.ice:64: `e2': an enumeration can be defined only at module scope
-IdentAsKeywordUnderscore.ice:66: `i1': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:67: `i2': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:69: `i3': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:70: `i4': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:72: `i5': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:72: syntax error
-IdentAsKeywordUnderscore.ice:73: `i6': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:75: `i7': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:76: `i8': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:78: `i9': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:79: `i10': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:81: `true': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:83: illegal leading underscore in identifier `_a'
-IdentAsKeywordUnderscore.ice:83: `_a': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:84: illegal leading underscore in identifier `_true'
-IdentAsKeywordUnderscore.ice:84: `_true': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:85: illegal leading underscore in identifier `_true'
-IdentAsKeywordUnderscore.ice:85: `_true': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:87: illegal trailing underscore in identifier `b_'
-IdentAsKeywordUnderscore.ice:87: `b_': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:89: illegal double underscore in identifier `b__c'
-IdentAsKeywordUnderscore.ice:89: `b__c': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:90: illegal double underscore in identifier `b___c'
-IdentAsKeywordUnderscore.ice:90: `b___c': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:92: `a_b': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:93: `a_b_c': an interface can be defined only at module scope
-IdentAsKeywordUnderscore.ice:95: syntax error
+IdentAsKeywordUnderscore.ice:21: `inTERface': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:22: keyword `interface' cannot be used as class name
+IdentAsKeywordUnderscore.ice:22: `interface': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:24: `MOdule': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:25: keyword `module' cannot be used as class name
+IdentAsKeywordUnderscore.ice:25: `module': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:27: `C': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:28: `C': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:28: keyword `extends' cannot be used as data member name
+IdentAsKeywordUnderscore.ice:29: `D': a class can be defined only at module scope
+IdentAsKeywordUnderscore.ice:29: keyword `extends' cannot be used as data member name
+IdentAsKeywordUnderscore.ice:34: keyword `Object' cannot be used as interface name
+IdentAsKeywordUnderscore.ice:34: `Object': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:35: `object': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:36: keyword `long' cannot be used as interface name
+IdentAsKeywordUnderscore.ice:36: `long': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:38: `impLEments': a sequence can be defined only at module scope
+IdentAsKeywordUnderscore.ice:39: sequence `implements' differs only in capitalization from sequence `impLEments'
+IdentAsKeywordUnderscore.ice:39: keyword `implements' cannot be used as sequence name
+IdentAsKeywordUnderscore.ice:40: `short': a sequence can be defined only at module scope
+IdentAsKeywordUnderscore.ice:40: keyword `short' cannot be used as sequence name
+IdentAsKeywordUnderscore.ice:42: syntax error
+IdentAsKeywordUnderscore.ice:43: `moDule' is not defined
+IdentAsKeywordUnderscore.ice:45: `throws': a dictionary can be defined only at module scope
+IdentAsKeywordUnderscore.ice:45: keyword `throws' cannot be used as dictionary name
+IdentAsKeywordUnderscore.ice:46: dictionary `thRows' differs only in capitalization from dictionary `throws'
+IdentAsKeywordUnderscore.ice:49: syntax error
+IdentAsKeywordUnderscore.ice:50: `MODULE' is not defined
+IdentAsKeywordUnderscore.ice:52: syntax error
+IdentAsKeywordUnderscore.ice:53: `d4': a dictionary can be defined only at module scope
+IdentAsKeywordUnderscore.ice:55: syntax error
+IdentAsKeywordUnderscore.ice:56: `VOID' is an exception, which cannot be used as a type
+IdentAsKeywordUnderscore.ice:61: `e1': an enumeration can be defined only at module scope
+IdentAsKeywordUnderscore.ice:61: keyword `long' cannot be used as enumerator
+IdentAsKeywordUnderscore.ice:61: keyword `byte' cannot be used as enumerator
+IdentAsKeywordUnderscore.ice:62: `e2': an enumeration can be defined only at module scope
+IdentAsKeywordUnderscore.ice:64: `i1': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:65: `i2': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:67: `i3': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:68: `i4': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:70: `i5': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:70: syntax error
+IdentAsKeywordUnderscore.ice:71: `i6': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:73: `i7': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:74: `i8': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:76: `i9': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:77: `i10': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:79: `true': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:81: illegal leading underscore in identifier `_a'
+IdentAsKeywordUnderscore.ice:81: `_a': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:82: illegal leading underscore in identifier `_true'
+IdentAsKeywordUnderscore.ice:82: `_true': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:83: illegal leading underscore in identifier `_true'
+IdentAsKeywordUnderscore.ice:83: `_true': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:85: illegal trailing underscore in identifier `b_'
+IdentAsKeywordUnderscore.ice:85: `b_': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:87: illegal double underscore in identifier `b__c'
+IdentAsKeywordUnderscore.ice:87: `b__c': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:88: illegal double underscore in identifier `b___c'
+IdentAsKeywordUnderscore.ice:88: `b___c': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:90: `a_b': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:91: `a_b_c': an interface can be defined only at module scope
+IdentAsKeywordUnderscore.ice:93: syntax error

--- a/cpp/test/Slice/errorDetection/IdentAsKeywordUnderscore.ice
+++ b/cpp/test/Slice/errorDetection/IdentAsKeywordUnderscore.ice
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["underscore"]]
-
 module Test
 {
 

--- a/cpp/test/Slice/escape/Clash.ice
+++ b/cpp/test/Slice/escape/Clash.ice
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["underscore"]]
-
 module Clash
 {
 

--- a/cpp/test/Slice/escape/Key.ice
+++ b/cpp/test/Slice/escape/Key.ice
@@ -2,7 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["underscore"]]
 [["suppress-warning:deprecated"]]
 
 module and


### PR DESCRIPTION
This PR removes the stated metadata.
As of #1631, the parser allows underscores and ice prefixes by default, meaning these metadata are now no-op.
So there's no point using (and indirectly advertising) these metadata in our own Slice files.