### PR TITLE
Remove IceUtil::Thread from python

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -496,7 +496,6 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
                 try
                 {
                     self->shutdownFuture->get();
-                    assert(self->shutdownException->valid());
                 }
                 catch(const Ice::Exception& ex)
                 {

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -308,6 +308,7 @@ extern "C"
 static void
 adapterDealloc(ObjectAdapterObject* self)
 {
+
     delete self->adapter;
 
     delete self->deactivateThread;
@@ -379,7 +380,6 @@ adapterActivate(ObjectAdapterObject* self, PyObject* /*args*/)
         self->held = false;
         if(self->holdThread)
         {
-            self->holdThread->join();
             delete self->holdThread;
             self->holdThread = 0;
         }

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -447,7 +447,7 @@ adapterWaitForHold(ObjectAdapterObject* self, PyObject* args)
     //
     if(PyThread_get_thread_ident() == _mainThreadId)
     {
-        std::unique_lock lock(*self->holdMutex);
+        std::lock_guard lock(*self->holdMutex);
 
         if(!self->held)
         {

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -461,25 +461,22 @@ adapterWaitForHold(ObjectAdapterObject* self, PyObject* args)
                                                });
             }
 
-            if(!self->held)
             {
+                AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
+                if(self->holdFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
                 {
-                    AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
-                    if(self->holdFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
-                    {
-                        PyRETURN_FALSE;
-                    }
+                    PyRETURN_FALSE;
                 }
+            }
 
-                self->held = true;
-                try
-                {
-                    self->holdFuture->get();
-                }
-                catch(const Ice::Exception&)
-                {
-                    *self->holdException = current_exception();
-                }
+            self->held = true;
+            try
+            {
+                self->holdFuture->get();
+            }
+            catch(const Ice::Exception&)
+            {
+                *self->holdException = current_exception();
             }
         }
 
@@ -578,25 +575,22 @@ adapterWaitForDeactivate(ObjectAdapterObject* self, PyObject* args)
                                                    });
             }
 
-            if(!self->deactivated)
             {
+                AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
+                if(self->deactivateFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
                 {
-                    AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
-                    if(self->deactivateFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
-                    {
-                        PyRETURN_FALSE;
-                    }
+                    PyRETURN_FALSE;
                 }
+            }
 
-                self->deactivated = true;
-                try
-                {
-                    self->deactivateFuture->get();
-                }
-                catch(const Ice::Exception&)
-                {
-                    *self->deactivateException = current_exception();
-                }
+            self->deactivated = true;
+            try
+            {
+                self->deactivateFuture->get();
+            }
+            catch(const Ice::Exception&)
+            {
+                *self->deactivateException = current_exception();
             }
         }
 

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -570,7 +570,6 @@ adapterWaitForDeactivate(ObjectAdapterObject* self, PyObject* args)
 
             if(!self->deactivated)
             {
-
                 {
                     AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
                     if(self->deactivateFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -68,58 +68,6 @@ private:
 };
 typedef IceUtil::Handle<ThreadHook> ThreadHookPtr;
 
-//
-// This class invokes a function in a separate thread.
-//
-class InvokeThread
-{
-public:
-
-    InvokeThread(std::function<void()> func, std::mutex* mutex, std::condition_variable* cond, bool& done) :
-        _func(func),
-        _mutex(mutex),
-        _cond(cond),
-        _done(done),
-        _ex(0),
-        _thread([this] { run(); })
-    {
-    }
-
-    void run()
-    {
-        try
-        {
-            _func();
-        }
-        catch(const Ice::Exception& ex)
-        {
-            _ex = ex.ice_clone();
-        }
-        std::unique_lock lock(*_mutex);
-        _done = true;
-        _cond->notify_one();
-    }
-
-    ~InvokeThread()
-    {
-        _thread.join();
-        delete _ex;
-    }
-
-    Ice::Exception* getException() const
-    {
-        return _ex;
-    }
-
-private:
-    std::function<void()> _func;
-    std::mutex* _mutex;
-    std::condition_variable* _cond;
-    bool& _done;
-    Ice::Exception* _ex;
-    std::thread _thread;
-};
-
 }
 
 #endif

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -80,7 +80,7 @@ public:
         _mutex(mutex),
         _cond(cond),
         _done(done),
-        _ex(nullptr),
+        _ex(0),
         _thread([this] { run(); })
     {
     }
@@ -104,11 +104,6 @@ public:
     {
         _thread.join();
         delete _ex;
-    }
-
-    void join()
-    {
-        _thread.join();
     }
 
     Ice::Exception* getException() const

--- a/python/modules/IcePy/Thread.h
+++ b/python/modules/IcePy/Thread.h
@@ -11,8 +11,6 @@
 #include <IceUtil/Thread.h>
 #include <IceUtil/Monitor.h>
 
-#include <thread>
-
 namespace IcePy
 {
 


### PR DESCRIPTION
This PR removes the usage of IceUtil::Thread from the Python mapping