### PR TITLE
Cleanup cpp dir Python code

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,13 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
-    paths:
-      - "swift/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
-    paths:
-      - "swift/**"
 
 jobs:
   ruff-lint:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,27 @@
+name: Python lint and format
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - "swift/**"
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+    paths:
+      - "swift/**"
+
+jobs:
+  ruff-lint:
+    name: Ruff check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install SwiftLints
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check 'cpp' --ignore E402

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     ],
     "pylint.args": [
         "--rcfile=tox.ini"
-    ],
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,7 @@
     ],
     "pylint.args": [
         "--rcfile=tox.ini"
-    ]
+    ],
+    "python.analysis.autoImportCompletions": true,
+    "python.analysis.typeCheckingMode": "basic"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,4 @@
     "pylint.args": [
         "--rcfile=tox.ini"
     ],
-    "python.analysis.autoImportCompletions": true,
-    "python.analysis.typeCheckingMode": "basic"
 }

--- a/cpp/allTests.py
+++ b/cpp/allTests.py
@@ -5,8 +5,9 @@
 
 import os
 import sys
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from Util import runTestsWithPath
+from scripts.Util import runTestsWithPath
 
 runTestsWithPath(__file__)

--- a/cpp/allTests.py
+++ b/cpp/allTests.py
@@ -8,6 +8,6 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from scripts.Util import runTestsWithPath
+from Util import runTestsWithPath
 
 runTestsWithPath(__file__)

--- a/cpp/test/Glacier2/attack/test.py
+++ b/cpp/test/Glacier2/attack/test.py
@@ -3,4 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from Glacier2Util import Glacier2TestSuite
+
+
 Glacier2TestSuite(__name__, routerProps={"Glacier2.RoutingTable.MaxSize": 10})

--- a/cpp/test/Glacier2/dynamicFiltering/test.py
+++ b/cpp/test/Glacier2/dynamicFiltering/test.py
@@ -7,13 +7,28 @@
 # Note: we limit the send buffer size with Ice.TCP.SndSize, the
 # test relies on send() blocking
 #
-def routerProps(process, current): return {
-    'Glacier2.SessionManager': 'SessionManager:{0}'.format(current.getTestEndpoint(0)),
-    'Glacier2.PermissionsVerifier': 'Glacier2/NullPermissionsVerifier',
-    'Ice.Default.Locator': 'locator:{0}'.format(current.getTestEndpoint(1)),
-}
+from Glacier2Util import Glacier2Router, Glacier2TestSuite
+from Util import ClientServerTestCase, Server
 
 
-Glacier2TestSuite(__name__,
-                  testcases=[ClientServerTestCase(servers=[Glacier2Router(props=routerProps, passwords=None),
-                                                  Server(readyCount=3)])])
+def routerProps(process, current):
+    return {
+        "Glacier2.SessionManager": "SessionManager:{0}".format(
+            current.getTestEndpoint(0)
+        ),
+        "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
+        "Ice.Default.Locator": "locator:{0}".format(current.getTestEndpoint(1)),
+    }
+
+
+Glacier2TestSuite(
+    __name__,
+    testcases=[
+        ClientServerTestCase(
+            servers=[
+                Glacier2Router(props=routerProps, passwords=None),
+                Server(readyCount=3),
+            ]
+        )
+    ],
+)

--- a/cpp/test/Glacier2/hashpassword/test.py
+++ b/cpp/test/Glacier2/hashpassword/test.py
@@ -3,10 +3,13 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+import os
+import sys
+from Util import ClientTestCase, TestSuite, toplevel, run
+
+
 class Glacier2HashPasswordTestCase(ClientTestCase):
-
     def runClientSide(self, current):
-
         import passlib.hash
 
         hashpassword = os.path.join(toplevel, "scripts", "icehashpassword.py")
@@ -15,25 +18,42 @@ class Glacier2HashPasswordTestCase(ClientTestCase):
 
         def test(b):
             if not b:
-                raise RuntimeError('test assertion failed')
+                raise RuntimeError("test assertion failed")
 
         def hashPasswords(password, args=""):
-            return run('"%s" "%s" %s' % (sys.executable, hashpassword, args),
-                       stdin=(password + "\r\n").encode('UTF-8'),
-                       stdinRepeat=False)
+            return run(
+                '"%s" "%s" %s' % (sys.executable, hashpassword, args),
+                stdin=(password + "\r\n").encode("UTF-8"),
+                stdinRepeat=False,
+            )
 
         if usePBKDF2:
-
             current.write("Testing PBKDF2 crypt passwords...")
 
             test(passlib.hash.pbkdf2_sha256.verify("abc123", hashPasswords("abc123")))
             test(not passlib.hash.pbkdf2_sha256.verify("abc123", hashPasswords("abc")))
 
-            test(passlib.hash.pbkdf2_sha1.verify("abc123", hashPasswords("abc123", "-d sha1")))
-            test(not passlib.hash.pbkdf2_sha1.verify("abc123", hashPasswords("abc", "-d sha1")))
+            test(
+                passlib.hash.pbkdf2_sha1.verify(
+                    "abc123", hashPasswords("abc123", "-d sha1")
+                )
+            )
+            test(
+                not passlib.hash.pbkdf2_sha1.verify(
+                    "abc123", hashPasswords("abc", "-d sha1")
+                )
+            )
 
-            test(passlib.hash.pbkdf2_sha512.verify("abc123", hashPasswords("abc123", "-d sha512")))
-            test(not passlib.hash.pbkdf2_sha512.verify("abc123", hashPasswords("abc", "-d sha512")))
+            test(
+                passlib.hash.pbkdf2_sha512.verify(
+                    "abc123", hashPasswords("abc123", "-d sha512")
+                )
+            )
+            test(
+                not passlib.hash.pbkdf2_sha512.verify(
+                    "abc123", hashPasswords("abc", "-d sha512")
+                )
+            )
 
             #
             # Now use custom rounds
@@ -56,14 +76,21 @@ class Glacier2HashPasswordTestCase(ClientTestCase):
             current.writeln("ok")
 
         elif useCryptExt:
-
             current.write("Testing Linux crypt passwords...")
 
             test(passlib.hash.sha512_crypt.verify("abc123", hashPasswords("abc123")))
             test(not passlib.hash.sha512_crypt.verify("abc123", hashPasswords("abc")))
 
-            test(passlib.hash.sha256_crypt.verify("abc123", hashPasswords("abc123", "-d sha256")))
-            test(not passlib.hash.sha256_crypt.verify("abc123", hashPasswords("abc", "-d sha256")))
+            test(
+                passlib.hash.sha256_crypt.verify(
+                    "abc123", hashPasswords("abc123", "-d sha256")
+                )
+            )
+            test(
+                not passlib.hash.sha256_crypt.verify(
+                    "abc123", hashPasswords("abc", "-d sha256")
+                )
+            )
 
             #
             # Now use custom rounds

--- a/cpp/test/Glacier2/override/test.py
+++ b/cpp/test/Glacier2/override/test.py
@@ -7,22 +7,25 @@
 # Note: we limit the send buffer size with Ice.TCP.SndSize, the
 # test relies on send() blocking
 #
+from Glacier2Util import Glacier2TestSuite
+
+
 routerProps = {
-    'Ice.Warn.Dispatch': '0',
-    'Ice.Warn.Connections': '0',
-    'Ice.TCP.SndSize': '100000',
-    'Ice.ThreadPool.Server.Serialize': '1',
-    'Ice.ThreadPool.Client.Serialize': '1',
-    'Glacier2.Filter.Category.Accept': '"c"',
-    'Glacier2.PermissionsVerifier': 'Glacier2/NullPermissionsVerifier',
-    'Glacier2.Client.ForwardContext': '1',
-    'Glacier2.Client.ACM.Timeout': '"30"',
-    'Glacier2.Client.Trace.Override': '0',
-    'Glacier2.Client.Trace.Request': '0',
-    'Glacier2.Server.Trace.Override': '0',
-    'Glacier2.Server.Trace.Request': '0',
-    'Glacier2.Client.Buffered=1 --Glacier2.Server.Buffered': '1',
-    'Glacier2.Client.SleepTime=50 --Glacier2.Server.SleepTime': '50',
+    "Ice.Warn.Dispatch": "0",
+    "Ice.Warn.Connections": "0",
+    "Ice.TCP.SndSize": "100000",
+    "Ice.ThreadPool.Server.Serialize": "1",
+    "Ice.ThreadPool.Client.Serialize": "1",
+    "Glacier2.Filter.Category.Accept": '"c"',
+    "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
+    "Glacier2.Client.ForwardContext": "1",
+    "Glacier2.Client.ACM.Timeout": '"30"',
+    "Glacier2.Client.Trace.Override": "0",
+    "Glacier2.Client.Trace.Request": "0",
+    "Glacier2.Server.Trace.Override": "0",
+    "Glacier2.Server.Trace.Request": "0",
+    "Glacier2.Client.Buffered=1 --Glacier2.Server.Buffered": "1",
+    "Glacier2.Client.SleepTime=50 --Glacier2.Server.SleepTime": "50",
 }
 
 Glacier2TestSuite(__name__, routerProps=routerProps)

--- a/cpp/test/Glacier2/sessionControl/test.py
+++ b/cpp/test/Glacier2/sessionControl/test.py
@@ -7,10 +7,22 @@
 # Note: we limit the send buffer size with Ice.TCP.SndSize, the
 # test relies on send() blocking
 #
-def routerProps(process, current): return {
-    'Glacier2.SessionManager': 'SessionManager:{0}'.format(current.getTestEndpoint(0)),
-    'Glacier2.PermissionsVerifier': 'Glacier2/NullPermissionsVerifier',
-}
+from Glacier2Util import Glacier2Router, Glacier2TestSuite
+from Util import ClientServerTestCase, Server
 
 
-Glacier2TestSuite(__name__, testcases=[ClientServerTestCase(servers=[Glacier2Router(props=routerProps), Server()])])
+def routerProps(process, current):
+    return {
+        "Glacier2.SessionManager": "SessionManager:{0}".format(
+            current.getTestEndpoint(0)
+        ),
+        "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
+    }
+
+
+Glacier2TestSuite(
+    __name__,
+    testcases=[
+        ClientServerTestCase(servers=[Glacier2Router(props=routerProps), Server()])
+    ],
+)

--- a/cpp/test/Glacier2/ssl/test.py
+++ b/cpp/test/Glacier2/ssl/test.py
@@ -3,25 +3,51 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-def routerProps(process, current): return {
-    'Ice.Warn.Dispatch': '0',
-    'Glacier2.AddConnectionContext': '1',
-    'Glacier2.Client.Endpoints': '{0}:{1}'.format(current.getTestEndpoint(0, "tcp"), current.getTestEndpoint(1, "ssl")),
-    'Ice.Admin.Endpoints': current.getTestEndpoint(2, "tcp"),
-    'Glacier2.SessionManager': 'sessionmanager:{0}'.format(current.getTestEndpoint(3, "tcp")),
-    'Glacier2.PermissionsVerifier': 'verifier:{0}'.format(current.getTestEndpoint(3, "tcp")),
-    'Glacier2.SSLSessionManager': 'sslsessionmanager:{0}'.format(current.getTestEndpoint(3, "tcp")),
-    'Glacier2.SSLPermissionsVerifier': 'sslverifier:{0}'.format(current.getTestEndpoint(3, "tcp")),
-}
+from Glacier2Util import Glacier2Router, Glacier2TestSuite
+from Util import Client, ClientServerTestCase, Server
+
+
+def routerProps(process, current):
+    return {
+        "Ice.Warn.Dispatch": "0",
+        "Glacier2.AddConnectionContext": "1",
+        "Glacier2.Client.Endpoints": "{0}:{1}".format(
+            current.getTestEndpoint(0, "tcp"), current.getTestEndpoint(1, "ssl")
+        ),
+        "Ice.Admin.Endpoints": current.getTestEndpoint(2, "tcp"),
+        "Glacier2.SessionManager": "sessionmanager:{0}".format(
+            current.getTestEndpoint(3, "tcp")
+        ),
+        "Glacier2.PermissionsVerifier": "verifier:{0}".format(
+            current.getTestEndpoint(3, "tcp")
+        ),
+        "Glacier2.SSLSessionManager": "sslsessionmanager:{0}".format(
+            current.getTestEndpoint(3, "tcp")
+        ),
+        "Glacier2.SSLPermissionsVerifier": "sslverifier:{0}".format(
+            current.getTestEndpoint(3, "tcp")
+        ),
+    }
+
 
 #
 # Always enable SSL for the Glacier2 router and client
 #
 
 
-def sslProps(process, current): return current.testcase.getMapping().getSSLProps(process, current)
+def sslProps(process, current):
+    return current.testcase.getMapping().getSSLProps(process, current)
 
 
-Glacier2TestSuite(__name__, routerProps=routerProps, options={"ipv6": [False]}, multihost=False,
-                  testcases=[ClientServerTestCase(servers=[Glacier2Router(props=sslProps), Server()],
-                                                  client=Client(props=sslProps))])
+Glacier2TestSuite(
+    __name__,
+    routerProps=routerProps,
+    options={"ipv6": [False]},
+    multihost=False,
+    testcases=[
+        ClientServerTestCase(
+            servers=[Glacier2Router(props=sslProps), Server()],
+            client=Client(props=sslProps),
+        )
+    ],
+)

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -4,62 +4,84 @@
 #
 
 import os
+from Glacier2Util import Glacier2Router, Glacier2TestSuite
+
+from Util import Client, ClientServerTestCase, Server
 
 
 class Glacier2StaticFilteringTestCase(ClientServerTestCase):
-
     def __init__(self, testcase, hostname):
         self.hostname = hostname
         description, self.tcArgs, self.attacks, self.xtraConfig = testcase
 
         clientProps = {"Ice.Config": "{testdir}/client.cfg", "Ice.Warn.Connections": 0}
         serverProps = {"Ice.Config": "{testdir}/server.cfg", "Ice.Warn.Connections": 0}
-        routerProps = {"Ice.Config": "{testdir}/router.cfg", "Glacier2.RoutingTable.MaxSize": 10}
+        routerProps = {
+            "Ice.Config": "{testdir}/router.cfg",
+            "Glacier2.RoutingTable.MaxSize": 10,
+        }
 
         # Override the server/router default host property, we don't want to use the loopback
         serverProps["Ice.Default.Host"] = ""
         routerProps["Ice.Default.Host"] = ""
 
-        ClientServerTestCase.__init__(self,
-                                      description,
-                                      desc=description,
-                                      servers=[Glacier2Router(props=routerProps), Server(props=serverProps)],
-                                      client=Client(props=clientProps))
+        ClientServerTestCase.__init__(
+            self,
+            description,
+            desc=description,
+            servers=[Glacier2Router(props=routerProps), Server(props=serverProps)],
+            client=Client(props=clientProps),
+        )
 
     def setupClientSide(self, current):
         current.write("testing {0}... ".format(self))
 
     def setupServerSide(self, current):
-        acceptFilter, rejectFilter, maxEndpoints, categoryFilter, idFilter, adapterFilter = self.tcArgs
+        (
+            acceptFilter,
+            rejectFilter,
+            maxEndpoints,
+            categoryFilter,
+            idFilter,
+            adapterFilter,
+        ) = self.tcArgs
 
         #
         # The test client performs multiple tests during one 'run'. We could
         # use command line arguments to pass the test cases in, but a
         # configuration file is easier.
         #
-        with open(os.path.join(self.getTestSuite().getPath(), 'client.cfg'), 'w') as clientConfig:
+        with open(
+            os.path.join(self.getTestSuite().getPath(), "client.cfg"), "w"
+        ) as clientConfig:
             accepts = 0
             rejects = 0
             for expect, proxy in self.attacks:
                 if expect:
-                    clientConfig.write('Accept.Proxy.' + str(accepts) + '=')
+                    clientConfig.write("Accept.Proxy." + str(accepts) + "=")
                     accepts += 1
                 else:
-                    clientConfig.write('Reject.Proxy.' + str(rejects) + '=')
+                    clientConfig.write("Reject.Proxy." + str(rejects) + "=")
                     rejects += 1
-                clientConfig.write(proxy + '\n')
+                clientConfig.write(proxy + "\n")
 
-        with open(os.path.join(self.getTestSuite().getPath(), 'server.cfg'), 'w') as serverConfig:
+        with open(
+            os.path.join(self.getTestSuite().getPath(), "server.cfg"), "w"
+        ) as serverConfig:
             if current.config.protocol != "ssl":
                 serverConfig.write("BackendAdapter.Endpoints=tcp -p 12010\n")
 
-        with open(os.path.join(self.getTestSuite().getPath(), "router.cfg"), "w") as routerConfig:
-            routerConfig.write("Ice.Default.Locator=locator:tcp -h %s -p 12010\n" % self.hostname)
+        with open(
+            os.path.join(self.getTestSuite().getPath(), "router.cfg"), "w"
+        ) as routerConfig:
+            routerConfig.write(
+                "Ice.Default.Locator=locator:tcp -h %s -p 12010\n" % self.hostname
+            )
             routerConfig.write("Glacier2.Client.Trace.Reject=0\n")
             routerConfig.write("#\n")
 
-            for l in self.xtraConfig:
-                routerConfig.write(l)
+            for line in self.xtraConfig:
+                routerConfig.write(line)
                 routerConfig.write("\n")
 
             #
@@ -73,11 +95,15 @@ class Glacier2StaticFilteringTestCase(ClientServerTestCase):
             if not len(maxEndpoints) == 0:
                 routerConfig.write("Glacier2.Filter.ProxySizeMax=%s\n" % maxEndpoints)
             if not len(categoryFilter) == 0:
-                routerConfig.write("Glacier2.Filter.Category.Accept=%s\n" % categoryFilter)
+                routerConfig.write(
+                    "Glacier2.Filter.Category.Accept=%s\n" % categoryFilter
+                )
             if not len(idFilter) == 0:
                 routerConfig.write("Glacier2.Filter.Identity.Accept=%s\n" % idFilter)
             if not len(adapterFilter) == 0:
-                routerConfig.write("Glacier2.Filter.AdapterId.Accept=%s\n" % adapterFilter)
+                routerConfig.write(
+                    "Glacier2.Filter.AdapterId.Accept=%s\n" % adapterFilter
+                )
 
     def teardownServerSide(self, current, success):
         for c in ["client.cfg", "router.cfg", "server.cfg"]:
@@ -85,9 +111,7 @@ class Glacier2StaticFilteringTestCase(ClientServerTestCase):
 
 
 class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
-
     def setup(self, current):
-
         Glacier2TestSuite.setup(self, current)
 
         import socket
@@ -101,7 +125,11 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
         # Try and figure out what tests are reasonable with this host's
         # configuration.
         #
-        if fqdn.endswith("localdomain") or fqdn.endswith("local") or fqdn.endswith("domain"):
+        if (
+            fqdn.endswith("localdomain")
+            or fqdn.endswith("local")
+            or fqdn.endswith("domain")
+        ):
             #
             # No real configured domain name, this means that anything that
             # requires a domain name isn't likely going to work. Furthermore, it
@@ -132,7 +160,7 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
             limitedTests = True
         else:
             dot = fqdn.find(".")
-            domainname = fqdn[dot + 1:]
+            domainname = fqdn[dot + 1 :]
             #
             # Some Python installs are going to return a FQDN for gethostname().
             # This invalidates the tests that need to differentiate between the
@@ -157,147 +185,278 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
                 hostname = "127.0.0.1"
                 fqdn = ""
                 domainname = ""
-        except:
+        except socket.gaierror:
             limitedTests = True
             hostname = "127.0.0.1"
             fqdn = ""
             domainname = ""
 
         testcases = [
-            ('testing category filter',
-             ('', '', '', 'foo "a cat with spaces"', '', ''),
-             [(True, 'foo/helloA:tcp -h 127.0.0.1 -p 12010'),
-              (True, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
-              (False, 'nocat/helloC:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/helloD:tcp -h 127.0.0.1 -p 12010')], []),
-            ('testing adapter id filter',
-             ('', '*', '', '', '', 'foo "an adapter with spaces"'),
-             [(False, 'foo/helloA:tcp -h 127.0.0.1 -p 12010'),
-              (False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
-              (False, 'nocat/helloC:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/helloD:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'helloE @ bar'),
-              (True, 'helloF1 @ "an adapter with spaces"'),
-              (True, 'helloF @ foo')], []),
-            ('test identity filters',
-             ('', '', '', '', 'myident cata/fooa "a funny id/that might mess it up"', ''),
-             [(False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
-              (False, 'nocat/helloC:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/helloD:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'baz/myident:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cata/foo:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, 'myident:tcp -h 127.0.0.1 -p 12010'),
-              (True, 'cata/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010')], []),
-            ('test mixing filters',
-             ('', '', '', 'mycat "a sec cat"', 'myident cata/fooa "a funny id/that might mess it up" "a\\"nother"',
-                  'myadapter'),
-             [(False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
-              (False, 'nocat/helloC:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/helloD:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'baz/myident:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cata/foo:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, 'mycat/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, '"a sec cat/fooa":tcp -h 127.0.0.1 -p 12010'),
-              (True, 'mycat/foo @ jimbo'),
-              (False, 'hiscatA @ jimbo'),
-              (True, 'hiscat @ myadapter'),
-              (True, 'a\"nother @ jimbo'),
-              (True, 'myident:tcp -h 127.0.0.1 -p 12010'),
-              (True, 'cata/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010')], []),
-            ('test mixing filters (indirect only)',
-             ('', '*', '', 'mycat "a sec cat"', 'myident cata/fooa "a funny id/that might mess it up"', 'myadapter'),
-             [(False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
-              (False, 'nocat/helloC:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/helloD:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'baz/myident:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cata/foo:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cat/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'mycat/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (False, '"a sec cat/fooa":tcp -h 127.0.0.1 -p 12010'),
-              (True, 'mycat/foo @ jimbo'),
-              (False, 'hiscatA @ jimbo'),
-              (True, 'hiscat @ myadapter'),
-              (False, 'myident:tcp -h 127.0.0.1 -p 12010'),
-              (False, 'cata/fooa:tcp -h 127.0.0.1 -p 12010'),
-              (True, '"a funny id/that might mess it up" @ myadapter'),
-              (False, '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010')], []),
+            (
+                "testing category filter",
+                ("", "", "", 'foo "a cat with spaces"', "", ""),
+                [
+                    (True, "foo/helloA:tcp -h 127.0.0.1 -p 12010"),
+                    (True, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
+                    (False, "nocat/helloC:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/helloD:tcp -h 127.0.0.1 -p 12010"),
+                ],
+                [],
+            ),
+            (
+                "testing adapter id filter",
+                ("", "*", "", "", "", 'foo "an adapter with spaces"'),
+                [
+                    (False, "foo/helloA:tcp -h 127.0.0.1 -p 12010"),
+                    (False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
+                    (False, "nocat/helloC:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/helloD:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "helloE @ bar"),
+                    (True, 'helloF1 @ "an adapter with spaces"'),
+                    (True, "helloF @ foo"),
+                ],
+                [],
+            ),
+            (
+                "test identity filters",
+                (
+                    "",
+                    "",
+                    "",
+                    "",
+                    'myident cata/fooa "a funny id/that might mess it up"',
+                    "",
+                ),
+                [
+                    (False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
+                    (False, "nocat/helloC:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/helloD:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "baz/myident:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cata/foo:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (True, "myident:tcp -h 127.0.0.1 -p 12010"),
+                    (True, "cata/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (
+                        True,
+                        '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010',
+                    ),
+                ],
+                [],
+            ),
+            (
+                "test mixing filters",
+                (
+                    "",
+                    "",
+                    "",
+                    'mycat "a sec cat"',
+                    'myident cata/fooa "a funny id/that might mess it up" "a\\"nother"',
+                    "myadapter",
+                ),
+                [
+                    (False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
+                    (False, "nocat/helloC:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/helloD:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "baz/myident:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cata/foo:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (True, "mycat/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (True, '"a sec cat/fooa":tcp -h 127.0.0.1 -p 12010'),
+                    (True, "mycat/foo @ jimbo"),
+                    (False, "hiscatA @ jimbo"),
+                    (True, "hiscat @ myadapter"),
+                    (True, 'a"nother @ jimbo'),
+                    (True, "myident:tcp -h 127.0.0.1 -p 12010"),
+                    (True, "cata/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (
+                        True,
+                        '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010',
+                    ),
+                ],
+                [],
+            ),
+            (
+                "test mixing filters (indirect only)",
+                (
+                    "",
+                    "*",
+                    "",
+                    'mycat "a sec cat"',
+                    'myident cata/fooa "a funny id/that might mess it up"',
+                    "myadapter",
+                ),
+                [
+                    (False, '"a cat with spaces/helloB":tcp -h 127.0.0.1 -p 12010'),
+                    (False, "nocat/helloC:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/helloD:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "baz/myident:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cata/foo:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cat/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "mycat/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (False, '"a sec cat/fooa":tcp -h 127.0.0.1 -p 12010'),
+                    (True, "mycat/foo @ jimbo"),
+                    (False, "hiscatA @ jimbo"),
+                    (True, "hiscat @ myadapter"),
+                    (False, "myident:tcp -h 127.0.0.1 -p 12010"),
+                    (False, "cata/fooa:tcp -h 127.0.0.1 -p 12010"),
+                    (True, '"a funny id/that might mess it up" @ myadapter'),
+                    (
+                        False,
+                        '"a funny id/that might mess it up":tcp -h 127.0.0.1 -p 12010',
+                    ),
+                ],
+                [],
+            ),
         ]
 
         if not limitedTests:
-            testcases.extend([
-                ('testing reject all',
-                 ('', '*', '', '', '', ''),
-                 [(False, 'helloA:tcp -h %s -p 12010' % fqdn),
-                  (False, 'helloB:tcp -h %s -p 12010' % hostname),
-                  (False, 'helloC:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'bar @ foo')], []),
-                ('testing loopback only rule',
-                 ('127.0.0.1 localhost', '', '', '', '', ''),
-                 [(False, 'hello:tcp -h %s -p 12010' % fqdn),
-                  (False, 'hello:tcp -h %s -p 12010' % hostname),
-                  (False, '127.0.0.1:tcp -h %s -p 12010' % hostname),
-                  (False, 'localhost:tcp -h %s -p 12010' % hostname),
-                  (False, 'localhost/127.0.0.1:tcp -h %s -p 12010' % hostname),
-                  (True, 'localhost:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'localhost/127.0.0.1:tcp -h localhost -p 12010'),
-                  (True, 'hello:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'hello/somecat:tcp -h localhost -p 12010')], []),
-                ('testing port filter rule',
-                 ('127.0.0.1:12010 localhost:12010', '', '', '', '', ''),
-                 [(False, 'hello1:tcp -h 127.0.0.1 -p 12011'),
-                  (False, 'hello2:tcp -h localhost -p 12011'),
-                  (False, 'hello5:tcp -h %s -p 12010' % hostname),
-                  (True, 'hello3:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'hello4:tcp -h localhost -p 12010')], []),
-                ('testing reject port filter rule',
-                 ('', '127.0.0.1:[0-12009,12011-65535] localhost:[0-12009,12011-65535]', '', '', '', ''),
-                 [(False, 'hello1:tcp -h 127.0.0.1 -p 12011'),
-                  (False, 'hello2:tcp -h localhost -p 12011'),
-                  (True, 'hello5:tcp -h %s -p 12010' % hostname),
-                  (True, 'hello3:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'hello4:tcp -h localhost -p 12010')], []),
-                ('testing port filter rule with wildcard address rule',
-                 ('*:12010', '', '', '', '', ''),
-                 [(False, 'hello1:tcp -h 127.0.0.1 -p 12011'),
-                  (False, 'hello2:tcp -h localhost -p 12011'),
-                  (True, 'hello5:tcp -h %s -p 12010' % hostname),
-                  (True, 'hello3:tcp -h 127.0.0.1 -p 12010'),
-                  (True, 'hello4:tcp -h localhost -p 12010')], []),
-                ('testing domain filter rule (accept)',
-                 ("*" + domainname, '', '', '', '', ''),
-                 [(True, 'hello:tcp -h %s -p 12010' % fqdn),
-                  (False, 'hello:tcp -h %s -p 12010' % hostname)], []),
-                ('testing domain filter rule (reject)',
-                 ('', "*" + domainname, '', '', '', ''),
-                 [(False, 'hello:tcp -h %s -p 12010' % fqdn),
-                  (True, 'hello:tcp -h %s -p 12010' % hostname),
-                  (True, 'bar:tcp -h 127.0.0.1 -p 12010')], []),
-                ('testing domain filter rule (mixed)',
-                 ("127.0.0.1", fqdn, '', '', '', ''),
-                 [(False, 'hello:tcp -h %s -p 12010:tcp -h 127.0.0.1 -p 12010' % fqdn),
-                  (True, 'bar:tcp -h 127.0.0.1 -p 12010')], []),
-                ('testing maximum proxy length rule',
-                 ('', '', '53', '', '', ''),
-                 [(True, 'hello:tcp -h 127.0.0.1 -p 12010 -t infinite'),
-                  (False, '012345678901234567890123456789012345678901234567890123456789:tcp -h 127.0.0.1 -p 12010')], []),
-            ])
+            testcases.extend(
+                [
+                    (
+                        "testing reject all",
+                        ("", "*", "", "", "", ""),
+                        [
+                            (False, "helloA:tcp -h %s -p 12010" % fqdn),
+                            (False, "helloB:tcp -h %s -p 12010" % hostname),
+                            (False, "helloC:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "bar @ foo"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing loopback only rule",
+                        ("127.0.0.1 localhost", "", "", "", "", ""),
+                        [
+                            (False, "hello:tcp -h %s -p 12010" % fqdn),
+                            (False, "hello:tcp -h %s -p 12010" % hostname),
+                            (False, "127.0.0.1:tcp -h %s -p 12010" % hostname),
+                            (False, "localhost:tcp -h %s -p 12010" % hostname),
+                            (
+                                False,
+                                "localhost/127.0.0.1:tcp -h %s -p 12010" % hostname,
+                            ),
+                            (True, "localhost:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "localhost/127.0.0.1:tcp -h localhost -p 12010"),
+                            (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "hello/somecat:tcp -h localhost -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing port filter rule",
+                        ("127.0.0.1:12010 localhost:12010", "", "", "", "", ""),
+                        [
+                            (False, "hello1:tcp -h 127.0.0.1 -p 12011"),
+                            (False, "hello2:tcp -h localhost -p 12011"),
+                            (False, "hello5:tcp -h %s -p 12010" % hostname),
+                            (True, "hello3:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "hello4:tcp -h localhost -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing reject port filter rule",
+                        (
+                            "",
+                            "127.0.0.1:[0-12009,12011-65535] localhost:[0-12009,12011-65535]",
+                            "",
+                            "",
+                            "",
+                            "",
+                        ),
+                        [
+                            (False, "hello1:tcp -h 127.0.0.1 -p 12011"),
+                            (False, "hello2:tcp -h localhost -p 12011"),
+                            (True, "hello5:tcp -h %s -p 12010" % hostname),
+                            (True, "hello3:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "hello4:tcp -h localhost -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing port filter rule with wildcard address rule",
+                        ("*:12010", "", "", "", "", ""),
+                        [
+                            (False, "hello1:tcp -h 127.0.0.1 -p 12011"),
+                            (False, "hello2:tcp -h localhost -p 12011"),
+                            (True, "hello5:tcp -h %s -p 12010" % hostname),
+                            (True, "hello3:tcp -h 127.0.0.1 -p 12010"),
+                            (True, "hello4:tcp -h localhost -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing domain filter rule (accept)",
+                        ("*" + domainname, "", "", "", "", ""),
+                        [
+                            (True, "hello:tcp -h %s -p 12010" % fqdn),
+                            (False, "hello:tcp -h %s -p 12010" % hostname),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing domain filter rule (reject)",
+                        ("", "*" + domainname, "", "", "", ""),
+                        [
+                            (False, "hello:tcp -h %s -p 12010" % fqdn),
+                            (True, "hello:tcp -h %s -p 12010" % hostname),
+                            (True, "bar:tcp -h 127.0.0.1 -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing domain filter rule (mixed)",
+                        ("127.0.0.1", fqdn, "", "", "", ""),
+                        [
+                            (
+                                False,
+                                "hello:tcp -h %s -p 12010:tcp -h 127.0.0.1 -p 12010"
+                                % fqdn,
+                            ),
+                            (True, "bar:tcp -h 127.0.0.1 -p 12010"),
+                        ],
+                        [],
+                    ),
+                    (
+                        "testing maximum proxy length rule",
+                        ("", "", "53", "", "", ""),
+                        [
+                            (True, "hello:tcp -h 127.0.0.1 -p 12010 -t infinite"),
+                            (
+                                False,
+                                "012345678901234567890123456789012345678901234567890123456789:tcp -h 127.0.0.1 -p 12010",
+                            ),
+                        ],
+                        [],
+                    ),
+                ]
+            )
 
         if len(testcases) == 0:
-            current.writeln("WARNING: You are running this test with SSL disabled and the network ")
-            current.writeln("         configuration for this host does not permit the other tests ")
+            current.writeln(
+                "WARNING: You are running this test with SSL disabled and the network "
+            )
+            current.writeln(
+                "         configuration for this host does not permit the other tests "
+            )
             current.writeln("         to run correctly.")
         elif len(testcases) < 6:
-            current.writeln("WARNING: The network configuration for this host does not permit all ")
-            current.writeln("         tests to run correctly, some tests have been disabled.")
+            current.writeln(
+                "WARNING: The network configuration for this host does not permit all "
+            )
+            current.writeln(
+                "         tests to run correctly, some tests have been disabled."
+            )
 
         self.testcases = {}
         for testcase in testcases:
             self.addTestCase(Glacier2StaticFilteringTestCase(testcase, hostname))
 
 
-Glacier2StaticFilteringTestSuite(__name__, testcases=[], runOnMainThread=True,
-                                 options={"ipv6": [False]}, multihost=False)
+Glacier2StaticFilteringTestSuite(
+    __name__,
+    testcases=[],
+    runOnMainThread=True,
+    options={"ipv6": [False]},
+    multihost=False,
+)

--- a/cpp/test/Ice/echo/test.py
+++ b/cpp/test/Ice/echo/test.py
@@ -2,10 +2,15 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class EchoServerTestCase(ClientServerTestCase):
 
+from Util import ClientServerTestCase, Server, TestSuite
+
+
+class EchoServerTestCase(ClientServerTestCase):
     def __init__(self):
-        ClientServerTestCase.__init__(self, "server", server=Server(quiet=True, waitForShutdown=False))
+        ClientServerTestCase.__init__(
+            self, "server", server=Server(quiet=True, waitForShutdown=False)
+        )
 
     def runClientSide(self, current):
         pass

--- a/cpp/test/Ice/invoke/test.py
+++ b/cpp/test/Ice/invoke/test.py
@@ -2,7 +2,18 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-TestSuite(__file__,
-          [ClientServerTestCase(),
-           ClientServerTestCase(name="client/server array", servers=[Server(args=["--array"])]),
-           ClientServerTestCase(name="client/server async", servers=[Server(args=["--async"])])])
+from Util import ClientServerTestCase, TestSuite, Server
+
+
+TestSuite(
+    __file__,
+    [
+        ClientServerTestCase(),
+        ClientServerTestCase(
+            name="client/server array", servers=[Server(args=["--array"])]
+        ),
+        ClientServerTestCase(
+            name="client/server async", servers=[Server(args=["--async"])]
+        ),
+    ],
+)

--- a/cpp/test/Ice/library/test.py
+++ b/cpp/test/Ice/library/test.py
@@ -2,4 +2,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from Util import TestSuite
+
+
 TestSuite(__file__, libDirs=["gencode", "consumer", "alltests"])

--- a/cpp/test/Ice/logger/test.py
+++ b/cpp/test/Ice/logger/test.py
@@ -4,11 +4,21 @@
 #
 
 import glob
+import os
+import subprocess
+import sys
+
+from Util import Client, ClientTestCase, TestSuite, Windows, platform
 
 
 def test(process, current, match, enc, mapping):
     cmd = process.getCommandLine(current)
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=mapping.getEnv(process, current))
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=mapping.getEnv(process, current),
+    )
     out, err = p.communicate()
     ret = p.poll()
     if ret != 0:
@@ -18,9 +28,7 @@ def test(process, current, match, enc, mapping):
 
 
 class IceLoggerTestCase(ClientTestCase):
-
     def runClientSide(self, current):
-
         client1 = Client(exe="client1")
         client2 = Client(exe="client2")
         client3 = Client(exe="client3")
@@ -30,76 +38,98 @@ class IceLoggerTestCase(ClientTestCase):
         client1.run(current)
 
         sys.stdout.write("testing logger ISO-8859-15 output... ")
-        test(client2, current, b'aplicaci\xf3n', "ISO-8859-15", self.getMapping())
+        test(client2, current, b"aplicaci\xf3n", "ISO-8859-15", self.getMapping())
         print("ok")
 
         sys.stdout.write("testing logger UTF8 output without string converter... ")
-        test(client3, current, b'aplicaci\xc3\xb3n', "UTF8", self.getMapping())
+        test(client3, current, b"aplicaci\xc3\xb3n", "UTF8", self.getMapping())
         print("ok")
 
-        sys.stdout.write("testing logger UTF8 output with ISO-8859-15 narrow string converter... ")
+        sys.stdout.write(
+            "testing logger UTF8 output with ISO-8859-15 narrow string converter... "
+        )
         #
         # In Windows expected output is UTF8, because the console output code page is set to UTF-8
         # in Linux and OS X, the expected output is ISO-8859-15 because that is the narrow string
         # encoding used by the application.
         #
         if isinstance(platform, Windows):
-            test(client4, current, b'aplicaci\xc3\xb3n', "UTF8", self.getMapping())
+            test(client4, current, b"aplicaci\xc3\xb3n", "UTF8", self.getMapping())
         else:
-            test(client4, current, b'aplicaci\xf3n', "ISO-8859-15", self.getMapping())
+            test(client4, current, b"aplicaci\xf3n", "ISO-8859-15", self.getMapping())
         print("ok")
 
         sys.stdout.write("testing logger file rotation... ")
         self.clean()
 
         os.makedirs("log")
-        open("log/client5-4.log", 'a').close()
+        open("log/client5-4.log", "a").close()
 
         if isinstance(platform, Windows):
-            os.system("echo Y|cacls log /P \"%USERNAME%\":R 1> nul")
+            os.system('echo Y|cacls log /P "%USERNAME%":R 1> nul')
         else:
             os.system("chmod -w log")
 
         client5.run(current)
 
         if isinstance(platform, Windows):
-            os.system("echo Y|cacls log /P \"%USERNAME%\":F 1> nul")
+            os.system('echo Y|cacls log /P "%USERNAME%":F 1> nul')
         else:
             os.system("chmod +w log")
 
-        if (not os.path.isfile("client5-0.log") or
-            not os.stat("client5-0.log").st_size == 512 or
-                len(glob.glob("client5-0-*.log")) != 19):
+        if (
+            not os.path.isfile("client5-0.log")
+            or not os.stat("client5-0.log").st_size == 512
+            or len(glob.glob("client5-0-*.log")) != 19
+        ):
             raise RuntimeError("failed!")
 
         for f in glob.glob("client5-0-*.log"):
             if not os.stat(f).st_size == 512:
-                print("failed! file {0} size: {1} unexpected".format(f, os.stat(f).st_size))
+                print(
+                    "failed! file {0} size: {1} unexpected".format(
+                        f, os.stat(f).st_size
+                    )
+                )
                 sys.exit(1)
 
-        if (not os.path.isfile("client5-1.log") or
-            not os.stat("client5-1.log").st_size == 1024 or
-                len(glob.glob("client5-1-*.log")) != 0):
+        if (
+            not os.path.isfile("client5-1.log")
+            or not os.stat("client5-1.log").st_size == 1024
+            or len(glob.glob("client5-1-*.log")) != 0
+        ):
             raise RuntimeError("failed!")
 
-        if (not os.path.isfile("client5-2.log") or
-            not os.stat("client5-2.log").st_size == 128 or
-                len(glob.glob("client5-2-*.log")) != 7):
+        if (
+            not os.path.isfile("client5-2.log")
+            or not os.stat("client5-2.log").st_size == 128
+            or len(glob.glob("client5-2-*.log")) != 7
+        ):
             raise RuntimeError("failed!")
 
         for f in glob.glob("client5-2-*.log"):
             if not os.stat(f).st_size == 128:
-                print("failed! file {0} size: {1} unexpected".format(f, os.stat(f).st_size))
+                print(
+                    "failed! file {0} size: {1} unexpected".format(
+                        f, os.stat(f).st_size
+                    )
+                )
                 raise RuntimeError("failed!")
 
-        if (not os.path.isfile("client5-3.log") or
-            not os.stat("client5-2.log").st_size == 128 or
-                len(glob.glob("client5-2-*.log")) != 7):
+        if (
+            not os.path.isfile("client5-3.log")
+            or not os.stat("client5-2.log").st_size == 128
+            or len(glob.glob("client5-2-*.log")) != 7
+        ):
             raise RuntimeError("failed!")
 
         for f in glob.glob("client5-3-*.log"):
             if not os.stat(f).st_size == 128:
-                print("failed! file {0} size: {1} unexpected".format(f, os.stat(f).st_size))
+                print(
+                    "failed! file {0} size: {1} unexpected".format(
+                        f, os.stat(f).st_size
+                    )
+                )
                 raise RuntimeError("failed!")
 
         #
@@ -107,13 +137,20 @@ class IceLoggerTestCase(ClientTestCase):
         # root always has write access.
         #
         if isinstance(platform, Windows) or os.getuid() != 0:
-            if (not os.path.isfile("log/client5-4.log") or
-                os.stat("log/client5-4.log").st_size < 1024 or
-                    len(glob.glob("log/client5-4-*.log")) > 0):
+            if (
+                not os.path.isfile("log/client5-4.log")
+                or os.stat("log/client5-4.log").st_size < 1024
+                or len(glob.glob("log/client5-4-*.log")) > 0
+            ):
                 raise RuntimeError("failed!")
 
-            with open("log/client5-4.log", 'r') as f:
-                if f.read().count("error: FileLogger: cannot rename `log/client5-4.log'") != 1:
+            with open("log/client5-4.log", "r") as f:
+                if (
+                    f.read().count(
+                        "error: FileLogger: cannot rename `log/client5-4.log'"
+                    )
+                    != 1
+                ):
                     raise RuntimeError("failed!")
 
         print("ok")
@@ -126,7 +163,7 @@ class IceLoggerTestCase(ClientTestCase):
             os.remove(f)
         if os.path.exists("log"):
             if isinstance(platform, Windows):
-                os.system("echo Y|cacls log /P \"%USERNAME%\":F 1> nul")
+                os.system('echo Y|cacls log /P "%USERNAME%":F 1> nul')
             else:
                 os.system("chmod +w log")
             for f in glob.glob("log/client5-*.log"):

--- a/cpp/test/Ice/plugin/test.py
+++ b/cpp/test/Ice/plugin/test.py
@@ -2,6 +2,17 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-TestSuite(__file__,
-          [ClientTestCase(client=SimpleClient(args=lambda process, current: [current.getBuildDir("testplugin")]))],
-          libDirs=["testplugin"])
+from Util import ClientTestCase, SimpleClient, TestSuite
+
+
+TestSuite(
+    __file__,
+    [
+        ClientTestCase(
+            client=SimpleClient(
+                args=lambda process, current: [current.getBuildDir("testplugin")]
+            )
+        )
+    ],
+    libDirs=["testplugin"],
+)

--- a/cpp/test/Ice/threadPoolPriority/test.py
+++ b/cpp/test/Ice/threadPoolPriority/test.py
@@ -2,8 +2,18 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-if not isinstance(platform, Darwin) and (isinstance(platform, Windows) or os.getuid() == 0):
-    TestSuite(__file__, [
-        ClientServerTestCase(),
-        ClientServerTestCase(name="client/custom server", server="servercustom")
-    ], options={"mx": [False]})
+import os
+from Util import ClientServerTestCase, Darwin, TestSuite, Windows, platform
+
+
+if not isinstance(platform, Darwin) and (
+    isinstance(platform, Windows) or os.getuid() == 0
+):
+    TestSuite(
+        __file__,
+        [
+            ClientServerTestCase(),
+            ClientServerTestCase(name="client/custom server", server="servercustom"),
+        ],
+        options={"mx": [False]},
+    )

--- a/cpp/test/IceBridge/simple/test.py
+++ b/cpp/test/IceBridge/simple/test.py
@@ -3,4 +3,8 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from IceBridgeUtil import IceBridge
+from Util import ClientServerTestCase, Server, TestSuite
+
+
 TestSuite(__file__, [ClientServerTestCase(servers=[IceBridge(), Server()])])

--- a/cpp/test/IceGrid/activation/test.py
+++ b/cpp/test/IceGrid/activation/test.py
@@ -2,10 +2,21 @@
 #
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
-outfilters = [re.compile("cannot find the file specified"),
-              re.compile("warning: server activation failed"),
-              re.compile("cannot execute"),
-              re.compile("cannot change working directory")]
+import os
+import re
+from IceGridUtil import IceGridNode, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+outfilters = [
+    re.compile("cannot find the file specified"),
+    re.compile("warning: server activation failed"),
+    re.compile("cannot execute"),
+    re.compile("cannot change working directory"),
+]
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [IceGridTestCase(icegridnode=IceGridNode(outfilters=outfilters))], multihost=False)
+    TestSuite(
+        __file__,
+        [IceGridTestCase(icegridnode=IceGridNode(outfilters=outfilters))],
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -3,16 +3,27 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceGridAdminTestCase(IceGridTestCase):
 
+import os
+from Glacier2Util import Glacier2Router
+from IceGridUtil import IceGridAdmin, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
+class IceGridAdminTestCase(IceGridTestCase):
     def __init__(self):
         self.glacier2router = Glacier2Router(props=routerProps, waitForShutdown=False)
         IceGridTestCase.__init__(self, application=None, server=self.glacier2router)
 
     def runClientSide(self, current):
-
         def expect(admin, msg):
-            if admin.expect(current, ['error:', msg] if isinstance(msg, str) else ['error:'] + msg) == 0:
+            if (
+                admin.expect(
+                    current,
+                    ["error:", msg] if isinstance(msg, str) else ["error:"] + msg,
+                )
+                == 0
+            ):
                 raise RuntimeError(admin.getOutput(current))
 
         current.write("testing login with username/password... ")
@@ -20,41 +31,42 @@ class IceGridAdminTestCase(IceGridTestCase):
         admin = IceGridAdmin()
 
         admin.start(current)
-        expect(admin, '>>> ')
+        expect(admin, ">>> ")
         admin.sendline(current, "server list")
-        expect(admin, '>>> ')
-        admin.sendline(current, 'exit')
+        expect(admin, ">>> ")
+        admin.sendline(current, "exit")
         admin.stop(current, True)
 
-        defaultRouterProps = {"Ice.Default.Router": self.glacier2router.getClientProxy(current)}
+        defaultRouterProps = {
+            "Ice.Default.Router": self.glacier2router.getClientProxy(current)
+        }
 
         admin.start(current, props=defaultRouterProps)
-        expect(admin, '>>> ')
+        expect(admin, ">>> ")
         admin.sendline(current, "server list")
-        expect(admin, '>>> ')
-        admin.sendline(current, 'exit')
+        expect(admin, ">>> ")
+        admin.sendline(current, "exit")
         admin.stop(current, True)
 
         current.writeln("ok")
 
         if current.config.protocol == "ssl":
-
             current.write("testing login with ssl... ")
 
             # Direct registry connection with SSL
             admin.start(current, args=["--ssl"])
-            expect(admin, '>>> ')
+            expect(admin, ">>> ")
             admin.sendline(current, "server list")
-            expect(admin, '>>> ')
-            admin.sendline(current, 'exit')
+            expect(admin, ">>> ")
+            admin.sendline(current, "exit")
             admin.stop(current, True)
 
             # Glacier2 connection with username/password
             admin.start(current, args=["--ssl"], props=defaultRouterProps)
-            expect(admin, '>>> ')
+            expect(admin, ">>> ")
             admin.sendline(current, "server list")
-            expect(admin, '>>> ')
-            admin.sendline(current, 'exit')
+            expect(admin, ">>> ")
+            admin.sendline(current, "exit")
             admin.stop(current, True)
 
             current.writeln("ok")
@@ -64,88 +76,94 @@ class IceGridAdminTestCase(IceGridTestCase):
         try:
             serverDir = current.getBuildDir("server")
 
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application add application.xml server.dir=%s' % serverDir)
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application list')
-            expect(admin, 'Test')
-            admin.sendline(current, 'application describe Test')
-            expect(admin, 'application `Test\'')
-            expect(admin, '\\{.*\\}')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application diff application.xml server.dir=%s' % serverDir)
-            expect(admin, 'application `Test\'\n\\{.*\\}')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application update application.xml server.dir=%s' % serverDir)
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application patch Test')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server list')
-            expect(admin, 'server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server describe server')
-            expect(admin, 'server `server\'\n\\{.*\\}')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server start server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server state server')
-            expect(admin, '^active \\(.*\\)')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server pid server')
-            expect(admin, '[0-9]+')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server properties server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server property server Ice.Admin.ServerId')
+            expect(admin, ">>> ")
+            admin.sendline(
+                current, "application add application.xml server.dir=%s" % serverDir
+            )
+            expect(admin, ">>> ")
+            admin.sendline(current, "application list")
+            expect(admin, "Test")
+            admin.sendline(current, "application describe Test")
+            expect(admin, "application `Test'")
+            expect(admin, "\\{.*\\}")
+            expect(admin, ">>> ")
+            admin.sendline(
+                current, "application diff application.xml server.dir=%s" % serverDir
+            )
+            expect(admin, "application `Test'\n\\{.*\\}")
+            expect(admin, ">>> ")
+            admin.sendline(
+                current, "application update application.xml server.dir=%s" % serverDir
+            )
+            expect(admin, ">>> ")
+            admin.sendline(current, "application patch Test")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server list")
+            expect(admin, "server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server describe server")
+            expect(admin, "server `server'\n\\{.*\\}")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server start server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server state server")
+            expect(admin, "^active \\(.*\\)")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server pid server")
+            expect(admin, "[0-9]+")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server properties server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server property server Ice.Admin.ServerId")
             expect(admin, "^server")
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server patch server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server disable server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server enable server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'adapter list')
-            expect(admin, 'TestAdapter')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'adapter endpoints TestAdapter')
-            expect(admin, ['tcp', 'ssl', 'ws', 'wss'])
-            expect(admin, '>>> ')
-            admin.sendline(current, 'object list')
-            expect(admin, 'test')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'object describe')
-            expect(admin, 'proxy = `.*\' type = `.*\'')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'object find Test')
-            expect(admin, 'test')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'server stop server')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'application remove Test')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'registry list')
-            expect(admin, 'Master')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'registry ping Master')
-            expect(admin, 'registry is up')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'registry describe Master')
-            expect(admin, 'registry `Master\'\n{.*}')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'node list')
-            expect(admin, 'localnode')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'node describe localnode')
-            expect(admin, 'node `localnode\'\n{.*}')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'node load localnode')
-            expect(admin, 'load average.*\n')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'node ping localnode')
-            expect(admin, 'node is up')
-            expect(admin, '>>> ')
-            admin.sendline(current, 'exit')
+            expect(admin, ">>> ")
+            admin.sendline(current, "server patch server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server disable server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server enable server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "adapter list")
+            expect(admin, "TestAdapter")
+            expect(admin, ">>> ")
+            admin.sendline(current, "adapter endpoints TestAdapter")
+            expect(admin, ["tcp", "ssl", "ws", "wss"])
+            expect(admin, ">>> ")
+            admin.sendline(current, "object list")
+            expect(admin, "test")
+            expect(admin, ">>> ")
+            admin.sendline(current, "object describe")
+            expect(admin, "proxy = `.*' type = `.*'")
+            expect(admin, ">>> ")
+            admin.sendline(current, "object find Test")
+            expect(admin, "test")
+            expect(admin, ">>> ")
+            admin.sendline(current, "server stop server")
+            expect(admin, ">>> ")
+            admin.sendline(current, "application remove Test")
+            expect(admin, ">>> ")
+            admin.sendline(current, "registry list")
+            expect(admin, "Master")
+            expect(admin, ">>> ")
+            admin.sendline(current, "registry ping Master")
+            expect(admin, "registry is up")
+            expect(admin, ">>> ")
+            admin.sendline(current, "registry describe Master")
+            expect(admin, "registry `Master'\n{.*}")
+            expect(admin, ">>> ")
+            admin.sendline(current, "node list")
+            expect(admin, "localnode")
+            expect(admin, ">>> ")
+            admin.sendline(current, "node describe localnode")
+            expect(admin, "node `localnode'\n{.*}")
+            expect(admin, ">>> ")
+            admin.sendline(current, "node load localnode")
+            expect(admin, "load average.*\n")
+            expect(admin, ">>> ")
+            admin.sendline(current, "node ping localnode")
+            expect(admin, "node is up")
+            expect(admin, ">>> ")
+            admin.sendline(current, "exit")
             admin.stop(current, True)
             current.writeln("ok")
         except Exception as e:
@@ -153,15 +171,16 @@ class IceGridAdminTestCase(IceGridTestCase):
             raise RuntimeError("failed!\n" + str(e))
 
 
-def routerProps(process, current): return {
-    'Glacier2.SessionTimeout': 5,
-    'Glacier2.SessionManager': 'TestIceGrid/AdminSessionManager',
-    'Glacier2.PermissionsVerifier': 'Glacier2/NullPermissionsVerifier',
-    'Glacier2.SSLSessionManager': 'TestIceGrid/AdminSSLSessionManager',
-    'Glacier2.SSLPermissionsVerifier': 'Glacier2/NullSSLPermissionsVerifier',
-    'Ice.Default.Locator': current.testcase.getLocator(current),
-    'IceSSL.VerifyPeer': 1
-}
+def routerProps(process, current):
+    return {
+        "Glacier2.SessionTimeout": 5,
+        "Glacier2.SessionManager": "TestIceGrid/AdminSessionManager",
+        "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
+        "Glacier2.SSLSessionManager": "TestIceGrid/AdminSSLSessionManager",
+        "Glacier2.SSLPermissionsVerifier": "Glacier2/NullSSLPermissionsVerifier",
+        "Ice.Default.Locator": current.testcase.getLocator(current),
+        "IceSSL.VerifyPeer": 1,
+    }
 
 
 if isinstance(platform, Windows) or os.getuid() != 0:

--- a/cpp/test/IceGrid/allocation/test.py
+++ b/cpp/test/IceGrid/allocation/test.py
@@ -3,5 +3,15 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+import os
+from IceGridUtil import IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [IceGridTestCase(exevars={"verifier.dir": "verifier"})], runOnMainThread=True, multihost=False)
+    TestSuite(
+        __file__,
+        [IceGridTestCase(exevars={"verifier.dir": "verifier"})],
+        runOnMainThread=True,
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/deployer/test.py
+++ b/cpp/test/IceGrid/deployer/test.py
@@ -3,16 +3,32 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-def clientProps(process, current): return {"TestDir": current.getBuildDir("server")}
+
+import os
+from IceGridUtil import IceGridClient, IceGridNode, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
+def clientProps(process, current):
+    return {"TestDir": current.getBuildDir("server")}
 
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [
-        IceGridTestCase("without targets",
-                        icegridnode=IceGridNode(envs={"MY_FOO": 12}),
-                        client=IceGridClient(props=clientProps)),
-        IceGridTestCase("with targets",
-                        icegridnode=IceGridNode(envs={"MY_FOO": 12}),
-                        client=IceGridClient(props=clientProps),
-                        targets=["moreservers", "moreservices", "moreproperties"])
-    ], libDirs=["testservice"], multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridTestCase(
+                "without targets",
+                icegridnode=IceGridNode(envs={"MY_FOO": 12}),  # noqa: F821
+                client=IceGridClient(props=clientProps),
+            ),
+            IceGridTestCase(
+                "with targets",
+                icegridnode=IceGridNode(envs={"MY_FOO": 12}),
+                client=IceGridClient(props=clientProps),
+                targets=["moreservers", "moreservices", "moreproperties"],
+            ),
+        ],
+        libDirs=["testservice"],
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/distribution/test.py
+++ b/cpp/test/IceGrid/distribution/test.py
@@ -3,8 +3,14 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceGridDistributionTestCase(IceGridTestCase):
 
+import os
+from IceGridUtil import IceGridTestCase
+from IcePatch2Util import IcePatch2Calc
+from Util import TestSuite, Windows, platform
+
+
+class IceGridDistributionTestCase(IceGridTestCase):
     def setupClientSide(self, current):
         IceGridTestCase.setupClientSide(self, current)
 
@@ -28,7 +34,7 @@ class IceGridDistributionTestCase(IceGridTestCase):
             file = os.path.join(datadir, file)
             if not os.path.exists(os.path.dirname(file)):
                 os.makedirs(os.path.dirname(file))
-            f = open(file, 'w')
+            f = open(file, "w")
             f.write(content)
             f.close()
 
@@ -39,4 +45,6 @@ class IceGridDistributionTestCase(IceGridTestCase):
 
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [IceGridDistributionTestCase()], runOnMainThread=True, multihost=False)
+    TestSuite(
+        __file__, [IceGridDistributionTestCase()], runOnMainThread=True, multihost=False
+    )

--- a/cpp/test/IceGrid/fileLock/test.py
+++ b/cpp/test/IceGrid/fileLock/test.py
@@ -3,10 +3,14 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+
+import sys
+from IceGridUtil import IceGridRegistryMaster, IceGridTestCase
+from Util import TestSuite
+
+
 class IceGridAdminTestCase(IceGridTestCase):
-
     def runClientSide(self, current):
-
         sys.stdout.write("testing IceGrid file lock... ")
         registry = IceGridRegistryMaster(portnum=25, ready="", quiet=True)
         registry.start(current)
@@ -15,4 +19,9 @@ class IceGridAdminTestCase(IceGridTestCase):
         print("ok")
 
 
-TestSuite(__file__, [IceGridAdminTestCase(application=None)], runOnMainThread=True, multihost=False)
+TestSuite(
+    __file__,
+    [IceGridAdminTestCase(application=None)],
+    runOnMainThread=True,
+    multihost=False,
+)

--- a/cpp/test/IceGrid/noRestartUpdate/test.py
+++ b/cpp/test/IceGrid/noRestartUpdate/test.py
@@ -3,22 +3,35 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceGridNoRestartUpdateTestCase(IceGridTestCase):
 
+import os
+from IceBoxUtil import IceBox
+from IceGridUtil import IceGridClient, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
+class IceGridNoRestartUpdateTestCase(IceGridTestCase):
     def setupClientSide(self, current):
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node1")
         current.mkdirs("db/node2")
 
 
-def clientProps(process, current): return {
-    "IceBoxExe": IceBox().getCommandLine(current),
-    "ServerDir": current.getBuildDir("server"),
-    "ServiceDir": current.getBuildDir("testservice")
-}
+def clientProps(process, current):
+    return {
+        "IceBoxExe": IceBox().getCommandLine(current),
+        "ServerDir": current.getBuildDir("server"),
+        "ServiceDir": current.getBuildDir("testservice"),
+    }
 
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__,
-              [IceGridNoRestartUpdateTestCase(application=None, client=IceGridClient(props=clientProps))],
-              multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridNoRestartUpdateTestCase(
+                application=None, client=IceGridClient(props=clientProps)
+            )
+        ],
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/replicaGroup/test.py
+++ b/cpp/test/IceGrid/replicaGroup/test.py
@@ -3,9 +3,14 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+import os
+from IceGridUtil import IceGridClient, IceGridRegistryMaster, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
 registryProps = {
     "Ice.Plugin.RegistryPlugin": "RegistryPlugin:createRegistryPlugin",
-    "IceGrid.Registry.DynamicRegistration": 1
+    "IceGrid.Registry.DynamicRegistration": 1,
 }
 registryTraceProps = {
     "IceGrid.Registry.Trace.Locator": 2,
@@ -15,17 +20,22 @@ registryTraceProps = {
     "Ice.Trace.Protocol": 1,
 }
 
-clientProps = {
-    "Ice.RetryIntervals": "0 50 100 250"
-}
-clientTraceProps = {
-    "Ice.Trace.Locator": 2,
-    "Ice.Trace.Protocol": 1
-}
+clientProps = {"Ice.RetryIntervals": "0 50 100 250"}
+clientTraceProps = {"Ice.Trace.Locator": 2, "Ice.Trace.Protocol": 1}
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__,
-              [IceGridTestCase(icegridregistry=[IceGridRegistryMaster(props=registryProps, traceProps=registryTraceProps)],
-                               client=IceGridClient(props=clientProps, traceProps=clientTraceProps))],
-              libDirs=["registryplugin", "testservice"],
-              multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridTestCase(
+                icegridregistry=[
+                    IceGridRegistryMaster(
+                        props=registryProps, traceProps=registryTraceProps
+                    )
+                ],
+                client=IceGridClient(props=clientProps, traceProps=clientTraceProps),
+            )
+        ],
+        libDirs=["registryplugin", "testservice"],
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/replication/test.py
+++ b/cpp/test/IceGrid/replication/test.py
@@ -3,7 +3,14 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-def clientProps(process, current): return {"ServerDir": current.getBuildDir("server")}
+
+import os
+from IceGridUtil import IceGridClient, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
+def clientProps(process, current):
+    return {"ServerDir": current.getBuildDir("server")}
 
 
 # Enable some tracing to allow investigating test failures
@@ -11,11 +18,17 @@ traceProps = {
     "Ice.Trace.Network": 2,
     "Ice.Trace.Retry": 1,
     "Ice.Trace.Protocol": 1,
-    "Ice.ACM.Client.Heartbeat": 2
+    "Ice.ACM.Client.Heartbeat": 2,
 }
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__,
-              [IceGridTestCase(client=IceGridClient(props=clientProps, traceProps=traceProps))],
-              runOnMainThread=True,
-              multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridTestCase(
+                client=IceGridClient(props=clientProps, traceProps=traceProps)
+            )
+        ],
+        runOnMainThread=True,
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/session/test.py
+++ b/cpp/test/IceGrid/session/test.py
@@ -3,16 +3,28 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceGridSessionTestCase(IceGridTestCase):
 
+import os
+from IceGridUtil import (
+    IceGridClient,
+    IceGridNode,
+    IceGridRegistryMaster,
+    IceGridTestCase,
+)
+from Util import Server, TestSuite, Windows, platform
+
+
+class IceGridSessionTestCase(IceGridTestCase):
     def setupClientSide(self, current):
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node-1")
 
     def setupServerSide(self, current):
-        self.verifier = Server(exe="verifier", waitForShutdown=False, props={
-            "PermissionsVerifier.Endpoints": "tcp -p 12002"
-        })
+        self.verifier = Server(
+            exe="verifier",
+            waitForShutdown=False,
+            props={"PermissionsVerifier.Endpoints": "tcp -p 12002"},
+        )
         current.write("starting permission verifier... ")
         self.verifier.start(current)
         current.writeln("ok")
@@ -23,38 +35,51 @@ class IceGridSessionTestCase(IceGridTestCase):
 
 
 registryProps = {
-    'Ice.Warn.Dispatch': '0',
-    'IceGrid.Registry.DynamicRegistration': True,
-    'IceGrid.Registry.SessionFilters': True,
-    'IceGrid.Registry.AdminSessionFilters': True,
-    'IceGrid.Registry.PermissionsVerifier': 'ClientPermissionsVerifier',
-    'IceGrid.Registry.AdminPermissionsVerifier': 'AdminPermissionsVerifier:tcp -p 12002',
-    'IceGrid.Registry.SSLPermissionsVerifier': 'SSLPermissionsVerifier',
-    'IceGrid.Registry.AdminSSLPermissionsVerifier': 'SSLPermissionsVerifier',
+    "Ice.Warn.Dispatch": "0",
+    "IceGrid.Registry.DynamicRegistration": True,
+    "IceGrid.Registry.SessionFilters": True,
+    "IceGrid.Registry.AdminSessionFilters": True,
+    "IceGrid.Registry.PermissionsVerifier": "ClientPermissionsVerifier",
+    "IceGrid.Registry.AdminPermissionsVerifier": "AdminPermissionsVerifier:tcp -p 12002",
+    "IceGrid.Registry.SSLPermissionsVerifier": "SSLPermissionsVerifier",
+    "IceGrid.Registry.AdminSSLPermissionsVerifier": "SSLPermissionsVerifier",
 }
 
 
-def clientProps(process, current): return {
-    "IceGridNodeExe": IceGridNode().getCommandLine(current),
-    "ServerDir": current.getBuildDir("server"),
-    "TestDir": "{testdir}",
-}
+def clientProps(process, current):
+    return {
+        "IceGridNodeExe": IceGridNode().getCommandLine(current),
+        "ServerDir": current.getBuildDir("server"),
+        "TestDir": "{testdir}",
+    }
 
 
-def clientProps10(process, current): return {
-    "IceGridNodeExe": IceGridNode().getCommandLine(current),
-    "ServerDir": current.getBuildDir("server"),
-    "TestDir": "{testdir}",
-    "Ice.Default.EncodingVersion": "1.0"
-}
+def clientProps10(process, current):
+    return {
+        "IceGridNodeExe": IceGridNode().getCommandLine(current),
+        "ServerDir": current.getBuildDir("server"),
+        "TestDir": "{testdir}",
+        "Ice.Default.EncodingVersion": "1.0",
+    }
 
 
 icegridregistry = [IceGridRegistryMaster(props=registryProps)]
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__,
-              [IceGridSessionTestCase("with default encoding", icegridregistry=icegridregistry,
-                                      client=IceGridClient(props=clientProps)),
-               IceGridSessionTestCase("with 1.0 encoding", icegridregistry=icegridregistry,
-                                      client=IceGridClient(props=clientProps10))],
-              runOnMainThread=True, multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridSessionTestCase(
+                "with default encoding",
+                icegridregistry=icegridregistry,
+                client=IceGridClient(props=clientProps),
+            ),
+            IceGridSessionTestCase(
+                "with 1.0 encoding",
+                icegridregistry=icegridregistry,
+                client=IceGridClient(props=clientProps10),
+            ),
+        ],
+        runOnMainThread=True,
+        multihost=False,
+    )

--- a/cpp/test/IceGrid/update/test.py
+++ b/cpp/test/IceGrid/update/test.py
@@ -3,23 +3,39 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceGridUpdateTestCase(IceGridTestCase):
 
+import os
+from IceBoxUtil import IceBox
+from IceGridUtil import IceGridClient, IceGridNode, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
+class IceGridUpdateTestCase(IceGridTestCase):
     def setupClientSide(self, current):
         IceGridTestCase.setupClientSide(self, current)
         current.mkdirs("db/node-1")
         current.mkdirs("db/node-2")
 
 
-def clientProps(process, current): return {
-    "NodePropertiesOverride": current.testcase.icegridnode[0].getPropertiesOverride(current),
-    "IceBoxExe": IceBox().getCommandLine(current),
-    "IceGridNodeExe": IceGridNode().getCommandLine(current),
-    "ServerDir": current.getBuildDir("server"),
-    "TestDir": "{testdir}"
-}
+def clientProps(process, current):
+    return {
+        "NodePropertiesOverride": current.testcase.icegridnode[0].getPropertiesOverride(
+            current
+        ),
+        "IceBoxExe": IceBox().getCommandLine(current),
+        "IceGridNodeExe": IceGridNode().getCommandLine(current),
+        "ServerDir": current.getBuildDir("server"),
+        "TestDir": "{testdir}",
+    }
 
 
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [IceGridUpdateTestCase(application=None,
-              client=IceGridClient(props=clientProps))], multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridUpdateTestCase(
+                application=None, client=IceGridClient(props=clientProps)
+            )
+        ],
+        multihost=False,
+    )

--- a/cpp/test/IceSSL/certs/makecerts.py
+++ b/cpp/test/IceSSL/certs/makecerts.py
@@ -5,14 +5,15 @@
 
 import os
 import sys
-import socket
 import getopt
 
 try:
     import IceCertUtils
-except:
-    print("error: couldn't find IceCertUtils, install `zeroc-icecertutils' package "
-          "from Python package repository")
+except ImportError:
+    print(
+        "error: couldn't find IceCertUtils, install `zeroc-icecertutils' package "
+        "from Python package repository"
+    )
     sys.exit(1)
 
 if not IceCertUtils.CertificateUtils.opensslSupport:
@@ -51,7 +52,7 @@ except getopt.GetoptError as e:
     usage()
     sys.exit(1)
 
-for (o, a) in opts:
+for o, a in opts:
     if o == "-h" or o == "--help":
         usage()
         sys.exit(0)
@@ -82,16 +83,24 @@ if clean:
 # Create 2 CAs, the DSA ca is actually ca1 but with a different the DSA key generation algorithm.
 # ca2 is also used as a server. The serverAuth extension is required on some OSs (macOS Catalina)
 #
-ca1 = IceCertUtils.CertificateFactory(home=homeca1, cn="ZeroC Test CA 1", ip="127.0.0.1", email="issuer@zeroc.com")
-ca2 = IceCertUtils.CertificateFactory(home=homeca2, cn="ZeroC Test CA 2", ip="127.0.0.1", email="issuer@zeroc.com",
-                                      extendedKeyUsage="serverAuth")
+ca1 = IceCertUtils.CertificateFactory(
+    home=homeca1, cn="ZeroC Test CA 1", ip="127.0.0.1", email="issuer@zeroc.com"
+)
+ca2 = IceCertUtils.CertificateFactory(
+    home=homeca2,
+    cn="ZeroC Test CA 2",
+    ip="127.0.0.1",
+    email="issuer@zeroc.com",
+    extendedKeyUsage="serverAuth",
+)
 # CA3 include CRL distribution points
 ca3 = IceCertUtils.CertificateFactory(
     home=homeca3,
     cn="ZeroC Test CA 3",
     ip="127.0.0.1",
     email="issuer@zeroc.com",
-    crlDistributionPoints="http://127.0.0.1:20001/ca3.crl.pem")
+    crlDistributionPoints="http://127.0.0.1:20001/ca3.crl.pem",
+)
 
 # CA4 include AIA extension
 ca4 = IceCertUtils.CertificateFactory(
@@ -100,14 +109,22 @@ ca4 = IceCertUtils.CertificateFactory(
     ip="127.0.0.1",
     email="issuer@zeroc.com",
     ocspResponder="http://127.0.0.1:20002",
-    caIssuers="http://127.0.0.1:20001/cacert4.der")
+    caIssuers="http://127.0.0.1:20001/cacert4.der",
+)
 
-dsaca = IceCertUtils.OpenSSLCertificateFactory(home=ca1.home, keyalg="dsa", keysize=2048)
+dsaca = IceCertUtils.OpenSSLCertificateFactory(
+    home=ca1.home, keyalg="dsa", keysize=2048
+)
 
 #
 # Export CA certificates
 #
-for ca, name in [(ca1, "cacert1"), (ca2, "cacert2"), (ca3, "cacert3"), (ca4, "cacert4")]:
+for ca, name in [
+    (ca1, "cacert1"),
+    (ca2, "cacert2"),
+    (ca3, "cacert3"),
+    (ca4, "cacert4"),
+]:
     pem = "{}.pem".format(name)
     if force or not os.path.exists(pem):
         ca.getCA().save(pem)
@@ -139,17 +156,23 @@ if force or not os.path.exists("cacert2.p12"):
 # Create intermediate CAs
 cai1 = ca1.getIntermediateFactory("intermediate1")
 if not cai1:
-    cai1 = ca1.createIntermediateFactory("intermediate1", cn="ZeroC Test Intermediate CA 1")
+    cai1 = ca1.createIntermediateFactory(
+        "intermediate1", cn="ZeroC Test Intermediate CA 1"
+    )
 
 cai2 = cai1.getIntermediateFactory("intermediate1")
 if not cai2:
-    cai2 = cai1.createIntermediateFactory("intermediate1", cn="ZeroC Test Intermediate CA 2")
+    cai2 = cai1.createIntermediateFactory(
+        "intermediate1", cn="ZeroC Test Intermediate CA 2"
+    )
 
 cai3 = ca3.getIntermediateFactory("intermediate1")
 if not cai3:
-    cai3 = ca3.createIntermediateFactory("intermediate1",
-                                         cn="ZeroC Test Intermediate CA 3",
-                                         crlDistributionPoints="http://127.0.0.1:20001/cai3.crl.pem")
+    cai3 = ca3.createIntermediateFactory(
+        "intermediate1",
+        cn="ZeroC Test Intermediate CA 3",
+        crlDistributionPoints="http://127.0.0.1:20001/cai3.crl.pem",
+    )
 
 if force or not os.path.exists("cai3.pem"):
     cai3.getCA().save("cai3.pem")
@@ -158,10 +181,12 @@ if force or not os.path.exists("cai3.der"):
 
 cai4 = ca4.getIntermediateFactory("intermediate1")
 if not cai4:
-    cai4 = ca4.createIntermediateFactory("intermediate1",
-                                         cn="ZeroC Test Intermediate CA 4",
-                                         ocspResponder="http://127.0.0.1:20002",
-                                         caIssuers="http://127.0.0.1:20001/cai4.der")
+    cai4 = ca4.createIntermediateFactory(
+        "intermediate1",
+        cn="ZeroC Test Intermediate CA 4",
+        ocspResponder="http://127.0.0.1:20002",
+        caIssuers="http://127.0.0.1:20001/cai4.der",
+    )
 
 if force or not os.path.exists("cai4.pem"):
     cai4.getCA().save("cai4.pem")
@@ -172,23 +197,57 @@ if force or not os.path.exists("cai4.der"):
 # Create certificates (CA, alias, { creation parameters passed to ca.create(...) })
 #
 certs = [
-    (ca1, "s_rsa_ca1", {"cn": "Server", "ip": "127.0.0.1", "dns": "server", "serial": 1}),
-    (ca1, "c_rsa_ca1", {"cn": "Client", "ip": "127.0.0.1", "dns": "client", "serial": 2}),
+    (
+        ca1,
+        "s_rsa_ca1",
+        {"cn": "Server", "ip": "127.0.0.1", "dns": "server", "serial": 1},
+    ),
+    (
+        ca1,
+        "c_rsa_ca1",
+        {"cn": "Client", "ip": "127.0.0.1", "dns": "client", "serial": 2},
+    ),
     (ca1, "s_rsa_ca1_exp", {"cn": "Server", "validity": -1}),  # Expired certificate
     (ca1, "c_rsa_ca1_exp", {"cn": "Client", "validity": -1}),  # Expired certificate
-
-    (ca1, "s_rsa_ca1_cn1", {"cn": "Server", "dns": "localhost"}),       # DNS subjectAltName localhost
-    (ca1, "s_rsa_ca1_cn2", {"cn": "Server", "dns": "localhostXX"}),     # DNS subjectAltName localhostXX
-    (ca1, "s_rsa_ca1_cn3", {"cn": "localhost"}),                        # No subjectAltName, CN=localhost
-    (ca1, "s_rsa_ca1_cn4", {"cn": "localhostXX"}),                      # No subjectAltName, CN=localhostXX
-    (ca1, "s_rsa_ca1_cn5", {"cn": "localhost", "dns": "localhostXX"}),  # DNS subjectAltName localhostXX, CN=localhost
-    (ca1, "s_rsa_ca1_cn6", {"cn": "Server", "ip": "127.0.0.1"}),        # IP subjectAltName 127.0.0.1
-    (ca1, "s_rsa_ca1_cn7", {"cn": "Server", "ip": "127.0.0.2"}),        # IP subjectAltName 127.0.0.2
-    (ca1, "s_rsa_ca1_cn8", {"cn": "127.0.0.1"}),                        # No subjectAltName, CN=127.0.0.1
+    (
+        ca1,
+        "s_rsa_ca1_cn1",
+        {"cn": "Server", "dns": "localhost"},
+    ),  # DNS subjectAltName localhost
+    (
+        ca1,
+        "s_rsa_ca1_cn2",
+        {"cn": "Server", "dns": "localhostXX"},
+    ),  # DNS subjectAltName localhostXX
+    (ca1, "s_rsa_ca1_cn3", {"cn": "localhost"}),  # No subjectAltName, CN=localhost
+    (ca1, "s_rsa_ca1_cn4", {"cn": "localhostXX"}),  # No subjectAltName, CN=localhostXX
+    (
+        ca1,
+        "s_rsa_ca1_cn5",
+        {"cn": "localhost", "dns": "localhostXX"},
+    ),  # DNS subjectAltName localhostXX, CN=localhost
+    (
+        ca1,
+        "s_rsa_ca1_cn6",
+        {"cn": "Server", "ip": "127.0.0.1"},
+    ),  # IP subjectAltName 127.0.0.1
+    (
+        ca1,
+        "s_rsa_ca1_cn7",
+        {"cn": "Server", "ip": "127.0.0.2"},
+    ),  # IP subjectAltName 127.0.0.2
+    (ca1, "s_rsa_ca1_cn8", {"cn": "127.0.0.1"}),  # No subjectAltName, CN=127.0.0.1
     (ca1, "s_rsa_ca1_cn9", {"cn": "127.0.0.1", "ip": ["127.0.0.1", "::1"]}),
     (ca1, "s_rsa_ca1_cn10", {"cn": "127.0.0.1", "dns": ["host1", "host2"]}),
-    (ca1, "s_rsa_ca1_cn11", {"cn": "127.0.0.1", "ip": ["127.0.0.1", "127.0.0.2"], "dns": ["host1", "host2"]}),
-
+    (
+        ca1,
+        "s_rsa_ca1_cn11",
+        {
+            "cn": "127.0.0.1",
+            "ip": ["127.0.0.1", "127.0.0.2"],
+            "dns": ["host1", "host2"],
+        },
+    ),
     (ca2, "s_rsa_ca2", {"cn": "Server", "ip": "127.0.0.1", "dns": "server"}),
     (ca2, "c_rsa_ca2", {"cn": "Client", "ip": "127.0.0.1", "dns": "client"}),
     (dsaca, "s_dsa_ca1", {"cn": "Server", "ip": "127.0.0.1", "dns": "server"}),  # DSA
@@ -196,39 +255,79 @@ certs = [
     (cai1, "s_rsa_cai1", {"cn": "Server", "ip": "127.0.0.1", "dns": "server"}),
     (cai2, "s_rsa_cai2", {"cn": "Server", "ip": "127.0.0.1", "dns": "server"}),
     (cai2, "c_rsa_cai2", {"cn": "Client", "ip": "127.0.0.1", "dns": "client"}),
-
     # Certificates with CRL distribution points
     (ca3, "s_rsa_ca3", {"cn": "Server", "ip": "127.0.0.1", "dns": "server"}),
     (ca3, "c_rsa_ca3", {"cn": "Client", "ip": "127.0.0.1", "dns": "client"}),
-    (ca3, "s_rsa_ca3_revoked", {"cn": "Server ca3 revoked", "ip": "127.0.0.1", "dns": "server"}),
-    (ca3, "c_rsa_ca3_revoked", {"cn": "Client ca3 revoked", "ip": "127.0.0.1", "dns": "client"}),
-
+    (
+        ca3,
+        "s_rsa_ca3_revoked",
+        {"cn": "Server ca3 revoked", "ip": "127.0.0.1", "dns": "server"},
+    ),
+    (
+        ca3,
+        "c_rsa_ca3_revoked",
+        {"cn": "Client ca3 revoked", "ip": "127.0.0.1", "dns": "client"},
+    ),
     (cai3, "s_rsa_cai3", {"cn": "Server cai3", "ip": "127.0.0.1", "dns": "server"}),
     (cai3, "c_rsa_cai3", {"cn": "Client cai3", "ip": "127.0.0.1", "dns": "client"}),
-    (cai3, "s_rsa_cai3_revoked", {"cn": "Server cai3 revoked", "ip": "127.0.0.1", "dns": "server"}),
-    (cai3, "c_rsa_cai3_revoked", {"cn": "Client cai3 revoked", "ip": "127.0.0.1", "dns": "client"}),
-
+    (
+        cai3,
+        "s_rsa_cai3_revoked",
+        {"cn": "Server cai3 revoked", "ip": "127.0.0.1", "dns": "server"},
+    ),
+    (
+        cai3,
+        "c_rsa_cai3_revoked",
+        {"cn": "Client cai3 revoked", "ip": "127.0.0.1", "dns": "client"},
+    ),
     # Certificates with AIA extension
     (ca4, "s_rsa_ca4", {"cn": "Server ca4", "ip": "127.0.0.1", "dns": "server"}),
     (ca4, "c_rsa_ca4", {"cn": "Client ca4", "ip": "127.0.0.1", "dns": "client"}),
-    (ca4, "s_rsa_ca4_revoked", {"cn": "Server ca4 revoked", "ip": "127.0.0.1", "dns": "server"}),
-    (ca4, "c_rsa_ca4_revoked", {"cn": "Client ca4 revoked", "ip": "127.0.0.1", "dns": "client"}),
+    (
+        ca4,
+        "s_rsa_ca4_revoked",
+        {"cn": "Server ca4 revoked", "ip": "127.0.0.1", "dns": "server"},
+    ),
+    (
+        ca4,
+        "c_rsa_ca4_revoked",
+        {"cn": "Client ca4 revoked", "ip": "127.0.0.1", "dns": "client"},
+    ),
     # The OCSP responder doesn't know about this certs
-    (ca4, "s_rsa_ca4_unknown", {"cn": "Server ca4 unknown", "ip": "127.0.0.1", "dns": "server"}),
-    (ca4, "c_rsa_ca4_unknown", {"cn": "Client ca4 unknown", "ip": "127.0.0.1", "dns": "client"}),
-
+    (
+        ca4,
+        "s_rsa_ca4_unknown",
+        {"cn": "Server ca4 unknown", "ip": "127.0.0.1", "dns": "server"},
+    ),
+    (
+        ca4,
+        "c_rsa_ca4_unknown",
+        {"cn": "Client ca4 unknown", "ip": "127.0.0.1", "dns": "client"},
+    ),
     (cai4, "s_rsa_cai4", {"cn": "Server cai4", "ip": "127.0.0.1", "dns": "server"}),
     (cai4, "c_rsa_cai4", {"cn": "Client cai4", "ip": "127.0.0.1", "dns": "client"}),
-    (cai4, "s_rsa_cai4_revoked", {"cn": "Server cai4 revoked", "ip": "127.0.0.1", "dns": "server"}),
-    (cai4, "c_rsa_cai4_revoked", {"cn": "Client cai4 revoked", "ip": "127.0.0.1", "dns": "client"}),
+    (
+        cai4,
+        "s_rsa_cai4_revoked",
+        {"cn": "Server cai4 revoked", "ip": "127.0.0.1", "dns": "server"},
+    ),
+    (
+        cai4,
+        "c_rsa_cai4_revoked",
+        {"cn": "Client cai4 revoked", "ip": "127.0.0.1", "dns": "client"},
+    ),
 ]
 
 #
 # Create the certificates
 #
-for (ca, alias, args) in certs:
+for ca, alias, args in certs:
     if not ca.get(alias):
-        ca.create(alias, extendedKeyUsage="clientAuth" if alias.startswith("c_") else "serverAuth", **args)
+        ca.create(
+            alias,
+            extendedKeyUsage="clientAuth" if alias.startswith("c_") else "serverAuth",
+            **args,
+        )
 
 # Additional certs for extended key usage testing
 certs = [
@@ -239,10 +338,15 @@ certs = [
     (ca1, "rsa_ca1_emailProtection", "emailProtection", {"cn": "Email Protection"}),
     (ca1, "rsa_ca1_timeStamping", "timeStamping", {"cn": "Time Stamping"}),
     (ca1, "rsa_ca1_ocspSigning", "OCSPSigning", {"cn": "OCSP Signing"}),
-    (ca1, "rsa_ca1_anyExtendedKeyUsage", "anyExtendedKeyUsage", {"cn": "Any Extended Key Usage"})
+    (
+        ca1,
+        "rsa_ca1_anyExtendedKeyUsage",
+        "anyExtendedKeyUsage",
+        {"cn": "Any Extended Key Usage"},
+    ),
 ]
 
-for (ca, alias, extendedKeyUsage, args) in certs:
+for ca, alias, extendedKeyUsage, args in certs:
     if not ca.get(alias):
         ca.create(alias, extendedKeyUsage=extendedKeyUsage, **args)
 
@@ -262,7 +366,6 @@ savecerts = [
     (ca1, "s_rsa_ca1_cn9", None, {}),
     (ca1, "s_rsa_ca1_cn10", None, {}),
     (ca1, "s_rsa_ca1_cn11", None, {}),
-
     (ca1, "rsa_ca1_none", None, {}),
     (ca1, "rsa_ca1_serverAuth", None, {}),
     (ca1, "rsa_ca1_clientAuth", None, {}),
@@ -271,7 +374,6 @@ savecerts = [
     (ca1, "rsa_ca1_timeStamping", None, {}),
     (ca1, "rsa_ca1_ocspSigning", None, {}),
     (ca1, "rsa_ca1_anyExtendedKeyUsage", None, {}),
-
     (ca2, "s_rsa_ca2", None, {}),
     (ca2, "c_rsa_ca2", None, {}),
     (dsaca, "s_dsa_ca1", None, {}),
@@ -282,24 +384,20 @@ savecerts = [
     (ca1, "s_rsa_ca1", "s_rsa_wroot_ca1", {"root": True}),
     (ca1, "s_rsa_ca1", "s_rsa_pass_ca1", {"password": "server"}),
     (ca1, "c_rsa_ca1", "c_rsa_pass_ca1", {"password": "client"}),
-
     (ca3, "s_rsa_ca3", None, {}),
     (ca3, "c_rsa_ca3", None, {}),
     (ca3, "s_rsa_ca3_revoked", None, {}),
     (ca3, "c_rsa_ca3_revoked", None, {}),
-
     (cai3, "s_rsa_cai3", None, {}),
     (cai3, "c_rsa_cai3", None, {}),
     (cai3, "s_rsa_cai3_revoked", None, {}),
     (cai3, "c_rsa_cai3_revoked", None, {}),
-
     (ca4, "s_rsa_ca4", None, {}),
     (ca4, "c_rsa_ca4", None, {}),
     (ca4, "s_rsa_ca4_revoked", None, {}),
     (ca4, "c_rsa_ca4_revoked", None, {}),
     (ca4, "s_rsa_ca4_unknown", None, {}),
     (ca4, "c_rsa_ca4_unknown", None, {}),
-
     (cai4, "s_rsa_cai4", None, {}),
     (cai4, "c_rsa_cai4", None, {}),
     (cai4, "s_rsa_cai4_revoked", None, {}),
@@ -309,7 +407,7 @@ savecerts = [
 #
 # Save the certificates in PEM and PKCS12 format.
 #
-for (ca, alias, path, args) in savecerts:
+for ca, alias, path, args in savecerts:
     if not path:
         path = alias
     password = args.get("password", None)
@@ -333,8 +431,10 @@ for size in [512, 1024]:
 # Create certificate with custom extensions
 #
 if not os.path.exists("cacert_custom.pem"):
-    commands = ["openssl req -new -key cakey1.pem -out cacert_custom.csr -config cacert_custom.req",
-                "openssl x509 -req -in cacert_custom.csr -signkey cakey1.pem -out cacert_custom.pem -extfile cacert_custom.ext"]
+    commands = [
+        "openssl req -new -key cakey1.pem -out cacert_custom.csr -config cacert_custom.req",
+        "openssl x509 -req -in cacert_custom.csr -signkey cakey1.pem -out cacert_custom.pem -extfile cacert_custom.ext",
+    ]
     for command in commands:
         if os.system(command) != 0:
             print("error running command `{0}'".format(command))
@@ -362,27 +462,43 @@ def revokeCertificates(ca, cadir, certs):
 
     commands = []
     for cert in certs:
-        commands.append("openssl ca -config {ca}.cnf -revoke {cadir}/{cert} -passin pass:password".format(
-            ca=ca,
-            cadir=cadir,
-            cert=cert))
+        commands.append(
+            "openssl ca -config {ca}.cnf -revoke {cadir}/{cert} -passin pass:password".format(
+                ca=ca, cadir=cadir, cert=cert
+            )
+        )
 
     commands.append(
-        "openssl ca -config {ca}.cnf -gencrl -out {ca}.crl.pem -crldays 825 -passin pass:password".format(ca=ca))
+        "openssl ca -config {ca}.cnf -gencrl -out {ca}.crl.pem -crldays 825 -passin pass:password".format(
+            ca=ca
+        )
+    )
     runCommands(commands)
 
 
 crlfile = "ca.crl.pem"
 if force or not os.path.exists(crlfile):
-    revokeCertificates("ca3", "db/ca3", ["s_rsa_ca3_revoked.pem",
-                                         "c_rsa_ca3_revoked.pem",
-                                         "intermediate1/ca.pem"])
-    revokeCertificates("cai3", "db/ca3/intermediate1", ["s_rsa_cai3_revoked.pem", "c_rsa_cai3_revoked.pem"])
+    revokeCertificates(
+        "ca3",
+        "db/ca3",
+        ["s_rsa_ca3_revoked.pem", "c_rsa_ca3_revoked.pem", "intermediate1/ca.pem"],
+    )
+    revokeCertificates(
+        "cai3",
+        "db/ca3/intermediate1",
+        ["s_rsa_cai3_revoked.pem", "c_rsa_cai3_revoked.pem"],
+    )
 
-    revokeCertificates("ca4", "db/ca4", ["s_rsa_ca4_revoked.pem",
-                                         "c_rsa_ca4_revoked.pem",
-                                         "intermediate1/ca.pem"])
-    revokeCertificates("cai4", "db/ca4/intermediate1", ["s_rsa_cai4_revoked.pem", "c_rsa_cai4_revoked.pem"])
+    revokeCertificates(
+        "ca4",
+        "db/ca4",
+        ["s_rsa_ca4_revoked.pem", "c_rsa_ca4_revoked.pem", "intermediate1/ca.pem"],
+    )
+    revokeCertificates(
+        "cai4",
+        "db/ca4/intermediate1",
+        ["s_rsa_cai4_revoked.pem", "c_rsa_cai4_revoked.pem"],
+    )
 
     # Concatenate CRL files
     if os.path.exists(crlfile):

--- a/cpp/test/IceStorm/federation/test.py
+++ b/cpp/test/IceStorm/federation/test.py
@@ -3,10 +3,16 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-class IceStormFederationTestCase(IceStormTestCase):
 
+from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
+from Util import ClientServerTestCase, TestSuite
+
+
+class IceStormFederationTestCase(IceStormTestCase):
     def setupClientSide(self, current):
-        self.runadmin(current, "create fed1 fed2 fed3; link fed1 fed2 10; link fed2 fed3 5")
+        self.runadmin(
+            current, "create fed1 fed2 fed3; link fed1 fed2 10; link fed2 fed3 5"
+        )
 
     def runClientSide(self, current):
         current.write("testing oneway subscribers...")
@@ -14,7 +20,9 @@ class IceStormFederationTestCase(IceStormTestCase):
         current.writeln("ok")
 
         current.write("testing batch subscribers...")
-        ClientServerTestCase(client=Publisher(), server=Subscriber(args=["-b"])).run(current)
+        ClientServerTestCase(client=Publisher(), server=Subscriber(args=["-b"])).run(
+            current
+        )
         current.writeln("ok")
 
     def teardownClientSide(self, current, success):
@@ -23,13 +31,23 @@ class IceStormFederationTestCase(IceStormTestCase):
 
 
 # Override ReplicatedPublishEndpoints property to empty for testing without replicated publisher
-props = {'IceStorm.ReplicatedPublishEndpoints': ''}
+props = {"IceStorm.ReplicatedPublishEndpoints": ""}
 
-TestSuite(__file__, [
-    IceStormFederationTestCase("persistent", icestorm=IceStorm()),
-    IceStormFederationTestCase("transient", icestorm=IceStorm(transient=True)),
-    IceStormFederationTestCase("replicated with non-replicated publisher",
-                               icestorm=[IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]),
-    IceStormFederationTestCase("replicated with replicated publisher",
-                               icestorm=[IceStorm(replica=i, nreplicas=3) for i in range(0, 3)]),
-], multihost=False)
+TestSuite(
+    __file__,
+    [
+        IceStormFederationTestCase("persistent", icestorm=IceStorm()),
+        IceStormFederationTestCase("transient", icestorm=IceStorm(transient=True)),
+        IceStormFederationTestCase(
+            "replicated with non-replicated publisher",
+            icestorm=[
+                IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)
+            ],
+        ),
+        IceStormFederationTestCase(
+            "replicated with replicated publisher",
+            icestorm=[IceStorm(replica=i, nreplicas=3) for i in range(0, 3)],
+        ),
+    ],
+    multihost=False,
+)

--- a/cpp/test/IceStorm/federation2/test.py
+++ b/cpp/test/IceStorm/federation2/test.py
@@ -7,18 +7,32 @@
 # Publisher/subscriber test cases, publisher publishes on TestIceStorm1 instance(s) and
 # the subscriber subscribes to the TestIceStorm2 instance(s)
 #
-pub1Sub2Oneway = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2"))
-pub1Sub2Batch = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2", args=["-b"]))
+import re
+import time
+import Expect
+from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
+from Util import ClientServerTestCase, TestSuite
 
-pub1Sub1Oneway = ClientServerTestCase(client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm1"))
+
+pub1Sub2Oneway = ClientServerTestCase(
+    client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2")
+)
+pub1Sub2Batch = ClientServerTestCase(
+    client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm2", args=["-b"])
+)
+
+pub1Sub1Oneway = ClientServerTestCase(
+    client=Publisher("TestIceStorm1"), server=Subscriber("TestIceStorm1")
+)
 
 
 class IceStormFederation2TestCase(IceStormTestCase):
-
     def runClientSide(self, current):
-
         current.write("setting up the topics... ")
-        self.runadmin(current, "create TestIceStorm1/fed1 TestIceStorm2/fed1; link TestIceStorm1/fed1 TestIceStorm2/fed1")
+        self.runadmin(
+            current,
+            "create TestIceStorm1/fed1 TestIceStorm2/fed1; link TestIceStorm1/fed1 TestIceStorm2/fed1",
+        )
         current.writeln("ok")
 
         #
@@ -41,7 +55,9 @@ class IceStormFederation2TestCase(IceStormTestCase):
         # Stop and restart the service and repeat the test. This ensures that
         # the database is correct.
         #
-        current.write("restarting services to ensure that the database content is preserved... ")
+        current.write(
+            "restarting services to ensure that the database content is preserved... "
+        )
         self.restartIceStorm(current)
         current.writeln("ok")
 
@@ -64,8 +80,16 @@ class IceStormFederation2TestCase(IceStormTestCase):
         #
         self.stopIceStorm(current)
 
-        icestorm1 = [icestorm for icestorm in self.icestorm if icestorm.getInstanceName() == "TestIceStorm1"]
-        icestorm2 = [icestorm for icestorm in self.icestorm if icestorm.getInstanceName() == "TestIceStorm2"]
+        icestorm1 = [
+            icestorm
+            for icestorm in self.icestorm
+            if icestorm.getInstanceName() == "TestIceStorm1"
+        ]
+        icestorm2 = [
+            icestorm
+            for icestorm in self.icestorm
+            if icestorm.getInstanceName() == "TestIceStorm2"
+        ]
 
         #
         # Restart the first server and publish some events. Attach a
@@ -75,7 +99,6 @@ class IceStormFederation2TestCase(IceStormTestCase):
         # Ensure they are received by the linked server.
         #
         if self.getName().find("replicated") == -1:
-
             current.write("restarting only one IceStorm server... ")
             icestorm1[0].start(current)
             current.writeln("ok")
@@ -109,7 +132,9 @@ class IceStormFederation2TestCase(IceStormTestCase):
             current.writeln("ok")
 
             try:
-                icestorm1[0].expect(current, "topic.fed1.*subscriber offline", timeout=1)
+                icestorm1[0].expect(
+                    current, "topic.fed1.*subscriber offline", timeout=1
+                )
                 assert False
             except Expect.TIMEOUT:
                 pass
@@ -167,24 +192,55 @@ class IceStormFederation2TestCase(IceStormTestCase):
         # Destroy the remaining topic.
         #
         current.write("destroying topics... ")
-        self.runadmin(current, "destroy TestIceStorm1/fed1links TestIceStorm1", quiet=True)
+        self.runadmin(
+            current, "destroy TestIceStorm1/fed1links TestIceStorm1", quiet=True
+        )
         current.writeln("ok")
 
         self.stopIceStorm(current)
 
 
 # Override ReplicatedPublishEndpoints property to empty for testing without replicated publisher
-props = {'IceStorm.Discard.Interval': 2}
-nonRepProps = {'IceStorm.Discard.Interval': 2, 'IceStorm.ReplicatedPublishEndpoints': ''}
+props = {"IceStorm.Discard.Interval": 2}
+nonRepProps = {
+    "IceStorm.Discard.Interval": 2,
+    "IceStorm.ReplicatedPublishEndpoints": "",
+}
 
-TestSuite(__file__, [
-
-    IceStormFederation2TestCase("persistent", icestorm=[IceStorm("TestIceStorm1", quiet=True, props=props),
-                                                        IceStorm("TestIceStorm2", quiet=True, portnum=20, props=props)]),
-
-    IceStormFederation2TestCase("replicated with non-replicated publisher", icestorm=[IceStorm("TestIceStorm1", i, 3, quiet=True, props=nonRepProps) for i in range(0, 3)] +
-                                [IceStorm("TestIceStorm2", i, 3, quiet=True, portnum=20, props=nonRepProps) for i in range(0, 3)]),
-
-    IceStormFederation2TestCase("replicated with replicated publisher", icestorm=[IceStorm("TestIceStorm1", i, 3, quiet=True, props=props) for i in range(0, 3)] +
-                                [IceStorm("TestIceStorm2", i, 3, quiet=True, portnum=20, props=props) for i in range(0, 3)]),
-], multihost=False)
+TestSuite(
+    __file__,
+    [
+        IceStormFederation2TestCase(
+            "persistent",
+            icestorm=[
+                IceStorm("TestIceStorm1", quiet=True, props=props),
+                IceStorm("TestIceStorm2", quiet=True, portnum=20, props=props),
+            ],
+        ),
+        IceStormFederation2TestCase(
+            "replicated with non-replicated publisher",
+            icestorm=[
+                IceStorm("TestIceStorm1", i, 3, quiet=True, props=nonRepProps)
+                for i in range(0, 3)
+            ]
+            + [
+                IceStorm(
+                    "TestIceStorm2", i, 3, quiet=True, portnum=20, props=nonRepProps
+                )
+                for i in range(0, 3)
+            ],
+        ),
+        IceStormFederation2TestCase(
+            "replicated with replicated publisher",
+            icestorm=[
+                IceStorm("TestIceStorm1", i, 3, quiet=True, props=props)
+                for i in range(0, 3)
+            ]
+            + [
+                IceStorm("TestIceStorm2", i, 3, quiet=True, portnum=20, props=props)
+                for i in range(0, 3)
+            ],
+        ),
+    ],
+    multihost=False,
+)

--- a/cpp/test/IceStorm/persistent/test.py
+++ b/cpp/test/IceStorm/persistent/test.py
@@ -3,6 +3,10 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from IceStormUtil import IceStorm, IceStormAdmin, IceStormProcess
+from Util import Client, ClientTestCase, TestCase, TestSuite
+
+
 icestorm1 = IceStorm(createDb=True, cleanDb=False)
 icestorm2 = IceStorm(createDb=False, cleanDb=True)
 
@@ -13,7 +17,6 @@ def test(value):
 
 
 class IceStormPersistentTestCase(TestCase):
-
     def __init__(self, name, icestorm, *args, **kargs):
         TestCase.__init__(self, name, *args, **kargs)
         self.icestorm = icestorm
@@ -26,8 +29,11 @@ class IceStormPersistentTestCase(TestCase):
         current.driver.runClientServerTestCase(current)
 
     def teardownClientSide(self, current, success):
-        admin = IceStormAdmin(instance=self.icestorm, quiet=True,
-                              args=["-e", "topics {}".format(self.icestorm.getInstanceName())])
+        admin = IceStormAdmin(
+            instance=self.icestorm,
+            quiet=True,
+            args=["-e", "topics {}".format(self.icestorm.getInstanceName())],
+        )
         admin.run(current, exitstatus=0)
         #
         # Ensure all topics have been restored from the storage
@@ -36,9 +42,16 @@ class IceStormPersistentTestCase(TestCase):
         test(len(topics) == 10)
         for i in range(0, 10):
             topic = topics[i]
-            admin = IceStormAdmin(instance=self.icestorm, quiet=True,
-                                  args=["-e",
-                                        "current {0};subscribers {1}".format(self.icestorm.getInstanceName(), topic)])
+            admin = IceStormAdmin(
+                instance=self.icestorm,
+                quiet=True,
+                args=[
+                    "-e",
+                    "current {0};subscribers {1}".format(
+                        self.icestorm.getInstanceName(), topic
+                    ),
+                ],
+            )
             admin.run(current, exitstatus=0)
             subscribers = admin.getOutput(current).split()[2:]
             test("subscriber{0}".format(i) in subscribers)
@@ -49,19 +62,34 @@ class IceStormPersistentTestCase(TestCase):
 
 
 class PersistentClient(IceStormProcess, Client):
-
     processType = "client"
 
     def __init__(self, instanceName=None, instance=None, *args, **kargs):
         Client.__init__(self, *args, **kargs)
         IceStormProcess.__init__(self, instanceName, instance)
 
-    getParentProps = Client.getProps  # Used by IceStormProcess to get the client properties
+    getParentProps = (
+        Client.getProps
+    )  # Used by IceStormProcess to get the client properties
 
 
-TestSuite(__file__, [
-    IceStormPersistentTestCase("persistent create", icestorm1,
-                               client=ClientTestCase(client=PersistentClient(instance=icestorm1, args=["create"]))),
-    IceStormPersistentTestCase("persistent check", icestorm2,
-                               client=ClientTestCase(client=PersistentClient(instance=icestorm2, args=["check"]))),
-], multihost=False)
+TestSuite(
+    __file__,
+    [
+        IceStormPersistentTestCase(
+            "persistent create",
+            icestorm1,
+            client=ClientTestCase(
+                client=PersistentClient(instance=icestorm1, args=["create"])
+            ),
+        ),
+        IceStormPersistentTestCase(
+            "persistent check",
+            icestorm2,
+            client=ClientTestCase(
+                client=PersistentClient(instance=icestorm2, args=["check"])
+            ),
+        ),
+    ],
+    multihost=False,
+)

--- a/cpp/test/IceStorm/repgrid/test.py
+++ b/cpp/test/IceStorm/repgrid/test.py
@@ -5,7 +5,19 @@
 
 # Use the IceGridServer for the client because the client is an IceStorm subscriber and needs to be able
 # to accept connections (this is important for picking the correct server certificate for TLS).
+import os
+from IceGridUtil import IceGridRegistryMaster, IceGridServer, IceGridTestCase
+from Util import TestSuite, Windows, platform
+
+
 if isinstance(platform, Windows) or os.getuid() != 0:
-    TestSuite(__file__, [IceGridTestCase(icegridregistry=IceGridRegistryMaster(),
-                                         client=IceGridServer())],
-              runOnMainThread=True, multihost=False)
+    TestSuite(
+        __file__,
+        [
+            IceGridTestCase(
+                icegridregistry=IceGridRegistryMaster(), client=IceGridServer()
+            )
+        ],
+        runOnMainThread=True,
+        multihost=False,
+    )

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -10,20 +10,23 @@
 # send buffer size (causing the received messages to be
 # truncated). See also bug #6070.
 #
+import time
+from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
+from Util import Client, TestSuite
+
+
 props = {
     "IceStorm.Election.MasterTimeout": 2,
     "IceStorm.Election.ElectionTimeout": 2,
     "IceStorm.Election.ResponseTimeout": 2,
-    "Ice.Warn.Dispatch": 0
+    "Ice.Warn.Dispatch": 0,
 }
 
 icestorm = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]
 
 
 class IceStormRepStressTestCase(IceStormTestCase):
-
     def runClientSide(self, current):
-
         def stopReplica(num):
             self.icestorm[num].shutdown(current)
             self.icestorm[num].stop(current, True)
@@ -64,7 +67,7 @@ class IceStormRepStressTestCase(IceStormTestCase):
             stopReplica(0)
             current.writeln("ok")
             # This waits for the replication to startup
-            #self.runadmin(current, "list")
+            # self.runadmin(current, "list")
             time.sleep(2)
 
             # 0, 2
@@ -73,14 +76,14 @@ class IceStormRepStressTestCase(IceStormTestCase):
             stopReplica(1)
             current.writeln("ok")
             # This waits for the replication to startup
-            #self.runadmin(current, "list")
+            # self.runadmin(current, "list")
             time.sleep(2)
 
             current.write("starting 1 (all running)... ")
             startReplica(1)
             current.writeln("ok")
             # This waits for the replication to startup
-            #self.runadmin(current, "list")
+            # self.runadmin(current, "list")
             time.sleep(2)
 
         current.write("stopping publisher... ")
@@ -101,11 +104,16 @@ class IceStormRepStressTestCase(IceStormTestCase):
         subscriber.stop(current, True)
         current.writeln("ok")
 
-        current.writeln("publisher published %s events, subscriber received %s events" %
-                        (publisherCount, subscriberCount))
+        current.writeln(
+            "publisher published %s events, subscriber received %s events"
+            % (publisherCount, subscriberCount)
+        )
 
 
-TestSuite(__file__,
-          [IceStormRepStressTestCase("replicated", icestorm=icestorm)],
-          options={"ipv6": [False]},
-          multihost=False, runOnMainThread=True)
+TestSuite(
+    __file__,
+    [IceStormRepStressTestCase("replicated", icestorm=icestorm)],
+    options={"ipv6": [False]},
+    multihost=False,
+    runOnMainThread=True,
+)

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -10,17 +10,24 @@
 # send buffer size (causing the received messages to be truncated). See
 # bug #6070 and #7558.
 #
+from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
+from Util import ClientServerTestCase, TestSuite
+
+
 props = {"Ice.UDP.SndSize": 512 * 1024, "Ice.Warn.Dispatch": 0}
 persistent = IceStorm(props=props)
 transient = IceStorm(props=props, transient=True)
 replicated = [IceStorm(replica=i, nreplicas=3, props=props) for i in range(0, 3)]
 
-sub = Subscriber(args=["{testcase.parent.name}"], props={"Ice.UDP.RcvSize": 1024 * 1024}, readyCount=3)
+sub = Subscriber(
+    args=["{testcase.parent.name}"],
+    props={"Ice.UDP.RcvSize": 1024 * 1024},
+    readyCount=3,
+)
 pub = Publisher(args=["{testcase.parent.name}"])
 
 
 class IceStormSingleTestCase(IceStormTestCase):
-
     def setupClientSide(self, current):
         self.runadmin(current, "create single")
 
@@ -29,8 +36,24 @@ class IceStormSingleTestCase(IceStormTestCase):
         self.shutdown(current)
 
 
-TestSuite(__file__, [
-    IceStormSingleTestCase("persistent", icestorm=persistent, client=ClientServerTestCase(client=pub, server=sub)),
-    IceStormSingleTestCase("transient", icestorm=transient, client=ClientServerTestCase(client=pub, server=sub)),
-    IceStormSingleTestCase("replicated", icestorm=replicated, client=ClientServerTestCase(client=pub, server=sub)),
-], multihost=False)
+TestSuite(
+    __file__,
+    [
+        IceStormSingleTestCase(
+            "persistent",
+            icestorm=persistent,
+            client=ClientServerTestCase(client=pub, server=sub),
+        ),
+        IceStormSingleTestCase(
+            "transient",
+            icestorm=transient,
+            client=ClientServerTestCase(client=pub, server=sub),
+        ),
+        IceStormSingleTestCase(
+            "replicated",
+            icestorm=replicated,
+            client=ClientServerTestCase(client=pub, server=sub),
+        ),
+    ],
+    multihost=False,
+)

--- a/cpp/test/IceStorm/stress/test.py
+++ b/cpp/test/IceStorm/stress/test.py
@@ -7,21 +7,37 @@
 # Publisher/subscriber test cases, publisher publishes on TestIceStorm1 instance(s) and
 # the subscriber subscribes to the TestIceStorm2 instance(s)
 #
-pubSub = lambda si, pi, s={}, p={}: ClientServerTestCase(client=Publisher(args=s), server=Subscriber(args=p))
+from IceStormUtil import IceStorm, IceStormTestCase, Publisher, Subscriber
+from Util import ClientServerTestCase, TestSuite
+
+
+def pubSub(si, pi, s={}, p={}):
+    ClientServerTestCase(client=Publisher(args=s), server=Subscriber(args=p))
 
 
 class IceStormStressTestCase(IceStormTestCase):
-
     def runClientSide(self, current):
-
-        icestorm1 = [icestorm for icestorm in self.icestorm if icestorm.getInstanceName() == "TestIceStorm1"]
-        icestorm2 = [icestorm for icestorm in self.icestorm if icestorm.getInstanceName() == "TestIceStorm2"]
+        icestorm1 = [
+            icestorm
+            for icestorm in self.icestorm
+            if icestorm.getInstanceName() == "TestIceStorm1"
+        ]
+        # TODO: This variable is unused. Are we missing a test case?
+        # icestorm2 = [
+        #     icestorm
+        #     for icestorm in self.icestorm
+        #     if icestorm.getInstanceName() == "TestIceStorm2"
+        # ]
 
         def doTest(subOpts, pubOpts):
             # Create the subscribers
             subscribers = []
-            for (instanceName, opts) in subOpts if type(subOpts) == list else [subOpts]:
-                subscribers.append(Subscriber(instanceName or "TestIceStorm1", args=opts.split(" ")))
+            for instanceName, opts in (
+                subOpts if isinstance(subOpts, list) else [subOpts]
+            ):
+                subscribers.append(
+                    Subscriber(instanceName or "TestIceStorm1", args=opts.split(" "))
+                )
 
             # Create the publisher
             publisher = Publisher("TestIceStorm1", args=pubOpts.split(" "))
@@ -34,48 +50,68 @@ class IceStormStressTestCase(IceStormTestCase):
         current.writeln("ok")
 
         current.write("Sending 5000 ordered events... ")
-        doTest(("TestIceStorm1", '--events 5000 --qos "reliability,ordered"'), '--events 5000')
+        doTest(
+            ("TestIceStorm1", '--events 5000 --qos "reliability,ordered"'),
+            "--events 5000",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "link TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 5000 ordered events across a link... ")
-        doTest(("TestIceStorm2", '--events 5000 --qos "reliability,ordered"'), '--events 5000')
+        doTest(
+            ("TestIceStorm2", '--events 5000 --qos "reliability,ordered"'),
+            "--events 5000",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "unlink TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered events... ")
-        doTest(("TestIceStorm1", '--events 20000'), '--events 20000 --oneway')
+        doTest(("TestIceStorm1", "--events 20000"), "--events 20000 --oneway")
         current.writeln("ok")
 
         self.runadmin(current, "link TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered events across a link... ")
-        doTest(("TestIceStorm2", '--events 20000'), '--events 20000 --oneway')
+        doTest(("TestIceStorm2", "--events 20000"), "--events 20000 --oneway")
         current.writeln("ok")
 
         self.runadmin(current, "unlink TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered batch events... ")
-        doTest(("TestIceStorm1", '--events 20000 --qos "reliability,batch"'), '--events 20000 --oneway')
+        doTest(
+            ("TestIceStorm1", '--events 20000 --qos "reliability,batch"'),
+            "--events 20000 --oneway",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "link TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered batch events across a link... ")
-        doTest(("TestIceStorm2", '--events 20000 --qos "reliability,batch"'), '--events 20000 --oneway')
+        doTest(
+            ("TestIceStorm2", '--events 20000 --qos "reliability,batch"'),
+            "--events 20000 --oneway",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "unlink TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered events with slow subscriber... ")
-        doTest([("TestIceStorm1", '--events 2 --slow'),
-                ("TestIceStorm1", '--events 20000 ')],
-               '--events 20000 --oneway')
+        doTest(
+            [
+                ("TestIceStorm1", "--events 2 --slow"),
+                ("TestIceStorm1", "--events 20000 "),
+            ],
+            "--events 20000 --oneway",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "link TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered events with slow subscriber & link... ")
-        doTest([("TestIceStorm1", '--events 2 --slow'),
-                ("TestIceStorm1", '--events 20000'),
-                ("TestIceStorm2", '--events 2 --slow'),
-                ("TestIceStorm2", '--events 20000')],
-               '--events 20000 --oneway')
+        doTest(
+            [
+                ("TestIceStorm1", "--events 2 --slow"),
+                ("TestIceStorm1", "--events 20000"),
+                ("TestIceStorm2", "--events 2 --slow"),
+                ("TestIceStorm2", "--events 20000"),
+            ],
+            "--events 20000 --oneway",
+        )
         current.writeln("ok")
 
         current.write("shutting down icestorm services... ")
@@ -93,21 +129,40 @@ class IceStormStressTestCase(IceStormTestCase):
 
         self.runadmin(current, "unlink TestIceStorm1/fed1 TestIceStorm2/fed1")
         current.write("Sending 20000 unordered events with erratic subscriber... ")
-        doTest([("TestIceStorm1", '--erratic 5 --qos "reliability,ordered" --events 20000'),
-                ("TestIceStorm1", '--erratic 5 --events 20000'),
-                ("TestIceStorm1", '--events 20000')],
-               '--events 20000 --oneway')
+        doTest(
+            [
+                (
+                    "TestIceStorm1",
+                    '--erratic 5 --qos "reliability,ordered" --events 20000',
+                ),
+                ("TestIceStorm1", "--erratic 5 --events 20000"),
+                ("TestIceStorm1", "--events 20000"),
+            ],
+            "--events 20000 --oneway",
+        )
         current.writeln("ok")
 
         self.runadmin(current, "link TestIceStorm1/fed1 TestIceStorm2/fed1")
-        current.write("Sending 20000 unordered events with erratic subscriber across a link... ")
-        doTest([("TestIceStorm1", '--events 20000'),
-                ("TestIceStorm1", '--erratic 5 --qos "reliability,ordered" --events 20000 '),
-                ("TestIceStorm1", '--erratic 5 --events 20000 '),
-                ("TestIceStorm2", '--events 20000'),
-                ("TestIceStorm2", '--erratic 5 --qos "reliability,ordered" --events 20000 '),
-                ("TestIceStorm2", '--erratic 5 --events 20000 ')],
-               '--events 20000 --oneway ')
+        current.write(
+            "Sending 20000 unordered events with erratic subscriber across a link... "
+        )
+        doTest(
+            [
+                ("TestIceStorm1", "--events 20000"),
+                (
+                    "TestIceStorm1",
+                    '--erratic 5 --qos "reliability,ordered" --events 20000 ',
+                ),
+                ("TestIceStorm1", "--erratic 5 --events 20000 "),
+                ("TestIceStorm2", "--events 20000"),
+                (
+                    "TestIceStorm2",
+                    '--erratic 5 --qos "reliability,ordered" --events 20000 ',
+                ),
+                ("TestIceStorm2", "--erratic 5 --events 20000 "),
+            ],
+            "--events 20000 --oneway ",
+        )
         current.writeln("ok")
 
         #
@@ -121,31 +176,55 @@ class IceStormStressTestCase(IceStormTestCase):
         opts = " --IceStorm.Send.QueueSizeMax=2000 --IceStorm.Send.QueueSizeMaxPolicy=DropEvents"
         for s in icestorm1:
             s.start(current, args=opts.split(" "))
-        doTest(("TestIceStorm1", '--events 5000 --qos "reliability,ordered" --maxQueueDropEvents=2000'),
-               '--events 5000 --maxQueueTest')
+        doTest(
+            (
+                "TestIceStorm1",
+                '--events 5000 --qos "reliability,ordered" --maxQueueDropEvents=2000',
+            ),
+            "--events 5000 --maxQueueTest",
+        )
         for s in icestorm1:
             s.shutdown(current)
             s.stop(current, True)
         current.writeln("ok")
 
-        current.write("Sending 5000 ordered events with max queue size remove subscriber... ")
+        current.write(
+            "Sending 5000 ordered events with max queue size remove subscriber... "
+        )
         opts = " --IceStorm.Send.QueueSizeMax=2000 --IceStorm.Send.QueueSizeMaxPolicy=RemoveSubscriber"
         for s in icestorm1:
             s.start(current, args=opts.split(" "))
-        doTest(("TestIceStorm1", '--events 5000 --qos "reliability,ordered" --maxQueueRemoveSub=2000'),
-               '--events 5000 --maxQueueTest')
+        doTest(
+            (
+                "TestIceStorm1",
+                '--events 5000 --qos "reliability,ordered" --maxQueueRemoveSub=2000',
+            ),
+            "--events 5000 --maxQueueTest",
+        )
         for s in icestorm1:
             s.shutdown(current)
             s.stop(current, True)
         current.writeln("ok")
 
 
-TestSuite(__file__, [
-
-    IceStormStressTestCase("persistent", icestorm=[IceStorm("TestIceStorm1", quiet=True),
-                                                   IceStorm("TestIceStorm2", quiet=True, portnum=20)]),
-
-    IceStormStressTestCase("replicated with replicated publisher", icestorm=[IceStorm("TestIceStorm1", i, 3, quiet=True) for i in range(0, 3)] +
-                           [IceStorm("TestIceStorm2", i, 3, portnum=20, quiet=True) for i in range(0, 3)]),
-
-], multihost=False)
+TestSuite(
+    __file__,
+    [
+        IceStormStressTestCase(
+            "persistent",
+            icestorm=[
+                IceStorm("TestIceStorm1", quiet=True),
+                IceStorm("TestIceStorm2", quiet=True, portnum=20),
+            ],
+        ),
+        IceStormStressTestCase(
+            "replicated with replicated publisher",
+            icestorm=[IceStorm("TestIceStorm1", i, 3, quiet=True) for i in range(0, 3)]
+            + [
+                IceStorm("TestIceStorm2", i, 3, portnum=20, quiet=True)
+                for i in range(0, 3)
+            ],
+        ),
+    ],
+    multihost=False,
+)

--- a/cpp/test/IceUtil/priority/test.py
+++ b/cpp/test/IceUtil/priority/test.py
@@ -2,5 +2,12 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-if not isinstance(platform, Darwin) and (isinstance(platform, Windows) or os.getuid() == 0):
+
+import os
+from Util import TestSuite, platform, Windows, Darwin
+
+
+if not isinstance(platform, Darwin) and (
+    isinstance(platform, Windows) or os.getuid() == 0
+):
     TestSuite(__name__)

--- a/cpp/test/IceUtil/stacktrace/test.py
+++ b/cpp/test/IceUtil/stacktrace/test.py
@@ -3,4 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from Util import TestSuite
+
+
 TestSuite(__name__, options={"cpp11": [False]})

--- a/cpp/test/IceUtil/unicode/test.py
+++ b/cpp/test/IceUtil/unicode/test.py
@@ -3,4 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+from Util import ClientTestCase, SimpleClient, TestSuite
+
+
 TestSuite(__name__, [ClientTestCase(client=SimpleClient(args=["{testdir}"]))])

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -5,11 +5,13 @@
 
 import glob
 import os
+import re
 import shutil
+
+from Util import ClientTestCase, SliceTranslator, TestSuite
 
 
 class SliceErrorDetectionTestCase(ClientTestCase):
-
     def runClientSide(self, current):
         testdir = current.testsuite.getPath()
         slice2cpp = SliceTranslator("slice2cpp")
@@ -28,7 +30,9 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                 args = ["-I.", file, "--output-dir", "tmp"]
 
                 # Don't print out slice2cpp output and expect failures
-                slice2cpp.run(current, args=args, exitstatus=0 if file.find("Warning") >= 0 else 1)
+                slice2cpp.run(
+                    current, args=args, exitstatus=0 if file.find("Warning") >= 0 else 1
+                )
                 output = slice2cpp.getOutput(current)
 
                 regex1 = re.compile("\.ice$", re.IGNORECASE)
@@ -38,7 +42,11 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                     if len(lines1) != len(lines2):
                         current.writeln("lines1 = {0}".format(lines1))
                         current.writeln("lines2 = {0}".format(lines2))
-                        raise RuntimeError("failed (lines1 = {0}, lines2 = {1})!".format(len(lines1), len(lines2)))
+                        raise RuntimeError(
+                            "failed (lines1 = {0}, lines2 = {1})!".format(
+                                len(lines1), len(lines2)
+                            )
+                        )
 
                     regex2 = re.compile("^.*(?=" + os.path.basename(file) + ")")
                     i = 0
@@ -46,17 +54,34 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                         line1 = regex2.sub("", lines1[i]).strip()
                         line2 = regex2.sub("", lines2[i]).strip()
                         if line1 != line2:
-                            raise RuntimeError("failed! (line1 = \"{0}\", line2 = \"{1}\"".format(line1, line2))
+                            raise RuntimeError(
+                                'failed! (line1 = "{0}", line2 = "{1}"'.format(
+                                    line1, line2
+                                )
+                            )
                         i = i + 1
                     else:
                         current.writeln("ok")
 
             current.write("Forward.ice... ")
-            for language in ["cpp", "cs", "html", "java", "js", "matlab", "php", "py", "rb", "swift"]:
-                compiler = SliceTranslator('slice2%s' % language)
+            for language in [
+                "cpp",
+                "cs",
+                "html",
+                "java",
+                "js",
+                "matlab",
+                "php",
+                "py",
+                "rb",
+                "swift",
+            ]:
+                compiler = SliceTranslator("slice2%s" % language)
                 if not os.path.isfile(compiler.getCommandLine(current)):
                     continue
-                compiler.run(current, args=["forward/Forward.ice", "--output-dir", "tmp"])
+                compiler.run(
+                    current, args=["forward/Forward.ice", "--output-dir", "tmp"]
+                )
             current.writeln("ok")
         finally:
             if os.path.exists(outdir):

--- a/cpp/test/Slice/unicodePaths/test.py
+++ b/cpp/test/Slice/unicodePaths/test.py
@@ -3,18 +3,21 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
+import os
 import shutil
 import locale
 
+from Util import ClientTestCase, platform, TestSuite, SliceTranslator, AIX, Linux
+
 
 class SliceUnicodePathsTestCase(ClientTestCase):
-
     def runClientSide(self, current):
-
         if isinstance(platform, Linux) or isinstance(platform, AIX):
             encoding = locale.getdefaultlocale()[1]
             if encoding != "UTF-8":
-                current.writeln("Please set LC_ALL to xx_xx.UTF-8, for example FR_FR.UTF-8")
+                current.writeln(
+                    "Please set LC_ALL to xx_xx.UTF-8, for example FR_FR.UTF-8"
+                )
                 current.writeln("Skipping test")
                 return
 
@@ -26,11 +29,16 @@ class SliceUnicodePathsTestCase(ClientTestCase):
             shutil.rmtree(srcPath)
         os.mkdir(srcPath)
 
-        current.createFile("%s/Test.ice" % srcPath,
-                           ["module Test { ",
-                            "class Point{int x; int y; };",
-                            "interface Canvas{ void draw(Point p); };",
-                            "};"], "utf-8")
+        current.createFile(
+            "%s/Test.ice" % srcPath,
+            [
+                "module Test { ",
+                "class Point{int x; int y; };",
+                "interface Canvas{ void draw(Point p); };",
+                "};",
+            ],
+            "utf-8",
+        )
 
         tests = [
             ("cpp", ["Test.cpp", "Test.h", "TestI.cpp", "TestI.h"], "--impl-c++11"),
@@ -39,20 +47,25 @@ class SliceUnicodePathsTestCase(ClientTestCase):
             ("html", ["index.html"], ""),
             ("java", ["Test/Point.java", "Test/CanvasI.java"], "--impl"),
             ("js", ["Test.js"], ""),
-            ("php", ["Test.php"], "")]
+            ("php", ["Test.php"], ""),
+        ]
 
         try:
             for language, generated, args in tests:
-                compiler = SliceTranslator('slice2%s' % language)
+                compiler = SliceTranslator("slice2%s" % language)
                 if not os.path.isfile(compiler.getCommandLine(current)):
                     continue
 
-                args = [srcPath + "/Test.ice", "--output-dir", srcPath] + args.split(" ")
+                args = [srcPath + "/Test.ice", "--output-dir", srcPath] + args.split(
+                    " "
+                )
                 compiler.run(current, args=args)
 
                 for f in generated:
                     if not os.path.isfile(os.path.join(srcPath, f)):
-                        raise RuntimeError("failed! (can't find {0})".format(os.path.join(srcPath, f)))
+                        raise RuntimeError(
+                            "failed! (can't find {0})".format(os.path.join(srcPath, f))
+                        )
                     os.remove(os.path.join(srcPath, f))
 
             current.writeln("ok")

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,6 @@ max-line-length = 120
 [pylint]
 max-line-length = 120
 disable=
+    invalid-name,
     missing-docstring,
     wrong-import-position


### PR DESCRIPTION
This PR cleans up (lint and format) the Python code in the cpp directory using the formatter/linter defaults.

In follow-up PRs I plan to cleanup the other mapping's python files. 