### PR TITLE
Remove LocalObject from Ruby

### DIFF
--- a/ruby/ruby/Ice.rb
+++ b/ruby/ruby/Ice.rb
@@ -77,6 +77,10 @@ module Ice
     # Ice::Value
     #
     T_Value = Ice.__declareClass('::Ice::Object')
+
+    #
+    # Object proxy
+    #
     T_ObjectPrx = Ice.__declareProxy('::Ice::Object')
 
     #

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -1973,13 +1973,14 @@ IceRuby::ClassInfo::ClassInfo(VALUE ident, bool loc) :
     defined(false)
 {
     const_cast<string&>(id) = getString(ident);
-    if(isLocal)
+    if (isLocal)
     {
-        const_cast<bool&>(isBase) = id == "::Ice::LocalObject";
+        // We don't define LocalObject anymore.
+        assert(id != "::Ice::LocalObject");
     }
     else
     {
-        const_cast<bool&>(isBase) = id == Ice::Object::ice_staticId();
+        const_cast<bool&>(isBase) = id == Ice::Value::ice_staticId();
     }
 }
 
@@ -2026,27 +2027,7 @@ IceRuby::ClassInfo::validate(VALUE val)
     //
     volatile VALUE cls = CLASS_OF(val);
     volatile VALUE type = Qnil;
-    try
-    {
-        type = callRuby(rb_const_get, cls, rb_intern("ICE_TYPE"));
-    }
-    catch(const RubyException& ex)
-    {
-        if(callRuby(rb_obj_is_instance_of, ex.ex, rb_eNameError) == Qtrue)
-        {
-            //
-            // The ICE_TYPE constant will be missing from an instance of LocalObject
-            // if it does not implement a user-defined type. This means the user
-            // could potentially pass any kind of object; there isn't much we can do
-            // since LocalObject maps to the base object type.
-            //
-            return id == "::Ice::LocalObject";
-        }
-        else
-        {
-            throw;
-        }
-    }
+    type = callRuby(rb_const_get, cls, rb_intern("ICE_TYPE"));
     assert(!NIL_P(type));
     ClassInfoPtr info = dynamic_pointer_cast<ClassInfo>(getType(type));
     assert(info);
@@ -2093,7 +2074,7 @@ IceRuby::ClassInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap* valueMap, 
     }
 
     //
-    // Ice::ValueWriter is a subclass of Ice::Object that wraps a Ruby object for marshaling.
+    // Ice::ValueWriter is a subclass of Ice::Value that wraps a Ruby object for marshaling.
     // It is possible that this Ruby object has already been marshaled, therefore we first must
     // check the object map to see if this object is present. If so, we use the existing ValueWriter,
     // otherwise we create a new one.
@@ -2175,36 +2156,8 @@ IceRuby::ClassInfo::print(VALUE value, IceUtilInternal::Output& out, PrintObject
             volatile VALUE cls = CLASS_OF(value);
             volatile VALUE type = Qnil;
             ClassInfoPtr info;
-            try
-            {
-                type = callRuby(rb_const_get, cls, rb_intern("ICE_TYPE"));
-                info = dynamic_pointer_cast<ClassInfo>(getType(type));
-            }
-            catch(const RubyException& ex)
-            {
-                if(callRuby(rb_obj_is_instance_of, ex.ex, rb_eNameError) == Qtrue)
-                {
-                    //
-                    // The ICE_TYPE constant will be missing from an instance of LocalObject
-                    // if it does not implement a user-defined type. This means the user
-                    // could potentially pass any kind of object; there isn't much we can do
-                    // since LocalObject maps to the base object type.
-                    //
-                    if(id == "::Ice::LocalObject")
-                    {
-                        info = shared_from_this();
-                    }
-                    else
-                    {
-                        out << "<invalid value - expected " << id << ">";
-                        return;
-                    }
-                }
-                else
-                {
-                    throw;
-                }
-            }
+            type = callRuby(rb_const_get, cls, rb_intern("ICE_TYPE"));
+            info = dynamic_pointer_cast<ClassInfo>(getType(type));
             assert(info);
             out << "object #" << history->index << " (" << info->id << ')';
             history->objects.insert(map<VALUE, int>::value_type(value, history->index));
@@ -2304,7 +2257,7 @@ IceRuby::ProxyInfo::ProxyInfo(VALUE ident) :
     isBase(false), rubyClass(Qnil), typeObj(Qnil)
 {
     const_cast<string&>(id) = getString(ident);
-    const_cast<bool&>(isBase) = id == "::Ice::Object";
+    const_cast<bool&>(isBase) = id == Ice::Object::ice_staticId();
 }
 
 void
@@ -2637,7 +2590,7 @@ IceRuby::ValueReader::_iceRead(Ice::InputStream* is)
     //
     // Unmarshal the slices of a user-defined class.
     //
-    if(!unknown && _info->id != Ice::Object::ice_staticId())
+    if(!unknown && _info->id != Ice::Value::ice_staticId())
     {
         ClassInfoPtr info = _info;
         while(info)

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -404,7 +404,7 @@ public:
 
     const std::string id;
     const Ice::Int compactId;
-    const bool isBase; // Is this the ClassInfo for Ice::Object or Ice::LocalObject?
+    const bool isBase; // Is this the ClassInfo for Value?
     const bool isLocal;
     const bool preserve;
     const bool interface;

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -21,7 +21,7 @@ getClassInfo(const string& id)
 {
     ClassInfoPtr info;
 
-    if(id == Ice::Object::ice_staticId())
+    if(id == Ice::Value::ice_staticId())
     {
         // When the ID is that of Ice::Object, it indicates that the stream has not
         // found a factory and is providing us an opportunity to preserve the object.


### PR DESCRIPTION
This PR removes LocalObject remnants in Ice for Ruby.