### PR TITLE
Fix ice_invoke and ice_invokeAsync to handle empty result buffer

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -138,7 +138,7 @@ public:
             const ::Ice::Byte* encaps;
             ::Ice::Int sz;
             stream->readEncapsulation(encaps, sz);
-            return R{ ok, { encaps, encaps + sz } };
+            return R { ok, { encaps, encaps + sz } };
         };
 
         try
@@ -224,8 +224,7 @@ public:
     {
         if(done)
         {
-            Ice::ByteSeq empty;
-            this->_promise.set_value(R { true, empty });
+            this->_promise.set_value(R { true, { static_cast<Ice::Byte*>(nullptr), static_cast<Ice::Byte*>(nullptr) } });
         }
         return false;
     }

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -101,20 +101,6 @@ typedef IceUtil::Handle<ProxyGetConnection> ProxyGetConnectionPtr;
 namespace IceInternal
 {
 
-template <typename T> T makeIceInvokeResult(bool ok, const Ice::Byte* first, ::Ice::Int size)
-{
-    return std::make_pair(ok, std::make_pair(first, first + size));
-}
-
-template <> inline ::Ice::Object::Ice_invokeResult
-makeIceInvokeResult<::Ice::Object::Ice_invokeResult>(
-    bool ok,
-    const Ice::Byte* first,
-    ::Ice::Int size)
-{
-    return Ice::Object::Ice_invokeResult { ok, Ice::ByteSeq(first, first + size) };
-}
-
 template<typename P>
 ::std::shared_ptr<P> createProxy()
 {
@@ -152,7 +138,7 @@ public:
             const ::Ice::Byte* encaps;
             ::Ice::Int sz;
             stream->readEncapsulation(encaps, sz);
-            return makeIceInvokeResult<R>(ok, encaps, sz);
+            return R{ ok, { encaps, encaps + sz } };
         };
 
         try
@@ -201,7 +187,7 @@ public:
             {
                 if(this->_is.b.empty())
                 {
-                    response(makeIceInvokeResult<R>(true, 0, 0));
+                    response(R { ok, { static_cast<Ice::Byte*>(nullptr), static_cast<Ice::Byte*>(nullptr) } });
                 }
                 else
                 {
@@ -225,7 +211,7 @@ public:
         {
             if(this->_is.b.empty())
             {
-                this->_promise.set_value(makeIceInvokeResult<R>(true, 0, 0));
+                this->_promise.set_value(R { ok, { static_cast<Ice::Byte*>(nullptr), static_cast<Ice::Byte*>(nullptr) } });
             }
             else
             {

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -385,7 +385,7 @@ allTests(Test::TestHelper* helper)
         Ice::ByteSeq inEncaps, outEncaps;
         bool returnValue = oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
         test(returnValue);
-        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
+        test(outEncaps.size() == 0); // Empty encapsulation
     }
 
     cout << "ok" << endl;
@@ -442,54 +442,16 @@ allTests(Test::TestHelper* helper)
         test(completed.get_future().get());
     }
 
-    {
-        // Call oneway with a regular (twoway) proxy
-        promise<pair<bool, vector<Ice::Byte>>> completed;
-        Ice::ByteSeq inEncaps, outEncaps;
-        cl->ice_invokeAsync(
-            "opOneway",
-            Ice::OperationMode::Normal,
-            inEncaps,
-            [&](bool ok, vector<Ice::Byte> ouEncaps)
-            {
-                completed.set_value(make_pair(ok, std::move(ouEncaps)));
-            },
-            [&](exception_ptr ex)
-            {
-                completed.set_exception(ex);
-            });
-        pair<bool, vector<Ice::Byte>> result = completed.get_future().get();
-        test(result.first);
-        test(result.second.size() == 6); // Empty encapsulation
-    }
-
     //
     // repeat with the future API.
     //
-
-    {
-        // Oneway operation with a twoway proxy must return empty encapsulation.
-        Ice::ByteSeq inEncaps;
-        auto completed = cl->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps);
-        auto result = completed.get();
-        test(result.returnValue);
-        test(result.outParams.size() == 6); // Empty encapsulation
-    }
-
-    {
-        // Oneway operation with a twoway proxy must return empty encapsulation buffer.
-        Ice::ByteSeq inEncaps, outEncaps;
-        auto returnValue = cl->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps);
-        test(returnValue);
-        test(outEncaps.size() == 6); // Empty encapsulation
-    }
 
     {
         // Oneway operation with a oneway proxy must return empty encapsulation.
         Ice::ByteSeq inEncaps, outEncaps;
         bool returnValue = oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
         test(returnValue);
-        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
+        test(outEncaps.size() == 0); // Empty encapsulation
     }
 
     {
@@ -498,7 +460,7 @@ allTests(Test::TestHelper* helper)
         auto completed = oneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps);
         auto result = completed.get();
         test(result.returnValue);
-        test(result.outParams.size() == 0 || result.outParams.size() == 6); // Empty encapsulation
+        test(result.outParams.size() == 0); // Empty encapsulation
     }
 
     {

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -449,7 +449,7 @@ allTests(Test::TestHelper* helper)
     {
         // Oneway operation with a oneway proxy must return empty encapsulation.
         Ice::ByteSeq inEncaps, outEncaps;
-        bool returnValue = oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        bool returnValue = oneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(returnValue);
         test(outEncaps.size() == 0); // Empty encapsulation
     }
@@ -666,7 +666,7 @@ allTests(Test::TestHelper* helper)
             test(false);
         }
         test(result);
-        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
+        test(outEncaps.size() == 0); // Empty encapsulation
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -380,6 +380,14 @@ allTests(Test::TestHelper* helper)
         }
     }
 
+    {
+        // Oneway operation with a oneway proxy must return empty encapsulation.
+        Ice::ByteSeq inEncaps, outEncaps;
+        bool returnValue = oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        test(returnValue);
+        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
+    }
+
     cout << "ok" << endl;
 
     cout << "testing asynchronous ice_invoke... " << flush;
@@ -434,14 +442,63 @@ allTests(Test::TestHelper* helper)
         test(completed.get_future().get());
     }
 
+    {
+        // Call oneway with a regular (twoway) proxy
+        promise<pair<bool, vector<Ice::Byte>>> completed;
+        Ice::ByteSeq inEncaps, outEncaps;
+        cl->ice_invokeAsync(
+            "opOneway",
+            Ice::OperationMode::Normal,
+            inEncaps,
+            [&](bool ok, vector<Ice::Byte> ouEncaps)
+            {
+                completed.set_value(make_pair(ok, std::move(ouEncaps)));
+            },
+            [&](exception_ptr ex)
+            {
+                completed.set_exception(ex);
+            });
+        pair<bool, vector<Ice::Byte>> result = completed.get_future().get();
+        test(result.first);
+        test(result.second.size() == 6); // Empty encapsulation
+    }
+
     //
     // repeat with the future API.
     //
 
     {
+        // Oneway operation with a twoway proxy must return empty encapsulation.
+        Ice::ByteSeq inEncaps;
+        auto completed = cl->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps);
+        auto result = completed.get();
+        test(result.returnValue);
+        test(result.outParams.size() == 6); // Empty encapsulation
+    }
+
+    {
+        // Oneway operation with a twoway proxy must return empty encapsulation buffer.
         Ice::ByteSeq inEncaps, outEncaps;
+        auto returnValue = cl->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps);
+        test(returnValue);
+        test(outEncaps.size() == 6); // Empty encapsulation
+    }
+
+    {
+        // Oneway operation with a oneway proxy must return empty encapsulation.
+        Ice::ByteSeq inEncaps, outEncaps;
+        bool returnValue = oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        test(returnValue);
+        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
+    }
+
+    {
+        // Oneway operation with a oneway proxy must return empty encapsulation.
+        Ice::ByteSeq inEncaps;
         auto completed = oneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps);
-        test(completed.get().returnValue);
+        auto result = completed.get();
+        test(result.returnValue);
+        test(result.outParams.size() == 0 || result.outParams.size() == 6); // Empty encapsulation
     }
 
     {
@@ -646,6 +703,8 @@ allTests(Test::TestHelper* helper)
         {
             test(false);
         }
+        test(result);
+        test(outEncaps.size() == 0 || outEncaps.size() == 6); // Empty encapsulation
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();


### PR DESCRIPTION
Fix #1728