### PR TITLE
Remove MutexPtrLock usage from Slice compilers

### DIFF
--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -4,13 +4,13 @@
 
 #include <IceUtil/Options.h>
 #include <IceUtil/CtrlCHandler.h>
-#include <IceUtil/Mutex.h>
-#include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/ConsoleUtil.h>
 #include <Slice/Preprocessor.h>
 #include <Slice/FileTracker.h>
 #include <Slice/Util.h>
 #include <Gen.h>
+
+#include <mutex>
 
 using namespace std;
 using namespace Slice;
@@ -19,34 +19,15 @@ using namespace IceUtilInternal;
 namespace
 {
 
-IceUtil::Mutex* globalMutex = 0;
+mutex globalMutex;
 bool interrupted = false;
-
-class Init
-{
-public:
-
-    Init()
-    {
-        globalMutex = new IceUtil::Mutex;
-    }
-
-    ~Init()
-    {
-        delete globalMutex;
-        globalMutex = 0;
-    }
-};
-
-Init init;
 
 }
 
 void
 interruptedCallback(int /*signal*/)
 {
-    IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+    lock_guard lock(globalMutex);
     interrupted = true;
 }
 
@@ -237,8 +218,7 @@ compile(const vector<string>& argv)
         ++i;
 
         {
-            IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+            lock_guard lock(globalMutex);
             if(interrupted)
             {
                 FileTracker::instance()->cleanup();

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -4,14 +4,14 @@
 
 #include <IceUtil/Options.h>
 #include <IceUtil/CtrlCHandler.h>
-#include <IceUtil/Mutex.h>
-#include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/ConsoleUtil.h>
 
 #include <Slice/Preprocessor.h>
 #include <Slice/FileTracker.h>
 #include <Slice/Util.h>
 #include "Gen.h"
+
+#include <mutex>
 
 using namespace std;
 using namespace Slice;
@@ -20,34 +20,15 @@ using namespace IceUtilInternal;
 namespace
 {
 
-IceUtil::Mutex* globalMutex = 0;
+mutex globalMutex;
 bool interrupted = false;
-
-class Init
-{
-public:
-
-    Init()
-    {
-        globalMutex = new IceUtil::Mutex;
-    }
-
-    ~Init()
-    {
-        delete globalMutex;
-        globalMutex = 0;
-    }
-};
-
-Init init;
 
 }
 
 void
 interruptedCallback(int /*signal*/)
 {
-    IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+    lock_guard lock(globalMutex);
     interrupted = true;
 }
 
@@ -340,8 +321,7 @@ compile(const vector<string>& argv)
         }
 
         {
-            IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+            lock_guard lock(globalMutex);
             if(interrupted)
             {
                 FileTracker::instance()->cleanup();

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -4,13 +4,13 @@
 
 #include <IceUtil/Options.h>
 #include <IceUtil/CtrlCHandler.h>
-#include <IceUtil/Mutex.h>
-#include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/ConsoleUtil.h>
 #include <Slice/Preprocessor.h>
 #include <Slice/FileTracker.h>
 #include <Slice/Util.h>
 #include "Gen.h"
+
+#include <mutex>
 
 using namespace std;
 using namespace Slice;
@@ -19,34 +19,15 @@ using namespace IceUtilInternal;
 namespace
 {
 
-IceUtil::Mutex* globalMutex = 0;
+mutex globalMutex;
 bool interrupted = false;
-
-class Init
-{
-public:
-
-    Init()
-    {
-        globalMutex = new IceUtil::Mutex;
-    }
-
-    ~Init()
-    {
-        delete globalMutex;
-        globalMutex = 0;
-    }
-};
-
-Init init;
 
 }
 
 void
 interruptedCallback(int /*signal*/)
 {
-    IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+    lock_guard lock(globalMutex);
     interrupted = true;
 }
 
@@ -317,8 +298,7 @@ compile(const vector<string>& argv)
         }
 
         {
-            IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+            lock_guard lock(globalMutex);
             if(interrupted)
             {
                 FileTracker::instance()->cleanup();

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -4,13 +4,13 @@
 
 #include <IceUtil/Options.h>
 #include <IceUtil/CtrlCHandler.h>
-#include <IceUtil/Mutex.h>
-#include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/ConsoleUtil.h>
 #include <Slice/Preprocessor.h>
 #include <Slice/FileTracker.h>
 #include <Slice/Util.h>
 #include <Gen.h>
+
+#include <mutex>
 
 using namespace std;
 using namespace Slice;
@@ -19,34 +19,15 @@ using namespace IceUtilInternal;
 namespace
 {
 
-IceUtil::Mutex* globalMutex = 0;
+mutex globalMutex;
 bool interrupted = false;
-
-class Init
-{
-public:
-
-    Init()
-    {
-        globalMutex = new IceUtil::Mutex;
-    }
-
-    ~Init()
-    {
-        delete globalMutex;
-        globalMutex = 0;
-    }
-};
-
-Init init;
 
 }
 
 void
 interruptedCallback(int /*signal*/)
 {
-    IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+    lock_guard lock(globalMutex);
     interrupted = true;
 }
 
@@ -367,8 +348,7 @@ compile(const vector<string>& argv)
         }
 
         {
-            IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+            lock_guard lock(globalMutex);
             if(interrupted)
             {
                 FileTracker::instance()->cleanup();

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -8,16 +8,16 @@
 #include <IceUtil/Options.h>
 #include <IceUtil/OutputUtil.h>
 #include <IceUtil/StringUtil.h>
-#include <IceUtil/Mutex.h>
-#include <IceUtil/MutexPtrLock.h>
 #include <IceUtil/ConsoleUtil.h>
 #include <Slice/Preprocessor.h>
 #include <Slice/FileTracker.h>
 #include "PHPUtil.h"
 #include <Slice/Parser.h>
 #include <Slice/Util.h>
+
 #include <cstring>
 #include <climits>
+#include <mutex>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1338,34 +1338,15 @@ printHeader(IceUtilInternal::Output& out)
 namespace
 {
 
-IceUtil::Mutex* globalMutex = 0;
+mutex globalMutex;
 bool interrupted = false;
-
-class Init
-{
-public:
-
-    Init()
-    {
-        globalMutex = new IceUtil::Mutex;
-    }
-
-    ~Init()
-    {
-        delete globalMutex;
-        globalMutex = 0;
-    }
-};
-
-Init init;
 
 }
 
 static void
 interruptedCallback(int /*signal*/)
 {
-    IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+    lock_guard lock(globalMutex);
     interrupted = true;
 }
 
@@ -1645,8 +1626,7 @@ compile(const vector<string>& argv)
         }
 
         {
-            IceUtilInternal::MutexPtrLock<IceUtil::Mutex> sync(globalMutex);
-
+            lock_guard lock(globalMutex);
             if(interrupted)
             {
                 FileTracker::instance()->cleanup();


### PR DESCRIPTION
This PR removes MutextPtrLock usage from Slice compilers.