### PR TITLE
Use == and != for string comparisons in C#

### DIFF
--- a/csharp/src/Glacier2/SessionFactoryHelper.cs
+++ b/csharp/src/Glacier2/SessionFactoryHelper.cs
@@ -140,7 +140,7 @@ public class SessionFactoryHelper
     public bool
     getSecure()
     {
-        return getProtocol().Equals("ssl");
+        return getProtocol() == "ssl";
     }
 
     /// <summary>
@@ -157,10 +157,10 @@ public class SessionFactoryHelper
                 throw new ArgumentException("You must use a valid protocol");
             }
 
-            if(!protocol.Equals("tcp") &&
-               !protocol.Equals("ssl") &&
-               !protocol.Equals("wss") &&
-               !protocol.Equals("ws"))
+            if(protocol != "tcp" &&
+               protocol != "ssl" &&
+               protocol != "wss" &&
+               protocol != "ws")
             {
                 throw new ArgumentException("Unknown protocol `" + protocol + "'");
             }
@@ -239,8 +239,8 @@ public class SessionFactoryHelper
     private int
     getPortInternal()
     {
-        return _port == 0 ? ((_protocol.Equals("ssl") ||
-                              _protocol.Equals("wss"))? GLACIER2_SSL_PORT : GLACIER2_TCP_PORT) : _port;
+        return _port == 0 ? ((_protocol == "ssl" ||
+                              _protocol == "wss")? GLACIER2_SSL_PORT : GLACIER2_TCP_PORT) : _port;
     }
 
     /**
@@ -357,7 +357,7 @@ public class SessionFactoryHelper
         // plug-in has already been setup we don't want to override the
         // configuration so it can be loaded from a custom location.
         //
-        if((_protocol.Equals("ssl") || _protocol.Equals("wss")) &&
+        if((_protocol == "ssl" || _protocol == "wss") &&
            initData.properties.getProperty("Ice.Plugin.IceSSL").Length == 0)
         {
             initData.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL:IceSSL.PluginFactory");

--- a/csharp/src/Ice/ACM.cs
+++ b/csharp/src/Ice/ACM.cs
@@ -21,7 +21,7 @@ namespace IceInternal
             Debug.Assert(prefix != null);
 
             string timeoutProperty;
-            if((prefix.Equals("Ice.ACM.Client") || prefix.Equals("Ice.ACM.Server")) &&
+            if((prefix == "Ice.ACM.Client" || prefix == "Ice.ACM.Server") &&
                p.getProperty(prefix + ".Timeout").Length == 0)
             {
                 timeoutProperty = prefix; // Deprecated property.

--- a/csharp/src/Ice/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/DefaultsAndOverrides.cs
@@ -135,11 +135,11 @@ namespace IceInternal
                 properties.getPropertyAsIntWithDefault("Ice.Default.CollocationOptimized", 1) > 0;
 
             val = properties.getPropertyWithDefault("Ice.Default.EndpointSelection", "Random");
-            if(val.Equals("Random"))
+            if(val == "Random")
             {
                 defaultEndpointSelection = Ice.EndpointSelectionType.Random;
             }
-            else if(val.Equals("Ordered"))
+            else if(val == "Ordered")
             {
                 defaultEndpointSelection = Ice.EndpointSelectionType.Ordered;
             }

--- a/csharp/src/Ice/EndpointFactoryManager.cs
+++ b/csharp/src/Ice/EndpointFactoryManager.cs
@@ -74,7 +74,7 @@ namespace IceInternal
             string protocol = v[0];
             v.RemoveAt(0);
 
-            if(protocol.Equals("default"))
+            if(protocol == "default")
             {
                 protocol = _instance.defaultsAndOverrides().defaultProtocol;
             }
@@ -124,7 +124,7 @@ namespace IceInternal
             // If the stringified endpoint is opaque, create an unknown endpoint,
             // then see whether the type matches one of the known endpoints.
             //
-            if(protocol.Equals("opaque"))
+            if(protocol == "opaque")
             {
                 EndpointI ue = new OpaqueEndpointI(v);
                 if(v.Count > 0)

--- a/csharp/src/Ice/IPEndpointI.cs
+++ b/csharp/src/Ice/IPEndpointI.cs
@@ -326,7 +326,7 @@ namespace IceInternal
             {
                 host_ = instance_.defaultHost();
             }
-            else if(host_.Equals("*"))
+            else if(host_ == "*")
             {
                 if(oaEndpoint)
                 {
@@ -359,7 +359,7 @@ namespace IceInternal
 
         protected override bool checkOption(string option, string argument, string endpoint)
         {
-            if(option.Equals("-h"))
+            if(option == "-h")
             {
                 if(argument == null)
                 {
@@ -368,7 +368,7 @@ namespace IceInternal
                 }
                 host_ = argument;
             }
-            else if(option.Equals("-p"))
+            else if(option == "-p")
             {
                 if(argument == null)
                 {
@@ -393,7 +393,7 @@ namespace IceInternal
                                                          "' out of range in endpoint " + endpoint);
                 }
             }
-            else if(option.Equals("--sourceAddress"))
+            else if(option == "--sourceAddress")
             {
                 if(argument == null)
                 {

--- a/csharp/src/Ice/ImplicitContextI.cs
+++ b/csharp/src/Ice/ImplicitContextI.cs
@@ -14,15 +14,15 @@ namespace Ice
     {
         public static ImplicitContextI create(string kind)
         {
-            if(kind.Equals("None") || kind.Length == 0)
+            if(kind == "None" || kind.Length == 0)
             {
                 return null;
             }
-            else if(kind.Equals("Shared"))
+            else if(kind == "Shared")
             {
                 return new SharedImplicitContext();
             }
-            else if(kind.Equals("PerThread"))
+            else if(kind == "PerThread")
             {
                 return new PerThreadImplicitContext();
             }

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -164,7 +164,7 @@ namespace IceMX
                 Resolver resolver;
                 if(!_attributes.TryGetValue(attribute, out resolver))
                 {
-                    if(attribute.Equals("none"))
+                    if(attribute == "none")
                     {
                         return "";
                     }

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -306,14 +306,14 @@ namespace Ice
                 if(dotPos != -1)
                 {
                     string suffix = name.Substring(dotPos + 1);
-                    if(suffix.Equals("cpp") || suffix.Equals("java"))
+                    if(suffix == "cpp" || suffix == "java")
                     {
                         //
                         // Ignored
                         //
                         plugins.Remove(key);
                     }
-                    else if(suffix.Equals("clr"))
+                    else if(suffix == "clr")
                     {
                         name = name.Substring(0, dotPos);
                         loadPlugin(name, val, ref cmdArgs);

--- a/csharp/src/Ice/PropertiesI.cs
+++ b/csharp/src/Ice/PropertiesI.cs
@@ -611,7 +611,7 @@ namespace Ice
         private void loadConfig()
         {
             string val = getProperty("Ice.Config");
-            if(val.Length == 0 || val.Equals("1"))
+            if(val.Length == 0 || val == "1")
             {
                 string s = Environment.GetEnvironmentVariable("ICE_CONFIG");
                 if(s != null && s.Length != 0)

--- a/csharp/src/Ice/ProxyFactory.cs
+++ b/csharp/src/Ice/ProxyFactory.cs
@@ -99,7 +99,7 @@ namespace IceInternal
             Ice.ObjectNotExistException one = ex as Ice.ObjectNotExistException;
             if(one != null)
             {
-                if(@ref.getRouterInfo() != null && one.operation.Equals("ice_add_proxy"))
+                if(@ref.getRouterInfo() != null && one.operation == "ice_add_proxy")
                 {
                     //
                     // If we have a router, an ObjectNotExistException with an

--- a/csharp/src/Ice/ReferenceFactory.cs
+++ b/csharp/src/Ice/ReferenceFactory.cs
@@ -828,11 +828,11 @@ namespace IceInternal
                 if(properties.getProperty(property).Length > 0)
                 {
                     string type = properties.getProperty(property);
-                    if(type.Equals("Random"))
+                    if(type == "Random")
                     {
                         endpointSelection = Ice.EndpointSelectionType.Random;
                     }
-                    else if(type.Equals("Ordered"))
+                    else if(type == "Ordered")
                     {
                         endpointSelection = Ice.EndpointSelectionType.Ordered;
                     }

--- a/csharp/src/Ice/TcpEndpointI.cs
+++ b/csharp/src/Ice/TcpEndpointI.cs
@@ -226,7 +226,7 @@ namespace IceInternal
                                                              endpoint);
                     }
 
-                    if(argument.Equals("infinite"))
+                    if(argument == "infinite")
                     {
                         _timeout = -1;
                     }

--- a/csharp/src/Ice/UdpEndpointI.cs
+++ b/csharp/src/Ice/UdpEndpointI.cs
@@ -157,7 +157,7 @@ namespace IceInternal
         {
             base.initWithOptions(args, oaEndpoint);
 
-            if(_mcastInterface.Equals("*"))
+            if(_mcastInterface == "*")
             {
                 if(oaEndpoint)
                 {
@@ -326,7 +326,7 @@ namespace IceInternal
                 return true;
             }
 
-            if(option.Equals("-c"))
+            if(option == "-c")
             {
                 if(argument != null)
                 {
@@ -337,7 +337,7 @@ namespace IceInternal
 
                 _connect = true;
             }
-            else if(option.Equals("-z"))
+            else if(option == "-z")
             {
                 if(argument != null)
                 {
@@ -348,7 +348,7 @@ namespace IceInternal
 
                 _compress = true;
             }
-            else if(option.Equals("-v") || option.Equals("-e"))
+            else if(option == "-v" || option == "-e")
             {
                 if(argument == null)
                 {
@@ -372,7 +372,7 @@ namespace IceInternal
                     throw e;
                 }
             }
-            else if(option.Equals("--ttl"))
+            else if(option == "--ttl")
             {
                 if(argument == null)
                 {
@@ -399,7 +399,7 @@ namespace IceInternal
                     throw e;
                 }
             }
-            else if(option.Equals("--interface"))
+            else if(option == "--interface")
             {
                 if(argument == null)
                 {

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -739,23 +739,23 @@ namespace IceInternal
             {
                 s = s.Substring("ThreadPriority.".Length, s.Length);
             }
-            if(s.Equals("Lowest"))
+            if(s == "Lowest")
             {
                 return ThreadPriority.Lowest;
             }
-            else if(s.Equals("BelowNormal"))
+            else if(s == "BelowNormal")
             {
                 return ThreadPriority.BelowNormal;
             }
-            else if(s.Equals("Normal"))
+            else if(s == "Normal")
             {
                 return ThreadPriority.Normal;
             }
-            else if(s.Equals("AboveNormal"))
+            else if(s == "AboveNormal")
             {
                 return ThreadPriority.AboveNormal;
             }
-            else if(s.Equals("Highest"))
+            else if(s == "Highest")
             {
                 return ThreadPriority.Highest;
             }

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -757,7 +757,7 @@ namespace IceInternal
             {
                 throw new WebSocketException("missing value for Upgrade field");
             }
-            else if(!val.Equals("websocket"))
+            else if(val != "websocket")
             {
                 throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
             }
@@ -784,7 +784,7 @@ namespace IceInternal
             {
                 throw new WebSocketException("missing value for WebSocket version");
             }
-            else if(!val.Equals("13"))
+            else if(val != "13")
             {
                 throw new WebSocketException("unsupported WebSocket version `" + val + "'");
             }
@@ -910,7 +910,7 @@ namespace IceInternal
             {
                 throw new WebSocketException("missing value for Upgrade field");
             }
-            else if(!val.Equals("websocket"))
+            else if(val != "websocket")
             {
                 throw new WebSocketException("invalid value `" + val + "' for Upgrade field");
             }

--- a/csharp/src/IceBoxNet/Server.cs
+++ b/csharp/src/IceBoxNet/Server.cs
@@ -35,12 +35,12 @@ public class Server
 
         foreach(string arg in args)
         {
-            if(arg.Equals("-h") || arg.Equals("--help"))
+            if(arg == "-h" || arg == "--help")
             {
                 usage();
                 return 0;
             }
-            else if(arg.Equals("-v") || arg.Equals("--version"))
+            else if(arg == "-v" || arg == "--version")
             {
                 Console.Out.WriteLine(Ice.Util.stringVersion());
                 return 0;

--- a/csharp/src/IceBoxNet/ServiceManagerI.cs
+++ b/csharp/src/IceBoxNet/ServiceManagerI.cs
@@ -365,7 +365,7 @@ class ServiceManagerI : ServiceManagerDisp_
                     // never added.
                     foreach(KeyValuePair<string, Ice.Object> p in _sharedCommunicator.findAllAdminFacets())
                     {
-                        if(!p.Key.Equals("Process"))
+                        if(p.Key != "Process")
                         {
                             _communicator.addAdminFacet(p.Value, facetNamePrefix + p.Key);
                         }
@@ -587,7 +587,7 @@ class ServiceManagerI : ServiceManagerDisp_
                     // which is never added
                     foreach(KeyValuePair<string, Ice.Object> p in communicator.findAllAdminFacets())
                     {
-                        if(!p.Key.Equals("Process"))
+                        if(p.Key != "Process")
                         {
                             _communicator.addAdminFacet(p.Value, serviceFacetNamePrefix + p.Key);
                         }

--- a/csharp/src/IceSSL/RFC2253.cs
+++ b/csharp/src/IceSSL/RFC2253.cs
@@ -271,8 +271,8 @@ namespace IceSSL
             // First the OID case.
             //
             if(char.IsDigit(data[pos]) ||
-               (data.Length - pos >= 4 && (data.Substring(pos, 4).Equals("oid.") ||
-                                                       data.Substring(pos, 4).Equals("OID."))))
+               (data.Length - pos >= 4 && (data.Substring(pos, 4) == "oid." ||
+                                                       data.Substring(pos, 4) == "OID.")))
             {
                 if(!char.IsDigit(data[pos]))
                 {

--- a/csharp/src/IceSSL/SSLEngine.cs
+++ b/csharp/src/IceSSL/SSLEngine.cs
@@ -548,11 +548,11 @@ namespace IceSSL
             }
 
             string sloc = store.Substring(0, pos).ToUpperInvariant();
-            if(sloc.Equals("CURRENTUSER"))
+            if(sloc == "CURRENTUSER")
             {
                 loc = StoreLocation.CurrentUser;
             }
-            else if(sloc.Equals("LOCALMACHINE"))
+            else if(sloc == "LOCALMACHINE")
             {
                 loc = StoreLocation.LocalMachine;
             }
@@ -770,31 +770,31 @@ namespace IceSSL
                         //
                         string field = value.Substring(start, pos - start).Trim().ToUpperInvariant();
                         X509FindType findType;
-                        if(field.Equals("SUBJECT"))
+                        if(field == "SUBJECT")
                         {
                             findType = X509FindType.FindBySubjectName;
                         }
-                        else if(field.Equals("SUBJECTDN"))
+                        else if(field == "SUBJECTDN")
                         {
                             findType = X509FindType.FindBySubjectDistinguishedName;
                         }
-                        else if(field.Equals("ISSUER"))
+                        else if(field == "ISSUER")
                         {
                             findType = X509FindType.FindByIssuerName;
                         }
-                        else if(field.Equals("ISSUERDN"))
+                        else if(field == "ISSUERDN")
                         {
                             findType = X509FindType.FindByIssuerDistinguishedName;
                         }
-                        else if(field.Equals("THUMBPRINT"))
+                        else if(field == "THUMBPRINT")
                         {
                             findType = X509FindType.FindByThumbprint;
                         }
-                        else if(field.Equals("SUBJECTKEYID"))
+                        else if(field == "SUBJECTKEYID")
                         {
                             findType = X509FindType.FindBySubjectKeyIdentifier;
                         }
-                        else if(field.Equals("SERIAL"))
+                        else if(field == "SERIAL")
                         {
                             findType = X509FindType.FindBySerialNumber;
                         }

--- a/csharp/test/Glacier2/application/Client.cs
+++ b/csharp/test/Glacier2/application/Client.cs
@@ -80,7 +80,7 @@ public class Client : Test.TestHelper
         public override int runWithSession(string[] args)
         {
             test(router() != null);
-            test(categoryForClient() != "");
+            test(categoryForClient().Length > 0);
             test(objectAdapter() != null);
 
             if(_restart == 0)

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -272,7 +272,7 @@ public class Client : Test.TestHelper
                 catch(CallbackException ex)
                 {
                     test(ex.someValue == 3.14);
-                    test(ex.someString.Equals("3.14"));
+                    test(ex.someString == "3.14");
                 }
                 callbackReceiverImpl.callbackOK();
                 Console.Out.WriteLine("ok");
@@ -336,7 +336,7 @@ public class Client : Test.TestHelper
                 Console.Out.WriteLine("ok");
             }
 
-            if(args.Length >= 1 && args[0].Equals("--shutdown"))
+            if(args.Length >= 1 && args[0] == "--shutdown")
             {
                 Console.Out.Write("testing server shutdown... ");
                 Console.Out.Flush();
@@ -392,7 +392,7 @@ public class Client : Test.TestHelper
                 }
             }
 
-            if(args.Length >= 1 && args[0].Equals("--shutdown"))
+            if(args.Length >= 1 && args[0] == "--shutdown")
             {
                 {
                     Console.Out.Write("uninstalling router with communicator... ");

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -297,7 +297,7 @@ public class Client : Test.TestHelper
                 Console.Out.Flush();
                 try
                 {
-                    test(!session.categoryForClient().Equals(""));
+                    test(session.categoryForClient() != "");
                 }
                 catch(Glacier2.SessionNotExistException)
                 {
@@ -353,7 +353,7 @@ public class Client : Test.TestHelper
                 Console.Out.Flush();
                 try
                 {
-                    test(!session.categoryForClient().Equals(""));
+                    test(session.categoryForClient() != "");
                     test(false);
                 }
                 catch(Glacier2.SessionNotExistException)

--- a/csharp/test/Glacier2/sessionHelper/Client.cs
+++ b/csharp/test/Glacier2/sessionHelper/Client.cs
@@ -297,7 +297,7 @@ public class Client : Test.TestHelper
                 Console.Out.Flush();
                 try
                 {
-                    test(session.categoryForClient() != "");
+                    test(session.categoryForClient().Length > 0);
                 }
                 catch(Glacier2.SessionNotExistException)
                 {
@@ -353,7 +353,7 @@ public class Client : Test.TestHelper
                 Console.Out.Flush();
                 try
                 {
-                    test(session.categoryForClient() != "");
+                    test(session.categoryForClient().Length > 0);
                     test(false);
                 }
                 catch(Glacier2.SessionNotExistException)

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -79,7 +79,7 @@ namespace Ice
                     Ice.ObjectAdapter adapter = communicator.createObjectAdapter("PAdapter");
                     test(adapter.getPublishedEndpoints().Length == 1);
                     Ice.Endpoint endpt = adapter.getPublishedEndpoints()[0];
-                    test(endpt.ToString().Equals("tcp -h localhost -p 12345 -t 30000"));
+                    test(endpt.ToString() == "tcp -h localhost -p 12345 -t 30000");
                     Ice.ObjectPrx prx =
                         communicator.stringToProxy("dummy:tcp -h localhost -p 12346 -t 20000:tcp -h localhost -p 12347 -t 10000");
                     adapter.setPublishedEndpoints(prx.ice_getEndpoints());
@@ -94,7 +94,7 @@ namespace Ice
                     communicator.getProperties().setProperty("PAdapter.PublishedEndpoints", "tcp -h localhost -p 12345 -t 20000");
                     adapter.refreshPublishedEndpoints();
                     test(adapter.getPublishedEndpoints().Length == 1);
-                    test(adapter.getPublishedEndpoints()[0].ToString().Equals("tcp -h localhost -p 12345 -t 20000"));
+                    test(adapter.getPublishedEndpoints()[0].ToString() == "tcp -h localhost -p 12345 -t 20000");
                     adapter.destroy();
                     test(adapter.getPublishedEndpoints().Length == 0);
                 }
@@ -128,10 +128,10 @@ namespace Ice
                         Ice.RouterPrxHelper.uncheckedCast(@base.ice_identity(routerId).ice_connectionId("rc"));
                     Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithRouter("", router);
                     test(adapter.getPublishedEndpoints().Length == 1);
-                    test(adapter.getPublishedEndpoints()[0].ToString().Equals("tcp -h localhost -p 23456 -t 30000"));
+                    test(adapter.getPublishedEndpoints()[0].ToString() == "tcp -h localhost -p 23456 -t 30000");
                     adapter.refreshPublishedEndpoints();
                     test(adapter.getPublishedEndpoints().Length == 1);
-                    test(adapter.getPublishedEndpoints()[0].ToString().Equals("tcp -h localhost -p 23457 -t 30000"));
+                    test(adapter.getPublishedEndpoints()[0].ToString() == "tcp -h localhost -p 23457 -t 30000");
                     try
                     {
                         adapter.setPublishedEndpoints(router.ice_getEndpoints());

--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -63,14 +63,14 @@ namespace Ice
                     test(!_deactivated);
                 }
 
-                if(current.id.name.Equals("router"))
+                if(current.id.name == "router")
                 {
                     cookie = null;
                     return _router;
                 }
 
                 test(current.id.category.Length == 0);
-                test(current.id.name.Equals("test"));
+                test(current.id.name == "test");
 
                 cookie = new Cookie();
 
@@ -84,13 +84,13 @@ namespace Ice
                     test(!_deactivated);
                 }
 
-                if(current.id.name.Equals("router"))
+                if(current.id.name == "router")
                 {
                     return;
                 }
 
                 Cookie co = (Cookie)cookie;
-                test(co.message().Equals("blahblah"));
+                test(co.message() == "blahblah");
             }
 
             public void deactivate(string category)

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -209,19 +209,19 @@ namespace Ice
                     //
                     // Test: PropertiesAdmin::getProperty()
                     //
-                    test(pa.getProperty("Prop2").Equals("2"));
-                    test(pa.getProperty("Bogus").Equals(""));
+                    test(pa.getProperty("Prop2") == "2");
+                    test(pa.getProperty("Bogus") == "");
 
                     //
                     // Test: PropertiesAdmin::getProperties()
                     //
                     Dictionary<string, string> pd = pa.getPropertiesForPrefix("");
                     test(pd.Count == 5);
-                    test(pd["Ice.Admin.Endpoints"].Equals("tcp -h 127.0.0.1"));
-                    test(pd["Ice.Admin.InstanceName"].Equals("Test"));
-                    test(pd["Prop1"].Equals("1"));
-                    test(pd["Prop2"].Equals("2"));
-                    test(pd["Prop3"].Equals("3"));
+                    test(pd["Ice.Admin.Endpoints"] == "tcp -h 127.0.0.1");
+                    test(pd["Ice.Admin.InstanceName"] == "Test");
+                    test(pd["Prop1"] == "1");
+                    test(pd["Prop2"] == "2");
+                    test(pd["Prop3"] == "3");
 
                     Dictionary<string, string> changes;
 
@@ -235,18 +235,18 @@ namespace Ice
                     setProps.Add("Prop4", "4"); // Added
                     setProps.Add("Prop5", "5"); // Added
                     pa.setProperties(setProps);
-                    test(pa.getProperty("Prop1").Equals("10"));
-                    test(pa.getProperty("Prop2").Equals("20"));
-                    test(pa.getProperty("Prop3").Equals(""));
-                    test(pa.getProperty("Prop4").Equals("4"));
-                    test(pa.getProperty("Prop5").Equals("5"));
+                    test(pa.getProperty("Prop1") == "10");
+                    test(pa.getProperty("Prop2") == "20");
+                    test(pa.getProperty("Prop3") == "");
+                    test(pa.getProperty("Prop4") == "4");
+                    test(pa.getProperty("Prop5") == "5");
                     changes = com.getChanges();
                     test(changes.Count == 5);
-                    test(changes["Prop1"].Equals("10"));
-                    test(changes["Prop2"].Equals("20"));
-                    test(changes["Prop3"].Equals(""));
-                    test(changes["Prop4"].Equals("4"));
-                    test(changes["Prop5"].Equals("5"));
+                    test(changes["Prop1"] == "10");
+                    test(changes["Prop2"] == "20");
+                    test(changes["Prop3"] == "");
+                    test(changes["Prop4"] == "4");
+                    test(changes["Prop5"] == "5");
                     pa.setProperties(setProps);
                     changes = com.getChanges();
                     test(changes.Count == 0);
@@ -281,11 +281,11 @@ namespace Ice
                     Ice.LogMessage[] logMessages = logger.getLog(null, null, -1, out prefix);
 
                     test(logMessages.Length == 4);
-                    test(prefix.Equals("NullLogger"));
-                    test(logMessages[0].traceCategory.Equals("testCat") && logMessages[0].message.Equals("trace"));
-                    test(logMessages[1].message.Equals("warning"));
-                    test(logMessages[2].message.Equals("error"));
-                    test(logMessages[3].message.Equals("print"));
+                    test(prefix == "NullLogger");
+                    test(logMessages[0].traceCategory == "testCat" && logMessages[0].message == "trace");
+                    test(logMessages[1].message == "warning");
+                    test(logMessages[2].message == "error");
+                    test(logMessages[3].message == "print");
 
                     //
                     // Get only errors and warnings
@@ -303,7 +303,7 @@ namespace Ice
                     logMessages = logger.getLog(messageTypes, null, -1, out prefix);
 
                     test(logMessages.Length == 4);
-                    test(prefix.Equals("NullLogger"));
+                    test(prefix == "NullLogger");
 
                     foreach(var msg in logMessages)
                     {
@@ -325,12 +325,12 @@ namespace Ice
                     string[] categories = { "testCat" };
                     logMessages = logger.getLog(messageTypes, categories, -1, out prefix);
                     test(logMessages.Length == 5);
-                    test(prefix.Equals("NullLogger"));
+                    test(prefix == "NullLogger");
 
                     foreach(var msg in logMessages)
                     {
                         test(msg.type == Ice.LogMessageType.ErrorMessage ||
-                            (msg.type == Ice.LogMessageType.TraceMessage && msg.traceCategory.Equals("testCat")));
+                            (msg.type == Ice.LogMessageType.TraceMessage && msg.traceCategory == "testCat"));
                     }
 
                     //
@@ -340,10 +340,10 @@ namespace Ice
 
                     logMessages = logger.getLog(messageTypes, categories, 2, out prefix);
                     test(logMessages.Length == 2);
-                    test(prefix.Equals("NullLogger"));
+                    test(prefix == "NullLogger");
 
-                    test(logMessages[0].message.Equals("trace3"));
-                    test(logMessages[1].message.Equals("error3"));
+                    test(logMessages[0].message == "trace3");
+                    test(logMessages[1].message == "error3");
 
                     //
                     // Now, test RemoteLogger
@@ -511,7 +511,7 @@ namespace Ice
                     var com = factory.createCommunicator(props);
                     Ice.ObjectPrx obj = com.getAdmin();
                     Ice.PropertiesAdminPrx pa = Ice.PropertiesAdminPrxHelper.checkedCast(obj, "Properties");
-                    test(pa.getProperty("Ice.Admin.InstanceName").Equals("Test"));
+                    test(pa.getProperty("Ice.Admin.InstanceName") == "Test");
                     var tf = Test.TestFacetPrxHelper.checkedCast(obj, "TestFacet");
                     tf.op();
                     Ice.ProcessPrx proc = Ice.ProcessPrxHelper.checkedCast(obj, "Process");

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -210,7 +210,7 @@ namespace Ice
                     // Test: PropertiesAdmin::getProperty()
                     //
                     test(pa.getProperty("Prop2") == "2");
-                    test(pa.getProperty("Bogus") == "");
+                    test(pa.getProperty("Bogus").Length == 0);
 
                     //
                     // Test: PropertiesAdmin::getProperties()
@@ -237,14 +237,14 @@ namespace Ice
                     pa.setProperties(setProps);
                     test(pa.getProperty("Prop1") == "10");
                     test(pa.getProperty("Prop2") == "20");
-                    test(pa.getProperty("Prop3") == "");
+                    test(pa.getProperty("Prop3").Length == 0);
                     test(pa.getProperty("Prop4") == "4");
                     test(pa.getProperty("Prop5") == "5");
                     changes = com.getChanges();
                     test(changes.Count == 5);
                     test(changes["Prop1"] == "10");
                     test(changes["Prop2"] == "20");
-                    test(changes["Prop3"] == "");
+                    test(changes["Prop3"].Length == 0);
                     test(changes["Prop4"] == "4");
                     test(changes["Prop5"] == "5");
                     pa.setProperties(setProps);

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -152,9 +152,9 @@ namespace Ice
                     await p.ice_pingAsync(ctx);
 
                     var id = await p.ice_idAsync();
-                    test(id.Equals("::Test::TestIntf"));
+                    test(id == "::Test::TestIntf");
                     id = await p.ice_idAsync(ctx);
-                    test(id.Equals("::Test::TestIntf"));
+                    test(id == "::Test::TestIntf");
 
                     var ids = await p.ice_idsAsync();
                     test(ids.Length == 2);

--- a/csharp/test/Ice/background/AllTests.cs
+++ b/csharp/test/Ice/background/AllTests.cs
@@ -215,8 +215,8 @@ public class AllTests
         }
         Console.Out.WriteLine("ok");
 
-        bool ws = communicator.getProperties().getProperty("Ice.Default.Protocol").Equals("test-ws");
-        bool wss = communicator.getProperties().getProperty("Ice.Default.Protocol").Equals("test-wss");
+        bool ws = communicator.getProperties().getProperty("Ice.Default.Protocol") == "test-ws";
+        bool wss = communicator.getProperties().getProperty("Ice.Default.Protocol") == "test-wss";
         if(!ws && !wss)
         {
             Console.Write("testing buffered transport... ");
@@ -557,8 +557,8 @@ public class AllTests
             configuration.readException(null);
         }
 
-        if (!background.ice_getCommunicator().getProperties().getProperty("Ice.Default.Protocol").Equals("test-ssl") &&
-           !background.ice_getCommunicator().getProperties().getProperty("Ice.Default.Protocol").Equals("test-wss"))
+        if (background.ice_getCommunicator().getProperties().getProperty("Ice.Default.Protocol") != "test-ssl" &&
+           background.ice_getCommunicator().getProperties().getProperty("Ice.Default.Protocol") != "test-wss")
         {
             try
             {

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -190,7 +190,7 @@ namespace Ice
                     //
                     com.deactivateObjectAdapter((Test.RemoteObjectAdapterPrx)adapters[2]);
                     var obj = createTestIntfPrx(adapters);
-                    test(obj.getAdapterName().Equals("Adapter12"));
+                    test(obj.getAdapterName() == "Adapter12");
 
                     deactivate(com, adapters);
                 }
@@ -362,7 +362,7 @@ namespace Ice
                     //
                     com.deactivateObjectAdapter(adapters[2]);
                     var obj = createTestIntfPrx(adapters);
-                    test((await obj.getAdapterNameAsync()).Equals("AdapterAMI12"));
+                    test((await obj.getAdapterNameAsync()) == "AdapterAMI12");
 
                     deactivate(com, adapters);
                 }
@@ -423,13 +423,13 @@ namespace Ice
                     // Ensure that endpoints are tried in order by deactiving the adapters
                     // one after the other.
                     //
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter31"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter31"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[0]);
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter32"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter32"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[1]);
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter33"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter33"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[2]);
 
@@ -453,15 +453,15 @@ namespace Ice
                     // order.
                     //
                     adapters.Add(com.createObjectAdapter("Adapter36", endpoints[2].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter36"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter36"; i++) ;
                     test(i == nRetry);
                     obj.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait);
                     adapters.Add(com.createObjectAdapter("Adapter35", endpoints[1].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter35"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter35"; i++) ;
                     test(i == nRetry);
                     obj.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait);
                     adapters.Add(com.createObjectAdapter("Adapter34", endpoints[0].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter34"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter34"; i++) ;
                     test(i == nRetry);
 
                     deactivate(com, adapters);
@@ -530,7 +530,7 @@ namespace Ice
 
                     com.deactivateObjectAdapter(adapters[2]);
 
-                    test(obj.getAdapterName().Equals("Adapter52"));
+                    test(obj.getAdapterName() == "Adapter52");
 
                     deactivate(com, adapters);
                 }
@@ -567,7 +567,7 @@ namespace Ice
 
                     com.deactivateObjectAdapter(adapters[2]);
 
-                    test((await obj.getAdapterNameAsync()).Equals("AdapterAMI52"));
+                    test((await obj.getAdapterNameAsync()) == "AdapterAMI52");
 
                     deactivate(com, adapters);
                 }
@@ -593,13 +593,13 @@ namespace Ice
                     // Ensure that endpoints are tried in order by deactiving the adapters
                     // one after the other.
                     //
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter61"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter61"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[0]);
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter62"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter62"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[1]);
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter63"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter63"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[2]);
 
@@ -623,13 +623,13 @@ namespace Ice
                     // order.
                     //
                     adapters.Add(com.createObjectAdapter("Adapter66", endpoints[2].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter66"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter66"; i++) ;
                     test(i == nRetry);
                     adapters.Add(com.createObjectAdapter("Adapter65", endpoints[1].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter65"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter65"; i++) ;
                     test(i == nRetry);
                     adapters.Add(com.createObjectAdapter("Adapter64", endpoints[0].ToString()));
-                    for(i = 0; i < nRetry && obj.getAdapterName().Equals("Adapter64"); i++) ;
+                    for(i = 0; i < nRetry && obj.getAdapterName() == "Adapter64"; i++) ;
                     test(i == nRetry);
 
                     deactivate(com, adapters);
@@ -656,13 +656,13 @@ namespace Ice
                     // Ensure that endpoints are tried in order by deactiving the adapters
                     // one after the other.
                     //
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI61"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI61"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[0]);
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI62"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI62"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[1]);
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI63"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI63"; i++) ;
                     test(i == nRetry);
                     com.deactivateObjectAdapter(adapters[2]);
 
@@ -686,13 +686,13 @@ namespace Ice
                     // order.
                     //
                     adapters.Add(com.createObjectAdapter("AdapterAMI66", endpoints[2].ToString()));
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI66"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI66"; i++) ;
                     test(i == nRetry);
                     adapters.Add(com.createObjectAdapter("AdapterAMI65", endpoints[1].ToString()));
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI65"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI65"; i++) ;
                     test(i == nRetry);
                     adapters.Add(com.createObjectAdapter("AdapterAMI64", endpoints[0].ToString()));
-                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()).Equals("AdapterAMI64"); i++) ;
+                    for(i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI64"; i++) ;
                     test(i == nRetry);
 
                     deactivate(com, adapters);
@@ -707,7 +707,7 @@ namespace Ice
                     adapters.Add(com.createObjectAdapter("Adapter72", "udp"));
 
                     var obj = createTestIntfPrx(adapters);
-                    test(obj.getAdapterName().Equals("Adapter71"));
+                    test(obj.getAdapterName() == "Adapter71");
 
                     var testUDP = Test.TestIntfPrxHelper.uncheckedCast(obj.ice_datagram());
                     test(obj.ice_getConnection() != testUDP.ice_getConnection());
@@ -733,7 +733,7 @@ namespace Ice
                         int i;
                         for(i = 0; i < 5; i++)
                         {
-                            test(obj.getAdapterName().Equals("Adapter82"));
+                            test(obj.getAdapterName() == "Adapter82");
                             obj.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait);
                         }
 
@@ -749,7 +749,7 @@ namespace Ice
 
                         for(i = 0; i < 5; i++)
                         {
-                            test(obj.getAdapterName().Equals("Adapter81"));
+                            test(obj.getAdapterName() == "Adapter81");
                             obj.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait);
                         }
 
@@ -757,7 +757,7 @@ namespace Ice
 
                         for(i = 0; i < 5; i++)
                         {
-                            test(obj.getAdapterName().Equals("Adapter83"));
+                            test(obj.getAdapterName() == "Adapter83");
                             obj.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait);
                         }
 

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -31,7 +31,7 @@ namespace Ice
                     test(v.nc1 == Test.Nested.Color.red);
                     test(v.nc2 == Test.Nested.Color.green);
                     test(v.nc3 == Test.Nested.Color.blue);
-                    test(v.noDefault.Equals(""));
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -75,7 +75,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     //test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-                    //test(v.str.Equals("foo bar"));
+                    //test(v.str == "foo bar");
                     test(v.c1 == Test.Color.red);
                     test(v.c2 == Test.Color.green);
                     test(v.c3 == Test.Color.blue);
@@ -102,7 +102,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     //test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-                    //test(v.str.Equals("foo bar"));
+                    //test(v.str == "foo bar");
                     test(v.c1 == Test.Color.red);
                     test(v.c2 == Test.Color.green);
                     test(v.c3 == Test.Color.blue);
@@ -129,7 +129,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-                    test(v.noDefault.Equals(""));
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -155,7 +155,7 @@ namespace Ice
                     test(v.nc1 == Test.Nested.Color.red);
                     test(v.nc2 == Test.Nested.Color.green);
                     test(v.nc3 == Test.Nested.Color.blue);
-                    test(v.noDefault.Equals(""));
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -175,7 +175,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                    test(v.noDefault.Equals(""));
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -195,7 +195,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                    test(v.noDefault.Equals(""));
+                    test(v.noDefault == "");
                     test(v.c1 == Test.Color.red);
                     test(v.c2 == Test.Color.green);
                     test(v.c3 == Test.Color.blue);
@@ -220,8 +220,8 @@ namespace Ice
                     test(v.l == 4);
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
-                    test(v.str.Equals("foo bar"));
-                    test(v.noDefault.Equals(""));
+                    test(v.str == "foo bar");
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -258,8 +258,8 @@ namespace Ice
                     test(v.l == 4);
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
-                    test(v.str.Equals("foo bar"));
-                    test(v.noDefault.Equals(""));
+                    test(v.str == "foo bar");
+                    test(v.noDefault == "");
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -281,7 +281,7 @@ namespace Ice
                     test(v.l == 0);
                     test(v.f == 0.0);
                     test(v.d == 0.0);
-                    test(v.str.Equals(""));
+                    test(v.str == "");
                     test(v.c1 == Test.Color.red);
                     test(v.bs == null);
                     test(v.iseq == null);
@@ -290,7 +290,7 @@ namespace Ice
                     test(v.dict == null);
 
                     Test.ExceptionNoDefaults e = new Test.ExceptionNoDefaults();
-                    test(e.str.Equals(""));
+                    test(e.str == "");
                     test(e.c1 == Test.Color.red);
                     test(e.bs == null);
                     test(e.st.a == 0);
@@ -298,7 +298,7 @@ namespace Ice
                     test(e.dict == null);
 
                     Test.ClassNoDefaults cl = new Test.ClassNoDefaults();
-                    test(cl.str.Equals(""));
+                    test(cl.str == "");
                     test(cl.c1 == Test.Color.red);
                     test(cl.bs == null);
                     test(cl.st.a == 0);

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -31,7 +31,7 @@ namespace Ice
                     test(v.nc1 == Test.Nested.Color.red);
                     test(v.nc2 == Test.Nested.Color.green);
                     test(v.nc3 == Test.Nested.Color.blue);
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -129,7 +129,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -155,7 +155,7 @@ namespace Ice
                     test(v.nc1 == Test.Nested.Color.red);
                     test(v.nc2 == Test.Nested.Color.green);
                     test(v.nc3 == Test.Nested.Color.blue);
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -175,7 +175,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -195,7 +195,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.c1 == Test.Color.red);
                     test(v.c2 == Test.Color.green);
                     test(v.c3 == Test.Color.blue);
@@ -221,7 +221,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo bar");
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -259,7 +259,7 @@ namespace Ice
                     test(v.f == 5.1F);
                     test(v.d == 6.2);
                     test(v.str == "foo bar");
-                    test(v.noDefault == "");
+                    test(v.noDefault.Length == 0);
                     test(v.zeroI == 0);
                     test(v.zeroL == 0);
                     test(v.zeroF == 0);
@@ -281,7 +281,7 @@ namespace Ice
                     test(v.l == 0);
                     test(v.f == 0.0);
                     test(v.d == 0.0);
-                    test(v.str == "");
+                    test(v.str.Length == 0);
                     test(v.c1 == Test.Color.red);
                     test(v.bs == null);
                     test(v.iseq == null);
@@ -290,7 +290,7 @@ namespace Ice
                     test(v.dict == null);
 
                     Test.ExceptionNoDefaults e = new Test.ExceptionNoDefaults();
-                    test(e.str == "");
+                    test(e.str.Length == 0);
                     test(e.c1 == Test.Color.red);
                     test(e.bs == null);
                     test(e.st.a == 0);
@@ -298,7 +298,7 @@ namespace Ice
                     test(e.dict == null);
 
                     Test.ClassNoDefaults cl = new Test.ClassNoDefaults();
-                    test(cl.str == "");
+                    test(cl.str.Length == 0);
                     test(cl.c1 == Test.Color.red);
                     test(cl.bs == null);
                     test(cl.st.a == 0);

--- a/csharp/test/Ice/enums/AllTests.cs
+++ b/csharp/test/Ice/enums/AllTests.cs
@@ -71,7 +71,7 @@ namespace Ice
                 Ice.OutputStream ostr;
                 byte[] bytes;
 
-                bool encoding_1_0 = communicator.getProperties().getProperty("Ice.Default.EncodingVersion").Equals("1.0");
+                bool encoding_1_0 = communicator.getProperties().getProperty("Ice.Default.EncodingVersion") == "1.0";
 
                 ostr = new Ice.OutputStream(communicator);
                 ostr.writeEnum((int)Test.ByteEnum.benum11,(int)Test.ByteEnum.benum11);

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -115,7 +115,7 @@ namespace Ice
                     }
                     catch(IllegalIdentityException e)
                     {
-                        test(e.id.name.Equals(""));
+                        test(e.id.name == "");
                     }
 
                     try
@@ -494,7 +494,7 @@ namespace Ice
                     }
                     catch(FacetNotExistException ex)
                     {
-                        test(ex.facet.Equals("no such facet"));
+                        test(ex.facet == "no such facet");
                     }
                 }
                 catch(Exception)
@@ -515,7 +515,7 @@ namespace Ice
                 }
                 catch(OperationNotExistException ex)
                 {
-                    test(ex.operation.Equals("noSuchOperation"));
+                    test(ex.operation == "noSuchOperation");
                 }
 
                 output.WriteLine("ok");
@@ -754,7 +754,7 @@ namespace Ice
                 }
                 catch(FacetNotExistException ex)
                 {
-                    test(ex.facet.Equals("no such facet"));
+                    test(ex.facet == "no such facet");
                 }
 
                 output.WriteLine("ok");
@@ -770,7 +770,7 @@ namespace Ice
                 }
                 catch (OperationNotExistException ex)
                 {
-                    test(ex.operation.Equals("noSuchOperation"));
+                    test(ex.operation == "noSuchOperation");
                 }
 
                 output.WriteLine("ok");
@@ -880,7 +880,7 @@ namespace Ice
                 }
                 catch (FacetNotExistException ex)
                 {
-                    test(ex.facet.Equals("no such facet"));
+                    test(ex.facet == "no such facet");
                 }
 
                 output.WriteLine("ok");
@@ -896,7 +896,7 @@ namespace Ice
                 }
                 catch (OperationNotExistException ex)
                 {
-                    test(ex.operation.Equals("noSuchOperation"));
+                    test(ex.operation == "noSuchOperation");
                 }
 
                 output.WriteLine("ok");

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -115,7 +115,7 @@ namespace Ice
                     }
                     catch(IllegalIdentityException e)
                     {
-                        test(e.id.name == "");
+                        test(e.id.name.Length == 0);
                     }
 
                     try

--- a/csharp/test/Ice/facets/AllTests.cs
+++ b/csharp/test/Ice/facets/AllTests.cs
@@ -20,17 +20,17 @@ namespace Ice
                 test(communicator.getProperties().getPropertyAsList("Ice.Admin.Facets").Length == 0);
                 communicator.getProperties().setProperty("Ice.Admin.Facets", "foobar");
                 String[] facetFilter = communicator.getProperties().getPropertyAsList("Ice.Admin.Facets");
-                test(facetFilter.Length == 1 && facetFilter[0].Equals("foobar"));
+                test(facetFilter.Length == 1 && facetFilter[0] == "foobar");
                 communicator.getProperties().setProperty("Ice.Admin.Facets", "foo\\'bar");
                 facetFilter = communicator.getProperties().getPropertyAsList("Ice.Admin.Facets");
-                test(facetFilter.Length == 1 && facetFilter[0].Equals("foo'bar"));
+                test(facetFilter.Length == 1 && facetFilter[0] == "foo'bar");
                 communicator.getProperties().setProperty("Ice.Admin.Facets", "'foo bar' toto 'titi'");
                 facetFilter = communicator.getProperties().getPropertyAsList("Ice.Admin.Facets");
-                test(facetFilter.Length == 3 && facetFilter[0].Equals("foo bar") && facetFilter[1].Equals("toto")
-                     && facetFilter[2].Equals("titi"));
+                test(facetFilter.Length == 3 && facetFilter[0] == "foo bar" && facetFilter[1] == "toto"
+                     && facetFilter[2] == "titi");
                 communicator.getProperties().setProperty("Ice.Admin.Facets", "'foo bar\\' toto' 'titi'");
                 facetFilter = communicator.getProperties().getPropertyAsList("Ice.Admin.Facets");
-                test(facetFilter.Length == 2 && facetFilter[0].Equals("foo bar' toto") && facetFilter[1].Equals("titi"));
+                test(facetFilter.Length == 2 && facetFilter[0] == "foo bar' toto" && facetFilter[1] == "titi");
                 // communicator.getProperties().setProperty("Ice.Admin.Facets", "'foo bar' 'toto titi");
                 // facetFilter = communicator.getProperties().getPropertyAsList("Ice.Admin.Facets");
                 // test(facetFilter.Length == 0);
@@ -145,43 +145,43 @@ namespace Ice
                 d = Test.DPrxHelper.checkedCast(db);
                 test(d != null);
                 test(d.Equals(db));
-                test(d.callA().Equals("A"));
-                test(d.callB().Equals("B"));
-                test(d.callC().Equals("C"));
-                test(d.callD().Equals("D"));
+                test(d.callA() == "A");
+                test(d.callB() == "B");
+                test(d.callC() == "C");
+                test(d.callD() == "D");
                 output.WriteLine("ok");
 
                 output.Write("testing facets A, B, C, and D... ");
                 output.Flush();
                 df = Test.DPrxHelper.checkedCast(d, "facetABCD");
                 test(df != null);
-                test(df.callA().Equals("A"));
-                test(df.callB().Equals("B"));
-                test(df.callC().Equals("C"));
-                test(df.callD().Equals("D"));
+                test(df.callA() == "A");
+                test(df.callB() == "B");
+                test(df.callC() == "C");
+                test(df.callD() == "D");
                 output.WriteLine("ok");
 
                 output.Write("testing facets E and F... ");
                 output.Flush();
                 var ff = Test.FPrxHelper.checkedCast(d, "facetEF");
                 test(ff != null);
-                test(ff.callE().Equals("E"));
-                test(ff.callF().Equals("F"));
+                test(ff.callE() == "E");
+                test(ff.callF() == "F");
                 output.WriteLine("ok");
 
                 output.Write("testing facet G... ");
                 output.Flush();
                 var gf = Test.GPrxHelper.checkedCast(ff, "facetGH");
                 test(gf != null);
-                test(gf.callG().Equals("G"));
+                test(gf.callG() == "G");
                 output.WriteLine("ok");
 
                 output.Write("testing whether casting preserves the facet... ");
                 output.Flush();
                 var hf = Test.HPrxHelper.checkedCast(gf);
                 test(hf != null);
-                test(hf.callG().Equals("G"));
-                test(hf.callH().Equals("H"));
+                test(hf.callG() == "G");
+                test(hf.callH() == "H");
                 output.WriteLine("ok");
                 return gf;
             }

--- a/csharp/test/Ice/info/AllTests.cs
+++ b/csharp/test/Ice/info/AllTests.cs
@@ -50,9 +50,9 @@ namespace Ice
 
                     Ice.EndpointInfo info = endps[0].getInfo();
                     Ice.TCPEndpointInfo tcpEndpoint = getTCPEndpointInfo(info);
-                    test(tcpEndpoint.host.Equals("tcphost"));
+                    test(tcpEndpoint.host == "tcphost");
                     test(tcpEndpoint.port == 10000);
-                    test(tcpEndpoint.sourceAddress.Equals("10.10.10.10"));
+                    test(tcpEndpoint.sourceAddress == "10.10.10.10");
                     test(tcpEndpoint.timeout == 1200);
                     test(tcpEndpoint.compress);
                     test(!tcpEndpoint.datagram());
@@ -67,11 +67,11 @@ namespace Ice
                          tcpEndpoint.type() == Ice.WSSEndpointType.value && info is Ice.WSEndpointInfo);
 
                     Ice.UDPEndpointInfo udpEndpoint =(Ice.UDPEndpointInfo)endps[1].getInfo();
-                    test(udpEndpoint.host.Equals("udphost"));
+                    test(udpEndpoint.host == "udphost");
                     test(udpEndpoint.port == 10001);
-                    test(udpEndpoint.mcastInterface.Equals("eth0"));
+                    test(udpEndpoint.mcastInterface == "eth0");
                     test(udpEndpoint.mcastTtl == 5);
-                    test(udpEndpoint.sourceAddress.Equals("10.10.10.10"));
+                    test(udpEndpoint.sourceAddress == "10.10.10.10");
                     test(udpEndpoint.timeout == -1);
                     test(!udpEndpoint.compress);
                     test(!udpEndpoint.secure());
@@ -138,7 +138,7 @@ namespace Ice
                     }
 
                     tcpEndpoint = getTCPEndpointInfo(publishedEndpoints[0].getInfo());
-                    test(tcpEndpoint.host.Equals("127.0.0.1"));
+                    test(tcpEndpoint.host == "127.0.0.1");
                     test(tcpEndpoint.port == port);
 
                     adapter.destroy();
@@ -165,7 +165,7 @@ namespace Ice
 
                     Dictionary<string, string> ctx = testIntf.getEndpointInfoAsContext();
                     test(ctx["host"].Equals(tcpinfo.host));
-                    test(ctx["compress"].Equals("false"));
+                    test(ctx["compress"] == "false");
                     int port = System.Int32.Parse(ctx["port"]);
                     test(port > 0);
 
@@ -188,7 +188,7 @@ namespace Ice
                     test(info.adapterName.Length == 0);
                     test(ipInfo.remotePort == endpointPort);
                     test(ipInfo.localPort > 0);
-                    if(defaultHost.Equals("127.0.0.1"))
+                    if(defaultHost == "127.0.0.1")
                     {
                         test(ipInfo.localAddress.Equals(defaultHost));
                         test(ipInfo.remoteAddress.Equals(defaultHost));
@@ -197,25 +197,25 @@ namespace Ice
                     test(ipInfo.sndSize >= 2048);
 
                     Dictionary<string, string> ctx = testIntf.getConnectionInfoAsContext();
-                    test(ctx["incoming"].Equals("true"));
-                    test(ctx["adapterName"].Equals("TestAdapter"));
+                    test(ctx["incoming"] == "true");
+                    test(ctx["adapterName"] == "TestAdapter");
                     test(ctx["remoteAddress"].Equals(ipInfo.localAddress));
                     test(ctx["localAddress"].Equals(ipInfo.remoteAddress));
                     test(ctx["remotePort"].Equals(ipInfo.localPort.ToString()));
                     test(ctx["localPort"].Equals(ipInfo.remotePort.ToString()));
 
-                    if(@base.ice_getConnection().type().Equals("ws") || @base.ice_getConnection().type().Equals("wss"))
+                    if(@base.ice_getConnection().type() == "ws" || @base.ice_getConnection().type() == "wss")
                     {
                         Dictionary<string, string> headers =((Ice.WSConnectionInfo)info).headers;
-                        test(headers["Upgrade"].Equals("websocket"));
-                        test(headers["Connection"].Equals("Upgrade"));
-                        test(headers["Sec-WebSocket-Protocol"].Equals("ice.zeroc.com"));
+                        test(headers["Upgrade"] == "websocket");
+                        test(headers["Connection"] == "Upgrade");
+                        test(headers["Sec-WebSocket-Protocol"] == "ice.zeroc.com");
                         test(headers["Sec-WebSocket-Accept"] != null);
 
-                        test(ctx["ws.Upgrade"].Equals("websocket"));
-                        test(ctx["ws.Connection"].Equals("Upgrade"));
-                        test(ctx["ws.Sec-WebSocket-Protocol"].Equals("ice.zeroc.com"));
-                        test(ctx["ws.Sec-WebSocket-Version"].Equals("13"));
+                        test(ctx["ws.Upgrade"] == "websocket");
+                        test(ctx["ws.Connection"] == "Upgrade");
+                        test(ctx["ws.Sec-WebSocket-Protocol"] == "ice.zeroc.com");
+                        test(ctx["ws.Sec-WebSocket-Version"] == "13");
                         test(ctx["ws.Sec-WebSocket-Key"] != null);
                     }
 
@@ -228,7 +228,7 @@ namespace Ice
                     test(udpInfo.localPort > 0);
                     test(udpInfo.remotePort == endpointPort);
 
-                    if(defaultHost.Equals("127.0.0.1"))
+                    if(defaultHost == "127.0.0.1")
                     {
                         test(udpInfo.remoteAddress.Equals(defaultHost));
                         test(udpInfo.localAddress.Equals(defaultHost));

--- a/csharp/test/Ice/interceptor/Client.cs
+++ b/csharp/test/Ice/interceptor/Client.cs
@@ -21,22 +21,22 @@ namespace Ice
                 test(interceptor.getLastOperation() == null);
                 test(!interceptor.getLastStatus());
                 prx.ice_ping();
-                test(interceptor.getLastOperation().Equals("ice_ping"));
+                test(interceptor.getLastOperation() == "ice_ping");
                 test(!interceptor.getLastStatus());
                 String typeId = prx.ice_id();
-                test(interceptor.getLastOperation().Equals("ice_id"));
+                test(interceptor.getLastOperation() == "ice_id");
                 test(!interceptor.getLastStatus());
                 test(prx.ice_isA(typeId));
-                test(interceptor.getLastOperation().Equals("ice_isA"));
+                test(interceptor.getLastOperation() == "ice_isA");
                 test(!interceptor.getLastStatus());
                 test(prx.add(33, 12) == 45);
-                test(interceptor.getLastOperation().Equals("add"));
+                test(interceptor.getLastOperation() == "add");
                 test(!interceptor.getLastStatus());
                 output.WriteLine("ok");
                 output.Write("testing retry... ");
                 output.Flush();
                 test(prx.addWithRetry(33, 12) == 45);
-                test(interceptor.getLastOperation().Equals("addWithRetry"));
+                test(interceptor.getLastOperation() == "addWithRetry");
                 test(!interceptor.getLastStatus());
                 output.WriteLine("ok");
                 output.Write("testing user exception... ");
@@ -50,7 +50,7 @@ namespace Ice
                 {
                     // expected
                 }
-                test(interceptor.getLastOperation().Equals("badAdd"));
+                test(interceptor.getLastOperation() == "badAdd");
                 test(!interceptor.getLastStatus());
                 output.WriteLine("ok");
                 output.Write("testing ONE... ");
@@ -65,7 +65,7 @@ namespace Ice
                 {
                     // expected
                 }
-                test(interceptor.getLastOperation().Equals("notExistAdd"));
+                test(interceptor.getLastOperation() == "notExistAdd");
                 test(!interceptor.getLastStatus());
                 output.WriteLine("ok");
                 output.Write("testing system exception... ");
@@ -88,7 +88,7 @@ namespace Ice
                 {
                     test(false);
                 }
-                test(interceptor.getLastOperation().Equals("badSystemAdd"));
+                test(interceptor.getLastOperation() == "badSystemAdd");
                 test(!interceptor.getLastStatus());
                 output.WriteLine("ok");
 
@@ -106,14 +106,14 @@ namespace Ice
                 test(interceptor.getLastOperation() == null);
                 test(!interceptor.getLastStatus());
                 test(prx.amdAdd(33, 12) == 45);
-                test(interceptor.getLastOperation().Equals("amdAdd"));
+                test(interceptor.getLastOperation() == "amdAdd");
                 test(interceptor.getLastStatus());
                 output.WriteLine("ok");
 
                 output.Write("testing retry... ");
                 output.Flush();
                 test(prx.amdAddWithRetry(33, 12) == 45);
-                test(interceptor.getLastOperation().Equals("amdAddWithRetry"));
+                test(interceptor.getLastOperation() == "amdAddWithRetry");
                 test(interceptor.getLastStatus());
 
                 {
@@ -122,7 +122,7 @@ namespace Ice
                     for(int i = 0; i < 10; ++i)
                     {
                         test(prx.amdAdd(33, 12, ctx) == 45);
-                        test(interceptor.getLastOperation().Equals("amdAdd"));
+                        test(interceptor.getLastOperation() == "amdAdd");
                         test(interceptor.getLastStatus());
                     }
                 }
@@ -139,7 +139,7 @@ namespace Ice
                 {
                     // expected
                 }
-                test(interceptor.getLastOperation().Equals("amdBadAdd"));
+                test(interceptor.getLastOperation() == "amdBadAdd");
                 test(interceptor.getLastStatus());
                 Console.WriteLine("ok");
 
@@ -155,7 +155,7 @@ namespace Ice
                 {
                     // expected
                 }
-                test(interceptor.getLastOperation().Equals("amdNotExistAdd"));
+                test(interceptor.getLastOperation() == "amdNotExistAdd");
                 test(interceptor.getLastStatus());
                 output.WriteLine("ok");
 
@@ -179,7 +179,7 @@ namespace Ice
                 {
                     test(false);
                 }
-                test(interceptor.getLastOperation().Equals("amdBadSystemAdd"));
+                test(interceptor.getLastOperation() == "amdBadSystemAdd");
                 test(interceptor.getLastStatus());
                 output.WriteLine("ok");
 
@@ -249,19 +249,19 @@ namespace Ice
                     }
                     catch(Ice.UnknownUserException)
                     {
-                        test(e.Item2.Equals("user"));
+                        test(e.Item2 == "user");
                     }
                     catch(Ice.ObjectNotExistException)
                     {
-                        test(e.Item2.Equals("notExist"));
+                        test(e.Item2 == "notExist");
                     }
                     catch(Ice.UnknownException)
                     {
-                        test(e.Item2.Equals("system")); // non-collocated
+                        test(e.Item2 == "system"); // non-collocated
                     }
                     catch(MySystemException)
                     {
-                        test(e.Item2.Equals("system")); // collocated
+                        test(e.Item2 == "system"); // collocated
                     }
                     {
                         Ice.ObjectPrx batch = prx.ice_batchOneway();

--- a/csharp/test/Ice/interceptor/InterceptorI.cs
+++ b/csharp/test/Ice/interceptor/InterceptorI.cs
@@ -33,15 +33,15 @@ namespace Ice
                 string context;
                 if(current.ctx.TryGetValue("raiseBeforeDispatch", out context))
                 {
-                    if(context.Equals("user"))
+                    if(context == "user")
                     {
                         throw new Test.InvalidInputException();
                     }
-                    else if(context.Equals("notExist"))
+                    else if(context == "notExist")
                     {
                         throw new Ice.ObjectNotExistException();
                     }
-                    else if(context.Equals("system"))
+                    else if(context == "system")
                     {
                         throw new MySystemException();
                     }
@@ -49,7 +49,7 @@ namespace Ice
 
                 lastOperation_ = current.operation;
 
-                if(lastOperation_.Equals("addWithRetry") || lastOperation_.Equals("amdAddWithRetry"))
+                if(lastOperation_ == "addWithRetry" || lastOperation_ == "amdAddWithRetry")
                 {
                     for(int i = 0; i < 10; ++i)
                     {
@@ -75,7 +75,7 @@ namespace Ice
 
                     current.ctx["retry"] = "no";
                 }
-                else if(current.ctx.TryGetValue("retry", out context) && context.Equals("yes"))
+                else if(current.ctx.TryGetValue("retry", out context) && context == "yes")
                 {
                     //
                     // Retry the dispatch to ensure that abandoning the result of the dispatch
@@ -90,15 +90,15 @@ namespace Ice
 
                 if(current.ctx.TryGetValue("raiseAfterDispatch", out context))
                 {
-                    if(context.Equals("user"))
+                    if(context == "user")
                     {
                         throw new Test.InvalidInputException();
                     }
-                    else if(context.Equals("notExist"))
+                    else if(context == "notExist")
                     {
                         throw new Ice.ObjectNotExistException();
                     }
-                    else if(context.Equals("system"))
+                    else if(context == "system")
                     {
                         throw new MySystemException();
                     }

--- a/csharp/test/Ice/interceptor/MyObjectI.cs
+++ b/csharp/test/Ice/interceptor/MyObjectI.cs
@@ -53,7 +53,7 @@ namespace Ice
                 test(current != null);
                 test(current.ctx != null);
 
-                if(current.ctx.ContainsKey("retry") && current.ctx["retry"].Equals("no"))
+                if(current.ctx.ContainsKey("retry") && current.ctx["retry"] == "no")
                 {
                     return x + y;
                 }
@@ -91,7 +91,7 @@ namespace Ice
             public override async Task<int>
             amdAddWithRetryAsync(int x, int y, Ice.Current current)
             {
-                if(current.ctx.ContainsKey("retry") && current.ctx["retry"].Equals("no"))
+                if(current.ctx.ContainsKey("retry") && current.ctx["retry"] == "no")
                 {
                     await Task.Delay(10);
                     return x + y;

--- a/csharp/test/Ice/invoke/BlobjectI.cs
+++ b/csharp/test/Ice/invoke/BlobjectI.cs
@@ -18,12 +18,12 @@ namespace Ice
                 inS.startEncapsulation();
                 Ice.OutputStream outS = new Ice.OutputStream(communicator);
                 outS.startEncapsulation();
-                if(current.operation.Equals("opOneway"))
+                if(current.operation == "opOneway")
                 {
                     outParams = new byte[0];
                     return true;
                 }
-                else if(current.operation.Equals("opString"))
+                else if(current.operation == "opString")
                 {
                     string s = inS.readString();
                     outS.writeString(s);
@@ -32,7 +32,7 @@ namespace Ice
                     outParams = outS.finished();
                     return true;
                 }
-                else if(current.operation.Equals("opException"))
+                else if(current.operation == "opException")
                 {
                     if(current.ctx.ContainsKey("raise"))
                     {
@@ -44,16 +44,16 @@ namespace Ice
                     outParams = outS.finished();
                     return false;
                 }
-                else if(current.operation.Equals("shutdown"))
+                else if(current.operation == "shutdown")
                 {
                     communicator.shutdown();
                     outParams = null;
                     return true;
                 }
-                else if(current.operation.Equals("ice_isA"))
+                else if(current.operation == "ice_isA")
                 {
                     string s = inS.readString();
-                    if(s.Equals("::Test::MyClass"))
+                    if(s == "::Test::MyClass")
                     {
                         outS.writeBool(true);
                     }
@@ -86,11 +86,11 @@ namespace Ice
                 inS.startEncapsulation();
                 Ice.OutputStream outS = new Ice.OutputStream(communicator);
                 outS.startEncapsulation();
-                if(current.operation.Equals("opOneway"))
+                if(current.operation == "opOneway")
                 {
                     return Task.FromResult(new Ice.Object_Ice_invokeResult(true, new byte[0]));
                 }
-                else if(current.operation.Equals("opString"))
+                else if(current.operation == "opString")
                 {
                     string s = inS.readString();
                     outS.writeString(s);
@@ -98,22 +98,22 @@ namespace Ice
                     outS.endEncapsulation();
                     return Task.FromResult(new Ice.Object_Ice_invokeResult(true, outS.finished()));
                 }
-                else if(current.operation.Equals("opException"))
+                else if(current.operation == "opException")
                 {
                     Test.MyException ex = new Test.MyException();
                     outS.writeException(ex);
                     outS.endEncapsulation();
                     return Task.FromResult(new Ice.Object_Ice_invokeResult(false, outS.finished()));
                 }
-                else if(current.operation.Equals("shutdown"))
+                else if(current.operation == "shutdown")
                 {
                     communicator.shutdown();
                     return Task.FromResult(new Ice.Object_Ice_invokeResult(true, null));
                 }
-                else if(current.operation.Equals("ice_isA"))
+                else if(current.operation == "ice_isA")
                 {
                     string s = inS.readString();
-                    if(s.Equals("::Test::MyClass"))
+                    if(s == "::Test::MyClass")
                     {
                         outS.writeBool(true);
                     }

--- a/csharp/test/Ice/invoke/Server.cs
+++ b/csharp/test/Ice/invoke/Server.cs
@@ -48,7 +48,7 @@ namespace Ice
         {
             public override void run(string[] args)
             {
-                bool async = args.Any(v => v.Equals("--async"));
+                bool async = args.Any(v => v == "--async");
                 using(var communicator = initialize(ref args))
                 {
                     communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -197,8 +197,8 @@ namespace Ice
                 }
                 catch(Ice.NotRegisteredException ex)
                 {
-                    test(ex.kindOfObject.Equals("object"));
-                    test(ex.id.Equals("unknown/unknown"));
+                    test(ex.kindOfObject == "object");
+                    test(ex.id == "unknown/unknown");
                 }
                 output.WriteLine("ok");
 
@@ -212,8 +212,8 @@ namespace Ice
                 }
                 catch(Ice.NotRegisteredException ex)
                 {
-                    test(ex.kindOfObject.Equals("object adapter"));
-                    test(ex.id.Equals("TestAdapterUnknown"));
+                    test(ex.kindOfObject == "object adapter");
+                    test(ex.id == "TestAdapterUnknown");
                 }
                 output.WriteLine("ok");
 
@@ -259,10 +259,10 @@ namespace Ice
                 output.Flush();
                 obj = Test.TestIntfPrxHelper.checkedCast(communicator.stringToProxy("test@TestAdapter"));
                 var hello = obj.getHello();
-                test(hello.ice_getAdapterId().Equals("TestAdapter"));
+                test(hello.ice_getAdapterId() == "TestAdapter");
                 hello.sayHello();
                 hello = obj.getReplicatedHello();
-                test(hello.ice_getAdapterId().Equals("ReplicatedAdapter"));
+                test(hello.ice_getAdapterId() == "ReplicatedAdapter");
                 hello.sayHello();
                 output.WriteLine("ok");
 
@@ -325,7 +325,7 @@ namespace Ice
                 catch(Ice.NotRegisteredException ex)
                 {
                     test(ex.kindOfObject == "object adapter");
-                    test(ex.id.Equals("TestAdapter3"));
+                    test(ex.id == "TestAdapter3");
                 }
                 registry.setAdapterDirectProxy("TestAdapter3", locator.findAdapterById("TestAdapter"));
                 try
@@ -378,7 +378,7 @@ namespace Ice
                 catch(Ice.NotRegisteredException ex)
                 {
                     test(ex.kindOfObject == "object adapter");
-                    test(ex.id.Equals("TestUnknown"));
+                    test(ex.id == "TestUnknown");
                 }
                 registry.addObject(communicator.stringToProxy("test3@TestAdapter4")); // Update
                 registry.setAdapterDirectProxy("TestAdapter4",

--- a/csharp/test/Ice/location/ServerLocator.cs
+++ b/csharp/test/Ice/location/ServerLocator.cs
@@ -22,7 +22,7 @@ namespace Ice
             findAdapterByIdAsync(string adapter, Ice.Current current)
             {
                 ++_requestCount;
-                if(adapter.Equals("TestAdapter10") || adapter.Equals("TestAdapter10-2"))
+                if(adapter == "TestAdapter10" || adapter == "TestAdapter10-2")
                 {
                     Debug.Assert(current.encoding.Equals(Ice.Util.Encoding_1_0));
                     return Task.FromResult(_registry.getAdapter("TestAdapter"));

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -322,7 +322,7 @@ public class AllTests : Test.AllTests
     {
         Dictionary<string, string> dict = new Dictionary<string, string>();
         dict.Add("IceMX.Metrics.View.Map." + map + ".GroupBy", attr);
-        if(props.ice_getIdentity().category.Equals("client"))
+        if(props.ice_getIdentity().category == "client")
         {
             props.setProperties(getClientProps(props, dict, map));
             update.waitForUpdate();
@@ -351,7 +351,7 @@ public class AllTests : Test.AllTests
         }
 
         dict.Clear();
-        if(props.ice_getIdentity().category.Equals("client"))
+        if(props.ice_getIdentity().category == "client")
         {
             props.setProperties(getClientProps(props, dict, map));
             update.waitForUpdate();

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -62,31 +62,31 @@ namespace Ice
             {
                 public static Ice.Value MyValueFactory(string type)
                 {
-                    if(type.Equals("::Test::B"))
+                    if(type == "::Test::B")
                     {
                         return new BI();
                     }
-                    else if(type.Equals("::Test::C"))
+                    else if(type == "::Test::C")
                     {
                         return new CI();
                     }
-                    else if(type.Equals("::Test::D"))
+                    else if(type == "::Test::D")
                     {
                         return new DI();
                     }
-                    else if(type.Equals("::Test::E"))
+                    else if(type == "::Test::E")
                     {
                         return new EI();
                     }
-                    else if(type.Equals("::Test::F"))
+                    else if(type == "::Test::F")
                     {
                         return new FI();
                     }
-                    else if(type.Equals("::Test::I"))
+                    else if(type == "::Test::I")
                     {
                         return new II();
                     }
-                    else if(type.Equals("::Test::J"))
+                    else if(type == "::Test::J")
                     {
                         return new JI();
                     }
@@ -233,7 +233,7 @@ namespace Ice
                         var k = initial.getK();
                         var l = k.value as L;
                         test(l != null);
-                        test(l.data.Equals("l"));
+                        test(l.data == "l");
                     }
                     output.WriteLine("ok");
 
@@ -243,24 +243,24 @@ namespace Ice
                         Ice.Value v1 = new L("l");
                         Ice.Value v2;
                         Ice.Value v3 = initial.opValue(v1, out v2);
-                        test(((L)v2).data.Equals("l"));
-                        test(((L)v3).data.Equals("l"));
+                        test(((L)v2).data == "l");
+                        test(((L)v3).data == "l");
                     }
                     {
                         L l = new L("l");
                         Ice.Value[] v1 = new Ice.Value[]{ l };
                         Ice.Value[] v2;
                         Ice.Value[] v3 = initial.opValueSeq(v1, out v2);
-                        test(((L)v2[0]).data.Equals("l"));
-                        test(((L)v3[0]).data.Equals("l"));
+                        test(((L)v2[0]).data == "l");
+                        test(((L)v3[0]).data == "l");
                     }
                     {
                         L l = new L("l");
                         Dictionary<string, Ice.Value> v1 = new Dictionary<string, Ice.Value>{ {"l", l} };
                         Dictionary<string, Ice.Value> v2;
                         Dictionary<string, Ice.Value> v3 = initial.opValueMap(v1, out v2);
-                        test(((L)v2["l"]).data.Equals("l"));
-                        test(((L)v3["l"]).data.Equals("l"));
+                        test(((L)v2["l"]).data == "l");
+                        test(((L)v3["l"]).data == "l");
                     }
                     output.WriteLine("ok");
 
@@ -268,10 +268,10 @@ namespace Ice
                     output.Flush();
                     D1 d1 = new D1(new A1("a1"), new A1("a2"), new A1("a3"), new A1("a4"));
                     d1 = initial.getD1(d1);
-                    test(d1.a1.name.Equals("a1"));
-                    test(d1.a2.name.Equals("a2"));
-                    test(d1.a3.name.Equals("a3"));
-                    test(d1.a4.name.Equals("a4"));
+                    test(d1.a1.name == "a1");
+                    test(d1.a2.name == "a2");
+                    test(d1.a3.name == "a3");
+                    test(d1.a4.name == "a4");
                     output.WriteLine("ok");
 
                     output.Write("throw EDerived... ");
@@ -283,10 +283,10 @@ namespace Ice
                     }
                     catch(EDerived ederived)
                     {
-                        test(ederived.a1.name.Equals("a1"));
-                        test(ederived.a2.name.Equals("a2"));
-                        test(ederived.a3.name.Equals("a3"));
-                        test(ederived.a4.name.Equals("a4"));
+                        test(ederived.a1.name == "a1");
+                        test(ederived.a2.name == "a2");
+                        test(ederived.a3.name == "a3");
+                        test(ederived.a4.name == "a4");
                     }
                     output.WriteLine("ok");
 
@@ -385,8 +385,8 @@ namespace Ice
                     }
                     catch(Ice.UnexpectedObjectException ex)
                     {
-                        test(ex.type.Equals("::Test::AlsoEmpty"));
-                        test(ex.expectedType.Equals("::Test::Empty"));
+                        test(ex.type == "::Test::AlsoEmpty");
+                        test(ex.expectedType == "::Test::Empty");
                     }
                     catch(System.Exception ex)
                     {
@@ -398,13 +398,13 @@ namespace Ice
                     output.Write("testing partial ice_initialize...");
                     output.Flush();
                     var ib1 = new IBase();
-                    test(ib1.id.Equals("My id"));
+                    test(ib1.id == "My id");
                     var id1 = new IDerived();
-                    test(id1.id.Equals("My id"));
-                    test(id1.name.Equals("My name"));
+                    test(id1.id == "My id");
+                    test(id1.name == "My name");
 
                     var id2 = new Test.IDerived2();
-                    test(id2.id.Equals("My id"));
+                    test(id2.id == "My id");
                     var i2 = new I2();
                     test(i2.called);
 
@@ -416,7 +416,7 @@ namespace Ice
                     test(s1.id == 1);
 
                     var sc1 = new SC1();
-                    test(sc1.id.Equals("My id"));
+                    test(sc1.id == "My id");
                     output.WriteLine("ok");
 
                     output.Write("testing class containing complex dictionary... ");
@@ -433,11 +433,11 @@ namespace Ice
                         test(m1.v.Count == 2);
                         test(m2.v.Count == 2);
 
-                        test(m1.v[k1].data.Equals("one"));
-                        test(m2.v[k1].data.Equals("one"));
+                        test(m1.v[k1].data == "one");
+                        test(m2.v[k1].data == "one");
 
-                        test(m1.v[k2].data.Equals("two"));
-                        test(m2.v[k2].data.Equals("two"));
+                        test(m1.v[k2].data == "two");
+                        test(m2.v[k2].data == "two");
 
                     }
                     output.WriteLine("ok");
@@ -447,16 +447,16 @@ namespace Ice
                     {
                         F1 f12;
                         F1 f11 = initial.opF1(new F1("F11"), out f12);
-                        test(f11.name.Equals("F11"));
-                        test(f12.name.Equals("F12"));
+                        test(f11.name == "F11");
+                        test(f12.name == "F12");
 
                         F2Prx f22;
                         F2Prx f21 = initial.opF2(
                             F2PrxHelper.uncheckedCast(communicator.stringToProxy("F21:" + helper.getTestEndpoint())),
                             out f22);
-                        test(f21.ice_getIdentity().name.Equals("F21"));
+                        test(f21.ice_getIdentity().name == "F21");
                         f21.op();
-                        test(f22.ice_getIdentity().name.Equals("F22"));
+                        test(f22.ice_getIdentity().name == "F22");
 
                         if(initial.hasF3())
                         {
@@ -465,11 +465,11 @@ namespace Ice
                                                          F2PrxHelper.uncheckedCast(communicator.stringToProxy("F21"))),
                                                   out f32);
 
-                            test(f31.f1.name.Equals("F11"));
-                            test(f31.f2.ice_getIdentity().name.Equals("F21"));
+                            test(f31.f1.name == "F11");
+                            test(f31.f2.ice_getIdentity().name == "F21");
 
-                            test(f32.f1.name.Equals("F12"));
-                            test(f32.f2.ice_getIdentity().name.Equals("F22"));
+                            test(f32.f1.name == "F12");
+                            test(f32.f2.ice_getIdentity().name == "F22");
                         }
                     }
                     output.WriteLine("ok");

--- a/csharp/test/Ice/objects/EI.cs
+++ b/csharp/test/Ice/objects/EI.cs
@@ -14,7 +14,7 @@ namespace Ice
 
             public bool checkValues()
             {
-                return i == 1 && s.Equals("hello");
+                return i == 1 && s == "hello";
             }
         }
     }

--- a/csharp/test/Ice/objects/Server.cs
+++ b/csharp/test/Ice/objects/Server.cs
@@ -14,11 +14,11 @@ namespace Ice
         {
             public static Ice.Value MyValueFactory(string type)
             {
-                if(type.Equals("::Test::I"))
+                if(type == "::Test::I")
                 {
                     return new II();
                 }
-                else if(type.Equals("::Test::J"))
+                else if(type == "::Test::J")
                 {
                     return new JI();
                 }

--- a/csharp/test/Ice/operations/BatchOneways.cs
+++ b/csharp/test/Ice/operations/BatchOneways.cs
@@ -20,7 +20,7 @@ namespace Ice
             {
                 public void enqueue(Ice.BatchRequest request, int count, int size)
                 {
-                    test(request.getOperation().Equals("opByteSOneway") || request.getOperation().Equals("ice_ping"));
+                    test(request.getOperation() == "opByteSOneway" || request.getOperation() == "ice_ping");
                     test(request.getProxy().ice_isBatchOneway());
 
                     if (count > 0)
@@ -171,7 +171,7 @@ namespace Ice
                 }
 
                 if (supportsCompress && p.ice_getConnection() != null &&
-                   p.ice_getCommunicator().getProperties().getProperty("Ice.Override.Compress").Equals(""))
+                   p.ice_getCommunicator().getProperties().getProperty("Ice.Override.Compress") == "")
                 {
                     Ice.ObjectPrx prx = p.ice_getConnection().createProxy(p.ice_getIdentity()).ice_batchOneway();
 

--- a/csharp/test/Ice/operations/BatchOneways.cs
+++ b/csharp/test/Ice/operations/BatchOneways.cs
@@ -171,7 +171,7 @@ namespace Ice
                 }
 
                 if (supportsCompress && p.ice_getConnection() != null &&
-                   p.ice_getCommunicator().getProperties().getProperty("Ice.Override.Compress") == "")
+                   p.ice_getCommunicator().getProperties().getProperty("Ice.Override.Compress").Length == 0)
                 {
                     Ice.ObjectPrx prx = p.ice_getConnection().createProxy(p.ice_getIdentity()).ice_batchOneway();
 

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -296,7 +296,7 @@ namespace Ice
                     rso = p.opStruct(si1, si2, out so);
                     test(rso.p == null);
                     test(rso.e == Test.MyEnum.enum1);
-                    test(rso.s.s == "");
+                    test(rso.s.s.Length == 0);
                     test(so.p == null);
                     test(so.e == Test.MyEnum.enum1);
                     test(so.s.s == "a new string");
@@ -639,10 +639,10 @@ namespace Ice
                     test(ssso[0][0][1] == "de");
                     test(ssso[0][1][0] == "xyz");
                     test(ssso[1][0][0] == "hello");
-                    test(ssso[2][0][0] == "");
-                    test(ssso[2][0][1] == "");
+                    test(ssso[2][0][0].Length == 0);
+                    test(ssso[2][0][1].Length == 0);
                     test(ssso[2][1][0] == "abcd");
-                    test(ssso[3][0][0] == "");
+                    test(ssso[3][0][0].Length == 0);
 
                     test(rsso.Length == 3);
                     test(rsso[0].Length == 0);
@@ -651,9 +651,9 @@ namespace Ice
                     test(rsso[2].Length == 2);
                     test(rsso[2][0].Length == 2);
                     test(rsso[2][1].Length == 1);
-                    test(rsso[1][0][0] == "");
-                    test(rsso[2][0][0] == "");
-                    test(rsso[2][0][1] == "");
+                    test(rsso[1][0][0].Length == 0);
+                    test(rsso[2][0][0].Length == 0);
+                    test(rsso[2][0][1].Length == 0);
                     test(rsso[2][1][0] == "abcd");
                 }
 
@@ -1457,7 +1457,7 @@ namespace Ice
 
                         test(ic.getImplicitContext().containsKey("zero") == false);
                         String r = ic.getImplicitContext().put("zero", "ZERO");
-                        test(r == "");
+                        test(r.Length == 0);
                         test(ic.getImplicitContext().get("zero") == "ZERO");
 
                         ctx = ic.getImplicitContext().getContext();

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -56,57 +56,57 @@ namespace Ice
                 Ice.Communicator communicator = helper.communicator();
                 string[] literals = p.opStringLiterals();
 
-                test(Test.s0.value.Equals("\\") &&
+                test(Test.s0.value == "\\" &&
                      Test.s0.value.Equals(Test.sw0.value) &&
                      Test.s0.value.Equals(literals[0]) &&
                      Test.s0.value.Equals(literals[11]));
 
-                test(Test.s1.value.Equals("A") &&
+                test(Test.s1.value == "A" &&
                      Test.s1.value.Equals(Test.sw1.value) &&
                      Test.s1.value.Equals(literals[1]) &&
                      Test.s1.value.Equals(literals[12]));
 
-                test(Test.s2.value.Equals("Ice") &&
+                test(Test.s2.value == "Ice" &&
                      Test.s2.value.Equals(Test.sw2.value) &&
                      Test.s2.value.Equals(literals[2]) &&
                      Test.s2.value.Equals(literals[13]));
 
-                test(Test.s3.value.Equals("A21") &&
+                test(Test.s3.value == "A21" &&
                      Test.s3.value.Equals(Test.sw3.value) &&
                      Test.s3.value.Equals(literals[3]) &&
                      Test.s3.value.Equals(literals[14]));
 
-                test(Test.s4.value.Equals("\\u0041 \\U00000041") &&
+                test(Test.s4.value == "\\u0041 \\U00000041" &&
                      Test.s4.value.Equals(Test.sw4.value) &&
                      Test.s4.value.Equals(literals[4]) &&
                      Test.s4.value.Equals(literals[15]));
 
-                test(Test.s5.value.Equals("\u00FF") &&
+                test(Test.s5.value == "\u00FF" &&
                      Test.s5.value.Equals(Test.sw5.value) &&
                      Test.s5.value.Equals(literals[5]) &&
                      Test.s5.value.Equals(literals[16]));
 
-                test(Test.s6.value.Equals("\u03FF") &&
+                test(Test.s6.value == "\u03FF" &&
                      Test.s6.value.Equals(Test.sw6.value) &&
                      Test.s6.value.Equals(literals[6]) &&
                      Test.s6.value.Equals(literals[17]));
 
-                test(Test.s7.value.Equals("\u05F0") &&
+                test(Test.s7.value == "\u05F0" &&
                      Test.s7.value.Equals(Test.sw7.value) &&
                      Test.s7.value.Equals(literals[7]) &&
                      Test.s7.value.Equals(literals[18]));
 
-                test(Test.s8.value.Equals("\U00010000") &&
+                test(Test.s8.value == "\U00010000" &&
                      Test.s8.value.Equals(Test.sw8.value) &&
                      Test.s8.value.Equals(literals[8]) &&
                      Test.s8.value.Equals(literals[19]));
 
-                test(Test.s9.value.Equals("\U0001F34C") &&
+                test(Test.s9.value == "\U0001F34C" &&
                      Test.s9.value.Equals(Test.sw9.value) &&
                      Test.s9.value.Equals(literals[9]) &&
                      Test.s9.value.Equals(literals[20]));
 
-                test(Test.s10.value.Equals("\u0DA7") &&
+                test(Test.s10.value == "\u0DA7" &&
                      Test.s10.value.Equals(Test.sw10.value) &&
                      Test.s10.value.Equals(literals[10]) &&
                      Test.s10.value.Equals(literals[21]));
@@ -118,13 +118,13 @@ namespace Ice
                      Test.ss0.value.Equals(literals[23]) &&
                      Test.ss0.value.Equals(literals[24]));
 
-                test(Test.ss3.value.Equals("\\\\U\\u\\") &&
+                test(Test.ss3.value == "\\\\U\\u\\" &&
                      Test.ss3.value.Equals(literals[25]));
 
-                test(Test.ss4.value.Equals("\\A\\") &&
+                test(Test.ss4.value == "\\A\\" &&
                     Test.ss4.value.Equals(literals[26]));
 
-                test(Test.ss5.value.Equals("\\u0041\\") &&
+                test(Test.ss5.value == "\\u0041\\" &&
                      Test.ss5.value.Equals(literals[27]));
 
                 test(Test.su0.value.Equals(Test.su1.value) &&
@@ -144,9 +144,9 @@ namespace Ice
                 {
                     string[] ids = p.ice_ids();
                     test(ids.Length == 3);
-                    test(ids[0].Equals("::Ice::Object"));
-                    test(ids[1].Equals("::Test::MyClass"));
-                    test(ids[2].Equals("::Test::MyDerivedClass"));
+                    test(ids[0] == "::Ice::Object");
+                    test(ids[1] == "::Test::MyClass");
+                    test(ids[2] == "::Test::MyDerivedClass");
                 }
 
                 {
@@ -222,8 +222,8 @@ namespace Ice
                     string r;
 
                     r = p.opString("hello", "world", out s);
-                    test(s.Equals("world hello"));
-                    test(r.Equals("hello world"));
+                    test(s == "world hello");
+                    test(r == "hello world");
                 }
 
                 {
@@ -281,10 +281,10 @@ namespace Ice
                     Test.Structure rso = p.opStruct(si1, si2, out so);
                     test(rso.p == null);
                     test(rso.e == Test.MyEnum.enum2);
-                    test(rso.s.s.Equals("def"));
+                    test(rso.s.s == "def");
                     test(so.p.Equals(p));
                     test(so.e == Test.MyEnum.enum3);
-                    test(so.s.s.Equals("a new string"));
+                    test(so.s.s == "a new string");
                     so.p.opVoid();
 
                     //
@@ -296,10 +296,10 @@ namespace Ice
                     rso = p.opStruct(si1, si2, out so);
                     test(rso.p == null);
                     test(rso.e == Test.MyEnum.enum1);
-                    test(rso.s.s.Equals(""));
+                    test(rso.s.s == "");
                     test(so.p == null);
                     test(so.e == Test.MyEnum.enum1);
-                    test(so.s.s.Equals("a new string"));
+                    test(so.s.s == "a new string");
                 }
 
                 {
@@ -411,14 +411,14 @@ namespace Ice
 
                     rso = p.opStringS(ssi1, ssi2, out sso);
                     test(sso.Length == 4);
-                    test(sso[0].Equals("abc"));
-                    test(sso[1].Equals("de"));
-                    test(sso[2].Equals("fghi"));
-                    test(sso[3].Equals("xyz"));
+                    test(sso[0] == "abc");
+                    test(sso[1] == "de");
+                    test(sso[2] == "fghi");
+                    test(sso[3] == "xyz");
                     test(rso.Length == 3);
-                    test(rso[0].Equals("fghi"));
-                    test(rso[1].Equals("de"));
-                    test(rso[2].Equals("abc"));
+                    test(rso[0] == "fghi");
+                    test(rso[1] == "de");
+                    test(rso[2] == "abc");
                 }
 
                 {
@@ -588,17 +588,17 @@ namespace Ice
                     rso = p.opStringSS(ssi1, ssi2, out sso);
                     test(sso.Length == 5);
                     test(sso[0].Length == 1);
-                    test(sso[0][0].Equals("abc"));
+                    test(sso[0][0] == "abc");
                     test(sso[1].Length == 2);
-                    test(sso[1][0].Equals("de"));
-                    test(sso[1][1].Equals("fghi"));
+                    test(sso[1][0] == "de");
+                    test(sso[1][1] == "fghi");
                     test(sso[2].Length == 0);
                     test(sso[3].Length == 0);
                     test(sso[4].Length == 1);
-                    test(sso[4][0].Equals("xyz"));
+                    test(sso[4][0] == "xyz");
                     test(rso.Length == 3);
                     test(rso[0].Length == 1);
-                    test(rso[0][0].Equals("xyz"));
+                    test(rso[0][0] == "xyz");
                     test(rso[1].Length == 0);
                     test(rso[2].Length == 0);
                 }
@@ -635,14 +635,14 @@ namespace Ice
                     test(ssso[3].Length == 1);
                     test(ssso[3][0].Length == 1);
                     test(ssso[4].Length == 0);
-                    test(ssso[0][0][0].Equals("abc"));
-                    test(ssso[0][0][1].Equals("de"));
-                    test(ssso[0][1][0].Equals("xyz"));
-                    test(ssso[1][0][0].Equals("hello"));
-                    test(ssso[2][0][0].Equals(""));
-                    test(ssso[2][0][1].Equals(""));
-                    test(ssso[2][1][0].Equals("abcd"));
-                    test(ssso[3][0][0].Equals(""));
+                    test(ssso[0][0][0] == "abc");
+                    test(ssso[0][0][1] == "de");
+                    test(ssso[0][1][0] == "xyz");
+                    test(ssso[1][0][0] == "hello");
+                    test(ssso[2][0][0] == "");
+                    test(ssso[2][0][1] == "");
+                    test(ssso[2][1][0] == "abcd");
+                    test(ssso[3][0][0] == "");
 
                     test(rsso.Length == 3);
                     test(rsso[0].Length == 0);
@@ -651,10 +651,10 @@ namespace Ice
                     test(rsso[2].Length == 2);
                     test(rsso[2][0].Length == 2);
                     test(rsso[2][1].Length == 1);
-                    test(rsso[1][0][0].Equals(""));
-                    test(rsso[2][0][0].Equals(""));
-                    test(rsso[2][0][1].Equals(""));
-                    test(rsso[2][1][0].Equals("abcd"));
+                    test(rsso[1][0][0] == "");
+                    test(rsso[2][0][0] == "");
+                    test(rsso[2][0][1] == "");
+                    test(rsso[2][1][0] == "abcd");
                 }
 
                 {
@@ -731,10 +731,10 @@ namespace Ice
 
                     test(Ice.CollectionComparer.Equals(_do, di1));
                     test(ro.Count == 4);
-                    test(ro["foo"].Equals("abc -1.1"));
-                    test(ro["FOO"].Equals("abc -100.4"));
-                    test(ro["bar"].Equals("abc 123123.2"));
-                    test(ro["BAR"].Equals("abc 0.5"));
+                    test(ro["foo"] == "abc -1.1");
+                    test(ro["FOO"] == "abc -100.4");
+                    test(ro["bar"] == "abc 123123.2");
+                    test(ro["BAR"] == "abc 0.5");
                 }
 
                 {
@@ -769,9 +769,9 @@ namespace Ice
 
                     test(Ice.CollectionComparer.Equals(_do, di1));
                     test(ro.Count == 3);
-                    test(ro[Test.MyEnum.enum1].Equals("abc"));
-                    test(ro[Test.MyEnum.enum2].Equals("Hello!!"));
-                    test(ro[Test.MyEnum.enum3].Equals("qwerty"));
+                    test(ro[Test.MyEnum.enum1] == "abc");
+                    test(ro[Test.MyEnum.enum2] == "Hello!!");
+                    test(ro[Test.MyEnum.enum3] == "qwerty");
                 }
 
                 {
@@ -951,23 +951,23 @@ namespace Ice
 
                     test(ro.Length == 2);
                     test(ro[0].Count == 3);
-                    test(ro[0]["foo"].Equals("abc -1.1"));
-                    test(ro[0]["FOO"].Equals("abc -100.4"));
-                    test(ro[0]["BAR"].Equals("abc 0.5"));
+                    test(ro[0]["foo"] == "abc -1.1");
+                    test(ro[0]["FOO"] == "abc -100.4");
+                    test(ro[0]["BAR"] == "abc 0.5");
                     test(ro[1].Count == 2);
                     test(ro[1]["foo"] == "abc -1.1");
                     test(ro[1]["bar"] == "abc 123123.2");
 
                     test(_do.Length == 3);
                     test(_do[0].Count == 1);
-                    test(_do[0]["f00"].Equals("ABC -3.14"));
+                    test(_do[0]["f00"] == "ABC -3.14");
                     test(_do[1].Count == 2);
-                    test(_do[1]["foo"].Equals("abc -1.1"));
-                    test(_do[1]["bar"].Equals("abc 123123.2"));
+                    test(_do[1]["foo"] == "abc -1.1");
+                    test(_do[1]["bar"] == "abc 123123.2");
                     test(_do[2].Count == 3);
-                    test(_do[2]["foo"].Equals("abc -1.1"));
-                    test(_do[2]["FOO"].Equals("abc -100.4"));
-                    test(_do[2]["BAR"].Equals("abc 0.5"));
+                    test(_do[2]["foo"] == "abc -1.1");
+                    test(_do[2]["FOO"] == "abc -100.4");
+                    test(_do[2]["BAR"] == "abc 0.5");
                 }
 
                 {
@@ -1033,19 +1033,19 @@ namespace Ice
 
                     test(ro.Length == 2);
                     test(ro[0].Count == 2);
-                    test(ro[0][Test.MyEnum.enum2].Equals("Hello!!"));
-                    test(ro[0][Test.MyEnum.enum3].Equals("qwerty"));
+                    test(ro[0][Test.MyEnum.enum2] == "Hello!!");
+                    test(ro[0][Test.MyEnum.enum3] == "qwerty");
                     test(ro[1].Count == 1);
-                    test(ro[1][Test.MyEnum.enum1].Equals("abc"));
+                    test(ro[1][Test.MyEnum.enum1] == "abc");
 
                     test(_do.Length == 3);
                     test(_do[0].Count == 1);
-                    test(_do[0][Test.MyEnum.enum1].Equals("Goodbye"));
+                    test(_do[0][Test.MyEnum.enum1] == "Goodbye");
                     test(_do[1].Count == 1);
-                    test(_do[1][Test.MyEnum.enum1].Equals("abc"));
+                    test(_do[1][Test.MyEnum.enum1] == "abc");
                     test(_do[2].Count == 2);
-                    test(_do[2][Test.MyEnum.enum2].Equals("Hello!!"));
-                    test(_do[2][Test.MyEnum.enum3].Equals("qwerty"));
+                    test(_do[2][Test.MyEnum.enum2] == "Hello!!");
+                    test(_do[2][Test.MyEnum.enum3] == "qwerty");
                 }
 
                 {
@@ -1335,20 +1335,20 @@ namespace Ice
 
                     test(_do.Count == 1);
                     test(_do["ghi"].Length == 2);
-                    test(_do["ghi"][0].Equals("and"));
-                    test(_do["ghi"][1].Equals("xor"));
+                    test(_do["ghi"][0] == "and");
+                    test(_do["ghi"][1] == "xor");
 
                     test(ro.Count == 3);
                     test(ro["abc"].Length == 3);
-                    test(ro["abc"][0].Equals("abc"));
-                    test(ro["abc"][1].Equals("de"));
-                    test(ro["abc"][2].Equals("fghi"));
+                    test(ro["abc"][0] == "abc");
+                    test(ro["abc"][1] == "de");
+                    test(ro["abc"][2] == "fghi");
                     test(ro["def"].Length == 2);
-                    test(ro["def"][0].Equals("xyz"));
-                    test(ro["def"][1].Equals("or"));
+                    test(ro["def"][0] == "xyz");
+                    test(ro["def"][1] == "or");
                     test(ro["ghi"].Length == 2);
-                    test(ro["ghi"][0].Equals("and"));
-                    test(ro["ghi"][1].Equals("xor"));
+                    test(ro["ghi"][0] == "and");
+                    test(ro["ghi"][1] == "xor");
                 }
 
                 {
@@ -1457,8 +1457,8 @@ namespace Ice
 
                         test(ic.getImplicitContext().containsKey("zero") == false);
                         String r = ic.getImplicitContext().put("zero", "ZERO");
-                        test(r.Equals(""));
-                        test(ic.getImplicitContext().get("zero").Equals("ZERO"));
+                        test(r == "");
+                        test(ic.getImplicitContext().get("zero") == "ZERO");
 
                         ctx = ic.getImplicitContext().getContext();
                         test(Ice.CollectionComparer.Equals(p3.opContext(), ctx));
@@ -1479,7 +1479,7 @@ namespace Ice
                                 // Ignore.
                             }
                         }
-                        test(combined["one"].Equals("UN"));
+                        test(combined["one"] == "UN");
 
                         p3 = Test.MyClassPrxHelper.uncheckedCast(p3.ice_context(prxContext));
 
@@ -1489,9 +1489,9 @@ namespace Ice
                         ic.getImplicitContext().setContext(ctx);
                         test(Ice.CollectionComparer.Equals(p3.opContext(), combined));
 
-                        test(ic.getImplicitContext().remove("one").Equals("ONE"));
+                        test(ic.getImplicitContext().remove("one") == "ONE");
 
-                        if (impls[i].Equals("PerThread"))
+                        if (impls[i] == "PerThread")
                         {
                             var thread = new PerThreadContextInvokeThread(
                                 Test.MyClassPrxHelper.uncheckedCast(p3.ice_context(null)));
@@ -1517,7 +1517,7 @@ namespace Ice
                     test(p.opLong1(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF);
                     test(p.opFloat1(1.0f) == 1.0f);
                     test(p.opDouble1(1.0d) == 1.0d);
-                    test(p.opString1("opString1").Equals("opString1"));
+                    test(p.opString1("opString1") == "opString1");
                     test(p.opStringS1(null).Length == 0);
                     test(p.opByteBoolD1(null).Count == 0);
                     test(p.opStringS2(null).Length == 0);
@@ -1529,17 +1529,17 @@ namespace Ice
                     s.myClass = null;
                     s.myStruct1 = "MyStruct1.myStruct1";
                     s = d.opMyStruct1(s);
-                    test(s.tesT.Equals("MyStruct1.s"));
+                    test(s.tesT == "MyStruct1.s");
                     test(s.myClass == null);
-                    test(s.myStruct1.Equals("MyStruct1.myStruct1"));
+                    test(s.myStruct1 == "MyStruct1.myStruct1");
                     var c = new Test.MyClass1();
                     c.tesT = "MyClass1.testT";
                     c.myClass = null;
                     c.myClass1 = "MyClass1.myClass1";
                     c = d.opMyClass1(c);
-                    test(c.tesT.Equals("MyClass1.testT"));
+                    test(c.tesT == "MyClass1.testT");
                     test(c.myClass == null);
-                    test(c.myClass1.Equals("MyClass1.myClass1"));
+                    test(c.myClass1 == "MyClass1.myClass1");
                 }
 
                 {

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -436,10 +436,10 @@ namespace Ice
                     test(result.p3[0][0][1] == "de");
                     test(result.p3[0][1][0] == "xyz");
                     test(result.p3[1][0][0] == "hello");
-                    test(result.p3[2][0][0] == "");
-                    test(result.p3[2][0][1] == "");
+                    test(result.p3[2][0][0].Length == 0);
+                    test(result.p3[2][0][1].Length == 0);
                     test(result.p3[2][1][0] == "abcd");
-                    test(result.p3[3][0][0] == "");
+                    test(result.p3[3][0][0].Length == 0);
 
                     test(result.returnValue.Length == 3);
                     test(result.returnValue[0].Length == 0);
@@ -448,9 +448,9 @@ namespace Ice
                     test(result.returnValue[2].Length == 2);
                     test(result.returnValue[2][0].Length == 2);
                     test(result.returnValue[2][1].Length == 1);
-                    test(result.returnValue[1][0][0] == "");
-                    test(result.returnValue[2][0][0] == "");
-                    test(result.returnValue[2][0][1] == "");
+                    test(result.returnValue[1][0][0].Length == 0);
+                    test(result.returnValue[2][0][0].Length == 0);
+                    test(result.returnValue[2][0][1].Length == 0);
                     test(result.returnValue[2][1][0] == "abcd");
                 }
 

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -76,8 +76,8 @@ namespace Ice
 
                 {
                     var result = await p.opStringAsync("hello", "world");
-                    test(result.p3.Equals("world hello"));
-                    test(result.returnValue.Equals("hello world"));
+                    test(result.p3 == "world hello");
+                    test(result.returnValue == "hello world");
                 }
 
                 {
@@ -125,9 +125,9 @@ namespace Ice
                     var ret = p.opStructAsync(si1, si2).Result;
                     test(ret.returnValue.p == null);
                     test(ret.returnValue.e == Test.MyEnum.enum2);
-                    test(ret.returnValue.s.s.Equals("def"));
+                    test(ret.returnValue.s.s == "def");
                     test(ret.p3.e == Test.MyEnum.enum3);
-                    test(ret.p3.s.s.Equals("a new string"));
+                    test(ret.p3.s.s == "a new string");
 
                     //
                     // We can't do the callbacks below in connection serialization mode.
@@ -229,14 +229,14 @@ namespace Ice
 
                     var result = await p.opStringSAsync(ssi1, ssi2);
                     test(result.p3.Length == 4);
-                    test(result.p3[0].Equals("abc"));
-                    test(result.p3[1].Equals("de"));
-                    test(result.p3[2].Equals("fghi"));
-                    test(result.p3[3].Equals("xyz"));
+                    test(result.p3[0] == "abc");
+                    test(result.p3[1] == "de");
+                    test(result.p3[2] == "fghi");
+                    test(result.p3[3] == "xyz");
                     test(result.returnValue.Length == 3);
-                    test(result.returnValue[0].Equals("fghi"));
-                    test(result.returnValue[1].Equals("de"));
-                    test(result.returnValue[2].Equals("abc"));
+                    test(result.returnValue[0] == "fghi");
+                    test(result.returnValue[1] == "de");
+                    test(result.returnValue[2] == "abc");
                 }
 
                 {
@@ -388,17 +388,17 @@ namespace Ice
                     var result = await p.opStringSSAsync(ssi1, ssi2);
                     test(result.p3.Length == 5);
                     test(result.p3[0].Length == 1);
-                    test(result.p3[0][0].Equals("abc"));
+                    test(result.p3[0][0] == "abc");
                     test(result.p3[1].Length == 2);
-                    test(result.p3[1][0].Equals("de"));
-                    test(result.p3[1][1].Equals("fghi"));
+                    test(result.p3[1][0] == "de");
+                    test(result.p3[1][1] == "fghi");
                     test(result.p3[2].Length == 0);
                     test(result.p3[3].Length == 0);
                     test(result.p3[4].Length == 1);
-                    test(result.p3[4][0].Equals("xyz"));
+                    test(result.p3[4][0] == "xyz");
                     test(result.returnValue.Length == 3);
                     test(result.returnValue[0].Length == 1);
-                    test(result.returnValue[0][0].Equals("xyz"));
+                    test(result.returnValue[0][0] == "xyz");
                     test(result.returnValue[1].Length == 0);
                     test(result.returnValue[2].Length == 0);
                 }
@@ -432,14 +432,14 @@ namespace Ice
                     test(result.p3[3].Length == 1);
                     test(result.p3[3][0].Length == 1);
                     test(result.p3[4].Length == 0);
-                    test(result.p3[0][0][0].Equals("abc"));
-                    test(result.p3[0][0][1].Equals("de"));
-                    test(result.p3[0][1][0].Equals("xyz"));
-                    test(result.p3[1][0][0].Equals("hello"));
-                    test(result.p3[2][0][0].Equals(""));
-                    test(result.p3[2][0][1].Equals(""));
-                    test(result.p3[2][1][0].Equals("abcd"));
-                    test(result.p3[3][0][0].Equals(""));
+                    test(result.p3[0][0][0] == "abc");
+                    test(result.p3[0][0][1] == "de");
+                    test(result.p3[0][1][0] == "xyz");
+                    test(result.p3[1][0][0] == "hello");
+                    test(result.p3[2][0][0] == "");
+                    test(result.p3[2][0][1] == "");
+                    test(result.p3[2][1][0] == "abcd");
+                    test(result.p3[3][0][0] == "");
 
                     test(result.returnValue.Length == 3);
                     test(result.returnValue[0].Length == 0);
@@ -448,10 +448,10 @@ namespace Ice
                     test(result.returnValue[2].Length == 2);
                     test(result.returnValue[2][0].Length == 2);
                     test(result.returnValue[2][1].Length == 1);
-                    test(result.returnValue[1][0][0].Equals(""));
-                    test(result.returnValue[2][0][0].Equals(""));
-                    test(result.returnValue[2][0][1].Equals(""));
-                    test(result.returnValue[2][1][0].Equals("abcd"));
+                    test(result.returnValue[1][0][0] == "");
+                    test(result.returnValue[2][0][0] == "");
+                    test(result.returnValue[2][0][1] == "");
+                    test(result.returnValue[2][1][0] == "abcd");
                 }
 
                 {
@@ -762,23 +762,23 @@ namespace Ice
 
                     test(result.returnValue.Length == 2);
                     test(result.returnValue[0].Count == 3);
-                    test(result.returnValue[0]["foo"].Equals("abc -1.1"));
-                    test(result.returnValue[0]["FOO"].Equals("abc -100.4"));
-                    test(result.returnValue[0]["BAR"].Equals("abc 0.5"));
+                    test(result.returnValue[0]["foo"] == "abc -1.1");
+                    test(result.returnValue[0]["FOO"] == "abc -100.4");
+                    test(result.returnValue[0]["BAR"] == "abc 0.5");
                     test(result.returnValue[1].Count == 2);
                     test(result.returnValue[1]["foo"] == "abc -1.1");
                     test(result.returnValue[1]["bar"] == "abc 123123.2");
 
                     test(result.p3.Length == 3);
                     test(result.p3[0].Count == 1);
-                    test(result.p3[0]["f00"].Equals("ABC -3.14"));
+                    test(result.p3[0]["f00"] == "ABC -3.14");
                     test(result.p3[1].Count == 2);
-                    test(result.p3[1]["foo"].Equals("abc -1.1"));
-                    test(result.p3[1]["bar"].Equals("abc 123123.2"));
+                    test(result.p3[1]["foo"] == "abc -1.1");
+                    test(result.p3[1]["bar"] == "abc 123123.2");
                     test(result.p3[2].Count == 3);
-                    test(result.p3[2]["foo"].Equals("abc -1.1"));
-                    test(result.p3[2]["FOO"].Equals("abc -100.4"));
-                    test(result.p3[2]["BAR"].Equals("abc 0.5"));
+                    test(result.p3[2]["foo"] == "abc -1.1");
+                    test(result.p3[2]["FOO"] == "abc -100.4");
+                    test(result.p3[2]["BAR"] == "abc 0.5");
                 }
 
                 {
@@ -854,19 +854,19 @@ namespace Ice
 
                     test(result.returnValue.Length == 2);
                     test(result.returnValue[0].Count == 2);
-                    test(result.returnValue[0][Test.MyEnum.enum2].Equals("Hello!!"));
-                    test(result.returnValue[0][Test.MyEnum.enum3].Equals("qwerty"));
+                    test(result.returnValue[0][Test.MyEnum.enum2] == "Hello!!");
+                    test(result.returnValue[0][Test.MyEnum.enum3] == "qwerty");
                     test(result.returnValue[1].Count == 1);
-                    test(result.returnValue[1][Test.MyEnum.enum1].Equals("abc"));
+                    test(result.returnValue[1][Test.MyEnum.enum1] == "abc");
 
                     test(result.p3.Length == 3);
                     test(result.p3[0].Count == 1);
-                    test(result.p3[0][Test.MyEnum.enum1].Equals("Goodbye"));
+                    test(result.p3[0][Test.MyEnum.enum1] == "Goodbye");
                     test(result.p3[1].Count == 1);
-                    test(result.p3[1][Test.MyEnum.enum1].Equals("abc"));
+                    test(result.p3[1][Test.MyEnum.enum1] == "abc");
                     test(result.p3[2].Count == 2);
-                    test(result.p3[2][Test.MyEnum.enum2].Equals("Hello!!"));
-                    test(result.p3[2][Test.MyEnum.enum3].Equals("qwerty"));
+                    test(result.p3[2][Test.MyEnum.enum2] == "Hello!!");
+                    test(result.p3[2][Test.MyEnum.enum3] == "qwerty");
                 }
 
                 {
@@ -1153,20 +1153,20 @@ namespace Ice
 
                     test(result.p3.Count == 1);
                     test(result.p3["ghi"].Length == 2);
-                    test(result.p3["ghi"][0].Equals("and"));
-                    test(result.p3["ghi"][1].Equals("xor"));
+                    test(result.p3["ghi"][0] == "and");
+                    test(result.p3["ghi"][1] == "xor");
 
                     test(result.returnValue.Count == 3);
                     test(result.returnValue["abc"].Length == 3);
-                    test(result.returnValue["abc"][0].Equals("abc"));
-                    test(result.returnValue["abc"][1].Equals("de"));
-                    test(result.returnValue["abc"][2].Equals("fghi"));
+                    test(result.returnValue["abc"][0] == "abc");
+                    test(result.returnValue["abc"][1] == "de");
+                    test(result.returnValue["abc"][2] == "fghi");
                     test(result.returnValue["def"].Length == 2);
-                    test(result.returnValue["def"][0].Equals("xyz"));
-                    test(result.returnValue["def"][1].Equals("or"));
+                    test(result.returnValue["def"][0] == "xyz");
+                    test(result.returnValue["def"][1] == "or");
                     test(result.returnValue["ghi"].Length == 2);
-                    test(result.returnValue["ghi"][0].Equals("and"));
-                    test(result.returnValue["ghi"][1].Equals("xor"));
+                    test(result.returnValue["ghi"][0] == "and");
+                    test(result.returnValue["ghi"][1] == "xor");
                 }
 
                 {
@@ -1303,7 +1303,7 @@ namespace Ice
                                 // Ignore.
                             }
                         }
-                        test(combined["one"].Equals("UN"));
+                        test(combined["one"] == "UN");
 
                         p3 = Test.MyClassPrxHelper.uncheckedCast(p.ice_context(prxContext));
 
@@ -1361,7 +1361,7 @@ namespace Ice
                 }
 
                 {
-                    test(p.opString1Async("opString1").Result.Equals("opString1"));
+                    test(p.opString1Async("opString1").Result == "opString1");
                 }
 
                 {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -1032,7 +1032,7 @@ namespace Ice
 
                     // Test null struct
                     p2 = initial.opVarStruct((Test.VarStruct)null, out p3);
-                    test(p2.Value.m == "" && p3.Value.m == "");
+                    test(p2.Value.m.Length == 0 && p3.Value.m.Length == 0);
 
                     var result = await initial.opVarStructAsync(p1);
                     test(result.returnValue.Value.m == "test" && result.p3.Value.m == "test");

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -96,7 +96,7 @@ namespace Ice
                 test(mo1.e.Value == 99);
                 test(mo1.f.Value ==(float)5.5);
                 test(mo1.g.Value == 1.0);
-                test(mo1.h.Value.Equals("test"));
+                test(mo1.h.Value == "test");
                 test(mo1.i.Value == Test.MyEnum.MyEnumMember);
                 test(mo1.j.Value.Equals(communicator.stringToProxy("test")));
                 test(mo1.k.Value == mo1);
@@ -509,7 +509,7 @@ namespace Ice
                 {
                     Test.WD wd =(Test.WD)initial.pingPong(new Test.WD());
                     test(wd.a.Value == 5);
-                    test(wd.s.Value.Equals("test"));
+                    test(wd.s.Value == "test");
                     wd.a = Ice.Util.None;
                     wd.s = Ice.Util.None;
                     wd =(Test.WD)initial.pingPong(wd);
@@ -862,10 +862,10 @@ namespace Ice
 
                     p1 = "test";
                     p2 = initial.opString(p1, out p3);
-                    test(p2.Value.Equals("test") && p3.Value.Equals("test"));
+                    test(p2.Value == "test" && p3.Value == "test");
 
                     var result = await initial.opStringAsync(p1);
-                    test(result.returnValue.Value.Equals("test") && result.p3.Value.Equals("test"));
+                    test(result.returnValue.Value == "test" && result.p3.Value == "test");
 
                     p2 = initial.opString(new Optional<string>(), out p3);
                     test(!p2.HasValue && !p3.HasValue); // Ensure out parameter is cleared.
@@ -880,9 +880,9 @@ namespace Ice
                     @in = new InputStream(communicator, outEncaps);
                     @in.startEncapsulation();
                     test(@in.readOptional(1, OptionalFormat.VSize));
-                    test(@in.readString().Equals("test"));
+                    test(@in.readString() == "test");
                     test(@in.readOptional(3, OptionalFormat.VSize));
-                    test(@in.readString().Equals("test"));
+                    test(@in.readString() == "test");
                     @in.endEncapsulation();
 
                     @in = new InputStream(communicator, outEncaps);
@@ -1028,14 +1028,14 @@ namespace Ice
 
                     p1 = new Test.VarStruct("test");
                     p2 = initial.opVarStruct(p1, out p3);
-                    test(p2.Value.m.Equals("test") && p3.Value.m.Equals("test"));
+                    test(p2.Value.m == "test" && p3.Value.m == "test");
 
                     // Test null struct
                     p2 = initial.opVarStruct((Test.VarStruct)null, out p3);
-                    test(p2.Value.m.Equals("") && p3.Value.m.Equals(""));
+                    test(p2.Value.m == "" && p3.Value.m == "");
 
                     var result = await initial.opVarStructAsync(p1);
-                    test(result.returnValue.Value.m.Equals("test") && result.p3.Value.m.Equals("test"));
+                    test(result.returnValue.Value.m == "test" && result.p3.Value.m == "test");
 
                     p2 = initial.opVarStruct(new Optional<Test.VarStruct>(), out p3);
                     test(!p2.HasValue && !p3.HasValue); // Ensure out parameter is cleared.
@@ -1055,11 +1055,11 @@ namespace Ice
                     @in.skip(4);
                     Test.VarStruct v = new Test.VarStruct();
                     v.ice_readMembers(@in);
-                    test(v.m.Equals("test"));
+                    test(v.m == "test");
                     test(@in.readOptional(3, OptionalFormat.FSize));
                     @in.skip(4);
                     v.ice_readMembers(@in);
-                    test(v.m.Equals("test"));
+                    test(v.m == "test");
                     @in.endEncapsulation();
 
                     @in = new InputStream(communicator, outEncaps);
@@ -1994,7 +1994,7 @@ namespace Ice
                     catch(Test.OptionalException ex)
                     {
                         test(ex.a.Value == 30);
-                        test(ex.b.Value.Equals("test"));
+                        test(ex.b.Value == "test");
                         test(ex.o.Value.a.Value == 53);
                     }
 
@@ -2043,9 +2043,9 @@ namespace Ice
                     catch(Test.DerivedException ex)
                     {
                         test(ex.a.Value == 30);
-                        test(ex.b.Value.Equals("test2"));
+                        test(ex.b.Value == "test2");
                         test(ex.o.Value.a.Value == 53);
-                        test(ex.ss.Value.Equals("test2"));
+                        test(ex.ss.Value == "test2");
                         test(ex.o2.Value.a.Value == 53);
                         test(ex.d1 == "d1");
                         test(ex.d2 == "d2");
@@ -2063,7 +2063,7 @@ namespace Ice
                         test(!ex.a.HasValue);
                         test(!ex.b.HasValue);
                         test(!ex.o.HasValue);
-                        test(ex.ss.Equals("test"));
+                        test(ex.ss == "test");
                         test(ex.o2 == null);
                     }
 
@@ -2077,9 +2077,9 @@ namespace Ice
                     catch(Test.RequiredException ex)
                     {
                         test(ex.a.Value == 30);
-                        test(ex.b.Value.Equals("test2"));
+                        test(ex.b.Value == "test2");
                         test(ex.o.Value.a.Value == 53);
-                        test(ex.ss.Equals("test2"));
+                        test(ex.ss == "test2");
                         test(ex.o2.a.Value == 53);
                     }
                 }
@@ -2323,12 +2323,12 @@ namespace Ice
                     // ::Test::D
                     @in.startSlice();
                     string s = @in.readString();
-                    test(s.Equals("test"));
+                    test(s == "test");
                     test(@in.readOptional(1, Ice.OptionalFormat.FSize));
                     @in.skip(4);
                     string[] o = @in.readStringSeq();
                     test(o.Length == 4 &&
-                         o[0].Equals("test1") && o[1].Equals("test2") && o[2].Equals("test3") && o[3].Equals("test4"));
+                         o[0] == "test1" && o[1] == "test2" && o[2] == "test3" && o[3] == "test4");
                     test(@in.readOptional(1000, Ice.OptionalFormat.Class));
                     @in.readValue(a.invoke);
                     @in.endSlice();
@@ -2402,11 +2402,11 @@ namespace Ice
                     {
                         return new CValueReader();
                     }
-                    else if(typeId.Equals("::Test::D"))
+                    else if(typeId == "::Test::D")
                     {
                         return new DValueReader();
                     }
-                    else if(typeId.Equals("::Test::F"))
+                    else if(typeId == "::Test::F")
                     {
                         return new FValueReader();
                     }

--- a/csharp/test/Ice/plugin/Client.cs
+++ b/csharp/test/Ice/plugin/Client.cs
@@ -46,7 +46,7 @@ public class Client : Test.TestHelper
             }
             catch(Ice.PluginInitializationException ex)
             {
-                test(ex.InnerException.Message.Equals("PluginInitializeFailException"));
+                test(ex.InnerException.Message == "PluginInitializeFailException");
             }
             Console.WriteLine("ok");
         }
@@ -110,7 +110,7 @@ public class Client : Test.TestHelper
             }
             catch(Ice.PluginInitializationException ex)
             {
-                test(ex.InnerException.Message.Equals("PluginInitializeFailException"));
+                test(ex.InnerException.Message == "PluginInitializeFailException");
             }
             Console.WriteLine("ok");
         }

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -20,10 +20,10 @@ public class Client : Test.TestHelper
         run(String[] args)
         {
             Ice.Properties properties = communicator().getProperties();
-            test(properties.getProperty("Ice.Trace.Network").Equals("1"));
-            test(properties.getProperty("Ice.Trace.Protocol").Equals("1"));
-            test(properties.getProperty("Config.Path").Equals("./config/中国_client.config"));
-            test(properties.getProperty("Ice.ProgramName").Equals("PropertiesClient"));
+            test(properties.getProperty("Ice.Trace.Network") == "1");
+            test(properties.getProperty("Ice.Trace.Protocol") == "1");
+            test(properties.getProperty("Config.Path") == "./config/中国_client.config");
+            test(properties.getProperty("Ice.ProgramName") == "PropertiesClient");
             test(appName().Equals(properties.getProperty("Ice.ProgramName")));
             return 0;
         }
@@ -36,10 +36,10 @@ public class Client : Test.TestHelper
             Console.Out.Flush();
             Ice.Properties properties = Ice.Util.createProperties();
             properties.load("./config/中国_client.config");
-            test(properties.getProperty("Ice.Trace.Network").Equals("1"));
-            test(properties.getProperty("Ice.Trace.Protocol").Equals("1"));
-            test(properties.getProperty("Config.Path").Equals("./config/中国_client.config"));
-            test(properties.getProperty("Ice.ProgramName").Equals("PropertiesClient"));
+            test(properties.getProperty("Ice.Trace.Network") == "1");
+            test(properties.getProperty("Ice.Trace.Protocol") == "1");
+            test(properties.getProperty("Config.Path") == "./config/中国_client.config");
+            test(properties.getProperty("Ice.ProgramName") == "PropertiesClient");
             Console.Out.WriteLine("ok");
             Console.Out.Write("testing load properties from UTF-8 path using Ice::Application... ");
             Console.Out.Flush();
@@ -56,9 +56,9 @@ public class Client : Test.TestHelper
             Console.Out.Flush();
             string[] args1 = new string[]{"--Ice.Config=config/config.1, config/config.2, config/config.3"};
             Ice.Properties properties = Ice.Util.createProperties(ref args1);
-            test(properties.getProperty("Config1").Equals("Config1"));
-            test(properties.getProperty("Config2").Equals("Config2"));
-            test(properties.getProperty("Config3").Equals("Config3"));
+            test(properties.getProperty("Config1") == "Config1");
+            test(properties.getProperty("Config2") == "Config2");
+            test(properties.getProperty("Config3") == "Config3");
             Console.Out.WriteLine("ok");
         }
 

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -23,19 +23,19 @@ namespace Ice
                 test(baseProxy != null);
 
                 var b1 = communicator.stringToProxy("test");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getAdapterId().Length == 0 && b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy("test ");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy(" test ");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy(" test");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy("'test -f facet'");
-                test(b1.ice_getIdentity().name.Equals("test -f facet") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test -f facet" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 try
                 {
@@ -46,13 +46,13 @@ namespace Ice
                 {
                 }
                 b1 = communicator.stringToProxy("\"test -f facet\"");
-                test(b1.ice_getIdentity().name.Equals("test -f facet") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test -f facet" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy("\"test -f facet@test\"");
-                test(b1.ice_getIdentity().name.Equals("test -f facet@test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test -f facet@test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 b1 = communicator.stringToProxy("\"test -f facet@test @test\"");
-                test(b1.ice_getIdentity().name.Equals("test -f facet@test @test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test -f facet@test @test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getFacet().Length == 0);
                 try
                 {
@@ -63,7 +63,7 @@ namespace Ice
                 {
                 }
                 b1 = communicator.stringToProxy("test\\040test");
-                test(b1.ice_getIdentity().name.Equals("test test") && b1.ice_getIdentity().category.Length == 0);
+                test(b1.ice_getIdentity().name == "test test" && b1.ice_getIdentity().category.Length == 0);
                 try
                 {
                     b1 = communicator.stringToProxy("test\\777");
@@ -73,23 +73,23 @@ namespace Ice
                 {
                 }
                 b1 = communicator.stringToProxy("test\\40test");
-                test(b1.ice_getIdentity().name.Equals("test test"));
+                test(b1.ice_getIdentity().name == "test test");
 
                 // Test some octal and hex corner cases.
                 b1 = communicator.stringToProxy("test\\4test");
-                test(b1.ice_getIdentity().name.Equals("test\u0004test"));
+                test(b1.ice_getIdentity().name == "test\u0004test");
                 b1 = communicator.stringToProxy("test\\04test");
-                test(b1.ice_getIdentity().name.Equals("test\u0004test"));
+                test(b1.ice_getIdentity().name == "test\u0004test");
                 b1 = communicator.stringToProxy("test\\004test");
-                test(b1.ice_getIdentity().name.Equals("test\u0004test"));
+                test(b1.ice_getIdentity().name == "test\u0004test");
                 b1 = communicator.stringToProxy("test\\1114test");
-                test(b1.ice_getIdentity().name.Equals("test\u00494test"));
+                test(b1.ice_getIdentity().name == "test\u00494test");
 
                 b1 = communicator.stringToProxy("test\\b\\f\\n\\r\\t\\'\\\"\\\\test");
                 test(b1.ice_getIdentity().name.Equals("test\b\f\n\r\t\'\"\\test") && b1.ice_getIdentity().category.Length == 0);
 
                 b1 = communicator.stringToProxy("category/test");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category") &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category" &&
                      b1.ice_getAdapterId().Length == 0);
 
                 b1 = communicator.stringToProxy("test:tcp --sourceAddress \"::1\"");
@@ -120,8 +120,8 @@ namespace Ice
                 }
 
                 b1 = communicator.stringToProxy("test@adapter");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getAdapterId().Equals("adapter"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getAdapterId() == "adapter");
                 try
                 {
                     b1 = communicator.stringToProxy("id@adapter test");
@@ -131,36 +131,36 @@ namespace Ice
                 {
                 }
                 b1 = communicator.stringToProxy("category/test@adapter");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category") &&
-                     b1.ice_getAdapterId().Equals("adapter"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category" &&
+                     b1.ice_getAdapterId() == "adapter");
                 b1 = communicator.stringToProxy("category/test@adapter:tcp");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category") &&
-                     b1.ice_getAdapterId().Equals("adapter:tcp"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category" &&
+                     b1.ice_getAdapterId() == "adapter:tcp");
                 b1 = communicator.stringToProxy("'category 1/test'@adapter");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category 1") &&
-                     b1.ice_getAdapterId().Equals("adapter"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category 1" &&
+                     b1.ice_getAdapterId() == "adapter");
                 b1 = communicator.stringToProxy("'category/test 1'@adapter");
-                test(b1.ice_getIdentity().name.Equals("test 1") && b1.ice_getIdentity().category.Equals("category") &&
-                     b1.ice_getAdapterId().Equals("adapter"));
+                test(b1.ice_getIdentity().name == "test 1" && b1.ice_getIdentity().category == "category" &&
+                     b1.ice_getAdapterId() == "adapter");
                 b1 = communicator.stringToProxy("'category/test'@'adapter 1'");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category") &&
-                     b1.ice_getAdapterId().Equals("adapter 1"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category" &&
+                     b1.ice_getAdapterId() == "adapter 1");
                 b1 = communicator.stringToProxy("\"category \\/test@foo/test\"@adapter");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category /test@foo") &&
-                     b1.ice_getAdapterId().Equals("adapter"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category /test@foo" &&
+                     b1.ice_getAdapterId() == "adapter");
                 b1 = communicator.stringToProxy("\"category \\/test@foo/test\"@\"adapter:tcp\"");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Equals("category /test@foo") &&
-                     b1.ice_getAdapterId().Equals("adapter:tcp"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category == "category /test@foo" &&
+                     b1.ice_getAdapterId() == "adapter:tcp");
 
                 b1 = communicator.stringToProxy("id -f facet");
-                test(b1.ice_getIdentity().name.Equals("id") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet"));
+                test(b1.ice_getIdentity().name == "id" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet");
                 b1 = communicator.stringToProxy("id -f 'facet x'");
-                test(b1.ice_getIdentity().name.Equals("id") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet x"));
+                test(b1.ice_getIdentity().name == "id" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet x");
                 b1 = communicator.stringToProxy("id -f \"facet x\"");
-                test(b1.ice_getIdentity().name.Equals("id") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet x"));
+                test(b1.ice_getIdentity().name == "id" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet x");
                 try
                 {
                     b1 = communicator.stringToProxy("id -f \"facet x");
@@ -178,20 +178,20 @@ namespace Ice
                 {
                 }
                 b1 = communicator.stringToProxy("test -f facet:tcp");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet") && b1.ice_getAdapterId().Length == 0);
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet" && b1.ice_getAdapterId().Length == 0);
                 b1 = communicator.stringToProxy("test -f \"facet:tcp\"");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet:tcp") && b1.ice_getAdapterId().Length == 0);
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet:tcp" && b1.ice_getAdapterId().Length == 0);
                 b1 = communicator.stringToProxy("test -f facet@test");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet") && b1.ice_getAdapterId().Equals("test"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet" && b1.ice_getAdapterId() == "test");
                 b1 = communicator.stringToProxy("test -f 'facet@test'");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet@test") && b1.ice_getAdapterId().Length == 0);
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet@test" && b1.ice_getAdapterId().Length == 0);
                 b1 = communicator.stringToProxy("test -f 'facet@test'@test");
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
-                     b1.ice_getFacet().Equals("facet@test") && b1.ice_getAdapterId().Equals("test"));
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
+                     b1.ice_getFacet() == "facet@test" && b1.ice_getAdapterId() == "test");
                 try
                 {
                     b1 = communicator.stringToProxy("test -f facet@test @test");
@@ -226,10 +226,10 @@ namespace Ice
                 test(b1.ice_getEncodingVersion().major == 6 && b1.ice_getEncodingVersion().minor == 5);
 
                 b1 = communicator.stringToProxy("test -p 1.0 -e 1.0");
-                test(b1.ToString().Equals("test -t -e 1.0"));
+                test(b1.ToString() == "test -t -e 1.0");
 
                 b1 = communicator.stringToProxy("test -p 6.5 -e 1.0");
-                test(b1.ToString().Equals("test -t -p 6.5 -e 1.0"));
+                test(b1.ToString() == "test -t -p 6.5 -e 1.0");
 
                 try
                 {
@@ -397,7 +397,7 @@ namespace Ice
                 String propertyPrefix = "Foo.Proxy";
                 prop.setProperty(propertyPrefix, "test:" + helper.getTestEndpoint(0));
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getIdentity().name.Equals("test") && b1.ice_getIdentity().category.Length == 0 &&
+                test(b1.ice_getIdentity().name == "test" && b1.ice_getIdentity().category.Length == 0 &&
                      b1.ice_getAdapterId().Length == 0 && b1.ice_getFacet().Length == 0);
 
                 string property;
@@ -406,7 +406,7 @@ namespace Ice
                 test(b1.ice_getLocator() == null);
                 prop.setProperty(property, "locator:default -p 10000");
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getLocator() != null && b1.ice_getLocator().ice_getIdentity().name.Equals("locator"));
+                test(b1.ice_getLocator() != null && b1.ice_getLocator().ice_getIdentity().name == "locator");
                 prop.setProperty(property, "");
                 property = propertyPrefix + ".LocatorCacheTimeout";
                 test(b1.ice_getLocatorCacheTimeout() == -1);
@@ -420,7 +420,7 @@ namespace Ice
                 property = propertyPrefix + ".Locator";
                 prop.setProperty(property, "locator:default -p 10000");
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getLocator() != null && b1.ice_getLocator().ice_getIdentity().name.Equals("locator"));
+                test(b1.ice_getLocator() != null && b1.ice_getLocator().ice_getIdentity().name == "locator");
                 prop.setProperty(property, "");
 
                 property = propertyPrefix + ".LocatorCacheTimeout";
@@ -444,7 +444,7 @@ namespace Ice
                 test(b1.ice_getRouter() == null);
                 prop.setProperty(property, "router:default -p 10000");
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getRouter() != null && b1.ice_getRouter().ice_getIdentity().name.Equals("router"));
+                test(b1.ice_getRouter() != null && b1.ice_getRouter().ice_getIdentity().name == "router");
                 prop.setProperty(property, "");
 
                 property = propertyPrefix + ".PreferSecure";
@@ -489,13 +489,13 @@ namespace Ice
                 test(!b1.ice_getContext().ContainsKey("c1"));
                 prop.setProperty(property, "TEST");
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getContext()["c1"].Equals("TEST"));
+                test(b1.ice_getContext()["c1"] == "TEST");
 
                 property = propertyPrefix + ".Context.c2";
                 test(!b1.ice_getContext().ContainsKey("c2"));
                 prop.setProperty(property, "TEST");
                 b1 = communicator.propertyToProxy(propertyPrefix);
-                test(b1.ice_getContext()["c2"].Equals("TEST"));
+                test(b1.ice_getContext()["c2"] == "TEST");
 
                 prop.setProperty(propertyPrefix + ".Context.c1", "");
                 prop.setProperty(propertyPrefix + ".Context.c2", "");
@@ -536,32 +536,32 @@ namespace Ice
                 Dictionary<string, string> proxyProps = communicator.proxyToProperty(b1, "Test");
                 test(proxyProps.Count == 21);
 
-                test(proxyProps["Test"].Equals("test -t -e 1.0"));
-                test(proxyProps["Test.CollocationOptimized"].Equals("1"));
-                test(proxyProps["Test.ConnectionCached"].Equals("1"));
-                test(proxyProps["Test.PreferSecure"].Equals("0"));
-                test(proxyProps["Test.EndpointSelection"].Equals("Ordered"));
-                test(proxyProps["Test.LocatorCacheTimeout"].Equals("100"));
-                test(proxyProps["Test.InvocationTimeout"].Equals("1234"));
+                test(proxyProps["Test"] == "test -t -e 1.0");
+                test(proxyProps["Test.CollocationOptimized"] == "1");
+                test(proxyProps["Test.ConnectionCached"] == "1");
+                test(proxyProps["Test.PreferSecure"] == "0");
+                test(proxyProps["Test.EndpointSelection"] == "Ordered");
+                test(proxyProps["Test.LocatorCacheTimeout"] == "100");
+                test(proxyProps["Test.InvocationTimeout"] == "1234");
 
                 test(proxyProps["Test.Locator"].Equals(
                          "locator -t -e " + Ice.Util.encodingVersionToString(Ice.Util.currentEncoding)));
                 // Locator collocation optimization is always disabled.
-                //test(proxyProps["Test.Locator.CollocationOptimized"].Equals("1"));
-                test(proxyProps["Test.Locator.ConnectionCached"].Equals("0"));
-                test(proxyProps["Test.Locator.PreferSecure"].Equals("1"));
-                test(proxyProps["Test.Locator.EndpointSelection"].Equals("Random"));
-                test(proxyProps["Test.Locator.LocatorCacheTimeout"].Equals("300"));
-                test(proxyProps["Test.Locator.InvocationTimeout"].Equals("1500"));
+                //test(proxyProps["Test.Locator.CollocationOptimized"] == "1");
+                test(proxyProps["Test.Locator.ConnectionCached"] == "0");
+                test(proxyProps["Test.Locator.PreferSecure"] == "1");
+                test(proxyProps["Test.Locator.EndpointSelection"] == "Random");
+                test(proxyProps["Test.Locator.LocatorCacheTimeout"] == "300");
+                test(proxyProps["Test.Locator.InvocationTimeout"] == "1500");
 
                 test(proxyProps["Test.Locator.Router"].Equals(
                          "router -t -e " + Ice.Util.encodingVersionToString(Ice.Util.currentEncoding)));
-                test(proxyProps["Test.Locator.Router.CollocationOptimized"].Equals("0"));
-                test(proxyProps["Test.Locator.Router.ConnectionCached"].Equals("1"));
-                test(proxyProps["Test.Locator.Router.PreferSecure"].Equals("1"));
-                test(proxyProps["Test.Locator.Router.EndpointSelection"].Equals("Random"));
-                test(proxyProps["Test.Locator.Router.LocatorCacheTimeout"].Equals("200"));
-                test(proxyProps["Test.Locator.Router.InvocationTimeout"].Equals("1500"));
+                test(proxyProps["Test.Locator.Router.CollocationOptimized"] == "0");
+                test(proxyProps["Test.Locator.Router.ConnectionCached"] == "1");
+                test(proxyProps["Test.Locator.Router.PreferSecure"] == "1");
+                test(proxyProps["Test.Locator.Router.EndpointSelection"] == "Random");
+                test(proxyProps["Test.Locator.Router.LocatorCacheTimeout"] == "200");
+                test(proxyProps["Test.Locator.Router.InvocationTimeout"] == "1500");
 
                 output.WriteLine("ok");
 
@@ -573,9 +573,9 @@ namespace Ice
                 output.Write("testing proxy methods... ");
 
                 test(communicator.identityToString(
-                    baseProxy.ice_identity(Util.stringToIdentity("other")).ice_getIdentity()).Equals("other"));
-                test(baseProxy.ice_facet("facet").ice_getFacet().Equals("facet"));
-                test(baseProxy.ice_adapterId("id").ice_getAdapterId().Equals("id"));
+                    baseProxy.ice_identity(Util.stringToIdentity("other")).ice_getIdentity()) == "other");
+                test(baseProxy.ice_facet("facet").ice_getFacet() == "facet");
+                test(baseProxy.ice_adapterId("id").ice_getAdapterId() == "id");
                 test(baseProxy.ice_twoway().ice_isTwoway());
                 test(baseProxy.ice_oneway().ice_isOneway());
                 test(baseProxy.ice_batchOneway().ice_isBatchOneway());
@@ -702,8 +702,8 @@ namespace Ice
 
                 test(compObj.ice_connectionId("id2").Equals(compObj.ice_connectionId("id2")));
                 test(!compObj.ice_connectionId("id1").Equals(compObj.ice_connectionId("id2")));
-                test(compObj.ice_connectionId("id1").ice_getConnectionId().Equals("id1"));
-                test(compObj.ice_connectionId("id2").ice_getConnectionId().Equals("id2"));
+                test(compObj.ice_connectionId("id1").ice_getConnectionId() == "id1");
+                test(compObj.ice_connectionId("id2").ice_getConnectionId() == "id2");
 
                 test(compObj.ice_compress(true).Equals(compObj.ice_compress(true)));
                 test(!compObj.ice_compress(false).Equals(compObj.ice_compress(true)));
@@ -818,7 +818,7 @@ namespace Ice
                         test(prx.ice_isFixed());
                         prx.ice_ping();
                         test(cl.ice_secure(true).ice_fixed(connection).ice_isSecure());
-                        test(cl.ice_facet("facet").ice_fixed(connection).ice_getFacet().Equals("facet"));
+                        test(cl.ice_facet("facet").ice_fixed(connection).ice_getFacet() == "facet");
                         test(cl.ice_oneway().ice_fixed(connection).ice_isOneway());
                         Dictionary<string, string> ctx = new Dictionary<string, string>();
                         ctx["one"] = "hello";
@@ -1086,29 +1086,29 @@ namespace Ice
                 // Legal TCP endpoint expressed as opaque endpoint
                 Ice.ObjectPrx p1 = communicator.stringToProxy("test -e 1.1:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMeouAAAQJwAAAA==");
                 string pstr = communicator.proxyToString(p1);
-                test(pstr.Equals("test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
+                test(pstr == "test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000");
 
                 // Opaque endpoint encoded with 1.1 encoding.
                 Ice.ObjectPrx p2 = communicator.stringToProxy("test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==");
-                test(communicator.proxyToString(p2).Equals("test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000"));
+                test(communicator.proxyToString(p2) == "test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000");
 
                 if(communicator.getProperties().getPropertyAsInt("Ice.IPv6") == 0)
                 {
                     // Working?
-                    bool ssl = communicator.getProperties().getProperty("Ice.Default.Protocol").Equals("ssl");
-                    bool tcp = communicator.getProperties().getProperty("Ice.Default.Protocol").Equals("tcp");
+                    bool ssl = communicator.getProperties().getProperty("Ice.Default.Protocol") == "ssl";
+                    bool tcp = communicator.getProperties().getProperty("Ice.Default.Protocol") == "tcp";
 
                     // Two legal TCP endpoints expressed as opaque endpoints
                     p1 = communicator.stringToProxy("test -e 1.0:opaque -e 1.0 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==:opaque -e 1.0 -t 1 -v CTEyNy4wLjAuMusuAAAQJwAAAA==");
                     pstr = communicator.proxyToString(p1);
-                    test(pstr.Equals("test -t -e 1.0:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000"));
+                    test(pstr == "test -t -e 1.0:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000");
 
                     // Test that an SSL endpoint and a nonsense endpoint get written back out as an opaque endpoint.
                     p1 = communicator.stringToProxy("test -e 1.0:opaque -e 1.0 -t 2 -v CTEyNy4wLjAuMREnAAD/////AA==:opaque -e 1.0 -t 99 -v abch");
                     pstr = communicator.proxyToString(p1);
                     if(ssl)
                     {
-                        test(pstr.Equals("test -t -e 1.0:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.0 -v abch"));
+                        test(pstr == "test -t -e 1.0:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.0 -v abch");
                     }
                     else if(tcp)
                     {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -307,7 +307,7 @@ namespace Ice
 
                 // Input string with various pitfalls
                 id = Ice.Util.stringToIdentity("\\342\\x82\\254\\60\\x9\\60\\");
-                test(id.name == "€0\t0\\" && id.category == "");
+                test(id.name == "€0\t0\\" && id.category.Length == 0);
 
                 try
                 {

--- a/csharp/test/Ice/servantLocator/AllTests.cs
+++ b/csharp/test/Ice/servantLocator/AllTests.cs
@@ -21,7 +21,7 @@ namespace Ice
                 {
                     test(ex.id.Equals(obj.ice_getIdentity()));
                     test(ex.facet.Equals(obj.ice_getFacet()));
-                    test(ex.operation.Equals("requestFailedException"));
+                    test(ex.operation == "requestFailedException");
                 }
                 catch(Exception)
                 {
@@ -35,7 +35,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownUserException ex)
                 {
-                    test(ex.unknown.Equals("reason"));
+                    test(ex.unknown == "reason");
                 }
                 catch(Exception)
                 {
@@ -49,7 +49,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownLocalException ex)
                 {
-                    test(ex.unknown.Equals("reason"));
+                    test(ex.unknown == "reason");
                 }
                 catch(Exception)
                 {
@@ -63,7 +63,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownException ex)
                 {
-                    test(ex.unknown.Equals("reason"));
+                    test(ex.unknown == "reason");
                 }
                 catch(Exception)
                 {
@@ -127,7 +127,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownException ex)
                 {
-                    test(ex.unknown.Equals("reason"));
+                    test(ex.unknown == "reason");
                 }
                 catch(Exception)
                 {
@@ -221,7 +221,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownUserException ex)
                 {
-                    test(ex.unknown.Equals("::Test::TestIntfUserException"));
+                    test(ex.unknown == "::Test::TestIntfUserException");
                 }
                 catch(Exception)
                 {
@@ -236,7 +236,7 @@ namespace Ice
                 }
                 catch(Ice.UnknownUserException ex)
                 {
-                    test(ex.unknown.Equals("::Test::TestIntfUserException"));
+                    test(ex.unknown == "::Test::TestIntfUserException");
                 }
                 catch(Exception)
                 {

--- a/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
@@ -44,20 +44,20 @@ namespace Ice
 
                     test(current.id.category.Equals(_category) || _category.Length == 0);
 
-                    if(current.id.name.Equals("unknown"))
+                    if(current.id.name == "unknown")
                     {
                         cookie = null;
                         return null;
                     }
 
-                    if(current.id.name.Equals("invalidReturnValue") || current.id.name.Equals("invalidReturnType"))
+                    if(current.id.name == "invalidReturnValue" || current.id.name == "invalidReturnType")
                     {
                         cookie = null;
                         return null;
                     }
 
-                    test(current.id.name.Equals("locate") || current.id.name.Equals("finished"));
-                    if(current.id.name.Equals("locate"))
+                    test(current.id.name == "locate" || current.id.name == "finished");
+                    if(current.id.name == "locate")
                     {
                         exception(current);
                     }
@@ -87,15 +87,15 @@ namespace Ice
                     _requestId = -1;
 
                     test(current.id.category.Equals(_category) || _category.Length == 0);
-                    test(current.id.name.Equals("locate") || current.id.name.Equals("finished"));
+                    test(current.id.name == "locate" || current.id.name == "finished");
 
-                    if(current.id.name.Equals("finished"))
+                    if(current.id.name == "finished")
                     {
                         exception(current);
                     }
 
                     var co =(Cookie)cookie;
-                    test(co.message().Equals("blahblah"));
+                    test(co.message() == "blahblah");
                 }
 
                 public void deactivate(string category)
@@ -110,63 +110,63 @@ namespace Ice
 
                 private void exception(Ice.Current current)
                 {
-                    if(current.operation.Equals("ice_ids"))
+                    if(current.operation == "ice_ids")
                     {
                         throw new Test.TestIntfUserException();
                     }
-                    else if(current.operation.Equals("requestFailedException"))
+                    else if(current.operation == "requestFailedException")
                     {
                         throw new Ice.ObjectNotExistException();
                     }
-                    else if(current.operation.Equals("unknownUserException"))
+                    else if(current.operation == "unknownUserException")
                     {
                         var ex = new Ice.UnknownUserException();
                         ex.unknown = "reason";
                         throw ex;
                     }
-                    else if(current.operation.Equals("unknownLocalException"))
+                    else if(current.operation == "unknownLocalException")
                     {
                         var ex = new Ice.UnknownLocalException();
                         ex.unknown = "reason";
                         throw ex;
                     }
-                    else if(current.operation.Equals("unknownException"))
+                    else if(current.operation == "unknownException")
                     {
                         var ex = new Ice.UnknownException();
                         ex.unknown = "reason";
                         throw ex;
                     }
-                    else if(current.operation.Equals("userException"))
+                    else if(current.operation == "userException")
                     {
                         throw new Test.TestIntfUserException();
                     }
-                    else if(current.operation.Equals("localException"))
+                    else if(current.operation == "localException")
                     {
                         var ex = new Ice.SocketException();
                         ex.error = 0;
                         throw ex;
                     }
-                    else if(current.operation.Equals("csException"))
+                    else if(current.operation == "csException")
                     {
                         throw new System.Exception("message");
                     }
-                    else if(current.operation.Equals("unknownExceptionWithServantException"))
+                    else if(current.operation == "unknownExceptionWithServantException")
                     {
                         throw new Ice.UnknownException("reason");
                     }
-                    else if(current.operation.Equals("impossibleException"))
+                    else if(current.operation == "impossibleException")
                     {
                         throw new Test.TestIntfUserException(); // Yes, it really is meant to be TestIntfException.
                     }
-                    else if(current.operation.Equals("intfUserException"))
+                    else if(current.operation == "intfUserException")
                     {
                         throw new Test.TestImpossibleException(); // Yes, it really is meant to be TestImpossibleException.
                     }
-                    else if(current.operation.Equals("asyncResponse"))
+                    else if(current.operation == "asyncResponse")
                     {
                         throw new Test.TestImpossibleException();
                     }
-                    else if(current.operation.Equals("asyncException"))
+                    else if(current.operation == "asyncException")
                     {
                         throw new Test.TestImpossibleException();
                     }

--- a/csharp/test/Ice/servantLocator/ServantLocatorI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorI.cs
@@ -42,20 +42,20 @@ namespace Ice
 
                 test(current.id.category.Equals(_category) || _category.Length == 0);
 
-                if(current.id.name.Equals("unknown"))
+                if(current.id.name == "unknown")
                 {
                     cookie = null;
                     return null;
                 }
 
-                if(current.id.name.Equals("invalidReturnValue") || current.id.name.Equals("invalidReturnType"))
+                if(current.id.name == "invalidReturnValue" || current.id.name == "invalidReturnType")
                 {
                     cookie = null;
                     return null;
                 }
 
-                test(current.id.name.Equals("locate") || current.id.name.Equals("finished"));
-                if(current.id.name.Equals("locate"))
+                test(current.id.name == "locate" || current.id.name == "finished");
+                if(current.id.name == "locate")
                 {
                     exception(current);
                 }
@@ -85,15 +85,15 @@ namespace Ice
                 _requestId = -1;
 
                 test(current.id.category.Equals(_category) || _category.Length == 0);
-                test(current.id.name.Equals("locate") || current.id.name.Equals("finished"));
+                test(current.id.name == "locate" || current.id.name == "finished");
 
-                if(current.id.name.Equals("finished"))
+                if(current.id.name == "finished")
                 {
                     exception(current);
                 }
 
                 var co =(Cookie)cookie;
-                test(co.message().Equals("blahblah"));
+                test(co.message() == "blahblah");
             }
 
             public void deactivate(string category)
@@ -108,63 +108,63 @@ namespace Ice
 
             private void exception(Ice.Current current)
             {
-                if(current.operation.Equals("ice_ids"))
+                if(current.operation == "ice_ids")
                 {
                     throw new Test.TestIntfUserException();
                 }
-                else if(current.operation.Equals("requestFailedException"))
+                else if(current.operation == "requestFailedException")
                 {
                     throw new Ice.ObjectNotExistException();
                 }
-                else if(current.operation.Equals("unknownUserException"))
+                else if(current.operation == "unknownUserException")
                 {
                     var ex = new Ice.UnknownUserException();
                     ex.unknown = "reason";
                     throw ex;
                 }
-                else if(current.operation.Equals("unknownLocalException"))
+                else if(current.operation == "unknownLocalException")
                 {
                     var ex = new Ice.UnknownLocalException();
                     ex.unknown = "reason";
                     throw ex;
                 }
-                else if(current.operation.Equals("unknownException"))
+                else if(current.operation == "unknownException")
                 {
                     var ex = new Ice.UnknownException();
                     ex.unknown = "reason";
                     throw ex;
                 }
-                else if(current.operation.Equals("userException"))
+                else if(current.operation == "userException")
                 {
                     throw new Test.TestIntfUserException();
                 }
-                else if(current.operation.Equals("localException"))
+                else if(current.operation == "localException")
                 {
                     var ex = new Ice.SocketException();
                     ex.error = 0;
                     throw ex;
                 }
-                else if(current.operation.Equals("csException"))
+                else if(current.operation == "csException")
                 {
                     throw new System.Exception("message");
                 }
-                else if(current.operation.Equals("unknownExceptionWithServantException"))
+                else if(current.operation == "unknownExceptionWithServantException")
                 {
                     throw new Ice.UnknownException("reason");
                 }
-                else if(current.operation.Equals("impossibleException"))
+                else if(current.operation == "impossibleException")
                 {
                     throw new Test.TestIntfUserException(); // Yes, it really is meant to be TestIntfException.
                 }
-                else if(current.operation.Equals("intfUserException"))
+                else if(current.operation == "intfUserException")
                 {
                     throw new Test.TestImpossibleException(); // Yes, it really is meant to be TestImpossibleException.
                 }
-                else if(current.operation.Equals("asyncResponse"))
+                else if(current.operation == "asyncResponse")
                 {
                     throw new Test.TestImpossibleException();
                 }
-                else if(current.operation.Equals("asyncException"))
+                else if(current.operation == "asyncException")
                 {
                     throw new Test.TestImpossibleException();
                 }

--- a/csharp/test/Ice/slicing/exceptions/AllTests.cs
+++ b/csharp/test/Ice/slicing/exceptions/AllTests.cs
@@ -114,8 +114,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("Base.b"));
-                test(b.GetType().FullName.Equals("Test.Base"));
+                test(b.b == "Base.b");
+                test(b.GetType().FullName == "Test.Base");
             }
             catch(Exception)
             {
@@ -133,8 +133,8 @@ public class AllTests : Test.AllTests
             }
             catch (Base b)
             {
-                test(b.b.Equals("Base.b"));
-                test(b.GetType().Name.Equals("Base"));
+                test(b.b == "Base.b");
+                test(b.GetType().Name == "Base");
             }
         }
         output.WriteLine("ok");
@@ -149,8 +149,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownDerived.b"));
-                test(b.GetType().FullName.Equals("Test.Base"));
+                test(b.b == "UnknownDerived.b");
+                test(b.GetType().FullName == "Test.Base");
             }
             catch(Exception)
             {
@@ -169,8 +169,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownDerived.b"));
-                test(b.GetType().Name.Equals("Base"));
+                test(b.b == "UnknownDerived.b");
+                test(b.GetType().Name == "Base");
             }
         }
         output.WriteLine("ok");
@@ -185,9 +185,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownDerived k)
             {
-                test(k.b.Equals("KnownDerived.b"));
-                test(k.kd.Equals("KnownDerived.kd"));
-                test(k.GetType().FullName.Equals("Test.KnownDerived"));
+                test(k.b == "KnownDerived.b");
+                test(k.kd == "KnownDerived.kd");
+                test(k.GetType().FullName == "Test.KnownDerived");
             }
             catch(Exception)
             {
@@ -206,9 +206,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownDerived k)
             {
-                test(k.b.Equals("KnownDerived.b"));
-                test(k.kd.Equals("KnownDerived.kd"));
-                test(k.GetType().Name.Equals("KnownDerived"));
+                test(k.b == "KnownDerived.b");
+                test(k.kd == "KnownDerived.kd");
+                test(k.GetType().Name == "KnownDerived");
             }
         }
         output.WriteLine("ok");
@@ -223,9 +223,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownDerived k)
             {
-                test(k.b.Equals("KnownDerived.b"));
-                test(k.kd.Equals("KnownDerived.kd"));
-                test(k.GetType().FullName.Equals("Test.KnownDerived"));
+                test(k.b == "KnownDerived.b");
+                test(k.kd == "KnownDerived.kd");
+                test(k.GetType().FullName == "Test.KnownDerived");
             }
             catch(Exception)
             {
@@ -244,9 +244,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownDerived k)
             {
-                test(k.b.Equals("KnownDerived.b"));
-                test(k.kd.Equals("KnownDerived.kd"));
-                test(k.GetType().Name.Equals("KnownDerived"));
+                test(k.b == "KnownDerived.b");
+                test(k.kd == "KnownDerived.kd");
+                test(k.GetType().Name == "KnownDerived");
             }
         }
         output.WriteLine("ok");
@@ -261,8 +261,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownIntermediate.b"));
-                test(b.GetType().FullName.Equals("Test.Base"));
+                test(b.b == "UnknownIntermediate.b");
+                test(b.GetType().FullName == "Test.Base");
             }
             catch(Exception)
             {
@@ -281,8 +281,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownIntermediate.b"));
-                test(b.GetType().Name.Equals("Base"));
+                test(b.b == "UnknownIntermediate.b");
+                test(b.GetType().Name == "Base");
             }
         }
         output.WriteLine("ok");
@@ -297,9 +297,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("KnownIntermediate.b"));
-                test(ki.ki.Equals("KnownIntermediate.ki"));
-                test(ki.GetType().FullName.Equals("Test.KnownIntermediate"));
+                test(ki.b == "KnownIntermediate.b");
+                test(ki.ki == "KnownIntermediate.ki");
+                test(ki.GetType().FullName == "Test.KnownIntermediate");
             }
             catch(Exception)
             {
@@ -318,9 +318,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("KnownIntermediate.b"));
-                test(ki.ki.Equals("KnownIntermediate.ki"));
-                test(ki.GetType().Name.Equals("KnownIntermediate"));
+                test(ki.b == "KnownIntermediate.b");
+                test(ki.ki == "KnownIntermediate.ki");
+                test(ki.GetType().Name == "KnownIntermediate");
             }
         }
         output.WriteLine("ok");
@@ -335,10 +335,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().FullName.Equals("Test.KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().FullName == "Test.KnownMostDerived");
             }
             catch(Exception)
             {
@@ -357,10 +357,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().Name.Equals("KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().Name == "KnownMostDerived");
             }
         }
         output.WriteLine("ok");
@@ -375,9 +375,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("KnownIntermediate.b"));
-                test(ki.ki.Equals("KnownIntermediate.ki"));
-                test(ki.GetType().FullName.Equals("Test.KnownIntermediate"));
+                test(ki.b == "KnownIntermediate.b");
+                test(ki.ki == "KnownIntermediate.ki");
+                test(ki.GetType().FullName == "Test.KnownIntermediate");
             }
             catch(Exception)
             {
@@ -396,9 +396,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("KnownIntermediate.b"));
-                test(ki.ki.Equals("KnownIntermediate.ki"));
-                test(ki.GetType().Name.Equals("KnownIntermediate"));
+                test(ki.b == "KnownIntermediate.b");
+                test(ki.ki == "KnownIntermediate.ki");
+                test(ki.GetType().Name == "KnownIntermediate");
             }
         }
         output.WriteLine("ok");
@@ -413,10 +413,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().FullName.Equals("Test.KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().FullName == "Test.KnownMostDerived");
             }
             catch(Exception)
             {
@@ -435,10 +435,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().Name.Equals("KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().Name == "KnownMostDerived");
             }
         }
         output.WriteLine("ok");
@@ -453,10 +453,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().FullName.Equals("Test.KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().FullName == "Test.KnownMostDerived");
             }
             catch(Exception)
             {
@@ -475,10 +475,10 @@ public class AllTests : Test.AllTests
             }
             catch(KnownMostDerived kmd)
             {
-                test(kmd.b.Equals("KnownMostDerived.b"));
-                test(kmd.ki.Equals("KnownMostDerived.ki"));
-                test(kmd.kmd.Equals("KnownMostDerived.kmd"));
-                test(kmd.GetType().Name.Equals("KnownMostDerived"));
+                test(kmd.b == "KnownMostDerived.b");
+                test(kmd.ki == "KnownMostDerived.ki");
+                test(kmd.kmd == "KnownMostDerived.kmd");
+                test(kmd.GetType().Name == "KnownMostDerived");
             }
         }
         output.WriteLine("ok");
@@ -493,9 +493,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("UnknownMostDerived1.b"));
-                test(ki.ki.Equals("UnknownMostDerived1.ki"));
-                test(ki.GetType().FullName.Equals("Test.KnownIntermediate"));
+                test(ki.b == "UnknownMostDerived1.b");
+                test(ki.ki == "UnknownMostDerived1.ki");
+                test(ki.GetType().FullName == "Test.KnownIntermediate");
             }
             catch(Exception)
             {
@@ -514,9 +514,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("UnknownMostDerived1.b"));
-                test(ki.ki.Equals("UnknownMostDerived1.ki"));
-                test(ki.GetType().Name.Equals("KnownIntermediate"));
+                test(ki.b == "UnknownMostDerived1.b");
+                test(ki.ki == "UnknownMostDerived1.ki");
+                test(ki.GetType().Name == "KnownIntermediate");
             }
         }
         output.WriteLine("ok");
@@ -531,9 +531,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("UnknownMostDerived1.b"));
-                test(ki.ki.Equals("UnknownMostDerived1.ki"));
-                test(ki.GetType().FullName.Equals("Test.KnownIntermediate"));
+                test(ki.b == "UnknownMostDerived1.b");
+                test(ki.ki == "UnknownMostDerived1.ki");
+                test(ki.GetType().FullName == "Test.KnownIntermediate");
             }
             catch(Exception)
             {
@@ -552,9 +552,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownIntermediate ki)
             {
-                test(ki.b.Equals("UnknownMostDerived1.b"));
-                test(ki.ki.Equals("UnknownMostDerived1.ki"));
-                test(ki.GetType().Name.Equals("KnownIntermediate"));
+                test(ki.b == "UnknownMostDerived1.b");
+                test(ki.ki == "UnknownMostDerived1.ki");
+                test(ki.GetType().Name == "KnownIntermediate");
             }
         }
         output.WriteLine("ok");
@@ -569,8 +569,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownMostDerived2.b"));
-                test(b.GetType().FullName.Equals("Test.Base"));
+                test(b.b == "UnknownMostDerived2.b");
+                test(b.GetType().FullName == "Test.Base");
             }
             catch(Exception)
             {
@@ -589,8 +589,8 @@ public class AllTests : Test.AllTests
             }
             catch(Base b)
             {
-                test(b.b.Equals("UnknownMostDerived2.b"));
-                test(b.GetType().Name.Equals("Base"));
+                test(b.b == "UnknownMostDerived2.b");
+                test(b.GetType().Name == "Base");
             }
         }
         output.WriteLine("ok");
@@ -647,8 +647,8 @@ public class AllTests : Test.AllTests
                     Ice.SlicedData slicedData = ex.ice_getSlicedData();
                     test(slicedData != null);
                     test(slicedData.slices.Length == 2);
-                    test(slicedData.slices[1].typeId.Equals("::Test::SPreserved1"));
-                    test(slicedData.slices[0].typeId.Equals("::Test::SPreserved2"));
+                    test(slicedData.slices[1].typeId == "::Test::SPreserved1");
+                    test(slicedData.slices[0].typeId == "::Test::SPreserved2");
                 }
             }
 
@@ -659,7 +659,7 @@ public class AllTests : Test.AllTests
             }
             catch(KnownPreserved ex)
             {
-                test(ex.kp.Equals("preserved"));
+                test(ex.kp == "preserved");
                 if(testPrx.ice_getEncodingVersion().Equals(Ice.Util.Encoding_1_0))
                 {
                     test(ex.ice_getSlicedData() == null);
@@ -669,8 +669,8 @@ public class AllTests : Test.AllTests
                     Ice.SlicedData slicedData = ex.ice_getSlicedData();
                     test(slicedData != null);
                     test(slicedData.slices.Length == 2);
-                    test(slicedData.slices[1].typeId.Equals("::Test::SPreserved1"));
-                    test(slicedData.slices[0].typeId.Equals("::Test::SPreserved2"));
+                    test(slicedData.slices[1].typeId == "::Test::SPreserved1");
+                    test(slicedData.slices[0].typeId == "::Test::SPreserved2");
                 }
             }
 
@@ -686,9 +686,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownPreservedDerived ex)
             {
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
             }
             catch(Ice.OperationNotExistException)
             {
@@ -705,9 +705,9 @@ public class AllTests : Test.AllTests
             }
             catch(KnownPreservedDerived ex)
             {
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
             }
             catch(Ice.OperationNotExistException)
             {
@@ -724,13 +724,13 @@ public class AllTests : Test.AllTests
             }
             catch(Preserved2 ex)
             {
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
                 test(ex.p1.ice_id().Equals(PreservedClass.ice_staticId()));
                 PreservedClass pc = ex.p1 as PreservedClass;
-                test(pc.bc.Equals("bc"));
-                test(pc.pc.Equals("pc"));
+                test(pc.bc == "bc");
+                test(pc.pc == "pc");
                 test(ex.p2 == ex.p1);
             }
             catch(KnownPreservedDerived ex)
@@ -739,9 +739,9 @@ public class AllTests : Test.AllTests
                 // For the 1.0 encoding, the unknown exception is sliced to KnownPreserved.
                 //
                 test(testPrx.ice_getEncodingVersion().Equals(Ice.Util.Encoding_1_0));
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
             }
             catch(Ice.OperationNotExistException)
             {
@@ -758,13 +758,13 @@ public class AllTests : Test.AllTests
             }
             catch(Preserved2 ex)
             {
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
                 test(ex.p1.ice_id().Equals(PreservedClass.ice_staticId()));
                 PreservedClass pc = ex.p1 as PreservedClass;
-                test(pc.bc.Equals("bc"));
-                test(pc.pc.Equals("pc"));
+                test(pc.bc == "bc");
+                test(pc.pc == "pc");
                 test(ex.p2 == ex.p1);
             }
             catch(KnownPreservedDerived ex)
@@ -773,9 +773,9 @@ public class AllTests : Test.AllTests
                 // For the 1.0 encoding, the unknown exception is sliced to KnownPreserved.
                 //
                 test(testPrx.ice_getEncodingVersion().Equals(Ice.Util.Encoding_1_0));
-                test(ex.b.Equals("base"));
-                test(ex.kp.Equals("preserved"));
-                test(ex.kpd.Equals("derived"));
+                test(ex.b == "base");
+                test(ex.kp == "preserved");
+                test(ex.kpd == "derived");
             }
             catch(Ice.OperationNotExistException)
             {

--- a/csharp/test/Ice/slicing/objects/AllTests.cs
+++ b/csharp/test/Ice/slicing/objects/AllTests.cs
@@ -97,7 +97,7 @@ public class AllTests : Test.AllTests
             {
                 o = testPrx.SBaseAsObject();
                 test(o != null);
-                test(o.ice_id().Equals("::Test::SBase"));
+                test(o.ice_id() == "::Test::SBase");
                 sb = (SBase) o;
             }
             catch(Exception ex)
@@ -106,7 +106,7 @@ public class AllTests : Test.AllTests
                 test(false);
             }
             test(sb != null);
-            test(sb.sb.Equals("SBase.sb"));
+            test(sb.sb == "SBase.sb");
         }
         output.WriteLine("ok");
 
@@ -115,10 +115,10 @@ public class AllTests : Test.AllTests
         {
             Ice.Value o = testPrx.SBaseAsObjectAsync().Result;
             test(o != null);
-            test(o.ice_id().Equals("::Test::SBase"));
+            test(o.ice_id() == "::Test::SBase");
             SBase sb = (SBase)o;
             test(sb != null);
-            test(sb.sb.Equals("SBase.sb"));
+            test(sb.sb == "SBase.sb");
         }
         output.WriteLine("ok");
 
@@ -129,7 +129,7 @@ public class AllTests : Test.AllTests
             try
             {
                 sb = testPrx.SBaseAsSBase();
-                test(sb.sb.Equals("SBase.sb"));
+                test(sb.sb == "SBase.sb");
             }
             catch(Exception ex)
             {
@@ -143,7 +143,7 @@ public class AllTests : Test.AllTests
         output.Flush();
         {
             SBase sb = testPrx.SBaseAsSBaseAsync().Result;
-            test(sb.sb.Equals("SBase.sb"));
+            test(sb.sb == "SBase.sb");
         }
         output.WriteLine("ok");
 
@@ -155,7 +155,7 @@ public class AllTests : Test.AllTests
             try
             {
                 sb = testPrx.SBSKnownDerivedAsSBase();
-                test(sb.sb.Equals("SBSKnownDerived.sb"));
+                test(sb.sb == "SBSKnownDerived.sb");
                 sbskd = (SBSKnownDerived) sb;
             }
             catch(Exception ex)
@@ -164,7 +164,7 @@ public class AllTests : Test.AllTests
                 test(false);
             }
             test(sbskd != null);
-            test(sbskd.sbskd.Equals("SBSKnownDerived.sbskd"));
+            test(sbskd.sbskd == "SBSKnownDerived.sbskd");
         }
         output.WriteLine("ok");
 
@@ -172,10 +172,10 @@ public class AllTests : Test.AllTests
         output.Flush();
         {
             SBase sb = testPrx.SBSKnownDerivedAsSBaseAsync().Result;
-            test(sb.sb.Equals("SBSKnownDerived.sb"));
+            test(sb.sb == "SBSKnownDerived.sb");
             SBSKnownDerived sbskd = (SBSKnownDerived)sb;
             test(sbskd != null);
-            test(sbskd.sbskd.Equals("SBSKnownDerived.sbskd"));
+            test(sbskd.sbskd == "SBSKnownDerived.sbskd");
         }
         output.WriteLine("ok");
 
@@ -186,7 +186,7 @@ public class AllTests : Test.AllTests
             try
             {
                 sbskd = testPrx.SBSKnownDerivedAsSBSKnownDerived();
-                test(sbskd.sbskd.Equals("SBSKnownDerived.sbskd"));
+                test(sbskd.sbskd == "SBSKnownDerived.sbskd");
             }
             catch(Exception ex)
             {
@@ -200,7 +200,7 @@ public class AllTests : Test.AllTests
         output.Flush();
         {
             SBSKnownDerived sbskd = testPrx.SBSKnownDerivedAsSBSKnownDerivedAsync().Result;
-            test(sbskd.sbskd.Equals("SBSKnownDerived.sbskd"));
+            test(sbskd.sbskd == "SBSKnownDerived.sbskd");
         }
         output.WriteLine("ok");
 
@@ -211,7 +211,7 @@ public class AllTests : Test.AllTests
             try
             {
                 sb = testPrx.SBSUnknownDerivedAsSBase();
-                test(sb.sb.Equals("SBSUnknownDerived.sb"));
+                test(sb.sb == "SBSUnknownDerived.sb");
             }
             catch(Exception ex)
             {
@@ -224,7 +224,7 @@ public class AllTests : Test.AllTests
             try
             {
                 SBase sb = testPrx.SBSUnknownDerivedAsSBaseCompact();
-                test(sb.sb.Equals("SBSUnknownDerived.sb"));
+                test(sb.sb == "SBSUnknownDerived.sb");
             }
             catch(Exception ex)
             {
@@ -259,7 +259,7 @@ public class AllTests : Test.AllTests
         output.Flush();
         {
             SBase sb = testPrx.SBSUnknownDerivedAsSBaseAsync().Result;
-            test(sb.sb.Equals("SBSUnknownDerived.sb"));
+            test(sb.sb == "SBSUnknownDerived.sb");
         }
         if(testPrx.ice_getEncodingVersion().Equals(Ice.Util.Encoding_1_0))
         {
@@ -268,7 +268,7 @@ public class AllTests : Test.AllTests
             //
             {
                 SBase sb = testPrx.SBSUnknownDerivedAsSBaseCompactAsync().Result;
-                test(sb.sb.Equals("SBSUnknownDerived.sb"));
+                test(sb.sb == "SBSUnknownDerived.sb");
             }
         }
         else
@@ -296,7 +296,7 @@ public class AllTests : Test.AllTests
                 Ice.Value o = testPrx.SUnknownAsObject();
                 test(!testPrx.ice_getEncodingVersion().Equals(Ice.Util.Encoding_1_0));
                 test(o is Ice.UnknownSlicedValue);
-                test((o as Ice.UnknownSlicedValue).ice_id().Equals("::Test::SUnknown"));
+                test((o as Ice.UnknownSlicedValue).ice_id() == "::Test::SUnknown");
                 test((o as Ice.UnknownSlicedValue).ice_getSlicedData() != null);
                 testPrx.checkSUnknown(o);
             }
@@ -331,7 +331,7 @@ public class AllTests : Test.AllTests
                         }
                         catch(Ice.Exception ex)
                         {
-                            test(ex.GetType().FullName.Equals("Ice.NoValueFactoryException"));
+                            test(ex.GetType().FullName == "Ice.NoValueFactoryException");
                         }
                     }
                 }
@@ -341,7 +341,7 @@ public class AllTests : Test.AllTests
                     {
                         var o = testPrx.SUnknownAsObjectAsync().Result;
                         test(o is Ice.UnknownSlicedValue);
-                        test((o as Ice.UnknownSlicedValue).ice_id().Equals("::Test::SUnknown"));
+                        test((o as Ice.UnknownSlicedValue).ice_id() == "::Test::SUnknown");
                     }
                     catch(AggregateException ex)
                     {
@@ -365,8 +365,8 @@ public class AllTests : Test.AllTests
             {
                 B b = testPrx.oneElementCycle();
                 test(b != null);
-                test(b.ice_id().Equals("::Test::B"));
-                test(b.sb.Equals("B1.sb"));
+                test(b.ice_id() == "::Test::B");
+                test(b.sb == "B1.sb");
                 test(b.pb == b);
             }
             catch(Exception ex)
@@ -382,8 +382,8 @@ public class AllTests : Test.AllTests
         {
             var b = testPrx.oneElementCycleAsync().Result;
             test(b != null);
-            test(b.ice_id().Equals("::Test::B"));
-            test(b.sb.Equals("B1.sb"));
+            test(b.ice_id() == "::Test::B");
+            test(b.sb == "B1.sb");
             test(b.pb == b);
         }
         output.WriteLine("ok");
@@ -395,13 +395,13 @@ public class AllTests : Test.AllTests
             {
                 B b1 = testPrx.twoElementCycle();
                 test(b1 != null);
-                test(b1.ice_id().Equals("::Test::B"));
-                test(b1.sb.Equals("B1.sb"));
+                test(b1.ice_id() == "::Test::B");
+                test(b1.sb == "B1.sb");
 
                 B b2 = b1.pb;
                 test(b2 != null);
-                test(b2.ice_id().Equals("::Test::B"));
-                test(b2.sb.Equals("B2.sb"));
+                test(b2.ice_id() == "::Test::B");
+                test(b2.sb == "B2.sb");
                 test(b2.pb == b1);
             }
             catch(Exception ex)
@@ -417,13 +417,13 @@ public class AllTests : Test.AllTests
         {
             B b1 = testPrx.twoElementCycleAsync().Result;
             test(b1 != null);
-            test(b1.ice_id().Equals("::Test::B"));
-            test(b1.sb.Equals("B1.sb"));
+            test(b1.ice_id() == "::Test::B");
+            test(b1.sb == "B1.sb");
 
             B b2 = b1.pb;
             test(b2 != null);
-            test(b2.ice_id().Equals("::Test::B"));
-            test(b2.sb.Equals("B2.sb"));
+            test(b2.ice_id() == "::Test::B");
+            test(b2.sb == "B2.sb");
             test(b2.pb == b1);
         }
         output.WriteLine("ok");
@@ -436,13 +436,13 @@ public class AllTests : Test.AllTests
                 B b1;
                 b1 = testPrx.D1AsB();
                 test(b1 != null);
-                test(b1.ice_id().Equals("::Test::D1"));
-                test(b1.sb.Equals("D1.sb"));
+                test(b1.ice_id() == "::Test::D1");
+                test(b1.sb == "D1.sb");
                 test(b1.pb != null);
                 test(b1.pb != b1);
                 D1 d1 = (D1) b1;
                 test(d1 != null);
-                test(d1.sd1.Equals("D1.sd1"));
+                test(d1.sd1 == "D1.sd1");
                 test(d1.pd1 != null);
                 test(d1.pd1 != b1);
                 test(b1.pb == d1.pd1);
@@ -450,8 +450,8 @@ public class AllTests : Test.AllTests
                 B b2 = b1.pb;
                 test(b2 != null);
                 test(b2.pb == b1);
-                test(b2.sb.Equals("D2.sb"));
-                test(b2.ice_id().Equals("::Test::B"));
+                test(b2.sb == "D2.sb");
+                test(b2.ice_id() == "::Test::B");
             }
             catch(Exception ex)
             {
@@ -466,13 +466,13 @@ public class AllTests : Test.AllTests
         {
             B b1 = testPrx.D1AsBAsync().Result;
             test(b1 != null);
-            test(b1.ice_id().Equals("::Test::D1"));
-            test(b1.sb.Equals("D1.sb"));
+            test(b1.ice_id() == "::Test::D1");
+            test(b1.sb == "D1.sb");
             test(b1.pb != null);
             test(b1.pb != b1);
             D1 d1 = (D1)b1;
             test(d1 != null);
-            test(d1.sd1.Equals("D1.sd1"));
+            test(d1.sd1 == "D1.sd1");
             test(d1.pd1 != null);
             test(d1.pd1 != b1);
             test(b1.pb == d1.pd1);
@@ -480,8 +480,8 @@ public class AllTests : Test.AllTests
             B b2 = b1.pb;
             test(b2 != null);
             test(b2.pb == b1);
-            test(b2.sb.Equals("D2.sb"));
-            test(b2.ice_id().Equals("::Test::B"));
+            test(b2.sb == "D2.sb");
+            test(b2.ice_id() == "::Test::B");
         }
         output.WriteLine("ok");
 
@@ -493,15 +493,15 @@ public class AllTests : Test.AllTests
                 D1 d1;
                 d1 = testPrx.D1AsD1();
                 test(d1 != null);
-                test(d1.ice_id().Equals("::Test::D1"));
-                test(d1.sb.Equals("D1.sb"));
+                test(d1.ice_id() == "::Test::D1");
+                test(d1.sb == "D1.sb");
                 test(d1.pb != null);
                 test(d1.pb != d1);
 
                 B b2 = d1.pb;
                 test(b2 != null);
-                test(b2.ice_id().Equals("::Test::B"));
-                test(b2.sb.Equals("D2.sb"));
+                test(b2.ice_id() == "::Test::B");
+                test(b2.sb == "D2.sb");
                 test(b2.pb == d1);
             }
             catch(Exception ex)
@@ -517,15 +517,15 @@ public class AllTests : Test.AllTests
         {
             D1 d1 = testPrx.D1AsD1Async().Result;
             test(d1 != null);
-            test(d1.ice_id().Equals("::Test::D1"));
-            test(d1.sb.Equals("D1.sb"));
+            test(d1.ice_id() == "::Test::D1");
+            test(d1.sb == "D1.sb");
             test(d1.pb != null);
             test(d1.pb != d1);
 
             B b2 = d1.pb;
             test(b2 != null);
-            test(b2.ice_id().Equals("::Test::B"));
-            test(b2.sb.Equals("D2.sb"));
+            test(b2.ice_id() == "::Test::B");
+            test(b2.sb == "D2.sb");
             test(b2.pb == d1);
         }
         output.WriteLine("ok");
@@ -538,19 +538,19 @@ public class AllTests : Test.AllTests
                 B b2;
                 b2 = testPrx.D2AsB();
                 test(b2 != null);
-                test(b2.ice_id().Equals("::Test::B"));
-                test(b2.sb.Equals("D2.sb"));
+                test(b2.ice_id() == "::Test::B");
+                test(b2.sb == "D2.sb");
                 test(b2.pb != null);
                 test(b2.pb != b2);
 
                 B b1 = b2.pb;
                 test(b1 != null);
-                test(b1.ice_id().Equals("::Test::D1"));
-                test(b1.sb.Equals("D1.sb"));
+                test(b1.ice_id() == "::Test::D1");
+                test(b1.sb == "D1.sb");
                 test(b1.pb == b2);
                 D1 d1 = (D1) b1;
                 test(d1 != null);
-                test(d1.sd1.Equals("D1.sd1"));
+                test(d1.sd1 == "D1.sd1");
                 test(d1.pd1 == b2);
             }
             catch(Exception ex)
@@ -566,19 +566,19 @@ public class AllTests : Test.AllTests
         {
             B b2 = testPrx.D2AsBAsync().Result;
             test(b2 != null);
-            test(b2.ice_id().Equals("::Test::B"));
-            test(b2.sb.Equals("D2.sb"));
+            test(b2.ice_id() == "::Test::B");
+            test(b2.sb == "D2.sb");
             test(b2.pb != null);
             test(b2.pb != b2);
 
             B b1 = b2.pb;
             test(b1 != null);
-            test(b1.ice_id().Equals("::Test::D1"));
-            test(b1.sb.Equals("D1.sb"));
+            test(b1.ice_id() == "::Test::D1");
+            test(b1.sb == "D1.sb");
             test(b1.pb == b2);
             D1 d1 = (D1)b1;
             test(d1 != null);
-            test(d1.sd1.Equals("D1.sd1"));
+            test(d1.sd1 == "D1.sd1");
             test(d1.pd1 == b2);
         }
         output.WriteLine("ok");
@@ -593,17 +593,17 @@ public class AllTests : Test.AllTests
                 testPrx.paramTest1(out b1, out b2);
 
                 test(b1 != null);
-                test(b1.ice_id().Equals("::Test::D1"));
-                test(b1.sb.Equals("D1.sb"));
+                test(b1.ice_id() == "::Test::D1");
+                test(b1.sb == "D1.sb");
                 test(b1.pb == b2);
                 D1 d1 = (D1) b1;
                 test(d1 != null);
-                test(d1.sd1.Equals("D1.sd1"));
+                test(d1.sd1 == "D1.sd1");
                 test(d1.pd1 == b2);
 
                 test(b2 != null);
-                test(b2.ice_id().Equals("::Test::B")); // No factory, must be sliced
-                test(b2.sb.Equals("D2.sb"));
+                test(b2.ice_id() == "::Test::B"); // No factory, must be sliced
+                test(b2.sb == "D2.sb");
                 test(b2.pb == b1);
             }
             catch(Exception ex)
@@ -622,17 +622,17 @@ public class AllTests : Test.AllTests
             B b2 = result.p2;
 
             test(b1 != null);
-            test(b1.ice_id().Equals("::Test::D1"));
-            test(b1.sb.Equals("D1.sb"));
+            test(b1.ice_id() == "::Test::D1");
+            test(b1.sb == "D1.sb");
             test(b1.pb == b2);
             D1 d1 = (D1)b1;
             test(d1 != null);
-            test(d1.sd1.Equals("D1.sd1"));
+            test(d1.sd1 == "D1.sd1");
             test(d1.pd1 == b2);
 
             test(b2 != null);
-            test(b2.ice_id().Equals("::Test::B")); // No factory, must be sliced
-            test(b2.sb.Equals("D2.sb"));
+            test(b2.ice_id() == "::Test::B"); // No factory, must be sliced
+            test(b2.sb == "D2.sb");
             test(b2.pb == b1);
         }
         output.WriteLine("ok");
@@ -647,17 +647,17 @@ public class AllTests : Test.AllTests
                 testPrx.paramTest2(out b2, out b1);
 
                 test(b1 != null);
-                test(b1.ice_id().Equals("::Test::D1"));
-                test(b1.sb.Equals("D1.sb"));
+                test(b1.ice_id() == "::Test::D1");
+                test(b1.sb == "D1.sb");
                 test(b1.pb == b2);
                 D1 d1 = (D1) b1;
                 test(d1 != null);
-                test(d1.sd1.Equals("D1.sd1"));
+                test(d1.sd1 == "D1.sd1");
                 test(d1.pd1 == b2);
 
                 test(b2 != null);
-                test(b2.ice_id().Equals("::Test::B")); // No factory, must be sliced
-                test(b2.sb.Equals("D2.sb"));
+                test(b2.ice_id() == "::Test::B"); // No factory, must be sliced
+                test(b2.sb == "D2.sb");
                 test(b2.pb == b1);
             }
             catch(Exception ex)
@@ -675,17 +675,17 @@ public class AllTests : Test.AllTests
             B b2 = result.p2;
             B b1 = result.p1;
             test(b1 != null);
-            test(b1.ice_id().Equals("::Test::D1"));
-            test(b1.sb.Equals("D1.sb"));
+            test(b1.ice_id() == "::Test::D1");
+            test(b1.sb == "D1.sb");
             test(b1.pb == b2);
             D1 d1 = (D1)b1;
             test(d1 != null);
-            test(d1.sd1.Equals("D1.sd1"));
+            test(d1.sd1 == "D1.sd1");
             test(d1.pd1 == b2);
 
             test(b2 != null);
-            test(b2.ice_id().Equals("::Test::B")); // No factory, must be sliced
-            test(b2.sb.Equals("D2.sb"));
+            test(b2.ice_id() == "::Test::B"); // No factory, must be sliced
+            test(b2.sb == "D2.sb");
             test(b2.pb == b1);
         }
         output.WriteLine("ok");
@@ -761,17 +761,17 @@ public class AllTests : Test.AllTests
                 B b1 = testPrx.returnTest3(d1, d3);
 
                 test(b1 != null);
-                test(b1.sb.Equals("D1.sb"));
-                test(b1.ice_id().Equals("::Test::D1"));
+                test(b1.sb == "D1.sb");
+                test(b1.ice_id() == "::Test::D1");
                 D1 p1 = (D1) b1;
                 test(p1 != null);
-                test(p1.sd1.Equals("D1.sd1"));
+                test(p1.sd1 == "D1.sd1");
                 test(p1.pd1 == b1.pb);
 
                 B b2 = b1.pb;
                 test(b2 != null);
-                test(b2.sb.Equals("D3.sb"));
-                test(b2.ice_id().Equals("::Test::B")); // Sliced by server
+                test(b2.sb == "D3.sb");
+                test(b2.ice_id() == "::Test::B"); // Sliced by server
                 test(b2.pb == b1);
                 try
                 {
@@ -813,17 +813,17 @@ public class AllTests : Test.AllTests
             B b1 = testPrx.returnTest3Async(d1, d3).Result;
 
             test(b1 != null);
-            test(b1.sb.Equals("D1.sb"));
-            test(b1.ice_id().Equals("::Test::D1"));
+            test(b1.sb == "D1.sb");
+            test(b1.ice_id() == "::Test::D1");
             D1 p1 = (D1)b1;
             test(p1 != null);
-            test(p1.sd1.Equals("D1.sd1"));
+            test(p1.sd1 == "D1.sd1");
             test(p1.pd1 == b1.pb);
 
             B b2 = b1.pb;
             test(b2 != null);
-            test(b2.sb.Equals("D3.sb"));
-            test(b2.ice_id().Equals("::Test::B")); // Sliced by server
+            test(b2.sb == "D3.sb");
+            test(b2.ice_id() == "::Test::B"); // Sliced by server
             test(b2.pb == b1);
             try
             {
@@ -862,8 +862,8 @@ public class AllTests : Test.AllTests
                 B b1 = testPrx.returnTest3(d3, d1);
 
                 test(b1 != null);
-                test(b1.sb.Equals("D3.sb"));
-                test(b1.ice_id().Equals("::Test::B")); // Sliced by server
+                test(b1.sb == "D3.sb");
+                test(b1.ice_id() == "::Test::B"); // Sliced by server
 
                 try
                 {
@@ -877,12 +877,12 @@ public class AllTests : Test.AllTests
 
                 B b2 = b1.pb;
                 test(b2 != null);
-                test(b2.sb.Equals("D1.sb"));
-                test(b2.ice_id().Equals("::Test::D1"));
+                test(b2.sb == "D1.sb");
+                test(b2.ice_id() == "::Test::D1");
                 test(b2.pb == b1);
                 D1 p3 = (D1) b2;
                 test(p3 != null);
-                test(p3.sd1.Equals("D1.sd1"));
+                test(p3.sd1 == "D1.sd1");
                 test(p3.pd1 == b1);
 
                 test(b1 != d1);
@@ -915,8 +915,8 @@ public class AllTests : Test.AllTests
             B b1 = testPrx.returnTest3Async(d3, d1).Result;
 
             test(b1 != null);
-            test(b1.sb.Equals("D3.sb"));
-            test(b1.ice_id().Equals("::Test::B")); // Sliced by server
+            test(b1.sb == "D3.sb");
+            test(b1.ice_id() == "::Test::B"); // Sliced by server
 
             try
             {
@@ -931,12 +931,12 @@ public class AllTests : Test.AllTests
 
             B b2 = b1.pb;
             test(b2 != null);
-            test(b2.sb.Equals("D1.sb"));
-            test(b2.ice_id().Equals("::Test::D1"));
+            test(b2.sb == "D1.sb");
+            test(b2.ice_id() == "::Test::D1");
             test(b2.pb == b1);
             D1 p3 = (D1)b2;
             test(p3 != null);
-            test(p3.sd1.Equals("D1.sd1"));
+            test(p3.sd1 == "D1.sd1");
             test(p3.pd1 == b1);
 
             test(b1 != d1);
@@ -956,19 +956,19 @@ public class AllTests : Test.AllTests
                 B ret = testPrx.paramTest3(out p1, out p2);
 
                 test(p1 != null);
-                test(p1.sb.Equals("D2.sb (p1 1)"));
+                test(p1.sb == "D2.sb (p1 1)");
                 test(p1.pb == null);
-                test(p1.ice_id().Equals("::Test::B"));
+                test(p1.ice_id() == "::Test::B");
 
                 test(p2 != null);
-                test(p2.sb.Equals("D2.sb (p2 1)"));
+                test(p2.sb == "D2.sb (p2 1)");
                 test(p2.pb == null);
-                test(p2.ice_id().Equals("::Test::B"));
+                test(p2.ice_id() == "::Test::B");
 
                 test(ret != null);
-                test(ret.sb.Equals("D1.sb (p2 2)"));
+                test(ret.sb == "D1.sb (p2 2)");
                 test(ret.pb == null);
-                test(ret.ice_id().Equals("::Test::D1"));
+                test(ret.ice_id() == "::Test::D1");
             }
             catch(Exception ex)
             {
@@ -987,19 +987,19 @@ public class AllTests : Test.AllTests
             B p1 = result.p1;
             B p2 = result.p2;
             test(p1 != null);
-            test(p1.sb.Equals("D2.sb (p1 1)"));
+            test(p1.sb == "D2.sb (p1 1)");
             test(p1.pb == null);
-            test(p1.ice_id().Equals("::Test::B"));
+            test(p1.ice_id() == "::Test::B");
 
             test(p2 != null);
-            test(p2.sb.Equals("D2.sb (p2 1)"));
+            test(p2.sb == "D2.sb (p2 1)");
             test(p2.pb == null);
-            test(p2.ice_id().Equals("::Test::B"));
+            test(p2.ice_id() == "::Test::B");
 
             test(ret != null);
-            test(ret.sb.Equals("D1.sb (p2 2)"));
+            test(ret.sb == "D1.sb (p2 2)");
             test(ret.pb == null);
-            test(ret.ice_id().Equals("::Test::D1"));
+            test(ret.ice_id() == "::Test::D1");
         }
         output.WriteLine("ok");
 
@@ -1012,14 +1012,14 @@ public class AllTests : Test.AllTests
                 B ret = testPrx.paramTest4(out b);
 
                 test(b != null);
-                test(b.sb.Equals("D4.sb (1)"));
+                test(b.sb == "D4.sb (1)");
                 test(b.pb == null);
-                test(b.ice_id().Equals("::Test::B"));
+                test(b.ice_id() == "::Test::B");
 
                 test(ret != null);
-                test(ret.sb.Equals("B.sb (2)"));
+                test(ret.sb == "B.sb (2)");
                 test(ret.pb == null);
-                test(ret.ice_id().Equals("::Test::B"));
+                test(ret.ice_id() == "::Test::B");
             }
             catch(Exception ex)
             {
@@ -1037,14 +1037,14 @@ public class AllTests : Test.AllTests
             B b = result.p;
 
             test(b != null);
-            test(b.sb.Equals("D4.sb (1)"));
+            test(b.sb == "D4.sb (1)");
             test(b.pb == null);
-            test(b.ice_id().Equals("::Test::B"));
+            test(b.ice_id() == "::Test::B");
 
             test(ret != null);
-            test(ret.sb.Equals("B.sb (2)"));
+            test(ret.sb == "B.sb (2)");
             test(ret.pb == null);
-            test(ret.ice_id().Equals("::Test::B"));
+            test(ret.ice_id() == "::Test::B");
         }
         output.WriteLine("ok");
 
@@ -1070,8 +1070,8 @@ public class AllTests : Test.AllTests
                 B ret = testPrx.returnTest3(d3, b2);
 
                 test(ret != null);
-                test(ret.ice_id().Equals("::Test::B"));
-                test(ret.sb.Equals("D3.sb"));
+                test(ret.ice_id() == "::Test::B");
+                test(ret.sb == "D3.sb");
                 test(ret.pb == ret);
             }
             catch(Exception ex)
@@ -1102,8 +1102,8 @@ public class AllTests : Test.AllTests
             B rv = testPrx.returnTest3Async(d3, b2).Result;
 
             test(rv != null);
-            test(rv.ice_id().Equals("::Test::B"));
-            test(rv.sb.Equals("D3.sb"));
+            test(rv.ice_id() == "::Test::B");
+            test(rv.sb == "D3.sb");
             test(rv.pb == rv);
         }
         output.WriteLine("ok");
@@ -1132,8 +1132,8 @@ public class AllTests : Test.AllTests
 
                 B ret = testPrx.returnTest3(d3, d12);
                 test(ret != null);
-                test(ret.ice_id().Equals("::Test::B"));
-                test(ret.sb.Equals("D3.sb"));
+                test(ret.ice_id() == "::Test::B");
+                test(ret.sb == "D3.sb");
                 test(ret.pb == ret);
             }
             catch(Exception ex)
@@ -1167,8 +1167,8 @@ public class AllTests : Test.AllTests
             B rv = testPrx.returnTest3Async(d3, d12).Result;
 
             test(rv != null);
-            test(rv.ice_id().Equals("::Test::B"));
-            test(rv.sb.Equals("D3.sb"));
+            test(rv.ice_id() == "::Test::B");
+            test(rv.sb == "D3.sb");
             test(rv.pb == rv);
         }
         output.WriteLine("ok");
@@ -1248,13 +1248,13 @@ public class AllTests : Test.AllTests
                 test(ss2d2.pb == ss2b2);
                 test(ss2d4.pb == ss2b2);
 
-                test(ss1b2.ice_id().Equals("::Test::B"));
-                test(ss1d2.ice_id().Equals("::Test::D1"));
-                test(ss1d4.ice_id().Equals("::Test::B"));
+                test(ss1b2.ice_id() == "::Test::B");
+                test(ss1d2.ice_id() == "::Test::D1");
+                test(ss1d4.ice_id() == "::Test::B");
 
-                test(ss2b2.ice_id().Equals("::Test::B"));
-                test(ss2d2.ice_id().Equals("::Test::D1"));
-                test(ss2d4.ice_id().Equals("::Test::B"));
+                test(ss2b2.ice_id() == "::Test::B");
+                test(ss2d2.ice_id() == "::Test::D1");
+                test(ss2d4.ice_id() == "::Test::B");
             }
             catch(Exception ex)
             {
@@ -1336,13 +1336,13 @@ public class AllTests : Test.AllTests
             test(ss2d6.pb == ss2b3);
             test(ss2d6.pb == ss2b3);
 
-            test(ss1b3.ice_id().Equals("::Test::B"));
-            test(ss1d5.ice_id().Equals("::Test::D1"));
-            test(ss1d6.ice_id().Equals("::Test::B"));
+            test(ss1b3.ice_id() == "::Test::B");
+            test(ss1d5.ice_id() == "::Test::D1");
+            test(ss1d6.ice_id() == "::Test::B");
 
-            test(ss2b3.ice_id().Equals("::Test::B"));
-            test(ss2d5.ice_id().Equals("::Test::D1"));
-            test(ss2d6.ice_id().Equals("::Test::B"));
+            test(ss2b3.ice_id() == "::Test::B");
+            test(ss2d5.ice_id() == "::Test::D1");
+            test(ss2d6.ice_id() == "::Test::B");
         }
         output.WriteLine("ok");
 
@@ -1462,10 +1462,10 @@ public class AllTests : Test.AllTests
             }
             catch(BaseException e)
             {
-                test(e.GetType().FullName.Equals("Test.BaseException"));
-                test(e.sbe.Equals("sbe"));
+                test(e.GetType().FullName == "Test.BaseException");
+                test(e.sbe == "sbe");
                 test(e.pb != null);
-                test(e.pb.sb.Equals("sb"));
+                test(e.pb.sb == "sb");
                 test(e.pb.pb == e.pb);
             }
             catch(Exception ex)
@@ -1488,9 +1488,9 @@ public class AllTests : Test.AllTests
                 try
                 {
                     BaseException e = (BaseException)ae.InnerException;
-                    test(e.sbe.Equals("sbe"));
+                    test(e.sbe == "sbe");
                     test(e.pb != null);
-                    test(e.pb.sb.Equals("sb"));
+                    test(e.pb.sb == "sb");
                     test(e.pb.pb == e.pb);
                 }
                 catch(Exception ex)
@@ -1512,16 +1512,16 @@ public class AllTests : Test.AllTests
             }
             catch(DerivedException e)
             {
-                test(e.GetType().FullName.Equals("Test.DerivedException"));
-                test(e.sbe.Equals("sbe"));
+                test(e.GetType().FullName == "Test.DerivedException");
+                test(e.sbe == "sbe");
                 test(e.pb != null);
-                test(e.pb.sb.Equals("sb1"));
+                test(e.pb.sb == "sb1");
                 test(e.pb.pb == e.pb);
-                test(e.sde.Equals("sde1"));
+                test(e.sde == "sde1");
                 test(e.pd1 != null);
-                test(e.pd1.sb.Equals("sb2"));
+                test(e.pd1.sb == "sb2");
                 test(e.pd1.pb == e.pd1);
-                test(e.pd1.sd1.Equals("sd2"));
+                test(e.pd1.sd1 == "sd2");
                 test(e.pd1.pd1 == e.pd1);
             }
             catch(Exception ex)
@@ -1544,15 +1544,15 @@ public class AllTests : Test.AllTests
                 try
                 {
                     DerivedException e = (DerivedException)ae.InnerException;
-                    test(e.sbe.Equals("sbe"));
+                    test(e.sbe == "sbe");
                     test(e.pb != null);
-                    test(e.pb.sb.Equals("sb1"));
+                    test(e.pb.sb == "sb1");
                     test(e.pb.pb == e.pb);
-                    test(e.sde.Equals("sde1"));
+                    test(e.sde == "sde1");
                     test(e.pd1 != null);
-                    test(e.pd1.sb.Equals("sb2"));
+                    test(e.pd1.sb == "sb2");
                     test(e.pd1.pb == e.pd1);
-                    test(e.pd1.sd1.Equals("sd2"));
+                    test(e.pd1.sd1 == "sd2");
                     test(e.pd1.pd1 == e.pd1);
                 }
                 catch(Exception ex)
@@ -1574,16 +1574,16 @@ public class AllTests : Test.AllTests
             }
             catch(DerivedException e)
             {
-                test(e.GetType().FullName.Equals("Test.DerivedException"));
-                test(e.sbe.Equals("sbe"));
+                test(e.GetType().FullName == "Test.DerivedException");
+                test(e.sbe == "sbe");
                 test(e.pb != null);
-                test(e.pb.sb.Equals("sb1"));
+                test(e.pb.sb == "sb1");
                 test(e.pb.pb == e.pb);
-                test(e.sde.Equals("sde1"));
+                test(e.sde == "sde1");
                 test(e.pd1 != null);
-                test(e.pd1.sb.Equals("sb2"));
+                test(e.pd1.sb == "sb2");
                 test(e.pd1.pb == e.pd1);
-                test(e.pd1.sd1.Equals("sd2"));
+                test(e.pd1.sd1 == "sd2");
                 test(e.pd1.pd1 == e.pd1);
             }
             catch(Exception ex)
@@ -1606,15 +1606,15 @@ public class AllTests : Test.AllTests
                 try
                 {
                     DerivedException e = (DerivedException)ae.InnerException;
-                    test(e.sbe.Equals("sbe"));
+                    test(e.sbe == "sbe");
                     test(e.pb != null);
-                    test(e.pb.sb.Equals("sb1"));
+                    test(e.pb.sb == "sb1");
                     test(e.pb.pb == e.pb);
-                    test(e.sde.Equals("sde1"));
+                    test(e.sde == "sde1");
                     test(e.pd1 != null);
-                    test(e.pd1.sb.Equals("sb2"));
+                    test(e.pd1.sb == "sb2");
                     test(e.pd1.pb == e.pd1);
-                    test(e.pd1.sd1.Equals("sd2"));
+                    test(e.pd1.sd1 == "sd2");
                     test(e.pd1.pd1 == e.pd1);
                 }
                 catch(Exception ex)
@@ -1636,10 +1636,10 @@ public class AllTests : Test.AllTests
             }
             catch(BaseException e)
             {
-                test(e.GetType().FullName.Equals("Test.BaseException"));
-                test(e.sbe.Equals("sbe"));
+                test(e.GetType().FullName == "Test.BaseException");
+                test(e.sbe == "sbe");
                 test(e.pb != null);
-                test(e.pb.sb.Equals("sb d2"));
+                test(e.pb.sb == "sb d2");
                 test(e.pb.pb == e.pb);
             }
             catch(Exception ex)
@@ -1662,9 +1662,9 @@ public class AllTests : Test.AllTests
                 try
                 {
                     BaseException e = (BaseException)ae.InnerException;
-                    test(e.sbe.Equals("sbe"));
+                    test(e.sbe == "sbe");
                     test(e.pb != null);
-                    test(e.pb.sb.Equals("sb d2"));
+                    test(e.pb.sb == "sb d2");
                     test(e.pb.pb == e.pb);
                 }
                 catch(Exception ex)
@@ -1726,7 +1726,7 @@ public class AllTests : Test.AllTests
             PBase r = testPrx.exchangePBase(pd);
             PDerived p2 = r as PDerived;
             test(p2.pi == 3);
-            test(p2.ps.Equals("preserved"));
+            test(p2.ps == "preserved");
             test(p2.pb == p2);
         }
         catch(Ice.OperationNotExistException)
@@ -1869,7 +1869,7 @@ public class AllTests : Test.AllTests
                 Ice.SlicedData slicedData = p.ice_getSlicedData();
                 test(slicedData != null);
                 test(slicedData.slices.Length == 1);
-                test(slicedData.slices[0].typeId.Equals("::Test::PSUnknown"));
+                test(slicedData.slices[0].typeId == "::Test::PSUnknown");
                 (testPrx.ice_encodingVersion(Ice.Util.Encoding_1_0) as TestIntfPrx).checkPBSUnknown(p);
             }
             else
@@ -1896,7 +1896,7 @@ public class AllTests : Test.AllTests
 
             PDerived p2 = (PDerived)testPrx.exchangePBaseAsync(pd).Result;
             test(p2.pi == 3);
-            test(p2.ps.Equals("preserved"));
+            test(p2.ps == "preserved");
             test(p2.pb == p2);
         }
 

--- a/csharp/test/Ice/slicing/objects/TestAMDI.cs
+++ b/csharp/test/Ice/slicing/objects/TestAMDI.cs
@@ -74,7 +74,7 @@ public sealed class TestI : TestIntfDisp_
         else
         {
             SUnknown su = obj as SUnknown;
-            test(su.su.Equals("SUnknown.su"));
+            test(su.su == "SUnknown.su");
         }
         return null;
     }
@@ -323,14 +323,14 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             var pu = p as PSUnknown;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
-            test(pu.psu.Equals("unknown"));
+            test(pu.ps == "preserved");
+            test(pu.psu == "unknown");
             test(pu.graph == null);
             test(pu.cl != null && pu.cl.i == 15);
         }
@@ -358,14 +358,14 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             var pu = p as PSUnknown;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
-            test(pu.psu.Equals("unknown"));
+            test(pu.ps == "preserved");
+            test(pu.psu == "unknown");
             test(pu.graph != pu.graph.next);
             test(pu.graph.next != pu.graph.next.next);
             test(pu.graph.next.next.next == pu.graph);
@@ -390,13 +390,13 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown2));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             var pu = p as PSUnknown2;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
+            test(pu.ps == "preserved");
             test(pu.pb == pu);
         }
         return null;

--- a/csharp/test/Ice/slicing/objects/TestI.cs
+++ b/csharp/test/Ice/slicing/objects/TestI.cs
@@ -85,7 +85,7 @@ public sealed class TestI : TestIntfDisp_
         else
         {
             SUnknown su = obj as SUnknown;
-            test(su.su.Equals("SUnknown.su"));
+            test(su.su == "SUnknown.su");
         }
     }
 
@@ -301,14 +301,14 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             PSUnknown pu = p as PSUnknown;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
-            test(pu.psu.Equals("unknown"));
+            test(pu.ps == "preserved");
+            test(pu.psu == "unknown");
             test(pu.graph == null);
             test(pu.cl != null && pu.cl.i == 15);
         }
@@ -334,14 +334,14 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             PSUnknown pu = p as PSUnknown;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
-            test(pu.psu.Equals("unknown"));
+            test(pu.ps == "preserved");
+            test(pu.psu == "unknown");
             test(pu.graph != pu.graph.next);
             test(pu.graph.next != pu.graph.next.next);
             test(pu.graph.next.next.next == pu.graph);
@@ -364,13 +364,13 @@ public sealed class TestI : TestIntfDisp_
         {
             test(!(p is PSUnknown2));
             test(p.pi == 5);
-            test(p.ps.Equals("preserved"));
+            test(p.ps == "preserved");
         }
         else
         {
             PSUnknown2 pu = p as PSUnknown2;
             test(pu.pi == 5);
-            test(pu.ps.Equals("preserved"));
+            test(pu.ps == "preserved");
             test(pu.pb == pu);
         }
     }

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -244,7 +244,7 @@ namespace Ice
                     outS.writeString("hello world");
                     var data = outS.finished();
                     inS = new Ice.InputStream(communicator, data);
-                    test(inS.readString().Equals("hello world"));
+                    test(inS.readString() == "hello world");
                 }
 
                 output.WriteLine("ok");
@@ -297,7 +297,7 @@ namespace Ice
                     var o2 =(Test.OptionalClass)cb.obj;
                     test(o2.bo == o.bo);
                     test(o2.by == o.by);
-                    if(communicator.getProperties().getProperty("Ice.Default.EncodingVersion").Equals("1.0"))
+                    if(communicator.getProperties().getProperty("Ice.Default.EncodingVersion") == "1.0")
                     {
                         test(!o2.sh.HasValue);
                         test(!o2.i.HasValue);

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -51,7 +51,7 @@ namespace Ice
                     //
                     // Use loopback to prevent other machines to answer.
                     //
-                    if(properties.getProperty("Ice.IPv6").Equals("1"))
+                    if(properties.getProperty("Ice.IPv6") == "1")
                     {
                         endpoint.Append("udp -h \"ff15::1:1\"");
                         if(IceInternal.AssemblyUtil.isWindows || IceInternal.AssemblyUtil.isMacOS)

--- a/csharp/test/IceBox/admin/AllTests.cs
+++ b/csharp/test/IceBox/admin/AllTests.cs
@@ -36,20 +36,20 @@ public class AllTests : Test.AllTests
             //
             // Test: PropertiesAdmin::getProperty()
             //
-            test(pa.getProperty("Prop1").Equals("1"));
-            test(pa.getProperty("Bogus").Equals(""));
+            test(pa.getProperty("Prop1") == "1");
+            test(pa.getProperty("Bogus") == "");
 
             //
             // Test: PropertiesAdmin::getProperties()
             //
             Dictionary<string, string> pd = pa.getPropertiesForPrefix("");
             test(pd.Count == 6);
-            test(pd["Prop1"].Equals("1"));
-            test(pd["Prop2"].Equals("2"));
-            test(pd["Prop3"].Equals("3"));
-            test(pd["Ice.Config"].Equals("config.service"));
-            test(pd["Ice.ProgramName"].Equals("IceBox-TestService"));
-            test(pd["Ice.Admin.Enabled"].Equals("1"));
+            test(pd["Prop1"] == "1");
+            test(pd["Prop2"] == "2");
+            test(pd["Prop3"] == "3");
+            test(pd["Ice.Config"] == "config.service");
+            test(pd["Ice.ProgramName"] == "IceBox-TestService");
+            test(pd["Ice.Admin.Enabled"] == "1");
 
             Dictionary<string, string> changes;
 
@@ -63,18 +63,18 @@ public class AllTests : Test.AllTests
             setProps.Add("Prop4", "4"); // Added
             setProps.Add("Prop5", "5"); // Added
             pa.setProperties(setProps);
-            test(pa.getProperty("Prop1").Equals("10"));
-            test(pa.getProperty("Prop2").Equals("20"));
-            test(pa.getProperty("Prop3").Equals(""));
-            test(pa.getProperty("Prop4").Equals("4"));
-            test(pa.getProperty("Prop5").Equals("5"));
+            test(pa.getProperty("Prop1") == "10");
+            test(pa.getProperty("Prop2") == "20");
+            test(pa.getProperty("Prop3") == "");
+            test(pa.getProperty("Prop4") == "4");
+            test(pa.getProperty("Prop5") == "5");
             changes = facet.getChanges();
             test(changes.Count == 5);
-            test(changes["Prop1"].Equals("10"));
-            test(changes["Prop2"].Equals("20"));
-            test(changes["Prop3"].Equals(""));
-            test(changes["Prop4"].Equals("4"));
-            test(changes["Prop5"].Equals("5"));
+            test(changes["Prop1"] == "10");
+            test(changes["Prop2"] == "20");
+            test(changes["Prop3"] == "");
+            test(changes["Prop4"] == "4");
+            test(changes["Prop5"] == "5");
             pa.setProperties(setProps);
             changes = facet.getChanges();
             test(changes.Count == 0);

--- a/csharp/test/IceBox/admin/AllTests.cs
+++ b/csharp/test/IceBox/admin/AllTests.cs
@@ -37,7 +37,7 @@ public class AllTests : Test.AllTests
             // Test: PropertiesAdmin::getProperty()
             //
             test(pa.getProperty("Prop1") == "1");
-            test(pa.getProperty("Bogus") == "");
+            test(pa.getProperty("Bogus").Length == 0);
 
             //
             // Test: PropertiesAdmin::getProperties()
@@ -65,14 +65,14 @@ public class AllTests : Test.AllTests
             pa.setProperties(setProps);
             test(pa.getProperty("Prop1") == "10");
             test(pa.getProperty("Prop2") == "20");
-            test(pa.getProperty("Prop3") == "");
+            test(pa.getProperty("Prop3").Length == 0);
             test(pa.getProperty("Prop4") == "4");
             test(pa.getProperty("Prop5") == "5");
             changes = facet.getChanges();
             test(changes.Count == 5);
             test(changes["Prop1"] == "10");
             test(changes["Prop2"] == "20");
-            test(changes["Prop3"] == "");
+            test(changes["Prop3"].Length == 0);
             test(changes["Prop4"] == "4");
             test(changes["Prop5"] == "5");
             pa.setProperties(setProps);

--- a/csharp/test/IceBox/configuration/AllTests.cs
+++ b/csharp/test/IceBox/configuration/AllTests.cs
@@ -19,7 +19,7 @@ public class AllTests : Test.AllTests
         TestIntfPrx service4 = TestIntfPrxHelper.uncheckedCast(communicator.stringToProxy("test:" +
                                                                                           helper.getTestEndpoint(3)));
 
-        if(service1.getProperty("IceBox.InheritProperties") == "")
+        if(service1.getProperty("IceBox.InheritProperties").Length == 0)
         {
             Console.Out.Write("testing service properties... ");
             Console.Out.Flush();
@@ -27,7 +27,7 @@ public class AllTests : Test.AllTests
             test(service1.getProperty("Ice.ProgramName") == "IceBox-Service1");
             test(service1.getProperty("Service") == "1");
             test(service1.getProperty("Service1.Ovrd") == "2");
-            test(service1.getProperty("Service1.Unset") == "");
+            test(service1.getProperty("Service1.Unset").Length == 0);
             test(service1.getProperty("Arg") == "1");
 
             string[] args1 = {"-a", "--Arg=2"};
@@ -35,7 +35,7 @@ public class AllTests : Test.AllTests
 
             test(service2.getProperty("Ice.ProgramName") == "Test");
             test(service2.getProperty("Service") == "2");
-            test(service2.getProperty("Service1.ArgProp") == "");
+            test(service2.getProperty("Service1.ArgProp").Length == 0);
             test(service2.getProperty("IceBox.InheritProperties") == "1");
 
             string[] args2 = {"--Service1.ArgProp=1"};
@@ -48,13 +48,13 @@ public class AllTests : Test.AllTests
 
             test(service3.getProperty("Ice.ProgramName") == "IceBox-SharedCommunicator");
             test(service3.getProperty("Service") == "4");
-            test(service3.getProperty("Prop") == "");
+            test(service3.getProperty("Prop").Length == 0);
             test(service3.getProperty("Service3.Prop") == "1");
             test(service3.getProperty("Ice.Trace.Slicing") == "3");
 
             test(service4.getProperty("Ice.ProgramName") == "IceBox-SharedCommunicator");
             test(service4.getProperty("Service") == "4");
-            test(service4.getProperty("Prop") == "");
+            test(service4.getProperty("Prop").Length == 0);
             test(service4.getProperty("Service3.Prop") == "1");
             test(service4.getProperty("Ice.Trace.Slicing") == "3");
 
@@ -71,14 +71,14 @@ public class AllTests : Test.AllTests
             test(service1.getProperty("Ice.ProgramName") == "IceBox2-Service1");
             test(service1.getProperty("ServerProp") == "1");
             test(service1.getProperty("OverrideMe") == "2");
-            test(service1.getProperty("UnsetMe") == "");
+            test(service1.getProperty("UnsetMe").Length == 0);
             test(service1.getProperty("Service1.Prop") == "1");
             test(service1.getProperty("Service1.ArgProp") == "2");
 
             test(service2.getProperty("Ice.ProgramName") == "IceBox2-SharedCommunicator");
             test(service2.getProperty("ServerProp") == "1");
             test(service2.getProperty("OverrideMe") == "3");
-            test(service2.getProperty("UnsetMe") == "");
+            test(service2.getProperty("UnsetMe").Length == 0);
             test(service2.getProperty("Service2.Prop") == "1");
 
             Console.Out.WriteLine("ok");

--- a/csharp/test/IceBox/configuration/AllTests.cs
+++ b/csharp/test/IceBox/configuration/AllTests.cs
@@ -19,24 +19,24 @@ public class AllTests : Test.AllTests
         TestIntfPrx service4 = TestIntfPrxHelper.uncheckedCast(communicator.stringToProxy("test:" +
                                                                                           helper.getTestEndpoint(3)));
 
-        if(service1.getProperty("IceBox.InheritProperties").Equals(""))
+        if(service1.getProperty("IceBox.InheritProperties") == "")
         {
             Console.Out.Write("testing service properties... ");
             Console.Out.Flush();
 
-            test(service1.getProperty("Ice.ProgramName").Equals("IceBox-Service1"));
-            test(service1.getProperty("Service").Equals("1"));
-            test(service1.getProperty("Service1.Ovrd").Equals("2"));
-            test(service1.getProperty("Service1.Unset").Equals(""));
-            test(service1.getProperty("Arg").Equals("1"));
+            test(service1.getProperty("Ice.ProgramName") == "IceBox-Service1");
+            test(service1.getProperty("Service") == "1");
+            test(service1.getProperty("Service1.Ovrd") == "2");
+            test(service1.getProperty("Service1.Unset") == "");
+            test(service1.getProperty("Arg") == "1");
 
             string[] args1 = {"-a", "--Arg=2"};
             test(IceUtilInternal.Arrays.Equals(service1.getArgs(), args1));
 
-            test(service2.getProperty("Ice.ProgramName").Equals("Test"));
-            test(service2.getProperty("Service").Equals("2"));
-            test(service2.getProperty("Service1.ArgProp").Equals(""));
-            test(service2.getProperty("IceBox.InheritProperties").Equals("1"));
+            test(service2.getProperty("Ice.ProgramName") == "Test");
+            test(service2.getProperty("Service") == "2");
+            test(service2.getProperty("Service1.ArgProp") == "");
+            test(service2.getProperty("IceBox.InheritProperties") == "1");
 
             string[] args2 = {"--Service1.ArgProp=1"};
             test(IceUtilInternal.Arrays.Equals(service2.getArgs(), args2));
@@ -46,17 +46,17 @@ public class AllTests : Test.AllTests
             Console.Out.Write("testing with shared communicator... ");
             Console.Out.Flush();
 
-            test(service3.getProperty("Ice.ProgramName").Equals("IceBox-SharedCommunicator"));
-            test(service3.getProperty("Service").Equals("4"));
-            test(service3.getProperty("Prop").Equals(""));
-            test(service3.getProperty("Service3.Prop").Equals("1"));
-            test(service3.getProperty("Ice.Trace.Slicing").Equals("3"));
+            test(service3.getProperty("Ice.ProgramName") == "IceBox-SharedCommunicator");
+            test(service3.getProperty("Service") == "4");
+            test(service3.getProperty("Prop") == "");
+            test(service3.getProperty("Service3.Prop") == "1");
+            test(service3.getProperty("Ice.Trace.Slicing") == "3");
 
-            test(service4.getProperty("Ice.ProgramName").Equals("IceBox-SharedCommunicator"));
-            test(service4.getProperty("Service").Equals("4"));
-            test(service4.getProperty("Prop").Equals(""));
-            test(service4.getProperty("Service3.Prop").Equals("1"));
-            test(service4.getProperty("Ice.Trace.Slicing").Equals("3"));
+            test(service4.getProperty("Ice.ProgramName") == "IceBox-SharedCommunicator");
+            test(service4.getProperty("Service") == "4");
+            test(service4.getProperty("Prop") == "");
+            test(service4.getProperty("Service3.Prop") == "1");
+            test(service4.getProperty("Ice.Trace.Slicing") == "3");
 
             string[] args4 = {"--Service3.Prop=2"};
             test(IceUtilInternal.Arrays.Equals(service4.getArgs(), args4));
@@ -68,18 +68,18 @@ public class AllTests : Test.AllTests
             Console.Out.Write("testing property inheritance... ");
             Console.Out.Flush();
 
-            test(service1.getProperty("Ice.ProgramName").Equals("IceBox2-Service1"));
-            test(service1.getProperty("ServerProp").Equals("1"));
-            test(service1.getProperty("OverrideMe").Equals("2"));
-            test(service1.getProperty("UnsetMe").Equals(""));
-            test(service1.getProperty("Service1.Prop").Equals("1"));
-            test(service1.getProperty("Service1.ArgProp").Equals("2"));
+            test(service1.getProperty("Ice.ProgramName") == "IceBox2-Service1");
+            test(service1.getProperty("ServerProp") == "1");
+            test(service1.getProperty("OverrideMe") == "2");
+            test(service1.getProperty("UnsetMe") == "");
+            test(service1.getProperty("Service1.Prop") == "1");
+            test(service1.getProperty("Service1.ArgProp") == "2");
 
-            test(service2.getProperty("Ice.ProgramName").Equals("IceBox2-SharedCommunicator"));
-            test(service2.getProperty("ServerProp").Equals("1"));
-            test(service2.getProperty("OverrideMe").Equals("3"));
-            test(service2.getProperty("UnsetMe").Equals(""));
-            test(service2.getProperty("Service2.Prop").Equals("1"));
+            test(service2.getProperty("Ice.ProgramName") == "IceBox2-SharedCommunicator");
+            test(service2.getProperty("ServerProp") == "1");
+            test(service2.getProperty("OverrideMe") == "3");
+            test(service2.getProperty("UnsetMe") == "");
+            test(service2.getProperty("Service2.Prop") == "1");
 
             Console.Out.WriteLine("ok");
         }

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -227,7 +227,7 @@ public class AllTests : Test.AllTests
                 Ice.InitializationData initData = new Ice.InitializationData();
                 initData.properties = communicator.getProperties().ice_clone_();
                 string intf = initData.properties.getProperty("IceDiscovery.Interface");
-                if(intf != "")
+                if(intf.Length > 0)
                 {
                     intf = " --interface \"" + intf + "\"";
                 }

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -183,13 +183,13 @@ public class AllTests : Test.AllTests
             proxies[0].deactivateObjectAdapter("oa");
             proxies[1].deactivateObjectAdapter("oa");
             test(TestIntfPrxHelper.uncheckedCast(
-                     communicator.stringToProxy("object @ rg")).getAdapterId().Equals("oa3"));
+                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa3");
             proxies[2].deactivateObjectAdapter("oa");
 
             proxies[0].activateObjectAdapter("oa", "oa1", "rg");
             proxies[0].addObject("oa", "object");
             test(TestIntfPrxHelper.uncheckedCast(
-                     communicator.stringToProxy("object @ rg")).getAdapterId().Equals("oa1"));
+                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa1");
             proxies[0].deactivateObjectAdapter("oa");
         }
         output.WriteLine("ok");
@@ -198,7 +198,7 @@ public class AllTests : Test.AllTests
         output.Flush();
         {
             String multicast;
-            if(communicator.getProperties().getProperty("Ice.IPv6").Equals("1"))
+            if(communicator.getProperties().getProperty("Ice.IPv6") == "1")
             {
                 multicast = "\"ff15::1\"";
             }
@@ -227,7 +227,7 @@ public class AllTests : Test.AllTests
                 Ice.InitializationData initData = new Ice.InitializationData();
                 initData.properties = communicator.getProperties().ice_clone_();
                 string intf = initData.properties.getProperty("IceDiscovery.Interface");
-                if(!intf.Equals(""))
+                if(intf != "")
                 {
                     intf = " --interface \"" + intf + "\"";
                 }

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -184,7 +184,7 @@ public class AllTests : Test.AllTests
                                             "IceLocatorDiscovery:IceLocatorDiscovery.PluginFactory");
             {
                 string intf = initData.properties.getProperty("IceLocatorDiscovery.Interface");
-                if(intf != "")
+                if(intf.Length > 0)
                 {
                     intf = " --interface \"" + intf + "\"";
                 }

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -128,7 +128,7 @@ public class AllTests : Test.AllTests
             com.destroy();
 
             string multicast;
-            if(communicator.getProperties().getProperty("Ice.IPv6").Equals("1"))
+            if(communicator.getProperties().getProperty("Ice.IPv6") == "1")
             {
                 multicast = "\"ff15::1\"";
             }
@@ -184,7 +184,7 @@ public class AllTests : Test.AllTests
                                             "IceLocatorDiscovery:IceLocatorDiscovery.PluginFactory");
             {
                 string intf = initData.properties.getProperty("IceLocatorDiscovery.Interface");
-                if(!intf.Equals(""))
+                if(intf != "")
                 {
                     intf = " --interface \"" + intf + "\"";
                 }
@@ -278,8 +278,8 @@ public class AllTests : Test.AllTests
         }
         catch(Ice.NotRegisteredException ex)
         {
-            test(ex.kindOfObject.Equals("object"));
-            test(ex.id.Equals("unknown/unknown"));
+            test(ex.kindOfObject == "object");
+            test(ex.id == "unknown/unknown");
         }
         Console.Out.WriteLine("ok");
 
@@ -292,8 +292,8 @@ public class AllTests : Test.AllTests
         }
         catch(Ice.NotRegisteredException ex)
         {
-            test(ex.kindOfObject.Equals("object adapter"));
-            test(ex.id.Equals("TestAdapterUnknown"));
+            test(ex.kindOfObject == "object adapter");
+            test(ex.id == "TestAdapterUnknown");
         }
         Console.Out.WriteLine("ok");
 

--- a/csharp/test/IceGrid/simple/Client.cs
+++ b/csharp/test/IceGrid/simple/Client.cs
@@ -19,7 +19,7 @@ public class Client : Test.TestHelper
     {
         using(var communicator = initialize(ref args))
         {
-            if(args.Any(v => v.Equals("--with-deploy")))
+            if(args.Any(v => v == "--with-deploy"))
             {
                 AllTests.allTestsWithDeploy(this);
             }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -560,7 +560,7 @@ public class AllTests
                 // Test Hostname verification only when Ice.DefaultHost is 127.0.0.1
                 // as that is the IP address used in the test certificates.
                 //
-                if(defaultHost.Equals("127.0.0.1"))
+                if(defaultHost == "127.0.0.1")
                 {
                     //
                     // Test using localhost as target host

--- a/csharp/test/IceUtil/inputUtil/Client.cs
+++ b/csharp/test/IceUtil/inputUtil/Client.cs
@@ -18,54 +18,54 @@ public class Client : Test.TestHelper
             test(IceUtilInternal.Options.split("").Length == 0);
 
             args = IceUtilInternal.Options.split("\"\"");
-            test(args.Length == 1 && args[0].Equals(""));
+            test(args.Length == 1 && args[0] == "");
             args = IceUtilInternal.Options.split("''");
-            test(args.Length == 1 && args[0].Equals(""));
+            test(args.Length == 1 && args[0] == "");
             args = IceUtilInternal.Options.split("$''");
-            test(args.Length == 1 && args[0].Equals(""));
+            test(args.Length == 1 && args[0] == "");
 
             args = IceUtilInternal.Options.split("-a -b -c");
-            test(args.Length == 3 && args[0].Equals("-a") && args[1].Equals("-b") && args[2].Equals("-c"));
+            test(args.Length == 3 && args[0] == "-a" && args[1] == "-b" && args[2] == "-c");
             args = IceUtilInternal.Options.split("\"-a\" '-b' $'-c'");
-            test(args.Length == 3 && args[0].Equals("-a") && args[1].Equals("-b") && args[2].Equals("-c"));
+            test(args.Length == 3 && args[0] == "-a" && args[1] == "-b" && args[2] == "-c");
             args = IceUtilInternal.Options.split("  '-b' \"-a\" $'-c' ");
-            test(args.Length == 3 && args[0].Equals("-b") && args[1].Equals("-a") && args[2].Equals("-c"));
+            test(args.Length == 3 && args[0] == "-b" && args[1] == "-a" && args[2] == "-c");
             args = IceUtilInternal.Options.split(" $'-c' '-b' \"-a\"  ");
-            test(args.Length == 3 && args[0].Equals("-c") && args[1].Equals("-b") && args[2].Equals("-a"));
+            test(args.Length == 3 && args[0] == "-c" && args[1] == "-b" && args[2] == "-a");
 
             // Testing single quote
             args = IceUtilInternal.Options.split("-Dir='C:\\\\test\\\\file'"); // -Dir='C:\\test\\file'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\\\test\\\\file")); // -Dir=C:\\test\\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\\\test\\\\file"); // -Dir=C:\\test\\file
             args = IceUtilInternal.Options.split("-Dir='C:\\test\\file'"); // -Dir='C:\test\file'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
             args = IceUtilInternal.Options.split("-Dir='C:\\test\\filewith\"quote'"); // -Dir='C:\test\filewith"quote'
             test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\filewith\"quote")); // -Dir=C:\test\filewith"quote
 
             // Testing double quote
             args = IceUtilInternal.Options.split("-Dir=\"C:\\\\test\\\\file\""); // -Dir="C:\\test\\file"
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
                  args = IceUtilInternal.Options.split("-Dir=\"C:\\test\\file\""); // -Dir="C:\test\file"
-                 test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+                 test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
             args = IceUtilInternal.Options.split("-Dir=\"C:\\test\\filewith\\\"quote\""); // -Dir="C:\test\filewith\"quote"
             test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\filewith\"quote")); // -Dir=C:\test\filewith"quote
 
             // Testing ANSI quote
             args = IceUtilInternal.Options.split("-Dir=$'C:\\\\test\\\\file'"); // -Dir=$'C:\\test\\file'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
             args = IceUtilInternal.Options.split("-Dir=$'C:\\oest\\oile'"); // -Dir='C:\oest\oile'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\oest\\oile")); // -Dir=C:\oest\oile
+            test(args.Length == 1 && args[0] == "-Dir=C:\\oest\\oile"); // -Dir=C:\oest\oile
             args = IceUtilInternal.Options.split("-Dir=$'C:\\oest\\oilewith\"quote'"); // -Dir=$'C:\oest\oilewith"quote'
             test(args.Length == 1 && args[0].Equals("-Dir=C:\\oest\\oilewith\"quote")); // -Dir=C:\oest\oilewith"quote
             args = IceUtilInternal.Options.split("-Dir=$'\\103\\072\\134\\164\\145\\163\\164\\134\\146\\151\\154\\145'");
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
             args = IceUtilInternal.Options.split("-Dir=$'\\x43\\x3A\\x5C\\x74\\x65\\x73\\x74\\x5C\\x66\\x69\\x6C\\x65'");
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\test\\file")); // -Dir=C:\test\file
+            test(args.Length == 1 && args[0] == "-Dir=C:\\test\\file"); // -Dir=C:\test\file
             args = IceUtilInternal.Options.split("-Dir=$'\\cM\\c_'"); // Control characters
-            test(args.Length == 1 && args[0].Equals("-Dir=\x0D\x1F"));
+            test(args.Length == 1 && args[0] == "-Dir=\x0D\x1F");
             args = IceUtilInternal.Options.split("-Dir=$'C:\\\\\\146\\x66\\cMi'"); // -Dir=$'C:\\\146\x66i\cMi'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\ff\x0Di"));
+            test(args.Length == 1 && args[0] == "-Dir=C:\\ff\x0Di");
             args = IceUtilInternal.Options.split("-Dir=$'C:\\\\\\cM\\x66\\146i'"); // -Dir=$'C:\\\cM\x66\146i'
-            test(args.Length == 1 && args[0].Equals("-Dir=C:\\\x000Dffi"));
+            test(args.Length == 1 && args[0] == "-Dir=C:\\\x000Dffi");
         }
         catch(IceUtilInternal.Options.BadQuote)
         {
@@ -103,42 +103,42 @@ public class Client : Test.TestHelper
             arr = IceUtilInternal.StringUtil.splitString("", ":");
             test(arr.Length == 0);
             arr = IceUtilInternal.StringUtil.splitString("a", "");
-            test(arr.Length == 1 && arr[0].Equals("a"));
+            test(arr.Length == 1 && arr[0] == "a");
             arr = IceUtilInternal.StringUtil.splitString("a", ":");
-            test(arr.Length == 1 && arr[0].Equals("a"));
+            test(arr.Length == 1 && arr[0] == "a");
             arr = IceUtilInternal.StringUtil.splitString("ab", "");
-            test(arr.Length == 1 && arr[0].Equals("ab"));
+            test(arr.Length == 1 && arr[0] == "ab");
             arr = IceUtilInternal.StringUtil.splitString("ab:", ":");
-            test(arr.Length == 1 && arr[0].Equals("ab"));
+            test(arr.Length == 1 && arr[0] == "ab");
             arr = IceUtilInternal.StringUtil.splitString(":ab", ":");
-            test(arr.Length == 1 && arr[0].Equals("ab"));
+            test(arr.Length == 1 && arr[0] == "ab");
             arr = IceUtilInternal.StringUtil.splitString("a:b", ":");
-            test(arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
+            test(arr.Length == 2 && arr[0] == "a" && arr[1] == "b");
             arr = IceUtilInternal.StringUtil.splitString(":a:b:", ":");
-            test(arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
+            test(arr.Length == 2 && arr[0] == "a" && arr[1] == "b");
 
             arr = IceUtilInternal.StringUtil.splitString("\"a\"", ":");
-            test(arr.Length == 1 && arr[0].Equals("a"));
+            test(arr.Length == 1 && arr[0] == "a");
             arr = IceUtilInternal.StringUtil.splitString("\"a\":b", ":");
-            test(arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
+            test(arr.Length == 2 && arr[0] == "a" && arr[1] == "b");
             arr = IceUtilInternal.StringUtil.splitString("\"a\":\"b\"", ":");
-            test(arr.Length == 2 && arr[0].Equals("a") && arr[1].Equals("b"));
+            test(arr.Length == 2 && arr[0] == "a" && arr[1] == "b");
             arr = IceUtilInternal.StringUtil.splitString("\"a:b\"", ":");
-            test(arr.Length == 1 && arr[0].Equals("a:b"));
+            test(arr.Length == 1 && arr[0] == "a:b");
             arr = IceUtilInternal.StringUtil.splitString("a=\"a:b\"", ":");
-            test(arr.Length == 1 && arr[0].Equals("a=a:b"));
+            test(arr.Length == 1 && arr[0] == "a=a:b");
 
             arr = IceUtilInternal.StringUtil.splitString("'a'", ":");
-            test(arr.Length == 1 && arr[0].Equals("a"));
+            test(arr.Length == 1 && arr[0] == "a");
             arr = IceUtilInternal.StringUtil.splitString("'\"a'", ":");
             test(arr.Length == 1 && arr[0].Equals("\"a"));
             arr = IceUtilInternal.StringUtil.splitString("\"'a\"", ":");
-            test(arr.Length == 1 && arr[0].Equals("'a"));
+            test(arr.Length == 1 && arr[0] == "'a");
 
             arr = IceUtilInternal.StringUtil.splitString("a\\'b", ":");
-            test(arr.Length == 1 && arr[0].Equals("a'b"));
+            test(arr.Length == 1 && arr[0] == "a'b");
             arr = IceUtilInternal.StringUtil.splitString("'a:b\\'c'", ":");
-            test(arr.Length == 1 && arr[0].Equals("a:b'c"));
+            test(arr.Length == 1 && arr[0] == "a:b'c");
             arr = IceUtilInternal.StringUtil.splitString("a\\\"b", ":");
             test(arr.Length == 1 && arr[0].Equals("a\"b"));
             arr = IceUtilInternal.StringUtil.splitString("\"a:b\\\"c\"", ":");
@@ -146,7 +146,7 @@ public class Client : Test.TestHelper
             arr = IceUtilInternal.StringUtil.splitString("'a:b\"c'", ":");
             test(arr.Length == 1 && arr[0].Equals("a:b\"c"));
             arr = IceUtilInternal.StringUtil.splitString("\"a:b'c\"", ":");
-            test(arr.Length == 1 && arr[0].Equals("a:b'c"));
+            test(arr.Length == 1 && arr[0] == "a:b'c");
 
             test(IceUtilInternal.StringUtil.splitString("a\"b", ":") == null);
         }

--- a/csharp/test/IceUtil/inputUtil/Client.cs
+++ b/csharp/test/IceUtil/inputUtil/Client.cs
@@ -18,11 +18,11 @@ public class Client : Test.TestHelper
             test(IceUtilInternal.Options.split("").Length == 0);
 
             args = IceUtilInternal.Options.split("\"\"");
-            test(args.Length == 1 && args[0] == "");
+            test(args.Length == 1 && args[0].Length == 0);
             args = IceUtilInternal.Options.split("''");
-            test(args.Length == 1 && args[0] == "");
+            test(args.Length == 1 && args[0].Length == 0);
             args = IceUtilInternal.Options.split("$''");
-            test(args.Length == 1 && args[0] == "");
+            test(args.Length == 1 && args[0].Length == 0);
 
             args = IceUtilInternal.Options.split("-a -b -c");
             test(args.Length == 3 && args[0] == "-a" && args[1] == "-b" && args[2] == "-c");

--- a/csharp/test/Slice/macros/Client.cs
+++ b/csharp/test/Slice/macros/Client.cs
@@ -21,7 +21,7 @@ public class Client : TestHelper
         test(nd.y != 10);
 
         CsOnly c = new CsOnly();
-        test(c.lang.Equals("cs"));
+        test(c.lang == "cs");
         test(c.version == Ice.Util.intVersion());
         Console.Out.WriteLine("ok");
     }

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -69,7 +69,7 @@ namespace Test
         static public string getTestEndpoint(Ice.Properties properties, int num = 0, string protocol = "")
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append(protocol == "" ? properties.getPropertyWithDefault("Ice.Default.Protocol", "default") :
+            sb.Append(protocol.Length == 0 ? properties.getPropertyWithDefault("Ice.Default.Protocol", "default") :
                                        protocol);
             sb.Append(" -p ");
             sb.Append(properties.getPropertyAsIntWithDefault("Test.BasePort", 12010) + num);


### PR DESCRIPTION
This PR replaces .Equals by == or != for string comparisons in C#.

It also replaces "" comparisons by Length comparisons (0 or > 0).