### PR TITLE
php: update macOS ldflags

### DIFF
--- a/php/config/Make.rules
+++ b/php/config/Make.rules
@@ -77,7 +77,7 @@ endif
 
 ifeq ($(os),Darwin)
     php_cppflags        := $(php_cppflags) -Wno-unused-parameter -Wno-missing-field-initializers
-    php_ldflags         := ${wl}-flat_namespace ${wl}-undefined ${wl}suppress
+    php_ldflags         := -undefined dynamic_lookup
 endif
 
 ifeq ($(os),Linux)


### PR DESCRIPTION
-undefined suppress is deprecated as of the new linker in macOS 14
We now use -undefined dynamic_lookup
