### PR TITLE
Move IceFuture.py to main directory

### DIFF
--- a/python/python/Ice/IceFuture.py
+++ b/python/python/Ice/IceFuture.py
@@ -2,17 +2,11 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-#
-# This file should only be used in Python >= 3.5.
-#
-
 import asyncio
 
 
 #
 # This class defines an __await__ method so that coroutines can call 'await <future>'.
-#
-# Python 2.x rejects this code with a syntax error because a return statement is not allowed in a generator.
 #
 class FutureBase(object):
     def __await__(self):

--- a/python/python/Ice/Py3/__init__.py
+++ b/python/python/Ice/Py3/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) ZeroC, Inc. All rights reserved.
-#

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -71,7 +71,7 @@ loadSlice = IcePy.loadSlice
 AsyncResult = IcePy.AsyncResult
 Unset = IcePy.Unset
 
-from Ice.Py3.IceFuture import FutureBase, wrap_future
+from Ice.IceFuture import FutureBase, wrap_future
 
 
 class Future(FutureBase):

--- a/python/python/Makefile
+++ b/python/python/Makefile
@@ -31,8 +31,6 @@ $(eval $(call make-python-slice,$(slicedir),$(lang_srcdir)/python,Glacier2,Metri
 install:: | $(DESTDIR)$(install_pythondir)/Ice
 	$(E) "Installing generated code"
 	$(Q)$(INSTALL) -m 644 Ice/__init__.py $(DESTDIR)$(install_pythondir)/Ice
-	$(Q)$(MKDIR) -p -m 755 $(DESTDIR)$(install_pythondir)/Ice/Py3
-	$(Q)$(INSTALL) -m 644 Ice/Py3/IceFuture.py $(DESTDIR)$(install_pythondir)/Ice/Py3/
 
 install:: | $(DESTDIR)$(install_pythondir)/Glacier2
 	$(Q)$(INSTALL) -m 644 Glacier2/__init__.py $(DESTDIR)$(install_pythondir)/Glacier2


### PR DESCRIPTION
It requires Python >= 3.5, which is greater than the min Python requirement for Ice 3.8.