### PR TITLE
Remove unused servant delegate in Objective-C

### DIFF
--- a/cpp/src/slice2objc/Gen.cpp
+++ b/cpp/src/slice2objc/Gen.cpp
@@ -367,7 +367,7 @@ Slice::ObjCVisitor::writeDispatchAndMarshalling(const InterfaceDefPtr& p)
         _M << sp << nl << "-(void) iceDispatch:(ICECurrent *)current is:(id<ICEInputStream>)istr "
            << "os:(id<ICEOutputStream>)ostr";
         _M << sb;
-        _M << nl << "id target = [self iceTarget];";
+        _M << nl << "id target = self;";
         _M << nl << "switch(ICEInternalLookupString(iceS_" << name << "_all, sizeof(iceS_" << name
            << "_all) / sizeof(NSString*), current.operation))";
         _M << sb;

--- a/objective-c/include/objc/Ice/Object.h
+++ b/objective-c/include/objc/Ice/Object.h
@@ -42,17 +42,14 @@ ICE_API @interface ICEObject : NSObject<ICEObject, NSCopying>
 
 ICE_API @interface ICEServant : ICEObject
 {
+    // A pointer to the Ice::Object that wraps this ObjC object.
     void* iceObject_;
-    id iceDelegate_;
 }
--(id) initWithDelegate:(id)delegate;
-+(id) objectWithDelegate:(id)delegate;
 +(void) iceD_ice_isA:(id)servant current:(ICECurrent*)current is:(id<ICEInputStream>)is os:(id<ICEOutputStream>)os;
 +(void) iceD_ice_ping:(id)servant current:(ICECurrent*)current is:(id<ICEInputStream>)is os:(id<ICEOutputStream>)os;
 +(void) iceD_ice_id:(id)servant current:(ICECurrent*)current is:(id<ICEInputStream>)is os:(id<ICEOutputStream>)os;
 +(void) iceD_ice_ids:(id)servant current:(ICECurrent*)current is:(id<ICEInputStream>)is os:(id<ICEOutputStream>)os;
 -(void) iceDispatch:(ICECurrent*)current is:(id<ICEInputStream>)is os:(id<ICEOutputStream>)os;
--(id) iceTarget;
 @end
 
 ICE_API @protocol ICEBlobject<ICEObject>

--- a/objective-c/src/Ice/Object.mm
+++ b/objective-c/src/Ice/Object.mm
@@ -103,7 +103,6 @@ public:
 private:
 
     ICEBlobject* _blobject;
-    id _target;
 };
 
 ObjectI::ObjectI(ICEServant* object) : _object(object)
@@ -156,7 +155,7 @@ ObjectI::ice_invoke_async(const Ice::AMD_Object_ice_invokePtr& cb,
     [os release];
 }
 
-BlobjectI::BlobjectI(ICEBlobject* blobject) : _blobject(blobject), _target(blobject)
+BlobjectI::BlobjectI(ICEBlobject* blobject) : _blobject(blobject)
 {
 }
 
@@ -177,7 +176,8 @@ BlobjectI::ice_invoke_async(const Ice::AMD_Object_ice_invokePtr& cb,
                                      freeWhenDone:NO];
         @try
         {
-            ok = [_target ice_invoke:inE outEncaps:&outE current:c];
+            // The application-provided implementation of class ICEBlobject must implement the ICEBlobject protocol.
+            ok = [(id)_blobject ice_invoke:inE outEncaps:&outE current:c];
             [outE retain];
         }
         @catch(ICEUserException* ex)

--- a/objective-c/src/Ice/Object.mm
+++ b/objective-c/src/Ice/Object.mm
@@ -156,7 +156,7 @@ ObjectI::ice_invoke_async(const Ice::AMD_Object_ice_invokePtr& cb,
     [os release];
 }
 
-BlobjectI::BlobjectI(ICEBlobject* blobject) : _blobject(blobject), _target([blobject iceTarget])
+BlobjectI::BlobjectI(ICEBlobject* blobject) : _blobject(blobject), _target(blobject)
 {
 }
 
@@ -359,19 +359,6 @@ static NSString* ICEObject_all[4] =
         return nil;
     }
     iceObject_ = 0;
-    iceDelegate_ = 0;
-    return self;
-}
-
--(id)initWithDelegate:(id)delegate
-{
-    self = [super init];
-    if(!self)
-    {
-        return nil;
-    }
-    iceObject_ = 0;
-    iceDelegate_ = [delegate retain];
     return self;
 }
 
@@ -382,13 +369,7 @@ static NSString* ICEObject_all[4] =
         delete static_cast<IceObjC::ServantWrapper*>(iceObject_);
         iceObject_ = 0;
     }
-    [iceDelegate_ release];
     [super dealloc];
-}
-
-+(id)objectWithDelegate:(id)delegate
-{
-    return [[[self alloc] initWithDelegate:delegate] autorelease];
 }
 
 -(BOOL) ice_isA:(NSString*)typeId current:(ICECurrent*)__unused current
@@ -484,11 +465,6 @@ static NSString* ICEObject_all[4] =
                                                                facet:current.facet
                                                            operation:current.operation];
     }
-}
-
--(id)iceTarget
-{
-    return (iceDelegate_ == 0) ? self : iceDelegate_;
 }
 
 -(Ice::Object*) iceObject


### PR DESCRIPTION
ICEServant supports a delegate but this feature is not used anywhere. This PR removes it to simplify the code.