### PR TITLE
Fix objc build

### DIFF
--- a/objective-c/src/Ice/Object.mm
+++ b/objective-c/src/Ice/Object.mm
@@ -330,7 +330,7 @@ static NSString* ICEObject_ids[1] =
 -(BOOL) ice_isA:(NSString*)__unused typeId current:(ICECurrent*)__unused current
 {
     NSAssert(NO, @"ice_isA requires override");
-    return nil;
+    return false;
 }
 -(void) ice_ping:(ICECurrent*)__unused current
 {

--- a/objective-c/src/Ice/ObjectAdapterI.mm
+++ b/objective-c/src/Ice/ObjectAdapterI.mm
@@ -91,7 +91,12 @@ public:
     {
     }
 
-    ~ExceptionWriter() throw()
+    ExceptionWriter(const ExceptionWriter& other) : _ex(other._ex)
+    {
+        [_ex retain];
+    }
+
+    ~ExceptionWriter()
     {
         [_ex release];
     }

--- a/objective-c/src/Ice/Util.h
+++ b/objective-c/src/Ice/Util.h
@@ -221,7 +221,7 @@ public:
 
     Exception(id<NSObject>);
     Exception(const Exception&);
-    virtual ~Exception() throw();
+    ~Exception();
 
     virtual std::string ice_id() const;
     virtual void ice_print(std::ostream& os) const;

--- a/objective-c/src/Ice/Util.mm
+++ b/objective-c/src/Ice/Util.mm
@@ -409,7 +409,7 @@ IceObjC::Exception::Exception(const IceObjC::Exception& ex) : _ex([ex._ex retain
 {
 }
 
-IceObjC::Exception::~Exception() throw()
+IceObjC::Exception::~Exception()
 {
     [_ex release];
 }

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2881,7 +2881,6 @@ IceRuby::ExceptionReader::ExceptionReader(const ExceptionInfoPtr& info) :
 }
 
 IceRuby::ExceptionReader::~ExceptionReader()
-    throw()
 {
     rb_gc_unregister_address(&_ex);
 }

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -541,7 +541,7 @@ class ExceptionReader : public Ice::UserException
 public:
 
     ExceptionReader(const ExceptionInfoPtr&);
-    ~ExceptionReader() throw();
+    ~ExceptionReader();
 
     virtual std::string ice_id() const;
 #ifndef ICE_CPP11_MAPPING


### PR DESCRIPTION
Fixes the objc build. I couldn't figure out any other way to pass -std=c++17 only  for `.mm` files. 