### PR TITLE
Python `version_info` import removed

### DIFF
--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -1959,14 +1959,13 @@ Slice::Python::CodeVisitor::writeConstantValue(const TypePtr& type, const Syntax
             }
             case Slice::Builtin::KindString:
             {
-                string sv2 = toStringLiteral(value, "\a\b\f\n\r\t\v", "", Octal, 0);
-                string sv3 = toStringLiteral(value, "\a\b\f\n\r\t\v", "", UCN, 0);
+                const string controlChars = "\a\b\f\n\r\t\v";
+                const unsigned char cutOff = 0;
+                
+                string sv2 = toStringLiteral(value, controlChars, "", Octal, cutOff);
+                string sv3 = toStringLiteral(value, controlChars, "", UCN, cutOff);
 
-                _out << "\"" << sv2<< "\"";
-                if(sv2 != sv3)
-                {
-                    _out << " if _version_info_[0] < 3 else \"" << sv3 << "\"";
-                }
+                _out << "\"" << (sv2 == sv3 ? sv2 : sv3) << "\"";
                 break;
             }
             case Slice::Builtin::KindValue:
@@ -2843,7 +2842,6 @@ Slice::Python::generate(const UnitPtr& un, bool all, const vector<string>& inclu
     Slice::Python::MetaDataVisitor visitor;
     un->visit(&visitor, false);
 
-    out << nl << "from sys import version_info as _version_info_";
     out << nl << "import Ice, IcePy";
 
     if(!all)

--- a/cpp/src/Slice/PythonUtil.cpp
+++ b/cpp/src/Slice/PythonUtil.cpp
@@ -1962,10 +1962,7 @@ Slice::Python::CodeVisitor::writeConstantValue(const TypePtr& type, const Syntax
                 const string controlChars = "\a\b\f\n\r\t\v";
                 const unsigned char cutOff = 0;
                 
-                string sv2 = toStringLiteral(value, controlChars, "", Octal, cutOff);
-                string sv3 = toStringLiteral(value, controlChars, "", UCN, cutOff);
-
-                _out << "\"" << (sv2 == sv3 ? sv2 : sv3) << "\"";
+                _out << "\"" << toStringLiteral(value, controlChars, "", UCN, cutOff) << "\"";
                 break;
             }
             case Slice::Builtin::KindValue:

--- a/python/python/Ice/CommunicatorF_local.py
+++ b/python/python/Ice/CommunicatorF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Communicator_local.py
+++ b/python/python/Ice/Communicator_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.LoggerF_local
 import Ice.InstrumentationF_local

--- a/python/python/Ice/ConnectionF_local.py
+++ b/python/python/Ice/ConnectionF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Connection_local.py
+++ b/python/python/Ice/Connection_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.ObjectAdapterF_local
 import Ice.Identity_ice

--- a/python/python/Ice/Current_local.py
+++ b/python/python/Ice/Current_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.ObjectAdapterF_local
 import Ice.ConnectionF_local

--- a/python/python/Ice/EndpointF_local.py
+++ b/python/python/Ice/EndpointF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/EndpointSelectionType_local.py
+++ b/python/python/Ice/EndpointSelectionType_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Endpoint_local.py
+++ b/python/python/Ice/Endpoint_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.Version_ice
 import Ice.BuiltinSequences_ice

--- a/python/python/Ice/FacetMap_local.py
+++ b/python/python/Ice/FacetMap_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/ImplicitContextF_local.py
+++ b/python/python/Ice/ImplicitContextF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/ImplicitContext_local.py
+++ b/python/python/Ice/ImplicitContext_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.LocalException_local
 import Ice.Current_local

--- a/python/python/Ice/InstrumentationF_local.py
+++ b/python/python/Ice/InstrumentationF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Instrumentation_local.py
+++ b/python/python/Ice/Instrumentation_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.EndpointF_local
 import Ice.ConnectionF_local

--- a/python/python/Ice/LocalException_local.py
+++ b/python/python/Ice/LocalException_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.Identity_ice
 import Ice.Version_ice

--- a/python/python/Ice/LoggerF_local.py
+++ b/python/python/Ice/LoggerF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Logger_local.py
+++ b/python/python/Ice/Logger_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/ObjectAdapterF_local.py
+++ b/python/python/Ice/ObjectAdapterF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/ObjectAdapter_local.py
+++ b/python/python/Ice/ObjectAdapter_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.CommunicatorF_local
 import Ice.ServantLocatorF_local

--- a/python/python/Ice/PluginF_local.py
+++ b/python/python/Ice/PluginF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Plugin_local.py
+++ b/python/python/Ice/Plugin_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.LoggerF_local
 import Ice.BuiltinSequences_ice

--- a/python/python/Ice/PropertiesF_local.py
+++ b/python/python/Ice/PropertiesF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/Properties_local.py
+++ b/python/python/Ice/Properties_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.BuiltinSequences_ice
 import Ice.PropertyDict_ice

--- a/python/python/Ice/ServantLocatorF_local.py
+++ b/python/python/Ice/ServantLocatorF_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/Ice/ServantLocator_local.py
+++ b/python/python/Ice/ServantLocator_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.ObjectAdapterF_local
 import Ice.Current_local

--- a/python/python/Ice/ValueFactory_local.py
+++ b/python/python/Ice/ValueFactory_local.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 
 # Start of module Ice

--- a/python/python/IceBox/Service.py
+++ b/python/python/IceBox/Service.py
@@ -14,7 +14,6 @@
 # </auto-generated>
 #
 
-from sys import version_info as _version_info_
 import Ice, IcePy
 import Ice.BuiltinSequences_ice
 import Ice.CommunicatorF_ice


### PR DESCRIPTION
When having a little poke through the Python language mapping I noticed this import in a lot of files `from sys import version_info as _version_info_`. The only place I could find its use was for a Python2 vs Python3 check in `PythonUtils.cpp`.
Since Python2 support was removed in #1654, this seems to be dead code.
