### PR TITLE
Fix implementation of ids()

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3742,12 +3742,10 @@ Slice::InterfaceDef::ids() const
     StringList ids;
     InterfaceList bases = allBases();
     std::transform(bases.begin(), bases.end(), back_inserter(ids), [](const auto& c) { return c->scoped(); });
-    StringList other;
-    other.push_back(scoped());
-    other.push_back("::Ice::Object");
-    other.sort();
-    ids.merge(other);
+    ids.push_back(scoped());
+    ids.push_back("::Ice::Object");
     ids.unique();
+    ids.sort();
     return ids;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -655,7 +655,6 @@ public:
     virtual ContainedType containedType() const;
     virtual void visit(ParserVisitor*, bool);
     int compactId() const;
-    StringList ids() const;
     virtual std::string kindOf() const;
 
 protected:
@@ -793,6 +792,8 @@ public:
     virtual ContainedType containedType() const;
     virtual std::string kindOf() const;
     virtual void visit(ParserVisitor*, bool);
+
+    // Returns the type IDs of all the interfaces in the inheritance tree, in alphabetical order.
     StringList ids() const;
 
 protected:


### PR DESCRIPTION
This PR simplifies / fixes the implementation of InterfaceDef::ids.

It's already used in a few places but should be used more (for a follow-up PR).