### PR TITLE
Remove C++ 98 HELPER macros

### DIFF
--- a/cpp/include/Glacier2/Application.h
+++ b/cpp/include/Glacier2/Application.h
@@ -60,7 +60,7 @@ public:
      * Initializes an instance that calls Ice::Communicator::shutdown if
      * a signal is received.
      **/
-    Application(Ice::SignalPolicy = Ice::ICE_ENUM(SignalPolicy,HandleSignals));
+    Application(Ice::SignalPolicy = Ice::SignalPolicy::HandleSignals);
 
     Application(const Application&) = delete;
     Application& operator=(const Application&) = delete;

--- a/cpp/include/Glacier2/SessionHelper.h
+++ b/cpp/include/Glacier2/SessionHelper.h
@@ -88,7 +88,7 @@ public:
      */
     virtual Ice::ObjectAdapterPtr objectAdapter() = 0;
 };
-ICE_DEFINE_PTR(SessionHelperPtr, SessionHelper);
+using SessionHelperPtr = std::shared_ptr<SessionHelper>;
 
 /**
  * Allows an application to receive notification about events in the lifecycle of a Glacier2 session.
@@ -124,7 +124,7 @@ public:
      */
     virtual void connectFailed(const SessionHelperPtr& session, const Ice::Exception& ex) = 0;
 };
-ICE_DEFINE_PTR(SessionCallbackPtr, SessionCallback);
+using SessionCallbackPtr = std::shared_ptr<SessionCallback>;
 
 /// \cond INTERNAL
 class SessionThreadCallback;
@@ -295,7 +295,7 @@ private:
     bool _useCallbacks;
     std::map<const SessionHelper*, IceUtil::ThreadPtr> _threads;
 };
-ICE_DEFINE_PTR(SessionFactoryHelperPtr, SessionFactoryHelper);
+using SessionFactoryHelperPtr = std::shared_ptr<SessionFactoryHelper>;
 
 }
 

--- a/cpp/include/Ice/Application.h
+++ b/cpp/include/Ice/Application.h
@@ -41,7 +41,7 @@ public:
      * @param policy Specifies whether to handle signals. If not specified, the default behavior
      * is to handle signals.
      */
-    Application(SignalPolicy policy = ICE_ENUM(SignalPolicy, HandleSignals));
+    Application(SignalPolicy policy = SignalPolicy::HandleSignals);
 
     /// \cond IGNORE
     Application(const Application&) = delete;

--- a/cpp/include/Ice/DispatchInterceptor.h
+++ b/cpp/include/Ice/DispatchInterceptor.h
@@ -34,7 +34,7 @@ public:
     /// \endcond
 };
 
-ICE_DEFINE_PTR(DispatchInterceptorPtr, DispatchInterceptor);
+using DispatchInterceptorPtr = std::shared_ptr<DispatchInterceptor>;
 
 }
 

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -55,15 +55,15 @@ private:
 
     IceUtil::Mutex _m;
 
-    typedef ::std::pair< ::Ice::UserExceptionFactory, int> EFPair;
-    typedef ::std::map< ::std::string, EFPair> EFTable;
+    typedef ::std::pair<::Ice::UserExceptionFactory, int> EFPair;
+    typedef ::std::map<::std::string, EFPair> EFTable;
     EFTable _eft;
 
     typedef ::std::pair<::Ice::ValueFactoryFunc, int> VFPair;
-    typedef ::std::map< ::std::string, VFPair> VFTable;
+    typedef ::std::map<::std::string, VFPair> VFTable;
     VFTable _vft;
 
-    typedef ::std::pair< ::std::string, int> TypeIdPair;
+    typedef ::std::pair<::std::string, int> TypeIdPair;
     typedef ::std::map<int, TypeIdPair> TypeIdTable;
     TypeIdTable _typeIdTable;
 };

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -39,8 +39,8 @@ class ICE_API FactoryTable : private IceUtil::noncopyable
 {
 public:
 
-    void addExceptionFactory(const ::std::string&, ICE_IN(ICE_DELEGATE(::Ice::UserExceptionFactory)));
-    ICE_DELEGATE(::Ice::UserExceptionFactory) getExceptionFactory(const ::std::string&) const;
+    void addExceptionFactory(const ::std::string&, ::Ice::UserExceptionFactory);
+    ::Ice::UserExceptionFactory getExceptionFactory(const ::std::string&) const;
     void removeExceptionFactory(const ::std::string&);
 
     void addValueFactory(const ::std::string&, ::Ice::ValueFactoryFunc);
@@ -55,7 +55,7 @@ private:
 
     IceUtil::Mutex _m;
 
-    typedef ::std::pair< ICE_DELEGATE(::Ice::UserExceptionFactory), int> EFPair;
+    typedef ::std::pair< ::Ice::UserExceptionFactory, int> EFPair;
     typedef ::std::map< ::std::string, EFPair> EFTable;
     EFTable _eft;
 

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -335,7 +335,7 @@ namespace Ice
  * @throws IconvInitializationException If the code is not supported.
  */
 template<typename charT>
-ICE_HANDLE<IceUtil::BasicStringConverter<charT> >
+std::shared_ptr<IceUtil::BasicStringConverter<charT> >
 createIconvStringConverter(const std::string& internalCodeWithDefault = "")
 {
     std::string internalCode = internalCodeWithDefault;
@@ -345,7 +345,7 @@ createIconvStringConverter(const std::string& internalCodeWithDefault = "")
         internalCode = nl_langinfo(CODESET);
     }
 
-    return ICE_MAKE_SHARED(IceInternal::IconvStringConverter<charT>, internalCode);
+    return std::make_shared<IceInternal::IconvStringConverter<charT>>(internalCode);
 }
 
 }

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -675,7 +675,7 @@ ICE_API Identity stringToIdentity(const std::string& str);
  * @param mode Affects the handling of non-ASCII characters and non-printable ASCII characters.
  * @return The stringified identity.
  */
-ICE_API std::string identityToString(const Identity& id, ToStringMode mode = ICE_ENUM(ToStringMode, Unicode));
+ICE_API std::string identityToString(const Identity& id, ToStringMode mode = ToStringMode::Unicode);
 
 }
 

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -987,7 +987,7 @@ public:
      * the stream will attempt to instantiate the exception using static type information.
      * @throws UserException The user exception that was unmarshaled.
      */
-    void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory = ICE_NULLPTR);
+    void throwException(UserExceptionFactory factory = nullptr);
 
     /**
      * Skips one optional value with the given format.
@@ -1095,7 +1095,7 @@ private:
         virtual ~EncapsDecoder();
 
         virtual void read(PatchFunc, void*) = 0;
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory))) = 0;
+        virtual void throwException(UserExceptionFactory) = 0;
 
         virtual void startInstance(SliceType) = 0;
         virtual SlicedDataPtr endInstance(bool) = 0;
@@ -1170,7 +1170,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)));
+        virtual void throwException(UserExceptionFactory);
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);
@@ -1205,7 +1205,7 @@ private:
         }
 
         virtual void read(PatchFunc, void*);
-        virtual void throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)));
+        virtual void throwException(UserExceptionFactory);
 
         virtual void startInstance(SliceType);
         virtual SlicedDataPtr endInstance(bool);

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -114,7 +114,7 @@ template<class MetricsType> class MetricsMapT : public MetricsMapI, private IceU
 public:
 
     using T = MetricsType;
-    using TPtr = ICE_SHARED_PTR<MetricsType>;
+    using TPtr = std::shared_ptr<MetricsType>;
     using MetricsMapTPtr = std::shared_ptr<MetricsMapT>;
 
     typedef IceMX::MetricsMap MetricsType::* SubMapMember;

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -31,7 +31,7 @@ public:
 
     virtual std::string operator()(const std::string&) const = 0;
 
-    virtual void initMetrics(const ICE_SHARED_PTR<T>&) const
+    virtual void initMetrics(const std::shared_ptr<T>&) const
     {
         // To be overridden in specialization to initialize state attributes
     }

--- a/cpp/include/Ice/NativePropertiesAdmin.h
+++ b/cpp/include/Ice/NativePropertiesAdmin.h
@@ -26,7 +26,7 @@ public:
      */
     virtual std::function<void()> addUpdateCallback(std::function<void(const PropertyDict&)> cb) = 0;
 };
-ICE_DEFINE_SHARED_PTR(NativePropertiesAdminPtr, NativePropertiesAdmin);
+using NativePropertiesAdminPtr = std::shared_ptr<NativePropertiesAdmin>;
 
 }
 

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -168,8 +168,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(ICE_IN(std::vector<Byte>) inEncaps, std::vector<Byte>& outEncaps,
-                            const Current& current) = 0;
+    virtual bool ice_invoke(std::vector<Byte> inEncaps, std::vector<Byte>& outEncaps, const Current& current) = 0;
 
     /// \cond INTERNAL
     virtual bool _iceDispatch(IceInternal::Incoming&, const Current&);
@@ -197,7 +196,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(ICE_IN(std::pair<const Byte*, const Byte*>) inEncaps, std::vector<Byte>& outEncaps,
+    virtual bool ice_invoke(std::pair<const Byte*, const Byte*> inEncaps, std::vector<Byte>& outEncaps,
                             const Current& current) = 0;
 
     /// \cond INTERNAL

--- a/cpp/include/Ice/ObserverHelper.h
+++ b/cpp/include/Ice/ObserverHelper.h
@@ -32,7 +32,7 @@ public:
 
     operator bool() const
     {
-        return _observer != ICE_NULLPTR;
+        return _observer != nullptr;
     }
 
     T* operator->() const
@@ -139,7 +139,7 @@ public:
         {
             return _observer->getRemoteObserver(con, endpt, requestId, size);
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     ::Ice::Instrumentation::ChildInvocationObserverPtr
@@ -149,7 +149,7 @@ public:
         {
             return _observer->getCollocatedObserver(adapter, requestId, size);
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     void

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -1000,7 +1000,7 @@ private:
 
     public:
 
-        Encaps() : format(ICE_ENUM(FormatType, DefaultFormat)), encoder(0), previous(0)
+        Encaps() : format(FormatType::DefaultFormat), encoder(0), previous(0)
         {
             // Inlined for performance reasons.
         }

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -614,7 +614,7 @@ struct GetOptionalFormat;
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F1);
+    static const OptionalFormat value = OptionalFormat::F1;
 };
 
 /**
@@ -624,7 +624,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 2, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F2);
+    static const OptionalFormat value = OptionalFormat::F2;
 };
 
 /**
@@ -634,7 +634,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 2, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 4, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F4);
+    static const OptionalFormat value = OptionalFormat::F4;
 };
 
 /**
@@ -644,7 +644,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 4, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 8, true>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, F8);
+    static const OptionalFormat value = OptionalFormat::F8;
 };
 
 /**
@@ -654,7 +654,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 8, true>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat value = OptionalFormat::VSize;
 };
 
 /**
@@ -664,7 +664,7 @@ struct GetOptionalFormat<StreamHelperCategoryBuiltin, 1, false>
 template<>
 struct GetOptionalFormat<StreamHelperCategoryClass, 1, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, Class);
+    static const OptionalFormat value = OptionalFormat::Class;
 };
 
 /**
@@ -674,7 +674,7 @@ struct GetOptionalFormat<StreamHelperCategoryClass, 1, false>
 template<int minWireSize>
 struct GetOptionalFormat<StreamHelperCategoryEnum, minWireSize, false>
 {
-    static const OptionalFormat value = ICE_SCOPED_ENUM(OptionalFormat, Size);
+    static const OptionalFormat value = OptionalFormat::Size;
 };
 
 /**
@@ -713,7 +713,7 @@ struct StreamOptionalHelper
 template<typename T>
 struct StreamOptionalHelper<T, StreamHelperCategoryStruct, true>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v)
@@ -737,7 +737,7 @@ struct StreamOptionalHelper<T, StreamHelperCategoryStruct, true>
 template<typename T>
 struct StreamOptionalHelper<T, StreamHelperCategoryStruct, false>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, FSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
     template<class S> static inline void
     write(S* stream, const T& v)
@@ -790,7 +790,7 @@ struct StreamOptionalContainerHelper;
 template<typename T, int sz>
 struct StreamOptionalContainerHelper<T, false, sz>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, FSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int)
@@ -814,7 +814,7 @@ struct StreamOptionalContainerHelper<T, false, sz>
 template<typename T, int sz>
 struct StreamOptionalContainerHelper<T, true, sz>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int n)
@@ -846,7 +846,7 @@ struct StreamOptionalContainerHelper<T, true, sz>
 template<typename T>
 struct StreamOptionalContainerHelper<T, true, 1>
 {
-    static const OptionalFormat optionalFormat = ICE_SCOPED_ENUM(OptionalFormat, VSize);
+    static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
     template<class S> static inline void
     write(S* stream, const T& v, Int)

--- a/cpp/include/IceBT/Plugin.h
+++ b/cpp/include/IceBT/Plugin.h
@@ -59,7 +59,7 @@ public:
      */
     virtual DeviceMap getDevices() const = 0;
 };
-ICE_DEFINE_PTR(PluginPtr, Plugin);
+using PluginPtr = std::shared_ptr<Plugin>;
 
 }
 

--- a/cpp/include/IceSSL/OpenSSL.h
+++ b/cpp/include/IceSSL/OpenSSL.h
@@ -57,7 +57,7 @@ namespace OpenSSL
 {
 
 class Certificate;
-ICE_DEFINE_PTR(CertificatePtr, Certificate);
+using CertificatePtr = std::shared_ptr<Certificate>;
 
 /**
  * Encapsulates an OpenSSL X.509 certificate.
@@ -138,7 +138,7 @@ public:
      */
     virtual SSL_CTX* getContext() = 0;
 };
-ICE_DEFINE_PTR(PluginPtr, Plugin);
+using PluginPtr = std::shared_ptr<Plugin>;
 
 } // OpenSSL namespace end
 

--- a/cpp/include/IceSSL/Plugin.h
+++ b/cpp/include/IceSSL/Plugin.h
@@ -345,10 +345,10 @@ public:
      */
     virtual std::vector<Ice::Byte> getData() const = 0;
 };
-ICE_DEFINE_PTR(X509ExtensionPtr, X509Extension);
+using X509ExtensionPtr = std::shared_ptr<X509Extension>;
 
 class Certificate;
-ICE_DEFINE_PTR(CertificatePtr, Certificate);
+using CertificatePtr = std::shared_ptr<Certificate>;
 
 /**
  * This convenience class is a wrapper around a native certificate.
@@ -577,7 +577,7 @@ public:
      */
     virtual CertificatePtr decode(const std::string& str) const = 0;
 };
-ICE_DEFINE_PTR(PluginPtr, Plugin);
+using PluginPtr = std::shared_ptr<Plugin>;
 
 }
 

--- a/cpp/include/IceSSL/SChannel.h
+++ b/cpp/include/IceSSL/SChannel.h
@@ -18,7 +18,7 @@ namespace SChannel
 {
 
 class Certificate;
-ICE_DEFINE_PTR(CertificatePtr, Certificate);
+using CertificatePtr = std::shared_ptr<Certificate>;
 
 /**
  * This convenience class is a wrapper around a native certificate.

--- a/cpp/include/IceSSL/SecureTransport.h
+++ b/cpp/include/IceSSL/SecureTransport.h
@@ -17,7 +17,7 @@ namespace SecureTransport
 {
 
 class Certificate;
-ICE_DEFINE_PTR(CertificatePtr, Certificate);
+using CertificatePtr = std::shared_ptr<Certificate>;
 
 /**
  * This convenience class is a wrapper around a native certificate.

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -277,24 +277,13 @@ typedef long long Int64;
 // TODO remove the helper macros
 #   include <memory>
 #   include <future>
-#   define ICE_HANDLE ::std::shared_ptr
-#   define ICE_INTERNAL_HANDLE ::std::shared_ptr
-#   define ICE_SHARED_PTR ::std::shared_ptr
-#   define ICE_PROXY_HANDLE ::std::shared_ptr
-#   define ICE_MAKE_SHARED(T, ...) ::std::make_shared<T>(__VA_ARGS__)
-#   define ICE_DEFINE_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
-#   define ICE_DEFINE_SHARED_PTR(TPtr, T) using TPtr = ::std::shared_ptr<T>
 #   define ICE_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
 #   define ICE_SCOPED_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
-#   define ICE_NULLPTR nullptr
 #   define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
-#   define ICE_SHARED_FROM_THIS shared_from_this()
 #   define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()
 #   define ICE_GET_SHARED_FROM_THIS(p) p->shared_from_this()
 #   define ICE_CHECKED_CAST(T, ...) Ice::checkedCast<T>(__VA_ARGS__)
 #   define ICE_UNCHECKED_CAST(T, ...) Ice::uncheckedCast<T>(__VA_ARGS__)
-#   define ICE_DELEGATE(T) T
-#   define ICE_IN(...) __VA_ARGS__
 #   define ICE_SET_EXCEPTION_FROM_CLONE(T, V)  T = V
 
 #endif

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -282,6 +282,5 @@ typedef long long Int64;
 #   define ICE_GET_SHARED_FROM_THIS(p) p->shared_from_this()
 #   define ICE_CHECKED_CAST(T, ...) Ice::checkedCast<T>(__VA_ARGS__)
 #   define ICE_UNCHECKED_CAST(T, ...) Ice::uncheckedCast<T>(__VA_ARGS__)
-#   define ICE_SET_EXCEPTION_FROM_CLONE(T, V)  T = V
 
 #endif

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -277,8 +277,6 @@ typedef long long Int64;
 // TODO remove the helper macros
 #   include <memory>
 #   include <future>
-#   define ICE_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
-#   define ICE_SCOPED_ENUM(CLASS,ENUMERATOR) CLASS::ENUMERATOR
 #   define ICE_DYNAMIC_CAST(T,V) ::std::dynamic_pointer_cast<T>(V)
 #   define ICE_SHARED_FROM_CONST_THIS(T) const_cast<T*>(this)->shared_from_this()
 #   define ICE_GET_SHARED_FROM_THIS(p) p->shared_from_this()

--- a/cpp/include/IceUtil/ConsoleUtil.h
+++ b/cpp/include/IceUtil/ConsoleUtil.h
@@ -15,7 +15,7 @@ namespace IceUtilInternal
 #if defined(_WIN32)
 
 class ConsoleUtil;
-ICE_DEFINE_PTR(ConsoleUtilPtr, ConsoleUtil);
+using ConsoleUtilPtr = std::shared_ptr<ConsoleUtil>;
 
 class ICE_API ConsoleUtil
 {

--- a/cpp/include/IceUtil/CtrlCHandler.h
+++ b/cpp/include/IceUtil/CtrlCHandler.h
@@ -39,7 +39,7 @@ public:
      * Only a single CtrlCHandler object can exist in a process at a give time.
      * @param cb The callback function to invoke when a signal is received.
      */
-    explicit CtrlCHandler(CtrlCHandlerCallback cb = ICE_NULLPTR);
+    explicit CtrlCHandler(CtrlCHandlerCallback cb = nullptr);
 
      /**
      * Unregisters the callback function.

--- a/cpp/include/IceUtil/StringConverter.h
+++ b/cpp/include/IceUtil/StringConverter.h
@@ -74,11 +74,11 @@ template class ICE_API BasicStringConverter<wchar_t>;
 
 /** A narrow string converter. */
 typedef BasicStringConverter<char> StringConverter;
-ICE_DEFINE_PTR(StringConverterPtr, StringConverter);
+using StringConverterPtr = std::shared_ptr<StringConverter>;
 
 /** A wide string converter. */
 typedef BasicStringConverter<wchar_t> WstringConverter;
-ICE_DEFINE_PTR(WstringConverterPtr, WstringConverter);
+using WstringConverterPtr = std::shared_ptr<WstringConverter>;
 
 /**
  * Creates a WstringConverter that converts to and from UTF-16 or UTF-32 depending on sizeof(wchar_t).

--- a/cpp/include/IceUtil/StringUtil.h
+++ b/cpp/include/IceUtil/StringUtil.h
@@ -67,7 +67,7 @@ ICE_API bool match(const std::string&, const std::string&, bool = false);
 //
 ICE_API std::string lastErrorToString();
 #ifdef _WIN32
-ICE_API std::string errorToString(int, LPCVOID = ICE_NULLPTR);
+ICE_API std::string errorToString(int, LPCVOID = nullptr);
 #else
 ICE_API std::string errorToString(int);
 #endif

--- a/cpp/include/IceUtil/Timer.h
+++ b/cpp/include/IceUtil/Timer.h
@@ -32,7 +32,7 @@ public:
 
     virtual void runTimerTask() = 0;
 };
-ICE_DEFINE_PTR(TimerTaskPtr, TimerTask);
+using TimerTaskPtr = std::shared_ptr<TimerTask>;
 
 //
 // The timer class is used to schedule tasks for one-time execution or

--- a/cpp/src/Glacier2Lib/Application.cpp
+++ b/cpp/src/Glacier2Lib/Application.cpp
@@ -147,7 +147,7 @@ Glacier2::Application::doMain(Ice::StringSeq& args, const Ice::InitializationDat
             //
             // The default is to destroy when a signal is received.
             //
-            if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+            if(_signalPolicy == SignalPolicy::HandleSignals)
             {
                 destroyOnInterrupt();
             }
@@ -184,7 +184,7 @@ Glacier2::Application::doMain(Ice::StringSeq& args, const Ice::InitializationDat
                 {
                     Ice::ConnectionPtr connection = _router->ice_getCachedConnection();
                     assert(connection);
-                    connection->setACM(acmTimeout, IceUtil::None, ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                    connection->setACM(acmTimeout, IceUtil::None, ACMHeartbeat::HeartbeatAlways);
                     connection->setCloseCallback(
                         [this](Ice::ConnectionPtr)
                         {
@@ -272,7 +272,7 @@ Glacier2::Application::doMain(Ice::StringSeq& args, const Ice::InitializationDat
     // it would not make sense to release a held signal to run
     // shutdown or destroy.
     //
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         ignoreInterrupt();
     }

--- a/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
@@ -119,8 +119,8 @@ Init::createObjects()
     if(!_adapter)
     {
         _adapter = _communicator->createObjectAdapter(""); // colloc-only adapter
-        _adapter->add(ICE_MAKE_SHARED(NullPermissionsVerifier), _nullPVId);
-        _adapter->add(ICE_MAKE_SHARED(NullSSLPermissionsVerifier), _nullSSLPVId);
+        _adapter->add(std::make_shared<NullPermissionsVerifier>(), _nullPVId);
+        _adapter->add(std::make_shared<NullSSLPermissionsVerifier>(), _nullSSLPVId);
         _adapter->activate();
     }
 }

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -33,7 +33,7 @@ private:
 
     const SessionFactoryHelperPtr _factory;
 };
-ICE_DEFINE_PTR(SessionThreadCallbackPtr, SessionThreadCallback);
+using SessionThreadCallbackPtr = std::shared_ptr<SessionThreadCallback>;
 
 };
 
@@ -47,7 +47,7 @@ public:
 
     virtual Glacier2::SessionPrxPtr connect(const Glacier2::RouterPrxPtr& router) = 0;
 };
-ICE_DEFINE_PTR(ConnectStrategyPtr, ConnectStrategy);
+using ConnectStrategyPtr = std::shared_ptr<ConnectStrategy>;
 
 class Disconnected : public Ice::DispatcherCall
 {
@@ -123,7 +123,7 @@ private:
     const string _finder;
     const bool _useCallbacks;
 };
-ICE_DEFINE_PTR(SessionHelperIPtr, SessionHelperI);
+using SessionHelperIPtr = std::shared_ptr<SessionHelperI>;
 
 class DestroyInternal : public IceUtil::Thread
 {
@@ -141,7 +141,7 @@ public:
     virtual void run()
     {
         _session->destroyInternal(_disconnected);
-        _session = ICE_NULLPTR;
+        _session = nullptr;
 
         //
         // Join the connect thread to free resources.
@@ -173,7 +173,7 @@ public:
     virtual void run()
     {
         _session->destroyCommunicator();
-        _session = ICE_NULLPTR;
+        _session = nullptr;
 
         //
         // Join the connect thread to free resources.
@@ -225,15 +225,15 @@ SessionHelperI::destroy()
         // We destroy the communicator to trigger the immediate
         // failure of the connection establishment.
         //
-        destroyThread = new DestroyCommunicator(ICE_SHARED_FROM_THIS, _threadCB);
+        destroyThread = new DestroyCommunicator(shared_from_this(), _threadCB);
     }
     else
     {
-        destroyThread = new DestroyInternal(ICE_SHARED_FROM_THIS, _callback, _threadCB);
+        destroyThread = new DestroyInternal(shared_from_this(), _callback, _threadCB);
         _connected = false;
-        _session = ICE_NULLPTR;
+        _session = nullptr;
     }
-    _threadCB = ICE_NULLPTR;
+    _threadCB = nullptr;
 
     //
     // Run destroy in a thread because it can block.
@@ -374,14 +374,14 @@ void
 SessionHelperI::connect(const map<string, string>& context)
 {
     IceUtil::Mutex::Lock sync(_mutex);
-    connectImpl(ICE_MAKE_SHARED(ConnectStrategySecureConnection, context));
+    connectImpl(make_shared<ConnectStrategySecureConnection>(context));
 }
 
 void
 SessionHelperI::connect(const string& user, const string& password, const map<string, string>& context)
 {
     IceUtil::Mutex::Lock sync(_mutex);
-    connectImpl(ICE_MAKE_SHARED(ConnectStrategyUserPassword, user, password, context));
+    connectImpl(make_shared<ConnectStrategyUserPassword>(user, password, context));
 }
 
 void
@@ -393,7 +393,7 @@ SessionHelperI::destroyInternal(const Ice::DispatcherCallPtr& disconnected)
     {
         IceUtil::Mutex::Lock sync(_mutex);
         router = _router;
-        _router = ICE_NULLPTR;
+        _router = nullptr;
         _connected = false;
 
         communicator = _communicator;
@@ -434,7 +434,7 @@ SessionHelperI::destroyInternal(const Ice::DispatcherCallPtr& disconnected)
     {
         communicator->destroy();
     }
-    dispatchCallback(disconnected, ICE_NULLPTR);
+    dispatchCallback(disconnected, nullptr);
 }
 
 void
@@ -550,7 +550,7 @@ public:
                 IceUtil::Mutex::Lock sync(_session->_mutex);
                 _session->_destroy = true;
             }
-            _session->dispatchCallback(new ConnectFailed(_callback, _session, ex), ICE_NULLPTR);
+            _session->dispatchCallback(new ConnectFailed(_callback, _session, ex), nullptr);
             return;
         }
 
@@ -625,7 +625,7 @@ public:
     virtual void run()
     {
         _session->dispatchCallback(_call, _conn);
-        _session = ICE_NULLPTR;
+        _session = nullptr;
     }
 
 private:
@@ -641,7 +641,7 @@ void
 SessionHelperI::connectImpl(const ConnectStrategyPtr& factory)
 {
     assert(!_destroy);
-    IceUtil::ThreadPtr thread = new ConnectThread(_callback, ICE_SHARED_FROM_THIS, factory, _finder);
+    IceUtil::ThreadPtr thread = new ConnectThread(_callback, shared_from_this(), factory, _finder);
     _threadCB->add(this, thread);
     thread->start();
 }
@@ -755,11 +755,11 @@ SessionHelperI::connected(const Glacier2::RouterPrxPtr& router, const Glacier2::
         // connected() is only called from the ConnectThread so it is ok to
         // call destroyInternal here.
         //
-        destroyInternal(new Disconnected(ICE_SHARED_FROM_THIS, _callback));
+        destroyInternal(new Disconnected(shared_from_this(), _callback));
     }
     else
     {
-        dispatchCallback(new Connected(_callback, ICE_SHARED_FROM_THIS), conn);
+        dispatchCallback(new Connected(_callback, shared_from_this()), conn);
     }
 }
 
@@ -1051,12 +1051,11 @@ Glacier2::SessionFactoryHelper::connect()
     map<string, string> context;
     {
         IceUtil::Mutex::Lock sync(_mutex);
-        session = ICE_MAKE_SHARED(SessionHelperI,
-                                  ICE_MAKE_SHARED(SessionThreadCallback, ICE_SHARED_FROM_THIS),
-                                  _callback,
-                                  createInitData(),
-                                  getRouterFinderStr(),
-                                  _useCallbacks);
+        session = make_shared<SessionHelperI>(make_shared<SessionThreadCallback>(shared_from_this()),
+                                              _callback,
+                                              createInitData(),
+                                              getRouterFinderStr(),
+                                              _useCallbacks);
         context = _context;
     }
     session->connect(context);
@@ -1070,12 +1069,11 @@ Glacier2::SessionFactoryHelper::connect(const string& user,  const string& passw
     map<string, string> context;
     {
         IceUtil::Mutex::Lock sync(_mutex);
-        session = ICE_MAKE_SHARED(SessionHelperI,
-                                  ICE_MAKE_SHARED(SessionThreadCallback, ICE_SHARED_FROM_THIS),
-                                  _callback,
-                                  createInitData(),
-                                  getRouterFinderStr(),
-                                  _useCallbacks);
+        session = make_shared<SessionHelperI>(make_shared<SessionThreadCallback>(shared_from_this()),
+                                              _callback,
+                                              createInitData(),
+                                              getRouterFinderStr(),
+                                              _useCallbacks);
         context = _context;
     }
     session->connect(user, password, _context);

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -739,7 +739,7 @@ SessionHelperI::connected(const Glacier2::RouterPrxPtr& router, const Glacier2::
             {
                 Ice::ConnectionPtr connection = _router->ice_getCachedConnection();
                 assert(connection);
-                connection->setACM(acmTimeout, IceUtil::None, Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                connection->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
                 auto self = shared_from_this();
                 connection->setCloseCallback([self](Ice::ConnectionPtr)
                 {
@@ -1122,7 +1122,7 @@ string
 Glacier2::SessionFactoryHelper::createProxyStr(const Ice::Identity& ident)
 {
     ostringstream os;
-    os << "\"" << identityToString(ident, Ice::ICE_ENUM(ToStringMode, Unicode)) << "\":" << _protocol
+    os << "\"" << identityToString(ident, Ice::ToStringMode::Unicode) << "\":" << _protocol
        << " -p " << getPortInternal() << " -h \"" << _routerHost << "\"";
 
     if(_timeout > 0)

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -480,7 +480,7 @@ public:
         _callback(callback),
         _session(session)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+        _ex = ex.ice_clone();
     }
 
     virtual void

--- a/cpp/src/Ice/ACM.cpp
+++ b/cpp/src/Ice/ACM.cpp
@@ -107,8 +107,8 @@ IceInternal::FactoryACMMonitor::destroy()
     //
     if(!_connections.empty())
     {
-        _instance->timer()->cancel(ICE_SHARED_FROM_THIS);
-        _instance->timer()->schedule(ICE_SHARED_FROM_THIS, IceUtil::Time());
+        _instance->timer()->cancel(shared_from_this());
+        _instance->timer()->schedule(shared_from_this(), IceUtil::Time());
     }
 
     _instance = 0;
@@ -135,7 +135,7 @@ IceInternal::FactoryACMMonitor::add(const ConnectionIPtr& connection)
     if(_connections.empty())
     {
         _connections.insert(connection);
-        _instance->timer()->scheduleRepeated(ICE_SHARED_FROM_THIS, _config.timeout / 2);
+        _instance->timer()->scheduleRepeated(shared_from_this(), _config.timeout / 2);
     }
     else
     {
@@ -184,7 +184,7 @@ IceInternal::FactoryACMMonitor::acm(const IceUtil::Optional<int>& timeout,
     {
         config.heartbeat = *heartbeat;
     }
-    return ICE_MAKE_SHARED(ConnectionACMMonitor, ICE_SHARED_FROM_THIS, _instance->timer(), config);
+    return make_shared<ConnectionACMMonitor>(shared_from_this(), _instance->timer(), config);
 }
 
 Ice::ACM
@@ -231,7 +231,7 @@ IceInternal::FactoryACMMonitor::runTimerTask()
 
         if(_connections.empty())
         {
-            _instance->timer()->cancel(ICE_SHARED_FROM_THIS);
+            _instance->timer()->cancel(shared_from_this());
             return;
         }
     }
@@ -304,7 +304,7 @@ IceInternal::ConnectionACMMonitor::add(const ConnectionIPtr& connection)
     _connection = connection;
     if(_config.timeout != IceUtil::Time())
     {
-        _timer->scheduleRepeated(ICE_SHARED_FROM_THIS, _config.timeout / 2);
+        _timer->scheduleRepeated(shared_from_this(), _config.timeout / 2);
     }
 }
 
@@ -318,7 +318,7 @@ IceInternal::ConnectionACMMonitor::remove(ICE_MAYBE_UNUSED const ConnectionIPtr&
     assert(_connection == connection);
     if(_config.timeout != IceUtil::Time())
     {
-        _timer->cancel(ICE_SHARED_FROM_THIS);
+        _timer->cancel(shared_from_this());
     }
     _connection = 0;
 }

--- a/cpp/src/Ice/ACM.cpp
+++ b/cpp/src/Ice/ACM.cpp
@@ -15,8 +15,8 @@ using namespace IceInternal;
 
 IceInternal::ACMConfig::ACMConfig(bool server) :
     timeout(IceUtil::Time::seconds(60)),
-    heartbeat(ICE_ENUM(ACMHeartbeat, HeartbeatOnDispatch)),
-    close(server ? ICE_ENUM(ACMClose, CloseOnInvocation) : ICE_ENUM(ACMClose, CloseOnInvocationAndIdle))
+    heartbeat(ACMHeartbeat::HeartbeatOnDispatch),
+    close(server ? ACMClose::CloseOnInvocation : ACMClose::CloseOnInvocationAndIdle)
 {
 }
 
@@ -47,8 +47,8 @@ IceInternal::ACMConfig::ACMConfig(const Ice::PropertiesPtr& p,
     }
 
     int hb = p->getPropertyAsIntWithDefault(prefix + ".Heartbeat", static_cast<int>(dflt.heartbeat));
-    if(hb >= static_cast<int>(ICE_ENUM(ACMHeartbeat, HeartbeatOff)) &&
-       hb <= static_cast<int>(ICE_ENUM(ACMHeartbeat, HeartbeatAlways)))
+    if(hb >= static_cast<int>(ACMHeartbeat::HeartbeatOff) &&
+       hb <= static_cast<int>(ACMHeartbeat::HeartbeatAlways))
     {
         heartbeat = static_cast<Ice::ACMHeartbeat>(hb);
     }
@@ -59,8 +59,8 @@ IceInternal::ACMConfig::ACMConfig(const Ice::PropertiesPtr& p,
     }
 
     int cl = p->getPropertyAsIntWithDefault(prefix + ".Close", static_cast<int>(dflt.close));
-    if(cl >= static_cast<int>(ICE_ENUM(ACMClose, CloseOff)) &&
-       cl <= static_cast<int>(ICE_ENUM(ACMClose, CloseOnIdleForceful)))
+    if(cl >= static_cast<int>(ACMClose::CloseOff) &&
+       cl <= static_cast<int>(ACMClose::CloseOnIdleForceful))
     {
         close = static_cast<Ice::ACMClose>(cl);
     }

--- a/cpp/src/Ice/Application.cpp
+++ b/cpp/src/Ice/Application.cpp
@@ -41,7 +41,7 @@ namespace
 // Variables than can change while run() and communicator->destroy() are running!
 //
 bool _released = true;
-CtrlCHandlerCallback _previousCallback = ICE_NULLPTR;
+CtrlCHandlerCallback _previousCallback = nullptr;
 
 //
 // Variables that are immutable during run() and until communicator->destroy() has returned;
@@ -73,7 +73,7 @@ Ice::Application::main(int argc, const char* const argv[], ICE_CONFIG_FILE_STRIN
 
     if(argc > 0 && argv[0] && ICE_DYNAMIC_CAST(LoggerI, getProcessLogger()))
     {
-        setProcessLogger(ICE_MAKE_SHARED(LoggerI, argv[0], "", true));
+        setProcessLogger(make_shared<LoggerI>(argv[0], "", true));
     }
 
     InitializationData initData;
@@ -129,7 +129,7 @@ Ice::Application::main(int argc, const char* const argv[], const InitializationD
         const bool convert = initializationData.properties ?
             initializationData.properties->getPropertyAsIntWithDefault("Ice.LogStdErr.Convert", 1) > 0 &&
             initializationData.properties->getProperty("Ice.StdErr").empty() : true;
-        setProcessLogger(ICE_MAKE_SHARED(LoggerI, argv[0], "", convert));
+        setProcessLogger(make_shared<LoggerI>(argv[0], "", convert));
     }
 
     if(_communicator != 0)
@@ -413,7 +413,7 @@ Ice::Application::doMain(int argc, char* argv[], const InitializationData& initD
                 initData.properties->getPropertyAsIntWithDefault("Ice.LogStdErr.Convert", 1) > 0 &&
                 initData.properties->getProperty("Ice.StdErr").empty();
 
-            setProcessLogger(ICE_MAKE_SHARED(LoggerI, initData.properties->getProperty("Ice.ProgramName"), "", convert));
+            setProcessLogger(make_shared<LoggerI>(initData.properties->getProperty("Ice.ProgramName"), "", convert));
         }
 
         _communicator = initialize(argc, argv, initData, version);
@@ -508,7 +508,7 @@ Ice::Application::doMain(int argc, char* argv[], const InitializationData& initD
 void
 Ice::Application::holdInterruptCallback(int signal)
 {
-    CtrlCHandlerCallback callback = ICE_NULLPTR;
+    CtrlCHandlerCallback callback = nullptr;
     {
         Mutex::Lock lock(_mutex);
         while(!_released)

--- a/cpp/src/Ice/Application.cpp
+++ b/cpp/src/Ice/Application.cpp
@@ -31,7 +31,7 @@ bool Ice::Application::_interrupted = false;
 
 string Ice::Application::_appName;
 Ice::CommunicatorPtr Ice::Application::_communicator;
-Ice::SignalPolicy Ice::Application::_signalPolicy = ICE_ENUM(SignalPolicy, HandleSignals);
+Ice::SignalPolicy Ice::Application::_signalPolicy = SignalPolicy::HandleSignals;
 Ice::Application* Ice::Application::_application = 0;
 
 namespace
@@ -177,7 +177,7 @@ Ice::Application::main(int argc, const char* const argv[], const InitializationD
 
     _application = this;
 
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         try
         {
@@ -244,7 +244,7 @@ Ice::Application::communicator()
 void
 Ice::Application::destroyOnInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -267,7 +267,7 @@ Ice::Application::destroyOnInterrupt()
 void
 Ice::Application::shutdownOnInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -290,7 +290,7 @@ Ice::Application::shutdownOnInterrupt()
 void
 Ice::Application::ignoreInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -313,7 +313,7 @@ Ice::Application::ignoreInterrupt()
 void
 Ice::Application::callbackOnInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -336,7 +336,7 @@ Ice::Application::callbackOnInterrupt()
 void
 Ice::Application::holdInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -359,7 +359,7 @@ Ice::Application::holdInterrupt()
 void
 Ice::Application::releaseInterrupt()
 {
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         if(_ctrlCHandler != 0)
         {
@@ -422,7 +422,7 @@ Ice::Application::doMain(int argc, char* argv[], const InitializationData& initD
         //
         // The default is to destroy when a signal is received.
         //
-        if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+        if(_signalPolicy == SignalPolicy::HandleSignals)
         {
             destroyOnInterrupt();
         }
@@ -465,7 +465,7 @@ Ice::Application::doMain(int argc, char* argv[], const InitializationData& initD
     // it would not make sense to release a held signal to run
     // shutdown or destroy.
     //
-    if(_signalPolicy == ICE_ENUM(SignalPolicy, HandleSignals))
+    if(_signalPolicy == SignalPolicy::HandleSignals)
     {
         ignoreInterrupt();
     }

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -80,7 +80,7 @@ CollocatedRequestHandler::~CollocatedRequestHandler()
 RequestHandlerPtr
 CollocatedRequestHandler::update(const RequestHandlerPtr& previousHandler, const RequestHandlerPtr& newHandler)
 {
-    return previousHandler.get() == this ? newHandler : ICE_SHARED_FROM_THIS;
+    return previousHandler.get() == this ? newHandler : shared_from_this();
 }
 
 AsyncStatus
@@ -145,7 +145,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         //
         // This will throw if the request is canceled
         //
-        outAsync->cancelable(ICE_SHARED_FROM_THIS);
+        outAsync->cancelable(shared_from_this());
 
         if(_response)
         {
@@ -168,7 +168,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         // Don't invoke from the user thread if async or invocation timeout is set
         _adapter->getThreadPool()->dispatch(new InvokeAllAsync(ICE_GET_SHARED_FROM_THIS(outAsync),
                                                                outAsync->getOs(),
-                                                               ICE_SHARED_FROM_THIS,
+                                                               shared_from_this(),
                                                                requestId,
                                                                batchRequestNum));
     }
@@ -176,7 +176,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
     {
         _adapter->getThreadPool()->dispatchFromThisThread(new InvokeAllAsync(ICE_GET_SHARED_FROM_THIS(outAsync),
                                                                              outAsync->getOs(),
-                                                                             ICE_SHARED_FROM_THIS,
+                                                                             shared_from_this(),
                                                                              requestId,
                                                                              batchRequestNum));
     }
@@ -188,7 +188,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         // if a retry occurs.
         //
 
-        CollocatedRequestHandlerPtr self(ICE_SHARED_FROM_THIS);
+        CollocatedRequestHandlerPtr self(shared_from_this());
         if(sentAsync(outAsync))
         {
             invokeAll(outAsync->getOs(), requestId, batchRequestNum);

--- a/cpp/src/Ice/CollocatedRequestHandler.h
+++ b/cpp/src/Ice/CollocatedRequestHandler.h
@@ -77,7 +77,7 @@ private:
     std::map<OutgoingAsyncBasePtr, Ice::Int> _sendAsyncRequests;
     std::map<Ice::Int, OutgoingAsyncBasePtr> _asyncRequests;
 };
-ICE_DEFINE_PTR(CollocatedRequestHandlerPtr, CollocatedRequestHandler);
+using CollocatedRequestHandlerPtr = std::shared_ptr<CollocatedRequestHandler>;
 
 }
 

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -127,11 +127,11 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
         }
         else
         {
-            if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, Yes))
+            if(compressBatch == CompressBatch::Yes)
             {
                 compress = true;
             }
-            else if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, No))
+            else if(compressBatch == CompressBatch::No)
             {
                 compress = false;
             }

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -118,7 +118,7 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
 
     try
     {
-        OutgoingAsyncBasePtr flushBatch = ICE_MAKE_SHARED(FlushBatch, ICE_SHARED_FROM_THIS, _instance, _observer);
+        OutgoingAsyncBasePtr flushBatch = make_shared<FlushBatch>(shared_from_this(), _instance, _observer);
         bool compress;
         int batchRequestNum = con->getBatchRequestQueue()->swap(flushBatch->getOs(), compress);
         if(batchRequestNum == 0)
@@ -149,8 +149,8 @@ void
 CommunicatorFlushBatchAsync::invoke(const string& operation, CompressBatch compressBatch)
 {
     _observer.attach(_instance.get(), operation);
-    _instance->outgoingConnectionFactory()->flushAsyncBatchRequests(ICE_SHARED_FROM_THIS, compressBatch);
-    _instance->objectAdapterFactory()->flushAsyncBatchRequests(ICE_SHARED_FROM_THIS, compressBatch);
+    _instance->outgoingConnectionFactory()->flushAsyncBatchRequests(shared_from_this(), compressBatch);
+    _instance->objectAdapterFactory()->flushAsyncBatchRequests(shared_from_this(), compressBatch);
     check(true);
 }
 
@@ -261,7 +261,7 @@ Ice::CommunicatorI::identityToString(const Identity& ident) const
 ObjectAdapterPtr
 Ice::CommunicatorI::createObjectAdapter(const string& name)
 {
-    return _instance->objectAdapterFactory()->createObjectAdapter(name, ICE_NULLPTR);
+    return _instance->objectAdapterFactory()->createObjectAdapter(name, nullptr);
 }
 
 ObjectAdapterPtr
@@ -274,7 +274,7 @@ Ice::CommunicatorI::createObjectAdapterWithEndpoints(const string& name, const s
     }
 
     getProperties()->setProperty(oaName + ".Endpoints", endpoints);
-    return _instance->objectAdapterFactory()->createObjectAdapter(oaName, ICE_NULLPTR);
+    return _instance->objectAdapterFactory()->createObjectAdapter(oaName, nullptr);
 }
 
 ObjectAdapterPtr
@@ -443,7 +443,7 @@ Ice::CommunicatorI::findAllAdminFacets()
 CommunicatorIPtr
 Ice::CommunicatorI::create(const InitializationData& initData)
 {
-    Ice::CommunicatorIPtr communicator = ICE_MAKE_SHARED(CommunicatorI);
+    Ice::CommunicatorIPtr communicator = make_shared<CommunicatorI>();
     try
     {
         const_cast<InstancePtr&>(communicator->_instance) = new Instance(communicator, initData);
@@ -477,7 +477,7 @@ Ice::CommunicatorI::finishSetup(int& argc, const char* argv[])
 {
     try
     {
-        _instance->finishSetup(argc, argv, ICE_SHARED_FROM_THIS);
+        _instance->finishSetup(argc, argv, shared_from_this());
     }
     catch(...)
     {

--- a/cpp/src/Ice/CommunicatorI.h
+++ b/cpp/src/Ice/CommunicatorI.h
@@ -49,7 +49,7 @@ namespace Ice
 {
 
 class CommunicatorI;
-ICE_DEFINE_PTR(CommunicatorIPtr, CommunicatorI);
+using CommunicatorIPtr = std::shared_ptr<CommunicatorI>;
 
 class CommunicatorI : public Communicator, public std::enable_shared_from_this<CommunicatorI>
 {

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -33,13 +33,13 @@ ConnectRequestHandler::connect(const Ice::ObjectPrxPtr& proxy)
     {
         _proxies.insert(proxy);
     }
-    return _requestHandler ? _requestHandler : ICE_SHARED_FROM_THIS;
+    return _requestHandler ? _requestHandler : shared_from_this();
 }
 
 RequestHandlerPtr
 ConnectRequestHandler::update(const RequestHandlerPtr& previousHandler, const RequestHandlerPtr& newHandler)
 {
-    return previousHandler.get() == this ? newHandler : ICE_SHARED_FROM_THIS;
+    return previousHandler.get() == this ? newHandler : shared_from_this();
 }
 
 AsyncStatus
@@ -49,7 +49,7 @@ ConnectRequestHandler::sendAsyncRequest(const ProxyOutgoingAsyncBasePtr& out)
         Lock sync(*this);
         if(!_initialized)
         {
-            out->cancelable(ICE_SHARED_FROM_THIS); // This will throw if the request is canceled
+            out->cancelable(shared_from_this()); // This will throw if the request is canceled
         }
 
         if(!initialized())
@@ -107,7 +107,7 @@ ConnectRequestHandler::getConnection()
     {
         _exception->ice_throw();
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::ConnectionIPtr
@@ -152,7 +152,7 @@ ConnectRequestHandler::setConnection(const Ice::ConnectionIPtr& connection, bool
     // add this proxy to the router info object.
     //
     RouterInfoPtr ri = _reference->getRouterInfo();
-    if(ri && !ri->addProxy(_proxy, ICE_SHARED_FROM_THIS))
+    if(ri && !ri->addProxy(_proxy, shared_from_this()))
     {
         return; // The request handler will be initialized once addProxy returns.
     }
@@ -180,7 +180,7 @@ ConnectRequestHandler::setException(const Ice::LocalException& ex)
     //
     try
     {
-        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
     }
     catch(const Ice::CommunicatorDestroyedException&)
     {
@@ -285,7 +285,7 @@ ConnectRequestHandler::flushRequests()
             ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.get()->ice_clone());
 
             // Remove the request handler before retrying.
-            _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+            _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
 
             req->retryException(*exception);
         }
@@ -309,10 +309,10 @@ ConnectRequestHandler::flushRequests()
     //
     if(_reference->getCacheConnection() && !exception)
     {
-        _requestHandler = ICE_MAKE_SHARED(ConnectionRequestHandler, _reference, _connection, _compress);
+        _requestHandler = make_shared<ConnectionRequestHandler>(_reference, _connection, _compress);
         for(set<Ice::ObjectPrxPtr>::const_iterator p = _proxies.begin(); p != _proxies.end(); ++p)
         {
-            (*p)->_updateRequestHandler(ICE_SHARED_FROM_THIS, _requestHandler);
+            (*p)->_updateRequestHandler(shared_from_this(), _requestHandler);
         }
     }
 
@@ -327,10 +327,10 @@ ConnectRequestHandler::flushRequests()
         // Only remove once all the requests are flushed to
         // guarantee serialization.
         //
-        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, ICE_SHARED_FROM_THIS);
+        _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
 
         _proxies.clear();
-        _proxy = ICE_NULLPTR; // Break cyclic reference count.
+        _proxy = nullptr; // Break cyclic reference count.
         notifyAll();
     }
 }

--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -170,7 +170,7 @@ ConnectRequestHandler::setException(const Ice::LocalException& ex)
         Lock sync(*this);
         assert(!_flushing && !_initialized && !_exception);
         _flushing = true; // Ensures request handler is removed before processing new requests.
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
     }
 
     //
@@ -282,7 +282,7 @@ ConnectRequestHandler::flushRequests()
         }
         catch(const RetryException& ex)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.get()->ice_clone());
+            exception = ex.get()->ice_clone();
 
             // Remove the request handler before retrying.
             _reference->getInstance()->requestHandlerFactory()->removeRequestHandler(_reference, shared_from_this());
@@ -291,7 +291,7 @@ ConnectRequestHandler::flushRequests()
         }
         catch(const Ice::LocalException& ex)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(exception, ex.ice_clone());
+            exception = ex.ice_clone();
 
             if(req->exception(ex))
             {

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1335,7 +1335,7 @@ IceInternal::IncomingConnectionFactory::startAsync(SocketOperation)
     }
     catch(const Ice::LocalException& ex)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_acceptorException, ex.ice_clone());
+        _acceptorException = ex.ice_clone();
         _acceptor->getNativeInfo()->completed(SocketOperationRead);
     }
     return true;

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -125,7 +125,7 @@ private:
         std::vector<ConnectorInfo> _connectors;
         std::vector<ConnectorInfo>::const_iterator _iter;
     };
-    ICE_DEFINE_PTR(ConnectCallbackPtr, ConnectCallback);
+    using ConnectCallbackPtr = std::shared_ptr<ConnectCallback>;
     friend class ConnectCallback;
 
     std::vector<EndpointIPtr> applyOverrides(const std::vector<EndpointIPtr>&);

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2192,7 +2192,7 @@ Ice::ConnectionI::setState(State state, const LocalException& ex)
         // If we are in closed state, an exception must be set.
         //
         assert(_state != StateClosed);
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
         //
         // We don't warn if we are not validated.
         //

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -186,11 +186,11 @@ ConnectionFlushBatchAsync::invoke(const string& operation, Ice::CompressBatch co
         }
         else
         {
-            if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, Yes))
+            if(compressBatch == CompressBatch::Yes)
             {
                 compress = true;
             }
-            else if(compressBatch == ICE_SCOPED_ENUM(CompressBatch, No))
+            else if(compressBatch == CompressBatch::No)
             {
                 compress = false;
             }
@@ -488,17 +488,17 @@ Ice::ConnectionI::close(ConnectionClose mode) noexcept
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
 
-    if(mode == ICE_SCOPED_ENUM(ConnectionClose, Forcefully))
+    if(mode == ConnectionClose::Forcefully)
     {
         setState(StateClosed, ConnectionManuallyClosedException(__FILE__, __LINE__, false));
     }
-    else if(mode == ICE_SCOPED_ENUM(ConnectionClose, Gracefully))
+    else if(mode == ConnectionClose::Gracefully)
     {
         setState(StateClosing, ConnectionManuallyClosedException(__FILE__, __LINE__, true));
     }
     else
     {
-        assert(mode == ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        assert(mode == ConnectionClose::GracefullyWithWait);
 
         //
         // Wait until all outstanding requests have been completed.
@@ -636,11 +636,11 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
     // per timeout period because the monitor() method is still only
     // called every (timeout / 2) period.
     //
-    if(acm.heartbeat == ICE_ENUM(ACMHeartbeat, HeartbeatAlways) ||
-       (acm.heartbeat != ICE_ENUM(ACMHeartbeat, HeartbeatOff) &&
+    if(acm.heartbeat == ACMHeartbeat::HeartbeatAlways ||
+       (acm.heartbeat != ACMHeartbeat::HeartbeatOff &&
         _writeStream.b.empty() && now >= (_acmLastActivity + acm.timeout / 4)))
     {
-        if(acm.heartbeat != ICE_ENUM(ACMHeartbeat, HeartbeatOnDispatch) || _dispatchCount > 0)
+        if(acm.heartbeat != ACMHeartbeat::HeartbeatOnDispatch || _dispatchCount > 0)
         {
             sendHeartbeatNow();
         }
@@ -657,10 +657,10 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
         return;
     }
 
-    if(acm.close != ICE_ENUM(ACMClose, CloseOff) && now >= (_acmLastActivity + acm.timeout))
+    if(acm.close != ACMClose::CloseOff && now >= (_acmLastActivity + acm.timeout))
     {
-        if(acm.close == ICE_ENUM(ACMClose, CloseOnIdleForceful) ||
-           (acm.close != ICE_ENUM(ACMClose, CloseOnIdle) && !_asyncRequests.empty()))
+        if(acm.close == ACMClose::CloseOnIdleForceful ||
+           (acm.close != ACMClose::CloseOnIdle && !_asyncRequests.empty()))
         {
             //
             // Close the connection if we didn't receive a heartbeat in
@@ -668,7 +668,7 @@ Ice::ConnectionI::monitor(const IceUtil::Time& now, const ACMConfig& acm)
             //
             setState(StateClosed, ConnectionTimeoutException(__FILE__, __LINE__));
         }
-        else if(acm.close != ICE_ENUM(ACMClose, CloseOnInvocation) &&
+        else if(acm.close != ACMClose::CloseOnInvocation &&
                 _dispatchCount == 0 && _batchRequestQueue->isEmpty() && _asyncRequests.empty())
         {
             //
@@ -1015,8 +1015,8 @@ Ice::ConnectionI::getACM() noexcept
     IceUtil::Monitor<IceUtil::Mutex>::Lock sync(*this);
     ACM acm;
     acm.timeout = 0;
-    acm.close = ICE_ENUM(ACMClose, CloseOff);
-    acm.heartbeat = ICE_ENUM(ACMHeartbeat, HeartbeatOff);
+    acm.close = ACMClose::CloseOff;
+    acm.heartbeat = ACMHeartbeat::HeartbeatOff;
     return _monitor ? _monitor->getACM() : acm;
 }
 

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -156,8 +156,8 @@ public:
                             ::std::function<void(::std::exception_ptr)>,
                             ::std::function<void(bool)> = nullptr);
 
-    virtual void setCloseCallback(ICE_IN(ICE_DELEGATE(CloseCallback)));
-    virtual void setHeartbeatCallback(ICE_IN(ICE_DELEGATE(HeartbeatCallback)));
+    virtual void setCloseCallback(CloseCallback);
+    virtual void setHeartbeatCallback(HeartbeatCallback);
 
     virtual void heartbeat();
 
@@ -212,10 +212,11 @@ public:
     void dispatch(const StartCallbackPtr&, const std::vector<OutgoingMessage>&, Byte, Int, Int,
                   const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&,
                   const IceInternal::OutgoingAsyncBasePtr&,
-                  const ICE_DELEGATE(HeartbeatCallback)&, Ice::InputStream&);
+                  const HeartbeatCallback&,
+                  Ice::InputStream&);
     void finish(bool);
 
-    void closeCallback(const ICE_DELEGATE(CloseCallback)&);
+    void closeCallback(const CloseCallback&);
 
     virtual ~ConnectionI();
 
@@ -263,7 +264,7 @@ private:
 
     IceInternal::SocketOperation parseMessage(Ice::InputStream&, Int&, Int&, Byte&,
                                               IceInternal::ServantManagerPtr&, ObjectAdapterPtr&,
-                                              IceInternal::OutgoingAsyncBasePtr&, ICE_DELEGATE(HeartbeatCallback)&, int&);
+                                              IceInternal::OutgoingAsyncBasePtr&, HeartbeatCallback&, int&);
 
     void invokeAll(Ice::InputStream&, Int, Int, Byte,
                    const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&);
@@ -338,8 +339,8 @@ private:
     bool _initialized;
     bool _validated;
 
-    ICE_DELEGATE(CloseCallback) _closeCallback;
-    ICE_DELEGATE(HeartbeatCallback) _heartbeatCallback;
+    CloseCallback _closeCallback;
+    HeartbeatCallback _heartbeatCallback;
 };
 
 }

--- a/cpp/src/Ice/ConnectionRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectionRequestHandler.cpp
@@ -45,7 +45,7 @@ ConnectionRequestHandler::update(const RequestHandlerPtr& previousHandler, const
     {
         // Ignore.
     }
-    return ICE_SHARED_FROM_THIS;
+    return shared_from_this();
 }
 
 AsyncStatus

--- a/cpp/src/Ice/DefaultsAndOverrides.cpp
+++ b/cpp/src/Ice/DefaultsAndOverrides.cpp
@@ -104,11 +104,11 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
     value = properties->getPropertyWithDefault("Ice.Default.EndpointSelection", "Random");
     if(value == "Random")
     {
-        defaultEndpointSelection = ICE_ENUM(EndpointSelectionType, Random);
+        defaultEndpointSelection = EndpointSelectionType::Random;
     }
     else if(value == "Ordered")
     {
-        defaultEndpointSelection = ICE_ENUM(EndpointSelectionType, Ordered);
+        defaultEndpointSelection = EndpointSelectionType::Ordered;
     }
     else
     {
@@ -155,5 +155,5 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
 
     bool slicedFormat = properties->getPropertyAsIntWithDefault("Ice.Default.SlicedFormat", 0) > 0;
     const_cast<FormatType&>(defaultFormat) = slicedFormat ?
-        ICE_ENUM(FormatType, SlicedFormat) : ICE_ENUM(FormatType, CompactFormat);
+        FormatType::SlicedFormat : FormatType::CompactFormat;
 }

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -66,7 +66,7 @@ IceInternal::EndpointFactoryManager::get(Short type) const
             return _factories[i];
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 EndpointIPtr
@@ -140,7 +140,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
     //
     if(protocol == "opaque")
     {
-        EndpointIPtr ue = ICE_MAKE_SHARED(OpaqueEndpointI, v);
+        EndpointIPtr ue = make_shared<OpaqueEndpointI>(v);
         if(!v.empty())
         {
             throw EndpointParseException(__FILE__, __LINE__, "unrecognized argument `" + v.front() + "' in endpoint `" +
@@ -168,7 +168,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
         return ue; // Endpoint is opaque, but we don't have a factory for its type.
     }
 
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 EndpointIPtr
@@ -194,7 +194,7 @@ IceInternal::EndpointFactoryManager::read(InputStream* s) const
     //
     if(!e)
     {
-        e = ICE_MAKE_SHARED(OpaqueEndpointI, type, s);
+        e = make_shared<OpaqueEndpointI>(type, s);
     }
 
     s->endEncapsulation();

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -100,7 +100,7 @@ Ice::UserException::ice_clone() const
 Ice::SlicedDataPtr
 Ice::UserException::ice_getSlicedData() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -306,7 +306,7 @@ void
 Ice::IllegalIdentityException::ice_print(ostream& out) const
 {
     Exception::ice_print(out);
-    out << ":\nillegal identity: `" << identityToString(id, ICE_ENUM(ToStringMode, Unicode)) << "'";
+    out << ":\nillegal identity: `" << identityToString(id, ToStringMode::Unicode) << "'";
 }
 
 void
@@ -319,7 +319,7 @@ Ice::IllegalServantException::ice_print(ostream& out) const
 static void
 printFailedRequestData(ostream& out, const RequestFailedException& ex)
 {
-    out << ":\nidentity: `" << identityToString(ex.id, ICE_ENUM(ToStringMode, Unicode)) << "'";
+    out << ":\nidentity: `" << identityToString(ex.id, ToStringMode::Unicode) << "'";
     out << "\nfacet: " << ex.facet;
     out << "\noperation: " << ex.operation;
 }

--- a/cpp/src/Ice/FactoryTable.cpp
+++ b/cpp/src/Ice/FactoryTable.cpp
@@ -12,7 +12,7 @@ using namespace std;
 // If the factory is present already, increment its reference count.
 //
 void
-IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(ICE_DELEGATE(::Ice::UserExceptionFactory)) f)
+IceInternal::FactoryTable::addExceptionFactory(const string& t, Ice::UserExceptionFactory f)
 {
     IceUtil::Mutex::Lock lock(_m);
     assert(f);
@@ -30,12 +30,12 @@ IceInternal::FactoryTable::addExceptionFactory(const string& t, ICE_IN(ICE_DELEG
 //
 // Return the exception factory for a given type ID
 //
-ICE_DELEGATE(::Ice::UserExceptionFactory)
+Ice::UserExceptionFactory
 IceInternal::FactoryTable::getExceptionFactory(const string& t) const
 {
     IceUtil::Mutex::Lock lock(_m);
     EFTable::const_iterator i = _eft.find(t);
-    return i != _eft.end() ? i->second.first : ICE_DELEGATE(::Ice::UserExceptionFactory)();
+    return i != _eft.end() ? i->second.first : Ice::UserExceptionFactory();
 }
 
 //

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -148,7 +148,7 @@ IceInternal::IPEndpointI::expandHost(EndpointIPtr& publish) const
     vector<Address> addrs = getAddresses(_host,
                                          _port,
                                          _instance->protocolSupport(),
-                                         Ice::ICE_ENUM(EndpointSelectionType, Ordered),
+                                         Ice::EndpointSelectionType::Ordered,
                                          _instance->preferIPv6(),
                                          true);
 

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -47,7 +47,7 @@ IceInternal::IPEndpointInfoI::secure() const noexcept
 Ice::EndpointInfoPtr
 IceInternal::IPEndpointI::getInfo() const noexcept
 {
-    Ice::IPEndpointInfoPtr info = ICE_MAKE_SHARED(IPEndpointInfoI, ICE_SHARED_FROM_CONST_THIS(IPEndpointI));
+    Ice::IPEndpointInfoPtr info = make_shared<IPEndpointInfoI>(ICE_SHARED_FROM_CONST_THIS(IPEndpointI));
     fillEndpointInfo(info.get());
     return info;
 }

--- a/cpp/src/Ice/ImplicitContextI.cpp
+++ b/cpp/src/Ice/ImplicitContextI.cpp
@@ -110,11 +110,11 @@ ImplicitContextI::create(const std::string& kind)
     }
     else if(kind == "Shared")
     {
-        return ICE_MAKE_SHARED(SharedImplicitContext);
+        return std::make_shared<SharedImplicitContext>();
     }
     else if(kind == "PerThread")
     {
-        return ICE_MAKE_SHARED(PerThreadImplicitContext);
+        return std::make_shared<PerThreadImplicitContext>();
     }
     else
     {

--- a/cpp/src/Ice/ImplicitContextI.h
+++ b/cpp/src/Ice/ImplicitContextI.h
@@ -14,7 +14,7 @@ namespace Ice
 // The base class for all ImplicitContext implementations
 //
 class ImplicitContextI;
-ICE_DEFINE_PTR(ImplicitContextIPtr,ImplicitContextI);
+using ImplicitContextIPtr = std::shared_ptr<ImplicitContextI>;
 
 class ImplicitContextI : public ImplicitContext
 {
@@ -42,7 +42,7 @@ public:
 
 };
 
-ICE_DEFINE_PTR(ImplicitContextIPtr, ImplicitContextI);
+using ImplicitContextIPtr = std::shared_ptr<ImplicitContextI>;
 
 }
 #endif

--- a/cpp/src/Ice/Incoming.cpp
+++ b/cpp/src/Ice/Incoming.cpp
@@ -45,7 +45,7 @@ IceInternal::IncomingBase::IncomingBase(Instance* instance, ResponseHandler* res
                                         bool response, Byte compress, Int requestId) :
     _response(response),
     _compress(compress),
-    _format(Ice::ICE_ENUM(FormatType, DefaultFormat)),
+    _format(Ice::FormatType::DefaultFormat),
     _os(instance, Ice::currentProtocolEncoding),
     _responseHandler(responseHandler)
 {

--- a/cpp/src/Ice/Initialize.cpp
+++ b/cpp/src/Ice/Initialize.cpp
@@ -143,13 +143,13 @@ Ice::stringSeqToArgs(const StringSeq& args, int& argc, const wchar_t* argv[])
 PropertiesPtr
 Ice::createProperties()
 {
-    return ICE_MAKE_SHARED(PropertiesI);
+    return make_shared<PropertiesI>();
 }
 
 PropertiesPtr
 Ice::createProperties(StringSeq& args, const PropertiesPtr& defaults)
 {
-    return ICE_MAKE_SHARED(PropertiesI, args, defaults);
+    return make_shared<PropertiesI>(args, defaults);
 }
 
 PropertiesPtr
@@ -333,12 +333,12 @@ Ice::getProcessLogger()
 {
     lock_guard lock(globalMutex);
 
-    if(processLogger == ICE_NULLPTR)
+    if(processLogger == nullptr)
     {
        //
        // TODO: Would be nice to be able to use process name as prefix by default.
        //
-       processLogger = ICE_MAKE_SHARED(LoggerI, "", "", true);
+       processLogger = make_shared<LoggerI>("", "", true);
     }
     return processLogger;
 }
@@ -402,7 +402,7 @@ Ice::CommunicatorHolder::~CommunicatorHolder()
 
 Ice::CommunicatorHolder::operator bool() const
 {
-    return _communicator != ICE_NULLPTR;
+    return _communicator != nullptr;
 }
 
 const Ice::CommunicatorPtr&

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1207,7 +1207,7 @@ Ice::InputStream::readEnum(Int maxValue)
 }
 
 void
-Ice::InputStream::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::throwException(UserExceptionFactory factory)
 {
     initEncaps();
     _currentEncaps->decoder->throwException(factory);
@@ -1586,7 +1586,7 @@ Ice::InputStream::EncapsDecoder::addPatchEntry(Int index, PatchFunc patchFunc, v
     IndexToPtrMap::iterator p = _unmarshaledMap.find(index);
     if(p != _unmarshaledMap.end())
     {
-        if (p->second == ICE_NULLPTR)
+        if (p->second == nullptr)
         {
             assert(!_stream->_instance->acceptClassCycles());
             throw MarshalException(__FILE__, __LINE__, "cycle detected during Value unmarshaling");
@@ -1724,7 +1724,7 @@ Ice::InputStream::EncapsDecoder10::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::EncapsDecoder10::throwException(UserExceptionFactory factory)
 {
     assert(_sliceType == NoSlice);
 
@@ -1746,7 +1746,7 @@ Ice::InputStream::EncapsDecoder10::throwException(ICE_IN(ICE_DELEGATE(UserExcept
     //
     startSlice();
     const string mostDerivedId = _typeId;
-    ICE_DELEGATE(UserExceptionFactory) exceptionFactory = factory;
+    UserExceptionFactory exceptionFactory = factory;
     while(true)
     {
         //
@@ -2049,7 +2049,7 @@ Ice::InputStream::EncapsDecoder11::read(PatchFunc patchFunc, void* patchAddr)
 }
 
 void
-Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(ICE_DELEGATE(UserExceptionFactory)) factory)
+Ice::InputStream::EncapsDecoder11::throwException(UserExceptionFactory factory)
 {
     assert(!_current);
 
@@ -2060,7 +2060,7 @@ Ice::InputStream::EncapsDecoder11::throwException(ICE_IN(ICE_DELEGATE(UserExcept
     //
     startSlice();
     const string mostDerivedId = _current->typeId;
-    ICE_DELEGATE(UserExceptionFactory) exceptionFactory = factory;
+    UserExceptionFactory exceptionFactory = factory;
     while(true)
     {
         //

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1271,37 +1271,37 @@ Ice::InputStream::skipOptional(OptionalFormat type)
 {
     switch(type)
     {
-        case ICE_SCOPED_ENUM(OptionalFormat, F1):
+        case OptionalFormat::F1:
         {
             skip(1);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F2):
+        case OptionalFormat::F2:
         {
             skip(2);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F4):
+        case OptionalFormat::F4:
         {
             skip(4);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, F8):
+        case OptionalFormat::F8:
         {
             skip(8);
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, Size):
+        case OptionalFormat::Size:
         {
             skipSize();
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, VSize):
+        case OptionalFormat::VSize:
         {
             skip(static_cast<size_t>(readSize()));
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, FSize):
+        case OptionalFormat::FSize:
         {
             Int sz;
             read(sz);
@@ -1312,7 +1312,7 @@ Ice::InputStream::skipOptional(OptionalFormat type)
             skip(static_cast<size_t>(sz));
             break;
         }
-        case ICE_SCOPED_ENUM(OptionalFormat, Class):
+        case OptionalFormat::Class:
         {
             read(0, 0);
             break;

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1071,9 +1071,9 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                     throw InitializationException(__FILE__, __LINE__, "Both syslog and file logger cannot be enabled.");
                 }
 
-                _initData.logger = ICE_MAKE_SHARED(SysLoggerI,
-                                                   _initData.properties->getProperty("Ice.ProgramName"),
-                                                   _initData.properties->getPropertyWithDefault("Ice.SyslogFacility", "LOG_USER"));
+                _initData.logger = make_shared<SysLoggerI>(
+                    _initData.properties->getProperty("Ice.ProgramName"),
+                    _initData.properties->getPropertyWithDefault("Ice.SyslogFacility", "LOG_USER"));
             }
             else
 #endif
@@ -1081,8 +1081,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 #ifdef ICE_SWIFT
             if(!_initData.logger && _initData.properties->getPropertyAsInt("Ice.UseOSLog") > 0)
             {
-                _initData.logger = ICE_MAKE_SHARED(OSLogLoggerI,
-                                                   _initData.properties->getProperty("Ice.ProgramName"));
+                _initData.logger = make_shared<OSLogLoggerI>(_initData.properties->getProperty("Ice.ProgramName"));
             }
             else
 #endif
@@ -1090,8 +1089,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 #ifdef ICE_USE_SYSTEMD
             if(_initData.properties->getPropertyAsInt("Ice.UseSystemdJournal") > 0)
             {
-                _initData.logger = ICE_MAKE_SHARED(SystemdJournalI,
-                                                   _initData.properties->getProperty("Ice.ProgramName"));
+                _initData.logger = make_shared<SystemdJournalI>(_initData.properties->getProperty("Ice.ProgramName"));
             }
             else
 #endif
@@ -1102,7 +1100,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                 {
                     sz = 0;
                 }
-                _initData.logger = ICE_MAKE_SHARED(LoggerI, _initData.properties->getProperty("Ice.ProgramName"),
+                _initData.logger = make_shared<LoggerI>(_initData.properties->getProperty("Ice.ProgramName"),
                                                    logfile, true, static_cast<size_t>(sz));
             }
             else
@@ -1110,7 +1108,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
                 _initData.logger = getProcessLogger();
                 if(ICE_DYNAMIC_CAST(LoggerI, _initData.logger))
                 {
-                    _initData.logger = ICE_MAKE_SHARED(LoggerI, _initData.properties->getProperty("Ice.ProgramName"), "", logStdErrConvert);
+                    _initData.logger = make_shared<LoggerI>(_initData.properties->getProperty("Ice.ProgramName"), "", logStdErrConvert);
                 }
             }
         }
@@ -1242,7 +1240,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 
         _dynamicLibraryList = new DynamicLibraryList;
 
-        _pluginManager = ICE_MAKE_SHARED(PluginManagerI, communicator, _dynamicLibraryList);
+        _pluginManager = make_shared<PluginManagerI>(communicator, _dynamicLibraryList);
 
         if(!_initData.valueFactoryManager)
         {
@@ -1251,7 +1249,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
 
         _outgoingConnectionFactory = new OutgoingConnectionFactory(communicator, this);
 
-        _objectAdapterFactory = ICE_MAKE_SHARED(ObjectAdapterFactory, this, communicator);
+        _objectAdapterFactory = make_shared<ObjectAdapterFactory>(this, communicator);
 
         _retryQueue = new RetryQueue(this);
 
@@ -1385,7 +1383,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
         PropertiesAdminIPtr propsAdmin;
         if(_adminFacetFilter.empty() || _adminFacetFilter.find(propertiesFacetName) != _adminFacetFilter.end())
         {
-            propsAdmin = ICE_MAKE_SHARED(PropertiesAdminI, this);
+            propsAdmin = make_shared<PropertiesAdminI>(this);
             _adminFacets.insert(make_pair(propertiesFacetName, propsAdmin));
         }
 

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -923,7 +923,7 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
     _messageSizeMax(0),
     _batchAutoFlushSize(0),
     _classGraphDepthMax(0),
-    _toStringMode(ICE_ENUM(ToStringMode, Unicode)),
+    _toStringMode(ToStringMode::Unicode),
     _acceptClassCycles(false),
     _implicitContext(0),
     _stringConverter(Ice::getProcessStringConverter()),
@@ -1187,11 +1187,11 @@ IceInternal::Instance::Instance(const CommunicatorPtr& communicator, const Initi
         string toStringModeStr = _initData.properties->getPropertyWithDefault("Ice.ToStringMode", "Unicode");
         if(toStringModeStr == "ASCII")
         {
-            const_cast<ToStringMode&>(_toStringMode) = ICE_ENUM(ToStringMode, ASCII);
+            const_cast<ToStringMode&>(_toStringMode) = ToStringMode::ASCII;
         }
         else if(toStringModeStr == "Compat")
         {
-            const_cast<ToStringMode&>(_toStringMode) = ICE_ENUM(ToStringMode, Compat);
+            const_cast<ToStringMode&>(_toStringMode) = ToStringMode::Compat;
         }
         else if(toStringModeStr != "Unicode")
         {

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -452,7 +452,7 @@ IceInternal::LocatorInfo::Request::exception(const Ice::Exception& ex)
         IceUtil::Monitor<IceUtil::Mutex>::Lock sync(_monitor);
         _locatorInfo->finishRequest(_reference, _wellKnownRefs, 0, dynamic_cast<const Ice::UserException*>(&ex));
 
-        ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+        _exception = ex.ice_clone();
         _monitor.notifyAll();
     }
     for(vector<RequestCallbackPtr>::const_iterator p = _callbacks.begin(); p != _callbacks.end(); ++p)

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -519,7 +519,7 @@ IceInternal::LocatorInfo::getLocatorRegistry()
         // endpoint selection in case the locator returned a proxy
         // with some endpoints which are prefered to be tried first.
         //
-        _locatorRegistry = locatorRegistry->ice_locator(0)->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        _locatorRegistry = locatorRegistry->ice_locator(0)->ice_endpointSelection(Ice::EndpointSelectionType::Ordered);
         return _locatorRegistry;
     }
 }

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -197,7 +197,7 @@ filterLogMessages(LogMessageSeq& logMessages, const set<LogMessageType>& message
             bool keepIt = false;
             if(messageTypes.empty() || messageTypes.count(p->type) != 0)
             {
-                if(p->type != ICE_ENUM(LogMessageType, TraceMessage) || traceCategories.empty() ||
+                if(p->type != LogMessageType::TraceMessage || traceCategories.empty() ||
                    traceCategories.count(p->traceCategory) != 0)
                 {
                     keepIt = true;
@@ -494,12 +494,12 @@ LoggerAdminI::log(const LogMessage& logMessage)
     //
     // Put message in _queue
     //
-    if((logMessage.type != ICE_ENUM(LogMessageType, TraceMessage) && _maxLogCount > 0) ||
-       (logMessage.type == ICE_ENUM(LogMessageType, TraceMessage) && _maxTraceCount > 0))
+    if((logMessage.type != LogMessageType::TraceMessage && _maxLogCount > 0) ||
+       (logMessage.type == LogMessageType::TraceMessage && _maxTraceCount > 0))
     {
         list<LogMessage>::iterator p = _queue.insert(_queue.end(), logMessage);
 
-        if(logMessage.type != ICE_ENUM(LogMessageType, TraceMessage))
+        if(logMessage.type != LogMessageType::TraceMessage)
         {
             assert(_maxLogCount > 0);
             if(_logCount == _maxLogCount)
@@ -509,7 +509,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
                 //
                 assert(_oldestLog != _queue.end());
                 _oldestLog = _queue.erase(_oldestLog);
-                while(_oldestLog != _queue.end() && _oldestLog->type == ICE_ENUM(LogMessageType, TraceMessage))
+                while(_oldestLog != _queue.end() && _oldestLog->type == LogMessageType::TraceMessage)
                 {
                     _oldestLog++;
                 }
@@ -535,7 +535,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
                 //
                 assert(_oldestTrace != _queue.end());
                 _oldestTrace = _queue.erase(_oldestTrace);
-                while(_oldestTrace != _queue.end() && _oldestTrace->type != ICE_ENUM(LogMessageType, TraceMessage))
+                while(_oldestTrace != _queue.end() && _oldestTrace->type != LogMessageType::TraceMessage)
                 {
                     _oldestTrace++;
                 }
@@ -561,7 +561,7 @@ LoggerAdminI::log(const LogMessage& logMessage)
 
             if(filters.messageTypes.empty() || filters.messageTypes.count(logMessage.type) != 0)
             {
-                if(logMessage.type != ICE_ENUM(LogMessageType, TraceMessage) || filters.traceCategories.empty() ||
+                if(logMessage.type != LogMessageType::TraceMessage || filters.traceCategories.empty() ||
                    filters.traceCategories.count(logMessage.traceCategory) != 0)
                 {
                     remoteLoggers.push_back(q->first);
@@ -627,7 +627,7 @@ LoggerAdminLoggerI::LoggerAdminLoggerI(const PropertiesPtr& props,
 void
 LoggerAdminLoggerI::print(const string& message)
 {
-   LogMessage logMessage = { ICE_ENUM(LogMessageType, PrintMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+   LogMessage logMessage = { LogMessageType::PrintMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->print(message);
     log(logMessage);
@@ -636,7 +636,7 @@ LoggerAdminLoggerI::print(const string& message)
 void
 LoggerAdminLoggerI::trace(const string& category, const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, TraceMessage), IceUtil::Time::now().toMicroSeconds(), category, message };
+    LogMessage logMessage = { LogMessageType::TraceMessage, IceUtil::Time::now().toMicroSeconds(), category, message };
 
     _localLogger->trace(category, message);
     log(logMessage);
@@ -645,7 +645,7 @@ LoggerAdminLoggerI::trace(const string& category, const string& message)
 void
 LoggerAdminLoggerI::warning(const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, WarningMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+    LogMessage logMessage = { LogMessageType::WarningMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->warning(message);
     log(logMessage);
@@ -654,7 +654,7 @@ LoggerAdminLoggerI::warning(const string& message)
 void
 LoggerAdminLoggerI::error(const string& message)
 {
-    LogMessage logMessage = { ICE_ENUM(LogMessageType, ErrorMessage), IceUtil::Time::now().toMicroSeconds(), "", message };
+    LogMessage logMessage = { LogMessageType::ErrorMessage, IceUtil::Time::now().toMicroSeconds(), "", message };
 
     _localLogger->error(message);
     log(logMessage);

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -156,7 +156,7 @@ private:
     IceUtil::ThreadPtr _sendLogThread;
     std::deque<JobPtr> _jobQueue;
 };
-ICE_DEFINE_PTR(LoggerAdminLoggerIPtr, LoggerAdminLoggerI);
+using LoggerAdminLoggerIPtr = std::shared_ptr<LoggerAdminLoggerI>;
 
 class SendLogThread : public IceUtil::Thread
 {
@@ -689,7 +689,7 @@ LoggerAdminLoggerI::log(const LogMessage& logMessage)
 
         if(!_sendLogThread)
         {
-            _sendLogThread = new SendLogThread(ICE_SHARED_FROM_THIS);
+            _sendLogThread = new SendLogThread(shared_from_this());
             _sendLogThread->start();
         }
 
@@ -830,7 +830,7 @@ LoggerAdminLoggerPtr
 createLoggerAdminLogger(const PropertiesPtr& props,
                         const LoggerPtr& localLogger)
 {
-    return ICE_MAKE_SHARED(LoggerAdminLoggerI, props, localLogger);
+    return make_shared<LoggerAdminLoggerI>(props, localLogger);
 }
 
 }

--- a/cpp/src/Ice/LoggerAdminI.h
+++ b/cpp/src/Ice/LoggerAdminI.h
@@ -31,7 +31,7 @@ public:
     //
     virtual void destroy() = 0;
 };
-ICE_DEFINE_PTR(LoggerAdminLoggerPtr, LoggerAdminLogger);
+using LoggerAdminLoggerPtr = std::shared_ptr<LoggerAdminLogger>;
 
 LoggerAdminLoggerPtr
 createLoggerAdminLogger(const Ice::PropertiesPtr&, const Ice::LoggerPtr&);

--- a/cpp/src/Ice/LoggerI.cpp
+++ b/cpp/src/Ice/LoggerI.cpp
@@ -106,7 +106,7 @@ LoggerPtr
 Ice::LoggerI::cloneWithPrefix(const std::string& prefix)
 {
     lock_guard lock(outputMutex); // for _sizeMax
-    return ICE_MAKE_SHARED(LoggerI, prefix, _file, _convert, _sizeMax);
+    return make_shared<LoggerI>(prefix, _file, _convert, _sizeMax);
 }
 
 void

--- a/cpp/src/Ice/LoggerI.h
+++ b/cpp/src/Ice/LoggerI.h
@@ -45,7 +45,7 @@ private:
     //
     IceUtil::Time _nextRetry;
 };
-ICE_DEFINE_PTR(LoggerIPtr, LoggerI);
+using LoggerIPtr = std::shared_ptr<LoggerI>;
 
 }
 

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -337,7 +337,7 @@ MetricsViewI::getMap(const string& mapName) const
     {
         return p->second;
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 MetricsAdminI::MetricsAdminI(const PropertiesPtr& properties, const LoggerPtr& logger) :
@@ -568,7 +568,7 @@ MetricsAdminI::getMetricsView(const std::string& name)
         {
             throw UnknownMetricsView();
         }
-        return ICE_NULLPTR;
+        return nullptr;
     }
     return p->second;
 }

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -182,20 +182,20 @@ getLocalAddresses(ProtocolSupport protocol, bool includeLoopback, bool singleAdd
     }
 
     DWORD size = 0;
-    DWORD rv = GetAdaptersAddresses(family, 0, ICE_NULLPTR, ICE_NULLPTR, &size);
+    DWORD rv = GetAdaptersAddresses(family, 0, nullptr, nullptr, &size);
     if(rv == ERROR_BUFFER_OVERFLOW)
     {
         PIP_ADAPTER_ADDRESSES adapter_addresses = (PIP_ADAPTER_ADDRESSES) malloc(size);
-        rv = GetAdaptersAddresses(family, 0, ICE_NULLPTR, adapter_addresses, &size);
+        rv = GetAdaptersAddresses(family, 0, nullptr, adapter_addresses, &size);
         if(rv == ERROR_SUCCESS)
         {
-            for(PIP_ADAPTER_ADDRESSES aa = adapter_addresses; aa != ICE_NULLPTR; aa = aa->Next)
+            for(PIP_ADAPTER_ADDRESSES aa = adapter_addresses; aa != nullptr; aa = aa->Next)
             {
                 if(aa->OperStatus != IfOperStatusUp)
                 {
                     continue;
                 }
-                for(PIP_ADAPTER_UNICAST_ADDRESS ua = aa->FirstUnicastAddress; ua != ICE_NULLPTR; ua = ua->Next)
+                for(PIP_ADAPTER_UNICAST_ADDRESS ua = aa->FirstUnicastAddress; ua != nullptr; ua = ua->Next)
                 {
                     Address addr;
                     memcpy(&addr.saStorage, ua->Address.lpSockaddr, ua->Address.iSockaddrLength);
@@ -886,7 +886,7 @@ IceInternal::getAddresses(const string& host, int port, ProtocolSupport protocol
         throw DNSException(__FILE__, __LINE__, rs, host);
     }
 
-    for(struct addrinfo* p = info; p != ICE_NULLPTR; p = p->ai_next)
+    for(struct addrinfo* p = info; p != nullptr; p = p->ai_next)
     {
         memcpy(&addr.saStorage, p->ai_addr, p->ai_addrlen);
         if(p->ai_family == PF_INET)
@@ -2129,7 +2129,7 @@ IceInternal::doConnectAsync(SOCKET fd, const Address& addr, const Address& sourc
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }
 
-    LPFN_CONNECTEX ConnectEx = ICE_NULLPTR; // a pointer to the 'ConnectEx()' function
+    LPFN_CONNECTEX ConnectEx = nullptr; // a pointer to the 'ConnectEx()' function
     GUID GuidConnectEx = WSAID_CONNECTEX; // The Guid
     DWORD dwBytes;
     if(WSAIoctl(fd,
@@ -2139,8 +2139,8 @@ IceInternal::doConnectAsync(SOCKET fd, const Address& addr, const Address& sourc
                 &ConnectEx,
                 sizeof(ConnectEx),
                 &dwBytes,
-                ICE_NULLPTR,
-                ICE_NULLPTR) == SOCKET_ERROR)
+                nullptr,
+                nullptr) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }
@@ -2190,7 +2190,7 @@ IceInternal::doFinishConnectAsync(SOCKET fd, AsyncInfo& info)
         }
     }
 
-    if(setsockopt(fd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, ICE_NULLPTR, 0) == SOCKET_ERROR)
+    if(setsockopt(fd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, nullptr, 0) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -86,7 +86,7 @@ public:
 void
 sortAddresses(vector<Address>& addrs, ProtocolSupport protocol, Ice::EndpointSelectionType selType, bool preferIPv6)
 {
-    if(selType == Ice::ICE_ENUM(EndpointSelectionType, Random))
+    if(selType == Ice::EndpointSelectionType::Random)
     {
         IceUtilInternal::shuffle(addrs.begin(), addrs.end());
     }
@@ -954,7 +954,7 @@ IceInternal::getAddressForServer(const string& host, int port, ProtocolSupport p
         }
         return addr;
     }
-    vector<Address> addrs = getAddresses(host, port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Ordered),
+    vector<Address> addrs = getAddresses(host, port, protocol, Ice::EndpointSelectionType::Ordered,
                                          preferIPv6, canBlock);
     return addrs.empty() ? Address() : addrs[0];
 }
@@ -1654,7 +1654,7 @@ IceInternal::doBind(SOCKET fd, const Address& addr, const string&)
 Address
 IceInternal::getNumericAddress(const std::string& address)
 {
-    vector<Address> addrs = getAddresses(address, 0, EnableBoth, Ice::ICE_ENUM(EndpointSelectionType, Ordered), false,
+    vector<Address> addrs = getAddresses(address, 0, EnableBoth, Ice::EndpointSelectionType::Ordered, false,
                                          false);
     if(addrs.empty())
     {

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -160,7 +160,7 @@ NetworkProxyPtr
 SOCKSNetworkProxy::resolveHost(ProtocolSupport protocol) const
 {
     assert(!_host.empty());
-    return new SOCKSNetworkProxy(getAddresses(_host, _port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Random), false, true)[0]);
+    return new SOCKSNetworkProxy(getAddresses(_host, _port, protocol, Ice::EndpointSelectionType::Random, false, true)[0]);
 }
 
 Address
@@ -263,7 +263,7 @@ NetworkProxyPtr
 HTTPNetworkProxy::resolveHost(ProtocolSupport protocol) const
 {
     assert(!_host.empty());
-    return new HTTPNetworkProxy(getAddresses(_host, _port, protocol, Ice::ICE_ENUM(EndpointSelectionType, Random), false, true)[0], protocol);
+    return new HTTPNetworkProxy(getAddresses(_host, _port, protocol, Ice::EndpointSelectionType::Random, false, true)[0], protocol);
 }
 
 Address

--- a/cpp/src/Ice/OSLogLoggerI.cpp
+++ b/cpp/src/Ice/OSLogLoggerI.cpp
@@ -51,7 +51,7 @@ Ice::OSLogLoggerI::getPrefix()
 LoggerPtr
 Ice::OSLogLoggerI::cloneWithPrefix(const std::string& prefix)
 {
-    return ICE_MAKE_SHARED(OSLogLoggerI, prefix);
+    return make_shared<OSLogLoggerI>(prefix);
 }
 
 #endif

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -193,13 +193,13 @@ operationModeToString(OperationMode mode)
 {
     switch(mode)
     {
-    case ICE_ENUM(OperationMode, Normal):
+    case OperationMode::Normal:
         return "::Ice::Normal";
 
-    case ICE_ENUM(OperationMode, Nonmutating):
+    case OperationMode::Nonmutating:
         return "::Ice::Nonmutating";
 
-    case ICE_ENUM(OperationMode, Idempotent):
+    case OperationMode::Idempotent:
         return "::Ice::Idempotent";
     }
     //
@@ -216,8 +216,8 @@ Ice::Object::_iceCheckMode(OperationMode expected, OperationMode received)
 {
     if(expected != received)
     {
-        assert(expected != ICE_ENUM(OperationMode, Nonmutating)); // We never expect Nonmutating
-        if(expected == ICE_ENUM(OperationMode, Idempotent) && received == ICE_ENUM(OperationMode, Nonmutating))
+        assert(expected != OperationMode::Nonmutating); // We never expect Nonmutating
+        if(expected == OperationMode::Idempotent && received == OperationMode::Nonmutating)
         {
             //
             // Fine: typically an old client still using the deprecated nonmutating keyword

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -31,8 +31,8 @@ IceInternal::ObjectAdapterFactory::shutdown()
 
         adapters = _adapters;
 
-        _instance = ICE_NULLPTR;
-        _communicator = ICE_NULLPTR;
+        _instance = nullptr;
+        _communicator = nullptr;
 
         notifyAll();
     }
@@ -127,7 +127,7 @@ IceInternal::ObjectAdapterFactory::createObjectAdapter(const string& name, const
         if(name.empty())
         {
             string uuid = Ice::generateUUID();
-            adapter = make_shared<ObjectAdapterI>(_instance, _communicator, ICE_SHARED_FROM_THIS, uuid, true);
+            adapter = make_shared<ObjectAdapterI>(_instance, _communicator, shared_from_this(), uuid, true);
         }
         else
         {
@@ -135,7 +135,7 @@ IceInternal::ObjectAdapterFactory::createObjectAdapter(const string& name, const
             {
                 throw AlreadyRegisteredException(__FILE__, __LINE__, "object adapter", name);
             }
-            adapter = make_shared<ObjectAdapterI>(_instance, _communicator, ICE_SHARED_FROM_THIS, name, false);
+            adapter = make_shared<ObjectAdapterI>(_instance, _communicator, shared_from_this(), name, false);
             _adapterNamesInUse.insert(name);
         }
     }
@@ -187,7 +187,7 @@ IceInternal::ObjectAdapterFactory::findObjectAdapter(const ObjectPrxPtr& proxy)
 
         if(!_instance)
         {
-            return ICE_NULLPTR;
+            return nullptr;
         }
 
         adapters = _adapters;
@@ -208,7 +208,7 @@ IceInternal::ObjectAdapterFactory::findObjectAdapter(const ObjectPrxPtr& proxy)
         }
     }
 
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -1032,11 +1032,8 @@ Ice::ObjectAdapterI::initialize(const RouterPrxPtr& router)
                 vector<EndpointIPtr> expanded = (*p)->expandHost(publishedEndpoint);
                 for(vector<EndpointIPtr>::iterator q = expanded.begin(); q != expanded.end(); ++q)
                 {
-                    IncomingConnectionFactoryPtr factory = ICE_MAKE_SHARED(IncomingConnectionFactory,
-                                                                           _instance,
-                                                                           *q,
-                                                                           publishedEndpoint,
-                                                                           shared_from_this());
+                    auto factory =
+                        make_shared<IncomingConnectionFactory>(_instance, *q, publishedEndpoint, shared_from_this());
                     factory->initialize();
                     _incomingConnectionFactories.push_back(factory);
                 }

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -83,7 +83,7 @@ private:
 //
 OpaqueEndpointInfoI::OpaqueEndpointInfoI(Ice::Short type, const Ice::EncodingVersion& rawEncodingP,
                                          const Ice::ByteSeq& rawBytesP) :
-    Ice::OpaqueEndpointInfo(ICE_NULLPTR, -1, false, rawEncodingP, rawBytesP),
+    Ice::OpaqueEndpointInfo(nullptr, -1, false, rawEncodingP, rawBytesP),
     _type(type)
 {
 }
@@ -99,7 +99,7 @@ IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 Ice::EndpointInfoPtr
 IceInternal::OpaqueEndpointI::getInfo() const noexcept
 {
-    return ICE_MAKE_SHARED(OpaqueEndpointInfoI, _type, _rawEncoding, _rawBytes);
+    return make_shared<OpaqueEndpointInfoI>(_type, _rawEncoding, _rawBytes);
 }
 
 Short
@@ -165,7 +165,7 @@ IceInternal::OpaqueEndpointI::secure() const
 TransceiverPtr
 IceInternal::OpaqueEndpointI::transceiver() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 void
@@ -177,7 +177,7 @@ IceInternal::OpaqueEndpointI::connectors_async(Ice::EndpointSelectionType, const
 AcceptorPtr
 IceInternal::OpaqueEndpointI::acceptor(const string&) const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 vector<EndpointIPtr>

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -91,7 +91,7 @@ OpaqueEndpointInfoI::OpaqueEndpointInfoI(Ice::Short type, const Ice::EncodingVer
 void
 IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 {
-    s->startEncapsulation(_rawEncoding, ICE_ENUM(FormatType, DefaultFormat));
+    s->startEncapsulation(_rawEncoding, FormatType::DefaultFormat);
     s->writeBlob(_rawBytes);
     s->endEncapsulation();
 }

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -282,7 +282,7 @@ bool
 OutgoingAsyncBase::exceptionImpl(const Exception& ex)
 {
     Lock sync(_m);
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+    _ex = ex.ice_clone();
     if(_childObserver)
     {
         _childObserver.failed(ex.ice_id());
@@ -316,7 +316,7 @@ OutgoingAsyncBase::responseImpl(bool ok, bool invoke)
     }
     catch(const Ice::Exception& ex)
     {
-        ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+        _ex = ex.ice_clone();
         invoke = handleException(ex);
     }
     if(!invoke)
@@ -334,7 +334,7 @@ OutgoingAsyncBase::cancel(const Ice::LocalException& ex)
         Lock sync(_m);
         if(!_cancellationHandler)
         {
-            ICE_SET_EXCEPTION_FROM_CLONE(_cancellationException, ex.ice_clone());
+            _cancellationException = ex.ice_clone();
             return;
         }
         handler = _cancellationHandler;

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -471,7 +471,7 @@ ProxyOutgoingAsyncBase::abort(const Ice::Exception& ex)
 ProxyOutgoingAsyncBase::ProxyOutgoingAsyncBase(const ObjectPrxPtr& prx) :
     OutgoingAsyncBase(prx->_getReference()->getInstance()),
     _proxy(prx),
-    _mode(ICE_ENUM(OperationMode, Normal)),
+    _mode(OperationMode::Normal),
     _cnt(0),
     _sent(false)
 {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -70,7 +70,7 @@ Ice::OutputStream::OutputStream() :
     _instance(0),
     _closure(0),
     _encoding(currentEncoding),
-    _format(ICE_ENUM(FormatType, CompactFormat)),
+    _format(FormatType::CompactFormat),
     _currentEncaps(0)
 {
 }
@@ -210,7 +210,7 @@ Ice::OutputStream::startEncapsulation()
     }
     else
     {
-        startEncapsulation(_encoding, Ice::ICE_ENUM(FormatType, DefaultFormat));
+        startEncapsulation(_encoding, Ice::FormatType::DefaultFormat);
     }
 }
 
@@ -862,7 +862,7 @@ Ice::OutputStream::initEncaps()
         _currentEncaps->encoding = _encoding;
     }
 
-    if(_currentEncaps->format == Ice::ICE_ENUM(FormatType, DefaultFormat))
+    if(_currentEncaps->format == Ice::FormatType::DefaultFormat)
     {
         _currentEncaps->format = _format;
     }
@@ -1084,7 +1084,7 @@ Ice::OutputStream::EncapsEncoder11::write(const shared_ptr<Value>& v)
     {
         _stream->writeSize(0); // Nil reference.
     }
-    else if(_current && _encaps->format == ICE_ENUM(FormatType, SlicedFormat))
+    else if(_current && _encaps->format == FormatType::SlicedFormat)
     {
         //
         // If writing an instance within a slice and using the sliced
@@ -1152,7 +1152,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(const string& typeId, int compact
     _current->sliceFlagsPos = _stream->b.size();
 
     _current->sliceFlags = 0;
-    if(_encaps->format == ICE_ENUM(FormatType, SlicedFormat))
+    if(_encaps->format == FormatType::SlicedFormat)
     {
         _current->sliceFlags |= FLAG_HAS_SLICE_SIZE; // Encode the slice size if using the sliced format.
     }
@@ -1174,7 +1174,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(const string& typeId, int compact
         // Encode the type ID (only in the first slice for the compact
         // encoding).
         //
-        if(_encaps->format == ICE_ENUM(FormatType, SlicedFormat) || _current->firstSlice)
+        if(_encaps->format == FormatType::SlicedFormat || _current->firstSlice)
         {
             if(compactId >= 0)
             {
@@ -1239,7 +1239,7 @@ Ice::OutputStream::EncapsEncoder11::endSlice()
     //
     if(!_current->indirectionTable.empty())
     {
-        assert(_encaps->format == ICE_ENUM(FormatType, SlicedFormat));
+        assert(_encaps->format == FormatType::SlicedFormat);
         _current->sliceFlags |= FLAG_HAS_INDIRECTION_TABLE;
 
         //
@@ -1294,7 +1294,7 @@ Ice::OutputStream::EncapsEncoder11::writeSlicedData(const SlicedDataPtr& slicedD
     // essentially "slices" the instance into the most-derived type
     // known by the sender.
     //
-    if(_encaps->format != ICE_ENUM(FormatType, SlicedFormat))
+    if(_encaps->format != FormatType::SlicedFormat)
     {
         return;
     }

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -574,7 +574,7 @@ Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = ICE_NULLPTR;
+        Byte* lastByte = nullptr;
         bool converted = false;
         if(_instance)
         {
@@ -686,7 +686,7 @@ Ice::OutputStream::write(const wstring& v)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = ICE_NULLPTR;
+        Byte* lastByte = nullptr;
 
         // Note: wstringConverter is never null; when set to null, get returns the default unicode wstring converter
         if(_instance)

--- a/cpp/src/Ice/PropertiesAdminI.h
+++ b/cpp/src/Ice/PropertiesAdminI.h
@@ -39,7 +39,7 @@ private:
 
     std::list<std::function<void(const Ice::PropertyDict&)>> _updateCallbacks;
 };
-ICE_DEFINE_SHARED_PTR(PropertiesAdminIPtr, PropertiesAdminI);
+using PropertiesAdminIPtr = std::shared_ptr<PropertiesAdminI>;
 
 }
 

--- a/cpp/src/Ice/PropertiesI.cpp
+++ b/cpp/src/Ice/PropertiesI.cpp
@@ -310,8 +310,8 @@ Ice::PropertiesI::load(const std::string& file)
         DWORD numValues;
         try
         {
-            err = RegQueryInfoKey(iceKey, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR,
-                                  &numValues, &maxNameSize, &maxDataSize, ICE_NULLPTR, ICE_NULLPTR);
+            err = RegQueryInfoKey(iceKey, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                  &numValues, &maxNameSize, &maxDataSize, nullptr, nullptr);
             if(err != ERROR_SUCCESS)
             {
                 throw InitializationException(__FILE__, __LINE__, "could not open Windows registry key `" + file +
@@ -325,7 +325,7 @@ Ice::PropertiesI::load(const std::string& file)
                 DWORD keyType;
                 DWORD nameBufSize = static_cast<DWORD>(nameBuf.size());
                 DWORD dataBufSize = static_cast<DWORD>(dataBuf.size());
-                err = RegEnumValueW(iceKey, i, &nameBuf[0], &nameBufSize, ICE_NULLPTR, &keyType, &dataBuf[0], &dataBufSize);
+                err = RegEnumValueW(iceKey, i, &nameBuf[0], &nameBufSize, nullptr, &keyType, &dataBuf[0], &dataBufSize);
                 if(err != ERROR_SUCCESS || nameBufSize == 0)
                 {
                     ostringstream os;
@@ -424,7 +424,7 @@ PropertiesPtr
 Ice::PropertiesI::clone() noexcept
 {
     IceUtil::Mutex::Lock sync(*this);
-    return ICE_MAKE_SHARED(PropertiesI, this);
+    return make_shared<PropertiesI>(this);
 }
 
 set<string>

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -63,7 +63,7 @@ ProxyFlushBatchAsync::invokeRemote(const ConnectionIPtr& connection, bool compre
         }
     }
     _cachedConnection = connection;
-    return connection->sendAsyncRequest(ICE_SHARED_FROM_THIS, compress, false, _batchRequestNum);
+    return connection->sendAsyncRequest(shared_from_this(), compress, false, _batchRequestNum);
 }
 
 AsyncStatus
@@ -878,7 +878,7 @@ ICE_OBJECT_PRX::_getRequestHandler()
             return _requestHandler;
         }
     }
-    return _reference->getRequestHandler(ICE_SHARED_FROM_THIS);
+    return _reference->getRequestHandler(shared_from_this());
 }
 
 IceInternal::BatchRequestQueuePtr

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -154,7 +154,7 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<IceInternal::OutgoingAsyncT<bool>>& o
                           const Context& ctx)
 {
     _checkTwowayOnly(ice_isA_name);
-    outAsync->invoke(ice_isA_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx,
+    outAsync->invoke(ice_isA_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx,
                      [&](Ice::OutputStream* os)
                      {
                          os->write(typeId, false);
@@ -165,14 +165,14 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<IceInternal::OutgoingAsyncT<bool>>& o
 void
 Ice::ObjectPrx::_iceI_ping(const shared_ptr<IceInternal::OutgoingAsyncT<void>>& outAsync, const Context& ctx)
 {
-    outAsync->invoke(ice_ping_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr);
+    outAsync->invoke(ice_ping_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr);
 }
 
 void
 Ice::ObjectPrx::_iceI_ids(const shared_ptr<IceInternal::OutgoingAsyncT<vector<string>>>& outAsync, const Context& ctx)
 {
     _checkTwowayOnly(ice_ids_name);
-    outAsync->invoke(ice_ids_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr,
+    outAsync->invoke(ice_ids_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          vector<string> v;
@@ -185,7 +185,7 @@ void
 Ice::ObjectPrx::_iceI_id(const shared_ptr<IceInternal::OutgoingAsyncT<string>>& outAsync, const Context& ctx)
 {
     _checkTwowayOnly(ice_id_name);
-    outAsync->invoke(ice_id_name, OperationMode::Nonmutating, ICE_ENUM(FormatType, DefaultFormat), ctx, nullptr, nullptr,
+    outAsync->invoke(ice_id_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          string v;
@@ -843,7 +843,7 @@ ICE_OBJECT_PRX::_handleException(const Exception& ex,
     //
     const LocalException* localEx = dynamic_cast<const LocalException*>(&ex);
     if(localEx && (!sent ||
-                   mode == ICE_ENUM(OperationMode, Nonmutating) || mode == ICE_ENUM(OperationMode, Idempotent) ||
+                   mode == OperationMode::Nonmutating || mode == OperationMode::Idempotent ||
                    dynamic_cast<const CloseConnectionException*>(&ex) ||
                    dynamic_cast<const ObjectNotExistException*>(&ex)))
     {

--- a/cpp/src/Ice/ProxyFactory.cpp
+++ b/cpp/src/Ice/ProxyFactory.cpp
@@ -86,7 +86,7 @@ IceInternal::ProxyFactory::referenceToProxy(const ReferencePtr& ref) const
     }
     else
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 }
 

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -591,7 +591,7 @@ IceInternal::FixedReference::getPreferSecure() const
 Ice::EndpointSelectionType
 IceInternal::FixedReference::getEndpointSelection() const
 {
-    return ICE_ENUM(EndpointSelectionType, Random);
+    return EndpointSelectionType::Random;
 }
 
 int
@@ -1237,7 +1237,7 @@ IceInternal::RoutableReference::toProperty(const string& prefix) const
     properties[prefix + ".CollocationOptimized"] = _collocationOptimized ? "1" : "0";
     properties[prefix + ".ConnectionCached"] = _cacheConnection ? "1" : "0";
     properties[prefix + ".PreferSecure"] = _preferSecure ? "1" : "0";
-    properties[prefix + ".EndpointSelection"] = _endpointSelection == ICE_ENUM(EndpointSelectionType, Random) ? "Random" : "Ordered";
+    properties[prefix + ".EndpointSelection"] = _endpointSelection == EndpointSelectionType::Random ? "Random" : "Ordered";
     {
         ostringstream s;
         s << _locatorCacheTimeout;
@@ -1871,12 +1871,12 @@ IceInternal::RoutableReference::filterEndpoints(const vector<EndpointIPtr>& allE
     //
     switch(getEndpointSelection())
     {
-        case ICE_ENUM(EndpointSelectionType, Random):
+        case EndpointSelectionType::Random:
         {
             IceUtilInternal::shuffle(endpoints.begin(), endpoints.end());
             break;
         }
-        case ICE_ENUM(EndpointSelectionType, Ordered):
+        case EndpointSelectionType::Ordered:
         {
             // Nothing to do.
             break;

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1737,7 +1737,7 @@ IceInternal::RoutableReference::createConnection(const vector<EndpointIPtr>& all
             {
                 if(!_exception)
                 {
-                    ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+                    _exception = ex.ice_clone();
                 }
 
                 if(++_i == _endpoints.size())

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -773,7 +773,7 @@ IceInternal::FixedReference::getRequestHandler(const Ice::ObjectPrxPtr& proxy) c
     }
 
     ReferencePtr ref = const_cast<FixedReference*>(this);
-    return proxy->_setRequestHandler(ICE_MAKE_SHARED(ConnectionRequestHandler, ref, _fixedConnection, compress));
+    return proxy->_setRequestHandler(make_shared<ConnectionRequestHandler>(ref, _fixedConnection, compress));
 }
 
 BatchRequestQueuePtr
@@ -1614,7 +1614,7 @@ IceInternal::RoutableReference::getConnectionNoRouterInfo(const GetConnectionCal
 
             vector<EndpointIPtr> endpts = endpoints;
             _reference->applyOverrides(endpts);
-            _reference->createConnection(endpts, ICE_MAKE_SHARED(Callback2, _reference, _callback, cached));
+            _reference->createConnection(endpts, make_shared<Callback2>(_reference, _callback, cached));
         }
 
         virtual void

--- a/cpp/src/Ice/Reference.h
+++ b/cpp/src/Ice/Reference.h
@@ -45,7 +45,7 @@ public:
         virtual void setConnection(const Ice::ConnectionIPtr&, bool) = 0;
         virtual void setException(const Ice::LocalException&) = 0;
     };
-    ICE_DEFINE_PTR(GetConnectionCallbackPtr, GetConnectionCallback);
+    using GetConnectionCallbackPtr = std::shared_ptr<GetConnectionCallback>;
 
     enum Mode
     {

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -448,7 +448,7 @@ IceInternal::ReferenceFactory::create(const string& str, const string& propertyP
 
                 string es = s.substr(beg, end - beg);
                 EndpointIPtr endp = _instance->endpointFactoryManager()->create(es, false);
-                if(endp != ICE_NULLPTR)
+                if(endp != nullptr)
                 {
                     endpoints.push_back(endp);
                 }

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -812,11 +812,11 @@ IceInternal::ReferenceFactory::create(const Identity& ident,
             string type = properties->getProperty(property);
             if(type == "Random")
             {
-                endpointSelection = ICE_ENUM(EndpointSelectionType, Random);
+                endpointSelection = EndpointSelectionType::Random;
             }
             else if(type == "Ordered")
             {
-                endpointSelection = ICE_ENUM(EndpointSelectionType, Ordered);
+                endpointSelection = EndpointSelectionType::Ordered;
             }
             else
             {

--- a/cpp/src/Ice/RequestHandler.cpp
+++ b/cpp/src/Ice/RequestHandler.cpp
@@ -10,12 +10,12 @@ using namespace IceInternal;
 
 RetryException::RetryException(const Ice::LocalException& ex)
 {
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.ice_clone());
+    _ex = ex.ice_clone();
 }
 
 RetryException::RetryException(const RetryException& ex)
 {
-    ICE_SET_EXCEPTION_FROM_CLONE(_ex, ex.get()->ice_clone());
+    _ex = ex.get()->ice_clone();
 }
 
 const Ice::LocalException*

--- a/cpp/src/Ice/RequestHandlerFactory.cpp
+++ b/cpp/src/Ice/RequestHandlerFactory.cpp
@@ -25,7 +25,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
         Ice::ObjectAdapterPtr adapter = _instance->objectAdapterFactory()->findObjectAdapter(proxy);
         if(adapter)
         {
-            return proxy->_setRequestHandler(ICE_MAKE_SHARED(CollocatedRequestHandler, ref, adapter));
+            return proxy->_setRequestHandler(make_shared<CollocatedRequestHandler>(ref, adapter));
         }
     }
 
@@ -37,7 +37,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
         map<ReferencePtr, ConnectRequestHandlerPtr>::iterator p = _handlers.find(ref);
         if(p == _handlers.end())
         {
-            handler = ICE_MAKE_SHARED(ConnectRequestHandler, ref, proxy);
+            handler = make_shared<ConnectRequestHandler>(ref, proxy);
             _handlers.insert(make_pair(ref, handler));
             connect = true;
         }
@@ -48,7 +48,7 @@ IceInternal::RequestHandlerFactory::getRequestHandler(const RoutableReferencePtr
     }
     else
     {
-        handler = ICE_MAKE_SHARED(ConnectRequestHandler, ref, proxy);
+        handler = make_shared<ConnectRequestHandler>(ref, proxy);
         connect = true;
     }
     if(connect)

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -35,13 +35,13 @@ IceInternal::RetryTask::runTimerTask()
     // (we still need the client thread pool at this point to call
     // exception callbacks with CommunicatorDestroyedException).
     //
-    _queue->remove(ICE_SHARED_FROM_THIS);
+    _queue->remove(shared_from_this());
 }
 
 void
 IceInternal::RetryTask::asyncRequestCanceled(const OutgoingAsyncBasePtr& /*outAsync*/, const Ice::LocalException& ex)
 {
-    if(_queue->cancel(ICE_SHARED_FROM_THIS))
+    if(_queue->cancel(shared_from_this()))
     {
         if(_instance->traceLevels()->retry >= 1)
         {
@@ -86,7 +86,7 @@ IceInternal::RetryQueue::add(const ProxyOutgoingAsyncBasePtr& out, int interval)
     {
         throw CommunicatorDestroyedException(__FILE__, __LINE__);
     }
-    RetryTaskPtr task = ICE_MAKE_SHARED(RetryTask, _instance, this, out);
+    RetryTaskPtr task = make_shared<RetryTask>(_instance, this, out);
     out->cancelable(task); // This will throw if the request is canceled.
     try
     {

--- a/cpp/src/Ice/RetryQueue.h
+++ b/cpp/src/Ice/RetryQueue.h
@@ -38,7 +38,7 @@ private:
     const RetryQueuePtr _queue;
     const ProxyOutgoingAsyncBasePtr _outAsync;
 };
-ICE_DEFINE_PTR(RetryTaskPtr, RetryTask);
+using RetryTaskPtr = std::shared_ptr<RetryTask>;
 
 class RetryQueue : public IceUtil::Shared, public IceUtil::Monitor<IceUtil::Mutex>
 {

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -78,7 +78,7 @@ IceInternal::RouterManager::erase(const RouterPrxPtr& rtr)
     RouterInfoPtr info;
     if(rtr)
     {
-        RouterPrxPtr router = ICE_UNCHECKED_CAST(RouterPrx, rtr->ice_router(ICE_NULLPTR)); // The router cannot be routed.
+        RouterPrxPtr router = ICE_UNCHECKED_CAST(RouterPrx, rtr->ice_router(nullptr)); // The router cannot be routed.
         IceUtil::Mutex::Lock sync(*this);
 
         RouterInfoTable::iterator p = _table.end();

--- a/cpp/src/Ice/RouterInfo.h
+++ b/cpp/src/Ice/RouterInfo.h
@@ -65,7 +65,7 @@ public:
         virtual void addedProxy() = 0;
         virtual void setException(const Ice::LocalException&) = 0;
     };
-    ICE_DEFINE_PTR(AddProxyCallbackPtr, AddProxyCallback);
+    using AddProxyCallbackPtr = std::shared_ptr<AddProxyCallback>;
 
     RouterInfo(const Ice::RouterPrxPtr&);
 

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -38,8 +38,8 @@ Selector::~Selector()
 void
 Selector::setup(int sizeIO)
 {
-    _handle = CreateIoCompletionPort(INVALID_HANDLE_VALUE, ICE_NULLPTR, 0, sizeIO);
-    if(_handle == ICE_NULLPTR)
+    _handle = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, sizeIO);
+    if(_handle == nullptr)
     {
         throw Ice::SocketException(__FILE__, __LINE__, GetLastError());
     }
@@ -69,7 +69,7 @@ Selector::initialize(EventHandler* handler)
         if(CreateIoCompletionPort(reinterpret_cast<HANDLE>(socket),
                                   _handle,
                                   reinterpret_cast<ULONG_PTR>(handler),
-                                  0) == ICE_NULLPTR)
+                                  0) == nullptr)
         {
             throw Ice::SocketException(__FILE__, __LINE__, GetLastError());
         }

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -196,7 +196,7 @@ public:
     virtual Ice::LoggerPtr
     cloneWithPrefix(const string& prefix)
     {
-        return ICE_MAKE_SHARED(SMEventLoggerIWrapper, _logger, prefix);
+        return make_shared<SMEventLoggerIWrapper>(_logger, prefix);
     }
 
 private:
@@ -584,7 +584,7 @@ Ice::Service::main(int argc, const char* const argv[], const InitializationData&
             if(ICE_DYNAMIC_CAST(LoggerI, _logger))
             {
                 string eventLogSource = initData.properties->getPropertyWithDefault("Ice.EventLog.Source", name);
-                _logger = ICE_MAKE_SHARED(SMEventLoggerIWrapper, new SMEventLoggerI(eventLogSource, stringConverter), "");
+                _logger = make_shared<SMEventLoggerIWrapper>(new SMEventLoggerI(eventLogSource, stringConverter), "");
                 setProcessLogger(_logger);
             }
 
@@ -714,7 +714,7 @@ Ice::Service::main(int argc, const char* const argv[], const InitializationData&
                 initData.properties->getPropertyAsIntWithDefault("Ice.LogStdErr.Convert", 1) > 0 &&
                 initData.properties->getProperty("Ice.StdErr").empty();
 
-            _logger = ICE_MAKE_SHARED(LoggerI, initData.properties->getProperty("Ice.ProgramName"), "", convert);
+            _logger = make_shared<LoggerI>(initData.properties->getProperty("Ice.ProgramName"), "", convert);
             setProcessLogger(_logger);
         }
     }

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -354,7 +354,7 @@ StreamSocket::startWrite(Buffer& buf)
     _write.buf.len = static_cast<DWORD>(packetSize);
     _write.buf.buf = reinterpret_cast<char*>(&*buf.i);
     _write.error = ERROR_SUCCESS;
-    int err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, ICE_NULLPTR);
+    int err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, nullptr);
     if(err == SOCKET_ERROR)
     {
         if(!wouldBlock())
@@ -410,7 +410,7 @@ StreamSocket::startRead(Buffer& buf)
     _read.buf.len = static_cast<DWORD>(packetSize);
     _read.buf.buf = reinterpret_cast<char*>(&*buf.i);
     _read.error = ERROR_SUCCESS;
-    int err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, ICE_NULLPTR);
+    int err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, nullptr);
     if(err == SOCKET_ERROR)
     {
         if(!wouldBlock())

--- a/cpp/src/Ice/SysLoggerI.cpp
+++ b/cpp/src/Ice/SysLoggerI.cpp
@@ -160,7 +160,7 @@ Ice::SysLoggerI::getPrefix()
 Ice::LoggerPtr
 Ice::SysLoggerI::cloneWithPrefix(const string& prefix)
 {
-    return ICE_MAKE_SHARED(SysLoggerI, prefix, _facility);
+    return make_shared<SysLoggerI>(prefix, _facility);
 }
 
 #endif

--- a/cpp/src/Ice/SystemdJournalI.cpp
+++ b/cpp/src/Ice/SystemdJournalI.cpp
@@ -51,7 +51,7 @@ Ice::SystemdJournalI::getPrefix()
 Ice::LoggerPtr
 Ice::SystemdJournalI::cloneWithPrefix(const string& prefix)
 {
-    return ICE_MAKE_SHARED(SystemdJournalI, prefix);
+    return make_shared<SystemdJournalI>(prefix);
 }
 
 void

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -84,7 +84,7 @@ IceInternal::TcpAcceptor::getAsyncInfo(SocketOperation)
 void
 IceInternal::TcpAcceptor::startAccept()
 {
-    LPFN_ACCEPTEX AcceptEx = ICE_NULLPTR; // a pointer to the 'AcceptEx()' function
+    LPFN_ACCEPTEX AcceptEx = nullptr; // a pointer to the 'AcceptEx()' function
     GUID GuidAcceptEx = WSAID_ACCEPTEX; // The Guid
     DWORD dwBytes;
     if(WSAIoctl(_fd,
@@ -94,8 +94,8 @@ IceInternal::TcpAcceptor::startAccept()
                 &AcceptEx,
                 sizeof(AcceptEx),
                 &dwBytes,
-                ICE_NULLPTR,
-                ICE_NULLPTR) == SOCKET_ERROR)
+                nullptr,
+                nullptr) == SOCKET_ERROR)
     {
         throw SocketException(__FILE__, __LINE__, getSocketErrno());
     }

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -68,7 +68,7 @@ IceInternal::TcpEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceInternal::TcpEndpointI::getInfo() const noexcept
 {
-    TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(TcpEndpointI));
+    auto info = make_shared<InfoI<Ice::TCPEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(TcpEndpointI));
     fillEndpointInfo(info.get());
     return info;
 }
@@ -88,7 +88,7 @@ IceInternal::TcpEndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, _port, _sourceAddr, timeout, _connectionId, _compress);
+        return make_shared<TcpEndpointI>(_instance, _host, _port, _sourceAddr, timeout, _connectionId, _compress);
     }
 }
 
@@ -107,7 +107,7 @@ IceInternal::TcpEndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, _port, _sourceAddr, _timeout, _connectionId, compress);
+        return make_shared<TcpEndpointI>(_instance, _host, _port, _sourceAddr, _timeout, _connectionId, compress);
     }
 }
 
@@ -120,7 +120,7 @@ IceInternal::TcpEndpointI::datagram() const
 TransceiverPtr
 IceInternal::TcpEndpointI::transceiver() const
 {
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 AcceptorPtr
@@ -139,7 +139,7 @@ IceInternal::TcpEndpointI::endpoint(const TcpAcceptorPtr& acceptor) const
     }
     else
     {
-        return ICE_MAKE_SHARED(TcpEndpointI, _instance, _host, port, _sourceAddr, _timeout, _connectionId, _compress);
+        return make_shared<TcpEndpointI>(_instance, _host, port, _sourceAddr, _timeout, _connectionId, _compress);
     }
 }
 
@@ -322,7 +322,7 @@ IceInternal::TcpEndpointI::createConnector(const Address& address, const Network
 IPEndpointIPtr
 IceInternal::TcpEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(TcpEndpointI, _instance, host, port, _sourceAddr, _timeout, connectionId, _compress);
+    return make_shared<TcpEndpointI>(_instance, host, port, _sourceAddr, _timeout, connectionId, _compress);
 }
 
 IceInternal::TcpEndpointFactory::TcpEndpointFactory(const ProtocolInstancePtr& instance) : _instance(instance)
@@ -348,7 +348,7 @@ IceInternal::TcpEndpointFactory::protocol() const
 EndpointIPtr
 IceInternal::TcpEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(TcpEndpointI, _instance);
+    IPEndpointIPtr endpt = make_shared<TcpEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -356,7 +356,7 @@ IceInternal::TcpEndpointFactory::create(vector<string>& args, bool oaEndpoint) c
 EndpointIPtr
 IceInternal::TcpEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(TcpEndpointI, _instance, s);
+    return make_shared<TcpEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -102,7 +102,7 @@ IceInternal::TcpTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::TcpTransceiver::getInfo() const
 {
-    TCPConnectionInfoPtr info = ICE_MAKE_SHARED(TCPConnectionInfo);
+    TCPConnectionInfoPtr info = std::make_shared<TCPConnectionInfo>();
     fdToAddressAndPort(_stream->fd(), info->localAddress, info->localPort, info->remoteAddress, info->remotePort);
     if(_stream->fd() != INVALID_SOCKET)
     {

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -400,7 +400,7 @@ IceInternal::ThreadPool::ThreadPool(const InstancePtr& instance, const string& p
         const_cast<int&>(_priority) = properties->getPropertyAsInt("Ice.ThreadPriority");
     }
 
-    _workQueue = ICE_MAKE_SHARED(ThreadPoolWorkQueue, *this);
+    _workQueue = make_shared<ThreadPoolWorkQueue>(*this);
     _selector.initialize(_workQueue.get());
 
     if(_instance->traceLevels()->threadPool >= 1)

--- a/cpp/src/Ice/ThreadPool.h
+++ b/cpp/src/Ice/ThreadPool.h
@@ -30,7 +30,7 @@ namespace IceInternal
 class ThreadPoolCurrent;
 
 class ThreadPoolWorkQueue;
-ICE_DEFINE_PTR(ThreadPoolWorkQueuePtr, ThreadPoolWorkQueue);
+using ThreadPoolWorkQueuePtr = std::shared_ptr<ThreadPoolWorkQueue>;
 
 class ThreadPoolWorkItem : public virtual IceUtil::Shared
 {

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -250,7 +250,7 @@ Timer::run()
                 // in the synchronization block above. Clearing the task reference might end up
                 // calling user code which could trigger a deadlock. See also issue #352.
                 //
-                token.task = ICE_NULLPTR;
+                token.task = nullptr;
             }
         }
     }

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -24,7 +24,7 @@ using namespace IceInternal;
 static void
 printIdentityFacetOperation(ostream& s, InputStream& stream)
 {
-    ToStringMode toStringMode = ICE_ENUM(ToStringMode, Unicode);
+    ToStringMode toStringMode = ToStringMode::Unicode;
     if(stream.instance())
     {
         toStringMode = stream.instance()->toStringMode();
@@ -77,19 +77,19 @@ printRequestHeader(ostream& s, InputStream& stream)
     s << "\nmode = " << static_cast<int>(mode) << ' ';
     switch(static_cast<OperationMode>(mode))
     {
-        case ICE_ENUM(OperationMode, Normal):
+        case OperationMode::Normal:
         {
             s << "(normal)";
             break;
         }
 
-        case ICE_ENUM(OperationMode, Nonmutating):
+        case OperationMode::Nonmutating:
         {
             s << "(nonmutating)";
             break;
         }
 
-        case ICE_ENUM(OperationMode, Idempotent):
+        case OperationMode::Idempotent:
         {
             s << "(idempotent)";
             break;

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -95,8 +95,8 @@ IceInternal::UdpEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceInternal::UdpEndpointI::getInfo() const noexcept
 {
-    Ice::UDPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::UDPEndpointInfo>,
-                                                   ICE_DYNAMIC_CAST(UdpEndpointI, ICE_SHARED_FROM_CONST_THIS(UdpEndpointI)));
+    auto info = make_shared<InfoI<Ice::UDPEndpointInfo>>(
+        dynamic_pointer_cast<UdpEndpointI>(ICE_SHARED_FROM_CONST_THIS(UdpEndpointI)));
     fillEndpointInfo(info.get());
     return info;
 }
@@ -128,8 +128,8 @@ IceInternal::UdpEndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(UdpEndpointI, _instance, _host, _port, _sourceAddr, _mcastInterface, _mcastTtl,
-                               _connect, _connectionId, compress);
+        return make_shared<UdpEndpointI>(_instance, _host, _port, _sourceAddr, _mcastInterface, _mcastTtl,
+                                         _connect, _connectionId, compress);
     }
 }
 
@@ -162,8 +162,8 @@ IceInternal::UdpEndpointI::endpoint(const UdpTransceiverPtr& transceiver) const
     }
     else
     {
-        return ICE_MAKE_SHARED(UdpEndpointI, _instance, _host, port, _sourceAddr, _mcastInterface,_mcastTtl, _connect,
-                               _connectionId, _compress);
+        return make_shared<UdpEndpointI>(_instance, _host, port, _sourceAddr, _mcastInterface,_mcastTtl, _connect,
+                                         _connectionId, _compress);
     }
 }
 
@@ -443,8 +443,8 @@ IceInternal::UdpEndpointI::createConnector(const Address& address, const Network
 IPEndpointIPtr
 IceInternal::UdpEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(UdpEndpointI, _instance, host, port, _sourceAddr, _mcastInterface, _mcastTtl, _connect,
-                           connectionId, _compress);
+    return make_shared<UdpEndpointI>(_instance, host, port, _sourceAddr, _mcastInterface, _mcastTtl, _connect,
+                                     connectionId, _compress);
 }
 
 IceInternal::UdpEndpointFactory::UdpEndpointFactory(const ProtocolInstancePtr& instance) : _instance(instance)
@@ -470,7 +470,7 @@ IceInternal::UdpEndpointFactory::protocol() const
 EndpointIPtr
 IceInternal::UdpEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(UdpEndpointI, _instance);
+    IPEndpointIPtr endpt = make_shared<UdpEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -478,7 +478,7 @@ IceInternal::UdpEndpointFactory::create(vector<string>& args, bool oaEndpoint) c
 EndpointIPtr
 IceInternal::UdpEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(UdpEndpointI, _instance, s);
+    return make_shared<UdpEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -322,7 +322,7 @@ IceInternal::UdpTransceiver::startWrite(Buffer& buf)
     int err;
     if(_state == StateConnected)
     {
-        err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, ICE_NULLPTR);
+        err = WSASend(_fd, &_write.buf, 1, &_write.count, 0, &_write, nullptr);
     }
     else
     {
@@ -340,7 +340,7 @@ IceInternal::UdpTransceiver::startWrite(Buffer& buf)
             // No peer has sent a datagram yet.
             throw SocketException(__FILE__, __LINE__, 0);
         }
-        err = WSASendTo(_fd, &_write.buf, 1, &_write.count, 0, &_peerAddr.sa, len, &_write, ICE_NULLPTR);
+        err = WSASendTo(_fd, &_write.buf, 1, &_write.count, 0, &_peerAddr.sa, len, &_write, nullptr);
     }
 
     if(err == SOCKET_ERROR)
@@ -398,7 +398,7 @@ IceInternal::UdpTransceiver::startRead(Buffer& buf)
     int err;
     if(_state == StateConnected)
     {
-        err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, ICE_NULLPTR);
+        err = WSARecv(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_read, nullptr);
     }
     else
     {
@@ -406,7 +406,7 @@ IceInternal::UdpTransceiver::startRead(Buffer& buf)
         _readAddrLen = static_cast<socklen_t>(sizeof(sockaddr_storage));
 
         err = WSARecvFrom(_fd, &_read.buf, 1, &_read.count, &_read.flags, &_readAddr.sa, &_readAddrLen, &_read,
-                          ICE_NULLPTR);
+                          nullptr);
     }
 
     if(err == SOCKET_ERROR)
@@ -534,7 +534,7 @@ IceInternal::UdpTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::UdpTransceiver::getInfo() const
 {
-    Ice::UDPConnectionInfoPtr info = ICE_MAKE_SHARED(Ice::UDPConnectionInfo);
+    auto info = make_shared<Ice::UDPConnectionInfo>();
     if(_fd == INVALID_SOCKET)
     {
         return info;

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -40,7 +40,7 @@ getIPEndpointInfo(const EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }
@@ -111,7 +111,7 @@ IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& instance, const E
 EndpointInfoPtr
 IceInternal::WSEndpoint::getInfo() const noexcept
 {
-    WSEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<WSEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(WSEndpoint));
+    WSEndpointInfoPtr info = make_shared<InfoI<WSEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(WSEndpoint));
     info->underlying = _delegate->getInfo();
     info->compress = info->underlying->compress;
     info->timeout = info->underlying->timeout;
@@ -153,7 +153,7 @@ IceInternal::WSEndpoint::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->timeout(timeout), _resource);
+        return make_shared<WSEndpoint>(_instance, _delegate->timeout(timeout), _resource);
     }
 }
 
@@ -172,7 +172,7 @@ IceInternal::WSEndpoint::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->connectionId(connectionId), _resource);
+        return make_shared<WSEndpoint>(_instance, _delegate->connectionId(connectionId), _resource);
     }
 }
 
@@ -191,7 +191,7 @@ IceInternal::WSEndpoint::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, _delegate->compress(compress), _resource);
+        return make_shared<WSEndpoint>(_instance, _delegate->compress(compress), _resource);
     }
 }
 
@@ -256,7 +256,7 @@ IceInternal::WSEndpoint::connectors_async(EndpointSelectionType selType,
     {
         host << info->host << ":" << info->port;
     }
-    _delegate->connectors_async(selType, ICE_MAKE_SHARED(CallbackI, callback, _instance, host.str(), _resource));
+    _delegate->connectors_async(selType, make_shared<CallbackI>(callback, _instance, host.str(), _resource));
 }
 
 AcceptorPtr
@@ -275,7 +275,7 @@ IceInternal::WSEndpoint::endpoint(const EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(WSEndpoint, _instance, delEndp, _resource);
+        return make_shared<WSEndpoint>(_instance, delEndp, _resource);
     }
 }
 
@@ -291,7 +291,7 @@ IceInternal::WSEndpoint::expandIfWildcard() const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(WSEndpoint, _instance, *p, _resource);
+            *p = make_shared<WSEndpoint>(_instance, *p, _resource);
         }
     }
     return endps;
@@ -307,7 +307,7 @@ IceInternal::WSEndpoint::expandHost(EndpointIPtr& publish) const
     }
     else if(publish.get())
     {
-        publish = ICE_MAKE_SHARED(WSEndpoint, _instance, publish, _resource);
+        publish = make_shared<WSEndpoint>(_instance, publish, _resource);
     }
     for(vector<EndpointIPtr>::iterator p = endps.begin(); p != endps.end(); ++p)
     {
@@ -317,7 +317,7 @@ IceInternal::WSEndpoint::expandHost(EndpointIPtr& publish) const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(WSEndpoint, _instance, *p, _resource);
+            *p = make_shared<WSEndpoint>(_instance, *p, _resource);
         }
     }
     return endps;
@@ -477,11 +477,11 @@ IceInternal::WSEndpointFactory::cloneWithUnderlying(const ProtocolInstancePtr& i
 EndpointIPtr
 IceInternal::WSEndpointFactory::createWithUnderlying(const EndpointIPtr& underlying, vector<string>& args, bool) const
 {
-    return ICE_MAKE_SHARED(WSEndpoint, _instance, underlying, args);
+    return make_shared<WSEndpoint>(_instance, underlying, args);
 }
 
 EndpointIPtr
 IceInternal::WSEndpointFactory::readWithUnderlying(const EndpointIPtr& underlying, InputStream* s) const
 {
-    return ICE_MAKE_SHARED(WSEndpoint, _instance, underlying, s);
+    return make_shared<WSEndpoint>(_instance, underlying, s);
 }

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -780,7 +780,7 @@ IceInternal::WSTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceInternal::WSTransceiver::getInfo() const
 {
-    WSConnectionInfoPtr info = ICE_MAKE_SHARED(WSConnectionInfo);
+    WSConnectionInfoPtr info = std::make_shared<WSConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->headers = _parser->getHeaders();
     return info;

--- a/cpp/src/Ice/ios/StreamAcceptor.cpp
+++ b/cpp/src/Ice/ios/StreamAcceptor.cpp
@@ -72,7 +72,7 @@ IceObjC::StreamAcceptor::accept()
     UniqueRef<CFWriteStreamRef> writeStream;
     try
     {
-        CFStreamCreatePairWithSocket(ICE_NULLPTR, fd, &readStream.get(), &writeStream.get());
+        CFStreamCreatePairWithSocket(nullptr, fd, &readStream.get(), &writeStream.get());
         _instance->setupStreams(readStream.get(), writeStream.get(), true, "");
         return new StreamTransceiver(_instance, readStream.release(), writeStream.release(), fd);
     }

--- a/cpp/src/Ice/ios/StreamConnector.cpp
+++ b/cpp/src/Ice/ios/StreamConnector.cpp
@@ -27,9 +27,9 @@ IceObjC::StreamConnector::connect()
 {
     UniqueRef<CFReadStreamRef> readStream;
     UniqueRef<CFWriteStreamRef> writeStream;
-    UniqueRef<CFStringRef> h(CFStringCreateWithCString(ICE_NULLPTR, _host.c_str(), kCFStringEncodingUTF8));
-    UniqueRef<CFHostRef> host(CFHostCreateWithName(ICE_NULLPTR, h.get()));
-    CFStreamCreatePairWithSocketToCFHost(ICE_NULLPTR, host.get(), _port, &readStream.get(), &writeStream.get());
+    UniqueRef<CFStringRef> h(CFStringCreateWithCString(nullptr, _host.c_str(), kCFStringEncodingUTF8));
+    UniqueRef<CFHostRef> host(CFHostCreateWithName(nullptr, h.get()));
+    CFStreamCreatePairWithSocketToCFHost(nullptr, host.get(), _port, &readStream.get(), &writeStream.get());
     _instance->setupStreams(readStream.get(), writeStream.get(), false, _host);
     return new StreamTransceiver(_instance, readStream.release(), writeStream.release(), _host, _port);
 }

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -49,7 +49,7 @@ namespace
 inline CFStringRef
 toCFString(const string& s)
 {
-    return CFStringCreateWithCString(ICE_NULLPTR, s.c_str(), kCFStringEncodingUTF8);
+    return CFStringCreateWithCString(nullptr, s.c_str(), kCFStringEncodingUTF8);
 }
 
 }
@@ -143,7 +143,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance, Ice::Inpu
 EndpointInfoPtr
 IceObjC::StreamEndpointI::getInfo() const noexcept
 {
-    TCPEndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<Ice::TCPEndpointInfo>, ICE_SHARED_FROM_CONST_THIS(StreamEndpointI));
+    auto info = make_shared<InfoI<Ice::TCPEndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(StreamEndpointI));
     IPEndpointI::fillEndpointInfo(info.get());
     info->timeout = _timeout;
     info->compress = _compress;
@@ -165,7 +165,7 @@ IceObjC::StreamEndpointI::timeout(Int t) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, _port, _sourceAddr, t, _connectionId, _compress);
+        return make_shared<StreamEndpointI>(_streamInstance, _host, _port, _sourceAddr, t, _connectionId, _compress);
     }
 }
 
@@ -184,7 +184,7 @@ IceObjC::StreamEndpointI::compress(bool c) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, _port, _sourceAddr, _timeout, _connectionId, c);
+        return make_shared<StreamEndpointI>(_streamInstance, _host, _port, _sourceAddr, _timeout, _connectionId, c);
     }
 }
 
@@ -231,8 +231,8 @@ IceObjC::StreamEndpointI::endpoint(const StreamAcceptorPtr& a) const
     }
     else
     {
-        return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, _host, port, _sourceAddr, _timeout, _connectionId,
-                               _compress);
+        return make_shared<StreamEndpointI>(_streamInstance, _host, port, _sourceAddr, _timeout, _connectionId,
+                                            _compress);
     }
 }
 
@@ -417,8 +417,8 @@ IceObjC::StreamEndpointI::createConnector(const Address& /*address*/, const Netw
 IPEndpointIPtr
 IceObjC::StreamEndpointI::createEndpoint(const string& host, int port, const string& connectionId) const
 {
-    return ICE_MAKE_SHARED(StreamEndpointI, _streamInstance, host, port, _sourceAddr, _timeout, connectionId,
-                           _compress);
+    return make_shared<StreamEndpointI>(_streamInstance, host, port, _sourceAddr, _timeout, connectionId,
+                                        _compress);
 }
 
 IceObjC::StreamEndpointFactory::StreamEndpointFactory(const InstancePtr& instance) : _instance(instance)
@@ -444,7 +444,7 @@ IceObjC::StreamEndpointFactory::protocol() const
 EndpointIPtr
 IceObjC::StreamEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    IPEndpointIPtr endpt = ICE_MAKE_SHARED(StreamEndpointI, _instance);
+    IPEndpointIPtr endpt = make_shared<StreamEndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -452,7 +452,7 @@ IceObjC::StreamEndpointFactory::create(vector<string>& args, bool oaEndpoint) co
 EndpointIPtr
 IceObjC::StreamEndpointFactory::read(Ice::InputStream* s) const
 {
-    return ICE_MAKE_SHARED(StreamEndpointI, _instance, s);
+    return make_shared<StreamEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/Ice/ios/StreamEndpointI.h
+++ b/cpp/src/Ice/ios/StreamEndpointI.h
@@ -64,7 +64,7 @@ class StreamAcceptor;
 typedef IceUtil::Handle<StreamAcceptor> StreamAcceptorPtr;
 
 class StreamEndpointI;
-ICE_DEFINE_PTR(StreamEndpointIPtr, StreamEndpointI);
+using StreamEndpointIPtr = std::shared_ptr<StreamEndpointI>;
 
 class StreamEndpointI : public IceInternal::IPEndpointI
 {

--- a/cpp/src/Ice/ios/StreamTransceiver.cpp
+++ b/cpp/src/Ice/ios/StreamTransceiver.cpp
@@ -436,7 +436,7 @@ IceObjC::StreamTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceObjC::StreamTransceiver::getInfo() const
 {
-    Ice::TCPConnectionInfoPtr info = ICE_MAKE_SHARED(Ice::TCPConnectionInfo);
+    auto info = make_shared<Ice::TCPConnectionInfo>();
     fdToAddressAndPort(_fd, info->localAddress, info->localPort, info->remoteAddress, info->remotePort);
     info->rcvSize = getRecvBufferSize(_fd);
     info->sndSize = getSendBufferSize(_fd);

--- a/cpp/src/IceBT/AcceptorI.cpp
+++ b/cpp/src/IceBT/AcceptorI.cpp
@@ -79,7 +79,7 @@ IceBT::AcceptorI::listen()
 
     try
     {
-        ProfileCallbackPtr cb = ICE_MAKE_SHARED(ProfileCallbackI, this);
+        ProfileCallbackPtr cb = make_shared<ProfileCallbackI>(this);
         _path = _instance->engine()->registerProfile(_uuid, _name, _channel, cb);
     }
     catch(const BluetoothException& ex)

--- a/cpp/src/IceBT/DBus.h
+++ b/cpp/src/IceBT/DBus.h
@@ -512,7 +512,7 @@ public:
 
     virtual void completed(const AsyncResultPtr&) = 0;
 };
-ICE_DEFINE_PTR(AsyncCallbackPtr, AsyncCallback);
+using AsyncCallbackPtr = std::shared_ptr<AsyncCallback>;
 
 //
 // The result of an asynchronous DBus operation.
@@ -546,7 +546,7 @@ public:
     //
     virtual bool handleMessage(const ConnectionPtr&, const MessagePtr&) = 0;
 };
-ICE_DEFINE_PTR(FilterPtr, Filter);
+using FilterPtr = std::shared_ptr<Filter>;
 
 //
 // Allows a subclass to receive DBus method invocations.
@@ -557,7 +557,7 @@ public:
 
     virtual void handleMethodCall(const ConnectionPtr&, const MessagePtr&) = 0;
 };
-ICE_DEFINE_PTR(ServicePtr, Service);
+using ServicePtr = std::shared_ptr<Service>;
 
 //
 // Encapsulates a DBus connection.

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -101,7 +101,7 @@ IceBT::EndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, timeout, _connectionId, _compress);
+        return make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, timeout, _connectionId, _compress);
     }
 }
 
@@ -120,7 +120,7 @@ IceBT::EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, _timeout, connectionId, _compress);
+        return make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, _timeout, connectionId, _compress);
     }
 }
 
@@ -139,7 +139,7 @@ IceBT::EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, _channel, _timeout, _connectionId, compress);
+        return make_shared<EndpointI>(_instance, _addr, _uuid, _name, _channel, _timeout, _connectionId, compress);
     }
 }
 
@@ -186,8 +186,8 @@ IceBT::EndpointI::expandIfWildcard() const
         // getDefaultAdapterAddress will raise BluetoothException if no adapter is present.
         //
         string addr = _instance->engine()->getDefaultAdapterAddress();
-        endps.push_back(ICE_MAKE_SHARED(EndpointI, _instance, addr, _uuid, _name, _channel, _timeout, _connectionId,
-                                        _compress));
+        endps.push_back(make_shared<EndpointI>(_instance, addr, _uuid, _name, _channel, _timeout, _connectionId,
+                                               _compress));
     }
     else
     {
@@ -424,7 +424,7 @@ IceBT::EndpointI::options() const
 Ice::EndpointInfoPtr
 IceBT::EndpointI::getInfo() const noexcept
 {
-    EndpointInfoPtr info = ICE_MAKE_SHARED(EndpointInfoI, ICE_SHARED_FROM_CONST_THIS(EndpointI));
+    EndpointInfoPtr info = make_shared<EndpointInfoI>(ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->addr = _addr;
     info->uuid = _uuid;
     return info;
@@ -488,7 +488,7 @@ IceBT::EndpointI::initWithOptions(vector<string>& args, bool oaEndpoint)
 IceBT::EndpointIPtr
 IceBT::EndpointI::endpoint(const AcceptorIPtr& acceptor) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _instance, _addr, _uuid, _name, acceptor->effectiveChannel(), _timeout,
+    return make_shared<EndpointI>(_instance, _addr, _uuid, _name, acceptor->effectiveChannel(), _timeout,
                            _connectionId, _compress);
 }
 
@@ -642,7 +642,7 @@ IceBT::EndpointFactoryI::protocol() const
 IceInternal::EndpointIPtr
 IceBT::EndpointFactoryI::create(vector<string>& args, bool oaEndpoint) const
 {
-    EndpointIPtr endpt = ICE_MAKE_SHARED(EndpointI, _instance);
+    EndpointIPtr endpt = make_shared<EndpointI>(_instance);
     endpt->initWithOptions(args, oaEndpoint);
     return endpt;
 }
@@ -650,7 +650,7 @@ IceBT::EndpointFactoryI::create(vector<string>& args, bool oaEndpoint) const
 IceInternal::EndpointIPtr
 IceBT::EndpointFactoryI::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _instance, s);
+    return make_shared<EndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -158,7 +158,7 @@ protected:
 
     virtual void newConnection(int) = 0;
 };
-ICE_DEFINE_PTR(ProfilePtr, Profile);
+using ProfilePtr = std::shared_ptr<Profile>;
 
 //
 // ClientProfile represents an outgoing connection profile.
@@ -194,7 +194,7 @@ private:
     ConnectionPtr _connection;
     ConnectCallbackPtr _callback;
 };
-ICE_DEFINE_PTR(ClientProfilePtr, ClientProfile);
+using ClientProfilePtr = std::shared_ptr<ClientProfile>;
 
 //
 // ServerProfile represents an incoming connection profile.
@@ -219,7 +219,7 @@ private:
 
     ProfileCallbackPtr _callback;
 };
-ICE_DEFINE_PTR(ServerProfilePtr, ServerProfile);
+using ServerProfilePtr = std::shared_ptr<ServerProfile>;
 
 //
 // Engine delegates to BluetoothService. It encapsulates a snapshot of the "objects" managed by the
@@ -314,7 +314,7 @@ public:
             // from the Bluetooth service.
             //
             _dbusConnection = DBus::Connection::getSystemBus();
-            _dbusConnection->addFilter(ICE_SHARED_FROM_THIS);
+            _dbusConnection->addFilter(shared_from_this());
             getManagedObjects();
         }
         catch(const DBus::Exception& ex)
@@ -519,7 +519,7 @@ public:
         // As a subclass of DBus::Service, the ServerProfile object will receive DBus method
         // invocations for a given object path.
         //
-        ProfilePtr profile = ICE_MAKE_SHARED(ServerProfile, cb);
+        ProfilePtr profile = make_shared<ServerProfile>(cb);
 
         string path = generatePath();
 
@@ -569,7 +569,7 @@ public:
         //
         // Start a thread to establish the connection.
         //
-        IceUtil::ThreadPtr t = new ConnectThread(ICE_SHARED_FROM_THIS, addr, uuid, cb);
+        IceUtil::ThreadPtr t = new ConnectThread(shared_from_this(), addr, uuid, cb);
         _connectThreads.push_back(t);
         t->start();
     }
@@ -1152,7 +1152,7 @@ public:
             DBus::ConnectionPtr dbusConn = DBus::Connection::getSystemBus();
             conn = new ConnectionI(dbusConn, devicePath, uuid);
 
-            ProfilePtr profile = ICE_MAKE_SHARED(ClientProfile, conn, cb);
+            ProfilePtr profile = make_shared<ClientProfile>(conn, cb);
             string path = generatePath();
 
             //
@@ -1285,7 +1285,7 @@ IceBT::Engine::communicator() const
 void
 IceBT::Engine::initialize()
 {
-    _service = ICE_MAKE_SHARED(BluetoothService);
+    _service = make_shared<BluetoothService>();
     _service->init();
     _initialized = true;
 }

--- a/cpp/src/IceBT/Engine.h
+++ b/cpp/src/IceBT/Engine.h
@@ -23,7 +23,7 @@ public:
 
     virtual void newConnection(int) = 0;
 };
-ICE_DEFINE_PTR(ProfileCallbackPtr, ProfileCallback);
+using ProfileCallbackPtr = std::shared_ptr<ProfileCallback>;
 
 //
 // Represents an outgoing (client) connection. The transport must keep a reference to this object
@@ -48,7 +48,7 @@ public:
     virtual void completed(int, const ConnectionPtr&) = 0;
     virtual void failed(const Ice::LocalException&) = 0;
 };
-ICE_DEFINE_PTR(ConnectCallbackPtr, ConnectCallback);
+using ConnectCallbackPtr = std::shared_ptr<ConnectCallback>;
 
 //
 // Engine encapsulates all Bluetooth activities.

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -43,7 +43,7 @@ IceBT::TransceiverI::initialize(IceInternal::Buffer& /*readBuffer*/, IceInternal
         // We need to initiate a connection attempt.
         //
         _needConnect = false;
-        _instance->engine()->connect(_addr, _uuid, ICE_MAKE_SHARED(ConnectCallbackI, this));
+        _instance->engine()->connect(_addr, _uuid, make_shared<ConnectCallbackI>(this));
         return IceInternal::SocketOperationConnect;
     }
 
@@ -119,7 +119,7 @@ IceBT::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceBT::TransceiverI::getInfo() const
 {
-    IceBT::ConnectionInfoPtr info = ICE_MAKE_SHARED(IceBT::ConnectionInfo);
+    auto info = make_shared<IceBT::ConnectionInfo>();
     fdToAddressAndChannel(_stream->fd(), info->localAddress, info->localChannel, info->remoteAddress,
                           info->remoteChannel);
     if(_stream->fd() != INVALID_SOCKET)

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -184,7 +184,7 @@ IceBT::TransceiverI::connectFailed(const Ice::LocalException& ex)
     //
     // Save the exception - it will be raised in initialize().
     //
-    ICE_SET_EXCEPTION_FROM_CLONE(_exception, ex.ice_clone());
+    _exception = ex.ice_clone();
     //
     // Triggers a call to write() from a different thread.
     //

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -112,7 +112,7 @@ IceBox::ServiceManagerI::~ServiceManagerI()
 }
 
 void
-IceBox::ServiceManagerI::startService(ICE_IN(string) name, const Current&)
+IceBox::ServiceManagerI::startService(string name, const Current&)
 {
     ServiceInfo info;
     {
@@ -188,7 +188,7 @@ IceBox::ServiceManagerI::startService(ICE_IN(string) name, const Current&)
 }
 
 void
-IceBox::ServiceManagerI::stopService(ICE_IN(string) name, const Current&)
+IceBox::ServiceManagerI::stopService(string name, const Current&)
 {
     ServiceInfo info;
     {
@@ -264,7 +264,7 @@ IceBox::ServiceManagerI::stopService(ICE_IN(string) name, const Current&)
 }
 
 void
-IceBox::ServiceManagerI::addObserver(ICE_IN(ServiceObserverPrxPtr) observer, const Current&)
+IceBox::ServiceManagerI::addObserver(ServiceObserverPrxPtr observer, const Current&)
 {
     //
     // Null observers and duplicate registrations are ignored

--- a/cpp/src/IceBox/ServiceManagerI.h
+++ b/cpp/src/IceBox/ServiceManagerI.h
@@ -15,7 +15,7 @@ namespace IceBox
 {
 
 class ServiceManagerI;
-ICE_DEFINE_SHARED_PTR(ServiceManagerIPtr, ServiceManagerI);
+using ServiceManagerIPtr = std::shared_ptr<ServiceManagerI>;
 
 class ServiceManagerI : public ServiceManager,
                         public IceUtil::Monitor<IceUtil::Mutex>,
@@ -28,10 +28,10 @@ public:
 
     virtual ~ServiceManagerI();
 
-    virtual void startService(ICE_IN(std::string), const ::Ice::Current&);
-    virtual void stopService(ICE_IN(std::string), const ::Ice::Current&);
+    virtual void startService(std::string, const ::Ice::Current&);
+    virtual void stopService(std::string, const ::Ice::Current&);
 
-    virtual void addObserver(ICE_IN(ServiceObserverPrxPtr), const Ice::Current&);
+    virtual void addObserver(ServiceObserverPrxPtr, const Ice::Current&);
 
     virtual void shutdown(const ::Ice::Current&);
 

--- a/cpp/src/IceDiscovery/LocatorI.h
+++ b/cpp/src/IceDiscovery/LocatorI.h
@@ -49,10 +49,10 @@ private:
     std::map<std::string, Ice::ObjectPrxPtr> _adapters;
     std::map<std::string, std::set<std::string> > _replicaGroups;
 };
-ICE_DEFINE_SHARED_PTR(LocatorRegistryIPtr, LocatorRegistryI);
+using LocatorRegistryIPtr = std::shared_ptr<LocatorRegistryI>;
 
 class LookupI;
-ICE_DEFINE_SHARED_PTR(LookupIPtr, LookupI);
+using LookupIPtr = std::shared_ptr<LookupI>;
 
 class LocatorI : public Ice::Locator
 {

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -42,7 +42,7 @@ protected:
     size_t _lookupCount;
     size_t _failureCount;
 };
-ICE_DEFINE_PTR(RequestPtr, Request);
+using RequestPtr = std::shared_ptr<Request>;
 
 template<class T, class CB> class RequestT : public Request
 {
@@ -96,7 +96,7 @@ private:
     virtual void invokeWithLookup(const std::string&, const LookupPrxPtr&, const LookupReplyPrxPtr&);
     virtual void runTimerTask();
 };
-ICE_DEFINE_PTR(ObjectRequestPtr, ObjectRequest);
+using ObjectRequestPtr = std::shared_ptr<ObjectRequest>;
 
 class AdapterRequest : public RequestT<std::string, AdapterCB>, public std::enable_shared_from_this<AdapterRequest>
 {
@@ -123,7 +123,7 @@ private:
     IceUtil::Time _start;
     IceUtil::Time _latency;
 };
-ICE_DEFINE_PTR(AdapterRequestPtr, AdapterRequest);
+using AdapterRequestPtr = std::shared_ptr<AdapterRequest>;
 
 class LookupI : public Lookup,
                 public std::enable_shared_from_this<LookupI>,
@@ -138,9 +138,9 @@ public:
 
     void setLookupReply(const LookupReplyPrxPtr&);
 
-    virtual void findObjectById(ICE_IN(std::string), ICE_IN(Ice::Identity), ICE_IN(IceDiscovery::LookupReplyPrxPtr),
+    virtual void findObjectById(std::string, Ice::Identity, IceDiscovery::LookupReplyPrxPtr,
                                 const Ice::Current&);
-    virtual void findAdapterById(ICE_IN(std::string), ICE_IN(std::string), ICE_IN(IceDiscovery::LookupReplyPrxPtr),
+    virtual void findAdapterById(std::string, std::string, IceDiscovery::LookupReplyPrxPtr,
                                  const Ice::Current&);
     void findObject(const ObjectCB&, const Ice::Identity&);
     void findAdapter(const AdapterCB&, const std::string&);

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -120,21 +120,21 @@ PluginI::initialize()
     //
     // Setup locatory registry.
     //
-    LocatorRegistryIPtr locatorRegistry = ICE_MAKE_SHARED(LocatorRegistryI, _communicator);
+    LocatorRegistryIPtr locatorRegistry = make_shared<LocatorRegistryI>(_communicator);
     Ice::LocatorRegistryPrxPtr locatorRegistryPrx =
         ICE_UNCHECKED_CAST(Ice::LocatorRegistryPrx, _locatorAdapter->addWithUUID(locatorRegistry));
 
     Ice::ObjectPrxPtr lookupPrx = _communicator->stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
     // No collocation optimization for the multicast proxy!
-    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(ICE_NULLPTR);
+    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(nullptr);
 
     //
     // Add lookup and lookup reply Ice objects
     //
-    _lookup = ICE_MAKE_SHARED(LookupI, locatorRegistry, ICE_UNCHECKED_CAST(LookupPrx, lookupPrx), properties);
+    _lookup = make_shared<LookupI>(locatorRegistry, ICE_UNCHECKED_CAST(LookupPrx, lookupPrx), properties);
     _multicastAdapter->add(_lookup, Ice::stringToIdentity("IceDiscovery/Lookup"));
 
-    _replyAdapter->addDefaultServant(ICE_MAKE_SHARED(LookupReplyI, _lookup), "");
+    _replyAdapter->addDefaultServant(make_shared<LookupReplyI>(_lookup), "");
     Ice::Identity id;
     id.name = "dummy";
     _lookup->setLookupReply(ICE_UNCHECKED_CAST(LookupReplyPrx, _replyAdapter->createProxy(id)->ice_datagram()));
@@ -142,7 +142,7 @@ PluginI::initialize()
     //
     // Setup locator on the communicator.
     //
-    Ice::ObjectPrxPtr loc = _locatorAdapter->addWithUUID(ICE_MAKE_SHARED(LocatorI, _lookup, locatorRegistryPrx));
+    Ice::ObjectPrxPtr loc = _locatorAdapter->addWithUUID(make_shared<LocatorI>(_lookup, locatorRegistryPrx));
     _defaultLocator = _communicator->getDefaultLocator();
     _locator = ICE_UNCHECKED_CAST(Ice::LocatorPrx, loc);
     _communicator->setDefaultLocator(_locator);

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -369,7 +369,7 @@ Activator::activate(const string& name,
             // IceGrid doesn't support to use string converters, so don't need to use
             // any string converter in wstringToString conversions.
             //
-            if(SearchPathW(ICE_NULLPTR, stringToWstring(path).c_str(), ext.c_str(), _MAX_PATH, absbuf, &fPart) == 0)
+            if(SearchPathW(nullptr, stringToWstring(path).c_str(), ext.c_str(), _MAX_PATH, absbuf, &fPart) == 0)
             {
                 if(_traceLevels->activator > 0)
                 {
@@ -396,7 +396,7 @@ Activator::activate(const string& name,
     if(!pwd.empty())
     {
         wchar_t absbuf[_MAX_PATH];
-        if(_wfullpath(absbuf, stringToWstring(pwd).c_str(), _MAX_PATH) == ICE_NULLPTR)
+        if(_wfullpath(absbuf, stringToWstring(pwd).c_str(), _MAX_PATH) == nullptr)
         {
             if(_traceLevels->activator > 0)
             {
@@ -485,7 +485,7 @@ Activator::activate(const string& name,
     // any string converter in stringToWstring conversions.
     //
     wstring wpwd = stringToWstring(pwd);
-    const wchar_t* dir = !wpwd.empty() ? wpwd.c_str() : ICE_NULLPTR;
+    const wchar_t* dir = !wpwd.empty() ? wpwd.c_str() : nullptr;
 
     //
     // Make a copy of the command line.
@@ -498,7 +498,7 @@ Activator::activate(const string& name,
     // Since Windows is case insensitive wrt environment variables we convert the keys to
     // uppercase to ensure matches are found.
     //
-    const wchar_t* env = ICE_NULLPTR;
+    const wchar_t* env = nullptr;
     wstring envbuf;
     if(!envs.empty())
     {
@@ -1012,7 +1012,7 @@ Activator::sendSignal(const string& name, int signal)
     else if(signal == SIGKILL)
     {
         HANDLE hnd = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
-        if(hnd == ICE_NULLPTR)
+        if(hnd == nullptr)
         {
             throw SyscallException(__FILE__, __LINE__, getSystemErrno());
         }

--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -630,7 +630,7 @@ run(const Ice::StringSeq& args)
 
         if(acmTimeout > 0)
         {
-            session->ice_getConnection()->setACM(acmTimeout, IceUtil::None, Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+            session->ice_getConnection()->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
         }
 
         {

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -123,7 +123,7 @@ IceObjC::iAPEndpointI::streamWriteImpl(OutputStream* s) const
 EndpointInfoPtr
 IceObjC::iAPEndpointI::getInfo() const noexcept
 {
-    IceIAP::EndpointInfoPtr info = ICE_MAKE_SHARED(InfoI<IceIAP::EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(iAPEndpointI));
+    IceIAP::EndpointInfoPtr info = make_shared<InfoI<IceIAP::EndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(iAPEndpointI));
     info->timeout = _timeout;
     info->compress = _compress;
     info->manufacturer = _manufacturer;
@@ -172,8 +172,7 @@ IceObjC::iAPEndpointI::timeout(Int t) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, t, _connectionId,
-                               _compress);
+        return make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, t, _connectionId, _compress);
     }
 }
 
@@ -192,8 +191,7 @@ IceObjC::iAPEndpointI::connectionId(const string& cId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, _timeout, cId,
-                               _compress);
+        return make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, _timeout, cId, _compress);
     }
 }
 
@@ -212,8 +210,7 @@ IceObjC::iAPEndpointI::compress(bool c) const
     }
     else
     {
-        return ICE_MAKE_SHARED(iAPEndpointI, _instance, _manufacturer, _modelNumber, _name, _protocol, _timeout,
-                               _connectionId, c);
+        return make_shared<iAPEndpointI>(_instance, _manufacturer, _modelNumber, _name, _protocol, _timeout, _connectionId, c);
     }
 }
 
@@ -670,7 +667,8 @@ IceObjC::iAPEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
     {
         return 0;
     }
-    EndpointIPtr endpt = ICE_MAKE_SHARED(iAPEndpointI, _instance);
+
+    auto endpt = make_shared<iAPEndpointI>(_instance);
     endpt->initWithOptions(args);
     return endpt;
 }
@@ -678,7 +676,7 @@ IceObjC::iAPEndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 EndpointIPtr
 IceObjC::iAPEndpointFactory::read(InputStream* s) const
 {
-    return ICE_MAKE_SHARED(iAPEndpointI, _instance, s);
+    return make_shared<iAPEndpointI>(_instance, s);
 }
 
 void

--- a/cpp/src/IceIAP/Transceiver.mm
+++ b/cpp/src/IceIAP/Transceiver.mm
@@ -382,7 +382,7 @@ IceObjC::iAPTransceiver::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceObjC::iAPTransceiver::getInfo() const
 {
-    IceIAP::ConnectionInfoPtr info = ICE_MAKE_SHARED(IceIAP::ConnectionInfo);
+    IceIAP::ConnectionInfoPtr info = make_shared<IceIAP::ConnectionInfo>();
     info->manufacturer = [_session.accessory.manufacturer UTF8String];
     info->name = [_session.accessory.name UTF8String];
     info->modelNumber = [_session.accessory.modelNumber UTF8String];

--- a/cpp/src/IceLocatorDiscovery/Plugin.h
+++ b/cpp/src/IceLocatorDiscovery/Plugin.h
@@ -40,7 +40,7 @@ public:
 
     virtual std::vector<Ice::LocatorPrxPtr> getLocators(const std::string&, const IceUtil::Time&) const = 0;
 };
-ICE_DEFINE_PTR(PluginPtr, Plugin);
+using PluginPtr = std::shared_ptr<Plugin>;
 
 };
 

--- a/cpp/src/IcePatch2Lib/ClientUtil.cpp
+++ b/cpp/src/IcePatch2Lib/ClientUtil.cpp
@@ -1126,7 +1126,7 @@ PatcherI::updateFlags(const LargeFileInfoSeq& files)
 PatcherPtr
 PatcherFactory::create(const Ice::CommunicatorPtr& communicator, const PatcherFeedbackPtr& feedback)
 {
-    return ICE_MAKE_SHARED(PatcherI, communicator, feedback);
+    return make_shared<PatcherI>(communicator, feedback);
 }
 
 //
@@ -1141,5 +1141,5 @@ PatcherFactory::create(const FileServerPrxPtr& server,
                        Ice::Int chunkSize,
                        Ice::Int remove)
 {
-    return ICE_MAKE_SHARED(PatcherI, server, feedback, dataDir, thorough, chunkSize, remove);
+    return make_shared<PatcherI>(server, feedback, dataDir, thorough, chunkSize, remove);
 }

--- a/cpp/src/IceSSL/EndpointI.cpp
+++ b/cpp/src/IceSSL/EndpointI.cpp
@@ -32,7 +32,7 @@ getIPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }
@@ -51,7 +51,7 @@ IceSSL::EndpointI::streamWriteImpl(Ice::OutputStream* stream) const
 Ice::EndpointInfoPtr
 IceSSL::EndpointI::getInfo() const noexcept
 {
-    EndpointInfoPtr info = ICE_MAKE_SHARED(IceInternal::InfoI<EndpointInfo>, ICE_SHARED_FROM_CONST_THIS(EndpointI));
+    EndpointInfoPtr info = make_shared<IceInternal::InfoI<EndpointInfo>>(ICE_SHARED_FROM_CONST_THIS(EndpointI));
     info->underlying = _delegate->getInfo();
     info->compress = info->underlying->compress;
     info->timeout = info->underlying->timeout;
@@ -85,7 +85,7 @@ IceSSL::EndpointI::timeout(Int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->timeout(timeout));
+        return make_shared<EndpointI>(_instance, _delegate->timeout(timeout));
     }
 }
 
@@ -104,7 +104,7 @@ IceSSL::EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->connectionId(connectionId));
+        return make_shared<EndpointI>(_instance, _delegate->connectionId(connectionId));
     }
 }
 
@@ -123,7 +123,7 @@ IceSSL::EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, _delegate->compress(compress));
+        return make_shared<EndpointI>(_instance, _delegate->compress(compress));
     }
 }
 
@@ -182,7 +182,7 @@ IceSSL::EndpointI::connectors_async(Ice::EndpointSelectionType selType,
     };
 
     IPEndpointInfoPtr info = getIPEndpointInfo(_delegate->getInfo());
-    _delegate->connectors_async(selType, ICE_MAKE_SHARED(CallbackI, callback, _instance, info ? info->host : string()));
+    _delegate->connectors_async(selType, make_shared<CallbackI>(callback, _instance, info ? info->host : string()));
 }
 
 IceInternal::AcceptorPtr
@@ -200,7 +200,7 @@ IceSSL::EndpointI::endpoint(const IceInternal::EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, _instance, delEndp);
+        return make_shared<EndpointI>(_instance, delEndp);
     }
 }
 
@@ -216,7 +216,7 @@ IceSSL::EndpointI::expandIfWildcard() const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(EndpointI, _instance, *p);
+            *p = make_shared<EndpointI>(_instance, *p);
         }
     }
     return endps;
@@ -232,7 +232,7 @@ IceSSL::EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
     }
     else if(publish.get())
     {
-        publish = ICE_MAKE_SHARED(EndpointI, _instance, publish);
+        publish = make_shared<EndpointI>(_instance, publish);
     }
     for(vector<IceInternal::EndpointIPtr>::iterator p = endps.begin(); p != endps.end(); ++p)
     {
@@ -242,7 +242,7 @@ IceSSL::EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
         }
         else
         {
-            *p = ICE_MAKE_SHARED(EndpointI, _instance, *p);
+            *p = make_shared<EndpointI>(_instance, *p);
         }
     }
     return endps;
@@ -350,11 +350,11 @@ IceSSL::EndpointFactoryI::cloneWithUnderlying(const IceInternal::ProtocolInstanc
 IceInternal::EndpointIPtr
 IceSSL::EndpointFactoryI::createWithUnderlying(const IceInternal::EndpointIPtr& underlying, vector<string>&, bool) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _sslInstance, underlying);
+    return make_shared<EndpointI>(_sslInstance, underlying);
 }
 
 IceInternal::EndpointIPtr
 IceSSL::EndpointFactoryI::readWithUnderlying(const IceInternal::EndpointIPtr& underlying, Ice::InputStream*) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _sslInstance, underlying);
+    return make_shared<EndpointI>(_sslInstance, underlying);
 }

--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -489,7 +489,7 @@ OpenSSLCertificateI::loadX509Extensions() const
             len = OBJ_obj2txt(&oid[0], len, obj, 1);
             oid.resize(len);
             _extensions.push_back(ICE_DYNAMIC_CAST(IceSSL::X509Extension,
-                ICE_MAKE_SHARED(OpenSSLX509ExtensionI, ext, oid, _cert)));
+                make_shared<OpenSSLX509ExtensionI>(ext, oid, _cert)));
         }
     }
 }
@@ -585,7 +585,7 @@ OpenSSLCertificateI::getExtendedKeyUsage() const
 IceSSL::OpenSSL::CertificatePtr
 IceSSL::OpenSSL::Certificate::create(x509_st* cert)
 {
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, cert);
+    return make_shared<OpenSSLCertificateI>(cert);
 }
 
 IceSSL::OpenSSL::CertificatePtr
@@ -598,9 +598,9 @@ IceSSL::OpenSSL::Certificate::load(const std::string& file)
         throw CertificateReadException(__FILE__, __LINE__, "error opening file");
     }
 
-    x509_st* x = PEM_read_bio_X509(cert, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR);
+    x509_st* x = PEM_read_bio_X509(cert, nullptr, nullptr, nullptr);
     BIO_free(cert);
-    if(x == ICE_NULLPTR)
+    if(x == nullptr)
     {
         throw CertificateReadException(__FILE__, __LINE__, "error reading file:\n" + getSslErrors(false));
     }
@@ -609,16 +609,16 @@ IceSSL::OpenSSL::Certificate::load(const std::string& file)
     {
         throw CertificateReadException(__FILE__, __LINE__, "error loading certificate:\n" + getSslErrors(false));
     }
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, x);
+    return make_shared<OpenSSLCertificateI>(x);
 }
 
 IceSSL::OpenSSL::CertificatePtr
 IceSSL::OpenSSL::Certificate::decode(const std::string& encoding)
 {
     BIO *cert = BIO_new_mem_buf(static_cast<void*>(const_cast<char*>(&encoding[0])), static_cast<int>(encoding.size()));
-    x509_st* x = PEM_read_bio_X509(cert, ICE_NULLPTR, ICE_NULLPTR, ICE_NULLPTR);
+    x509_st* x = PEM_read_bio_X509(cert, nullptr, nullptr, nullptr);
     BIO_free(cert);
-    if(x == ICE_NULLPTR)
+    if(x == nullptr)
     {
         throw CertificateEncodingException(__FILE__, __LINE__, getSslErrors(false));
     }
@@ -627,5 +627,5 @@ IceSSL::OpenSSL::Certificate::decode(const std::string& encoding)
     {
         throw CertificateReadException(__FILE__, __LINE__, "error loading certificate:\n" + getSslErrors(false));
     }
-    return ICE_MAKE_SHARED(OpenSSLCertificateI, x);
+    return make_shared<OpenSSLCertificateI>(x);
 }

--- a/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
@@ -928,7 +928,7 @@ OpenSSL::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 OpenSSL::TransceiverI::getInfo() const
 {
-    ExtendedConnectionInfoPtr info = ICE_MAKE_SHARED(ExtendedConnectionInfo);
+    ExtendedConnectionInfoPtr info = std::make_shared<ExtendedConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/IceSSL/OpenSSLTransceiverI.cpp
@@ -63,66 +63,66 @@ TrustError trustStatusToTrustError(long status)
     switch (status)
     {
     case X509_V_OK:
-        return IceSSL::ICE_ENUM(TrustError, NoError);
+        return IceSSL::TrustError::NoError;
 
     case X509_V_ERR_CERT_CHAIN_TOO_LONG:
-        return IceSSL::ICE_ENUM(TrustError, ChainTooLong);
+        return IceSSL::TrustError::ChainTooLong;
 
     case X509_V_ERR_EXCLUDED_VIOLATION:
-        return IceSSL::ICE_ENUM(TrustError, HasExcludedNameConstraint);
+        return IceSSL::TrustError::HasExcludedNameConstraint;
 
     case X509_V_ERR_PERMITTED_VIOLATION:
-        return IceSSL::ICE_ENUM(TrustError, HasNonPermittedNameConstraint);
+        return IceSSL::TrustError::HasNonPermittedNameConstraint;
 
     case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
-        return IceSSL::ICE_ENUM(TrustError, HasNonSupportedCriticalExtension);
+        return IceSSL::TrustError::HasNonSupportedCriticalExtension;
 
     case X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE:
     case X509_V_ERR_SUBTREE_MINMAX:
-        return IceSSL::ICE_ENUM(TrustError, HasNonSupportedNameConstraint);
+        return IceSSL::TrustError::HasNonSupportedNameConstraint;
 
     case X509_V_ERR_HOSTNAME_MISMATCH:
     case X509_V_ERR_IP_ADDRESS_MISMATCH:
-        return IceSSL::ICE_ENUM(TrustError, HostNameMismatch);
+        return IceSSL::TrustError::HostNameMismatch;
 
     case X509_V_ERR_INVALID_CA:
     case X509_V_ERR_INVALID_NON_CA:
     case X509_V_ERR_PATH_LENGTH_EXCEEDED:
     case X509_V_ERR_KEYUSAGE_NO_CERTSIGN:
     case X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE:
-        return IceSSL::ICE_ENUM(TrustError, InvalidBasicConstraints);
+        return IceSSL::TrustError::InvalidBasicConstraints;
 
     case X509_V_ERR_INVALID_EXTENSION:
-        return IceSSL::ICE_ENUM(TrustError, InvalidExtension);
+        return IceSSL::TrustError::InvalidExtension;
 
     case X509_V_ERR_UNSUPPORTED_NAME_SYNTAX:
-        return IceSSL::ICE_ENUM(TrustError, InvalidNameConstraints);
+        return IceSSL::TrustError::InvalidNameConstraints;
 
     case X509_V_ERR_INVALID_POLICY_EXTENSION:
     case X509_V_ERR_NO_EXPLICIT_POLICY:
-        return IceSSL::ICE_ENUM(TrustError, InvalidPolicyConstraints);
+        return IceSSL::TrustError::InvalidPolicyConstraints;
 
     case X509_V_ERR_INVALID_PURPOSE:
-        return IceSSL::ICE_ENUM(TrustError, InvalidPurpose);
+        return IceSSL::TrustError::InvalidPurpose;
 
     case X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE:
     case X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY:
     case X509_V_ERR_CERT_SIGNATURE_FAILURE:
-        return IceSSL::ICE_ENUM(TrustError, InvalidSignature);
+        return IceSSL::TrustError::InvalidSignature;
 
     case X509_V_ERR_CERT_NOT_YET_VALID:
     case X509_V_ERR_CERT_HAS_EXPIRED:
     case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
     case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
-        return IceSSL::ICE_ENUM(TrustError, InvalidTime);
+        return IceSSL::TrustError::InvalidTime;
 
     case X509_V_ERR_CERT_REJECTED:
-        return IceSSL::ICE_ENUM(TrustError, NotTrusted);
+        return IceSSL::TrustError::NotTrusted;
 
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
     case X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE:
-        return IceSSL::ICE_ENUM(TrustError, PartialChain);
+        return IceSSL::TrustError::PartialChain;
 
     case X509_V_ERR_CRL_HAS_EXPIRED:
     case X509_V_ERR_CRL_NOT_YET_VALID:
@@ -135,18 +135,18 @@ TrustError trustStatusToTrustError(long status)
     case X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER:
     case X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION:
     case X509_V_ERR_CRL_PATH_VALIDATION_ERROR:
-        return IceSSL::ICE_ENUM(TrustError, RevocationStatusUnknown);
+        return IceSSL::TrustError::RevocationStatusUnknown;
 
     case X509_V_ERR_CERT_REVOKED:
-        return IceSSL::ICE_ENUM(TrustError, Revoked);
+        return IceSSL::TrustError::Revoked;
 
     case X509_V_ERR_CERT_UNTRUSTED:
     case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
     case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
-        return IceSSL::ICE_ENUM(TrustError, UntrustedRoot);
+        return IceSSL::TrustError::UntrustedRoot;
 
     default:
-        return IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+        return IceSSL::TrustError::UnknownTrustFailure;
     }
 }
 
@@ -442,7 +442,7 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
     }
     catch(const SecurityException&)
     {
-        _trustError = IceSSL::ICE_ENUM(TrustError, HostNameMismatch);
+        _trustError = IceSSL::TrustError::HostNameMismatch;
         _verified = false;
         if(_engine->getVerifyPeer() > 0)
         {

--- a/cpp/src/IceSSL/OpenSSLUtil.cpp
+++ b/cpp/src/IceSSL/OpenSSLUtil.cpp
@@ -272,7 +272,7 @@ IceSSL::OpenSSL::getSslErrors(bool verbose)
         else
         {
             const char* reason = ERR_reason_error_string(err);
-            ostr << (reason == ICE_NULLPTR ? "unknown reason" : reason);
+            ostr << (reason == nullptr ? "unknown reason" : reason);
             if(flags & ERR_TXT_STRING)
             {
                 ostr << ": " << data;

--- a/cpp/src/IceSSL/PluginI.cpp
+++ b/cpp/src/IceSSL/PluginI.cpp
@@ -102,7 +102,7 @@ IceSSL::getTrustError(const IceSSL::ConnectionInfoPtr& info)
     {
         return extendedInfo->errorCode;
     }
-    return info->verified ? IceSSL::ICE_ENUM(TrustError, NoError) : IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+    return info->verified ? IceSSL::TrustError::NoError : IceSSL::TrustError::UnknownTrustFailure;
 }
 
 std::string
@@ -110,89 +110,89 @@ IceSSL::getTrustErrorDescription(TrustError error)
 {
     switch(error)
     {
-        case IceSSL::ICE_ENUM(TrustError, NoError):
+        case IceSSL::TrustError::NoError:
         {
             return "no error";
         }
-        case IceSSL::ICE_ENUM(TrustError, ChainTooLong):
+        case IceSSL::TrustError::ChainTooLong:
         {
             return "the certificate chain length is greater than the specified maximum depth";
         }
-        case IceSSL::ICE_ENUM(TrustError, HasExcludedNameConstraint):
+        case IceSSL::TrustError::HasExcludedNameConstraint:
         {
             return "the X509 chain is invalid because a certificate has excluded a name constraint";
         }
-        case IceSSL::ICE_ENUM(TrustError, HasNonDefinedNameConstraint):
+        case IceSSL::TrustError::HasNonDefinedNameConstraint:
         {
             return "the certificate has an undefined name constraint";
         }
-        case IceSSL::ICE_ENUM(TrustError, HasNonPermittedNameConstraint):
+        case IceSSL::TrustError::HasNonPermittedNameConstraint:
         {
             return "the certificate has a non permitted name constrain";
         }
-        case IceSSL::ICE_ENUM(TrustError, HasNonSupportedCriticalExtension):
+        case IceSSL::TrustError::HasNonSupportedCriticalExtension:
         {
             return "the certificate does not support a critical extension";
         }
-        case IceSSL::ICE_ENUM(TrustError, HasNonSupportedNameConstraint):
+        case IceSSL::TrustError::HasNonSupportedNameConstraint:
         {
             return "the certificate does not have a supported name constraint or has a name constraint that "
                    "is unsupported";
         }
-        case IceSSL::ICE_ENUM(TrustError, HostNameMismatch):
+        case IceSSL::TrustError::HostNameMismatch:
         {
             return "a host name mismatch has occurred";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidBasicConstraints):
+        case IceSSL::TrustError::InvalidBasicConstraints:
         {
             return "the X509 chain is invalid due to invalid basic constraints";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidExtension):
+        case IceSSL::TrustError::InvalidExtension:
         {
             return "the X509 chain is invalid due to an invalid extension";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidNameConstraints):
+        case IceSSL::TrustError::InvalidNameConstraints:
         {
             return "the X509 chain is invalid due to invalid name constraints";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidPolicyConstraints):
+        case IceSSL::TrustError::InvalidPolicyConstraints:
         {
             return "the X509 chain is invalid due to invalid policy constraints";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidPurpose):
+        case IceSSL::TrustError::InvalidPurpose:
         {
             return "the supplied certificate cannot be used for the specified purpose";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidSignature):
+        case IceSSL::TrustError::InvalidSignature:
         {
             return "the X509 chain is invalid due to an invalid certificate signature";
         }
-        case IceSSL::ICE_ENUM(TrustError, InvalidTime):
+        case IceSSL::TrustError::InvalidTime:
         {
             return "the X509 chain is not valid due to an invalid time value, such as a value that indicates an "
                    "expired certificate";
         }
-        case IceSSL::ICE_ENUM(TrustError, NotTrusted):
+        case IceSSL::TrustError::NotTrusted:
         {
             return "the certificate is explicitly distrusted";
         }
-        case IceSSL::ICE_ENUM(TrustError, PartialChain):
+        case IceSSL::TrustError::PartialChain:
         {
             return "the X509 chain could not be built up to the root certificate";
         }
-        case IceSSL::ICE_ENUM(TrustError, RevocationStatusUnknown):
+        case IceSSL::TrustError::RevocationStatusUnknown:
         {
             return "it is not possible to determine whether the certificate has been revoked";
         }
-        case IceSSL::ICE_ENUM(TrustError, Revoked):
+        case IceSSL::TrustError::Revoked:
         {
             return "the X509 chain is invalid due to a revoked certificate";
         }
-        case IceSSL::ICE_ENUM(TrustError, UntrustedRoot):
+        case IceSSL::TrustError::UntrustedRoot:
         {
             return "the X509 chain is invalid due to an untrusted root certificate";
         }
-        case IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure):
+        case IceSSL::TrustError::UnknownTrustFailure:
         {
             return "unknown failure";
         }

--- a/cpp/src/IceSSL/PluginI.h
+++ b/cpp/src/IceSSL/PluginI.h
@@ -20,7 +20,7 @@ public:
     TrustError errorCode;
     std::string host;
 };
-ICE_DEFINE_PTR(ExtendedConnectionInfoPtr, ExtendedConnectionInfo);
+using ExtendedConnectionInfoPtr = std::shared_ptr<ExtendedConnectionInfo>;
 
 // TODO: This class provides new certificate virtual methods that canot be added directly to the certificate class
 // without breaking binary compatibility. The class can be removed once the relevant methods can be marked as virtual in

--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -529,9 +529,7 @@ SChannelCertificateI::loadX509Extensions() const
         for(size_t i = 0; i < _certInfo->cExtension; ++i)
         {
             CERT_EXTENSION ext = _certInfo->rgExtension[i];
-            _extensions.push_back(ICE_DYNAMIC_CAST(X509Extension,
-                ICE_MAKE_SHARED(SCHannelX509ExtensionI, ext, ext.pszObjId,
-                _certInfoHolder)));
+            _extensions.push_back(std::make_shared<SCHannelX509ExtensionI>(ext, ext.pszObjId, _certInfoHolder));
         }
     }
 }
@@ -676,7 +674,7 @@ SChannelCertificateI::getExtendedKeyUsage() const
 SChannel::CertificatePtr
 SChannel::Certificate::create(CERT_SIGNED_CONTENT_INFO* cert)
 {
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return make_shared<SChannelCertificateI>(cert);
 }
 
 SChannel::CertificatePtr
@@ -684,7 +682,7 @@ SChannel::Certificate::load(const std::string& file)
 {
     CERT_SIGNED_CONTENT_INFO* cert;
     loadCertificate(&cert, file);
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return make_shared<SChannelCertificateI>(cert);
 }
 
 SChannel::CertificatePtr
@@ -692,5 +690,5 @@ SChannel::Certificate::decode(const std::string& encoding)
 {
     CERT_SIGNED_CONTENT_INFO* cert;
     loadCertificate(&cert, encoding.c_str(), static_cast<DWORD>(encoding.size()));
-    return ICE_MAKE_SHARED(SChannelCertificateI, cert);
+    return make_shared<SChannelCertificateI>(cert);
 }

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -57,7 +57,7 @@ trustStatusToTrustError(DWORD status)
 {
     if (status & CERT_TRUST_NO_ERROR)
     {
-        return IceSSL::ICE_ENUM(TrustError, NoError);
+        return IceSSL::TrustError::NoError;
     }
     if ((status & CERT_TRUST_IS_UNTRUSTED_ROOT) ||
         (status & CERT_TRUST_IS_CYCLIC) ||
@@ -65,78 +65,78 @@ trustStatusToTrustError(DWORD status)
         (status & CERT_TRUST_CTL_IS_NOT_SIGNATURE_VALID) ||
         (status & CERT_TRUST_CTL_IS_NOT_VALID_FOR_USAGE))
     {
-        return IceSSL::ICE_ENUM(TrustError, UntrustedRoot);
+        return IceSSL::TrustError::UntrustedRoot;
     }
     if (status & CERT_TRUST_IS_EXPLICIT_DISTRUST)
     {
-        return IceSSL::ICE_ENUM(TrustError, NotTrusted);
+        return IceSSL::TrustError::NotTrusted;
     }
     if (status & CERT_TRUST_IS_PARTIAL_CHAIN)
     {
-        return IceSSL::ICE_ENUM(TrustError, PartialChain);
+        return IceSSL::TrustError::PartialChain;
     }
     if (status & CERT_TRUST_INVALID_BASIC_CONSTRAINTS)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidBasicConstraints);
+        return IceSSL::TrustError::InvalidBasicConstraints;
     }
     if (status & CERT_TRUST_IS_NOT_SIGNATURE_VALID)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidSignature);
+        return IceSSL::TrustError::InvalidSignature;
     }
     if (status & CERT_TRUST_IS_NOT_VALID_FOR_USAGE)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidPurpose);
+        return IceSSL::TrustError::InvalidPurpose;
     }
     if (status & CERT_TRUST_IS_REVOKED)
     {
-        return IceSSL::ICE_ENUM(TrustError, Revoked);
+        return IceSSL::TrustError::Revoked;
     }
     if (status & CERT_TRUST_INVALID_EXTENSION)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidExtension);
+        return IceSSL::TrustError::InvalidExtension;
     }
     if (status & CERT_TRUST_INVALID_POLICY_CONSTRAINTS)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidPolicyConstraints);
+        return IceSSL::TrustError::InvalidPolicyConstraints;
     }
     if (status & CERT_TRUST_INVALID_NAME_CONSTRAINTS)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidNameConstraints);
+        return IceSSL::TrustError::InvalidNameConstraints;
     }
     if (status & CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT)
     {
-        return IceSSL::ICE_ENUM(TrustError, HasNonSupportedNameConstraint);
+        return IceSSL::TrustError::HasNonSupportedNameConstraint;
     }
     if (status & CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT)
     {
-        return IceSSL::ICE_ENUM(TrustError, HasNonDefinedNameConstraint);
+        return IceSSL::TrustError::HasNonDefinedNameConstraint;
     }
     if (status & CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT)
     {
-        return IceSSL::ICE_ENUM(TrustError, HasNonPermittedNameConstraint);
+        return IceSSL::TrustError::HasNonPermittedNameConstraint;
     }
     if (status & CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT)
     {
-        return IceSSL::ICE_ENUM(TrustError, HasExcludedNameConstraint);
+        return IceSSL::TrustError::HasExcludedNameConstraint;
     }
     if (status & CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidPolicyConstraints);
+        return IceSSL::TrustError::InvalidPolicyConstraints;
     }
     if (status & CERT_TRUST_HAS_NOT_SUPPORTED_CRITICAL_EXT)
     {
-        return IceSSL::ICE_ENUM(TrustError, HasNonSupportedCriticalExtension);
+        return IceSSL::TrustError::HasNonSupportedCriticalExtension;
     }
     if (status & CERT_TRUST_IS_OFFLINE_REVOCATION ||
         status & CERT_TRUST_REVOCATION_STATUS_UNKNOWN)
     {
-        return IceSSL::ICE_ENUM(TrustError, RevocationStatusUnknown);
+        return IceSSL::TrustError::RevocationStatusUnknown;
     }
     if (status & CERT_TRUST_IS_NOT_TIME_VALID)
     {
-        return IceSSL::ICE_ENUM(TrustError, InvalidTime);
+        return IceSSL::TrustError::InvalidTime;
     }
-    return IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+    return IceSSL::TrustError::UnknownTrustFailure;
 }
 
 string
@@ -785,7 +785,7 @@ SChannel::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal:
         {
             CertFreeCertificateContext(cert);
             trustError = IceUtilInternal::lastErrorToString();
-            _trustError = IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+            _trustError = IceSSL::TrustError::UnknownTrustFailure;
         }
         else
         {
@@ -797,7 +797,7 @@ SChannel::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal:
             else
             {
                 _verified = true;
-                _trustError = IceSSL::ICE_ENUM(TrustError, NoError);
+                _trustError = IceSSL::TrustError::NoError;
             }
 
             CERT_SIMPLE_CHAIN* simpleChain = certChain->rgpChain[0];
@@ -862,9 +862,9 @@ SChannel::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal:
     }
     catch(const Ice::SecurityException&)
     {
-        _trustError = IceSSL::ICE_ENUM(TrustError, HostNameMismatch);
+        _trustError = IceSSL::TrustError::HostNameMismatch;
         _verified = false;
-        ICE_DYNAMIC_CAST(ExtendedConnectionInfo, info)->errorCode = IceSSL::ICE_ENUM(TrustError, HostNameMismatch);
+        ICE_DYNAMIC_CAST(ExtendedConnectionInfo, info)->errorCode = IceSSL::TrustError::HostNameMismatch;
         info->verified = false;
         if(_engine->getVerifyPeer() > 0)
         {

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -1113,7 +1113,7 @@ SChannel::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 SChannel::TransceiverI::getInfo() const
 {
-    ExtendedConnectionInfoPtr info = ICE_MAKE_SHARED(ExtendedConnectionInfo);
+    ExtendedConnectionInfoPtr info = std::make_shared<ExtendedConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/SecureTransportCertificateI.cpp
+++ b/cpp/src/IceSSL/SecureTransportCertificateI.cpp
@@ -883,7 +883,7 @@ SecureTransportCertificateI::getExtendedKeyUsage() const
 IceSSL::SecureTransport::CertificatePtr
 IceSSL::SecureTransport::Certificate::create(SecCertificateRef cert)
 {
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, cert);
+    return make_shared<SecureTransportCertificateI>(cert);
 }
 
 IceSSL::SecureTransport::CertificatePtr
@@ -892,7 +892,7 @@ IceSSL::SecureTransport::Certificate::load(const std::string& file)
     string resolved;
     if(checkPath(file, "", false, resolved))
     {
-        return ICE_MAKE_SHARED(SecureTransportCertificateI, loadCertificate(resolved));
+        return make_shared<SecureTransportCertificateI>(loadCertificate(resolved));
     }
     else
     {
@@ -927,7 +927,7 @@ IceSSL::SecureTransport::Certificate::decode(const std::string& encoding)
         assert(false);
         throw CertificateEncodingException(__FILE__, __LINE__, "certificate is not a valid PEM-encoded certificate");
     }
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, cert);
+    return make_shared<SecureTransportCertificateI>(cert);
 #else // macOS
     UniqueRef<CFDataRef> data(
         CFDataCreateWithBytesNoCopy(kCFAllocatorDefault,
@@ -951,6 +951,6 @@ IceSSL::SecureTransport::Certificate::decode(const std::string& encoding)
     UniqueRef<SecKeychainItemRef> item;
     item.retain(static_cast<SecKeychainItemRef>(const_cast<void*>(CFArrayGetValueAtIndex(items.get(), 0))));
     assert(SecCertificateGetTypeID() == CFGetTypeID(item.get()));
-    return ICE_MAKE_SHARED(SecureTransportCertificateI, reinterpret_cast<SecCertificateRef>(item.release()));
+    return make_shared<SecureTransportCertificateI>(reinterpret_cast<SecCertificateRef>(item.release()));
 #endif
 }

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
@@ -609,7 +609,7 @@ IceSSL::SecureTransport::TransceiverI::toDetailedString() const
 Ice::ConnectionInfoPtr
 IceSSL::SecureTransport::TransceiverI::getInfo() const
 {
-    IceSSL::ExtendedConnectionInfoPtr info = ICE_MAKE_SHARED(IceSSL::ExtendedConnectionInfo);
+    auto info = make_shared<IceSSL::ExtendedConnectionInfo>();
     info->underlying = _delegate->getInfo();
     info->incoming = _incoming;
     info->adapterName = _adapterName;

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
@@ -73,32 +73,32 @@ TrustError errorToTrustError(CFErrorRef err)
     {
         case errSecPathLengthConstraintExceeded:
         {
-            return IceSSL::ICE_ENUM(TrustError, ChainTooLong);
+            return IceSSL::TrustError::ChainTooLong;
         }
         case errSecUnknownCRLExtension:
         case errSecUnknownCriticalExtensionFlag:
         {
-            return IceSSL::ICE_ENUM(TrustError, HasNonSupportedCriticalExtension);
+            return IceSSL::TrustError::HasNonSupportedCriticalExtension;
         }
         case errSecHostNameMismatch:
         {
-            return IceSSL::ICE_ENUM(TrustError, HostNameMismatch);
+            return IceSSL::TrustError::HostNameMismatch;
         }
         case errSecCodeSigningNoBasicConstraints:
         case errSecNoBasicConstraints:
         case errSecNoBasicConstraintsCA:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidBasicConstraints);
+            return IceSSL::TrustError::InvalidBasicConstraints;
         }
         case errSecMissingRequiredExtension:
         case errSecUnknownCertExtension:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidExtension);
+            return IceSSL::TrustError::InvalidExtension;
         }
         case errSecCertificateNameNotAllowed:
         case errSecInvalidName:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidNameConstraints);
+            return IceSSL::TrustError::InvalidNameConstraints;
         }
         case errSecCertificatePolicyNotAllowed:
         case errSecInvalidPolicyIdentifiers:
@@ -106,44 +106,44 @@ TrustError errorToTrustError(CFErrorRef err)
         case errSecInvalidDigestAlgorithm:
         case errSecUnsupportedKeySize:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidPolicyConstraints);
+            return IceSSL::TrustError::InvalidPolicyConstraints;
         }
         case errSecInvalidExtendedKeyUsage:
         case errSecInvalidKeyUsageForPolicy:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidPurpose);
+            return IceSSL::TrustError::InvalidPurpose;
         }
         case errSecInvalidSignature:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidSignature);
+            return IceSSL::TrustError::InvalidSignature;
         }
         case errSecCertificateExpired:
         case errSecCertificateNotValidYet:
         case errSecCertificateValidityPeriodTooLong:
         {
-            return IceSSL::ICE_ENUM(TrustError, InvalidTime);
+            return IceSSL::TrustError::InvalidTime;
         }
         case errSecCreateChainFailed:
         {
-            return IceSSL::ICE_ENUM(TrustError, PartialChain);
+            return IceSSL::TrustError::PartialChain;
         }
         case errSecCertificateRevoked:
         {
-            return IceSSL::ICE_ENUM(TrustError, Revoked);
+            return IceSSL::TrustError::Revoked;
         }
         case errSecIncompleteCertRevocationCheck:
         case errSecOCSPNotTrustedToAnchor:
         {
-            return IceSSL::ICE_ENUM(TrustError, RevocationStatusUnknown);
+            return IceSSL::TrustError::RevocationStatusUnknown;
         }
         case errSecNotTrusted:
         case errSecVerifyActionFailed:
         {
-            return IceSSL::ICE_ENUM(TrustError, UntrustedRoot);
+            return IceSSL::TrustError::UntrustedRoot;
         }
         default:
         {
-            return IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+            return IceSSL::TrustError::UnknownTrustFailure;
         }
     }
 }
@@ -217,7 +217,7 @@ checkTrustResult(SecTrustRef trust,
         //
         if(SecTrustEvaluateWithError(trust, &trustErr.get()))
         {
-            return IceSSL::ICE_ENUM(TrustError, NoError);
+            return IceSSL::TrustError::NoError;
         }
         else
         {
@@ -246,7 +246,7 @@ checkTrustResult(SecTrustRef trust,
             }
         }
     }
-    return IceSSL::ICE_ENUM(TrustError, UnknownTrustFailure);
+    return IceSSL::TrustError::UnknownTrustFailure;
 }
 }
 
@@ -351,7 +351,7 @@ IceSSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuffe
             if(err == noErr)
             {
                 _trustError = checkTrustResult(_trust.get(), _engine, _instance, _host);
-                _verified = _trustError == IceSSL::ICE_ENUM(TrustError, NoError);
+                _verified = _trustError == IceSSL::TrustError::NoError;
                 continue; // Call SSLHandshake to resume the handsake.
             }
             // Let it fall through, this will raise a SecurityException with the SSLCopyPeerTrust error.

--- a/cpp/src/IceSSL/SecureTransportUtil.cpp
+++ b/cpp/src/IceSSL/SecureTransportUtil.cpp
@@ -89,7 +89,7 @@ CFDictionaryRef
 IceSSL::SecureTransport::getCertificateProperty(SecCertificateRef cert, CFTypeRef key)
 {
     UniqueRef<CFDictionaryRef> property;
-    UniqueRef<CFArrayRef> keys(CFArrayCreate(ICE_NULLPTR, &key , 1, &kCFTypeArrayCallBacks));
+    UniqueRef<CFArrayRef> keys(CFArrayCreate(nullptr, &key , 1, &kCFTypeArrayCallBacks));
     UniqueRef<CFErrorRef> err;
     UniqueRef<CFDictionaryRef> values(SecCertificateCopyValues(cert, keys.get(), &err.get()));
     if(err)

--- a/cpp/src/IceSSL/Util.h
+++ b/cpp/src/IceSSL/Util.h
@@ -31,7 +31,7 @@ std::string fromCFString(CFStringRef);
 inline CFStringRef
 toCFString(const std::string& s)
 {
-    return CFStringCreateWithCString(ICE_NULLPTR, s.c_str(), kCFStringEncodingUTF8);
+    return CFStringCreateWithCString(nullptr, s.c_str(), kCFStringEncodingUTF8);
 }
 #endif
 

--- a/cpp/src/IceUtil/CtrlCHandler.cpp
+++ b/cpp/src/IceUtil/CtrlCHandler.cpp
@@ -20,7 +20,7 @@ using namespace IceUtil;
 namespace
 {
 
-CtrlCHandlerCallback _callback = ICE_NULLPTR;
+CtrlCHandlerCallback _callback = nullptr;
 
 const CtrlCHandler* _handler = 0;
 
@@ -100,7 +100,7 @@ CtrlCHandler::~CtrlCHandler()
     {
         lock_guard lock(globalMutex);
         _handler = 0;
-        _callback = ICE_NULLPTR;
+        _callback = nullptr;
     }
 }
 
@@ -212,7 +212,7 @@ CtrlCHandler::~CtrlCHandler()
     {
         lock_guard lock(globalMutex);
         _handler = 0;
-        _callback = ICE_NULLPTR;
+        _callback = nullptr;
     }
 
     //

--- a/cpp/src/IceUtil/FileUtil.cpp
+++ b/cpp/src/IceUtil/FileUtil.cpp
@@ -244,7 +244,7 @@ IceUtilInternal::getcwd(string& cwd)
     // from Windows API.
     //
     wchar_t cwdbuf[_MAX_PATH];
-    if(_wgetcwd(cwdbuf, _MAX_PATH) == ICE_NULLPTR)
+    if(_wgetcwd(cwdbuf, _MAX_PATH) == nullptr)
     {
         return -1;
     }
@@ -281,7 +281,7 @@ IceUtilInternal::FileLock::FileLock(const std::string& path) :
     // to Windows API.
     //
     _fd = ::CreateFileW(stringToWstring(path, IceUtil::getProcessStringConverter()).c_str(),
-                        GENERIC_WRITE, 0, ICE_NULLPTR, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, ICE_NULLPTR);
+                        GENERIC_WRITE, 0, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     _path = path;
 
     if(_fd == INVALID_HANDLE_VALUE)
@@ -384,7 +384,7 @@ int
 IceUtilInternal::getcwd(string& cwd)
 {
     char cwdbuf[PATH_MAX];
-    if(::getcwd(cwdbuf, PATH_MAX) == ICE_NULLPTR)
+    if(::getcwd(cwdbuf, PATH_MAX) == nullptr)
     {
         return -1;
     }

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -174,7 +174,7 @@ private:
 const WstringConverterPtr&
 getUnicodeWstringConverter()
 {
-    static const WstringConverterPtr unicodeWstringConverter = ICE_MAKE_SHARED(UnicodeWstringConverter);
+    static const WstringConverterPtr unicodeWstringConverter = make_shared<UnicodeWstringConverter>();
     return unicodeWstringConverter;
 }
 
@@ -561,6 +561,6 @@ WindowsStringConverter::fromUTF8(const Byte* sourceStart, const Byte* sourceEnd,
 StringConverterPtr
 IceUtil::createWindowsStringConverter(unsigned int cp)
 {
-    return ICE_MAKE_SHARED(WindowsStringConverter, cp);
+    return make_shared<WindowsStringConverter>(cp);
 }
 #endif

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -150,7 +150,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
             }
             case '\a':
             {
-                if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                if(toStringMode == ToStringMode::Compat)
                 {
                     // Octal escape for compatibility with 3.6 and earlier
                     result.append("\\007");
@@ -188,7 +188,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
             }
             case '\v':
             {
-                if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                if(toStringMode == ToStringMode::Compat)
                 {
                     // Octal escape for compatibility with 3.6 and earlier
                     result.append("\\013");
@@ -212,7 +212,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
 
                     if(i < 32 || i > 126)
                     {
-                        if(toStringMode == ICE_ENUM(ToStringMode, Compat))
+                        if(toStringMode == ToStringMode::Compat)
                         {
                             // append octal string
 
@@ -234,7 +234,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
                             result.push_back(toHexDigit(i >> 4));
                             result.push_back(toHexDigit(i & 0x0F));
                         }
-                        else if(toStringMode == ICE_ENUM(ToStringMode, ASCII))
+                        else if(toStringMode == ToStringMode::ASCII)
                         {
                             // append \unnnn or \Unnnnnnnn after reading more UTF-8 bytes
                             appendUniversalName(c, p, u8s.end(), result);
@@ -256,7 +256,7 @@ IceUtilInternal::escapeString(const string& s, const string& special, ToStringMo
         }
     }
 
-    if(toStringMode == ICE_ENUM(ToStringMode, Unicode))
+    if(toStringMode == ToStringMode::Unicode)
     {
         //
         // Convert back to Native

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -818,13 +818,13 @@ IceUtilInternal::errorToString(int error, LPCVOID source)
             FORMAT_MESSAGE_ALLOCATE_BUFFER |
             FORMAT_MESSAGE_FROM_SYSTEM |
             FORMAT_MESSAGE_IGNORE_INSERTS |
-            (source != ICE_NULLPTR ? FORMAT_MESSAGE_FROM_HMODULE : 0),
+            (source != nullptr ? FORMAT_MESSAGE_FROM_HMODULE : 0),
             source,
             error,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
             reinterpret_cast<LPWSTR>(&msg),
             0,
-            ICE_NULLPTR);
+            nullptr);
 
         if(stored > 0)
         {

--- a/cpp/src/IceXML/Parser.cpp
+++ b/cpp/src/IceXML/Parser.cpp
@@ -376,7 +376,7 @@ IceXML::Parser::parse(const string& file, Handler& handler) // The given filenam
 void
 IceXML::Parser::parse(istream& in, Handler& handler)
 {
-    XML_Parser parser = XML_ParserCreate(ICE_NULLPTR);
+    XML_Parser parser = XML_ParserCreate(nullptr);
     CallbackData cb;
     cb.parser = parser;
     cb.handler = &handler;

--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -164,7 +164,7 @@ compile(const vector<string>& argv)
         if(preprocess)
         {
             char buf[4096];
-            while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+            while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
             {
                 if(fputs(buf, stdout) == EOF)
                 {

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -270,7 +270,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -240,7 +240,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -239,7 +239,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -268,7 +268,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -4698,7 +4698,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1541,7 +1541,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -615,7 +615,7 @@ Slice::Python::compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -755,7 +755,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
         }
 
-        bool afterLastRequiredParameter = lastRequiredParameter == ICE_NULLPTR;
+        bool afterLastRequiredParameter = lastRequiredParameter == nullptr;
         for(ParamDeclList::const_iterator q = paramList.begin(); q != paramList.end(); ++q)
         {
             if(!(*q)->isOutParam())

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -210,7 +210,7 @@ Slice::Ruby::compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -222,7 +222,7 @@ compile(const vector<string>& argv)
             if(preprocess)
             {
                 char buf[4096];
-                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != ICE_NULLPTR)
+                while(fgets(buf, static_cast<int>(sizeof(buf)), cppHandle) != nullptr)
                 {
                     if(fputs(buf, stdout) == EOF)
                     {

--- a/cpp/test/Glacier2/application/Client.cpp
+++ b/cpp/test/Glacier2/application/Client.cpp
@@ -48,13 +48,13 @@ public:
     IceUtil::Monitor<IceUtil::Mutex> _monitor;
     bool _received;
 };
-ICE_DEFINE_PTR(CallbackReceiverIPtr, CallbackReceiverI);
+using CallbackReceiverIPtr = std::shared_ptr<CallbackReceiverI>;
 
 class Application : public Glacier2::Application
 {
 public:
 
-    Application() : _restart(0), _destroyed(false), _receiver(ICE_MAKE_SHARED(CallbackReceiverI))
+    Application() : _restart(0), _destroyed(false), _receiver(std::make_shared<CallbackReceiverI>())
     {
     }
 

--- a/cpp/test/Glacier2/application/Server.cpp
+++ b/cpp/test/Glacier2/application/Server.cpp
@@ -19,7 +19,7 @@ class CallbackI : public Callback
 public:
 
     virtual void
-    initiateCallback(ICE_IN(CallbackReceiverPrxPtr) proxy, const Ice::Current& current)
+    initiateCallback(CallbackReceiverPrxPtr proxy, const Ice::Current& current)
     {
         proxy->callback(current.ctx);
     }
@@ -49,7 +49,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("CallbackAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("CallbackAdapter");
-    adapter->add(ICE_MAKE_SHARED(CallbackI), Ice::stringToIdentity("callback"));
+    adapter->add(std::make_shared<CallbackI>(), Ice::stringToIdentity("callback"));
     adapter->activate();
     communicator->waitForShutdown();
 }

--- a/cpp/test/Glacier2/sessionHelper/Server.cpp
+++ b/cpp/test/Glacier2/sessionHelper/Server.cpp
@@ -53,7 +53,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("CallbackAdapter.Endpoints", getTestEndpoint());
     auto adapter = communicator->createObjectAdapter("CallbackAdapter");
-    adapter->add(ICE_MAKE_SHARED(CallbackI), Ice::stringToIdentity("callback"));
+    adapter->add(std::make_shared<CallbackI>(), Ice::stringToIdentity("callback"));
     adapter->activate();
     communicator->waitForShutdown();
 }

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -90,7 +90,7 @@ public:
     virtual Ice::LoggerPtr
     cloneWithPrefix(const std::string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 
 private:
@@ -108,7 +108,7 @@ private:
     bool _started;
     vector<string> _messages;
 };
-ICE_DEFINE_PTR(LoggerIPtr, LoggerI);
+using LoggerIPtr = std::shared_ptr<LoggerI>;
 
 class TestCase : public enable_shared_from_this<TestCase>,
                  protected IceUtil::Monitor<IceUtil::Mutex>
@@ -270,7 +270,7 @@ protected:
     int _heartbeat;
     bool _closed;
 };
-ICE_DEFINE_PTR(TestCasePtr, TestCase);
+using TestCasePtr = std::shared_ptr<TestCase>;
 
 class InvocationHeartbeatTest final : public TestCase
 {
@@ -615,20 +615,20 @@ allTests(Test::TestHelper* helper)
 
     vector<TestCasePtr> tests;
 
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatOnHoldTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationNoHeartbeatTest, com));
-    tests.push_back(ICE_MAKE_SHARED(InvocationHeartbeatCloseOnIdleTest, com));
+    tests.push_back(make_shared<InvocationHeartbeatTest>(com));
+    tests.push_back(make_shared<InvocationHeartbeatOnHoldTest>(com));
+    tests.push_back(make_shared<InvocationNoHeartbeatTest>(com));
+    tests.push_back(make_shared<InvocationHeartbeatCloseOnIdleTest>(com));
 
-    tests.push_back(ICE_MAKE_SHARED(CloseOnIdleTest, com));
-    tests.push_back(ICE_MAKE_SHARED(CloseOnInvocationTest, com));
-    tests.push_back(ICE_MAKE_SHARED(CloseOnIdleAndInvocationTest, com));
-    tests.push_back(ICE_MAKE_SHARED(ForcefulCloseOnIdleAndInvocationTest, com));
+    tests.push_back(make_shared<CloseOnIdleTest>(com));
+    tests.push_back(make_shared<CloseOnInvocationTest>(com));
+    tests.push_back(make_shared<CloseOnIdleAndInvocationTest>(com));
+    tests.push_back(make_shared<ForcefulCloseOnIdleAndInvocationTest>(com));
 
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatOnIdleTest, com));
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatAlwaysTest, com));
-    tests.push_back(ICE_MAKE_SHARED(HeartbeatManualTest, com));
-    tests.push_back(ICE_MAKE_SHARED(SetACMTest, com));
+    tests.push_back(make_shared<HeartbeatOnIdleTest>(com));
+    tests.push_back(make_shared<HeartbeatAlwaysTest>(com));
+    tests.push_back(make_shared<HeartbeatManualTest>(com));
+    tests.push_back(make_shared<SetACMTest>(com));
 
     for(vector<TestCasePtr>::const_iterator p = tests.begin(); p != tests.end(); ++p)
     {

--- a/cpp/test/Ice/acm/AllTests.cpp
+++ b/cpp/test/Ice/acm/AllTests.cpp
@@ -555,21 +555,21 @@ public:
         Ice::ACM acm;
         acm = con->getACM();
         test(acm.timeout == 15);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnIdleForceful));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatOff));
+        test(acm.close == Ice::ACMClose::CloseOnIdleForceful);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatOff);
 
         con->setACM(IceUtil::None, IceUtil::None, IceUtil::None);
         acm = con->getACM();
         test(acm.timeout == 15);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnIdleForceful));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatOff));
+        test(acm.close == Ice::ACMClose::CloseOnIdleForceful);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatOff);
 
-        con->setACM(1, Ice::ICE_ENUM(ACMClose, CloseOnInvocationAndIdle),
-                                                 Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+        con->setACM(1, Ice::ACMClose::CloseOnInvocationAndIdle,
+                                                 Ice::ACMHeartbeat::HeartbeatAlways);
         acm = con->getACM();
         test(acm.timeout == 1);
-        test(acm.close == Ice::ICE_ENUM(ACMClose, CloseOnInvocationAndIdle));
-        test(acm.heartbeat == Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+        test(acm.close == Ice::ACMClose::CloseOnInvocationAndIdle);
+        test(acm.heartbeat == Ice::ACMHeartbeat::HeartbeatAlways);
 
         // Make sure the client sends a few heartbeats to the server.
         proxy->startHeartbeatCount();

--- a/cpp/test/Ice/acm/Server.cpp
+++ b/cpp/test/Ice/acm/Server.cpp
@@ -26,7 +26,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ACM.Timeout", "0");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("communicator");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorI>(), id);
     adapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/acm/TestI.cpp
+++ b/cpp/test/Ice/acm/TestI.cpp
@@ -52,7 +52,7 @@ RemoteCommunicatorI::createObjectAdapter(int timeout, int close, int heartbeat, 
     ObjectAdapterPtr adapter = com->createObjectAdapterWithEndpoints(name, protocol + opts);
 
     return ICE_UNCHECKED_CAST(RemoteObjectAdapterPrx, current.adapter->addWithUUID(
-                              ICE_MAKE_SHARED(RemoteObjectAdapterI, adapter)));
+                              make_shared<RemoteObjectAdapterI>(adapter)));
 }
 
 void
@@ -63,7 +63,7 @@ RemoteCommunicatorI::shutdown(const Ice::Current& current)
 
 RemoteObjectAdapterI::RemoteObjectAdapterI(const Ice::ObjectAdapterPtr& adapter) :
     _adapter(adapter),
-    _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx, _adapter->add(ICE_MAKE_SHARED(TestI),
+    _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx, _adapter->add(make_shared<TestI>(),
                                          stringToIdentity("test"))))
 {
     _adapter->activate();
@@ -124,7 +124,7 @@ TestI::interruptSleep(const Ice::Current&)
 void
 TestI::startHeartbeatCount(const Ice::Current& current)
 {
-    _callback = ICE_MAKE_SHARED(HeartbeatCallbackI);
+    _callback = make_shared<HeartbeatCallbackI>();
     HeartbeatCallbackIPtr callback = _callback;
     current.con->setHeartbeatCallback([callback](Ice::ConnectionPtr connection)
     {

--- a/cpp/test/Ice/acm/TestI.h
+++ b/cpp/test/Ice/acm/TestI.h
@@ -77,7 +77,7 @@ private:
 
         int _count;
     };
-    ICE_DEFINE_PTR(HeartbeatCallbackIPtr, HeartbeatCallbackI);
+    using HeartbeatCallbackIPtr = std::shared_ptr<HeartbeatCallbackI>;
 
     HeartbeatCallbackIPtr _callback;
 };

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -96,7 +96,7 @@ allTests(Test::TestHelper* helper)
         cout << "testing object adapter with bi-dir connection... " << flush;
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
         obj->ice_getConnection()->setAdapter(adapter);
-        obj->ice_getConnection()->setAdapter(ICE_NULLPTR);
+        obj->ice_getConnection()->setAdapter(nullptr);
         adapter->deactivate();
         try
         {

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
@@ -24,7 +24,7 @@ public:
     virtual Ice::ObjectPrxPtr
     getClientProxy(IceUtil::Optional<bool>&, const Ice::Current&) const
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectPrxPtr

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -21,9 +21,9 @@ testFacets(const Ice::CommunicatorPtr& com, bool builtInFacets = true)
         test(com->findAdminFacet("Metrics"));
     }
 
-    TestFacetPtr f1 = ICE_MAKE_SHARED(TestFacetI);
-    TestFacetPtr f2 = ICE_MAKE_SHARED(TestFacetI);
-    TestFacetPtr f3 = ICE_MAKE_SHARED(TestFacetI);
+    TestFacetPtr f1 = std::make_shared<TestFacetI>();
+    TestFacetPtr f2 = std::make_shared<TestFacetI>();
+    TestFacetPtr f3 = std::make_shared<TestFacetI>();
 
     com->addAdminFacet(f1, "Facet1");
     com->addAdminFacet(f2, "Facet2");
@@ -93,8 +93,8 @@ public:
 
     RemoteLoggerI();
 
-    virtual void init(ICE_IN(string), ICE_IN(Ice::LogMessageSeq), const Ice::Current&);
-    virtual void log(ICE_IN(Ice::LogMessage), const Ice::Current&);
+    virtual void init(string, Ice::LogMessageSeq, const Ice::Current&);
+    virtual void log(Ice::LogMessage, const Ice::Current&);
 
     void checkNextInit(const string&, Ice::LogMessageType, const string&, const string& = "");
     void checkNextLog(Ice::LogMessageType, const string&, const string& = "");
@@ -110,14 +110,14 @@ private:
     Ice::LogMessageSeq _logMessages;
 };
 
-ICE_DEFINE_SHARED_PTR(RemoteLoggerIPtr, RemoteLoggerI);
+using RemoteLoggerIPtr = std::shared_ptr<RemoteLoggerI>;
 
 RemoteLoggerI::RemoteLoggerI() : _receivedCalls(0)
 {
 }
 
 void
-RemoteLoggerI::init(ICE_IN(string) prefix, ICE_IN(Ice::LogMessageSeq) logMessages, const Ice::Current&)
+RemoteLoggerI::init(string prefix, Ice::LogMessageSeq logMessages, const Ice::Current&)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock lock(_monitor);
     _prefix = prefix;
@@ -127,7 +127,7 @@ RemoteLoggerI::init(ICE_IN(string) prefix, ICE_IN(Ice::LogMessageSeq) logMessage
 }
 
 void
-RemoteLoggerI::log(ICE_IN(Ice::LogMessage) logMessage, const Ice::Current&)
+RemoteLoggerI::log(Ice::LogMessage logMessage, const Ice::Current&)
 {
     IceUtil::Monitor<IceUtil::Mutex>::Lock lock(_monitor);
     _logMessages.push_back(logMessage);
@@ -489,7 +489,7 @@ allTests(Test::TestHelper* helper)
         Ice::ObjectAdapterPtr adapter =
             communicator->createObjectAdapterWithEndpoints("RemoteLoggerAdapter", "tcp -h localhost");
 
-        RemoteLoggerIPtr remoteLogger = ICE_MAKE_SHARED(RemoteLoggerI);
+        RemoteLoggerIPtr remoteLogger = std::make_shared<RemoteLoggerI>();
 
         Ice::RemoteLoggerPrxPtr myProxy =
             ICE_UNCHECKED_CAST(Ice::RemoteLoggerPrx, adapter->addWithUUID(remoteLogger));

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -426,8 +426,8 @@ allTests(Test::TestHelper* helper)
         com->warning("warning2");
 
         Ice::LogMessageTypeSeq messageTypes;
-        messageTypes.push_back(ICE_ENUM(LogMessageType, ErrorMessage));
-        messageTypes.push_back(ICE_ENUM(LogMessageType, WarningMessage));
+        messageTypes.push_back(LogMessageType::ErrorMessage);
+        messageTypes.push_back(LogMessageType::WarningMessage);
 
         logMessages =
             logger->getLog(messageTypes, Ice::StringSeq(), -1, prefix);
@@ -437,7 +437,7 @@ allTests(Test::TestHelper* helper)
         p = logMessages.begin();
         while(p != logMessages.end())
         {
-            test(p->type == ICE_ENUM(LogMessageType, ErrorMessage) || p->type == ICE_ENUM(LogMessageType, WarningMessage));
+            test(p->type == LogMessageType::ErrorMessage || p->type == LogMessageType::WarningMessage);
             ++p;
         }
 
@@ -449,8 +449,8 @@ allTests(Test::TestHelper* helper)
         com->trace("testCat2", "B");
 
         messageTypes.clear();
-        messageTypes.push_back(ICE_ENUM(LogMessageType, ErrorMessage));
-        messageTypes.push_back(ICE_ENUM(LogMessageType, TraceMessage));
+        messageTypes.push_back(LogMessageType::ErrorMessage);
+        messageTypes.push_back(LogMessageType::TraceMessage);
 
         Ice::StringSeq categories;
         categories.push_back("testCat");
@@ -463,8 +463,8 @@ allTests(Test::TestHelper* helper)
         p = logMessages.begin();
         while(p != logMessages.end())
         {
-            test(p->type == ICE_ENUM(LogMessageType, ErrorMessage) ||
-                (p->type == ICE_ENUM(LogMessageType, TraceMessage) && p->traceCategory == "testCat"));
+            test(p->type == LogMessageType::ErrorMessage ||
+                (p->type == LogMessageType::TraceMessage && p->traceCategory == "testCat"));
             ++p;
         }
 
@@ -514,10 +514,10 @@ allTests(Test::TestHelper* helper)
         com->print("rprint");
         test(remoteLogger->wait(4));
 
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, TraceMessage), "rtrace", "testCat");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, WarningMessage), "rwarning");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, ErrorMessage), "rerror");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, PrintMessage), "rprint");
+        remoteLogger->checkNextLog(LogMessageType::TraceMessage, "rtrace", "testCat");
+        remoteLogger->checkNextLog(LogMessageType::WarningMessage, "rwarning");
+        remoteLogger->checkNextLog(LogMessageType::ErrorMessage, "rerror");
+        remoteLogger->checkNextLog(LogMessageType::PrintMessage, "rprint");
 
         test(logger->detachRemoteLogger(myProxy));
         test(!logger->detachRemoteLogger(myProxy));
@@ -542,8 +542,8 @@ allTests(Test::TestHelper* helper)
         com->print("rprint2");
         test(remoteLogger->wait(2));
 
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, TraceMessage), "rtrace2", "testCat");
-        remoteLogger->checkNextLog(ICE_ENUM(LogMessageType, ErrorMessage), "rerror2");
+        remoteLogger->checkNextLog(LogMessageType::TraceMessage, "rtrace2", "testCat");
+        remoteLogger->checkNextLog(LogMessageType::ErrorMessage, "rerror2");
 
         //
         // Attempt reconnection with slightly different proxy

--- a/cpp/test/Ice/admin/Server.cpp
+++ b/cpp/test/Ice/admin/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 10000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("factory");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorFactoryI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorFactoryI>(), id);
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -41,7 +41,7 @@ public:
 
     virtual Ice::LoggerPtr cloneWithPrefix(const string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 };
 
@@ -109,23 +109,23 @@ RemoteCommunicatorI::removeUpdateCallback(const Ice::Current&)
 }
 
 void
-RemoteCommunicatorI::print(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::print(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->print(message);
 }
 void
-RemoteCommunicatorI::trace(ICE_IN(std::string) category,
-                           ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::trace(std::string category,
+                           std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->trace(category, message);
 }
 void
-RemoteCommunicatorI::warning(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::warning(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->warning(message);
 }
 void
-RemoteCommunicatorI::error(ICE_IN(std::string) message, const Ice::Current&)
+RemoteCommunicatorI::error(std::string message, const Ice::Current&)
 {
     _communicator->getLogger()->error(message);
 }
@@ -160,7 +160,7 @@ RemoteCommunicatorI::updated(const Ice::PropertyDict& changes)
 }
 
 Test::RemoteCommunicatorPrxPtr
-RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, const Ice::Current& current)
+RemoteCommunicatorFactoryI::createCommunicator(Ice::PropertyDict props, const Ice::Current& current)
 {
     //
     // Prepare the property set using the given properties.
@@ -174,7 +174,7 @@ RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, 
 
     if(init.properties->getPropertyAsInt("NullLogger") > 0)
     {
-        init.logger = ICE_MAKE_SHARED(NullLogger);
+        init.logger = make_shared<NullLogger>();
     }
 
     //
@@ -185,12 +185,12 @@ RemoteCommunicatorFactoryI::createCommunicator(ICE_IN(Ice::PropertyDict) props, 
     //
     // Install a custom admin facet.
     //
-    communicator->addAdminFacet(ICE_MAKE_SHARED(TestFacetI), "TestFacet");
+    communicator->addAdminFacet(make_shared<TestFacetI>(), "TestFacet");
 
     //
     // Set the callback on the admin facet.
     //
-    RemoteCommunicatorIPtr servant = ICE_MAKE_SHARED(RemoteCommunicatorI, communicator);
+    RemoteCommunicatorIPtr servant = make_shared<RemoteCommunicatorI>(communicator);
     servant->addUpdateCallback(Ice::emptyCurrent);
 
     Ice::ObjectPrxPtr proxy = current.adapter->addWithUUID(servant);

--- a/cpp/test/Ice/admin/TestI.h
+++ b/cpp/test/Ice/admin/TestI.h
@@ -22,10 +22,10 @@ public:
     virtual void addUpdateCallback(const Ice::Current&);
     virtual void removeUpdateCallback(const Ice::Current&);
 
-    virtual void print(ICE_IN(std::string), const Ice::Current&);
-    virtual void trace(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void warning(ICE_IN(std::string), const Ice::Current&);
-    virtual void error(ICE_IN(std::string), const Ice::Current&);
+    virtual void print(std::string, const Ice::Current&);
+    virtual void trace(std::string, std::string, const Ice::Current&);
+    virtual void warning(std::string, const Ice::Current&);
+    virtual void error(std::string, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
     virtual void waitForShutdown(const Ice::Current&);
@@ -40,13 +40,13 @@ private:
 
     std::function<void()> _removeCallback;
 };
-ICE_DEFINE_SHARED_PTR(RemoteCommunicatorIPtr, RemoteCommunicatorI);
+using RemoteCommunicatorIPtr = std::shared_ptr<RemoteCommunicatorI>;
 
 class RemoteCommunicatorFactoryI : public Test::RemoteCommunicatorFactory
 {
 public:
 
-    virtual Test::RemoteCommunicatorPrxPtr createCommunicator(ICE_IN(Ice::PropertyDict), const Ice::Current&);
+    virtual Test::RemoteCommunicatorPrxPtr createCommunicator(Ice::PropertyDict, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 };
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -36,7 +36,7 @@ private:
     bool _received;
 };
 
-ICE_DEFINE_SHARED_PTR(PingReplyIPtr, PingReplyI);
+using PingReplyIPtr = std::shared_ptr<PingReplyI>;
 
 enum ThrowType { LocalException, UserException, StandardException, OtherException };
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1071,7 +1071,7 @@ allTests(Test::TestHelper* helper, bool collocated)
             test(p->opBatchCount() == 0);
             auto b1 = p->ice_batchOneway();
             b1->opBatch();
-            b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
             auto id = this_thread::get_id();
             promise<void> promise;
@@ -1147,7 +1147,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                 auto b1 = Ice::uncheckedCast<Test::TestIntfPrx>(
                     p->ice_getConnection()->createProxy(p->ice_getIdentity())->ice_batchOneway());
                 b1->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 b1->ice_getConnection()->flushBatchRequestsAsync(
@@ -1227,7 +1227,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                 auto b1 = Ice::uncheckedCast<Test::TestIntfPrx>(
                     p->ice_getConnection()->createProxy(p->ice_getIdentity())->ice_batchOneway());
                 b1->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 auto id = this_thread::get_id();
@@ -1299,8 +1299,8 @@ allTests(Test::TestHelper* helper, bool collocated)
                 b2->ice_getConnection(); // Ensure connection is established.
                 b1->opBatch();
                 b2->opBatch();
-                b1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
-                b2->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                b1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
+                b2->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
                 promise<void> promise;
                 auto id = this_thread::get_id();
@@ -1409,7 +1409,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                               [s](exception_ptr ex) { s->set_exception(ex); });
                 auto f = s->get_future();
                 // Blocks until the request completes.
-                con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                con->close(Ice::ConnectionClose::GracefullyWithWait);
                 f.get(); // Should complete successfully.
                 fc.get();
             }

--- a/cpp/test/Ice/ami/Collocated.cpp
+++ b/cpp/test/Ice/ami/Collocated.cpp
@@ -28,10 +28,10 @@ Collocated::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfII), Ice::stringToIdentity("test2"));
+    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     //adapter->activate(); // Collocated test doesn't need to activate the OA
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -39,10 +39,10 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfII), Ice::stringToIdentity("test2"));
+    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(make_shared<TestIntfII>(), Ice::stringToIdentity("test2"));
     adapter->activate();
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -37,7 +37,7 @@ TestIntfI::opWithResultAndUE(const Ice::Current&)
 }
 
 void
-TestIntfI::opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&)
+TestIntfI::opWithPayload(Ice::ByteSeq, const Ice::Current&)
 {
 }
 
@@ -158,7 +158,7 @@ TestIntfI::supportsFunctionalTests(const Ice::Current&)
 }
 
 void
-TestIntfI::pingBiDir(ICE_IN(Test::PingReplyPrxPtr) reply, const Ice::Current& current)
+TestIntfI::pingBiDir(Test::PingReplyPrxPtr reply, const Ice::Current& current)
 {
     reply->ice_fixed(current.con)->replyAsync().get();
 }

--- a/cpp/test/Ice/ami/TestI.h
+++ b/cpp/test/Ice/ami/TestI.h
@@ -9,7 +9,7 @@
 #include <TestHelper.h>
 
 class TestIntfControllerI;
-ICE_DEFINE_SHARED_PTR(TestIntfControllerIPtr, TestIntfControllerI);
+using TestIntfControllerIPtr = std::shared_ptr<TestIntfControllerI>;
 
 class TestIntfI : public virtual Test::TestIntf, public IceUtil::Monitor<IceUtil::Mutex>
 {
@@ -21,7 +21,7 @@ public:
     virtual int opWithResult(const Ice::Current&);
     virtual void opWithUE(const Ice::Current&);
     virtual int opWithResultAndUE(const Ice::Current&);
-    virtual void opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual void opWithPayload(Ice::ByteSeq, const Ice::Current&);
     virtual void opBatch(const Ice::Current&);
     virtual Ice::Int opBatchCount(const Ice::Current&);
     virtual void opWithArgs(Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&, Ice::Int&,
@@ -37,7 +37,7 @@ public:
     virtual bool supportsAMD(const Ice::Current&);
     virtual bool supportsFunctionalTests(const Ice::Current&);
 
-    virtual void pingBiDir(ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
+    virtual void pingBiDir(Test::PingReplyPrxPtr, const Ice::Current&);
 
 private:
 

--- a/cpp/test/Ice/background/AllTests.cpp
+++ b/cpp/test/Ice/background/AllTests.cpp
@@ -339,7 +339,7 @@ allTests(Test::TestHelper* helper)
         configuration->buffered(true);
         backgroundController->buffered(true);
         background->opAsync();
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         background->opAsync();
 
         vector<future<void>> results;
@@ -382,7 +382,7 @@ connectTests(const ConfigurationPtr& configuration, const Test::BackgroundPrxPtr
     {
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     for(int i = 0; i < 4; ++i)
     {
@@ -471,7 +471,7 @@ connectTests(const ConfigurationPtr& configuration, const Test::BackgroundPrxPtr
         }
 
         configuration->connectException(new Ice::SocketException(__FILE__, __LINE__));
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         configuration->connectException(0);
         try
@@ -505,7 +505,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     for(int i = 0; i < 4; i++)
     {
@@ -576,7 +576,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -590,7 +590,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 #endif
 
     //
@@ -625,7 +625,7 @@ initializeTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -663,7 +663,7 @@ initializeTests(const ConfigurationPtr& configuration,
         }
 
         configuration->initializeException(new Ice::SocketException(__FILE__, __LINE__));
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         configuration->initializeException(0);
         try
@@ -685,12 +685,12 @@ initializeTests(const ConfigurationPtr& configuration,
         }
 
         configuration->initializeSocketOperation(IceInternal::SocketOperationWrite);
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         background->ice_ping();
         configuration->initializeSocketOperation(IceInternal::SocketOperationNone);
 
         ctl->initializeException(true);
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
         ctl->initializeException(false);
         try
@@ -715,11 +715,11 @@ initializeTests(const ConfigurationPtr& configuration,
         {
 #if !defined(ICE_USE_IOCP) && !defined(ICE_USE_CFSTREAM)
             ctl->initializeSocketOperation(IceInternal::SocketOperationWrite);
-            background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
             background->op();
             ctl->initializeSocketOperation(IceInternal::SocketOperationNone);
 #else
-            background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
             background->op();
 #endif
         }
@@ -751,7 +751,7 @@ validationTests(const ConfigurationPtr& configuration,
     {
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -812,7 +812,7 @@ validationTests(const ConfigurationPtr& configuration,
             cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
-        background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         try
         {
@@ -950,7 +950,7 @@ validationTests(const ConfigurationPtr& configuration,
         cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
-    background->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     try
     {
@@ -1031,7 +1031,7 @@ validationTests(const ConfigurationPtr& configuration,
     backgroundBatchOneway->op();
     ctl->resumeAdapter();
     backgroundBatchOneway->ice_flushBatchRequestsAsync();
-    backgroundBatchOneway->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    backgroundBatchOneway->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
     ctl->holdAdapter();
     backgroundBatchOneway->opWithPayload(seq);
@@ -1040,7 +1040,7 @@ validationTests(const ConfigurationPtr& configuration,
     backgroundBatchOneway->opWithPayload(seq);
     ctl->resumeAdapter();
     backgroundBatchOneway->ice_flushBatchRequestsAsync().get();
-    backgroundBatchOneway->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    backgroundBatchOneway->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 }
 
 void
@@ -1520,10 +1520,10 @@ readWriteTests(const ConfigurationPtr& configuration,
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
 
         background->ice_ping();
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
         IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(10));
 
-        background->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+        background->ice_getCachedConnection()->close(Ice::ConnectionClose::Forcefully);
     }
 
     thread1->destroy();

--- a/cpp/test/Ice/background/EndpointFactory.cpp
+++ b/cpp/test/Ice/background/EndpointFactory.cpp
@@ -33,7 +33,7 @@ EndpointFactory::protocol() const
 IceInternal::EndpointIPtr
 EndpointFactory::create(vector<string>& args, bool oaEndpoint) const
 {
-    return ICE_MAKE_SHARED(EndpointI, _factory->create(args, oaEndpoint));
+    return make_shared<EndpointI>(_factory->create(args, oaEndpoint));
 }
 
 IceInternal::EndpointIPtr
@@ -44,7 +44,7 @@ EndpointFactory::read(Ice::InputStream* s) const
     assert(type == _factory->type());
 
     s->startEncapsulation();
-    IceInternal::EndpointIPtr endpoint = ICE_MAKE_SHARED(EndpointI, _factory->read(s));
+    IceInternal::EndpointIPtr endpoint = make_shared<EndpointI>(_factory->read(s));
     s->endEncapsulation();
     return endpoint;
 }

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -71,7 +71,7 @@ EndpointI::timeout(int timeout) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -85,7 +85,7 @@ EndpointI::connectionId(const string& connectionId) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -105,7 +105,7 @@ EndpointI::compress(bool compress) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, endpoint);
+        return make_shared<EndpointI>(endpoint);
     }
 }
 
@@ -171,7 +171,7 @@ EndpointI::connectors_async(Ice::EndpointSelectionType selType, const IceInterna
     try
     {
         _configuration->checkConnectorsException();
-        _endpoint->connectors_async(selType, ICE_MAKE_SHARED(Callback, cb));
+        _endpoint->connectors_async(selType, make_shared<Callback>(cb));
     }
     catch(const Ice::LocalException& ex)
     {
@@ -209,7 +209,7 @@ EndpointI::endpoint(const IceInternal::EndpointIPtr& delEndp) const
     }
     else
     {
-        return ICE_MAKE_SHARED(EndpointI, delEndp);
+        return make_shared<EndpointI>(delEndp);
     }
 }
 
@@ -219,7 +219,7 @@ EndpointI::expandIfWildcard() const
     vector<IceInternal::EndpointIPtr> e = _endpoint->expandIfWildcard();
     for(vector<IceInternal::EndpointIPtr>::iterator p = e.begin(); p != e.end(); ++p)
     {
-        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, *p);
+        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : make_shared<EndpointI>(*p);
     }
     return e;
 }
@@ -230,11 +230,11 @@ EndpointI::expandHost(IceInternal::EndpointIPtr& publish) const
     vector<IceInternal::EndpointIPtr> e = _endpoint->expandHost(publish);
     if(publish)
     {
-        publish = publish == _endpoint ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, publish);
+        publish = publish == _endpoint ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : make_shared<EndpointI>(publish);
     }
     for(vector<IceInternal::EndpointIPtr>::iterator p = e.begin(); p != e.end(); ++p)
     {
-        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : ICE_MAKE_SHARED(EndpointI, *p);
+        *p = (*p == _endpoint) ? ICE_SHARED_FROM_CONST_THIS(EndpointI) : make_shared<EndpointI>(*p);
     }
     return e;
 }

--- a/cpp/test/Ice/background/EndpointI.h
+++ b/cpp/test/Ice/background/EndpointI.h
@@ -10,7 +10,7 @@
 #include <Configuration.h>
 
 class EndpointI;
-ICE_DEFINE_PTR(EndpointIPtr, EndpointI);
+using EndpointIPtr = std::shared_ptr<EndpointI>;
 
 class EndpointI : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
 {

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -53,7 +53,7 @@ public:
     virtual Ice::LocatorRegistryPrxPtr
     getRegistry(const Ice::Current&) const
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     LocatorI(const BackgroundControllerIPtr& controller) : _controller(controller)
@@ -74,18 +74,18 @@ public:
     {
         hasRoutingTable = true;
         _controller->checkCallPause(current);
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectPrxPtr
     getServerProxy(const Ice::Current& current) const
     {
         _controller->checkCallPause(current);
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::ObjectProxySeq
-    addProxies(ICE_IN(Ice::ObjectProxySeq), const Ice::Current&)
+    addProxies(Ice::ObjectProxySeq, const Ice::Current&)
     {
         return Ice::ObjectProxySeq();
     }
@@ -147,11 +147,11 @@ Server::run(int argc, char** argv)
     shared_ptr<PluginI> plugin = dynamic_pointer_cast<PluginI>(communicator->getPluginManager()->getPlugin("Test"));
     assert(plugin);
     ConfigurationPtr configuration = plugin->getConfiguration();
-    BackgroundControllerIPtr backgroundController = ICE_MAKE_SHARED(BackgroundControllerI, adapter, configuration);
+    BackgroundControllerIPtr backgroundController = make_shared<BackgroundControllerI>(adapter, configuration);
 
-    adapter->add(ICE_MAKE_SHARED(BackgroundI, backgroundController), Ice::stringToIdentity("background"));
-    adapter->add(ICE_MAKE_SHARED(LocatorI, backgroundController), Ice::stringToIdentity("locator"));
-    adapter->add(ICE_MAKE_SHARED(RouterI, backgroundController), Ice::stringToIdentity("router"));
+    adapter->add(make_shared<BackgroundI>(backgroundController), Ice::stringToIdentity("background"));
+    adapter->add(make_shared<LocatorI>(backgroundController), Ice::stringToIdentity("locator"));
+    adapter->add(make_shared<RouterI>(backgroundController), Ice::stringToIdentity("router"));
     adapter->activate();
 
     adapter2->add(backgroundController, Ice::stringToIdentity("backgroundController"));

--- a/cpp/test/Ice/background/TestI.cpp
+++ b/cpp/test/Ice/background/TestI.cpp
@@ -15,7 +15,7 @@ BackgroundI::op(const Ice::Current& current)
 }
 
 void
-BackgroundI::opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current& current)
+BackgroundI::opWithPayload(Ice::ByteSeq, const Ice::Current& current)
 {
     _controller->checkCallPause(current);
 }
@@ -32,14 +32,14 @@ BackgroundI::BackgroundI(const BackgroundControllerIPtr& controller) :
 }
 
 void
-BackgroundControllerI::pauseCall(ICE_IN(string) opName, const Ice::Current&)
+BackgroundControllerI::pauseCall(string opName, const Ice::Current&)
 {
     Lock sync(*this);
     _pausedCalls.insert(opName);
 }
 
 void
-BackgroundControllerI::resumeCall(ICE_IN(string) opName, const Ice::Current&)
+BackgroundControllerI::resumeCall(string opName, const Ice::Current&)
 {
     Lock sync(*this);
     _pausedCalls.erase(opName);

--- a/cpp/test/Ice/background/TestI.h
+++ b/cpp/test/Ice/background/TestI.h
@@ -11,14 +11,14 @@
 #include <set>
 
 class BackgroundControllerI;
-ICE_DEFINE_SHARED_PTR(BackgroundControllerIPtr, BackgroundControllerI);
+using BackgroundControllerIPtr = std::shared_ptr<BackgroundControllerI>;
 
 class BackgroundI : public virtual Test::Background
 {
 public:
 
     virtual void op(const Ice::Current&);
-    virtual void opWithPayload(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual void opWithPayload(Ice::ByteSeq, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 
     BackgroundI(const BackgroundControllerIPtr&);
@@ -32,8 +32,8 @@ class BackgroundControllerI : public Test::BackgroundController, IceUtil::Monito
 {
 public:
 
-    virtual void pauseCall(ICE_IN(std::string), const Ice::Current&);
-    virtual void resumeCall(ICE_IN(std::string), const Ice::Current&);
+    virtual void pauseCall(std::string, const Ice::Current&);
+    virtual void resumeCall(std::string, const Ice::Current&);
     virtual void checkCallPause(const Ice::Current&);
 
     virtual void holdAdapter(const Ice::Current&);

--- a/cpp/test/Ice/binding/AllTests.cpp
+++ b/cpp/test/Ice/binding/AllTests.cpp
@@ -109,7 +109,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -132,7 +132,7 @@ allTests(Test::TestHelper* helper)
             for(vector<RemoteObjectAdapterPrxPtr>::const_iterator q = adapters.begin(); q != adapters.end(); ++q)
             {
                 (*q)->getTestIntf()->ice_getConnection()->close(
-                    Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                    Ice::ConnectionClose::GracefullyWithWait);
             }
         }
 
@@ -157,7 +157,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -245,7 +245,7 @@ allTests(Test::TestHelper* helper)
                 try
                 {
                     (*q)->getTestIntf()->ice_getConnection()->close(
-                        Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                        Ice::ConnectionClose::GracefullyWithWait);
                 }
                 catch(const Ice::LocalException&)
                 {
@@ -285,7 +285,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(getAdapterNameWithAMI(test1));
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -308,7 +308,7 @@ allTests(Test::TestHelper* helper)
             for(vector<RemoteObjectAdapterPrxPtr>::const_iterator q = adapters.begin(); q != adapters.end(); ++q)
             {
                 (*q)->getTestIntf()->ice_getConnection()->close(
-                    Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                    Ice::ConnectionClose::GracefullyWithWait);
             }
         }
 
@@ -333,7 +333,7 @@ allTests(Test::TestHelper* helper)
             test(test2->ice_getConnection() == test3->ice_getConnection());
 
             names.erase(test1->getAdapterName());
-            test1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         //
@@ -356,7 +356,7 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter23", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
 
         set<string> names;
         names.insert("Adapter21");
@@ -365,11 +365,11 @@ allTests(Test::TestHelper* helper)
         while(!names.empty())
         {
             names.erase(test->getAdapterName());
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Random));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
 
         names.insert("Adapter21");
         names.insert("Adapter22");
@@ -377,7 +377,7 @@ allTests(Test::TestHelper* helper)
         while(!names.empty())
         {
             names.erase(test->getAdapterName());
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
 
         deactivate(com, adapters);
@@ -392,8 +392,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter33", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         const int nRetry = 5;
         int i;
 
@@ -405,7 +405,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter31"; i++);
         }
 #endif
@@ -415,7 +415,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter32"; i++);
         }
 #endif
@@ -425,7 +425,7 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter33"; i++);
         }
 #endif
@@ -455,29 +455,29 @@ allTests(Test::TestHelper* helper)
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter36"; i++);
         }
 #endif
         test(i == nRetry);
-        test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         adapters.push_back(com->createObjectAdapter("Adapter35", endpoints[1]->toString()));
         for(i = 0; i < nRetry && test->getAdapterName() == "Adapter35"; i++);
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter35"; i++);
         }
 #endif
         test(i == nRetry);
-        test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         adapters.push_back(com->createObjectAdapter("Adapter34", endpoints[0]->toString()));
         for(i = 0; i < nRetry && test->getAdapterName() == "Adapter34"; i++);
 #if TARGET_OS_IPHONE > 0
         if(i != nRetry)
         {
-            test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             for(i = 0; i < nRetry && test->getAdapterName() == "Adapter34"; i++);
         }
 #endif
@@ -597,8 +597,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("Adapter63", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_connectionCached(false));
         test(!test->ice_isConnectionCached());
         const int nRetry = 5;
@@ -682,8 +682,8 @@ allTests(Test::TestHelper* helper)
         adapters.push_back(com->createObjectAdapter("AdapterAMI63", "default"));
 
         TestIntfPrxPtr test = createTestIntfPrx(adapters);
-        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)));
-        test(test->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+        test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_endpointSelection(Ice::EndpointSelectionType::Ordered));
+        test(test->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
         test = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_connectionCached(false));
         test(!test->ice_isConnectionCached());
         const int nRetry = 5;
@@ -787,7 +787,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter82");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             TestIntfPrxPtr testSecure = ICE_UNCHECKED_CAST(TestIntfPrx, test->ice_secure(true));
@@ -803,7 +803,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter81");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             com->createObjectAdapter("Adapter83", (test->ice_getEndpoints()[1])->toString()); // Reactive tcp OA.
@@ -811,7 +811,7 @@ allTests(Test::TestHelper* helper)
             for(i = 0; i < 5; i++)
             {
                 test(test->getAdapterName() == "Adapter83");
-                test->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                test->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
 
             com->deactivateObjectAdapter(adapters[0]);

--- a/cpp/test/Ice/binding/Server.cpp
+++ b/cpp/test/Ice/binding/Server.cpp
@@ -42,7 +42,7 @@ public:
 
     virtual Ice::LoggerPtr cloneWithPrefix(const string&)
     {
-        return ICE_SHARED_FROM_THIS;
+        return shared_from_this();
     }
 };
 
@@ -61,12 +61,12 @@ Server::run(int argc, char** argv)
     Ice::InitializationData initData;
     initData.properties = createTestProperties(argc, argv);
     initData.properties->setProperty("Ice.Warn.Connections", "0");
-    initData.logger = ICE_MAKE_SHARED(NullLogger);
+    initData.logger = std::make_shared<NullLogger>();
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("communicator");
-    adapter->add(ICE_MAKE_SHARED(RemoteCommunicatorI), id);
+    adapter->add(std::make_shared<RemoteCommunicatorI>(), id);
     adapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/binding/TestI.cpp
+++ b/cpp/test/Ice/binding/TestI.cpp
@@ -36,7 +36,7 @@ RemoteCommunicatorI::createObjectAdapter(string name, string endpts, const Ice::
             com->getProperties()->setProperty(name + ".ThreadPool.Size", "1");
             ObjectAdapterPtr adapter = com->createObjectAdapterWithEndpoints(name, endpoints);
             return ICE_UNCHECKED_CAST(RemoteObjectAdapterPrx,
-                                      current.adapter->addWithUUID(ICE_MAKE_SHARED(RemoteObjectAdapterI, adapter)));
+                                      current.adapter->addWithUUID(make_shared<RemoteObjectAdapterI>(adapter)));
         }
         catch(const Ice::SocketException&)
         {
@@ -63,7 +63,7 @@ RemoteCommunicatorI::shutdown(const Ice::Current& current)
 RemoteObjectAdapterI::RemoteObjectAdapterI(const Ice::ObjectAdapterPtr& adapter) :
     _adapter(adapter),
     _testIntf(ICE_UNCHECKED_CAST(TestIntfPrx,
-                    _adapter->add(ICE_MAKE_SHARED(TestI),
+                    _adapter->add(make_shared<TestI>(),
                                   stringToIdentity("test"))))
 {
     _adapter->activate();

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -438,11 +438,11 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::E> in(5);
-        in[0] = Test:: ICE_ENUM(E, E1);
-        in[1] = Test:: ICE_ENUM(E, E2);
-        in[2] = Test:: ICE_ENUM(E, E3);
-        in[3] = Test:: ICE_ENUM(E, E1);
-        in[4] = Test:: ICE_ENUM(E, E3);
+        in[0] = Test:: E::E1;
+        in[1] = Test:: E::E2;
+        in[2] = Test:: E::E3;
+        in[3] = Test:: E::E1;
+        in[4] = Test:: E::E3;
 
         deque<Test::E> out;
         deque<Test::E> ret = t->opESeq(in, out);
@@ -452,11 +452,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::E> in;
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E2));
-        in.push_back(Test:: ICE_ENUM(E, E3));
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E3));
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E2);
+        in.push_back(Test:: E::E3);
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E3);
 
         list<Test::E> out;
         list<Test::E> ret = t->opEList(in, out);
@@ -1004,11 +1004,11 @@ allTests(Test::TestHelper* helper)
 
         {
             deque<Test::E> in(5);
-            in[0] = Test:: ICE_ENUM(E, E1);
-            in[1] = Test:: ICE_ENUM(E, E2);
-            in[2] = Test:: ICE_ENUM(E, E3);
-            in[3] = Test:: ICE_ENUM(E, E1);
-            in[4] = Test:: ICE_ENUM(E, E3);
+            in[0] = Test:: E::E1;
+            in[1] = Test:: E::E2;
+            in[2] = Test:: E::E3;
+            in[3] = Test:: E::E1;
+            in[4] = Test:: E::E3;
 
             auto r = t->opESeqAsync(in).get();
             test(r.outSeq == in);
@@ -1017,11 +1017,11 @@ allTests(Test::TestHelper* helper)
 
         {
             list<Test::E> in;
-            in.push_back(Test:: ICE_ENUM(E, E1));
-            in.push_back(Test:: ICE_ENUM(E, E2));
-            in.push_back(Test:: ICE_ENUM(E, E3));
-            in.push_back(Test:: ICE_ENUM(E, E1));
-            in.push_back(Test:: ICE_ENUM(E, E3));
+            in.push_back(Test:: E::E1);
+            in.push_back(Test:: E::E2);
+            in.push_back(Test:: E::E3);
+            in.push_back(Test:: E::E1);
+            in.push_back(Test:: E::E3);
 
             auto r = t->opEListAsync(in).get();
             test(r.outSeq == in);
@@ -1763,11 +1763,11 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::E> in(5);
-        in[0] = Test:: ICE_ENUM(E, E1);
-        in[1] = Test:: ICE_ENUM(E, E2);
-        in[2] = Test:: ICE_ENUM(E, E3);
-        in[3] = Test:: ICE_ENUM(E, E1);
-        in[4] = Test:: ICE_ENUM(E, E3);
+        in[0] = Test:: E::E1;
+        in[1] = Test:: E::E2;
+        in[2] = Test:: E::E3;
+        in[3] = Test:: E::E1;
+        in[4] = Test:: E::E3;
 
         promise<bool> done;
 
@@ -1788,11 +1788,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::E> in;
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E2));
-        in.push_back(Test:: ICE_ENUM(E, E3));
-        in.push_back(Test:: ICE_ENUM(E, E1));
-        in.push_back(Test:: ICE_ENUM(E, E3));
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E2);
+        in.push_back(Test:: E::E3);
+        in.push_back(Test:: E::E1);
+        in.push_back(Test:: E::E3);
 
         promise<bool> done;
 

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -507,7 +507,7 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::CPtr> in(5);
-        in[0] = ICE_MAKE_SHARED(Test::C);
+        in[0] = make_shared<Test::C>();
         in[1] = in[0];
         in[2] = in[0];
         in[3] = in[0];
@@ -526,11 +526,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::CPtr> in;
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
 
         list<Test::CPtr> out;
         list<Test::CPtr> ret = t->opCList(in, out);
@@ -1076,7 +1076,7 @@ allTests(Test::TestHelper* helper)
 
         {
             deque<Test::CPtr> in(5);
-            in[0] = ICE_MAKE_SHARED(Test::C);
+            in[0] = make_shared<Test::C>();
             in[1] = in[0];
             in[2] = in[0];
             in[3] = in[0];
@@ -1096,11 +1096,11 @@ allTests(Test::TestHelper* helper)
 
         {
             list<Test::CPtr> in;
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
-            in.push_back(ICE_MAKE_SHARED(Test::C));
+            in.push_back(make_shared<Test::C>());
+            in.push_back(make_shared<Test::C>());
+            in.push_back(make_shared<Test::C>());
+            in.push_back(make_shared<Test::C>());
+            in.push_back(make_shared<Test::C>());
 
             auto r = t->opCListAsync(in).get();
             test(r.outSeq.size() == in.size());
@@ -1875,7 +1875,7 @@ allTests(Test::TestHelper* helper)
 
     {
         deque<Test::CPtr> in(5);
-        in[0] = ICE_MAKE_SHARED(Test::C);
+        in[0] = make_shared<Test::C>();
         in[1] = in[0];
         in[2] = in[0];
         in[3] = in[0];
@@ -1900,11 +1900,11 @@ allTests(Test::TestHelper* helper)
 
     {
         list<Test::CPtr> in;
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
-        in.push_back(ICE_MAKE_SHARED(Test::C));
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
+        in.push_back(make_shared<Test::C>());
 
         promise<bool> done;
 

--- a/cpp/test/Ice/custom/Client.cpp
+++ b/cpp/test/Ice/custom/Client.cpp
@@ -19,8 +19,8 @@ public:
 void
 Client::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(make_shared<Test::WstringConverterI>());
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     Test::TestIntfPrxPtr test = allTests(this);

--- a/cpp/test/Ice/custom/Collocated.cpp
+++ b/cpp/test/Ice/custom/Collocated.cpp
@@ -20,16 +20,16 @@ public:
 void
 Collocated::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(make_shared<Test::WstringConverterI>());
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/custom/Server.cpp
+++ b/cpp/test/Ice/custom/Server.cpp
@@ -20,14 +20,14 @@ public:
 void
 Server::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(make_shared<Test::WstringConverterI>());
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/custom/ServerAMD.cpp
+++ b/cpp/test/Ice/custom/ServerAMD.cpp
@@ -20,16 +20,16 @@ public:
 void
 ServerAMD::run(int argc, char** argv)
 {
-    setProcessStringConverter(ICE_MAKE_SHARED(Test::StringConverterI));
-    setProcessWstringConverter(ICE_MAKE_SHARED(Test::WstringConverterI));
+    setProcessStringConverter(make_shared<Test::StringConverterI>());
+    setProcessWstringConverter(make_shared<Test::WstringConverterI>());
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("TEST"));
-    adapter->add(ICE_MAKE_SHARED(Test1::WstringClassI), Ice::stringToIdentity("WSTRING1"));
-    adapter->add(ICE_MAKE_SHARED(Test2::WstringClassI), Ice::stringToIdentity("WSTRING2"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("TEST"));
+    adapter->add(make_shared<Test1::WstringClassI>(), Ice::stringToIdentity("WSTRING1"));
+    adapter->add(make_shared<Test2::WstringClassI>(), Ice::stringToIdentity("WSTRING2"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -6,7 +6,7 @@
 #include <TestI.h>
 
 Test::DoubleSeq
-TestIntfI::opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*>) inSeq,
+TestIntfI::opDoubleArray(std::pair<const Ice::Double*, const Ice::Double*> inSeq,
                          Test::DoubleSeq& outSeq,
                          const Ice::Current&)
 {
@@ -15,7 +15,7 @@ TestIntfI::opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*
 }
 
 Test::BoolSeq
-TestIntfI::opBoolArray(ICE_IN(std::pair<const bool*, const bool*>) inSeq,
+TestIntfI::opBoolArray(std::pair<const bool*, const bool*> inSeq,
                        Test::BoolSeq& outSeq,
                        const Ice::Current&)
 {
@@ -24,7 +24,7 @@ TestIntfI::opBoolArray(ICE_IN(std::pair<const bool*, const bool*>) inSeq,
 }
 
 Test::ByteList
-TestIntfI::opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>) inSeq,
+TestIntfI::opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*> inSeq,
                        Test::ByteList& outSeq,
                        const Ice::Current&)
 {
@@ -33,7 +33,7 @@ TestIntfI::opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>) inS
 }
 
 Test::VariableList
-TestIntfI::opVariableArray(ICE_IN(std::pair<const Test::Variable*, const Test::Variable*>) inSeq,
+TestIntfI::opVariableArray(std::pair<const Test::Variable*, const Test::Variable*> inSeq,
                            Test::VariableList& outSeq,
                            const Ice::Current&)
 {
@@ -77,7 +77,7 @@ TestIntfI::opVariableRangeType(Test::VariableList inSeq, Test::VariableList& out
 }
 
 std::deque<bool>
-TestIntfI::opBoolSeq(ICE_IN(std::deque<bool>) inSeq,
+TestIntfI::opBoolSeq(std::deque<bool> inSeq,
                      std::deque<bool>& outSeq,
                      const Ice::Current&)
 {
@@ -86,7 +86,7 @@ TestIntfI::opBoolSeq(ICE_IN(std::deque<bool>) inSeq,
 }
 
 std::list<bool>
-TestIntfI::opBoolList(ICE_IN(std::list<bool>) inSeq,
+TestIntfI::opBoolList(std::list<bool> inSeq,
                       std::list<bool>& outSeq,
                       const Ice::Current&)
 {
@@ -95,14 +95,14 @@ TestIntfI::opBoolList(ICE_IN(std::list<bool>) inSeq,
 }
 
 ::Test::BoolDequeList
-TestIntfI::opBoolDequeList(ICE_IN(::Test::BoolDequeList) inSeq, ::Test::BoolDequeList& outSeq, const Ice::Current&)
+TestIntfI::opBoolDequeList(::Test::BoolDequeList inSeq, ::Test::BoolDequeList& outSeq, const Ice::Current&)
 {
     outSeq = inSeq;
     return inSeq;
 }
 
 ::Test::BoolDequeList
-TestIntfI::opBoolDequeListArray(ICE_IN(::std::pair<const std::deque<bool>*, const std::deque<bool>*>) inSeq,
+TestIntfI::opBoolDequeListArray(::std::pair<const std::deque<bool>*, const std::deque<bool>*> inSeq,
                                 ::Test::BoolDequeList& outSeq,
                                 const ::Ice::Current&)
 {
@@ -121,7 +121,7 @@ TestIntfI::opBoolDequeListRange(Test::BoolDequeList inSeq, Test::BoolDequeList& 
 }
 
 std::deque< ::Ice::Byte>
-TestIntfI::opByteSeq(ICE_IN(std::deque< ::Ice::Byte>) inSeq,
+TestIntfI::opByteSeq(std::deque< ::Ice::Byte> inSeq,
                      std::deque< ::Ice::Byte>& outSeq,
                      const Ice::Current&)
 {
@@ -130,7 +130,7 @@ TestIntfI::opByteSeq(ICE_IN(std::deque< ::Ice::Byte>) inSeq,
 }
 
 std::list< ::Ice::Byte>
-TestIntfI::opByteList(ICE_IN(std::list< ::Ice::Byte>) inSeq,
+TestIntfI::opByteList(std::list< ::Ice::Byte> inSeq,
                       std::list< ::Ice::Byte>& outSeq,
                       const Ice::Current&)
 {
@@ -139,7 +139,7 @@ TestIntfI::opByteList(ICE_IN(std::list< ::Ice::Byte>) inSeq,
 }
 
 MyByteSeq
-TestIntfI::opMyByteSeq(ICE_IN(MyByteSeq) inSeq,
+TestIntfI::opMyByteSeq(MyByteSeq inSeq,
                        MyByteSeq& outSeq,
                        const Ice::Current&)
 {
@@ -148,7 +148,7 @@ TestIntfI::opMyByteSeq(ICE_IN(MyByteSeq) inSeq,
 }
 
 std::string
-TestIntfI::opString(ICE_IN(Util::string_view) inString,
+TestIntfI::opString(Util::string_view inString,
                     std::string& outString,
                     const Ice::Current&)
 {
@@ -157,7 +157,7 @@ TestIntfI::opString(ICE_IN(Util::string_view) inString,
 }
 
 std::deque< ::std::string>
-TestIntfI::opStringSeq(ICE_IN(std::deque< ::std::string>) inSeq,
+TestIntfI::opStringSeq(std::deque< ::std::string> inSeq,
                        std::deque< ::std::string>& outSeq,
                        const Ice::Current&)
 {
@@ -166,7 +166,7 @@ TestIntfI::opStringSeq(ICE_IN(std::deque< ::std::string>) inSeq,
 }
 
 std::list< ::std::string>
-TestIntfI::opStringList(ICE_IN(std::list< ::std::string>) inSeq,
+TestIntfI::opStringList(std::list< ::std::string> inSeq,
                         std::list< ::std::string>& outSeq,
                         const Ice::Current&)
 {
@@ -175,7 +175,7 @@ TestIntfI::opStringList(ICE_IN(std::list< ::std::string>) inSeq,
 }
 
 std::deque< ::Test::Fixed>
-TestIntfI::opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>) inSeq,
+TestIntfI::opFixedSeq(std::deque< ::Test::Fixed> inSeq,
                       std::deque< ::Test::Fixed>& outSeq,
                       const Ice::Current&)
 {
@@ -184,7 +184,7 @@ TestIntfI::opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>) inSeq,
 }
 
 std::list< ::Test::Fixed>
-TestIntfI::opFixedList(ICE_IN(std::list< ::Test::Fixed>) inSeq,
+TestIntfI::opFixedList(std::list< ::Test::Fixed> inSeq,
                        std::list< ::Test::Fixed>& outSeq,
                        const Ice::Current&)
 {
@@ -193,7 +193,7 @@ TestIntfI::opFixedList(ICE_IN(std::list< ::Test::Fixed>) inSeq,
 }
 
 std::deque< ::Test::Variable>
-TestIntfI::opVariableSeq(ICE_IN(std::deque< ::Test::Variable>) inSeq,
+TestIntfI::opVariableSeq(std::deque< ::Test::Variable> inSeq,
                          std::deque< ::Test::Variable>& outSeq,
                          const Ice::Current&)
 {
@@ -202,7 +202,7 @@ TestIntfI::opVariableSeq(ICE_IN(std::deque< ::Test::Variable>) inSeq,
 }
 
 std::list< ::Test::Variable>
-TestIntfI::opVariableList(ICE_IN(std::list< ::Test::Variable>) inSeq,
+TestIntfI::opVariableList(std::list< ::Test::Variable> inSeq,
                           std::list< ::Test::Variable>& outSeq,
                           const Ice::Current&)
 {
@@ -211,7 +211,7 @@ TestIntfI::opVariableList(ICE_IN(std::list< ::Test::Variable>) inSeq,
 }
 
 std::deque< ::Test::StringStringDict>
-TestIntfI::opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>) inSeq,
+TestIntfI::opStringStringDictSeq(std::deque< ::Test::StringStringDict> inSeq,
                                        std::deque< ::Test::StringStringDict>& outSeq,
                                        const Ice::Current&)
 {
@@ -220,7 +220,7 @@ TestIntfI::opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>) i
 }
 
 std::list< ::Test::StringStringDict>
-TestIntfI::opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>) inSeq,
+TestIntfI::opStringStringDictList(std::list< ::Test::StringStringDict> inSeq,
                                         std::list< ::Test::StringStringDict>& outSeq,
                                         const Ice::Current&)
 {
@@ -229,7 +229,7 @@ TestIntfI::opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>) i
 }
 
 std::deque< ::Test::E>
-TestIntfI::opESeq(ICE_IN(std::deque< ::Test::E>) inSeq,
+TestIntfI::opESeq(std::deque< ::Test::E> inSeq,
                         std::deque< ::Test::E>& outSeq,
                         const Ice::Current&)
 {
@@ -238,7 +238,7 @@ TestIntfI::opESeq(ICE_IN(std::deque< ::Test::E>) inSeq,
 }
 
 std::list< ::Test::E>
-TestIntfI::opEList(ICE_IN(std::list< ::Test::E>) inSeq,
+TestIntfI::opEList(std::list< ::Test::E> inSeq,
                          std::list< ::Test::E>& outSeq,
                          const Ice::Current&)
 {
@@ -247,7 +247,7 @@ TestIntfI::opEList(ICE_IN(std::list< ::Test::E>) inSeq,
 }
 
 std::deque< ::Test::DPrxPtr>
-TestIntfI::opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>) inSeq,
+TestIntfI::opDPrxSeq(std::deque< ::Test::DPrxPtr> inSeq,
                            std::deque< ::Test::DPrxPtr>& outSeq,
                            const Ice::Current&)
 {
@@ -256,7 +256,7 @@ TestIntfI::opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>) inSeq,
 }
 
 std::list< ::Test::DPrxPtr>
-TestIntfI::opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>) inSeq,
+TestIntfI::opDPrxList(std::list< ::Test::DPrxPtr> inSeq,
                             std::list< ::Test::DPrxPtr>& outSeq,
                             const Ice::Current&)
 {
@@ -265,7 +265,7 @@ TestIntfI::opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>) inSeq,
 }
 
 std::deque< ::Test::CPtr>
-TestIntfI::opCSeq(ICE_IN(std::deque< ::Test::CPtr>) inSeq,
+TestIntfI::opCSeq(std::deque< ::Test::CPtr> inSeq,
                   std::deque< ::Test::CPtr>& outSeq,
                   const Ice::Current&)
 {
@@ -274,7 +274,7 @@ TestIntfI::opCSeq(ICE_IN(std::deque< ::Test::CPtr>) inSeq,
 }
 
 std::list< ::Test::CPtr>
-TestIntfI::opCList(ICE_IN(std::list< ::Test::CPtr>) inSeq,
+TestIntfI::opCList(std::list< ::Test::CPtr> inSeq,
                    std::list< ::Test::CPtr>& outSeq,
                    const Ice::Current&)
 {
@@ -295,26 +295,26 @@ TestIntfI::opClassStruct(Test::ClassStruct inS,
 }
 
 void
-TestIntfI::opOutArrayByteSeq(ICE_IN(Test::ByteSeq) data, Test::ByteSeq& copy, const Ice::Current&)
+TestIntfI::opOutArrayByteSeq(Test::ByteSeq data, Test::ByteSeq& copy, const Ice::Current&)
 {
     copy = data;
 }
 
 void
-TestIntfI::opOutRangeByteSeq(ICE_IN(Test::ByteSeq) data, Test::ByteSeq& copy, const Ice::Current&)
+TestIntfI::opOutRangeByteSeq(Test::ByteSeq data, Test::ByteSeq& copy, const Ice::Current&)
 {
     copy = data;
 }
 
 Test::IntStringDict
-TestIntfI::opIntStringDict(ICE_IN(Test::IntStringDict) data, Test::IntStringDict& copy, const Ice::Current&)
+TestIntfI::opIntStringDict(Test::IntStringDict data, Test::IntStringDict& copy, const Ice::Current&)
 {
     copy = data;
     return data;
 }
 
 Test::CustomMap<Ice::Long, Ice::Long>
-TestIntfI::opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>) data,
+TestIntfI::opVarDict(Test::CustomMap<std::string, Ice::Int> data,
                      Test::CustomMap<std::string, Ice::Int>& copy, const Ice::Current&)
 {
     copy = data;
@@ -329,7 +329,7 @@ TestIntfI::opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>) data,
 
 Test::CustomMap<Ice::Int, std::string>
 TestIntfI::opCustomIntStringDict(
-    ICE_IN(std::map<Ice::Int, Util::string_view>) data,
+    std::map<Ice::Int, Util::string_view> data,
     Test::CustomMap<Ice::Int, std::string>& copy,
     const Ice::Current&)
 {
@@ -345,21 +345,21 @@ TestIntfI::opCustomIntStringDict(
 }
 
 Test::ShortBuffer
-TestIntfI::opShortBuffer(ICE_IN(Test::ShortBuffer) inS, Test::ShortBuffer& outS, const Ice::Current&)
+TestIntfI::opShortBuffer(Test::ShortBuffer inS, Test::ShortBuffer& outS, const Ice::Current&)
 {
     outS = inS;
     return outS;
 }
 
 Test::CustomBuffer<bool>
-TestIntfI::opBoolBuffer(ICE_IN(Test::CustomBuffer<bool>) inS, Test::CustomBuffer<bool>& outS, const Ice::Current&)
+TestIntfI::opBoolBuffer(Test::CustomBuffer<bool> inS, Test::CustomBuffer<bool>& outS, const Ice::Current&)
 {
     outS = inS;
     return outS;
 }
 
 Test::BufferStruct
-TestIntfI::opBufferStruct(ICE_IN(Test::BufferStruct) bs, const Ice::Current&)
+TestIntfI::opBufferStruct(Test::BufferStruct bs, const Ice::Current&)
 {
     return bs;
 }

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -11,19 +11,19 @@ class TestIntfI : public virtual Test::TestIntf
 {
 public:
 
-    virtual Test::DoubleSeq opDoubleArray(ICE_IN(std::pair<const Ice::Double*, const Ice::Double*>),
+    virtual Test::DoubleSeq opDoubleArray(std::pair<const Ice::Double*, const Ice::Double*>,
                                           Test::DoubleSeq&,
                                           const Ice::Current&);
 
-    virtual Test::BoolSeq opBoolArray(ICE_IN(std::pair<const bool*, const bool*>),
+    virtual Test::BoolSeq opBoolArray(std::pair<const bool*, const bool*>,
                                       Test::BoolSeq&,
                                       const Ice::Current&);
 
-    virtual Test::ByteList opByteArray(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>),
+    virtual Test::ByteList opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*>,
                                        Test::ByteList&,
                                        const Ice::Current&);
 
-    virtual Test::VariableList opVariableArray(ICE_IN(std::pair<const Test::Variable*, const Test::Variable*>),
+    virtual Test::VariableList opVariableArray(std::pair<const Test::Variable*, const Test::Variable*>,
                                                Test::VariableList&,
                                                const Ice::Current&);
 
@@ -39,94 +39,94 @@ public:
     virtual Test::VariableList
     opVariableRangeType(Test::VariableList, Test::VariableList&, const Ice::Current&);
 
-    virtual std::deque<bool> opBoolSeq(ICE_IN(std::deque<bool>),
+    virtual std::deque<bool> opBoolSeq(std::deque<bool>,
                                        std::deque<bool>&,
                                        const Ice::Current&);
 
-    virtual std::list<bool> opBoolList(ICE_IN(std::list<bool>),
+    virtual std::list<bool> opBoolList(std::list<bool>,
                                        std::list<bool>&,
                                        const Ice::Current&);
 
-    virtual ::Test::BoolDequeList opBoolDequeList(ICE_IN(::Test::BoolDequeList),
+    virtual ::Test::BoolDequeList opBoolDequeList(::Test::BoolDequeList,
                                                   ::Test::BoolDequeList&,
                                                   const Ice::Current&);
 
-    virtual ::Test::BoolDequeList opBoolDequeListArray(ICE_IN(::std::pair<const std::deque<bool>*, const std::deque<bool>*>),
+    virtual ::Test::BoolDequeList opBoolDequeListArray(::std::pair<const std::deque<bool>*, const std::deque<bool>*>,
                                                        ::Test::BoolDequeList&,
                                                        const ::Ice::Current&);
 
     virtual ::Test::BoolDequeList opBoolDequeListRange(::Test::BoolDequeList,
                                                        ::Test::BoolDequeList&, const ::Ice::Current&);
 
-    virtual std::deque< ::Ice::Byte> opByteSeq(ICE_IN(std::deque< ::Ice::Byte>),
+    virtual std::deque< ::Ice::Byte> opByteSeq(std::deque< ::Ice::Byte>,
                                                std::deque< ::Ice::Byte>&,
                                                const Ice::Current&);
 
-    virtual std::list< ::Ice::Byte> opByteList(ICE_IN(std::list< ::Ice::Byte>),
+    virtual std::list< ::Ice::Byte> opByteList(std::list< ::Ice::Byte>,
                                                std::list< ::Ice::Byte>&,
                                                const Ice::Current&);
 
-    virtual MyByteSeq opMyByteSeq(ICE_IN(MyByteSeq),
+    virtual MyByteSeq opMyByteSeq(MyByteSeq,
                                   MyByteSeq&,
                                   const Ice::Current&);
 
-    virtual std::string opString(ICE_IN(Util::string_view),
+    virtual std::string opString(Util::string_view,
                                  std::string&,
                                  const Ice::Current&);
 
-    virtual std::deque< ::std::string> opStringSeq(ICE_IN(std::deque< ::std::string>),
+    virtual std::deque< ::std::string> opStringSeq(std::deque< ::std::string>,
                                                    std::deque< ::std::string>&,
                                                    const Ice::Current&);
 
-    virtual std::list< ::std::string> opStringList(ICE_IN(std::list< ::std::string>),
+    virtual std::list< ::std::string> opStringList(std::list< ::std::string>,
                                                    std::list< ::std::string>&,
                                                    const Ice::Current&);
 
-    virtual std::deque< ::Test::Fixed> opFixedSeq(ICE_IN(std::deque< ::Test::Fixed>),
+    virtual std::deque< ::Test::Fixed> opFixedSeq(std::deque< ::Test::Fixed>,
                                                   std::deque< ::Test::Fixed>&,
                                                   const Ice::Current&);
 
-    virtual std::list< ::Test::Fixed> opFixedList(ICE_IN(std::list< ::Test::Fixed>),
+    virtual std::list< ::Test::Fixed> opFixedList(std::list< ::Test::Fixed>,
                                                   std::list< ::Test::Fixed>&,
                                                   const Ice::Current&);
 
-    virtual std::deque< ::Test::Variable> opVariableSeq(ICE_IN(std::deque< ::Test::Variable>),
+    virtual std::deque< ::Test::Variable> opVariableSeq(std::deque< ::Test::Variable>,
                                                         std::deque< ::Test::Variable>&,
                                                         const Ice::Current&);
 
-    virtual std::list< ::Test::Variable> opVariableList(ICE_IN(std::list< ::Test::Variable>),
+    virtual std::list< ::Test::Variable> opVariableList(std::list< ::Test::Variable>,
                                                         std::list< ::Test::Variable>&,
                                                         const Ice::Current&);
 
-    virtual std::deque< ::Test::StringStringDict> opStringStringDictSeq(ICE_IN(std::deque< ::Test::StringStringDict>),
+    virtual std::deque< ::Test::StringStringDict> opStringStringDictSeq(std::deque< ::Test::StringStringDict>,
                                                                         std::deque< ::Test::StringStringDict>&,
                                                                         const Ice::Current&);
 
-    virtual std::list< ::Test::StringStringDict> opStringStringDictList(ICE_IN(std::list< ::Test::StringStringDict>),
+    virtual std::list< ::Test::StringStringDict> opStringStringDictList(std::list< ::Test::StringStringDict>,
                                                                         std::list< ::Test::StringStringDict>&,
                                                                         const Ice::Current&);
 
-    virtual std::deque< ::Test::E> opESeq(ICE_IN(std::deque< ::Test::E>),
+    virtual std::deque< ::Test::E> opESeq(std::deque< ::Test::E>,
                                           std::deque< ::Test::E>&,
                                           const Ice::Current&);
 
-    virtual std::list< ::Test::E> opEList(ICE_IN(std::list< ::Test::E>),
+    virtual std::list< ::Test::E> opEList(std::list< ::Test::E>,
                                           std::list< ::Test::E>&,
                                           const Ice::Current&);
 
-    virtual std::deque< ::Test::DPrxPtr> opDPrxSeq(ICE_IN(std::deque< ::Test::DPrxPtr>),
+    virtual std::deque< ::Test::DPrxPtr> opDPrxSeq(std::deque< ::Test::DPrxPtr>,
                                                 std::deque< ::Test::DPrxPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::list< ::Test::DPrxPtr> opDPrxList(ICE_IN(std::list< ::Test::DPrxPtr>),
+    virtual std::list< ::Test::DPrxPtr> opDPrxList(std::list< ::Test::DPrxPtr>,
                                                 std::list< ::Test::DPrxPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::deque< ::Test::CPtr> opCSeq(ICE_IN(std::deque< ::Test::CPtr>),
+    virtual std::deque< ::Test::CPtr> opCSeq(std::deque< ::Test::CPtr>,
                                                 std::deque< ::Test::CPtr>&,
                                                 const Ice::Current&);
 
-    virtual std::list< ::Test::CPtr> opCList(ICE_IN(std::list< ::Test::CPtr>),
+    virtual std::list< ::Test::CPtr> opCList(std::list< ::Test::CPtr>,
                                                 std::list< ::Test::CPtr>&,
                                                 const Ice::Current&);
 
@@ -136,26 +136,26 @@ public:
                                             Test::ClassStructSeq& outSeq,
                                             const Ice::Current&);
 
-    virtual void opOutArrayByteSeq(ICE_IN(Test::ByteSeq), Test::ByteSeq&, const Ice::Current&);
+    virtual void opOutArrayByteSeq(Test::ByteSeq, Test::ByteSeq&, const Ice::Current&);
 
-    virtual void opOutRangeByteSeq(ICE_IN(Test::ByteSeq), Test::ByteSeq&, const Ice::Current&);
+    virtual void opOutRangeByteSeq(Test::ByteSeq, Test::ByteSeq&, const Ice::Current&);
 
-    virtual Test::IntStringDict opIntStringDict(ICE_IN(Test::IntStringDict), Test::IntStringDict&,
+    virtual Test::IntStringDict opIntStringDict(Test::IntStringDict, Test::IntStringDict&,
                                                 const Ice::Current&);
 
-    virtual Test::CustomMap<Ice::Long, Ice::Long> opVarDict(ICE_IN(Test::CustomMap<std::string, Ice::Int>),
+    virtual Test::CustomMap<Ice::Long, Ice::Long> opVarDict(Test::CustomMap<std::string, Ice::Int>,
                                                             Test::CustomMap<std::string, Ice::Int>&,
                                                             const Ice::Current&);
 
     virtual Test::CustomMap<Ice::Int, std::string> opCustomIntStringDict(
-        ICE_IN(std::map<Ice::Int, Util::string_view>), Test::CustomMap<Ice::Int, std::string>&, const Ice::Current&);
+        std::map<Ice::Int, Util::string_view>, Test::CustomMap<Ice::Int, std::string>&, const Ice::Current&);
 
-    Test::ShortBuffer opShortBuffer(ICE_IN(Test::ShortBuffer), Test::ShortBuffer&, const Ice::Current&);
+    Test::ShortBuffer opShortBuffer(Test::ShortBuffer, Test::ShortBuffer&, const Ice::Current&);
 
-    Test::CustomBuffer<bool> opBoolBuffer(ICE_IN(Test::CustomBuffer<bool>), Test::CustomBuffer<bool>&,
+    Test::CustomBuffer<bool> opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&,
                                           const Ice::Current&);
 
-    Test::BufferStruct opBufferStruct(ICE_IN(Test::BufferStruct), const Ice::Current&);
+    Test::BufferStruct opBufferStruct(Test::BufferStruct, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };

--- a/cpp/test/Ice/custom/WstringI.cpp
+++ b/cpp/test/Ice/custom/WstringI.cpp
@@ -5,7 +5,7 @@
 #include <WstringI.h>
 
 ::std::wstring
-Test1::WstringClassI::opString(ICE_IN(::std::wstring) s1,
+Test1::WstringClassI::opString(::std::wstring s1,
                                ::std::wstring& s2,
                                const Ice::Current&)
 {
@@ -14,7 +14,7 @@ Test1::WstringClassI::opString(ICE_IN(::std::wstring) s1,
 }
 
 ::Test1::WstringStruct
-Test1::WstringClassI::opStruct(ICE_IN(::Test1::WstringStruct) s1,
+Test1::WstringClassI::opStruct(::Test1::WstringStruct s1,
                                ::Test1::WstringStruct& s2,
                                const Ice::Current&)
 {
@@ -23,7 +23,7 @@ Test1::WstringClassI::opStruct(ICE_IN(::Test1::WstringStruct) s1,
 }
 
 void
-Test1::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
+Test1::WstringClassI::throwExcept(::std::wstring reason,
                                   const Ice::Current&)
 {
     Test1::WstringException ex;
@@ -32,7 +32,7 @@ Test1::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
 }
 
 ::std::wstring
-Test2::WstringClassI::opString(ICE_IN(::std::wstring) s1,
+Test2::WstringClassI::opString(::std::wstring s1,
                                ::std::wstring& s2,
                                const Ice::Current&)
 {
@@ -41,7 +41,7 @@ Test2::WstringClassI::opString(ICE_IN(::std::wstring) s1,
 }
 
 ::Test2::WstringStruct
-Test2::WstringClassI::opStruct(ICE_IN(::Test2::WstringStruct) s1,
+Test2::WstringClassI::opStruct(::Test2::WstringStruct s1,
                                ::Test2::WstringStruct& s2,
                                const Ice::Current&)
 {
@@ -50,7 +50,7 @@ Test2::WstringClassI::opStruct(ICE_IN(::Test2::WstringStruct) s1,
 }
 
 void
-Test2::WstringClassI::throwExcept(ICE_IN(::std::wstring) reason,
+Test2::WstringClassI::throwExcept(::std::wstring reason,
                                   const Ice::Current&)
 {
     Test2::WstringException ex;

--- a/cpp/test/Ice/custom/WstringI.h
+++ b/cpp/test/Ice/custom/WstringI.h
@@ -14,15 +14,15 @@ class WstringClassI : public virtual WstringClass
 {
 public:
 
-    virtual ::std::wstring opString(ICE_IN(::std::wstring),
+    virtual ::std::wstring opString(::std::wstring,
                                     ::std::wstring&,
                                     const Ice::Current&);
 
-    virtual ::Test1::WstringStruct opStruct(ICE_IN(::Test1::WstringStruct),
+    virtual ::Test1::WstringStruct opStruct(::Test1::WstringStruct,
                                             ::Test1::WstringStruct&,
                                             const Ice::Current&);
 
-    virtual void throwExcept(ICE_IN(::std::wstring),
+    virtual void throwExcept(::std::wstring,
                              const Ice::Current&);
 };
 
@@ -35,15 +35,15 @@ class WstringClassI : public virtual WstringClass
 {
 public:
 
-    virtual ::std::wstring opString(ICE_IN(::std::wstring),
+    virtual ::std::wstring opString(::std::wstring,
                                     ::std::wstring&,
                                     const Ice::Current&);
 
-    virtual ::Test2::WstringStruct opStruct(ICE_IN(::Test2::WstringStruct),
+    virtual ::Test2::WstringStruct opStruct(::Test2::WstringStruct,
                                             ::Test2::WstringStruct&,
                                             const Ice::Current&);
 
-    virtual void throwExcept(ICE_IN(::std::wstring),
+    virtual void throwExcept(::std::wstring,
                              const Ice::Current&);
 };
 

--- a/cpp/test/Ice/defaultServant/AllTests.cpp
+++ b/cpp/test/Ice/defaultServant/AllTests.cpp
@@ -16,7 +16,7 @@ allTests(Test::TestHelper* helper)
     Ice::ObjectAdapterPtr oa = communicator->createObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");
     oa->activate();
 
-    Ice::ObjectPtr servant = ICE_MAKE_SHARED(MyObjectI);
+    Ice::ObjectPtr servant = std::make_shared<MyObjectI>();
 
     //
     // Register default servant with category "foo"

--- a/cpp/test/Ice/defaultValue/AllTests.cpp
+++ b/cpp/test/Ice/defaultValue/AllTests.cpp
@@ -91,7 +91,7 @@ allTests()
     }
 
     {
-        BasePtr v = ICE_MAKE_SHARED(Base);
+        BasePtr v = std::make_shared<Base>();
         test(!v->boolFalse);
         test(v->boolTrue);
         test(v->b == 1);
@@ -111,7 +111,7 @@ allTests()
     }
 
     {
-        DerivedPtr v = ICE_MAKE_SHARED(Derived);
+        DerivedPtr v = std::make_shared<Derived>();
         test(!v->boolFalse);
         test(v->boolTrue);
         test(v->b == 1);

--- a/cpp/test/Ice/dispatcher/AllTests.cpp
+++ b/cpp/test/Ice/dispatcher/AllTests.cpp
@@ -100,7 +100,7 @@ private:
     bool _called;
     bool _sentSynchronously;
 };
-ICE_DEFINE_PTR(CallbackPtr, Callback);
+using CallbackPtr = std::shared_ptr<Callback>;
 
 }
 
@@ -124,7 +124,7 @@ allTests(Test::TestHelper* helper)
     {
         p->op();
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opAsync(
             [cb]()
             {

--- a/cpp/test/Ice/dispatcher/Collocated.cpp
+++ b/cpp/test/Ice/dispatcher/Collocated.cpp
@@ -35,9 +35,9 @@ Collocated::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-    TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+    TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
 
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/dispatcher/Server.cpp
+++ b/cpp/test/Ice/dispatcher/Server.cpp
@@ -43,9 +43,9 @@ Server::run(int argc, char** argv)
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
         Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("ControllerAdapter");
 
-        TestIntfControllerIPtr testController = ICE_MAKE_SHARED(TestIntfControllerI, adapter);
+        TestIntfControllerIPtr testController = make_shared<TestIntfControllerI>(adapter);
 
-        adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         adapter->activate();
 
         adapter2->add(testController, Ice::stringToIdentity("testController"));

--- a/cpp/test/Ice/dispatcher/TestI.h
+++ b/cpp/test/Ice/dispatcher/TestI.h
@@ -9,7 +9,7 @@
 #include <Test.h>
 
 class TestIntfControllerI;
-ICE_DEFINE_SHARED_PTR(TestIntfControllerIPtr, TestIntfControllerI);
+using TestIntfControllerIPtr = std::shared_ptr<TestIntfControllerI>;
 
 class TestIntfI : public virtual Test::TestIntf
 {

--- a/cpp/test/Ice/echo/BlobjectI.h
+++ b/cpp/test/Ice/echo/BlobjectI.h
@@ -31,6 +31,6 @@ private:
     Ice::ConnectionPtr _connection;
 };
 
-ICE_DEFINE_SHARED_PTR(BlobjectIPtr, BlobjectI);
+using BlobjectIPtr = std::shared_ptr<BlobjectI>;
 
 #endif

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -56,9 +56,9 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    BlobjectIPtr blob = ICE_MAKE_SHARED(BlobjectI);
+    BlobjectIPtr blob = make_shared<BlobjectI>();
     adapter->addDefaultServant(blob, "");
-    adapter->add(ICE_MAKE_SHARED(EchoI, blob), Ice::stringToIdentity("__echo"));
+    adapter->add(make_shared<EchoI>(blob), Ice::stringToIdentity("__echo"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/enums/AllTests.cpp
+++ b/cpp/test/Ice/enums/AllTests.cpp
@@ -21,74 +21,74 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing enum values... " << flush;
 
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum1)) == 0);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum2)) == 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ByteEnum, benum11)) == ByteConst2);
+    test(static_cast<int>(ByteEnum::benum1) == 0);
+    test(static_cast<int>(ByteEnum::benum2) == 1);
+    test(static_cast<int>(ByteEnum::benum3) == ByteConst1);
+    test(static_cast<int>(ByteEnum::benum4) == ByteConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum5) == ShortConst1);
+    test(static_cast<int>(ByteEnum::benum6) == ShortConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum7) == IntConst1);
+    test(static_cast<int>(ByteEnum::benum8) == IntConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum9) == LongConst1);
+    test(static_cast<int>(ByteEnum::benum10) == LongConst1 + 1);
+    test(static_cast<int>(ByteEnum::benum11) == ByteConst2);
 
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum1)) == 3);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum2)) == 4);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(ShortEnum, senum11)) == ShortConst2);
+    test(static_cast<int>(ShortEnum::senum1) == 3);
+    test(static_cast<int>(ShortEnum::senum2) == 4);
+    test(static_cast<int>(ShortEnum::senum3) == ByteConst1);
+    test(static_cast<int>(ShortEnum::senum4) == ByteConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum5) == ShortConst1);
+    test(static_cast<int>(ShortEnum::senum6) == ShortConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum7) == IntConst1);
+    test(static_cast<int>(ShortEnum::senum8) == IntConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum9) == LongConst1);
+    test(static_cast<int>(ShortEnum::senum10) == LongConst1 + 1);
+    test(static_cast<int>(ShortEnum::senum11) == ShortConst2);
 
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum1)) == 0);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum2)) == 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum3)) == ByteConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum4)) == ByteConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum5)) == ShortConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum6)) == ShortConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum7)) == IntConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum8)) == IntConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum9)) == LongConst1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum10)) == LongConst1 + 1);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum11)) == IntConst2);
-    test(static_cast<int>(ICE_ENUM(IntEnum, ienum12)) == LongConst2);
+    test(static_cast<int>(IntEnum::ienum1) == 0);
+    test(static_cast<int>(IntEnum::ienum2) == 1);
+    test(static_cast<int>(IntEnum::ienum3) == ByteConst1);
+    test(static_cast<int>(IntEnum::ienum4) == ByteConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum5) == ShortConst1);
+    test(static_cast<int>(IntEnum::ienum6) == ShortConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum7) == IntConst1);
+    test(static_cast<int>(IntEnum::ienum8) == IntConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum9) == LongConst1);
+    test(static_cast<int>(IntEnum::ienum10) == LongConst1 + 1);
+    test(static_cast<int>(IntEnum::ienum11) == IntConst2);
+    test(static_cast<int>(IntEnum::ienum12) == LongConst2);
 
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, red)) == 0);
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, green)) == 1);
-    test(static_cast<int>(ICE_ENUM(SimpleEnum, blue)) == 2);
+    test(static_cast<int>(SimpleEnum::red) == 0);
+    test(static_cast<int>(SimpleEnum::green) == 1);
+    test(static_cast<int>(SimpleEnum::blue) == 2);
 
     cout << "ok" << endl;
 
     cout << "testing enum operations... " << flush;
 
     ByteEnum byteEnum;
-    test(proxy->opByte(ICE_ENUM(ByteEnum, benum1), byteEnum) == ICE_ENUM(ByteEnum, benum1));
-    test(byteEnum == ICE_ENUM(ByteEnum, benum1));
-    test(proxy->opByte(ICE_ENUM(ByteEnum, benum11), byteEnum) == ICE_ENUM(ByteEnum, benum11));
-    test(byteEnum == ICE_ENUM(ByteEnum, benum11));
+    test(proxy->opByte(ByteEnum::benum1, byteEnum) == ByteEnum::benum1);
+    test(byteEnum == ByteEnum::benum1);
+    test(proxy->opByte(ByteEnum::benum11, byteEnum) == ByteEnum::benum11);
+    test(byteEnum == ByteEnum::benum11);
 
     ShortEnum shortEnum;
-    test(proxy->opShort(ICE_ENUM(ShortEnum, senum1), shortEnum) == ICE_ENUM(ShortEnum, senum1));
-    test(shortEnum == ICE_ENUM(ShortEnum, senum1));
-    test(proxy->opShort(ICE_ENUM(ShortEnum, senum11), shortEnum) == ICE_ENUM(ShortEnum, senum11));
-    test(shortEnum == ICE_ENUM(ShortEnum, senum11));
+    test(proxy->opShort(ShortEnum::senum1, shortEnum) == ShortEnum::senum1);
+    test(shortEnum == ShortEnum::senum1);
+    test(proxy->opShort(ShortEnum::senum11, shortEnum) == ShortEnum::senum11);
+    test(shortEnum == ShortEnum::senum11);
 
     IntEnum intEnum;
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum1), intEnum) == ICE_ENUM(IntEnum, ienum1));
-    test(intEnum == ICE_ENUM(IntEnum, ienum1));
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum11), intEnum) == ICE_ENUM(IntEnum, ienum11));
-    test(intEnum == ICE_ENUM(IntEnum, ienum11));
-    test(proxy->opInt(ICE_ENUM(IntEnum, ienum12), intEnum) == ICE_ENUM(IntEnum, ienum12));
-    test(intEnum == ICE_ENUM(IntEnum, ienum12));
+    test(proxy->opInt(IntEnum::ienum1, intEnum) == IntEnum::ienum1);
+    test(intEnum == IntEnum::ienum1);
+    test(proxy->opInt(IntEnum::ienum11, intEnum) == IntEnum::ienum11);
+    test(intEnum == IntEnum::ienum11);
+    test(proxy->opInt(IntEnum::ienum12, intEnum) == IntEnum::ienum12);
+    test(intEnum == IntEnum::ienum12);
 
     SimpleEnum s;
-    test(proxy->opSimple(ICE_ENUM(SimpleEnum, green), s) == ICE_ENUM(SimpleEnum, green));
-    test(s == ICE_ENUM(SimpleEnum, green));
+    test(proxy->opSimple(SimpleEnum::green, s) == SimpleEnum::green);
+    test(s == SimpleEnum::green);
 
     cout << "ok" << endl;
 
@@ -97,17 +97,17 @@ allTests(Test::TestHelper* helper)
     {
         ByteEnum values[] =
         {
-            ICE_ENUM(ByteEnum, benum1),
-            ICE_ENUM(ByteEnum, benum2),
-            ICE_ENUM(ByteEnum, benum3),
-            ICE_ENUM(ByteEnum, benum4),
-            ICE_ENUM(ByteEnum, benum5),
-            ICE_ENUM(ByteEnum, benum6),
-            ICE_ENUM(ByteEnum, benum7),
-            ICE_ENUM(ByteEnum, benum8),
-            ICE_ENUM(ByteEnum, benum9),
-            ICE_ENUM(ByteEnum, benum10),
-            ICE_ENUM(ByteEnum, benum11)
+            ByteEnum::benum1,
+            ByteEnum::benum2,
+            ByteEnum::benum3,
+            ByteEnum::benum4,
+            ByteEnum::benum5,
+            ByteEnum::benum6,
+            ByteEnum::benum7,
+            ByteEnum::benum8,
+            ByteEnum::benum9,
+            ByteEnum::benum10,
+            ByteEnum::benum11
         };
         ByteEnumSeq b1(&values[0], &values[0] + sizeof(values) / sizeof(ByteEnum));
 
@@ -124,17 +124,17 @@ allTests(Test::TestHelper* helper)
     {
         ShortEnum values[] =
         {
-            ICE_ENUM(ShortEnum, senum1),
-            ICE_ENUM(ShortEnum, senum2),
-            ICE_ENUM(ShortEnum, senum3),
-            ICE_ENUM(ShortEnum, senum4),
-            ICE_ENUM(ShortEnum, senum5),
-            ICE_ENUM(ShortEnum, senum6),
-            ICE_ENUM(ShortEnum, senum7),
-            ICE_ENUM(ShortEnum, senum8),
-            ICE_ENUM(ShortEnum, senum9),
-            ICE_ENUM(ShortEnum, senum10),
-            ICE_ENUM(ShortEnum, senum11)
+            ShortEnum::senum1,
+            ShortEnum::senum2,
+            ShortEnum::senum3,
+            ShortEnum::senum4,
+            ShortEnum::senum5,
+            ShortEnum::senum6,
+            ShortEnum::senum7,
+            ShortEnum::senum8,
+            ShortEnum::senum9,
+            ShortEnum::senum10,
+            ShortEnum::senum11
         };
         ShortEnumSeq s1(&values[0], &values[0] + sizeof(values) / sizeof(ShortEnum));
 
@@ -151,17 +151,17 @@ allTests(Test::TestHelper* helper)
     {
         IntEnum values[] =
         {
-            ICE_ENUM(IntEnum, ienum1),
-            ICE_ENUM(IntEnum, ienum2),
-            ICE_ENUM(IntEnum, ienum3),
-            ICE_ENUM(IntEnum, ienum4),
-            ICE_ENUM(IntEnum, ienum5),
-            ICE_ENUM(IntEnum, ienum6),
-            ICE_ENUM(IntEnum, ienum7),
-            ICE_ENUM(IntEnum, ienum8),
-            ICE_ENUM(IntEnum, ienum9),
-            ICE_ENUM(IntEnum, ienum10),
-            ICE_ENUM(IntEnum, ienum11)
+            IntEnum::ienum1,
+            IntEnum::ienum2,
+            IntEnum::ienum3,
+            IntEnum::ienum4,
+            IntEnum::ienum5,
+            IntEnum::ienum6,
+            IntEnum::ienum7,
+            IntEnum::ienum8,
+            IntEnum::ienum9,
+            IntEnum::ienum10,
+            IntEnum::ienum11
         };
         IntEnumSeq i1(&values[0], &values[0] + sizeof(values) / sizeof(IntEnum));
 
@@ -178,9 +178,9 @@ allTests(Test::TestHelper* helper)
     {
         SimpleEnum values[] =
         {
-            ICE_ENUM(SimpleEnum, red),
-            ICE_ENUM(SimpleEnum, green),
-            ICE_ENUM(SimpleEnum, blue)
+            SimpleEnum::red,
+            SimpleEnum::green,
+            SimpleEnum::blue
         };
         SimpleEnumSeq s1(&values[0], &values[0] + sizeof(values) / sizeof(SimpleEnum));
 

--- a/cpp/test/Ice/enums/Server.cpp
+++ b/cpp/test/Ice/enums/Server.cpp
@@ -21,7 +21,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
 
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/enums/TestI.cpp
+++ b/cpp/test/Ice/enums/TestI.cpp
@@ -34,28 +34,28 @@ TestIntfI::opSimple(Test::SimpleEnum s1, Test::SimpleEnum& s2, const Ice::Curren
 }
 
 Test::ByteEnumSeq
-TestIntfI::opByteSeq(ICE_IN(Test::ByteEnumSeq) bs1, Test::ByteEnumSeq& bs2, const Ice::Current&)
+TestIntfI::opByteSeq(Test::ByteEnumSeq bs1, Test::ByteEnumSeq& bs2, const Ice::Current&)
 {
     bs2 = bs1;
     return bs1;
 }
 
 Test::ShortEnumSeq
-TestIntfI::opShortSeq(ICE_IN(Test::ShortEnumSeq) ss1, Test::ShortEnumSeq& ss2, const ::Ice::Current&)
+TestIntfI::opShortSeq(Test::ShortEnumSeq ss1, Test::ShortEnumSeq& ss2, const ::Ice::Current&)
 {
     ss2 = ss1;
     return ss1;
 }
 
 Test::IntEnumSeq
-TestIntfI::opIntSeq(ICE_IN(Test::IntEnumSeq) is1, Test::IntEnumSeq& is2, const ::Ice::Current&)
+TestIntfI::opIntSeq(Test::IntEnumSeq is1, Test::IntEnumSeq& is2, const ::Ice::Current&)
 {
     is2 = is1;
     return is1;
 }
 
 Test::SimpleEnumSeq
-TestIntfI::opSimpleSeq(ICE_IN(Test::SimpleEnumSeq) ss1, Test::SimpleEnumSeq& ss2, const ::Ice::Current&)
+TestIntfI::opSimpleSeq(Test::SimpleEnumSeq ss1, Test::SimpleEnumSeq& ss2, const ::Ice::Current&)
 {
     ss2 = ss1;
     return ss1;

--- a/cpp/test/Ice/enums/TestI.h
+++ b/cpp/test/Ice/enums/TestI.h
@@ -19,13 +19,13 @@ public:
 
     virtual Test::SimpleEnum opSimple(Test::SimpleEnum, Test::SimpleEnum&, const Ice::Current&);
 
-    virtual Test::ByteEnumSeq opByteSeq(ICE_IN(Test::ByteEnumSeq), Test::ByteEnumSeq&, const Ice::Current&);
+    virtual Test::ByteEnumSeq opByteSeq(Test::ByteEnumSeq, Test::ByteEnumSeq&, const Ice::Current&);
 
-    virtual Test::ShortEnumSeq opShortSeq(ICE_IN(Test::ShortEnumSeq), Test::ShortEnumSeq&, const ::Ice::Current&);
+    virtual Test::ShortEnumSeq opShortSeq(Test::ShortEnumSeq, Test::ShortEnumSeq&, const ::Ice::Current&);
 
-    virtual Test::IntEnumSeq opIntSeq(ICE_IN(Test::IntEnumSeq), Test::IntEnumSeq&, const ::Ice::Current&);
+    virtual Test::IntEnumSeq opIntSeq(Test::IntEnumSeq, Test::IntEnumSeq&, const ::Ice::Current&);
 
-    virtual Test::SimpleEnumSeq opSimpleSeq(ICE_IN(Test::SimpleEnumSeq), Test::SimpleEnumSeq&, const ::Ice::Current&);
+    virtual Test::SimpleEnumSeq opSimpleSeq(Test::SimpleEnumSeq, Test::SimpleEnumSeq&, const ::Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };

--- a/cpp/test/Ice/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/exceptions/AllTests.cpp
@@ -532,7 +532,7 @@ allTests(Test::TestHelper* helper)
         {
             communicator->getProperties()->setProperty("TestAdapter1.Endpoints", localOAEndpoint);
             Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter1");
-            Ice::ObjectPtr obj = ICE_MAKE_SHARED(EmptyI);
+            Ice::ObjectPtr obj = std::make_shared<EmptyI>();
             adapter->add(obj, Ice::stringToIdentity("x"));
             try
             {

--- a/cpp/test/Ice/exceptions/Collocated.cpp
+++ b/cpp/test/Ice/exceptions/Collocated.cpp
@@ -28,7 +28,7 @@ Collocated::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
 
     ThrowerPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/exceptions/Server.cpp
+++ b/cpp/test/Ice/exceptions/Server.cpp
@@ -33,7 +33,7 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
     Ice::ObjectAdapterPtr adapter3 = communicator->createObjectAdapter("TestAdapter3");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
     adapter2->add(object, Ice::stringToIdentity("thrower"));
     adapter3->add(object, Ice::stringToIdentity("thrower"));

--- a/cpp/test/Ice/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/exceptions/ServerAMD.cpp
@@ -32,7 +32,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
     Ice::ObjectAdapterPtr adapter3 = communicator->createObjectAdapter("TestAdapter3");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ThrowerI);
+    Ice::ObjectPtr object = std::make_shared<ThrowerI>();
     adapter->add(object, Ice::stringToIdentity("thrower"));
     adapter2->add(object, Ice::stringToIdentity("thrower"));
     adapter3->add(object, Ice::stringToIdentity("thrower"));

--- a/cpp/test/Ice/exceptions/TestAMDI.cpp
+++ b/cpp/test/Ice/exceptions/TestAMDI.cpp
@@ -292,7 +292,7 @@ ThrowerI::throwAssertExceptionAsync(function<void()>,
 }
 
 void
-ThrowerI::throwMemoryLimitExceptionAsync(ICE_IN(Ice::ByteSeq),
+ThrowerI::throwMemoryLimitExceptionAsync(Ice::ByteSeq,
                                          function<void(const Ice::ByteSeq&)> response,
                                          function<void(exception_ptr)>,
                                          const Ice::Current&)

--- a/cpp/test/Ice/exceptions/TestAMDI.h
+++ b/cpp/test/Ice/exceptions/TestAMDI.h
@@ -95,7 +95,7 @@ public:
                                            std::function<void(std::exception_ptr)>,
                                            const Ice::Current&);
 
-    virtual void throwMemoryLimitExceptionAsync(ICE_IN(Ice::ByteSeq),
+    virtual void throwMemoryLimitExceptionAsync(Ice::ByteSeq,
                                                 std::function<void(const Ice::ByteSeq&)>,
                                                 std::function<void(std::exception_ptr)>,
                                                 const Ice::Current&);

--- a/cpp/test/Ice/exceptions/TestI.cpp
+++ b/cpp/test/Ice/exceptions/TestI.cpp
@@ -148,7 +148,7 @@ ThrowerI::throwAssertException(const Ice::Current&)
 }
 
 Ice::ByteSeq
-ThrowerI::throwMemoryLimitException(ICE_IN(Ice::ByteSeq), const Ice::Current&)
+ThrowerI::throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&)
 {
     return Ice::ByteSeq(1024 * 20); // 20 KB.
 }

--- a/cpp/test/Ice/exceptions/TestI.h
+++ b/cpp/test/Ice/exceptions/TestI.h
@@ -35,7 +35,7 @@ public:
     virtual void throwLocalException(const Ice::Current&);
     virtual void throwNonIceException(const Ice::Current&);
     virtual void throwAssertException(const Ice::Current&);
-    virtual Ice::ByteSeq throwMemoryLimitException(ICE_IN(Ice::ByteSeq), const Ice::Current&);
+    virtual Ice::ByteSeq throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&);
 
     virtual void throwLocalExceptionIdempotent(const Ice::Current&);
 

--- a/cpp/test/Ice/facets/AllTests.cpp
+++ b/cpp/test/Ice/facets/AllTests.cpp
@@ -59,7 +59,7 @@ allTests(Test::TestHelper* helper)
        communicator->getProperties()->getProperty("Ice.Default.Protocol") != "wss")
     {
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("FacetExceptionTestAdapter");
-        Ice::ObjectPtr obj = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj = std::make_shared<EmptyI>();
         adapter->add(obj, Ice::stringToIdentity("d"));
         adapter->addFacet(obj, Ice::stringToIdentity("d"), "facetABCD");
         try
@@ -82,11 +82,11 @@ allTests(Test::TestHelper* helper)
         cout << "ok" << endl;
 
         cout << "testing removeAllFacets... " << flush;
-        Ice::ObjectPtr obj1 = ICE_MAKE_SHARED(EmptyI);
-        Ice::ObjectPtr obj2 = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj1 = std::make_shared<EmptyI>();
+        Ice::ObjectPtr obj2 = std::make_shared<EmptyI>();
         adapter->addFacet(obj1, Ice::stringToIdentity("id1"), "f1");
         adapter->addFacet(obj2, Ice::stringToIdentity("id1"), "f2");
-        Ice::ObjectPtr obj3 = ICE_MAKE_SHARED(EmptyI);
+        Ice::ObjectPtr obj3 = std::make_shared<EmptyI>();
         adapter->addFacet(obj1, Ice::stringToIdentity("id2"), "f1");
         adapter->addFacet(obj2, Ice::stringToIdentity("id2"), "f2");
         adapter->addFacet(obj3, Ice::stringToIdentity("id2"), "");

--- a/cpp/test/Ice/facets/Collocated.cpp
+++ b/cpp/test/Ice/facets/Collocated.cpp
@@ -22,12 +22,12 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr d = ICE_MAKE_SHARED(DI);
+    Ice::ObjectPtr d = std::make_shared<DI>();
     adapter->add(d, Ice::stringToIdentity("d"));
     adapter->addFacet(d, Ice::stringToIdentity("d"), "facetABCD");
-    Ice::ObjectPtr f = ICE_MAKE_SHARED(FI);
+    Ice::ObjectPtr f = std::make_shared<FI>();
     adapter->addFacet(f, Ice::stringToIdentity("d"), "facetEF");
-    Ice::ObjectPtr h = ICE_MAKE_SHARED(HI);
+    Ice::ObjectPtr h = std::make_shared<HI>();
     adapter->addFacet(h, Ice::stringToIdentity("d"), "facetGH");
 
     GPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/facets/Server.cpp
+++ b/cpp/test/Ice/facets/Server.cpp
@@ -19,12 +19,12 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr d = ICE_MAKE_SHARED(DI);
+    Ice::ObjectPtr d = std::make_shared<DI>();
     adapter->add(d, Ice::stringToIdentity("d"));
     adapter->addFacet(d, Ice::stringToIdentity("d"), "facetABCD");
-    Ice::ObjectPtr f = ICE_MAKE_SHARED(FI);
+    Ice::ObjectPtr f = std::make_shared<FI>();
     adapter->addFacet(f, Ice::stringToIdentity("d"), "facetEF");
-    Ice::ObjectPtr h = ICE_MAKE_SHARED(HI);
+    Ice::ObjectPtr h = std::make_shared<HI>();
     adapter->addFacet(h, Ice::stringToIdentity("d"), "facetGH");
     serverReady();
     adapter->activate();

--- a/cpp/test/Ice/faultTolerance/Server.cpp
+++ b/cpp/test/Ice/faultTolerance/Server.cpp
@@ -55,7 +55,7 @@ Server::run(int argc, char** argv)
     endpts << getTestEndpoint(port);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", endpts.str());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/hold/AllTests.cpp
+++ b/cpp/test/Ice/hold/AllTests.cpp
@@ -232,7 +232,7 @@ allTests(Test::TestHelper* helper)
             {
                 completed->get_future().get();
                 holdSerialized->ice_ping(); // Ensure everything's dispatched
-                holdSerialized->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+                holdSerialized->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
             }
         }
         completed->get_future().get();

--- a/cpp/test/Ice/hold/Server.cpp
+++ b/cpp/test/Ice/hold/Server.cpp
@@ -27,7 +27,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter1.ThreadPool.SizeWarn", "0");
     communicator->getProperties()->setProperty("TestAdapter1.ThreadPool.Serialize", "0");
     Ice::ObjectAdapterPtr adapter1 = communicator->createObjectAdapter("TestAdapter1");
-    adapter1->add(ICE_MAKE_SHARED(HoldI, timer, adapter1), Ice::stringToIdentity("hold"));
+    adapter1->add(make_shared<HoldI>(timer, adapter1), Ice::stringToIdentity("hold"));
 
     communicator->getProperties()->setProperty("TestAdapter2.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.Size", "5");
@@ -35,7 +35,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.SizeWarn", "0");
     communicator->getProperties()->setProperty("TestAdapter2.ThreadPool.Serialize", "1");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
-    adapter2->add(ICE_MAKE_SHARED(HoldI, timer, adapter2), Ice::stringToIdentity("hold"));
+    adapter2->add(make_shared<HoldI>(timer, adapter2), Ice::stringToIdentity("hold"));
 
     adapter1->activate();
     adapter2->activate();

--- a/cpp/test/Ice/hold/TestI.cpp
+++ b/cpp/test/Ice/hold/TestI.cpp
@@ -7,6 +7,8 @@
 #include <TestI.h>
 #include <TestHelper.h>
 
+using namespace std;
+
 HoldI::HoldI(const IceUtil::TimerPtr& timer, const Ice::ObjectAdapterPtr& adapter) :
     _last(0), _timer(timer), _adapter(adapter)
 {
@@ -59,7 +61,7 @@ HoldI::putOnHold(Ice::Int milliSeconds, const Ice::Current&)
     {
         try
         {
-            _timer->schedule(ICE_MAKE_SHARED(PutOnHold, _adapter), IceUtil::Time::milliSeconds(milliSeconds));
+            _timer->schedule(make_shared<PutOnHold>(_adapter), IceUtil::Time::milliSeconds(milliSeconds));
         }
         catch(const IceUtil::IllegalArgumentException&)
         {
@@ -103,7 +105,7 @@ HoldI::waitForHold(const Ice::Current& current)
 
     try
     {
-        _timer->schedule(ICE_MAKE_SHARED(WaitForHold, current.adapter), IceUtil::Time());
+        _timer->schedule(make_shared<WaitForHold>(current.adapter), IceUtil::Time());
     }
     catch(const IceUtil::IllegalArgumentException&)
     {

--- a/cpp/test/Ice/impl/Server.cpp
+++ b/cpp/test/Ice/impl/Server.cpp
@@ -29,7 +29,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/impl/ServerAMD.cpp
+++ b/cpp/test/Ice/impl/ServerAMD.cpp
@@ -29,7 +29,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/info/AllTests.cpp
+++ b/cpp/test/Ice/info/AllTests.cpp
@@ -24,7 +24,7 @@ getTCPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return tcpInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::TCPConnectionInfoPtr
@@ -38,7 +38,7 @@ getTCPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return tcpInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/info/Server.cpp
+++ b/cpp/test/Ice/info/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints",
                                                getTestEndpoint() + ":" + getTestEndpoint("udp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/info/TestI.cpp
+++ b/cpp/test/Ice/info/TestI.cpp
@@ -25,7 +25,7 @@ getIPEndpointInfo(const Ice::EndpointInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 Ice::IPConnectionInfoPtr
@@ -39,7 +39,7 @@ getIPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/inheritance/AllTests.cpp
+++ b/cpp/test/Ice/inheritance/AllTests.cpp
@@ -154,19 +154,19 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing one shot constructor... " << flush;
     {
-        MC::APtr a = ICE_MAKE_SHARED(MC::A, 1);
+        MC::APtr a = make_shared<MC::A>(1);
         test(a->aA == 1);
 
-        MC::BPtr b = ICE_MAKE_SHARED(MC::B, 1, 2);
+        MC::BPtr b = make_shared<MC::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MC::CPtr c = ICE_MAKE_SHARED(MC::C, 1, 2, 3);
+        MC::CPtr c = make_shared<MC::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MC::DPtr d = ICE_MAKE_SHARED(MC::D, 1, 2, 3, 4);
+        MC::DPtr d = make_shared<MC::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -174,19 +174,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MD::APtr a = ICE_MAKE_SHARED(MD::A, 1);
+        MD::APtr a = make_shared<MD::A>(1);
         test(a->aA == 1);
 
-        MD::BPtr b = ICE_MAKE_SHARED(MD::B, 1, 2);
+        MD::BPtr b = make_shared<MD::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MD::CPtr c = ICE_MAKE_SHARED(MD::C, 1, 2, 3);
+        MD::CPtr c = make_shared<MD::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MD::DPtr d = ICE_MAKE_SHARED(MD::D, 1, 2, 3, 4);
+        MD::DPtr d = make_shared<MD::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -194,19 +194,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        ME::APtr a = ICE_MAKE_SHARED(ME::A, 1);
+        ME::APtr a = make_shared<ME::A>(1);
         test(a->aA == 1);
 
-        ME::BPtr b = ICE_MAKE_SHARED(ME::B, 1, 2);
+        ME::BPtr b = make_shared<ME::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        ME::CPtr c = ICE_MAKE_SHARED(ME::C, 1, 2, 3);
+        ME::CPtr c = make_shared<ME::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        ME::DPtr d = ICE_MAKE_SHARED(ME::D, 1, 2, 3, 4);
+        ME::DPtr d = make_shared<ME::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -214,19 +214,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MF::APtr a = ICE_MAKE_SHARED(MF::A, 1);
+        MF::APtr a = make_shared<MF::A>(1);
         test(a->aA == 1);
 
-        MF::BPtr b = ICE_MAKE_SHARED(MF::B, 1, 2);
+        MF::BPtr b = make_shared<MF::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MF::CPtr c = ICE_MAKE_SHARED(MF::C, 1, 2, 3);
+        MF::CPtr c = make_shared<MF::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MF::DPtr d = ICE_MAKE_SHARED(MF::D, 1, 2, 3, 4);
+        MF::DPtr d = make_shared<MF::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -234,19 +234,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MG::APtr a = ICE_MAKE_SHARED(MG::A, 1);
+        MG::APtr a = make_shared<MG::A>(1);
         test(a->aA == 1);
 
-        MG::BPtr b = ICE_MAKE_SHARED(MG::B, 1, 2);
+        MG::BPtr b = make_shared<MG::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MG::CPtr c = ICE_MAKE_SHARED(MG::C, 1, 2, 3);
+        MG::CPtr c = make_shared<MG::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MG::DPtr d = ICE_MAKE_SHARED(MG::D, 1, 2, 3, 4);
+        MG::DPtr d = make_shared<MG::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);
@@ -254,19 +254,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        MH::APtr a = ICE_MAKE_SHARED(MH::A, 1);
+        MH::APtr a = make_shared<MH::A>(1);
         test(a->aA == 1);
 
-        MH::BPtr b = ICE_MAKE_SHARED(MH::B, 1, 2);
+        MH::BPtr b = make_shared<MH::B>(1, 2);
         test(b->aA == 1);
         test(b->bB == 2);
 
-        MH::CPtr c = ICE_MAKE_SHARED(MH::C, 1, 2, 3);
+        MH::CPtr c = make_shared<MH::C>(1, 2, 3);
         test(c->aA == 1);
         test(c->bB == 2);
         test(c->cC == 3);
 
-        MH::DPtr d = ICE_MAKE_SHARED(MH::D, 1, 2, 3, 4);
+        MH::DPtr d = make_shared<MH::D>(1, 2, 3, 4);
         test(d->aA == 1);
         test(d->bB == 2);
         test(d->cC == 3);

--- a/cpp/test/Ice/inheritance/Collocated.cpp
+++ b/cpp/test/Ice/inheritance/Collocated.cpp
@@ -22,7 +22,7 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(InitialI, adapter);
+    Ice::ObjectPtr object = make_shared<InitialI>(adapter);
     adapter->add(object, Ice::stringToIdentity("initial"));
     InitialPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/inheritance/Server.cpp
+++ b/cpp/test/Ice/inheritance/Server.cpp
@@ -21,7 +21,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(InitialI, adapter);
+    Ice::ObjectPtr object = make_shared<InitialI>(adapter);
     adapter->add(object, Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/inheritance/TestI.cpp
+++ b/cpp/test/Ice/inheritance/TestI.cpp
@@ -8,35 +8,35 @@
 using namespace Test;
 
 MA::IAPrxPtr
-IAI::iaop(ICE_IN(MA::IAPrxPtr) p, const Ice::Current&)
+IAI::iaop(MA::IAPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MB::IB1PrxPtr
-IB1I::ib1op(ICE_IN(MB::IB1PrxPtr) p, const Ice::Current&)
+IB1I::ib1op(MB::IB1PrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MB::IB2PrxPtr
-IB2I::ib2op(ICE_IN(MB::IB2PrxPtr) p, const Ice::Current&)
+IB2I::ib2op(MB::IB2PrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 MA::ICPrxPtr
-ICI::icop(ICE_IN(MA::ICPrxPtr) p, const Ice::Current&)
+ICI::icop(MA::ICPrxPtr p, const Ice::Current&)
 {
     return p;
 }
 
 InitialI::InitialI(const Ice::ObjectAdapterPtr& adapter)
 {
-    _ia = ICE_UNCHECKED_CAST(MA::IAPrx, adapter->addWithUUID(ICE_MAKE_SHARED(IAI)));
-    _ib1 = ICE_UNCHECKED_CAST(MB::IB1Prx, adapter->addWithUUID(ICE_MAKE_SHARED(IB1I)));
-    _ib2 = ICE_UNCHECKED_CAST(MB::IB2Prx, adapter->addWithUUID(ICE_MAKE_SHARED(IB2I)));
-    _ic = ICE_UNCHECKED_CAST(MA::ICPrx, adapter->addWithUUID(ICE_MAKE_SHARED(ICI)));
+    _ia = ICE_UNCHECKED_CAST(MA::IAPrx, adapter->addWithUUID(std::make_shared<IAI>()));
+    _ib1 = ICE_UNCHECKED_CAST(MB::IB1Prx, adapter->addWithUUID(std::make_shared<IB1I>()));
+    _ib2 = ICE_UNCHECKED_CAST(MB::IB2Prx, adapter->addWithUUID(std::make_shared<IB2I>()));
+    _ic = ICE_UNCHECKED_CAST(MA::ICPrx, adapter->addWithUUID(std::make_shared<ICI>()));
 }
 
 void

--- a/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
+++ b/cpp/test/Ice/interceptor/AMDInterceptorI.cpp
@@ -111,7 +111,7 @@ void
 AMDInterceptorI::setException(const IceUtil::Exception& e)
 {
     IceUtil::Mutex::Lock lock(_mutex);
-    ICE_SET_EXCEPTION_FROM_CLONE(_exception, e.ice_clone());
+    _exception = e.ice_clone();
 }
 
 IceUtil::Exception*

--- a/cpp/test/Ice/interceptor/AMDInterceptorI.h
+++ b/cpp/test/Ice/interceptor/AMDInterceptorI.h
@@ -27,6 +27,6 @@ private:
 
     IceUtil::Mutex _mutex;
 };
-ICE_DEFINE_SHARED_PTR(AMDInterceptorIPtr, AMDInterceptorI);
+using AMDInterceptorIPtr = std::shared_ptr<AMDInterceptorI>;
 
 #endif

--- a/cpp/test/Ice/interceptor/Client.cpp
+++ b/cpp/test/Ice/interceptor/Client.cpp
@@ -59,9 +59,9 @@ Client::run(int argc, char* argv[])
     //
     Ice::ObjectAdapterPtr oa = communicator->createObjectAdapterWithEndpoints("MyOA", "tcp -h localhost");
 
-    Ice::ObjectPtr servant = ICE_MAKE_SHARED(MyObjectI);
-    InterceptorIPtr interceptor = ICE_MAKE_SHARED(InterceptorI, servant);
-    AMDInterceptorIPtr amdInterceptor = ICE_MAKE_SHARED(AMDInterceptorI, servant);
+    Ice::ObjectPtr servant = make_shared<MyObjectI>();
+    InterceptorIPtr interceptor = make_shared<InterceptorI>(servant);
+    AMDInterceptorIPtr amdInterceptor = make_shared<AMDInterceptorI>(servant);
 
     Test::MyObjectPrxPtr prx = ICE_UNCHECKED_CAST(Test::MyObjectPrx, oa->addWithUUID(interceptor));
     Test::MyObjectPrxPtr prxForAMD = ICE_UNCHECKED_CAST(Test::MyObjectPrx, oa->addWithUUID(amdInterceptor));

--- a/cpp/test/Ice/interceptor/InterceptorI.h
+++ b/cpp/test/Ice/interceptor/InterceptorI.h
@@ -26,6 +26,6 @@ protected:
     std::string _lastOperation;
     bool _lastStatus;
 };
-ICE_DEFINE_SHARED_PTR(InterceptorIPtr, InterceptorI);
+using InterceptorIPtr = std::shared_ptr<InterceptorI>;
 
 #endif

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -28,15 +28,15 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::ByteSeq inEncaps, outEncaps;
-        if(!oneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps))
+        if(!oneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps))
         {
             test(false);
         }
 
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
-        test(batchOneway->ice_invoke("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
+        test(batchOneway->ice_invoke("opOneway", Ice::OperationMode::Normal, inEncaps, outEncaps));
         batchOneway->ice_flushBatchRequests();
 
         Ice::OutputStream out(communicator);
@@ -46,7 +46,7 @@ allTests(Test::TestHelper* helper)
         out.finished(inEncaps);
 
         // ice_invoke
-        if(cl->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps))
+        if(cl->ice_invoke("opString", Ice::OperationMode::Normal, inEncaps, outEncaps))
         {
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -64,7 +64,7 @@ allTests(Test::TestHelper* helper)
 
         // ice_invoke with array mapping
         pair<const ::Ice::Byte*, const ::Ice::Byte*> inPair(&inEncaps[0], &inEncaps[0] + inEncaps.size());
-        if(cl->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inPair, outEncaps))
+        if(cl->ice_invoke("opString", Ice::OperationMode::Normal, inPair, outEncaps))
         {
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -89,7 +89,7 @@ allTests(Test::TestHelper* helper)
         {
             ctx["raise"] = "";
         }
-        if(cl->ice_invoke("opException", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps, ctx))
+        if(cl->ice_invoke("opException", Ice::OperationMode::Normal, inEncaps, outEncaps, ctx))
         {
             test(false);
         }
@@ -117,7 +117,7 @@ allTests(Test::TestHelper* helper)
     cout << "testing asynchronous ice_invoke... " << flush;
     {
         Ice::ByteSeq inEncaps;
-        batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps,
+        batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps,
             [](bool, const vector<Ice::Byte>)
             {
                 test(false);
@@ -137,10 +137,10 @@ allTests(Test::TestHelper* helper)
     //
     {
         Ice::ByteSeq inEncaps;
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
-        test(batchOneway->ice_invokeAsync("opOneway", Ice::ICE_ENUM(OperationMode, Normal), inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
+        test(batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps).get().returnValue);
         batchOneway->ice_flushBatchRequests();
     }
 

--- a/cpp/test/Ice/invoke/BlobjectI.cpp
+++ b/cpp/test/Ice/invoke/BlobjectI.cpp
@@ -79,14 +79,14 @@ invokeInternal(Ice::InputStream& in, vector<Ice::Byte>& outEncaps, const Ice::Cu
 }
 
 bool
-BlobjectI::ice_invoke(ICE_IN(vector<Ice::Byte>) inEncaps, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
+BlobjectI::ice_invoke(vector<Ice::Byte> inEncaps, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);
     return invokeInternal(in, outEncaps, current);
 }
 
 bool
-BlobjectArrayI::ice_invoke(ICE_IN(pair<const Ice::Byte*, const Ice::Byte*>) inEncaps, vector<Ice::Byte>& outEncaps,
+BlobjectArrayI::ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inEncaps, vector<Ice::Byte>& outEncaps,
                            const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);

--- a/cpp/test/Ice/invoke/BlobjectI.h
+++ b/cpp/test/Ice/invoke/BlobjectI.h
@@ -11,14 +11,14 @@ class BlobjectI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::vector<Ice::Byte>), std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
 };
 
 class BlobjectArrayI : public Ice::BlobjectArray
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::pair<const Ice::Byte*, const Ice::Byte*>), std::vector<Ice::Byte>&,
+    virtual bool ice_invoke(std::pair<const Ice::Byte*, const Ice::Byte*>, std::vector<Ice::Byte>&,
                             const Ice::Current&);
 };
 

--- a/cpp/test/Ice/library/AllTests.cpp
+++ b/cpp/test/Ice/library/AllTests.cpp
@@ -32,7 +32,7 @@ TestI::op(bool throwIt, const Ice::Current&)
 ICE_DECLSPEC_EXPORT
 void allTests(const Ice::ObjectAdapterPtr& oa)
 {
-    Test::MyInterfacePtr servant = ICE_MAKE_SHARED(TestI);
+    Test::MyInterfacePtr servant = std::make_shared<TestI>();
     Test::MyInterfacePrxPtr proxy = ICE_UNCHECKED_CAST(Test::MyInterfacePrx, oa->addWithUUID(servant));
     consume(servant, proxy);
 }

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -79,7 +79,7 @@ allTests(Test::TestHelper* helper, const string& ref)
     Ice::LocatorPrxPtr anotherLocator = ICE_UNCHECKED_CAST(Ice::LocatorPrx, communicator->stringToProxy("anotherLocator"));
     base = base->ice_locator(anotherLocator);
     test(Ice::proxyIdentityEqual(base->ice_getLocator(), anotherLocator));
-    communicator->setDefaultLocator(ICE_NULLPTR);
+    communicator->setDefaultLocator(nullptr);
     base = communicator->stringToProxy("test @ TestAdapter");
     test(!base->ice_getLocator());
     base = base->ice_locator(anotherLocator);
@@ -654,7 +654,7 @@ allTests(Test::TestHelper* helper, const string& ref)
 
         Ice::Identity id;
         id.name = Ice::generateUUID();
-        adapter->add(ICE_MAKE_SHARED(HelloI), id);
+        adapter->add(std::make_shared<HelloI>(), id);
 
         // Ensure that calls on the well-known proxy is collocated.
         HelloPrxPtr helloPrx = ICE_CHECKED_CAST(HelloPrx, communicator->stringToProxy(communicator->identityToString(id)));

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -594,7 +594,7 @@ allTests(Test::TestHelper* helper, const string& ref)
     cout << "testing object migration... " << flush;
     hello = ICE_CHECKED_CAST(HelloPrx, communicator->stringToProxy("hello"));
     obj->migrateHello();
-    hello->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+    hello->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
     hello->sayHello();
     obj->migrateHello();
     hello->sayHello();

--- a/cpp/test/Ice/location/Server.cpp
+++ b/cpp/test/Ice/location/Server.cpp
@@ -39,16 +39,16 @@ Server::run(int argc, char** argv)
     // locator interface, this locator is used by the clients and the
     // 'servers' created with the server manager interface.
     //
-    ServerLocatorRegistryPtr registry = ICE_MAKE_SHARED(ServerLocatorRegistry);
+    ServerLocatorRegistryPtr registry = make_shared<ServerLocatorRegistry>();
     registry->addObject(adapter->createProxy(Ice::stringToIdentity("ServerManager")));
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(ServerManagerI, registry, initData);
+    Ice::ObjectPtr object = make_shared<ServerManagerI>(registry, initData);
     adapter->add(object, Ice::stringToIdentity("ServerManager"));
 
     Ice::LocatorRegistryPrxPtr registryPrx =
         ICE_UNCHECKED_CAST(Ice::LocatorRegistryPrx,
                            adapter->add(registry, Ice::stringToIdentity("registry")));
 
-    Ice::LocatorPtr locator = ICE_MAKE_SHARED(ServerLocator, registry, registryPrx);
+    Ice::LocatorPtr locator = make_shared<ServerLocator>(registry, registryPrx);
     adapter->add(locator, Ice::stringToIdentity("locator"));
 
     adapter->activate();

--- a/cpp/test/Ice/location/ServerLocator.h
+++ b/cpp/test/Ice/location/ServerLocator.h
@@ -42,7 +42,7 @@ private:
     ::std::map< ::std::string, ::Ice::ObjectPrxPtr> _adapters;
     ::std::map< ::Ice::Identity, ::Ice::ObjectPrxPtr> _objects;
 };
-ICE_DEFINE_SHARED_PTR(ServerLocatorRegistryPtr, ServerLocatorRegistry);
+using ServerLocatorRegistryPtr = std::shared_ptr<ServerLocatorRegistry>;
 
 class ServerLocator : public Test::TestLocator
 {

--- a/cpp/test/Ice/location/TestI.cpp
+++ b/cpp/test/Ice/location/TestI.cpp
@@ -7,6 +7,7 @@
 #include <TestI.h>
 #include <TestHelper.h>
 
+using namespace std;
 using namespace Test;
 
 ServerManagerI::ServerManagerI(const ServerLocatorRegistryPtr& registry,
@@ -67,7 +68,7 @@ ServerManagerI::startServer(const Ice::Current&)
             adapter->setLocator(ICE_UNCHECKED_CAST(Ice::LocatorPrx, locator));
             adapter2->setLocator(ICE_UNCHECKED_CAST(Ice::LocatorPrx, locator));
 
-            Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI, adapter, adapter2, _registry);
+            Ice::ObjectPtr object = make_shared<TestI>(adapter, adapter2, _registry);
             _registry->addObject(adapter->add(object, Ice::stringToIdentity("test")));
             _registry->addObject(adapter->add(object, Ice::stringToIdentity("test2")));
             adapter->add(object, Ice::stringToIdentity("test3"));
@@ -112,7 +113,7 @@ TestI::TestI(const Ice::ObjectAdapterPtr& adapter,
              const ServerLocatorRegistryPtr& registry) :
     _adapter1(adapter), _adapter2(adapter2), _registry(registry)
 {
-    _registry->addObject(_adapter1->add(ICE_MAKE_SHARED(HelloI), Ice::stringToIdentity("hello")));
+    _registry->addObject(_adapter1->add(make_shared<HelloI>(), Ice::stringToIdentity("hello")));
 }
 
 void

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -428,7 +428,7 @@ struct Connect
     {
         if(proxy->ice_getCachedConnection())
         {
-            proxy->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            proxy->ice_getCachedConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
         try
         {
@@ -439,7 +439,7 @@ struct Connect
         }
         if(proxy->ice_getCachedConnection())
         {
-            proxy->ice_getCachedConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            proxy->ice_getCachedConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
     }
 
@@ -672,9 +672,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
 
     if(!collocated)
     {
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         metrics->ice_connectionId("Con1")->ice_getConnection()->close(
-            Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            Ice::ConnectionClose::GracefullyWithWait);
 
         waitForCurrent(clientMetrics, "View", "Connection", 0);
         waitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -784,7 +784,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         map = toMap(serverMetrics->getMetricsView("View", timestamp)["Connection"]);
         test(map["holding"]->current == 1);
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Connection"]);
         test(map["closing"]->current == 1);
@@ -799,7 +799,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         props["IceMX.Metrics.View.Map.Connection.GroupBy"] = "none";
         updateProps(clientProps, serverProps, update.get(), props, "Connection");
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         metrics->ice_timeout(500)->ice_ping();
         controller->hold();
@@ -856,7 +856,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "mcastHost", "");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "mcastPort", "");
 
-        m->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        m->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         waitForCurrent(clientMetrics, "View", "Connection", 0);
         waitForCurrent(serverMetrics, "View", "Connection", 0);
@@ -875,7 +875,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         IceMX::MetricsPtr m1 = clientMetrics->getMetricsView("View", timestamp)["ConnectionEstablishment"][0];
         test(m1->current == 0 && m1->total == 1 && m1->id == hostAndPort);
 
-        metrics->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        metrics->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         controller->hold();
         try
         {
@@ -927,7 +927,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         try
         {
             prx->ice_ping();
-            prx->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+            prx->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         }
         catch(const Ice::LocalException&)
         {
@@ -1532,9 +1532,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         metricsBatchOneway = metricsBatchOneway->ice_fixed(con);
         metricsBatchOneway->op();
 
-        con->flushBatchRequests(ICE_SCOPED_ENUM(Ice::CompressBatch, No));
-        con->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No)).get();
-        con->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No), [cb](exception_ptr) {});
+        con->flushBatchRequests(Ice::CompressBatch::No);
+        con->flushBatchRequestsAsync(Ice::CompressBatch::No).get();
+        con->flushBatchRequestsAsync(Ice::CompressBatch::No, [cb](exception_ptr) {});
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Invocation"]);
         test(map.size() == 3);
 
@@ -1545,10 +1545,9 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         clearView(clientProps, serverProps, update.get());
         metricsBatchOneway->op();
 
-        communicator->flushBatchRequests(ICE_SCOPED_ENUM(Ice::CompressBatch, No));
-        communicator->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No)).get();
-        communicator->flushBatchRequestsAsync(ICE_SCOPED_ENUM(Ice::CompressBatch, No),
-                                              [cb](exception_ptr) {});
+        communicator->flushBatchRequests(Ice::CompressBatch::No);
+        communicator->flushBatchRequestsAsync(Ice::CompressBatch::No).get();
+        communicator->flushBatchRequestsAsync(Ice::CompressBatch::No, [cb](exception_ptr) {});
         map = toMap(clientMetrics->getMetricsView("View", timestamp)["Invocation"]);
         test(map.size() == 2);
 

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -314,7 +314,7 @@ private:
     bool _updated;
     Ice::PropertiesAdminPrxPtr _serverProps;
 };
-ICE_DEFINE_SHARED_PTR(UpdateCallbackIPtr, UpdateCallbackI);
+using UpdateCallbackIPtr = std::shared_ptr<UpdateCallbackI>;
 
 void
 waitForCurrent(const IceMX::MetricsAdminPrxPtr& metrics, const string& viewName, const string& map, int value)
@@ -590,7 +590,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     IceMX::MetricsAdminPrxPtr serverMetrics = ICE_CHECKED_CAST(IceMX::MetricsAdminPrx, admin, "Metrics");
     test(serverProps && serverMetrics);
 
-    UpdateCallbackIPtr update = ICE_MAKE_SHARED(UpdateCallbackI, serverProps);
+    UpdateCallbackIPtr update = make_shared<UpdateCallbackI>(serverProps);
 
     dynamic_pointer_cast<Ice::NativePropertiesAdmin>(communicator->findAdminFacet("Properties"))->addUpdateCallback(
         [update](const Ice::PropertyDict& changes) { update->updated(changes); });

--- a/cpp/test/Ice/metrics/Collocated.cpp
+++ b/cpp/test/Ice/metrics/Collocated.cpp
@@ -33,12 +33,12 @@ Collocated::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     //controllerAdapter->activate(); // Don't activate OA to ensure collocation is used.
 
     MetricsPrxPtr allTests(Test::TestHelper*, const CommunicatorObserverIPtr&);

--- a/cpp/test/Ice/metrics/Server.cpp
+++ b/cpp/test/Ice/metrics/Server.cpp
@@ -28,12 +28,12 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/metrics/ServerAMD.cpp
+++ b/cpp/test/Ice/metrics/ServerAMD.cpp
@@ -28,12 +28,12 @@ ServerAMD::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MetricsI), Ice::stringToIdentity("metrics"));
+    adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();
 
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/metrics/TestAMDI.cpp
+++ b/cpp/test/Ice/metrics/TestAMDI.cpp
@@ -16,7 +16,7 @@ MetricsI::opAsync(function<void()> response, function<void(exception_ptr)>, cons
 void
 MetricsI::failAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current& current)
 {
-    current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+    current.con->close(Ice::ConnectionClose::Forcefully);
     response();
 }
 

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -13,7 +13,7 @@ MetricsI::op(const Ice::Current&)
 void
 MetricsI::fail(const Ice::Current& current)
 {
-    current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+    current.con->close(Ice::ConnectionClose::Forcefully);
 }
 
 void

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -41,7 +41,7 @@ MetricsI::opWithUnknownException(const Ice::Current&)
 }
 
 void
-MetricsI::opByteS(ICE_IN(Test::ByteSeq), const Ice::Current&)
+MetricsI::opByteS(Test::ByteSeq, const Ice::Current&)
 {
 }
 

--- a/cpp/test/Ice/metrics/TestI.h
+++ b/cpp/test/Ice/metrics/TestI.h
@@ -21,7 +21,7 @@ class MetricsI : public Test::Metrics
 
     virtual void opWithUnknownException(const Ice::Current&);
 
-    virtual void opByteS(ICE_IN(Test::ByteSeq), const Ice::Current&);
+    virtual void opByteS(Test::ByteSeq, const Ice::Current&);
 
     virtual Ice::ObjectPrxPtr getAdmin(const Ice::Current&);
 

--- a/cpp/test/Ice/networkProxy/AllTests.cpp
+++ b/cpp/test/Ice/networkProxy/AllTests.cpp
@@ -23,7 +23,7 @@ getIPConnectionInfo(const Ice::ConnectionInfoPtr& info)
             return ipInfo;
         }
     }
-    return ICE_NULLPTR;
+    return nullptr;
 }
 
 }

--- a/cpp/test/Ice/networkProxy/Server.cpp
+++ b/cpp/test/Ice/networkProxy/Server.cpp
@@ -37,7 +37,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -100,13 +100,13 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing constructor, copy constructor, and assignment operator... " << flush;
 
-    BasePtr ba1 = ICE_MAKE_SHARED(Base);
+    BasePtr ba1 = make_shared<Base>();
     test(ba1->theS.str == "");
     test(ba1->str == "");
 
     S s;
     s.str = "hello";
-    BasePtr ba2 = ICE_MAKE_SHARED(Base, s, "hi");
+    BasePtr ba2 = make_shared<Base>(s, "hi");
     test(ba2->theS.str == "hello");
     test(ba2->str == "hi");
 
@@ -122,7 +122,7 @@ allTests(Test::TestHelper* helper)
     test(*ba1 >= *ba2);
     test(*ba1 <= *ba2);
 
-    BasePtr bp1 = ICE_MAKE_SHARED(Base);
+    BasePtr bp1 = make_shared<Base>();
     *bp1 = *ba2;
     test(bp1->theS.str == "hello");
     test(bp1->str == "hi");
@@ -166,7 +166,7 @@ allTests(Test::TestHelper* helper)
     test(c != dynamic_pointer_cast<C>(d));
 
     test(b1->theB == b1);
-    test(b1->theC == ICE_NULLPTR);
+    test(b1->theC == nullptr);
     test(ICE_DYNAMIC_CAST(B, b1->theA));
     test(ICE_DYNAMIC_CAST(B, b1->theA)->theA == b1->theA);
     test(ICE_DYNAMIC_CAST(B, b1->theA)->theB == b1);
@@ -182,7 +182,7 @@ allTests(Test::TestHelper* helper)
 
     // More tests possible for b2 and d, but I think this is already sufficient.
     test(b2->theA == b2);
-    test(d->theC == ICE_NULLPTR);
+    test(d->theC == nullptr);
 
     clear(b1);
     clear(b2);
@@ -247,7 +247,7 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing Value as parameter..." << flush;
     {
-        LPtr v1 = ICE_MAKE_SHARED(L, "l");
+        LPtr v1 = make_shared<L>("l");
         Ice::ValuePtr v2;
         Ice::ValuePtr v3 = initial->opValue(v1, v2);
         test(ICE_DYNAMIC_CAST(L, v2)->data == "l");
@@ -255,7 +255,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        LPtr l = ICE_MAKE_SHARED(L, "l");
+        LPtr l = make_shared<L>("l");
         Test::ValueSeq v1;
         v1.push_back(l);
         Test::ValueSeq v2;
@@ -265,7 +265,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        LPtr l = ICE_MAKE_SHARED(L, "l");
+        LPtr l = make_shared<L>("l");
         Test::ValueMap v1;
         v1["l"] = l;
         Test::ValueMap v2;
@@ -276,11 +276,10 @@ allTests(Test::TestHelper* helper)
     cout << "ok" << endl;
 
     cout << "getting D1... " << flush;
-    D1Ptr d1 = ICE_MAKE_SHARED(D1,
-                               ICE_MAKE_SHARED(A1, "a1"),
-                               ICE_MAKE_SHARED(A1, "a2"),
-                               ICE_MAKE_SHARED(A1, "a3"),
-                               ICE_MAKE_SHARED(A1, "a4"));
+    D1Ptr d1 = make_shared<D1>(make_shared<A1>("a1"),
+                               make_shared<A1>("a2"),
+                               make_shared<A1>("a3"),
+                               make_shared<A1>("a4"));
     d1 = initial->getD1(d1);
     test(d1->a1->name == "a1");
     test(d1->a2->name == "a2");
@@ -304,7 +303,7 @@ allTests(Test::TestHelper* helper)
     cout << "ok" << endl;
 
     cout << "setting G... " << flush;
-    GPtr g = ICE_MAKE_SHARED(G, s, "g");
+    GPtr g = make_shared<G>(s, "g");
     try
     {
         initial->setG(g);
@@ -319,13 +318,13 @@ allTests(Test::TestHelper* helper)
     retS = initial->opBaseSeq(inS, outS);
 
     inS.resize(1);
-    inS[0] = ICE_MAKE_SHARED(Base);
+    inS[0] = make_shared<Base>();
     retS = initial->opBaseSeq(inS, outS);
     test(retS.size() == 1 && outS.size() == 1);
     cout << "ok" << endl;
 
     cout << "testing recursive type... " << flush;
-    RecursivePtr top = ICE_MAKE_SHARED(Recursive);
+    RecursivePtr top = make_shared<Recursive>();
     int depth = 0;
     try
     {
@@ -338,7 +337,7 @@ allTests(Test::TestHelper* helper)
 #endif
         for(; depth <= maxDepth; ++depth)
         {
-            p->v = ICE_MAKE_SHARED(Recursive);
+            p->v = make_shared<Recursive>();
             p = p->v;
             if((depth < 10 && (depth % 10) == 0) ||
                (depth < 1000 && (depth % 100) == 0) ||
@@ -359,7 +358,7 @@ allTests(Test::TestHelper* helper)
     {
         // Expected stack overflow from the server (Java only)
     }
-    initial->setRecursive(ICE_MAKE_SHARED(Recursive));
+    initial->setRecursive(make_shared<Recursive>());
     cout << "ok" << endl;
 
     cout << "testing compact ID..." << flush;
@@ -419,17 +418,17 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing class containing complex dictionary... " << flush;
     {
-        Test::MPtr m = ICE_MAKE_SHARED(Test::M);
+        Test::MPtr m = make_shared<Test::M>();
 
         Test::StructKey k1;
         k1.i = 1;
         k1.s = "1";
-        m->v[k1] = ICE_MAKE_SHARED(L, "one");
+        m->v[k1] = make_shared<L>("one");
 
         Test::StructKey k2;
         k2.i = 2;
         k2.s = "2";
-        m->v[k2] = ICE_MAKE_SHARED(L, "two");
+        m->v[k2] = make_shared<L>("two");
 
         Test::MPtr m1;
         Test::MPtr m2 = initial->opM(m, m1);
@@ -449,7 +448,7 @@ allTests(Test::TestHelper* helper)
     cout << "testing forward declarations... " << flush;
     {
         F1Ptr f12;
-        F1Ptr f11 = initial->opF1(ICE_MAKE_SHARED(F1, "F11"), f12);
+        F1Ptr f11 = initial->opF1(make_shared<F1>("F11"), f12);
         test(f11->name == "F11");
         test(f12->name == "F12");
 
@@ -463,7 +462,7 @@ allTests(Test::TestHelper* helper)
         if(initial->hasF3())
         {
             F3Ptr f32;
-            F3Ptr f31 = initial->opF3(ICE_MAKE_SHARED(F3, f11, f21), f32);
+            F3Ptr f31 = initial->opF3(make_shared<F3>(f11, f21), f32);
             test(f31->f1->name == "F11");
             test(f31->f2->ice_getIdentity().name == "F21");
 
@@ -475,7 +474,7 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing sending class cycle... " << flush;
     {
-        RecursivePtr rec = ICE_MAKE_SHARED(Recursive);
+        RecursivePtr rec = make_shared<Recursive>();
         rec->v = rec;
         bool acceptsCycles = initial->acceptsClassCycles();
         try
@@ -489,7 +488,7 @@ allTests(Test::TestHelper* helper)
             // and throws a MarshalException
             test(!acceptsCycles);
         }
-        rec->v = ICE_NULLPTR;
+        rec->v = nullptr;
     }
     cout << "ok" << endl;
 

--- a/cpp/test/Ice/objects/Collocated.cpp
+++ b/cpp/test/Ice/objects/Collocated.cpp
@@ -41,10 +41,10 @@ Collocated::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI, adapter), Ice::stringToIdentity("initial"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(F2I), Ice::stringToIdentity("F21"));
-    adapter->add(ICE_MAKE_SHARED(UnexpectedObjectExceptionTestI), Ice::stringToIdentity("uoet"));
+    adapter->add(make_shared<InitialI>(adapter), Ice::stringToIdentity("initial"));
+    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(make_shared<F2I>(), Ice::stringToIdentity("F21"));
+    adapter->add(make_shared<UnexpectedObjectExceptionTestI>(), Ice::stringToIdentity("uoet"));
     InitialPrxPtr allTests(Test::TestHelper*);
     InitialPrxPtr initial = allTests(this);
     // We must call shutdown even in the collocated case for cyclic dependency cleanup

--- a/cpp/test/Ice/objects/Server.cpp
+++ b/cpp/test/Ice/objects/Server.cpp
@@ -26,11 +26,11 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI, adapter), Ice::stringToIdentity("initial"));
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
-    adapter->add(ICE_MAKE_SHARED(F2I), Ice::stringToIdentity("F21"));
+    adapter->add(make_shared<InitialI>(adapter), Ice::stringToIdentity("initial"));
+    adapter->add(make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter->add(make_shared<F2I>(), Ice::stringToIdentity("F21"));
 
-    adapter->add(ICE_MAKE_SHARED(UnexpectedObjectExceptionTestI), Ice::stringToIdentity("uoet"));
+    adapter->add(make_shared<UnexpectedObjectExceptionTestI>(), Ice::stringToIdentity("uoet"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -101,14 +101,14 @@ InitialI::InitialI(const Ice::ObjectAdapterPtr& adapter) :
 
 InitialI::~InitialI()
 {
-    _b1->theA = ICE_NULLPTR;
-    _b1->theB = ICE_NULLPTR;
+    _b1->theA = nullptr;
+    _b1->theB = nullptr;
 
-    _b2->theA = ICE_NULLPTR;
-    _b2->theB = ICE_NULLPTR;
-    _b2->theC = ICE_NULLPTR;
+    _b2->theA = nullptr;
+    _b2->theB = nullptr;
+    _b2->theC = nullptr;
 
-    _c->theB = ICE_NULLPTR;
+    _c->theB = nullptr;
 }
 
 void
@@ -167,7 +167,7 @@ InitialI::getF(const Ice::Current&)
 }
 
 void
-InitialI::setRecursive(ICE_IN(RecursivePtr), const Ice::Current&)
+InitialI::setRecursive(RecursivePtr, const Ice::Current&)
 {
 }
 
@@ -178,11 +178,11 @@ InitialI::supportsClassGraphDepthMax(const Ice::Current&)
 }
 
 void
-InitialI::setCycle(ICE_IN(RecursivePtr) r, const Ice::Current&)
+InitialI::setCycle(RecursivePtr r, const Ice::Current&)
 {
     // break the cycle
     assert(r);
-    r->v = ICE_NULLPTR;
+    r->v = nullptr;
 }
 
 bool
@@ -219,12 +219,12 @@ InitialI::getAll(BPtr& b1, BPtr& b2, CPtr& c, DPtr& d, const Ice::Current&)
 }
 
 void
-InitialI::setG(ICE_IN(Test::GPtr), const Ice::Current&)
+InitialI::setG(Test::GPtr, const Ice::Current&)
 {
 }
 
 BaseSeq
-InitialI::opBaseSeq(ICE_IN(BaseSeq) inSeq, BaseSeq& outSeq, const Ice::Current&)
+InitialI::opBaseSeq(BaseSeq inSeq, BaseSeq& outSeq, const Ice::Current&)
 {
     outSeq = inSeq;
     return inSeq;
@@ -233,19 +233,19 @@ InitialI::opBaseSeq(ICE_IN(BaseSeq) inSeq, BaseSeq& outSeq, const Ice::Current&)
 CompactPtr
 InitialI::getCompact(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(CompactExt);
+    return make_shared<CompactExt>();
 }
 
 Test::Inner::APtr
 InitialI::getInnerA(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(Inner::A, _b1);
+    return make_shared<Inner::A>(_b1);
 }
 
 Test::Inner::Sub::APtr
 InitialI::getInnerSubA(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(Inner::Sub::A, ICE_MAKE_SHARED(Inner::A, _b1));
+    return make_shared<Inner::Sub::A>(make_shared<Inner::A>(_b1));
 }
 
 void
@@ -267,32 +267,32 @@ InitialI::throwInnerSubEx(const Ice::Current&)
 KPtr
 InitialI::getK(const Ice::Current&)
 {
-    return ICE_MAKE_SHARED(K, ICE_MAKE_SHARED(L, "l"));
+    return make_shared<K>(make_shared<L>("l"));
 }
 
 Ice::ValuePtr
-InitialI::opValue(ICE_IN(Ice::ValuePtr) v1, Ice::ValuePtr& v2, const Ice::Current&)
+InitialI::opValue(Ice::ValuePtr v1, Ice::ValuePtr& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 Test::ValueSeq
-InitialI::opValueSeq(ICE_IN(Test::ValueSeq) v1, Test::ValueSeq& v2, const Ice::Current&)
+InitialI::opValueSeq(Test::ValueSeq v1, Test::ValueSeq& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 Test::ValueMap
-InitialI::opValueMap(ICE_IN(Test::ValueMap) v1, Test::ValueMap& v2, const Ice::Current&)
+InitialI::opValueMap(Test::ValueMap v1, Test::ValueMap& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 D1Ptr
-InitialI::getD1(ICE_IN(Test::D1Ptr) d1, const Ice::Current&)
+InitialI::getD1(Test::D1Ptr d1, const Ice::Current&)
 {
     return d1;
 }
@@ -300,28 +300,28 @@ InitialI::getD1(ICE_IN(Test::D1Ptr) d1, const Ice::Current&)
 void
 InitialI::throwEDerived(const Ice::Current&)
 {
-    throw EDerived(ICE_MAKE_SHARED(A1, "a1"),
-                   ICE_MAKE_SHARED(A1, "a2"),
-                   ICE_MAKE_SHARED(A1, "a3"),
-                   ICE_MAKE_SHARED(A1, "a4"));
+    throw EDerived(make_shared<A1>("a1"),
+                   make_shared<A1>("a2"),
+                   make_shared<A1>("a3"),
+                   make_shared<A1>("a4"));
 }
 
 Test::MPtr
-InitialI::opM(ICE_IN(Test::MPtr) v1, Test::MPtr& v2, const Ice::Current&)
+InitialI::opM(Test::MPtr v1, Test::MPtr& v2, const Ice::Current&)
 {
     v2 = v1;
     return v1;
 }
 
 bool
-UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
+UnexpectedObjectExceptionTestI::ice_invoke(std::vector<Ice::Byte>,
                                            std::vector<Ice::Byte>& outParams,
                                            const Ice::Current& current)
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
     Ice::OutputStream out(communicator);
     out.startEncapsulation(current.encoding, Ice::ICE_ENUM(FormatType, DefaultFormat));
-    AlsoEmptyPtr obj = ICE_MAKE_SHARED(AlsoEmpty);
+    AlsoEmptyPtr obj = make_shared<AlsoEmpty>();
     out.write(obj);
     out.writePendingValues();
     out.endEncapsulation();
@@ -330,24 +330,24 @@ UnexpectedObjectExceptionTestI::ice_invoke(ICE_IN(std::vector<Ice::Byte>),
 }
 
 Test::F1Ptr
-InitialI::opF1(ICE_IN(Test::F1Ptr) f11, Test::F1Ptr& f12, const Ice::Current&)
+InitialI::opF1(Test::F1Ptr f11, Test::F1Ptr& f12, const Ice::Current&)
 {
-    f12 = ICE_MAKE_SHARED(F1, "F12");
+    f12 = make_shared<F1>("F12");
     return f11;
 }
 
 Test::F2PrxPtr
-InitialI::opF2(ICE_IN(Test::F2PrxPtr) f21, Test::F2PrxPtr& f22, const Ice::Current& current)
+InitialI::opF2(Test::F2PrxPtr f21, Test::F2PrxPtr& f22, const Ice::Current& current)
 {
     f22 = ICE_UNCHECKED_CAST(F2Prx, current.adapter->getCommunicator()->stringToProxy("F22"));
     return f21;
 }
 
 Test::F3Ptr
-InitialI::opF3(ICE_IN(Test::F3Ptr) f31, Test::F3Ptr& f32, const Ice::Current& current)
+InitialI::opF3(Test::F3Ptr f31, Test::F3Ptr& f32, const Ice::Current& current)
 {
-    f32 = ICE_MAKE_SHARED(F3);
-    f32->f1 = ICE_MAKE_SHARED(F1, "F12");
+    f32 = make_shared<F3>();
+    f32->f1 = make_shared<F1>("F12");
     f32->f2 = ICE_UNCHECKED_CAST(F2Prx, current.adapter->getCommunicator()->stringToProxy("F22"));
     return f31;
 }

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -320,7 +320,7 @@ UnexpectedObjectExceptionTestI::ice_invoke(std::vector<Ice::Byte>,
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
     Ice::OutputStream out(communicator);
-    out.startEncapsulation(current.encoding, Ice::ICE_ENUM(FormatType, DefaultFormat));
+    out.startEncapsulation(current.encoding, Ice::FormatType::DefaultFormat);
     AlsoEmptyPtr obj = make_shared<AlsoEmpty>();
     out.write(obj);
     out.writePendingValues();

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -40,7 +40,7 @@ public:
 
     bool checkValues();
 };
-ICE_DEFINE_SHARED_PTR(EIPtr, EI);
+using EIPtr = std::shared_ptr<EI>;
 
 class FI : public Test::F
 {
@@ -51,7 +51,7 @@ public:
 
     bool checkValues();
 };
-ICE_DEFINE_SHARED_PTR(FIPtr, FI);
+using FIPtr = std::shared_ptr<FI>;
 
 class InitialI : public Test::Initial
 {
@@ -68,10 +68,10 @@ public:
     virtual Test::EPtr getE(const Ice::Current&);
     virtual Test::FPtr getF(const Ice::Current&);
 
-    virtual void setRecursive(ICE_IN(Test::RecursivePtr), const Ice::Current&);
+    virtual void setRecursive(Test::RecursivePtr, const Ice::Current&);
     virtual bool supportsClassGraphDepthMax(const Ice::Current&);
 
-    virtual void setCycle(ICE_IN(Test::RecursivePtr), const Ice::Current&);
+    virtual void setCycle(Test::RecursivePtr, const Ice::Current&);
     virtual bool acceptsClassCycles(const Ice::Current&);
 
     virtual GetMBMarshaledResult getMB(const Ice::Current&);
@@ -83,16 +83,16 @@ public:
 
     virtual Test::KPtr getK(const Ice::Current&);
 
-    virtual Ice::ValuePtr opValue(ICE_IN(Ice::ValuePtr), Ice::ValuePtr&, const Ice::Current&);
-    virtual Test::ValueSeq opValueSeq(ICE_IN(Test::ValueSeq), Test::ValueSeq&, const Ice::Current&);
-    virtual Test::ValueMap opValueMap(ICE_IN(Test::ValueMap), Test::ValueMap&, const Ice::Current&);
+    virtual Ice::ValuePtr opValue(Ice::ValuePtr, Ice::ValuePtr&, const Ice::Current&);
+    virtual Test::ValueSeq opValueSeq(Test::ValueSeq, Test::ValueSeq&, const Ice::Current&);
+    virtual Test::ValueMap opValueMap(Test::ValueMap, Test::ValueMap&, const Ice::Current&);
 
-    virtual Test::D1Ptr getD1(ICE_IN(Test::D1Ptr), const Ice::Current&);
+    virtual Test::D1Ptr getD1(Test::D1Ptr, const Ice::Current&);
     virtual void throwEDerived(const Ice::Current&);
 
-    virtual void setG(ICE_IN(Test::GPtr), const Ice::Current&);
+    virtual void setG(Test::GPtr, const Ice::Current&);
 
-    virtual Test::BaseSeq opBaseSeq(ICE_IN(Test::BaseSeq), Test::BaseSeq&, const Ice::Current&);
+    virtual Test::BaseSeq opBaseSeq(Test::BaseSeq, Test::BaseSeq&, const Ice::Current&);
 
     virtual Test::CompactPtr getCompact(const Ice::Current&);
 
@@ -102,11 +102,11 @@ public:
     virtual void throwInnerEx(const Ice::Current&);
     virtual void throwInnerSubEx(const Ice::Current&);
 
-    virtual Test::MPtr opM(ICE_IN(Test::MPtr), Test::MPtr&, const Ice::Current&);
+    virtual Test::MPtr opM(Test::MPtr, Test::MPtr&, const Ice::Current&);
 
-    virtual Test::F1Ptr opF1(ICE_IN(Test::F1Ptr), Test::F1Ptr&, const Ice::Current&);
-    virtual Test::F2PrxPtr opF2(ICE_IN(Test::F2PrxPtr), Test::F2PrxPtr&, const Ice::Current&);
-    virtual Test::F3Ptr opF3(ICE_IN(Test::F3Ptr), Test::F3Ptr&, const Ice::Current&);
+    virtual Test::F1Ptr opF1(Test::F1Ptr, Test::F1Ptr&, const Ice::Current&);
+    virtual Test::F2PrxPtr opF2(Test::F2PrxPtr, Test::F2PrxPtr&, const Ice::Current&);
+    virtual Test::F3Ptr opF3(Test::F3Ptr, Test::F3Ptr&, const Ice::Current&);
     virtual bool hasF3(const Ice::Current&);
 
 private:
@@ -124,9 +124,9 @@ class UnexpectedObjectExceptionTestI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(ICE_IN(std::vector<Ice::Byte>), std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
 };
-ICE_DEFINE_PTR(UnexpectedObjectExceptionTestIPtr, UnexpectedObjectExceptionTestI);
+using UnexpectedObjectExceptionTestIPtr = std::shared_ptr<UnexpectedObjectExceptionTestI>;
 
 class TestIntfI : public Test::TestIntf
 {

--- a/cpp/test/Ice/objects/TestIntfI.cpp
+++ b/cpp/test/Ice/objects/TestIntfI.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 BasePtr
 TestIntfI::opDerived(const Ice::Current&)
 {
-    DerivedPtr d = ICE_MAKE_SHARED(Derived);
+    DerivedPtr d = std::make_shared<Derived>();
     d->theS.str = "S.str";
     d->str = "str";
     d->b = "b";

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -65,7 +65,7 @@ private:
     int _size;
     int _lastRequestSize;
 };
-ICE_DEFINE_PTR(BatchRequestInterceptorIPtr, BatchRequestInterceptorI);
+using BatchRequestInterceptorIPtr = std::shared_ptr<BatchRequestInterceptorI>;
 
 }
 
@@ -145,7 +145,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
     {
         Ice::InitializationData initData;
         initData.properties = p->ice_getCommunicator()->getProperties()->clone();
-        BatchRequestInterceptorIPtr interceptor = ICE_MAKE_SHARED(BatchRequestInterceptorI);
+        BatchRequestInterceptorIPtr interceptor = std::make_shared<BatchRequestInterceptorI>();
 
         initData.batchRequestInterceptor = [=](const Ice::BatchRequest& request, int countP, int size)
         {

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -79,9 +79,9 @@ batchOneways(const Test::MyClassPrxPtr& p)
     batch->ice_flushBatchRequests(); // Empty flush
     if(batch->ice_getConnection())
     {
-        batch->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
     }
-    batch->ice_getCommunicator()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+    batch->ice_getCommunicator()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
     int i;
     p->opByteSOnewayCallCount(); // Reset the call count
@@ -114,7 +114,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch1->ice_ping();
         batch2->ice_ping();
         batch1->ice_flushBatchRequests();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_ping();
         batch2->ice_ping();
 
@@ -122,7 +122,7 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch2->ice_getConnection();
 
         batch1->ice_ping();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_ping();
         batch2->ice_ping();
     }
@@ -205,26 +205,26 @@ batchOneways(const Test::MyClassPrxPtr& p)
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, Yes));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::Yes);
 
         batch2->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, No));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::No);
 
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
         batch1->opByteSOneway(bs1);
         batch2->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
 
         batch1->opByteSOneway(bs1);
         batch3->opByteSOneway(bs1);
         batch1->opByteSOneway(bs1);
-        batch1->ice_getConnection()->flushBatchRequests(Ice::ICE_SCOPED_ENUM(CompressBatch, BasedOnProxy));
+        batch1->ice_getConnection()->flushBatchRequests(Ice::CompressBatch::BasedOnProxy);
     }
 }

--- a/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/BatchOnewaysAMI.cpp
@@ -120,7 +120,7 @@ batchOnewaysAMI(const Test::MyClassPrxPtr& p)
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();
         batch1->ice_flushBatchRequestsAsync().get();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();
 
@@ -128,7 +128,7 @@ batchOnewaysAMI(const Test::MyClassPrxPtr& p)
         batch2->ice_getConnection();
 
         batch1->ice_pingAsync().get();
-        batch1->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        batch1->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
 
         batch1->ice_pingAsync().get();
         batch2->ice_pingAsync().get();

--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -24,7 +24,7 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     communicator->getProperties()->setProperty("TestAdapter.AdapterId", "test");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPrxPtr prx = adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    Ice::ObjectPrxPtr prx = adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     test(!prx->ice_getConnection());

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -68,7 +68,7 @@ public:
         test(false);
     }
 };
-ICE_DEFINE_PTR(CallbackPtr, Callback);
+using CallbackPtr = std::shared_ptr<Callback>;
 
 }
 
@@ -78,7 +78,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     Test::MyClassPrxPtr p = ICE_UNCHECKED_CAST(Test::MyClassPrx, proxy->ice_oneway());
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_pingAsync(
             nullptr,
             [](exception_ptr)
@@ -137,7 +137,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opVoidAsync(
             nullptr,
             [](exception_ptr)
@@ -152,7 +152,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opIdempotentAsync(
             nullptr,
             [](exception_ptr)
@@ -167,7 +167,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->opNonmutatingAsync(
             nullptr,
             [](exception_ptr)
@@ -197,7 +197,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = std::make_shared<Callback>();
         p->ice_pingAsync(nullptr,
                         [=](exception_ptr e)
                         {

--- a/cpp/test/Ice/operations/Server.cpp
+++ b/cpp/test/Ice/operations/Server.cpp
@@ -29,7 +29,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/operations/ServerAMD.cpp
+++ b/cpp/test/Ice/operations/ServerAMD.cpp
@@ -29,7 +29,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -20,14 +20,14 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 bool
 MyDerivedClassI::ice_isA(string id, const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(std::move(id), current);
 }
 
 void
 MyDerivedClassI::ice_ping(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     Test::MyDerivedClass::ice_ping(current);
 
 }
@@ -35,14 +35,14 @@ MyDerivedClassI::ice_ping(const Ice::Current& current) const
 std::vector<std::string>
 MyDerivedClassI::ice_ids(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_ids(current);
 }
 
 std::string
 MyDerivedClassI::ice_id(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_id(current);
 }
 
@@ -983,7 +983,7 @@ MyDerivedClassI::opMStruct1Async(function<void(const OpMStruct1MarshaledResult&)
                                  const Ice::Current& current)
 {
     Test::Structure s;
-    s.e = ICE_ENUM(MyEnum, enum1); // enum must be initialized
+    s.e = MyEnum::enum1; // enum must be initialized
     response(OpMStruct1MarshaledResult(s, current));
 }
 

--- a/cpp/test/Ice/operations/TestAMDI.h
+++ b/cpp/test/Ice/operations/TestAMDI.h
@@ -375,7 +375,7 @@ public:
                                  ::std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
 
-    virtual void opMStruct2Async(ICE_IN(Test::Structure),
+    virtual void opMStruct2Async(Test::Structure,
                                  ::std::function<void(const OpMStruct2MarshaledResult&)>,
                                  ::std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
@@ -384,7 +384,7 @@ public:
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);
 
-    virtual void opMSeq2Async(ICE_IN(Test::StringS),
+    virtual void opMSeq2Async(Test::StringS,
                               ::std::function<void(const OpMSeq2MarshaledResult&)>,
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);
@@ -393,7 +393,7 @@ public:
                                ::std::function<void(std::exception_ptr)>,
                                const Ice::Current&);
 
-    virtual void opMDict2Async(ICE_IN(Test::StringStringD),
+    virtual void opMDict2Async(Test::StringStringD,
                                ::std::function<void(const OpMDict2MarshaledResult&)>,
                                ::std::function<void(std::exception_ptr)>,
                                const Ice::Current&);

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -20,28 +20,28 @@ MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0)
 bool
 MyDerivedClassI::ice_isA(string id, const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_isA(std::move(id), current);
 }
 
 void
 MyDerivedClassI::ice_ping(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     Test::MyDerivedClass::ice_ping(current);
 }
 
 std::vector<std::string>
 MyDerivedClassI::ice_ids(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_ids(current);
 }
 
 std::string
 MyDerivedClassI::ice_id(const Ice::Current& current) const
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
     return Test::MyDerivedClass::ice_id(current);
 }
 
@@ -64,7 +64,7 @@ MyDerivedClassI::supportsCompress(const Ice::Current&)
 void
 MyDerivedClassI::opVoid(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Normal));
+    test(current.mode == OperationMode::Normal);
 }
 
 Ice::Byte
@@ -130,7 +130,7 @@ MyDerivedClassI::opMyEnum(Test::MyEnum p1,
                           const Ice::Current&)
 {
     p2 = p1;
-    return ICE_ENUM(MyEnum, enum3);
+    return MyEnum::enum3;
 }
 
 Test::MyClassPrxPtr
@@ -651,13 +651,13 @@ MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, Test::DoubleS p2, const Ice:
 void
 MyDerivedClassI::opIdempotent(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Idempotent));
+    test(current.mode == OperationMode::Idempotent);
 }
 
 void
 MyDerivedClassI::opNonmutating(const Ice::Current& current)
 {
-    test(current.mode == ICE_ENUM(OperationMode, Nonmutating));
+    test(current.mode == OperationMode::Nonmutating);
 }
 
 void
@@ -831,7 +831,7 @@ MyDerivedClassI::OpMStruct1MarshaledResult
 MyDerivedClassI::opMStruct1(const Ice::Current& current)
 {
     Test::Structure s;
-    s.e = ICE_ENUM(MyEnum, enum1); // enum must be initialized
+    s.e = MyEnum::enum1; // enum must be initialized
     return OpMStruct1MarshaledResult(s, current);
 }
 

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -115,8 +115,8 @@ MyDerivedClassI::opFloatDouble(Ice::Float p1,
 }
 
 std::string
-MyDerivedClassI::opString(ICE_IN(string) p1,
-                          ICE_IN(string) p2,
+MyDerivedClassI::opString(string p1,
+                          string p2,
                           string& p3,
                           const Ice::Current&)
 {
@@ -134,7 +134,7 @@ MyDerivedClassI::opMyEnum(Test::MyEnum p1,
 }
 
 Test::MyClassPrxPtr
-MyDerivedClassI::opMyClass(ICE_IN(Test::MyClassPrxPtr) p1,
+MyDerivedClassI::opMyClass(Test::MyClassPrxPtr p1,
                            Test::MyClassPrxPtr& p2,
                            Test::MyClassPrxPtr& p3,
                            const Ice::Current& current)
@@ -147,8 +147,8 @@ MyDerivedClassI::opMyClass(ICE_IN(Test::MyClassPrxPtr) p1,
 }
 
 Test::Structure
-MyDerivedClassI::opStruct(ICE_IN(Test::Structure) p1,
-                          ICE_IN(Test::Structure) p2,
+MyDerivedClassI::opStruct(Test::Structure p1,
+                          Test::Structure p2,
                           ::Test::Structure& p3,
                           const Ice::Current&)
 {
@@ -158,8 +158,8 @@ MyDerivedClassI::opStruct(ICE_IN(Test::Structure) p1,
 }
 
 Test::ByteS
-MyDerivedClassI::opByteS(ICE_IN(Test::ByteS) p1,
-                         ICE_IN(Test::ByteS) p2,
+MyDerivedClassI::opByteS(Test::ByteS p1,
+                         Test::ByteS p2,
                          Test::ByteS& p3,
                          const Ice::Current&)
 {
@@ -171,8 +171,8 @@ MyDerivedClassI::opByteS(ICE_IN(Test::ByteS) p1,
 }
 
 Test::BoolS
-MyDerivedClassI::opBoolS(ICE_IN(Test::BoolS) p1,
-                         ICE_IN(Test::BoolS) p2,
+MyDerivedClassI::opBoolS(Test::BoolS p1,
+                         Test::BoolS p2,
                          Test::BoolS& p3,
                          const Ice::Current&)
 {
@@ -185,9 +185,9 @@ MyDerivedClassI::opBoolS(ICE_IN(Test::BoolS) p1,
 }
 
 Test::LongS
-MyDerivedClassI::opShortIntLongS(ICE_IN(Test::ShortS) p1,
-                                 ICE_IN(Test::IntS) p2,
-                                 ICE_IN(Test::LongS) p3,
+MyDerivedClassI::opShortIntLongS(Test::ShortS p1,
+                                 Test::IntS p2,
+                                 Test::LongS p3,
                                  Test::ShortS& p4,
                                  Test::IntS& p5,
                                  Test::LongS& p6,
@@ -202,8 +202,8 @@ MyDerivedClassI::opShortIntLongS(ICE_IN(Test::ShortS) p1,
 }
 
 Test::DoubleS
-MyDerivedClassI::opFloatDoubleS(ICE_IN(Test::FloatS) p1,
-                                ICE_IN(Test::DoubleS) p2,
+MyDerivedClassI::opFloatDoubleS(Test::FloatS p1,
+                                Test::DoubleS p2,
                                 Test::FloatS& p3,
                                 Test::DoubleS& p4,
                                 const Ice::Current&)
@@ -217,8 +217,8 @@ MyDerivedClassI::opFloatDoubleS(ICE_IN(Test::FloatS) p1,
 }
 
 Test::StringS
-MyDerivedClassI::opStringS(ICE_IN(Test::StringS) p1,
-                           ICE_IN(Test::StringS) p2,
+MyDerivedClassI::opStringS(Test::StringS p1,
+                           Test::StringS p2,
                            Test::StringS& p3,
                            const Ice::Current&)
 {
@@ -231,8 +231,8 @@ MyDerivedClassI::opStringS(ICE_IN(Test::StringS) p1,
 }
 
 Test::ByteSS
-MyDerivedClassI::opByteSS(ICE_IN(Test::ByteSS) p1,
-                          ICE_IN(Test::ByteSS) p2,
+MyDerivedClassI::opByteSS(Test::ByteSS p1,
+                          Test::ByteSS p2,
                           Test::ByteSS& p3,
                           const Ice::Current&)
 {
@@ -244,8 +244,8 @@ MyDerivedClassI::opByteSS(ICE_IN(Test::ByteSS) p1,
 }
 
 Test::BoolSS
-MyDerivedClassI::opBoolSS(ICE_IN(Test::BoolSS) p1,
-                          ICE_IN(Test::BoolSS) p2,
+MyDerivedClassI::opBoolSS(Test::BoolSS p1,
+                          Test::BoolSS p2,
                           Test::BoolSS& p3,
                           const Ice::Current&)
 {
@@ -258,9 +258,9 @@ MyDerivedClassI::opBoolSS(ICE_IN(Test::BoolSS) p1,
 }
 
 Test::LongSS
-MyDerivedClassI::opShortIntLongSS(ICE_IN(Test::ShortSS) p1,
-                                  ICE_IN(Test::IntSS) p2,
-                                  ICE_IN(Test::LongSS) p3,
+MyDerivedClassI::opShortIntLongSS(Test::ShortSS p1,
+                                  Test::IntSS p2,
+                                  Test::LongSS p3,
                                   Test::ShortSS& p4,
                                   Test::IntSS& p5,
                                   Test::LongSS& p6,
@@ -275,8 +275,8 @@ MyDerivedClassI::opShortIntLongSS(ICE_IN(Test::ShortSS) p1,
 }
 
 Test::DoubleSS
-MyDerivedClassI::opFloatDoubleSS(ICE_IN(Test::FloatSS) p1,
-                                 ICE_IN(Test::DoubleSS) p2,
+MyDerivedClassI::opFloatDoubleSS(Test::FloatSS p1,
+                                 Test::DoubleSS p2,
                                  Test::FloatSS& p3,
                                  Test::DoubleSS& p4,
                                  const Ice::Current&)
@@ -290,8 +290,8 @@ MyDerivedClassI::opFloatDoubleSS(ICE_IN(Test::FloatSS) p1,
 }
 
 Test::StringSS
-MyDerivedClassI::opStringSS(ICE_IN(Test::StringSS) p1,
-                            ICE_IN(Test::StringSS) p2,
+MyDerivedClassI::opStringSS(Test::StringSS p1,
+                            Test::StringSS p2,
                             Test::StringSS& p3,
                             const Ice::Current&)
 {
@@ -304,8 +304,8 @@ MyDerivedClassI::opStringSS(ICE_IN(Test::StringSS) p1,
 }
 
 Test::StringSSS
-MyDerivedClassI::opStringSSS(ICE_IN(Test::StringSSS) p1,
-                             ICE_IN(Test::StringSSS) p2,
+MyDerivedClassI::opStringSSS(Test::StringSSS p1,
+                             Test::StringSSS p2,
                              Test::StringSSS& p3,
                              const ::Ice::Current&)
 {
@@ -318,8 +318,8 @@ MyDerivedClassI::opStringSSS(ICE_IN(Test::StringSSS) p1,
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD(ICE_IN(Test::ByteBoolD) p1,
-                             ICE_IN(Test::ByteBoolD) p2,
+MyDerivedClassI::opByteBoolD(Test::ByteBoolD p1,
+                             Test::ByteBoolD p2,
                              Test::ByteBoolD& p3,
                              const Ice::Current&)
 {
@@ -330,8 +330,8 @@ MyDerivedClassI::opByteBoolD(ICE_IN(Test::ByteBoolD) p1,
 }
 
 Test::ShortIntD
-MyDerivedClassI::opShortIntD(ICE_IN(Test::ShortIntD) p1,
-                             ICE_IN(Test::ShortIntD) p2,
+MyDerivedClassI::opShortIntD(Test::ShortIntD p1,
+                             Test::ShortIntD p2,
                              Test::ShortIntD& p3,
                              const Ice::Current&)
 {
@@ -342,8 +342,8 @@ MyDerivedClassI::opShortIntD(ICE_IN(Test::ShortIntD) p1,
 }
 
 Test::LongFloatD
-MyDerivedClassI::opLongFloatD(ICE_IN(Test::LongFloatD) p1,
-                              ICE_IN(Test::LongFloatD) p2,
+MyDerivedClassI::opLongFloatD(Test::LongFloatD p1,
+                              Test::LongFloatD p2,
                               Test::LongFloatD& p3,
                               const Ice::Current&)
 {
@@ -354,8 +354,8 @@ MyDerivedClassI::opLongFloatD(ICE_IN(Test::LongFloatD) p1,
 }
 
 Test::StringStringD
-MyDerivedClassI::opStringStringD(ICE_IN(Test::StringStringD) p1,
-                                 ICE_IN(Test::StringStringD) p2,
+MyDerivedClassI::opStringStringD(Test::StringStringD p1,
+                                 Test::StringStringD p2,
                                  Test::StringStringD& p3,
                                  const Ice::Current&)
 {
@@ -366,8 +366,8 @@ MyDerivedClassI::opStringStringD(ICE_IN(Test::StringStringD) p1,
 }
 
 Test::StringMyEnumD
-MyDerivedClassI::opStringMyEnumD(ICE_IN(Test::StringMyEnumD) p1,
-                                 ICE_IN(Test::StringMyEnumD) p2,
+MyDerivedClassI::opStringMyEnumD(Test::StringMyEnumD p1,
+                                 Test::StringMyEnumD p2,
                                  Test::StringMyEnumD& p3,
                                  const Ice::Current&)
 {
@@ -378,8 +378,8 @@ MyDerivedClassI::opStringMyEnumD(ICE_IN(Test::StringMyEnumD) p1,
 }
 
 Test::MyEnumStringD
-MyDerivedClassI::opMyEnumStringD(ICE_IN(Test::MyEnumStringD) p1,
-                                 ICE_IN(Test::MyEnumStringD) p2,
+MyDerivedClassI::opMyEnumStringD(Test::MyEnumStringD p1,
+                                 Test::MyEnumStringD p2,
                                  Test::MyEnumStringD& p3,
                                  const Ice::Current&)
 {
@@ -390,8 +390,8 @@ MyDerivedClassI::opMyEnumStringD(ICE_IN(Test::MyEnumStringD) p1,
 }
 
 Test::MyStructMyEnumD
-MyDerivedClassI::opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD) p1,
-                                   ICE_IN(Test::MyStructMyEnumD) p2,
+MyDerivedClassI::opMyStructMyEnumD(Test::MyStructMyEnumD p1,
+                                   Test::MyStructMyEnumD p2,
                                    Test::MyStructMyEnumD& p3,
                                    const Ice::Current&)
 {
@@ -402,8 +402,8 @@ MyDerivedClassI::opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD) p1,
 }
 
 Test::ByteBoolDS
-MyDerivedClassI::opByteBoolDS(ICE_IN(Test::ByteBoolDS) p1,
-                              ICE_IN(Test::ByteBoolDS) p2,
+MyDerivedClassI::opByteBoolDS(Test::ByteBoolDS p1,
+                              Test::ByteBoolDS p2,
                               Test::ByteBoolDS& p3,
                               const Ice::Current&)
 {
@@ -416,8 +416,8 @@ MyDerivedClassI::opByteBoolDS(ICE_IN(Test::ByteBoolDS) p1,
 }
 
 Test::ShortIntDS
-MyDerivedClassI::opShortIntDS(ICE_IN(Test::ShortIntDS) p1,
-                              ICE_IN(Test::ShortIntDS) p2,
+MyDerivedClassI::opShortIntDS(Test::ShortIntDS p1,
+                              Test::ShortIntDS p2,
                               Test::ShortIntDS& p3,
                               const Ice::Current&)
 {
@@ -430,8 +430,8 @@ MyDerivedClassI::opShortIntDS(ICE_IN(Test::ShortIntDS) p1,
 }
 
 Test::LongFloatDS
-MyDerivedClassI::opLongFloatDS(ICE_IN(Test::LongFloatDS) p1,
-                               ICE_IN(Test::LongFloatDS) p2,
+MyDerivedClassI::opLongFloatDS(Test::LongFloatDS p1,
+                               Test::LongFloatDS p2,
                                Test::LongFloatDS& p3,
                                const Ice::Current&)
 {
@@ -444,8 +444,8 @@ MyDerivedClassI::opLongFloatDS(ICE_IN(Test::LongFloatDS) p1,
 }
 
 Test::StringStringDS
-MyDerivedClassI::opStringStringDS(ICE_IN(Test::StringStringDS) p1,
-                                  ICE_IN(Test::StringStringDS) p2,
+MyDerivedClassI::opStringStringDS(Test::StringStringDS p1,
+                                  Test::StringStringDS p2,
                                   Test::StringStringDS& p3,
                                   const Ice::Current&)
 {
@@ -458,8 +458,8 @@ MyDerivedClassI::opStringStringDS(ICE_IN(Test::StringStringDS) p1,
 }
 
 Test::StringMyEnumDS
-MyDerivedClassI::opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS) p1,
-                                  ICE_IN(Test::StringMyEnumDS) p2,
+MyDerivedClassI::opStringMyEnumDS(Test::StringMyEnumDS p1,
+                                  Test::StringMyEnumDS p2,
                                   Test::StringMyEnumDS& p3,
                                   const Ice::Current&)
 {
@@ -472,8 +472,8 @@ MyDerivedClassI::opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS) p1,
 }
 
 Test::MyEnumStringDS
-MyDerivedClassI::opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS) p1,
-                                  ICE_IN(Test::MyEnumStringDS) p2,
+MyDerivedClassI::opMyEnumStringDS(Test::MyEnumStringDS p1,
+                                  Test::MyEnumStringDS p2,
                                   Test::MyEnumStringDS& p3,
                                   const Ice::Current&)
 {
@@ -486,8 +486,8 @@ MyDerivedClassI::opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS) p1,
 }
 
 Test::MyStructMyEnumDS
-MyDerivedClassI::opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS) p1,
-                                    ICE_IN(Test::MyStructMyEnumDS) p2,
+MyDerivedClassI::opMyStructMyEnumDS(Test::MyStructMyEnumDS p1,
+                                    Test::MyStructMyEnumDS p2,
                                     Test::MyStructMyEnumDS& p3,
                                     const Ice::Current&)
 {
@@ -500,8 +500,8 @@ MyDerivedClassI::opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS) p1,
 }
 
 Test::ByteByteSD
-MyDerivedClassI::opByteByteSD(ICE_IN(Test::ByteByteSD) p1,
-                              ICE_IN(Test::ByteByteSD) p2,
+MyDerivedClassI::opByteByteSD(Test::ByteByteSD p1,
+                              Test::ByteByteSD p2,
                               Test::ByteByteSD& p3,
                               const Ice::Current&)
 {
@@ -512,8 +512,8 @@ MyDerivedClassI::opByteByteSD(ICE_IN(Test::ByteByteSD) p1,
 }
 
 Test::BoolBoolSD
-MyDerivedClassI::opBoolBoolSD(ICE_IN(Test::BoolBoolSD) p1,
-                              ICE_IN(Test::BoolBoolSD) p2,
+MyDerivedClassI::opBoolBoolSD(Test::BoolBoolSD p1,
+                              Test::BoolBoolSD p2,
                               Test::BoolBoolSD& p3,
                               const Ice::Current&)
 {
@@ -524,8 +524,8 @@ MyDerivedClassI::opBoolBoolSD(ICE_IN(Test::BoolBoolSD) p1,
 }
 
 Test::ShortShortSD
-MyDerivedClassI::opShortShortSD(ICE_IN(Test::ShortShortSD) p1,
-                                ICE_IN(Test::ShortShortSD) p2,
+MyDerivedClassI::opShortShortSD(Test::ShortShortSD p1,
+                                Test::ShortShortSD p2,
                                 Test::ShortShortSD& p3,
                                 const Ice::Current&)
 {
@@ -536,8 +536,8 @@ MyDerivedClassI::opShortShortSD(ICE_IN(Test::ShortShortSD) p1,
 }
 
 Test::IntIntSD
-MyDerivedClassI::opIntIntSD(ICE_IN(Test::IntIntSD) p1,
-                            ICE_IN(Test::IntIntSD) p2,
+MyDerivedClassI::opIntIntSD(Test::IntIntSD p1,
+                            Test::IntIntSD p2,
                             Test::IntIntSD& p3,
                             const Ice::Current&)
 {
@@ -548,8 +548,8 @@ MyDerivedClassI::opIntIntSD(ICE_IN(Test::IntIntSD) p1,
 }
 
 Test::LongLongSD
-MyDerivedClassI::opLongLongSD(ICE_IN(Test::LongLongSD) p1,
-                              ICE_IN(Test::LongLongSD) p2,
+MyDerivedClassI::opLongLongSD(Test::LongLongSD p1,
+                              Test::LongLongSD p2,
                               Test::LongLongSD& p3,
                               const Ice::Current&)
 {
@@ -560,8 +560,8 @@ MyDerivedClassI::opLongLongSD(ICE_IN(Test::LongLongSD) p1,
 }
 
 Test::StringFloatSD
-MyDerivedClassI::opStringFloatSD(ICE_IN(Test::StringFloatSD) p1,
-                                 ICE_IN(Test::StringFloatSD) p2,
+MyDerivedClassI::opStringFloatSD(Test::StringFloatSD p1,
+                                 Test::StringFloatSD p2,
                                  Test::StringFloatSD& p3,
                                  const Ice::Current&)
 {
@@ -572,8 +572,8 @@ MyDerivedClassI::opStringFloatSD(ICE_IN(Test::StringFloatSD) p1,
 }
 
 Test::StringDoubleSD
-MyDerivedClassI::opStringDoubleSD(ICE_IN(Test::StringDoubleSD) p1,
-                                  ICE_IN(Test::StringDoubleSD) p2,
+MyDerivedClassI::opStringDoubleSD(Test::StringDoubleSD p1,
+                                  Test::StringDoubleSD p2,
                                   Test::StringDoubleSD& p3,
                                   const Ice::Current&)
 {
@@ -584,8 +584,8 @@ MyDerivedClassI::opStringDoubleSD(ICE_IN(Test::StringDoubleSD) p1,
 }
 
 Test::StringStringSD
-MyDerivedClassI::opStringStringSD(ICE_IN(Test::StringStringSD) p1,
-                                  ICE_IN(Test::StringStringSD) p2,
+MyDerivedClassI::opStringStringSD(Test::StringStringSD p1,
+                                  Test::StringStringSD p2,
                                   Test::StringStringSD& p3,
                                   const Ice::Current&)
 {
@@ -596,8 +596,8 @@ MyDerivedClassI::opStringStringSD(ICE_IN(Test::StringStringSD) p1,
 }
 
 Test::MyEnumMyEnumSD
-MyDerivedClassI::opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD) p1,
-                                  ICE_IN(Test::MyEnumMyEnumSD) p2,
+MyDerivedClassI::opMyEnumMyEnumSD(Test::MyEnumMyEnumSD p1,
+                                  Test::MyEnumMyEnumSD p2,
                                   Test::MyEnumMyEnumSD& p3,
                                   const Ice::Current&)
 {
@@ -608,7 +608,7 @@ MyDerivedClassI::opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD) p1,
 }
 
 Test::IntS
-MyDerivedClassI::opIntS(ICE_IN(Test::IntS) s, const Ice::Current&)
+MyDerivedClassI::opIntS(Test::IntS s, const Ice::Current&)
 {
     Test::IntS r;
     std::transform(s.begin(), s.end(), std::back_inserter(r), std::negate<int>());
@@ -616,7 +616,7 @@ MyDerivedClassI::opIntS(ICE_IN(Test::IntS) s, const Ice::Current&)
 }
 
 void
-MyDerivedClassI::opByteSOneway(ICE_IN(Test::ByteS), const Ice::Current&)
+MyDerivedClassI::opByteSOneway(Test::ByteS, const Ice::Current&)
 {
     IceUtil::Mutex::Lock sync(_mutex);
     ++_opByteSOnewayCallCount;
@@ -638,7 +638,7 @@ MyDerivedClassI::opContext(const Ice::Current& c)
 }
 
 void
-MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, ICE_IN(Test::DoubleS) p2, const Ice::Current&)
+MyDerivedClassI::opDoubleMarshaling(Ice::Double p1, Test::DoubleS p2, const Ice::Current&)
 {
     Ice::Double d = 1278312346.0 / 13.0;
     test(p1 == d);
@@ -702,43 +702,43 @@ MyDerivedClassI::opDouble1(Ice::Double d, const Ice::Current&)
 }
 
 std::string
-MyDerivedClassI::opString1(ICE_IN(string) s, const Ice::Current&)
+MyDerivedClassI::opString1(string s, const Ice::Current&)
 {
     return s;
 }
 
 Test::StringS
-MyDerivedClassI::opStringS1(ICE_IN(Test::StringS) seq, const Ice::Current&)
+MyDerivedClassI::opStringS1(Test::StringS seq, const Ice::Current&)
 {
     return seq;
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD1(ICE_IN(Test::ByteBoolD) dict, const Ice::Current&)
+MyDerivedClassI::opByteBoolD1(Test::ByteBoolD dict, const Ice::Current&)
 {
     return dict;
 }
 
 Test::StringS
-MyDerivedClassI::opStringS2(ICE_IN(Test::StringS) seq, const Ice::Current&)
+MyDerivedClassI::opStringS2(Test::StringS seq, const Ice::Current&)
 {
     return seq;
 }
 
 Test::ByteBoolD
-MyDerivedClassI::opByteBoolD2(ICE_IN(Test::ByteBoolD) dict, const Ice::Current&)
+MyDerivedClassI::opByteBoolD2(Test::ByteBoolD dict, const Ice::Current&)
 {
     return dict;
 }
 
 Test::MyStruct1
-MyDerivedClassI::opMyStruct1(ICE_IN(Test::MyStruct1) s, const Ice::Current&)
+MyDerivedClassI::opMyStruct1(Test::MyStruct1 s, const Ice::Current&)
 {
     return s;
 }
 
 Test::MyClass1Ptr
-MyDerivedClassI::opMyClass1(ICE_IN(Test::MyClass1Ptr) c, const Ice::Current&)
+MyDerivedClassI::opMyClass1(Test::MyClass1Ptr c, const Ice::Current&)
 {
     return c;
 }
@@ -836,7 +836,7 @@ MyDerivedClassI::opMStruct1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMStruct2MarshaledResult
-MyDerivedClassI::opMStruct2(ICE_IN(Test::Structure) p1, const Ice::Current& current)
+MyDerivedClassI::opMStruct2(Test::Structure p1, const Ice::Current& current)
 {
     return OpMStruct2MarshaledResult(p1, p1, current);
 }
@@ -848,7 +848,7 @@ MyDerivedClassI::opMSeq1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMSeq2MarshaledResult
-MyDerivedClassI::opMSeq2(ICE_IN(Test::StringS) p1, const Ice::Current& current)
+MyDerivedClassI::opMSeq2(Test::StringS p1, const Ice::Current& current)
 {
     return OpMSeq2MarshaledResult(p1, p1, current);
 }
@@ -860,7 +860,7 @@ MyDerivedClassI::opMDict1(const Ice::Current& current)
 }
 
 MyDerivedClassI::OpMDict2MarshaledResult
-MyDerivedClassI::opMDict2(ICE_IN(Test::StringStringD) p1, const Ice::Current& current)
+MyDerivedClassI::opMDict2(Test::StringStringD p1, const Ice::Current& current)
 {
     return OpMDict2MarshaledResult(p1, p1, current);
 }

--- a/cpp/test/Ice/operations/TestI.h
+++ b/cpp/test/Ice/operations/TestI.h
@@ -51,8 +51,8 @@ public:
                                       Ice::Double&,
                                       const Ice::Current&);
 
-    virtual std::string opString(ICE_IN(std::string),
-                                 ICE_IN(std::string),
+    virtual std::string opString(std::string,
+                                 std::string,
                                  std::string&,
                                  const Ice::Current&);
 
@@ -60,201 +60,201 @@ public:
                                   Test::MyEnum&,
                                   const Ice::Current&);
 
-    virtual Test::MyClassPrxPtr opMyClass(ICE_IN(Test::MyClassPrxPtr),
+    virtual Test::MyClassPrxPtr opMyClass(Test::MyClassPrxPtr,
                                           Test::MyClassPrxPtr&, Test::MyClassPrxPtr&,
                                           const Ice::Current&);
 
-    virtual Test::Structure opStruct(ICE_IN(Test::Structure),
-                                     ICE_IN(Test::Structure),
+    virtual Test::Structure opStruct(Test::Structure,
+                                     Test::Structure,
                                      Test::Structure&,
                                      const Ice::Current&);
 
-    virtual Test::ByteS opByteS(ICE_IN(Test::ByteS),
-                                ICE_IN(Test::ByteS),
+    virtual Test::ByteS opByteS(Test::ByteS,
+                                Test::ByteS,
                                 Test::ByteS&,
                                 const Ice::Current&);
 
-    virtual Test::BoolS opBoolS(ICE_IN(Test::BoolS),
-                                ICE_IN(Test::BoolS),
+    virtual Test::BoolS opBoolS(Test::BoolS,
+                                Test::BoolS,
                                 Test::BoolS&,
                                 const Ice::Current&);
 
-    virtual Test::LongS opShortIntLongS(ICE_IN(Test::ShortS),
-                                        ICE_IN(Test::IntS),
-                                        ICE_IN(Test::LongS),
+    virtual Test::LongS opShortIntLongS(Test::ShortS,
+                                        Test::IntS,
+                                        Test::LongS,
                                         Test::ShortS&,
                                         Test::IntS&,
                                         Test::LongS&,
                                         const Ice::Current&);
 
-    virtual Test::DoubleS opFloatDoubleS(ICE_IN(Test::FloatS),
-                                         ICE_IN(Test::DoubleS),
+    virtual Test::DoubleS opFloatDoubleS(Test::FloatS,
+                                         Test::DoubleS,
                                          Test::FloatS&,
                                          Test::DoubleS&,
                                          const Ice::Current&);
 
-    virtual Test::StringS opStringS(ICE_IN(Test::StringS),
-                                    ICE_IN(Test::StringS),
+    virtual Test::StringS opStringS(Test::StringS,
+                                    Test::StringS,
                                     Test::StringS&,
                                     const Ice::Current&);
 
-    virtual Test::ByteSS opByteSS(ICE_IN(Test::ByteSS),
-                                  ICE_IN(Test::ByteSS),
+    virtual Test::ByteSS opByteSS(Test::ByteSS,
+                                  Test::ByteSS,
                                   Test::ByteSS&,
                                   const Ice::Current&);
 
-    virtual Test::BoolSS opBoolSS(ICE_IN(Test::BoolSS),
-                                  ICE_IN(Test::BoolSS),
+    virtual Test::BoolSS opBoolSS(Test::BoolSS,
+                                  Test::BoolSS,
                                   Test::BoolSS&,
                                   const Ice::Current&);
 
-    virtual Test::LongSS opShortIntLongSS(ICE_IN(Test::ShortSS),
-                                          ICE_IN(Test::IntSS),
-                                          ICE_IN(Test::LongSS),
+    virtual Test::LongSS opShortIntLongSS(Test::ShortSS,
+                                          Test::IntSS,
+                                          Test::LongSS,
                                           Test::ShortSS&,
                                           Test::IntSS&,
                                           Test::LongSS&,
                                           const Ice::Current&);
 
-    virtual Test::DoubleSS opFloatDoubleSS(ICE_IN(Test::FloatSS),
-                                           ICE_IN(Test::DoubleSS),
+    virtual Test::DoubleSS opFloatDoubleSS(Test::FloatSS,
+                                           Test::DoubleSS,
                                            Test::FloatSS&,
                                            Test::DoubleSS&,
                                            const Ice::Current&);
 
-    virtual Test::StringSS opStringSS(ICE_IN(Test::StringSS),
-                                      ICE_IN(Test::StringSS),
+    virtual Test::StringSS opStringSS(Test::StringSS,
+                                      Test::StringSS,
                                       Test::StringSS&,
                                       const Ice::Current&);
 
-    virtual Test::StringSSS opStringSSS(ICE_IN(Test::StringSSS),
-                                        ICE_IN(Test::StringSSS),
+    virtual Test::StringSSS opStringSSS(Test::StringSSS,
+                                        Test::StringSSS,
                                         Test::StringSSS&,
                                         const ::Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD(ICE_IN(Test::ByteBoolD),
-                                        ICE_IN(Test::ByteBoolD),
+    virtual Test::ByteBoolD opByteBoolD(Test::ByteBoolD,
+                                        Test::ByteBoolD,
                                         Test::ByteBoolD&,
                                         const Ice::Current&);
 
-    virtual Test::ShortIntD opShortIntD(ICE_IN(Test::ShortIntD),
-                                        ICE_IN(Test::ShortIntD),
+    virtual Test::ShortIntD opShortIntD(Test::ShortIntD,
+                                        Test::ShortIntD,
                                         Test::ShortIntD&,
                                         const Ice::Current&);
 
-    virtual Test::LongFloatD opLongFloatD(ICE_IN(Test::LongFloatD),
-                                          ICE_IN(Test::LongFloatD),
+    virtual Test::LongFloatD opLongFloatD(Test::LongFloatD,
+                                          Test::LongFloatD,
                                           Test::LongFloatD&,
                                           const Ice::Current&);
 
-    virtual Test::StringStringD opStringStringD(ICE_IN(Test::StringStringD),
-                                                ICE_IN(Test::StringStringD),
+    virtual Test::StringStringD opStringStringD(Test::StringStringD,
+                                                Test::StringStringD,
                                                 Test::StringStringD&,
                                                 const Ice::Current&);
 
-    virtual Test::StringMyEnumD opStringMyEnumD(ICE_IN(Test::StringMyEnumD),
-                                                ICE_IN(Test::StringMyEnumD),
+    virtual Test::StringMyEnumD opStringMyEnumD(Test::StringMyEnumD,
+                                                Test::StringMyEnumD,
                                                 Test::StringMyEnumD&,
                                                 const Ice::Current&);
 
-    virtual Test::MyEnumStringD opMyEnumStringD(ICE_IN(Test::MyEnumStringD),
-                                                ICE_IN(Test::MyEnumStringD),
+    virtual Test::MyEnumStringD opMyEnumStringD(Test::MyEnumStringD,
+                                                Test::MyEnumStringD,
                                                 Test::MyEnumStringD&,
                                                 const Ice::Current&);
 
-    virtual Test::MyStructMyEnumD opMyStructMyEnumD(ICE_IN(Test::MyStructMyEnumD),
-                                                    ICE_IN(Test::MyStructMyEnumD),
+    virtual Test::MyStructMyEnumD opMyStructMyEnumD(Test::MyStructMyEnumD,
+                                                    Test::MyStructMyEnumD,
                                                     Test::MyStructMyEnumD&,
                                                     const Ice::Current&);
 
-    virtual Test::ByteBoolDS opByteBoolDS(ICE_IN(Test::ByteBoolDS),
-                                          ICE_IN(Test::ByteBoolDS),
+    virtual Test::ByteBoolDS opByteBoolDS(Test::ByteBoolDS,
+                                          Test::ByteBoolDS,
                                           Test::ByteBoolDS&,
                                           const Ice::Current&);
 
-    virtual Test::ShortIntDS opShortIntDS(ICE_IN(Test::ShortIntDS),
-                                          ICE_IN(Test::ShortIntDS),
+    virtual Test::ShortIntDS opShortIntDS(Test::ShortIntDS,
+                                          Test::ShortIntDS,
                                           Test::ShortIntDS&,
                                           const Ice::Current&);
 
-    virtual Test::LongFloatDS opLongFloatDS(ICE_IN(Test::LongFloatDS),
-                                            ICE_IN(Test::LongFloatDS),
+    virtual Test::LongFloatDS opLongFloatDS(Test::LongFloatDS,
+                                            Test::LongFloatDS,
                                             Test::LongFloatDS&,
                                             const Ice::Current&);
 
-    virtual Test::StringStringDS opStringStringDS(ICE_IN(Test::StringStringDS),
-                                                  ICE_IN(Test::StringStringDS),
+    virtual Test::StringStringDS opStringStringDS(Test::StringStringDS,
+                                                  Test::StringStringDS,
                                                   Test::StringStringDS&,
                                                   const Ice::Current&);
 
-    virtual Test::StringMyEnumDS opStringMyEnumDS(ICE_IN(Test::StringMyEnumDS),
-                                                  ICE_IN(Test::StringMyEnumDS),
+    virtual Test::StringMyEnumDS opStringMyEnumDS(Test::StringMyEnumDS,
+                                                  Test::StringMyEnumDS,
                                                   Test::StringMyEnumDS&,
                                                   const Ice::Current&);
 
-    virtual Test::MyStructMyEnumDS opMyStructMyEnumDS(ICE_IN(Test::MyStructMyEnumDS),
-                                                      ICE_IN(Test::MyStructMyEnumDS),
+    virtual Test::MyStructMyEnumDS opMyStructMyEnumDS(Test::MyStructMyEnumDS,
+                                                      Test::MyStructMyEnumDS,
                                                       Test::MyStructMyEnumDS&,
                                                       const Ice::Current&);
 
-    virtual Test::MyEnumStringDS opMyEnumStringDS(ICE_IN(Test::MyEnumStringDS),
-                                                  ICE_IN(Test::MyEnumStringDS),
+    virtual Test::MyEnumStringDS opMyEnumStringDS(Test::MyEnumStringDS,
+                                                  Test::MyEnumStringDS,
                                                   Test::MyEnumStringDS&,
                                                   const Ice::Current&);
 
-    virtual Test::ByteByteSD opByteByteSD(ICE_IN(Test::ByteByteSD),
-                                          ICE_IN(Test::ByteByteSD),
+    virtual Test::ByteByteSD opByteByteSD(Test::ByteByteSD,
+                                          Test::ByteByteSD,
                                           Test::ByteByteSD&,
                                           const Ice::Current&);
 
-    virtual Test::BoolBoolSD opBoolBoolSD(ICE_IN(Test::BoolBoolSD),
-                                          ICE_IN(Test::BoolBoolSD),
+    virtual Test::BoolBoolSD opBoolBoolSD(Test::BoolBoolSD,
+                                          Test::BoolBoolSD,
                                           Test::BoolBoolSD&,
                                           const Ice::Current&);
 
-    virtual Test::ShortShortSD opShortShortSD(ICE_IN(Test::ShortShortSD),
-                                              ICE_IN(Test::ShortShortSD),
+    virtual Test::ShortShortSD opShortShortSD(Test::ShortShortSD,
+                                              Test::ShortShortSD,
                                               Test::ShortShortSD&,
                                               const Ice::Current&);
 
-    virtual Test::IntIntSD opIntIntSD(ICE_IN(Test::IntIntSD),
-                                      ICE_IN(Test::IntIntSD),
+    virtual Test::IntIntSD opIntIntSD(Test::IntIntSD,
+                                      Test::IntIntSD,
                                       Test::IntIntSD&,
                                       const Ice::Current&);
 
-    virtual Test::LongLongSD opLongLongSD(ICE_IN(Test::LongLongSD),
-                                          ICE_IN(Test::LongLongSD),
+    virtual Test::LongLongSD opLongLongSD(Test::LongLongSD,
+                                          Test::LongLongSD,
                                           Test::LongLongSD&,
                                           const Ice::Current&);
 
-    virtual Test::StringFloatSD opStringFloatSD(ICE_IN(Test::StringFloatSD),
-                                                ICE_IN(Test::StringFloatSD),
+    virtual Test::StringFloatSD opStringFloatSD(Test::StringFloatSD,
+                                                Test::StringFloatSD,
                                                 Test::StringFloatSD&,
                                                 const Ice::Current&);
 
-    virtual Test::StringDoubleSD opStringDoubleSD(ICE_IN(Test::StringDoubleSD),
-                                                  ICE_IN(Test::StringDoubleSD),
+    virtual Test::StringDoubleSD opStringDoubleSD(Test::StringDoubleSD,
+                                                  Test::StringDoubleSD,
                                                   Test::StringDoubleSD&,
                                                   const Ice::Current&);
 
-    virtual Test::StringStringSD opStringStringSD(ICE_IN(Test::StringStringSD),
-                                                  ICE_IN(Test::StringStringSD),
+    virtual Test::StringStringSD opStringStringSD(Test::StringStringSD,
+                                                  Test::StringStringSD,
                                                   Test::StringStringSD&,
                                                   const Ice::Current&);
 
-    virtual Test::MyEnumMyEnumSD opMyEnumMyEnumSD(ICE_IN(Test::MyEnumMyEnumSD),
-                                                  ICE_IN(Test::MyEnumMyEnumSD),
+    virtual Test::MyEnumMyEnumSD opMyEnumMyEnumSD(Test::MyEnumMyEnumSD,
+                                                  Test::MyEnumMyEnumSD,
                                                   Test::MyEnumMyEnumSD&,
                                                   const Ice::Current&);
 
-    virtual Test::IntS opIntS(ICE_IN(Test::IntS), const Ice::Current&);
+    virtual Test::IntS opIntS(Test::IntS, const Ice::Current&);
 
-    virtual void opByteSOneway(ICE_IN(Test::ByteS), const Ice::Current&);
+    virtual void opByteSOneway(Test::ByteS, const Ice::Current&);
     virtual int opByteSOnewayCallCount(const Ice::Current&);
 
     virtual Ice::Context opContext(const Ice::Current&);
 
-    virtual void opDoubleMarshaling(Ice::Double, ICE_IN(Test::DoubleS), const Ice::Current&);
+    virtual void opDoubleMarshaling(Ice::Double, Test::DoubleS, const Ice::Current&);
 
     virtual void opIdempotent(const Ice::Current&);
 
@@ -274,19 +274,19 @@ public:
 
     virtual Ice::Double opDouble1(Ice::Double, const Ice::Current&);
 
-    virtual std::string opString1(ICE_IN(std::string), const Ice::Current&);
+    virtual std::string opString1(std::string, const Ice::Current&);
 
-    virtual Test::StringS opStringS1(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual Test::StringS opStringS1(Test::StringS, const Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD1(ICE_IN(Test::ByteBoolD), const Ice::Current&);
+    virtual Test::ByteBoolD opByteBoolD1(Test::ByteBoolD, const Ice::Current&);
 
-    virtual Test::StringS opStringS2(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual Test::StringS opStringS2(Test::StringS, const Ice::Current&);
 
-    virtual Test::ByteBoolD opByteBoolD2(ICE_IN(Test::ByteBoolD), const Ice::Current&);
+    virtual Test::ByteBoolD opByteBoolD2(Test::ByteBoolD, const Ice::Current&);
 
-    virtual Test::MyStruct1 opMyStruct1(ICE_IN(Test::MyStruct1), const Ice::Current&);
+    virtual Test::MyStruct1 opMyStruct1(Test::MyStruct1, const Ice::Current&);
 
-    virtual Test::MyClass1Ptr opMyClass1(ICE_IN(Test::MyClass1Ptr), const Ice::Current&);
+    virtual Test::MyClass1Ptr opMyClass1(Test::MyClass1Ptr, const Ice::Current&);
 
     virtual Test::StringS opStringLiterals(const Ice::Current&);
 
@@ -294,15 +294,15 @@ public:
 
     virtual OpMStruct1MarshaledResult opMStruct1(const Ice::Current&);
 
-    virtual OpMStruct2MarshaledResult opMStruct2(ICE_IN(Test::Structure), const Ice::Current&);
+    virtual OpMStruct2MarshaledResult opMStruct2(Test::Structure, const Ice::Current&);
 
     virtual OpMSeq1MarshaledResult opMSeq1(const Ice::Current&);
 
-    virtual OpMSeq2MarshaledResult opMSeq2(ICE_IN(Test::StringS), const Ice::Current&);
+    virtual OpMSeq2MarshaledResult opMSeq2(Test::StringS, const Ice::Current&);
 
     virtual OpMDict1MarshaledResult opMDict1(const Ice::Current&);
 
-    virtual OpMDict2MarshaledResult opMDict2(ICE_IN(Test::StringStringD), const Ice::Current&);
+    virtual OpMDict2MarshaledResult opMDict2(Test::StringStringD, const Ice::Current&);
 
 private:
 

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -331,9 +331,9 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::MyEnum e;
         Test::MyEnum r;
 
-        r = p->opMyEnum(ICE_ENUM(MyEnum, enum2), e);
-        test(e == ICE_ENUM(MyEnum, enum2));
-        test(r == ICE_ENUM(MyEnum, enum3));
+        r = p->opMyEnum(MyEnum::enum2, e);
+        test(e == MyEnum::enum2);
+        test(r == MyEnum::enum3);
     }
 
     {
@@ -369,20 +369,20 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = ICE_ENUM(MyEnum, enum3);
+        si1.e = MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = ICE_ENUM(MyEnum, enum2);
+        si2.e = MyEnum::enum2;
         si2.s.s = "def";
 
         Test::Structure so;
         Test::Structure rso = p->opStruct(si1, si2, so);
         test(rso.p == 0);
-        test(rso.e == ICE_ENUM(MyEnum, enum2));
+        test(rso.e == MyEnum::enum2);
         test(rso.s.s == "def");
         test(Ice::targetEqualTo(so.p, p));
-        test(so.e == ICE_ENUM(MyEnum, enum3));
+        test(so.e == MyEnum::enum3);
         test(so.s.s == "a new string");
         so.p->opVoid();
     }
@@ -891,64 +891,64 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(MyEnum, enum1);
-        di1[""] = ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = MyEnum::enum1;
+        di1[""] = MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = MyEnum::enum1;
+        di2["qwerty"] = MyEnum::enum3;
+        di2["Hello!!"] = MyEnum::enum2;
 
         Test::StringMyEnumD _do;
         Test::StringMyEnumD ro = p->opStringMyEnumD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 4);
-        test(ro["abc"] == ICE_ENUM(MyEnum, enum1));
-        test(ro["qwerty"] == ICE_ENUM(MyEnum, enum3));
-        test(ro[""] == ICE_ENUM(MyEnum, enum2));
-        test(ro["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+        test(ro["abc"] == MyEnum::enum1);
+        test(ro["qwerty"] == MyEnum::enum3);
+        test(ro[""] == MyEnum::enum2);
+        test(ro["Hello!!"] == MyEnum::enum2);
     }
 
     {
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[MyEnum::enum2] = "Hello!!";
+        di2[MyEnum::enum3] = "qwerty";
 
         Test::MyEnumStringD _do;
         Test::MyEnumStringD ro = p->opMyEnumStringD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 3);
-        test(ro[ICE_ENUM(MyEnum, enum1)] == "abc");
-        test(ro[ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-        test(ro[ICE_ENUM(MyEnum, enum3)] == "qwerty");
+        test(ro[MyEnum::enum1] == "abc");
+        test(ro[MyEnum::enum2] == "Hello!!");
+        test(ro[MyEnum::enum3] == "qwerty");
     }
 
     {
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = MyEnum::enum1;
+        di1[ms12] = MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = MyEnum::enum1;
+        di2[ms22] = MyEnum::enum3;
+        di2[ms23] = MyEnum::enum2;
 
         Test::MyStructMyEnumD _do;
         Test::MyStructMyEnumD ro = p->opMyStructMyEnumD(di1, di2, _do);
 
         test(_do == di1);
         test(ro.size() == 4);
-        test(ro[ms11] == ICE_ENUM(MyEnum, enum1));
-        test(ro[ms12] == ICE_ENUM(MyEnum, enum2));
-        test(ro[ms22] == ICE_ENUM(MyEnum, enum3));
-        test(ro[ms23] == ICE_ENUM(MyEnum, enum2));
+        test(ro[ms11] == MyEnum::enum1);
+        test(ro[ms12] == MyEnum::enum2);
+        test(ro[ms22] == MyEnum::enum3);
+        test(ro[ms23] == MyEnum::enum2);
     }
 
     {
@@ -1159,14 +1159,14 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = ICE_ENUM(MyEnum, enum1);
-        di1[""] = ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = MyEnum::enum1;
+        di1[""] = MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = MyEnum::enum1;
+        di2["qwerty"] = MyEnum::enum3;
+        di2["Hello!!"] = MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1179,23 +1179,23 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
             test(ro.size() == 2);
             test(ro[0].size() == 3);
-            test(ro[0]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(ro[0]["qwerty"] == ICE_ENUM(MyEnum, enum3));
-            test(ro[0]["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+            test(ro[0]["abc"] == MyEnum::enum1);
+            test(ro[0]["qwerty"] == MyEnum::enum3);
+            test(ro[0]["Hello!!"] == MyEnum::enum2);
             test(ro[1].size() == 2);
-            test(ro[1]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(ro[1][""] == ICE_ENUM(MyEnum, enum2));
+            test(ro[1]["abc"] == MyEnum::enum1);
+            test(ro[1][""] == MyEnum::enum2);
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0]["Goodbye"] == ICE_ENUM(MyEnum, enum1));
+            test(_do[0]["Goodbye"] == MyEnum::enum1);
             test(_do[1].size() == 2);
-            test(_do[1]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(_do[1][""] == ICE_ENUM(MyEnum, enum2));
+            test(_do[1]["abc"] == MyEnum::enum1);
+            test(_do[1][""] == MyEnum::enum2);
             test(_do[2].size() == 3);
-            test(_do[2]["abc"] == ICE_ENUM(MyEnum, enum1));
-            test(_do[2]["qwerty"] == ICE_ENUM(MyEnum, enum3));
-            test(_do[2]["Hello!!"] == ICE_ENUM(MyEnum, enum2));
+            test(_do[2]["abc"] == MyEnum::enum1);
+            test(_do[2]["qwerty"] == MyEnum::enum3);
+            test(_do[2]["Hello!!"] == MyEnum::enum2);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1209,12 +1209,12 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[MyEnum::enum2] = "Hello!!";
+        di2[MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1227,19 +1227,19 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
             test(ro.size() == 2);
             test(ro[0].size() == 2);
-            test(ro[0][ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-            test(ro[0][ICE_ENUM(MyEnum, enum3)] == "qwerty");
+            test(ro[0][MyEnum::enum2] == "Hello!!");
+            test(ro[0][MyEnum::enum3] == "qwerty");
             test(ro[1].size() == 1);
-            test(ro[1][ICE_ENUM(MyEnum, enum1)] == "abc");
+            test(ro[1][MyEnum::enum1] == "abc");
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0][ICE_ENUM(MyEnum, enum1)] == "Goodbye");
+            test(_do[0][MyEnum::enum1] == "Goodbye");
             test(_do[1].size() == 1);
-            test(_do[1][ICE_ENUM(MyEnum, enum1)] == "abc");
+            test(_do[1][MyEnum::enum1] == "abc");
             test(_do[2].size() == 2);
-            test(_do[2][ICE_ENUM(MyEnum, enum2)] == "Hello!!");
-            test(_do[2][ICE_ENUM(MyEnum, enum3)] == "qwerty");
+            test(_do[2][MyEnum::enum2] == "Hello!!");
+            test(_do[2][MyEnum::enum3] == "qwerty");
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1255,18 +1255,18 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = MyEnum::enum1;
+        di1[ms12] = MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = MyEnum::enum1;
+        di2[ms22] = MyEnum::enum3;
+        di2[ms23] = MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1279,23 +1279,23 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
             test(ro.size() == 2);
             test(ro[0].size() == 3);
-            test(ro[0][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(ro[0][ms22] == ICE_ENUM(MyEnum, enum3));
-            test(ro[0][ms23] == ICE_ENUM(MyEnum, enum2));
+            test(ro[0][ms11] == MyEnum::enum1);
+            test(ro[0][ms22] == MyEnum::enum3);
+            test(ro[0][ms23] == MyEnum::enum2);
             test(ro[1].size() == 2);
-            test(ro[1][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(ro[1][ms12] == ICE_ENUM(MyEnum, enum2));
+            test(ro[1][ms11] == MyEnum::enum1);
+            test(ro[1][ms12] == MyEnum::enum2);
 
             test(_do.size() == 3);
             test(_do[0].size() == 1);
-            test(_do[0][ms23] == ICE_ENUM(MyEnum, enum3));
+            test(_do[0][ms23] == MyEnum::enum3);
             test(_do[1].size() == 2);
-            test(_do[1][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(_do[1][ms12] == ICE_ENUM(MyEnum, enum2));
+            test(_do[1][ms11] == MyEnum::enum1);
+            test(_do[1][ms12] == MyEnum::enum2);
             test(_do[2].size() == 3);
-            test(_do[2][ms11] == ICE_ENUM(MyEnum, enum1));
-            test(_do[2][ms22] == ICE_ENUM(MyEnum, enum3));
-            test(_do[2][ms23] == ICE_ENUM(MyEnum, enum2));
+            test(_do[2][ms11] == MyEnum::enum1);
+            test(_do[2][ms22] == MyEnum::enum3);
+            test(_do[2][ms23] == MyEnum::enum2);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1646,17 +1646,17 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(ICE_ENUM(MyEnum, enum1));
-        si1.push_back(ICE_ENUM(MyEnum, enum1));
-        si1.push_back(ICE_ENUM(MyEnum, enum2));
-        si2.push_back(ICE_ENUM(MyEnum, enum1));
-        si2.push_back(ICE_ENUM(MyEnum, enum2));
-        si3.push_back(ICE_ENUM(MyEnum, enum3));
-        si3.push_back(ICE_ENUM(MyEnum, enum3));
+        si1.push_back(MyEnum::enum1);
+        si1.push_back(MyEnum::enum1);
+        si1.push_back(MyEnum::enum2);
+        si2.push_back(MyEnum::enum1);
+        si2.push_back(MyEnum::enum2);
+        si3.push_back(MyEnum::enum3);
+        si3.push_back(MyEnum::enum3);
 
-        sdi1[ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[MyEnum::enum3] = si1;
+        sdi1[MyEnum::enum2] = si2;
+        sdi2[MyEnum::enum1] = si3;
 
         try
         {
@@ -1665,16 +1665,16 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
             test(_do == sdi2);
             test(ro.size() == 3);
-            test(ro[ICE_ENUM(MyEnum, enum3)].size() == 3);
-            test(ro[ICE_ENUM(MyEnum, enum3)][0] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum3)][1] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum3)][2] == ICE_ENUM(MyEnum, enum2));
-            test(ro[ICE_ENUM(MyEnum, enum2)].size() == 2);
-            test(ro[ICE_ENUM(MyEnum, enum2)][0] == ICE_ENUM(MyEnum, enum1));
-            test(ro[ICE_ENUM(MyEnum, enum2)][1] == ICE_ENUM(MyEnum, enum2));
-            test(ro[ICE_ENUM(MyEnum, enum1)].size() == 2);
-            test(ro[ICE_ENUM(MyEnum, enum1)][0] == ICE_ENUM(MyEnum, enum3));
-            test(ro[ICE_ENUM(MyEnum, enum1)][1] == ICE_ENUM(MyEnum, enum3));
+            test(ro[MyEnum::enum3].size() == 3);
+            test(ro[MyEnum::enum3][0] == MyEnum::enum1);
+            test(ro[MyEnum::enum3][1] == MyEnum::enum1);
+            test(ro[MyEnum::enum3][2] == MyEnum::enum2);
+            test(ro[MyEnum::enum2].size() == 2);
+            test(ro[MyEnum::enum2][0] == MyEnum::enum1);
+            test(ro[MyEnum::enum2][1] == MyEnum::enum2);
+            test(ro[MyEnum::enum1].size() == 2);
+            test(ro[MyEnum::enum1][0] == MyEnum::enum3);
+            test(ro[MyEnum::enum1][1] == MyEnum::enum3);
         }
         catch(const Ice::OperationNotExistException&)
         {
@@ -1840,7 +1840,7 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
     {
         Test::Structure p1 = p->opMStruct1();
-        p1.e = ICE_ENUM(MyEnum, enum3);
+        p1.e = MyEnum::enum3;
         Test::Structure p2, p3;
         p3 = p->opMStruct2(p1, p2);
         test(p2.e == p1.e && p3.e == p1.e);

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -1823,7 +1823,7 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
     test(s.myClass == 0);
     test(s.myStruct1 == "Test::MyStruct1::myStruct1");
 
-    Test::MyClass1Ptr c = ICE_MAKE_SHARED(Test::MyClass1);
+    Test::MyClass1Ptr c = make_shared<Test::MyClass1>();
     c->tesT = "Test::MyClass1::testT";
     c->myClass = 0;
     c->myClass1 = "Test::MyClass1::myClass1";

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -154,8 +154,8 @@ public:
 
     void opMyEnum(Test::MyEnum r, Test::MyEnum e)
     {
-        test(e == Test::ICE_ENUM(MyEnum, enum2));
-        test(r == Test::ICE_ENUM(MyEnum, enum3));
+        test(e == Test::MyEnum::enum2);
+        test(r == Test::MyEnum::enum3);
         called();
     }
 
@@ -187,9 +187,9 @@ public:
     void opStruct(const Test::Structure& rso, const Test::Structure& so)
     {
         test(rso.p == 0);
-        test(rso.e == Test::ICE_ENUM(MyEnum, enum2));
+        test(rso.e == Test::MyEnum::enum2);
         test(rso.s.s == "def");
-        test(so.e == Test::ICE_ENUM(MyEnum, enum3));
+        test(so.e == Test::MyEnum::enum3);
         test(so.s.s == "a new string");
 
         //
@@ -494,18 +494,18 @@ public:
     void opStringMyEnumD(const Test::StringMyEnumD& ro, const Test::StringMyEnumD& _do)
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         test(_do == di1);
         test(ro.size() == 4);
         test(ro.find("abc") != ro.end());
-        test(ro.find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find("abc")->second == Test::MyEnum::enum1);
         test(ro.find("qwerty") != ro.end());
-        test(ro.find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find("qwerty")->second == Test::MyEnum::enum3);
         test(ro.find("") != ro.end());
-        test(ro.find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find("")->second == Test::MyEnum::enum2);
         test(ro.find("Hello!!") != ro.end());
-        test(ro.find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find("Hello!!")->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -514,20 +514,20 @@ public:
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
         test(_do == di1);
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         test(ro.size() == 4);
         test(ro.find(ms11) != ro.end());
-        test(ro.find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro.find(ms11)->second == Test::MyEnum::enum1);
         test(ro.find(ms12) != ro.end());
-        test(ro.find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(ms12)->second == Test::MyEnum::enum2);
         test(ro.find(ms22) != ro.end());
-        test(ro.find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find(ms22)->second == Test::MyEnum::enum3);
         test(ro.find(ms23) != ro.end());
-        test(ro.find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro.find(ms23)->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -672,32 +672,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find("abc") != ro[0].end());
-        test(ro[0].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[0].find("abc")->second == Test::MyEnum::enum1);
         test(ro[0].find("qwerty") != ro[0].end());
-        test(ro[0].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro[0].find("qwerty")->second == Test::MyEnum::enum3);
         test(ro[0].find("Hello!!") != ro[0].end());
-        test(ro[0].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[0].find("Hello!!")->second == Test::MyEnum::enum2);
         test(ro[1].size() == 2);
         test(ro[1].find("abc") != ro[1].end());
-        test(ro[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[1].find("abc")->second == Test::MyEnum::enum1);
         test(ro[1].find("") != ro[1].end());
-        test(ro[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[1].find("")->second == Test::MyEnum::enum2);
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find("Goodbye") != _do[0].end());
-        test(_do[0].find("Goodbye")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[0].find("Goodbye")->second == Test::MyEnum::enum1);
         test(_do[1].size() == 2);
         test(_do[1].find("abc") != _do[1].end());
-        test(_do[1].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[1].find("abc")->second == Test::MyEnum::enum1);
         test(_do[1].find("") != _do[1].end());
-        test(_do[1].find("")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[1].find("")->second == Test::MyEnum::enum2);
         test(_do[2].size() == 3);
         test(_do[2].find("abc") != _do[2].end());
-        test(_do[2].find("abc")->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[2].find("abc")->second == Test::MyEnum::enum1);
         test(_do[2].find("qwerty") != _do[2].end());
-        test(_do[2].find("qwerty")->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[2].find("qwerty")->second == Test::MyEnum::enum3);
         test(_do[2].find("Hello!!") != _do[2].end());
-        test(_do[2].find("Hello!!")->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[2].find("Hello!!")->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -705,25 +705,25 @@ public:
     {
         test(ro.size() == 2);
         test(ro[0].size() == 2);
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2)) != ro[0].end());
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3)) != ro[0].end());
-        test(ro[0].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
+        test(ro[0].find(Test::MyEnum::enum2) != ro[0].end());
+        test(ro[0].find(Test::MyEnum::enum2)->second == "Hello!!");
+        test(ro[0].find(Test::MyEnum::enum3) != ro[0].end());
+        test(ro[0].find(Test::MyEnum::enum3)->second == "qwerty");
         test(ro[1].size() == 1);
-        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1)) != ro[1].end());
-        test(ro[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
+        test(ro[1].find(Test::MyEnum::enum1) != ro[1].end());
+        test(ro[1].find(Test::MyEnum::enum1)->second == "abc");
         test(_do.size() == 3);
         test(_do[0].size() == 1);
-        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[0].end());
-        test(_do[0].find(Test::ICE_ENUM(MyEnum, enum1))->second == "Goodbye");
+        test(_do[0].find(Test::MyEnum::enum1) != _do[0].end());
+        test(_do[0].find(Test::MyEnum::enum1)->second == "Goodbye");
         test(_do[1].size() == 1);
-        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1)) != _do[1].end());
-        test(_do[1].find(Test::ICE_ENUM(MyEnum, enum1))->second == "abc");
+        test(_do[1].find(Test::MyEnum::enum1) != _do[1].end());
+        test(_do[1].find(Test::MyEnum::enum1)->second == "abc");
         test(_do[2].size() == 2);
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2)) != _do[2].end());
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum2))->second == "Hello!!");
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3)) != _do[2].end());
-        test(_do[2].find(Test::ICE_ENUM(MyEnum, enum3))->second == "qwerty");
+        test(_do[2].find(Test::MyEnum::enum2) != _do[2].end());
+        test(_do[2].find(Test::MyEnum::enum2)->second == "Hello!!");
+        test(_do[2].find(Test::MyEnum::enum3) != _do[2].end());
+        test(_do[2].find(Test::MyEnum::enum3)->second == "qwerty");
         called();
     }
 
@@ -737,32 +737,32 @@ public:
         test(ro.size() == 2);
         test(ro[0].size() == 3);
         test(ro[0].find(ms11) != ro[0].end());
-        test(ro[0].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[0].find(ms11)->second == Test::MyEnum::enum1);
         test(ro[0].find(ms22) != ro[0].end());
-        test(ro[0].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro[0].find(ms22)->second == Test::MyEnum::enum3);
         test(ro[0].find(ms23) != ro[0].end());
-        test(ro[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[0].find(ms23)->second == Test::MyEnum::enum2);
         test(ro[1].size() == 2);
         test(ro[1].find(ms11) != ro[1].end());
-        test(ro[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(ro[1].find(ms11)->second == Test::MyEnum::enum1);
         test(ro[1].find(ms12) != ro[1].end());
-        test(ro[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(ro[1].find(ms12)->second == Test::MyEnum::enum2);
         test(_do.size() == 3);
         test(_do[0].size() == 1);
         test(_do[0].find(ms23) != _do[0].end());
-        test(_do[0].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[0].find(ms23)->second == Test::MyEnum::enum3);
         test(_do[1].size() == 2);
         test(_do[1].find(ms11) != _do[1].end());
-        test(_do[1].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[1].find(ms11)->second == Test::MyEnum::enum1);
         test(_do[1].find(ms12) != _do[1].end());
-        test(_do[1].find(ms12)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[1].find(ms12)->second == Test::MyEnum::enum2);
         test(_do[2].size() == 3);
         test(_do[2].find(ms11) != _do[2].end());
-        test(_do[2].find(ms11)->second == Test::ICE_ENUM(MyEnum, enum1));
+        test(_do[2].find(ms11)->second == Test::MyEnum::enum1);
         test(_do[2].find(ms22) != _do[2].end());
-        test(_do[2].find(ms22)->second == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do[2].find(ms22)->second == Test::MyEnum::enum3);
         test(_do[2].find(ms23) != _do[2].end());
-        test(_do[2].find(ms23)->second == Test::ICE_ENUM(MyEnum, enum2));
+        test(_do[2].find(ms23)->second == Test::MyEnum::enum2);
         called();
     }
 
@@ -955,24 +955,24 @@ public:
     void opMyEnumMyEnumSD(const Test::MyEnumMyEnumSD& ro, const Test::MyEnumMyEnumSD& _do)
     {
         test(_do.size() == 1);
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1)) != _do.end());
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
-        test(_do.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
+        test(_do.find(Test::MyEnum::enum1) != _do.end());
+        test(_do.find(Test::MyEnum::enum1)->second.size() == 2);
+        test(_do.find(Test::MyEnum::enum1)->second[0] == Test::MyEnum::enum3);
+        test(_do.find(Test::MyEnum::enum1)->second[1] == Test::MyEnum::enum3);
         test(ro.size() == 3);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second.size() == 3);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[1] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum3))->second[2] == Test::ICE_ENUM(MyEnum, enum2));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second.size() == 2);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[0] == Test::ICE_ENUM(MyEnum, enum1));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum2))->second[1] == Test::ICE_ENUM(MyEnum, enum2));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1)) != ro.end());
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second.size() == 2);
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[0] == Test::ICE_ENUM(MyEnum, enum3));
-        test(ro.find(Test::ICE_ENUM(MyEnum, enum1))->second[1] == Test::ICE_ENUM(MyEnum, enum3));
+        test(ro.find(Test::MyEnum::enum3) != ro.end());
+        test(ro.find(Test::MyEnum::enum3)->second.size() == 3);
+        test(ro.find(Test::MyEnum::enum3)->second[0] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum3)->second[1] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum3)->second[2] == Test::MyEnum::enum2);
+        test(ro.find(Test::MyEnum::enum2) != ro.end());
+        test(ro.find(Test::MyEnum::enum2)->second.size() == 2);
+        test(ro.find(Test::MyEnum::enum2)->second[0] == Test::MyEnum::enum1);
+        test(ro.find(Test::MyEnum::enum2)->second[1] == Test::MyEnum::enum2);
+        test(ro.find(Test::MyEnum::enum1) != ro.end());
+        test(ro.find(Test::MyEnum::enum1)->second.size() == 2);
+        test(ro.find(Test::MyEnum::enum1)->second[0] == Test::MyEnum::enum3);
+        test(ro.find(Test::MyEnum::enum1)->second[1] == Test::MyEnum::enum3);
         called();
     }
 
@@ -1184,11 +1184,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = Test::ICE_ENUM(MyEnum, enum3);
+        si1.e = Test::MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = Test::ICE_ENUM(MyEnum, enum2);
+        si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
         CallbackPtr cb = make_shared<Callback>(communicator);
@@ -1514,12 +1514,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
 
         CallbackPtr cb = make_shared<Callback>();
         p->opStringMyEnumDAsync(di1, di2,
@@ -1535,15 +1535,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         CallbackPtr cb = make_shared<Callback>();
         p->opMyStructMyEnumDAsync(di1, di2,
@@ -1683,14 +1683,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = Test::MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1713,12 +1713,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[Test::MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[Test::MyEnum::enum2] = "Hello!!";
+        di2[Test::MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[Test::MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -1743,18 +1743,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = Test::MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -2015,17 +2015,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum2);
+        si2.push_back(Test::MyEnum::enum1);
+        si2.push_back(Test::MyEnum::enum2);
+        si3.push_back(Test::MyEnum::enum3);
+        si3.push_back(Test::MyEnum::enum3);
 
-        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[Test::MyEnum::enum3] = si1;
+        sdi1[Test::MyEnum::enum2] = si2;
+        sdi2[Test::MyEnum::enum1] = si3;
 
         CallbackPtr cb = make_shared<Callback>();
         p->opMyEnumMyEnumSDAsync(sdi1, sdi2,
@@ -2519,11 +2519,11 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::Structure si1;
         si1.p = p;
-        si1.e = Test::ICE_ENUM(MyEnum, enum3);
+        si1.e = Test::MyEnum::enum3;
         si1.s.s = "abc";
         Test::Structure si2;
         si2.p = 0;
-        si2.e = Test::ICE_ENUM(MyEnum, enum2);
+        si2.e = Test::MyEnum::enum2;
         si2.s.s = "def";
 
         CallbackPtr cb = make_shared<Callback>(communicator);
@@ -2901,12 +2901,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringMyEnumDAsync(di1, di2);
@@ -2930,15 +2930,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyStructMyEnumDAsync(di1, di2);
@@ -3118,14 +3118,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::StringMyEnumD di1;
-        di1["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[""] = Test::ICE_ENUM(MyEnum, enum2);
+        di1["abc"] = Test::MyEnum::enum1;
+        di1[""] = Test::MyEnum::enum2;
         Test::StringMyEnumD di2;
-        di2["abc"] = Test::ICE_ENUM(MyEnum, enum1);
-        di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
-        di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
+        di2["abc"] = Test::MyEnum::enum1;
+        di2["qwerty"] = Test::MyEnum::enum3;
+        di2["Hello!!"] = Test::MyEnum::enum2;
         Test::StringMyEnumD di3;
-        di3["Goodbye"] = Test::ICE_ENUM(MyEnum, enum1);
+        di3["Goodbye"] = Test::MyEnum::enum1;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3156,12 +3156,12 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi2.resize(1);
 
         Test::MyEnumStringD di1;
-        di1[Test::ICE_ENUM(MyEnum, enum1)] = "abc";
+        di1[Test::MyEnum::enum1] = "abc";
         Test::MyEnumStringD di2;
-        di2[Test::ICE_ENUM(MyEnum, enum2)] = "Hello!!";
-        di2[Test::ICE_ENUM(MyEnum, enum3)] = "qwerty";
+        di2[Test::MyEnum::enum2] = "Hello!!";
+        di2[Test::MyEnum::enum3] = "qwerty";
         Test::MyEnumStringD di3;
-        di3[Test::ICE_ENUM(MyEnum, enum1)] = "Goodbye";
+        di3[Test::MyEnum::enum1] = "Goodbye";
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3194,18 +3194,18 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyStruct ms11 = { 1, 1 };
         Test::MyStruct ms12 = { 1, 2 };
         Test::MyStructMyEnumD di1;
-        di1[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di1[ms12] = Test::ICE_ENUM(MyEnum, enum2);
+        di1[ms11] = Test::MyEnum::enum1;
+        di1[ms12] = Test::MyEnum::enum2;
 
         Test::MyStruct ms22 = { 2, 2 };
         Test::MyStruct ms23 = { 2, 3 };
         Test::MyStructMyEnumD di2;
-        di2[ms11] = Test::ICE_ENUM(MyEnum, enum1);
-        di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
-        di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
+        di2[ms11] = Test::MyEnum::enum1;
+        di2[ms22] = Test::MyEnum::enum3;
+        di2[ms23] = Test::MyEnum::enum2;
 
         Test::MyStructMyEnumD di3;
-        di3[ms23] = Test::ICE_ENUM(MyEnum, enum3);
+        di3[ms23] = Test::MyEnum::enum3;
 
         dsi1[0] = di1;
         dsi1[1] = di2;
@@ -3539,17 +3539,17 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::MyEnumS si2;
         Test::MyEnumS si3;
 
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si1.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum1));
-        si2.push_back(Test::ICE_ENUM(MyEnum, enum2));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
-        si3.push_back(Test::ICE_ENUM(MyEnum, enum3));
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum1);
+        si1.push_back(Test::MyEnum::enum2);
+        si2.push_back(Test::MyEnum::enum1);
+        si2.push_back(Test::MyEnum::enum2);
+        si3.push_back(Test::MyEnum::enum3);
+        si3.push_back(Test::MyEnum::enum3);
 
-        sdi1[Test::ICE_ENUM(MyEnum, enum3)] = si1;
-        sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
-        sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
+        sdi1[Test::MyEnum::enum3] = si1;
+        sdi1[Test::MyEnum::enum2] = si2;
+        sdi2[Test::MyEnum::enum1] = si3;
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyEnumMyEnumSDAsync(sdi1, sdi2);

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -1025,7 +1025,7 @@ private:
 
     Ice::CommunicatorPtr _communicator;
 };
-ICE_DEFINE_PTR(CallbackPtr, Callback);
+using CallbackPtr = std::shared_ptr<Callback>;
 
 }
 
@@ -1049,7 +1049,7 @@ void
 twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& p)
 {
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->ice_pingAsync(
             [&]()
             {
@@ -1060,7 +1060,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->ice_isAAsync(
             Test::MyClass::ice_staticId(),
             [&](bool v)
@@ -1072,7 +1072,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->ice_idAsync(
             [&](string id)
             {
@@ -1083,7 +1083,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->ice_idsAsync(
             [&](vector<string> ids)
             {
@@ -1094,7 +1094,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opVoidAsync(
             [&]()
             {
@@ -1105,7 +1105,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
             [&](Ice::Byte b1, Ice::Byte b2)
             {
@@ -1116,7 +1116,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opBoolAsync(true, false,
             [&](bool b1, bool b2)
             {
@@ -1127,7 +1127,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortIntLongAsync(10, 11, 12,
             [&](long long int l1, short s1P, int i1, long long int l2)
             {
@@ -1138,7 +1138,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opFloatDoubleAsync(3.14f, 1.1E10,
             [&](double d1, float f1, double d2)
             {
@@ -1149,7 +1149,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringAsync("hello", "world",
             [&](string s1P, string s2P)
             {
@@ -1160,7 +1160,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opMyEnumAsync(Test::MyEnum::enum2,
                          [&](Test::MyEnum e1, Test::MyEnum e2)
             {
@@ -1171,7 +1171,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = make_shared<Callback>(communicator);
         p->opMyClassAsync(p,
                           [&](shared_ptr<Test::MyClassPrx> c1, shared_ptr<Test::MyClassPrx> c2, shared_ptr<Test::MyClassPrx> c3)
             {
@@ -1191,7 +1191,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         si2.e = Test::ICE_ENUM(MyEnum, enum2);
         si2.s.s = "def";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = make_shared<Callback>(communicator);
         p->opStructAsync(si1, si2,
             [&](Test::Structure si3, Test::Structure si4)
             {
@@ -1215,7 +1215,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2.push_back(Ice::Byte(0xf3));
         bsi2.push_back(Ice::Byte(0xf4));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteSAsync(bsi1, bsi2,
             [&](Test::ByteS bsi3, Test::ByteS bsi4)
             {
@@ -1235,7 +1235,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         bsi2.push_back(false);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opBoolSAsync(bsi1, bsi2,
             [&](Test::BoolS bsi3, Test::BoolS bsi4)
             {
@@ -1263,7 +1263,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi.push_back(30);
         lsi.push_back(20);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortIntLongSAsync(ssi, isi, lsi,
             [&](Test::LongS lsi1, Test::ShortS ssi1, Test::IntS isi1, Test::LongS lsi2)
             {
@@ -1284,7 +1284,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi.push_back(Ice::Double(1.2E10));
         dsi.push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opFloatDoubleSAsync(fsi, dsi,
             [&](Test::DoubleS dsi1, Test::FloatS fsi1, Test::DoubleS dsi2)
             {
@@ -1304,7 +1304,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2.push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringSAsync(ssi1, ssi2,
             [&](Test::StringS ssi3, Test::StringS ssi4)
             {
@@ -1329,7 +1329,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[1].push_back(Ice::Byte(0xf2));
         bsi2[1].push_back(Ice::Byte(0xf1));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteSSAsync(bsi1, bsi2,
             [&](Test::ByteSS bsi3, Test::ByteSS bsi4)
             {
@@ -1354,7 +1354,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[0].push_back(false);
         bsi2[0].push_back(true);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opBoolSSAsync(bsi1, bsi2,
             [&](Test::BoolSS bsi3, Test::BoolSS bsi4)
             {
@@ -1381,7 +1381,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi[0].push_back(496);
         lsi[0].push_back(1729);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortIntLongSSAsync(ssi, isi, lsi,
             [&](Test::LongSS lsi1, Test::ShortSS ssi1, Test::IntSS isi1, Test::LongSS lsi2)
             {
@@ -1404,7 +1404,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi[0].push_back(Ice::Double(1.2E10));
         dsi[0].push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opFloatDoubleSSAsync(fsi, dsi,
             [&](Test::DoubleSS dsi1, Test::FloatSS fsi1, Test::DoubleSS dsi2)
             {
@@ -1426,7 +1426,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2[2].push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringSSAsync(ssi1, ssi2,
             [&](Test::StringSS ssi3, Test::StringSS ssi4)
             {
@@ -1445,7 +1445,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[11] = false;
         di2[101] = true;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteBoolDAsync(di1, di2,
             [&](Test::ByteBoolD di3, Test::ByteBoolD di4)
             {
@@ -1464,7 +1464,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[111] = -100;
         di2[1101] = 0;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortIntDAsync(di1, di2,
             [&](Test::ShortIntD di3, Test::ShortIntD di4)
             {
@@ -1483,7 +1483,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[999999120] = Ice::Float(-100.4);
         di2[999999130] = Ice::Float(0.5);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opLongFloatDAsync(di1, di2,
             [&](Test::LongFloatD di3, Test::LongFloatD di4)
             {
@@ -1502,7 +1502,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["FOO"] = "abc -100.4";
         di2["BAR"] = "abc 0.5";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringStringDAsync(di1, di2,
             [&](Test::StringStringD di3, Test::StringStringD di4)
             {
@@ -1521,7 +1521,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
         di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringMyEnumDAsync(di1, di2,
             [&](Test::StringMyEnumD di3, Test::StringMyEnumD di4)
             {
@@ -1545,7 +1545,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
         di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opMyStructMyEnumDAsync(di1, di2,
             [&](Test::MyStructMyEnumD di3, Test::MyStructMyEnumD di4)
             {
@@ -1576,7 +1576,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteBoolDSAsync(dsi1, dsi2,
             [&](Test::ByteBoolDS dsi3, Test::ByteBoolDS dsi4)
             {
@@ -1606,7 +1606,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortIntDSAsync(dsi1, dsi2,
             [&](Test::ShortIntDS dsi3, Test::ShortIntDS dsi4)
             {
@@ -1636,7 +1636,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opLongFloatDSAsync(dsi1, dsi2,
             [&](Test::LongFloatDS dsi3, Test::LongFloatDS dsi4)
             {
@@ -1666,7 +1666,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringStringDSAsync(dsi1, dsi2,
             [&](Test::StringStringDS dsi3, Test::StringStringDS dsi4)
             {
@@ -1696,7 +1696,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringMyEnumDSAsync(dsi1, dsi2,
             [&](Test::StringMyEnumDS dsi3, Test::StringMyEnumDS dsi4)
             {
@@ -1724,7 +1724,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opMyEnumStringDSAsync(dsi1, dsi2,
             [&](Test::MyEnumStringDS dsi3, Test::MyEnumStringDS dsi4)
             {
@@ -1760,7 +1760,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opMyStructMyEnumDSAsync(dsi1, dsi2,
                                    [&](Test::MyStructMyEnumDS dsi3, Test::MyStructMyEnumDS dsi4)
             {
@@ -1788,7 +1788,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Ice::Byte(0x22)] = si2;
         sdi2[Ice::Byte(0xf1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opByteByteSDAsync(sdi1, sdi2,
             [&](Test::ByteByteSD sdi3, Test::ByteByteSD sdi4)
             {
@@ -1815,7 +1815,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[true] = si2;
         sdi2[false] = si1;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opBoolBoolSDAsync(sdi1, sdi2,
             [&](Test::BoolBoolSD sdi3, Test::BoolBoolSD sdi4)
             {
@@ -1845,7 +1845,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[2] = si2;
         sdi2[4] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opShortShortSDAsync(sdi1, sdi2,
             [&](Test::ShortShortSD sdi3, Test::ShortShortSD sdi4)
             {
@@ -1875,7 +1875,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[200] = si2;
         sdi2[400] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opIntIntSDAsync(sdi1, sdi2,
             [&](Test::IntIntSD sdi3, Test::IntIntSD sdi4)
             {
@@ -1905,7 +1905,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[999999991] = si2;
         sdi2[999999992] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opLongLongSDAsync(sdi1, sdi2,
             [&](Test::LongLongSD sdi3, Test::LongLongSD sdi4)
             {
@@ -1935,7 +1935,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["ABC"] = si2;
         sdi2["aBc"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringFloatSDAsync(sdi1, sdi2,
             [&](Test::StringFloatSD sdi3, Test::StringFloatSD sdi4)
             {
@@ -1965,7 +1965,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["Goodbye"] = si2;
         sdi2[""] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringDoubleSDAsync(sdi1, sdi2,
             [&](Test::StringDoubleSD sdi3, Test::StringDoubleSD sdi4)
             {
@@ -1997,7 +1997,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["def"] = si2;
         sdi2["ghi"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opStringStringSDAsync(sdi1, sdi2,
             [&](Test::StringStringSD sdi3, Test::StringStringSD sdi4)
             {
@@ -2027,7 +2027,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
         sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opMyEnumMyEnumSDAsync(sdi1, sdi2,
             [&](Test::MyEnumMyEnumSD sdi3, Test::MyEnumMyEnumSD sdi4)
             {
@@ -2047,7 +2047,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
             {
                 s.push_back(i);
             }
-            CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+            CallbackPtr cb = make_shared<Callback>();
             p->opIntSAsync(s,
                 [&](Test::IntS s1P)
                 {
@@ -2245,7 +2245,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Ice::Double d = 1278312346.0 / 13.0;
         Test::DoubleS ds(5, d);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opDoubleMarshalingAsync(d, ds,
             [&]()
             {
@@ -2256,7 +2256,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opIdempotentAsync(
             [&]()
             {
@@ -2267,7 +2267,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         p->opNonmutatingAsync(
             [&]()
             {
@@ -2280,7 +2280,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::MyDerivedClassPrxPtr derived = ICE_CHECKED_CAST(Test::MyDerivedClassPrx, p);
         test(derived);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         derived->opDerivedAsync(
             [&]()
             {
@@ -2291,7 +2291,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->ice_pingAsync();
         try
         {
@@ -2311,7 +2311,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->ice_isAAsync(Test::MyClass::ice_staticId());
         try
         {
@@ -2329,7 +2329,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->ice_idAsync();
         try
         {
@@ -2347,7 +2347,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->ice_idsAsync();
         try
         {
@@ -2365,7 +2365,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opVoidAsync();
         try
         {
@@ -2384,7 +2384,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f));
         try
         {
@@ -2403,7 +2403,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opBoolAsync(true, false);
         try
         {
@@ -2422,7 +2422,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opShortIntLongAsync(10, 11, 12);
         try
         {
@@ -2441,7 +2441,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opFloatDoubleAsync(3.14f, 1.1E10);
         try
         {
@@ -2460,7 +2460,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringAsync("hello", "world");
         try
         {
@@ -2479,7 +2479,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyEnumAsync(Test::MyEnum::enum2);
         try
         {
@@ -2498,7 +2498,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = make_shared<Callback>(communicator);
         auto f = p->opMyClassAsync(p);
         try
         {
@@ -2526,7 +2526,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         si2.e = Test::ICE_ENUM(MyEnum, enum2);
         si2.s.s = "def";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback, communicator);
+        CallbackPtr cb = make_shared<Callback>(communicator);
         auto f = p->opStructAsync(si1, si2);
         try
         {
@@ -2558,7 +2558,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2.push_back(Ice::Byte(0xf3));
         bsi2.push_back(Ice::Byte(0xf4));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteSAsync(bsi1, bsi2);
         try
         {
@@ -2586,7 +2586,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         bsi2.push_back(false);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opBoolSAsync(bsi1, bsi2);
         try
         {
@@ -2622,7 +2622,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         lsi.push_back(30);
         lsi.push_back(20);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opShortIntLongSAsync(ssi, isi, lsi);
         try
         {
@@ -2651,7 +2651,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi.push_back(Ice::Double(1.2E10));
         dsi.push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opFloatDoubleSAsync(fsi, dsi);
         try
         {
@@ -2679,7 +2679,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2.push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringSAsync(ssi1, ssi2);
         try
         {
@@ -2712,7 +2712,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         bsi2[1].push_back(Ice::Byte(0xf2));
         bsi2[1].push_back(Ice::Byte(0xf1));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteSSAsync(bsi1, bsi2);
         try
         {
@@ -2743,7 +2743,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi[0].push_back(Ice::Double(1.2E10));
         dsi[0].push_back(Ice::Double(1.3E10));
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opFloatDoubleSSAsync(fsi, dsi);
         try
         {
@@ -2773,7 +2773,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
         ssi2[2].push_back("xyz");
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringSSAsync(ssi1, ssi2);
         try
         {
@@ -2800,7 +2800,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[11] = false;
         di2[101] = true;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteBoolDAsync(di1, di2);
         try
         {
@@ -2827,7 +2827,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[111] = -100;
         di2[1101] = 0;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opShortIntDAsync(di1, di2);
         try
         {
@@ -2854,7 +2854,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[999999120] = Ice::Float(-100.4);
         di2[999999130] = Ice::Float(0.5);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opLongFloatDAsync(di1, di2);
         try
         {
@@ -2881,7 +2881,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["FOO"] = "abc -100.4";
         di2["BAR"] = "abc 0.5";
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringStringDAsync(di1, di2);
         try
         {
@@ -2908,7 +2908,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2["qwerty"] = Test::ICE_ENUM(MyEnum, enum3);
         di2["Hello!!"] = Test::ICE_ENUM(MyEnum, enum2);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringMyEnumDAsync(di1, di2);
         try
         {
@@ -2940,7 +2940,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         di2[ms22] = Test::ICE_ENUM(MyEnum, enum3);
         di2[ms23] = Test::ICE_ENUM(MyEnum, enum2);
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyStructMyEnumDAsync(di1, di2);
         try
         {
@@ -2979,7 +2979,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteBoolDSAsync(dsi1, dsi2);
         try
         {
@@ -3017,7 +3017,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opShortIntDSAsync(dsi1, dsi2);
         try
         {
@@ -3055,7 +3055,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opLongFloatDSAsync(dsi1, dsi2);
         try
         {
@@ -3093,7 +3093,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringStringDSAsync(dsi1, dsi2);
         try
         {
@@ -3131,7 +3131,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringMyEnumDSAsync(dsi1, dsi2);
         try
         {
@@ -3167,7 +3167,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyEnumStringDSAsync(dsi1, dsi2);
         try
         {
@@ -3211,7 +3211,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         dsi1[1] = di2;
         dsi2[0] = di3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyStructMyEnumDSAsync(dsi1, dsi2);
         try
         {
@@ -3247,7 +3247,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Ice::Byte(0x22)] = si2;
         sdi2[Ice::Byte(0xf1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteByteSDAsync(sdi1, sdi2);
         try
         {
@@ -3282,7 +3282,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[true] = si2;
         sdi2[false] = si1;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opBoolBoolSDAsync(sdi1, sdi2);
         try
         {
@@ -3320,7 +3320,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[2] = si2;
         sdi2[4] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opShortShortSDAsync(sdi1, sdi2);
         try
         {
@@ -3358,7 +3358,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[200] = si2;
         sdi2[400] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opIntIntSDAsync(sdi1, sdi2);
         try
         {
@@ -3396,7 +3396,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[999999991] = si2;
         sdi2[999999992] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opLongLongSDAsync(sdi1, sdi2);
         try
         {
@@ -3434,7 +3434,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["ABC"] = si2;
         sdi2["aBc"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringFloatSDAsync(sdi1, sdi2);
         try
         {
@@ -3472,7 +3472,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["Goodbye"] = si2;
         sdi2[""] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringDoubleSDAsync(sdi1, sdi2);
         try
         {
@@ -3512,7 +3512,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1["def"] = si2;
         sdi2["ghi"] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opStringStringSDAsync(sdi1, sdi2);
         try
         {
@@ -3551,7 +3551,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         sdi1[Test::ICE_ENUM(MyEnum, enum2)] = si2;
         sdi2[Test::ICE_ENUM(MyEnum, enum1)] = si3;
 
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opMyEnumMyEnumSDAsync(sdi1, sdi2);
         try
         {
@@ -3579,7 +3579,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
             {
                 s.push_back(i);
             }
-            CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+            CallbackPtr cb = make_shared<Callback>();
             auto f = p->opIntSAsync(s);
             try
             {
@@ -3600,7 +3600,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Ice::Double d = 1278312346.0 / 13.0;
         Test::DoubleS ds(5, d);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opDoubleMarshalingAsync(d, ds);
         try
         {
@@ -3619,7 +3619,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opIdempotentAsync();
         try
         {
@@ -3638,7 +3638,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     }
 
     {
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = p->opNonmutatingAsync();
         try
         {
@@ -3659,7 +3659,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         Test::MyDerivedClassPrxPtr derived = ICE_CHECKED_CAST(Test::MyDerivedClassPrx, p);
         test(derived);
-        CallbackPtr cb = ICE_MAKE_SHARED(Callback);
+        CallbackPtr cb = make_shared<Callback>();
         auto f = derived->opDerivedAsync();
         try
         {

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -134,7 +134,7 @@ public:
         o->push_back("test3");
         o->push_back("test4");
         out->write(1, o);
-        APtr a = ICE_MAKE_SHARED(A);
+        APtr a = make_shared<A>();
         a->mc = 18;
         out->write(1000, IceUtil::Optional<APtr>(a));
         out->endSlice();
@@ -217,7 +217,7 @@ public:
 
     virtual void _iceRead(Ice::InputStream* in)
     {
-        _f = ICE_MAKE_SHARED(F);
+        _f = make_shared<F>();
         in->startValue();
         in->startSlice();
         // Don't read af on purpose
@@ -330,24 +330,24 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing constructor, copy constructor, and assignment operator... " << flush;
 
-    OneOptionalPtr oo1 = ICE_MAKE_SHARED(OneOptional);
+    OneOptionalPtr oo1 = make_shared<OneOptional>();
     test(!oo1->a);
     oo1->a = 15;
     test(oo1->a && *oo1->a == 15);
 
-    OneOptionalPtr oo2 = ICE_MAKE_SHARED(OneOptional, 16);
+    OneOptionalPtr oo2 = make_shared<OneOptional>(16);
     test(oo2->a && *oo2->a == 16);
 
-    OneOptionalPtr oo3 = ICE_MAKE_SHARED(OneOptional, *oo2);
+    OneOptionalPtr oo3 = make_shared<OneOptional>(*oo2);
     test(oo3->a && *oo3->a == 16);
 
     *oo3 = *oo1;
     test(oo3->a && *oo3->a == 15);
 
-    OneOptionalPtr oon = ICE_MAKE_SHARED(OneOptional, IceUtil::None);
+    OneOptionalPtr oon = make_shared<OneOptional>(IceUtil::None);
     test(!oon->a);
 
-    MultiOptionalPtr mo1 = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mo1 = make_shared<MultiOptional>();
     mo1->a = static_cast<Ice::Byte>(15);
     mo1->b = true;
     mo1->c = static_cast<Ice::Short>(19);
@@ -396,7 +396,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->ivsd = IntVarStructDict();
     mo1->ivsd.value()[5] = vs;
     mo1->iood = IntOneOptionalDict();
-    mo1->iood.value()[5] = ICE_MAKE_SHARED(OneOptional);
+    mo1->iood.value()[5] = make_shared<OneOptional>();
     mo1->iood.value()[5]->a = 15;
     mo1->imipd = IntMyInterfacePrxDict();
     mo1->imipd.value()[5] = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test"));
@@ -406,9 +406,9 @@ allTests(Test::TestHelper* helper, bool)
     mo1->bos->push_back(true);
     mo1->bos->push_back(false);
 
-    MultiOptionalPtr mo2 = ICE_MAKE_SHARED(MultiOptional, *mo1);
+    MultiOptionalPtr mo2 = make_shared<MultiOptional>(*mo1);
 
-    MultiOptionalPtr mo3 = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mo3 = make_shared<MultiOptional>();
     *mo3 = *mo2;
 
     test(mo3->a == static_cast<Ice::Byte>(15));
@@ -465,13 +465,13 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing marshalling... " << flush;
-    OneOptionalPtr oo4 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(ICE_MAKE_SHARED(OneOptional)));
+    OneOptionalPtr oo4 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(make_shared<OneOptional>()));
     test(!oo4->a);
 
     OneOptionalPtr oo5 = ICE_DYNAMIC_CAST(OneOptional, initial->pingPong(oo1));
     test(oo1->a == oo5->a);
 
-    MultiOptionalPtr mo4 = ICE_DYNAMIC_CAST(MultiOptional, initial->pingPong(ICE_MAKE_SHARED(MultiOptional)));
+    MultiOptionalPtr mo4 = ICE_DYNAMIC_CAST(MultiOptional, initial->pingPong(make_shared<MultiOptional>()));
     test(!mo4->a);
     test(!mo4->b);
     test(!mo4->c);
@@ -552,7 +552,7 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->bos == mo1->bos);
 
     // Clear the first half of the optional parameters
-    MultiOptionalPtr mo6 = ICE_MAKE_SHARED(MultiOptional, *mo5);
+    MultiOptionalPtr mo6 = make_shared<MultiOptional>(*mo5);
     mo6->a = IceUtil::None;
     mo6->c = IceUtil::None;
     mo6->e = IceUtil::None;
@@ -604,7 +604,7 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->imipd);
 
     // Clear the second half of the optional parameters
-    MultiOptionalPtr mo8 = ICE_MAKE_SHARED(MultiOptional, *mo5);
+    MultiOptionalPtr mo8 = make_shared<MultiOptional>(*mo5);
     mo8->b = IceUtil::None;
     mo8->d = IceUtil::None;
     mo8->f = IceUtil::None;
@@ -711,7 +711,7 @@ allTests(Test::TestHelper* helper, bool)
     //
     // Use the 1.0 encoding with operations whose only class parameters are optional.
     //
-    IceUtil::Optional<OneOptionalPtr> oo(ICE_MAKE_SHARED(OneOptional, 53));
+    IceUtil::Optional<OneOptionalPtr> oo(make_shared<OneOptional>(53));
     initial->sendOptionalClass(true, oo);
     initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalClass(true, oo);
 
@@ -721,19 +721,19 @@ allTests(Test::TestHelper* helper, bool)
     test(!oo);
 
     RecursiveSeq recursive1;
-    recursive1.push_back(ICE_MAKE_SHARED(Recursive));
+    recursive1.push_back(make_shared<Recursive>());
     RecursiveSeq recursive2;
-    recursive2.push_back(ICE_MAKE_SHARED(Recursive));
+    recursive2.push_back(make_shared<Recursive>());
     recursive1[0]->value = recursive2;
-    RecursivePtr outer = ICE_MAKE_SHARED(Recursive);
+    RecursivePtr outer = make_shared<Recursive>();
     outer->value = recursive1;
     initial->pingPong(outer);
 
-    GPtr g = ICE_MAKE_SHARED(G);
-    g->gg1Opt = ICE_MAKE_SHARED(G1, "gg1Opt");
-    g->gg2 = ICE_MAKE_SHARED(G2, 10);
-    g->gg2Opt = ICE_MAKE_SHARED(G2, 20);
-    g->gg1 = ICE_MAKE_SHARED(G1, "gg1");
+    GPtr g = make_shared<G>();
+    g->gg1Opt = make_shared<G1>("gg1Opt");
+    g->gg2 = make_shared<G2>(10);
+    g->gg2Opt = make_shared<G2>(20);
+    g->gg1 = make_shared<G1>("gg1");
     GPtr r = initial->opG(g);
     test("gg1Opt" == r->gg1Opt.value()->a);
     test(10 == r->gg2->a);
@@ -755,7 +755,7 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing marshalling of large containers with fixed size elements..." << flush;
-    MultiOptionalPtr mc = ICE_MAKE_SHARED(MultiOptional);
+    MultiOptionalPtr mc = make_shared<MultiOptional>();
 
     ByteSeq byteSeq;
     byteSeq.resize(1000);
@@ -803,7 +803,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing tag marshalling... " << flush;
     {
-        BPtr b = ICE_MAKE_SHARED(B);
+        BPtr b = make_shared<B>();
         BPtr b2 = ICE_DYNAMIC_CAST(B, initial->pingPong(b));
         test(!b2->ma);
         test(!b2->mb);
@@ -840,9 +840,9 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing marshalling of objects with optional objects..." << flush;
     {
-        FPtr f = ICE_MAKE_SHARED(F);
+        FPtr f = make_shared<F>();
 
-        f->af = ICE_MAKE_SHARED(A);
+        f->af = make_shared<A>();
         f->ae = *f->af;
 
         FPtr rf = ICE_DYNAMIC_CAST(F, initial->pingPong(f));
@@ -867,7 +867,7 @@ allTests(Test::TestHelper* helper, bool)
     cout << "ok" << endl;
 
     cout << "testing optional with default values... " << flush;
-    WDPtr wd = ICE_DYNAMIC_CAST(WD, initial->pingPong(ICE_MAKE_SHARED(WD)));
+    WDPtr wd = ICE_DYNAMIC_CAST(WD, initial->pingPong(make_shared<WD>()));
     test(*wd->a == 5);
     test(*wd->s == "test");
     wd->a = IceUtil::None;
@@ -881,7 +881,7 @@ allTests(Test::TestHelper* helper, bool)
     {
         cout << "testing marshalling with unknown class slices... " << flush;
         {
-            CPtr c = ICE_MAKE_SHARED(C);
+            CPtr c = make_shared<C>();
             c->ss = "test";
             c->ms = string("testms");
 
@@ -906,7 +906,7 @@ allTests(Test::TestHelper* helper, bool)
                 factory->setEnabled(true);
                 Ice::OutputStream out(communicator);
                 out.startEncapsulation();
-                Ice::ValuePtr d = ICE_MAKE_SHARED(DObjectWriter);
+                Ice::ValuePtr d = make_shared<DObjectWriter>();
                 out.write(d);
                 out.endEncapsulation();
                 out.finished(inEncaps);
@@ -925,7 +925,7 @@ allTests(Test::TestHelper* helper, bool)
 
         cout << "testing optionals with unknown classes..." << flush;
         {
-            APtr a = ICE_MAKE_SHARED(A);
+            APtr a = make_shared<A>();
 
             Ice::OutputStream out(communicator);
             out.startEncapsulation();
@@ -1342,10 +1342,10 @@ allTests(Test::TestHelper* helper, bool)
         if(initial->supportsNullOptional())
         {
             p2 = initial->opOneOptional(OneOptionalPtr(), p3);
-            test(*p2 == ICE_NULLPTR && *p3 == ICE_NULLPTR);
+            test(*p2 == nullptr && *p3 == nullptr);
         }
 
-        p1 = ICE_MAKE_SHARED(OneOptional, 58);
+        p1 = make_shared<OneOptional>(58);
         p2 = initial->opOneOptional(p1, p3);
         test((*p2)->a == 58 && (*p3)->a == 58);
 
@@ -1398,8 +1398,8 @@ allTests(Test::TestHelper* helper, bool)
     }
 
     {
-        FPtr f = ICE_MAKE_SHARED(F);
-        f->af = ICE_MAKE_SHARED(A);
+        FPtr f = make_shared<F>();
+        f->af = make_shared<A>();
         (*f->af)->requiredA = 56;
         f->ae = *f->af;
 
@@ -1755,7 +1755,7 @@ allTests(Test::TestHelper* helper, bool)
         test(!p2 && !p3);
 
         IntOneOptionalDict ss;
-        ss.insert(make_pair<int, OneOptionalPtr>(1, ICE_MAKE_SHARED(OneOptional, 58)));
+        ss.insert(make_pair<int, OneOptionalPtr>(1, make_shared<OneOptional>(58)));
         p1 = ss;
         p2 = initial->opIntOneOptionalDict(p1, p3);
         test(p2 && p3);
@@ -1836,7 +1836,7 @@ allTests(Test::TestHelper* helper, bool)
 
         try
         {
-            initial->opOptionalException(30, string("test"), ICE_MAKE_SHARED(OneOptional, 53));
+            initial->opOptionalException(30, string("test"), make_shared<OneOptional>(53));
             test(false);
         }
         catch(const OptionalException& ex)
@@ -1852,7 +1852,7 @@ allTests(Test::TestHelper* helper, bool)
             // Use the 1.0 encoding with an exception whose only class members are optional.
             //
             initial->ice_encodingVersion(Ice::Encoding_1_0)->
-                opOptionalException(30, string("test"), ICE_MAKE_SHARED(OneOptional, 53));
+                opOptionalException(30, string("test"), make_shared<OneOptional>(53));
             test(false);
         }
         catch(const OptionalException& ex)
@@ -1889,7 +1889,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             IceUtil::Optional<Ice::Int> a = 30;
             IceUtil::Optional<string> b = string("test2");
-            IceUtil::Optional<OneOptionalPtr> o = ICE_MAKE_SHARED(OneOptional, 53);
+            IceUtil::Optional<OneOptionalPtr> o = make_shared<OneOptional>(53);
             initial->opDerivedException(a, b, o);
             test(false);
         }
@@ -1933,7 +1933,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             IceUtil::Optional<Ice::Int> a = 30;
             IceUtil::Optional<string> b = string("test2");
-            IceUtil::Optional<OneOptionalPtr> o = ICE_MAKE_SHARED(OneOptional, 53);
+            IceUtil::Optional<OneOptionalPtr> o = make_shared<OneOptional>(53);
             initial->opRequiredException(a, b, o);
             test(false);
         }
@@ -1995,7 +1995,7 @@ allTests(Test::TestHelper* helper, bool)
             p3 = initial->opMG2(IceUtil::None, p2);
             test(!p2 && !p3);
 
-            p1 = ICE_MAKE_SHARED(Test::G);
+            p1 = make_shared<Test::G>();
             p3 = initial->opMG2(p1, p2);
             test(p2 && p3 && *p3 == *p2);
         }

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -356,7 +356,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->f = 5.5f;
     mo1->g = 1.0;
     mo1->h = string("test");
-    mo1->i = ICE_ENUM(MyEnum, MyEnumMember);
+    mo1->i = MyEnum::MyEnumMember;
     mo1->j = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test"));
     mo1->k = mo1;
     mo1->bs = ByteSeq();
@@ -378,8 +378,8 @@ allTests(Test::TestHelper* helper, bool)
     mo1->shs = ShortSeq();
     mo1->shs->push_back(1);
     mo1->es = MyEnumSeq();
-    mo1->es->push_back(ICE_ENUM(MyEnum, MyEnumMember));
-    mo1->es->push_back(ICE_ENUM(MyEnum, MyEnumMember));
+    mo1->es->push_back(MyEnum::MyEnumMember);
+    mo1->es->push_back(MyEnum::MyEnumMember);
     mo1->fss = FixedStructSeq();
     mo1->fss->push_back(fs);
     mo1->vss = VarStructSeq();
@@ -390,7 +390,7 @@ allTests(Test::TestHelper* helper, bool)
     mo1->mips->push_back(ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test")));
 
     mo1->ied = IntEnumDict();
-    mo1->ied.value()[4] = ICE_ENUM(MyEnum, MyEnumMember);
+    mo1->ied.value()[4] = MyEnum::MyEnumMember;
     mo1->ifsd = IntFixedStructDict();
     mo1->ifsd.value()[4] = fs;
     mo1->ivsd = IntVarStructDict();
@@ -419,7 +419,7 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->f == 5.5f);
     test(mo3->g == 1.0);
     test(mo3->h == string("test"));
-    test(mo3->i = ICE_ENUM(MyEnum, MyEnumMember));
+    test(mo3->i = MyEnum::MyEnumMember);
     test(mo3->j = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test")));
     test(mo3->k == mo1);
     test(mo3->bs == mo1->bs);
@@ -673,7 +673,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(oo1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -688,7 +688,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(mo1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -749,7 +749,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, IceUtil::Optional<string>("test"));
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("opVoid", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("opVoid", Ice::OperationMode::Normal, inEncaps, outEncaps));
     }
 
     cout << "ok" << endl;
@@ -789,7 +789,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(mc);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -826,7 +826,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(b);
         out.endEncapsulation();
         out.finished(inEncaps);
-        test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+        test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         Ice::ValuePtr obj;
@@ -892,7 +892,7 @@ allTests(Test::TestHelper* helper, bool)
                 out.endEncapsulation();
                 out.finished(inEncaps);
                 factory->setEnabled(true);
-                test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+                test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
                 Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
                 in.startEncapsulation();
                 Ice::ValuePtr obj;
@@ -910,7 +910,7 @@ allTests(Test::TestHelper* helper, bool)
                 out.write(d);
                 out.endEncapsulation();
                 out.finished(inEncaps);
-                test(initial->ice_invoke("pingPong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+                test(initial->ice_invoke("pingPong", Ice::OperationMode::Normal, inEncaps, outEncaps));
                 Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
                 in.startEncapsulation();
                 Ice::ValuePtr obj;
@@ -933,7 +933,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(1, Ice::make_optional(make_shared<DObjectWriter>()));
             out.endEncapsulation();
             out.finished(inEncaps);
-            test(initial->ice_invoke("opClassAndUnknownOptional", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps));
+            test(initial->ice_invoke("opClassAndUnknownOptional", Ice::OperationMode::Normal, inEncaps, outEncaps));
 
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
@@ -960,7 +960,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opByte", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opByte", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -992,7 +992,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opBool", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opBool", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1022,7 +1022,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opShort", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opShort", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1052,7 +1052,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opInt", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opInt", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1082,7 +1082,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(1, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opLong", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opLong", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(2, p3);
@@ -1112,7 +1112,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFloat", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFloat", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1142,7 +1142,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opDouble", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opDouble", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1172,7 +1172,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opString", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1204,7 +1204,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(2, p1);
             out.endEncapsulation();
             out.finished(inEncaps);
-            initial->ice_invoke("opCustomString", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+            initial->ice_invoke("opCustomString", Ice::OperationMode::Normal, inEncaps, outEncaps);
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
             in.read(1, p2);
@@ -1224,22 +1224,22 @@ allTests(Test::TestHelper* helper, bool)
         IceUtil::Optional<Test::MyEnum> p2 = initial->opMyEnum(p1, p3);
         test(!p2 && !p3);
 
-        p1 = ICE_ENUM(MyEnum, MyEnumMember);
+        p1 = MyEnum::MyEnumMember;
         p2 = initial->opMyEnum(p1, p3);
-        test(p2 == ICE_ENUM(MyEnum, MyEnumMember) && p3 == ICE_ENUM(MyEnum, MyEnumMember));
+        test(p2 == MyEnum::MyEnumMember && p3 == MyEnum::MyEnumMember);
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opMyEnum", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opMyEnum", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
         in.read(3, p3);
         in.endEncapsulation();
-        test(p2 == ICE_ENUM(MyEnum, MyEnumMember) && p3 == ICE_ENUM(MyEnum, MyEnumMember));
+        test(p2 == MyEnum::MyEnumMember && p3 == MyEnum::MyEnumMember);
 
         Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
         in2.startEncapsulation();
@@ -1262,7 +1262,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opSmallStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opSmallStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1291,7 +1291,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFixedStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFixedStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1320,7 +1320,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opVarStruct", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opVarStruct", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1354,7 +1354,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opOneOptional", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opOneOptional", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1383,7 +1383,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opMyInterfaceProxy", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opMyInterfaceProxy", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1438,7 +1438,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opByteSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opByteSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1470,7 +1470,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opBoolSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opBoolSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1501,7 +1501,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opShortSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opShortSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1532,7 +1532,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1563,7 +1563,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opLongSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opLongSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1594,7 +1594,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFloatSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFloatSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1625,7 +1625,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opDoubleSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opDoubleSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1671,7 +1671,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opFixedStructSeq", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opFixedStructSeq", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1704,7 +1704,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntIntDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntIntDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1735,7 +1735,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opStringIntDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opStringIntDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1766,7 +1766,7 @@ allTests(Test::TestHelper* helper, bool)
         out.write(2, p1);
         out.endEncapsulation();
         out.finished(inEncaps);
-        initial->ice_invoke("opIntOneOptionalDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        initial->ice_invoke("opIntOneOptionalDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
         in.read(1, p2);
@@ -1801,7 +1801,7 @@ allTests(Test::TestHelper* helper, bool)
             out.write(2, p1);
             out.endEncapsulation();
             out.finished(inEncaps);
-            initial->ice_invoke("opCustomIntStringDict", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+            initial->ice_invoke("opCustomIntStringDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
             in.startEncapsulation();
             in.read(1, p2);

--- a/cpp/test/Ice/optional/Server.cpp
+++ b/cpp/test/Ice/optional/Server.cpp
@@ -24,7 +24,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<InitialI>(), Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/optional/ServerAMD.cpp
+++ b/cpp/test/Ice/optional/ServerAMD.cpp
@@ -23,7 +23,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(InitialI), Ice::stringToIdentity("initial"));
+    adapter->add(std::make_shared<InitialI>(), Ice::stringToIdentity("initial"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -431,7 +431,7 @@ InitialI::opMG1Async(function<void(const OpMG1MarshaledResult&)> response,
                      function<void(exception_ptr)>,
                      const Ice::Current& current)
 {
-    response(OpMG1MarshaledResult(ICE_MAKE_SHARED(G), current));
+    response(OpMG1MarshaledResult(std::make_shared<G>(), current));
 }
 
 void

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -33,9 +33,9 @@ InitialI::pingPong(shared_ptr<Value> obj, const Current& current)
 }
 
 void
-InitialI::opOptionalException(ICE_IN(Optional<Int>) a,
-                              ICE_IN(Optional<string>) b,
-                              ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opOptionalException(Optional<Int> a,
+                              Optional<string> b,
+                              Optional<OneOptionalPtr> o,
                               const Ice::Current&)
 {
     OptionalException ex;
@@ -46,9 +46,9 @@ InitialI::opOptionalException(ICE_IN(Optional<Int>) a,
 }
 
 void
-InitialI::opDerivedException(ICE_IN(Optional<Int>) a,
-                             ICE_IN(Optional<string>) b,
-                             ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opDerivedException(Optional<Int> a,
+                             Optional<string> b,
+                             Optional<OneOptionalPtr> o,
                              const Ice::Current&)
 {
     DerivedException ex;
@@ -63,9 +63,9 @@ InitialI::opDerivedException(ICE_IN(Optional<Int>) a,
 }
 
 void
-InitialI::opRequiredException(ICE_IN(Optional<Int>) a,
-                              ICE_IN(Optional<string>) b,
-                              ICE_IN(Optional<OneOptionalPtr>) o,
+InitialI::opRequiredException(Optional<Int> a,
+                              Optional<string> b,
+                              Optional<OneOptionalPtr> o,
                               const Ice::Current&)
 {
     RequiredException ex;
@@ -84,63 +84,63 @@ InitialI::opRequiredException(ICE_IN(Optional<Int>) a,
 }
 
 Optional<Ice::Byte>
-InitialI::opByte(ICE_IN(Optional<Ice::Byte>) p1, Optional<Ice::Byte>& p3, const Current&)
+InitialI::opByte(Optional<Ice::Byte> p1, Optional<Ice::Byte>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<bool>
-InitialI::opBool(ICE_IN(Optional<bool>) p1, Optional<bool>& p3, const Current&)
+InitialI::opBool(Optional<bool> p1, Optional<bool>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Short>
-InitialI::opShort(ICE_IN(Optional<Short>) p1, Optional<Short>& p3, const Current&)
+InitialI::opShort(Optional<Short> p1, Optional<Short>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Int>
-InitialI::opInt(ICE_IN(Optional<Int>) p1, Optional<Int>& p3, const Current&)
+InitialI::opInt(Optional<Int> p1, Optional<Int>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Long>
-InitialI::opLong(ICE_IN(Optional<Long>) p1, Optional<Long>& p3, const Current&)
+InitialI::opLong(Optional<Long> p1, Optional<Long>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Float>
-InitialI::opFloat(ICE_IN(Optional<Float>) p1, Optional<Float>& p3, const Current&)
+InitialI::opFloat(Optional<Float> p1, Optional<Float>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Double>
-InitialI::opDouble(ICE_IN(Optional<Double>) p1, Optional<Double>& p3, const Current&)
+InitialI::opDouble(Optional<Double> p1, Optional<Double>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<string>
-InitialI::opString(ICE_IN(Optional<string>) p1, Optional<string>& p3, const Current&)
+InitialI::opString(Optional<string> p1, Optional<string>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<string>
-InitialI::opCustomString(ICE_IN(Optional<Util::string_view>) p1, Optional<string>& p3, const Current&)
+InitialI::opCustomString(Optional<Util::string_view> p1, Optional<string>& p3, const Current&)
 {
     if(p1)
     {
@@ -150,49 +150,49 @@ InitialI::opCustomString(ICE_IN(Optional<Util::string_view>) p1, Optional<string
 }
 
 Optional<MyEnum>
-InitialI::opMyEnum(ICE_IN(Optional<MyEnum>) p1, Optional<MyEnum>& p3, const Current&)
+InitialI::opMyEnum(Optional<MyEnum> p1, Optional<MyEnum>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<SmallStruct>
-InitialI::opSmallStruct(ICE_IN(Optional<SmallStruct>) p1, Optional<SmallStruct>& p3, const Current&)
+InitialI::opSmallStruct(Optional<SmallStruct> p1, Optional<SmallStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<FixedStruct>
-InitialI::opFixedStruct(ICE_IN(Optional<FixedStruct>) p1, Optional<FixedStruct>& p3, const Current&)
+InitialI::opFixedStruct(Optional<FixedStruct> p1, Optional<FixedStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<VarStruct>
-InitialI::opVarStruct(ICE_IN(Optional<VarStruct>) p1, Optional<VarStruct>& p3, const Current&)
+InitialI::opVarStruct(Optional<VarStruct> p1, Optional<VarStruct>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<OneOptionalPtr>
-InitialI::opOneOptional(ICE_IN(Optional<OneOptionalPtr>) p1, Optional<OneOptionalPtr>& p3, const Current&)
+InitialI::opOneOptional(Optional<OneOptionalPtr> p1, Optional<OneOptionalPtr>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<MyInterfacePrxPtr>
-InitialI::opMyInterfaceProxy(ICE_IN(Optional<MyInterfacePrxPtr>) p1, Optional<MyInterfacePrxPtr>& p3, const Current&)
+InitialI::opMyInterfaceProxy(Optional<MyInterfacePrxPtr> p1, Optional<MyInterfacePrxPtr>& p3, const Current&)
 {
     p3 = p1;
     return p1;
 }
 
 Optional<Test::ByteSeq>
-InitialI::opByteSeq(ICE_IN(Optional<pair<const Ice::Byte*, const Ice::Byte*> >) p1, Optional<Test::ByteSeq>& p3,
+InitialI::opByteSeq(Optional<pair<const Ice::Byte*, const Ice::Byte*> > p1, Optional<Test::ByteSeq>& p3,
                     const Current&)
 {
     if(p1)
@@ -203,7 +203,7 @@ InitialI::opByteSeq(ICE_IN(Optional<pair<const Ice::Byte*, const Ice::Byte*> >) 
 }
 
 Optional<Test::BoolSeq>
-InitialI::opBoolSeq(ICE_IN(Optional<pair<const bool*, const bool*> >) p1, Optional<Test::BoolSeq>& p3, const Current&)
+InitialI::opBoolSeq(Optional<pair<const bool*, const bool*> > p1, Optional<Test::BoolSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -213,7 +213,7 @@ InitialI::opBoolSeq(ICE_IN(Optional<pair<const bool*, const bool*> >) p1, Option
 }
 
 Optional<Test::ShortSeq>
-InitialI::opShortSeq(ICE_IN(Optional<pair<const Short*, const Short*> >) p1, Optional<Test::ShortSeq>& p3,
+InitialI::opShortSeq(Optional<pair<const Short*, const Short*> > p1, Optional<Test::ShortSeq>& p3,
                      const Current&)
 {
     if(p1)
@@ -224,7 +224,7 @@ InitialI::opShortSeq(ICE_IN(Optional<pair<const Short*, const Short*> >) p1, Opt
 }
 
 Optional<Test::IntSeq>
-InitialI::opIntSeq(ICE_IN(Optional<pair<const Int*, const Int*> >) p1, Optional<Test::IntSeq>& p3, const Current&)
+InitialI::opIntSeq(Optional<pair<const Int*, const Int*> > p1, Optional<Test::IntSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -234,7 +234,7 @@ InitialI::opIntSeq(ICE_IN(Optional<pair<const Int*, const Int*> >) p1, Optional<
 }
 
 Optional<Test::LongSeq>
-InitialI::opLongSeq(ICE_IN(Optional<pair<const Long*, const Long*> >) p1, Optional<Test::LongSeq>& p3, const Current&)
+InitialI::opLongSeq(Optional<pair<const Long*, const Long*> > p1, Optional<Test::LongSeq>& p3, const Current&)
 {
     if(p1)
     {
@@ -244,7 +244,7 @@ InitialI::opLongSeq(ICE_IN(Optional<pair<const Long*, const Long*> >) p1, Option
 }
 
 Optional<Test::FloatSeq>
-InitialI::opFloatSeq(ICE_IN(Optional<pair<const Float*, const Float*> >) p1, Optional<Test::FloatSeq>& p3,
+InitialI::opFloatSeq(Optional<pair<const Float*, const Float*> > p1, Optional<Test::FloatSeq>& p3,
                      const Current&)
 {
     if(p1)
@@ -255,7 +255,7 @@ InitialI::opFloatSeq(ICE_IN(Optional<pair<const Float*, const Float*> >) p1, Opt
 }
 
 Optional<Test::DoubleSeq>
-InitialI::opDoubleSeq(ICE_IN(Optional<pair<const Double*, const Double*> >) p1, Optional<Test::DoubleSeq>& p3,
+InitialI::opDoubleSeq(Optional<pair<const Double*, const Double*> > p1, Optional<Test::DoubleSeq>& p3,
                       const Current&)
 {
     if(p1)
@@ -277,7 +277,7 @@ InitialI::opStringSeq(Ice::optional<Ice::StringSeq> p1,
 }
 
 Optional<SmallStructSeq>
-InitialI::opSmallStructSeq(ICE_IN(Optional<pair<const SmallStruct*, const SmallStruct*> >) p1,
+InitialI::opSmallStructSeq(Optional<pair<const SmallStruct*, const SmallStruct*> > p1,
                            Optional<SmallStructSeq>& p3, const Current&)
 {
     if(p1)
@@ -288,7 +288,7 @@ InitialI::opSmallStructSeq(ICE_IN(Optional<pair<const SmallStruct*, const SmallS
 }
 
 Optional<SmallStructList>
-InitialI::opSmallStructList(ICE_IN(Optional<pair<const SmallStruct*, const SmallStruct*> >) p1,
+InitialI::opSmallStructList(Optional<pair<const SmallStruct*, const SmallStruct*> > p1,
                             Optional<SmallStructList>& p3, const Current&)
 {
     if(p1)
@@ -299,7 +299,7 @@ InitialI::opSmallStructList(ICE_IN(Optional<pair<const SmallStruct*, const Small
 }
 
 Optional<FixedStructSeq>
-InitialI::opFixedStructSeq(ICE_IN(Optional<pair<const FixedStruct*, const FixedStruct*> >) p1,
+InitialI::opFixedStructSeq(Optional<pair<const FixedStruct*, const FixedStruct*> > p1,
                            Optional<FixedStructSeq>& p3, const Current&)
 {
     if(p1)
@@ -310,7 +310,7 @@ InitialI::opFixedStructSeq(ICE_IN(Optional<pair<const FixedStruct*, const FixedS
 }
 
 Optional<FixedStructList>
-InitialI::opFixedStructList(ICE_IN(Optional<pair<const FixedStruct*, const FixedStruct*> >) p1,
+InitialI::opFixedStructList(Optional<pair<const FixedStruct*, const FixedStruct*> > p1,
                             Optional<FixedStructList>& p3, const Current&)
 {
     if(p1)
@@ -332,35 +332,35 @@ InitialI::opVarStructSeq(Ice::optional<VarStructSeq> p1,
 }
 
 Optional<Serializable>
-InitialI::opSerializable(ICE_IN(Optional<Serializable>) p1, Optional<Serializable>& p3, const Current&)
+InitialI::opSerializable(Optional<Serializable> p1, Optional<Serializable>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntIntDict>
-InitialI::opIntIntDict(ICE_IN(Optional<IntIntDict>) p1, Optional<IntIntDict>& p3, const Current&)
+InitialI::opIntIntDict(Optional<IntIntDict> p1, Optional<IntIntDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<StringIntDict>
-InitialI::opStringIntDict(ICE_IN(Optional<StringIntDict>) p1, Optional<StringIntDict>& p3, const Current&)
+InitialI::opStringIntDict(Optional<StringIntDict> p1, Optional<StringIntDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntOneOptionalDict>
-InitialI::opIntOneOptionalDict(ICE_IN(Optional<IntOneOptionalDict>) p1, Optional<IntOneOptionalDict>& p3, const Current&)
+InitialI::opIntOneOptionalDict(Optional<IntOneOptionalDict> p1, Optional<IntOneOptionalDict>& p3, const Current&)
 {
     p3 = p1;
     return p3;
 }
 
 Optional<IntStringDict>
-InitialI::opCustomIntStringDict(ICE_IN(Optional<std::map<int, Util::string_view> >) p1,
+InitialI::opCustomIntStringDict(Optional<std::map<int, Util::string_view> > p1,
                                 Optional<IntStringDict>& p3, const Current&)
 {
     if(p1)
@@ -376,23 +376,23 @@ InitialI::opCustomIntStringDict(ICE_IN(Optional<std::map<int, Util::string_view>
 }
 
 void
-InitialI::opClassAndUnknownOptional(ICE_IN(APtr), const Ice::Current&)
+InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 {
 }
 
 void
-InitialI::sendOptionalClass(bool, ICE_IN(Optional<OneOptionalPtr>), const Ice::Current&)
+InitialI::sendOptionalClass(bool, Optional<OneOptionalPtr>, const Ice::Current&)
 {
 }
 
 void
 InitialI::returnOptionalClass(bool, Optional<OneOptionalPtr>& o, const Ice::Current&)
 {
-    o = ICE_MAKE_SHARED(OneOptional, 53);
+    o = make_shared<OneOptional>(53);
 }
 
 GPtr
-InitialI::opG(ICE_IN(GPtr) g, const Ice::Current&)
+InitialI::opG(GPtr g, const Ice::Current&)
 {
     return g;
 }
@@ -409,7 +409,7 @@ InitialI::opMStruct1(const Ice::Current& current)
 }
 
 InitialI::OpMStruct2MarshaledResult
-InitialI::opMStruct2(ICE_IN(IceUtil::Optional<Test::SmallStruct>) p1, const Ice::Current& current)
+InitialI::opMStruct2(IceUtil::Optional<Test::SmallStruct> p1, const Ice::Current& current)
 {
     return OpMStruct2MarshaledResult(p1, p1, current);
 }
@@ -421,7 +421,7 @@ InitialI::opMSeq1(const Ice::Current& current)
 }
 
 InitialI::OpMSeq2MarshaledResult
-InitialI::opMSeq2(ICE_IN(IceUtil::Optional<Test::StringSeq>) p1, const Ice::Current& current)
+InitialI::opMSeq2(IceUtil::Optional<Test::StringSeq> p1, const Ice::Current& current)
 {
     return OpMSeq2MarshaledResult(p1, p1, current);
 }
@@ -433,7 +433,7 @@ InitialI::opMDict1(const Ice::Current& current)
 }
 
 InitialI::OpMDict2MarshaledResult
-InitialI::opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>) p1, const Ice::Current& current)
+InitialI::opMDict2(IceUtil::Optional<Test::StringIntDict> p1, const Ice::Current& current)
 {
     return OpMDict2MarshaledResult(p1, p1, current);
 }
@@ -441,11 +441,11 @@ InitialI::opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>) p1, const Ice:
 InitialI::OpMG1MarshaledResult
 InitialI::opMG1(const Ice::Current& current)
 {
-    return OpMG1MarshaledResult(ICE_MAKE_SHARED(G), current);
+    return OpMG1MarshaledResult(make_shared<G>(), current);
 }
 
 InitialI::OpMG2MarshaledResult
-InitialI::opMG2(ICE_IN(IceUtil::Optional<Test::GPtr>) p1, const Ice::Current& current)
+InitialI::opMG2(IceUtil::Optional<Test::GPtr> p1, const Ice::Current& current)
 {
     return OpMG2MarshaledResult(p1, p1, current);
 }

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -14,114 +14,114 @@ public:
    InitialI();
 
     virtual void shutdown(const Ice::Current&);
-    virtual PingPongMarshaledResult pingPong(ICE_IN(Ice::ValuePtr), const Ice::Current&);
+    virtual PingPongMarshaledResult pingPong(Ice::ValuePtr, const Ice::Current&);
 
-    virtual void opOptionalException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                     ICE_IN(IceUtil::Optional< ::std::string>),
-                                     ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opOptionalException(IceUtil::Optional< ::Ice::Int>,
+                                     IceUtil::Optional< ::std::string>,
+                                     IceUtil::Optional<Test::OneOptionalPtr>,
                                      const Ice::Current&);
 
-    virtual void opDerivedException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                    ICE_IN(IceUtil::Optional< ::std::string>),
-                                    ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opDerivedException(IceUtil::Optional< ::Ice::Int>,
+                                    IceUtil::Optional< ::std::string>,
+                                    IceUtil::Optional<Test::OneOptionalPtr>,
                                     const Ice::Current&);
 
-    virtual void opRequiredException(ICE_IN(IceUtil::Optional< ::Ice::Int>),
-                                     ICE_IN(IceUtil::Optional< ::std::string>),
-                                     ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>),
+    virtual void opRequiredException(IceUtil::Optional< ::Ice::Int>,
+                                     IceUtil::Optional< ::std::string>,
+                                     IceUtil::Optional<Test::OneOptionalPtr>,
                                      const Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Byte> opByte(ICE_IN(IceUtil::Optional< ::Ice::Byte>),
+    virtual IceUtil::Optional< ::Ice::Byte> opByte(IceUtil::Optional< ::Ice::Byte>,
                                                    IceUtil::Optional< ::Ice::Byte>&,
                                                    const ::Ice::Current&);
 
-    virtual IceUtil::Optional<bool> opBool(ICE_IN(IceUtil::Optional<bool>), IceUtil::Optional<bool>&,
+    virtual IceUtil::Optional<bool> opBool(IceUtil::Optional<bool>, IceUtil::Optional<bool>&,
                                            const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Short> opShort(ICE_IN(IceUtil::Optional< ::Ice::Short>),
+    virtual IceUtil::Optional< ::Ice::Short> opShort(IceUtil::Optional< ::Ice::Short>,
                                                      IceUtil::Optional< ::Ice::Short>&,
                                                      const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Int> opInt(ICE_IN(IceUtil::Optional< ::Ice::Int>),
+    virtual IceUtil::Optional< ::Ice::Int> opInt(IceUtil::Optional< ::Ice::Int>,
                                                  IceUtil::Optional< ::Ice::Int>&,
                                                  const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Long> opLong(ICE_IN(IceUtil::Optional< ::Ice::Long>),
+    virtual IceUtil::Optional< ::Ice::Long> opLong(IceUtil::Optional< ::Ice::Long>,
                                                    IceUtil::Optional< ::Ice::Long>&,
                                                    const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Float> opFloat(ICE_IN(IceUtil::Optional< ::Ice::Float>),
+    virtual IceUtil::Optional< ::Ice::Float> opFloat(IceUtil::Optional< ::Ice::Float>,
                                                      IceUtil::Optional< ::Ice::Float>&,
                                                      const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::Ice::Double> opDouble(ICE_IN(IceUtil::Optional< ::Ice::Double>),
+    virtual IceUtil::Optional< ::Ice::Double> opDouble(IceUtil::Optional< ::Ice::Double>,
                                                        IceUtil::Optional< ::Ice::Double>&,
                                                        const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::std::string> opString(ICE_IN(IceUtil::Optional< ::std::string>),
+    virtual IceUtil::Optional< ::std::string> opString(IceUtil::Optional< ::std::string>,
                                                        IceUtil::Optional< ::std::string>&,
                                                        const ::Ice::Current&);
 
-    virtual IceUtil::Optional< ::std::string> opCustomString(ICE_IN(IceUtil::Optional< Util::string_view>),
+    virtual IceUtil::Optional< ::std::string> opCustomString(IceUtil::Optional< Util::string_view>,
                                                                IceUtil::Optional< ::std::string>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional< Test::MyEnum> opMyEnum(ICE_IN(IceUtil::Optional<Test::MyEnum>),
+    virtual IceUtil::Optional< Test::MyEnum> opMyEnum(IceUtil::Optional<Test::MyEnum>,
                                                       IceUtil::Optional<Test::MyEnum>&,
                                                       const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::SmallStruct> opSmallStruct(ICE_IN(IceUtil::Optional<Test::SmallStruct>),
+    virtual IceUtil::Optional<Test::SmallStruct> opSmallStruct(IceUtil::Optional<Test::SmallStruct>,
                                                                IceUtil::Optional<Test::SmallStruct>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::FixedStruct> opFixedStruct(ICE_IN(IceUtil::Optional<Test::FixedStruct>),
+    virtual IceUtil::Optional<Test::FixedStruct> opFixedStruct(IceUtil::Optional<Test::FixedStruct>,
                                                                IceUtil::Optional<Test::FixedStruct>&,
                                                                const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::VarStruct> opVarStruct(ICE_IN(IceUtil::Optional<Test::VarStruct>),
+    virtual IceUtil::Optional<Test::VarStruct> opVarStruct(IceUtil::Optional<Test::VarStruct>,
                                                            IceUtil::Optional<Test::VarStruct>&,
                                                            const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::OneOptionalPtr> opOneOptional(ICE_IN(IceUtil::Optional< Test::OneOptionalPtr>),
+    virtual IceUtil::Optional<Test::OneOptionalPtr> opOneOptional(IceUtil::Optional< Test::OneOptionalPtr>,
                                                                   IceUtil::Optional< Test::OneOptionalPtr>&,
                                                                   const ::Ice::Current&);
 
-    virtual IceUtil::Optional<Test::MyInterfacePrxPtr> opMyInterfaceProxy(ICE_IN(IceUtil::Optional< Test::MyInterfacePrxPtr>),
+    virtual IceUtil::Optional<Test::MyInterfacePrxPtr> opMyInterfaceProxy(IceUtil::Optional< Test::MyInterfacePrxPtr>,
                                                                           IceUtil::Optional< Test::MyInterfacePrxPtr>&,
                                                                           const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::ByteSeq> opByteSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Byte*, const ::Ice::Byte*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Byte*, const ::Ice::Byte*> >,
         IceUtil::Optional< ::Test::ByteSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::BoolSeq> opBoolSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const bool*, const bool*> >),
+        IceUtil::Optional< ::std::pair<const bool*, const bool*> >,
         IceUtil::Optional< ::Test::BoolSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::ShortSeq> opShortSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Short*, const ::Ice::Short*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Short*, const ::Ice::Short*> >,
         IceUtil::Optional< ::Test::ShortSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntSeq> opIntSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Int*, const ::Ice::Int*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Int*, const ::Ice::Int*> >,
         IceUtil::Optional< ::Test::IntSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::LongSeq> opLongSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Long*, const ::Ice::Long*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Long*, const ::Ice::Long*> >,
         IceUtil::Optional< ::Test::LongSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FloatSeq> opFloatSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Float*, const ::Ice::Float*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Float*, const ::Ice::Float*> >,
         IceUtil::Optional< ::Test::FloatSeq>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::DoubleSeq> opDoubleSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Ice::Double*, const ::Ice::Double*> >),
+        IceUtil::Optional< ::std::pair<const ::Ice::Double*, const ::Ice::Double*> >,
         IceUtil::Optional< ::Test::DoubleSeq>&,
         const ::Ice::Current&);
 
@@ -130,19 +130,19 @@ public:
          Ice::optional<::Test::StringSeq>&, const ::Ice::Current&) ;
 
     virtual IceUtil::Optional< ::Test::SmallStructSeq> opSmallStructSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >,
         IceUtil::Optional< ::Test::SmallStructSeq>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::SmallStructList> opSmallStructList(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*> >,
         IceUtil::Optional< ::Test::SmallStructList>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FixedStructSeq> opFixedStructSeq(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >,
         IceUtil::Optional< ::Test::FixedStructSeq>&, const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::FixedStructList> opFixedStructList(
-        ICE_IN(IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >),
+        IceUtil::Optional< ::std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*> >,
         IceUtil::Optional< ::Test::FixedStructList>&, const ::Ice::Current&);
 
     virtual Ice::optional<::Test::VarStructSeq> opVarStructSeq(
@@ -150,55 +150,55 @@ public:
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::Serializable> opSerializable(
-        ICE_IN(IceUtil::Optional< ::Test::Serializable>),
+        IceUtil::Optional< ::Test::Serializable>,
         IceUtil::Optional< ::Test::Serializable>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntIntDict> opIntIntDict(
-        ICE_IN(IceUtil::Optional< ::Test::IntIntDict>),
+        IceUtil::Optional< ::Test::IntIntDict>,
         IceUtil::Optional< ::Test::IntIntDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::StringIntDict> opStringIntDict(
-        ICE_IN(IceUtil::Optional< ::Test::StringIntDict>),
+        IceUtil::Optional< ::Test::StringIntDict>,
         IceUtil::Optional< ::Test::StringIntDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntOneOptionalDict> opIntOneOptionalDict(
-        ICE_IN(IceUtil::Optional< ::Test::IntOneOptionalDict>),
+        IceUtil::Optional< ::Test::IntOneOptionalDict>,
         IceUtil::Optional< ::Test::IntOneOptionalDict>&,
         const ::Ice::Current&);
 
     virtual IceUtil::Optional< ::Test::IntStringDict> opCustomIntStringDict(
-        ICE_IN(IceUtil::Optional<std::map<int, Util::string_view> >),
+        IceUtil::Optional<std::map<int, Util::string_view> >,
         IceUtil::Optional< ::Test::IntStringDict>&,
         const ::Ice::Current&);
 
-    virtual void opClassAndUnknownOptional(ICE_IN(Test::APtr), const Ice::Current&);
+    virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
-    virtual void sendOptionalClass(bool, ICE_IN(IceUtil::Optional<Test::OneOptionalPtr>), const Ice::Current&);
+    virtual void sendOptionalClass(bool, IceUtil::Optional<Test::OneOptionalPtr>, const Ice::Current&);
 
     virtual void returnOptionalClass(bool, IceUtil::Optional<Test::OneOptionalPtr>&, const Ice::Current&);
 
-    virtual ::Test::GPtr opG(ICE_IN(::Test::GPtr) g, const Ice::Current&);
+    virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
 
     virtual void opVoid(const Ice::Current&);
 
     virtual OpMStruct1MarshaledResult opMStruct1(const Ice::Current&);
 
-    virtual OpMStruct2MarshaledResult opMStruct2(ICE_IN(IceUtil::Optional<Test::SmallStruct>), const Ice::Current&);
+    virtual OpMStruct2MarshaledResult opMStruct2(IceUtil::Optional<Test::SmallStruct>, const Ice::Current&);
 
     virtual OpMSeq1MarshaledResult opMSeq1(const Ice::Current&);
 
-    virtual OpMSeq2MarshaledResult opMSeq2(ICE_IN(IceUtil::Optional<Test::StringSeq>), const Ice::Current&);
+    virtual OpMSeq2MarshaledResult opMSeq2(IceUtil::Optional<Test::StringSeq>, const Ice::Current&);
 
     virtual OpMDict1MarshaledResult opMDict1(const Ice::Current&);
 
-    virtual OpMDict2MarshaledResult opMDict2(ICE_IN(IceUtil::Optional<Test::StringIntDict>), const Ice::Current&);
+    virtual OpMDict2MarshaledResult opMDict2(IceUtil::Optional<Test::StringIntDict>, const Ice::Current&);
 
     virtual OpMG1MarshaledResult opMG1(const Ice::Current&);
 
-    virtual OpMG2MarshaledResult opMG2(ICE_IN(IceUtil::Optional<Test::GPtr>), const Ice::Current&);
+    virtual OpMG2MarshaledResult opMG2(IceUtil::Optional<Test::GPtr>, const Ice::Current&);
 
     virtual bool supportsRequiredParams(const Ice::Current&);
 

--- a/cpp/test/Ice/plugin/Client.cpp
+++ b/cpp/test/Ice/plugin/Client.cpp
@@ -55,7 +55,7 @@ private:
     bool _initialized;
     bool _destroyed;
 };
-ICE_DEFINE_PTR(MyPluginPtr, MyPlugin);
+using MyPluginPtr = std::shared_ptr<MyPlugin>;
 
 }
 
@@ -258,7 +258,7 @@ Client::run(int argc, char** argv)
         test(pm->getPlugin("PluginTwo"));
         test(pm->getPlugin("PluginThree"));
 
-        MyPluginPtr p4 = ICE_MAKE_SHARED(MyPlugin);
+        MyPluginPtr p4 = std::make_shared<MyPlugin>();
         pm->addPlugin("PluginFour", p4);
         test(pm->getPlugin("PluginFour"));
 

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -85,7 +85,7 @@ private:
 };
 
 class BasePlugin;
-ICE_DEFINE_PTR(BasePluginPtr, BasePlugin);
+using BasePluginPtr = std::shared_ptr<BasePlugin>;
 
 class BasePlugin : public Ice::Plugin
 {
@@ -201,7 +201,7 @@ public:
 };
 
 class BasePluginFail;
-ICE_DEFINE_PTR(BasePluginFailPtr, BasePluginFail);
+using BasePluginFailPtr = std::shared_ptr<BasePluginFail>;
 
 class BasePluginFail : public Ice::Plugin
 {

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -346,18 +346,18 @@ allTests(Test::TestHelper* helper)
     id.name = "test";
     id.category = "\x7F\xE2\x82\xAC";
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Unicode));
+    idStr = identityToString(id, Ice::ToStringMode::Unicode);
     test(idStr == "\\u007f\xE2\x82\xAC/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
     test(Ice::identityToString(id) == idStr);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, ASCII));
+    idStr = identityToString(id, Ice::ToStringMode::ASCII);
     test(idStr == "\\u007f\\u20ac/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Compat));
+    idStr = identityToString(id, Ice::ToStringMode::Compat);
     test(idStr == "\\177\\342\\202\\254/test");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
@@ -370,17 +370,17 @@ allTests(Test::TestHelper* helper)
     id.name = "banana \016-\U0001F34C\U000020AC\u00a2\u0024";
     id.category = "greek \U0001016A";
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Unicode));
+    idStr = identityToString(id, Ice::ToStringMode::Unicode);
     test(idStr == "greek \U0001016A/banana \\u000e-\U0001F34C\U000020AC\u00a2$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, ASCII));
+    idStr = identityToString(id, Ice::ToStringMode::ASCII);
     test(idStr == "greek \\U0001016a/banana \\u000e-\\U0001f34c\\u20ac\\u00a2$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
-    idStr = identityToString(id, Ice::ICE_ENUM(ToStringMode, Compat));
+    idStr = identityToString(id, Ice::ToStringMode::Compat);
     test(idStr == "greek \\360\\220\\205\\252/banana \\016-\\360\\237\\215\\214\\342\\202\\254\\302\\242$");
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
@@ -484,13 +484,13 @@ allTests(Test::TestHelper* helper)
     prop->setProperty(property, "");
 
     property = propertyPrefix + ".EndpointSelection";
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
     prop->setProperty(property, "Random");
     b1 = communicator->propertyToProxy(propertyPrefix);
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Random));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random);
     prop->setProperty(property, "Ordered");
     b1 = communicator->propertyToProxy(propertyPrefix);
-    test(b1->ice_getEndpointSelection() == Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+    test(b1->ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered);
     prop->setProperty(property, "");
 
     property = propertyPrefix + ".CollocationOptimized";
@@ -523,7 +523,7 @@ allTests(Test::TestHelper* helper)
     b1 = b1->ice_collocationOptimized(true);
     b1 = b1->ice_connectionCached(true);
     b1 = b1->ice_preferSecure(false);
-    b1 = b1->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered));
+    b1 = b1->ice_endpointSelection(Ice::EndpointSelectionType::Ordered);
     b1 = b1->ice_locatorCacheTimeout(100);
     b1 = b1->ice_invocationTimeout(1234);
     Ice::EncodingVersion v = { 1, 0 };
@@ -532,7 +532,7 @@ allTests(Test::TestHelper* helper)
     router = router->ice_collocationOptimized(false);
     router = router->ice_connectionCached(true);
     router = router->ice_preferSecure(true);
-    router = router->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random));
+    router = router->ice_endpointSelection(Ice::EndpointSelectionType::Random);
     router = router->ice_locatorCacheTimeout(200);
     router = router->ice_invocationTimeout(1500);
 
@@ -540,7 +540,7 @@ allTests(Test::TestHelper* helper)
     locator = locator->ice_collocationOptimized(true);
     locator = locator->ice_connectionCached(false);
     locator = locator->ice_preferSecure(true);
-    locator = locator->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random));
+    locator = locator->ice_endpointSelection(Ice::EndpointSelectionType::Random);
     locator = locator->ice_locatorCacheTimeout(300);
     locator = locator->ice_invocationTimeout(1500);
 
@@ -720,10 +720,10 @@ allTests(Test::TestHelper* helper)
     test(Ice::targetLess(compObj->ice_connectionCached(false), compObj->ice_connectionCached(true)));
     test(Ice::targetGreaterEqual(compObj->ice_connectionCached(true), compObj->ice_connectionCached(false)));
 
-    test(Ice::targetEqualTo(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random))));
-    test(Ice::targetNotEqualTo(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered))));
-    test(Ice::targetLess(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered))));
-    test(Ice::targetGreaterEqual(compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Ordered)), compObj->ice_endpointSelection(Ice::ICE_ENUM(EndpointSelectionType, Random))));
+    test(Ice::targetEqualTo(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random)));
+    test(Ice::targetNotEqualTo(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered)));
+    test(Ice::targetLess(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered)));
+    test(Ice::targetGreaterEqual(compObj->ice_endpointSelection(Ice::EndpointSelectionType::Ordered), compObj->ice_endpointSelection(Ice::EndpointSelectionType::Random)));
 
     test(Ice::targetEqualTo(compObj->ice_connectionId("id2"), compObj->ice_connectionId("id2")));
     test(Ice::targetNotEqualTo(compObj->ice_connectionId("id1"), compObj->ice_connectionId("id2")));
@@ -992,7 +992,7 @@ allTests(Test::TestHelper* helper)
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
         vector<Ice::Byte> outEncaps;
-        cl->ice_invoke("ice_ping", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }
     catch(const Ice::UnknownLocalException& ex)
@@ -1013,7 +1013,7 @@ allTests(Test::TestHelper* helper)
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
         vector<Ice::Byte> outEncaps;
-        cl->ice_invoke("ice_ping", Ice::ICE_ENUM(OperationMode, Normal), inEncaps, outEncaps);
+        cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }
     catch(const Ice::UnknownLocalException& ex)

--- a/cpp/test/Ice/proxy/Collocated.cpp
+++ b/cpp/test/Ice/proxy/Collocated.cpp
@@ -23,7 +23,7 @@ Collocated::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 
     Test::MyClassPrxPtr allTests(Test::TestHelper*);

--- a/cpp/test/Ice/proxy/Server.cpp
+++ b/cpp/test/Ice/proxy/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/proxy/ServerAMD.cpp
+++ b/cpp/test/Ice/proxy/ServerAMD.cpp
@@ -25,7 +25,7 @@ ServerAMD::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyDerivedClassI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/retry/Collocated.cpp
+++ b/cpp/test/Ice/retry/Collocated.cpp
@@ -15,7 +15,7 @@ void
 setupObjectAdapter(const Ice::CommunicatorPtr& communicator)
 {
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
-    adapter->add(ICE_MAKE_SHARED(RetryI), Ice::stringToIdentity("retry"));
+    adapter->add(std::make_shared<RetryI>(), Ice::stringToIdentity("retry"));
     //adapter->activate(); // Don't activate OA to ensure collocation is used.
 }
 

--- a/cpp/test/Ice/retry/InstrumentationI.cpp
+++ b/cpp/test/Ice/retry/InstrumentationI.cpp
@@ -55,13 +55,13 @@ public:
     virtual ::Ice::Instrumentation::RemoteObserverPtr
     getRemoteObserver(const ::Ice::ConnectionInfoPtr&, const ::Ice::EndpointPtr&, ::Ice::Int, ::Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual ::Ice::Instrumentation::CollocatedObserverPtr
     getCollocatedObserver(const Ice::ObjectAdapterPtr&, ::Ice::Int, ::Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
 };
@@ -75,13 +75,13 @@ public:
     virtual Ice::Instrumentation::ObserverPtr
     getConnectionEstablishmentObserver(const Ice::EndpointPtr&, const ::std::string&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ObserverPtr
     getEndpointLookupObserver(const Ice::EndpointPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ConnectionObserverPtr
@@ -90,7 +90,7 @@ public:
                           Ice::Instrumentation::ConnectionState,
                           const Ice::Instrumentation::ConnectionObserverPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::ThreadObserverPtr
@@ -99,7 +99,7 @@ public:
                       Ice::Instrumentation::ThreadState,
                       const Ice::Instrumentation::ThreadObserverPtr&)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual Ice::Instrumentation::InvocationObserverPtr
@@ -111,7 +111,7 @@ public:
     virtual Ice::Instrumentation::DispatchObserverPtr
     getDispatchObserver(const Ice::Current&, Ice::Int)
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     virtual void

--- a/cpp/test/Ice/retry/Server.cpp
+++ b/cpp/test/Ice/retry/Server.cpp
@@ -26,7 +26,7 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(RetryI), Ice::stringToIdentity("retry"));
+    adapter->add(std::make_shared<RetryI>(), Ice::stringToIdentity("retry"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/retry/TestI.cpp
+++ b/cpp/test/Ice/retry/TestI.cpp
@@ -17,7 +17,7 @@ RetryI::op(bool kill, const Ice::Current& current)
     {
         if(current.con)
         {
-            current.con->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, Forcefully));
+            current.con->close(Ice::ConnectionClose::Forcefully);
         }
         else
         {

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -60,8 +60,8 @@ allTests(Test::TestHelper* helper)
         test(cmap2["a"]->s == c1->s);
         test(cmap3["a"]->s == c1->s);
 
-        Test::E1 e = i->opE1(Test::ICE_ENUM(E1, v1));
-        test(e == Test::ICE_ENUM(E1, v1));
+        Test::E1 e = i->opE1(Test::E1::v1);
+        test(e == Test::E1::v1);
 
         Test::S1 s;
         s.s = "S1";

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -40,7 +40,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::CPtr c1 = ICE_MAKE_SHARED(Test::C, s1);
+        Test::CPtr c1 = make_shared<Test::C>(s1);
         Test::CPtr c2;
         Test::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -68,7 +68,7 @@ allTests(Test::TestHelper* helper)
         s = i->opS1(s);
         test(s.s == "S1");
 
-        Test::C1Ptr c = i->opC1(ICE_MAKE_SHARED(Test::C1, "C1"));
+        Test::C1Ptr c = i->opC1(make_shared<Test::C1>("C1"));
         test(c->s == "C1");
     }
 
@@ -139,7 +139,7 @@ allTests(Test::TestHelper* helper)
         }
 
         {
-            auto result = i->opC1Async(ICE_MAKE_SHARED(Test::C1, "C1")).get();
+            auto result = i->opC1Async(make_shared<Test::C1>("C1")).get();
             test(result->s == "C1");
         }
     }
@@ -373,7 +373,7 @@ allTests(Test::TestHelper* helper)
         {
             promise<void> p;
             auto f = p.get_future();
-            auto result = i->opC1Async(ICE_MAKE_SHARED(Test::C1, "C1"),
+            auto result = i->opC1Async(make_shared<Test::C1>("C1"),
                                        [&p](Test::C1Ptr v)
                                        {
                                            test(v->s == "C1");
@@ -422,7 +422,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::Inner::Inner2::CPtr c1 = ICE_MAKE_SHARED(Test::Inner::Inner2::C, s1);
+        Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         Test::Inner::Inner2::CPtr c2;
         Test::Inner::Inner2::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -701,7 +701,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::Inner::Inner2::CPtr c1 = ICE_MAKE_SHARED(Test::Inner::Inner2::C, s1);
+        Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         Test::Inner::Inner2::CPtr c2;
         Test::Inner::Inner2::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);
@@ -978,7 +978,7 @@ allTests(Test::TestHelper* helper)
         test(smap2 == smap1);
         test(smap3 == smap1);
 
-        Test::CPtr c1 = ICE_MAKE_SHARED(Test::C, s1);
+        Test::CPtr c1 = make_shared<Test::C>(s1);
         Test::CPtr c2;
         Test::CPtr c3 = i->opC(c1, c2);
         test(c2->s == c1->s);

--- a/cpp/test/Ice/scope/Server.cpp
+++ b/cpp/test/Ice/scope/Server.cpp
@@ -19,17 +19,17 @@ class I1 : public Test::I
 {
 public:
 
-    virtual Test::S opS(ICE_IN(Test::S), Test::S&, const Ice::Current&);
-    virtual Test::SSeq opSSeq(ICE_IN(Test::SSeq), Test::SSeq&, const Ice::Current&);
-    virtual Test::SMap opSMap(ICE_IN(Test::SMap), Test::SMap&, const Ice::Current&);
+    virtual Test::S opS(Test::S, Test::S&, const Ice::Current&);
+    virtual Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
+    virtual Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
 
-    virtual Test::CPtr opC(ICE_IN(Test::CPtr), Test::CPtr&, const Ice::Current&);
-    virtual Test::CSeq opCSeq(ICE_IN(Test::CSeq), Test::CSeq&, const Ice::Current&);
-    virtual Test::CMap opCMap(ICE_IN(Test::CMap), Test::CMap&, const Ice::Current&);
+    virtual Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
+    virtual Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
+    virtual Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
 
     virtual Test::E1 opE1(Test::E1, const Ice::Current&);
-    virtual Test::S1 opS1(ICE_IN(Test::S1), const Ice::Current&);
-    virtual Test::C1Ptr opC1(ICE_IN(Test::C1Ptr), const Ice::Current&);
+    virtual Test::S1 opS1(Test::S1, const Ice::Current&);
+    virtual Test::C1Ptr opC1(Test::C1Ptr, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -39,22 +39,22 @@ class I2 : public Test::Inner::Inner2::I
 public:
 
     virtual Test::Inner::Inner2::S
-    opS(ICE_IN(Test::Inner::Inner2::S), Test::Inner::Inner2::S&, const Ice::Current&);
+    opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SSeq
-    opSSeq(ICE_IN(Test::Inner::Inner2::SSeq), Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SMap
-    opSMap(ICE_IN(Test::Inner::Inner2::SMap), Test::Inner::Inner2::SMap&, const Ice::Current&);
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CPtr
-    opC(ICE_IN(Test::Inner::Inner2::CPtr), Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CSeq
-    opCSeq(ICE_IN(Test::Inner::Inner2::CSeq), Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CMap
-    opCMap(ICE_IN(Test::Inner::Inner2::CMap), Test::Inner::Inner2::CMap&, const Ice::Current&);
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -64,22 +64,22 @@ class I3 : public Test::Inner::I
 public:
 
     virtual Test::Inner::Inner2::S
-    opS(ICE_IN(Test::Inner::Inner2::S), Test::Inner::Inner2::S&, const Ice::Current&);
+    opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SSeq
-    opSSeq(ICE_IN(Test::Inner::Inner2::SSeq), Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::SMap
-    opSMap(ICE_IN(Test::Inner::Inner2::SMap), Test::Inner::Inner2::SMap&, const Ice::Current&);
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CPtr
-    opC(ICE_IN(Test::Inner::Inner2::CPtr), Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CSeq
-    opCSeq(ICE_IN(Test::Inner::Inner2::CSeq), Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
 
     virtual Test::Inner::Inner2::CMap
-    opCMap(ICE_IN(Test::Inner::Inner2::CMap), Test::Inner::Inner2::CMap&, const Ice::Current&);
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -89,22 +89,22 @@ class I4 : public Inner::Test::Inner2::I
 public:
 
     virtual Test::S
-    opS(ICE_IN(Test::S), Test::S&, const Ice::Current&);
+    opS(Test::S, Test::S&, const Ice::Current&);
 
     virtual Test::SSeq
-    opSSeq(ICE_IN(Test::SSeq), Test::SSeq&, const Ice::Current&);
+    opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
 
     virtual Test::SMap
-    opSMap(ICE_IN(Test::SMap), Test::SMap&, const Ice::Current&);
+    opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
 
     virtual Test::CPtr
-    opC(ICE_IN(Test::CPtr), Test::CPtr&, const Ice::Current&);
+    opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
 
     virtual Test::CSeq
-    opCSeq(ICE_IN(Test::CSeq), Test::CSeq&, const Ice::Current&);
+    opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
 
     virtual Test::CMap
-    opCMap(ICE_IN(Test::CMap), Test::CMap&, const Ice::Current&);
+    opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 };
@@ -113,41 +113,41 @@ public:
 // I1 implementation
 //
 Test::S
-I1::opS(ICE_IN(Test::S) s1, Test::S& s2, const Ice::Current&)
+I1::opS(Test::S s1, Test::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SSeq
-I1::opSSeq(ICE_IN(Test::SSeq) s1, Test::SSeq& s2, const Ice::Current&)
+I1::opSSeq(Test::SSeq s1, Test::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SMap
-I1::opSMap(ICE_IN(Test::SMap) s1, Test::SMap& s2, const Ice::Current&)
+I1::opSMap(Test::SMap s1, Test::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::CPtr
-I1::opC(ICE_IN(Test::CPtr) c1, Test::CPtr& c2, const Ice::Current&)
+I1::opC(Test::CPtr c1, Test::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CSeq
-I1::opCSeq(ICE_IN(Test::CSeq) c1, Test::CSeq& c2, const Ice::Current&)
+I1::opCSeq(Test::CSeq c1, Test::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::CMap
-I1::opCMap(ICE_IN(Test::CMap) c1, Test::CMap& c2, const Ice::Current&)
+I1::opCMap(Test::CMap c1, Test::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -160,13 +160,13 @@ I1::opE1(Test::E1 e1, const Ice::Current&)
 }
 
 Test::S1
-I1::opS1(ICE_IN(Test::S1) s1, const Ice::Current&)
+I1::opS1(Test::S1 s1, const Ice::Current&)
 {
     return s1;
 }
 
 Test::C1Ptr
-I1::opC1(ICE_IN(Test::C1Ptr) c1, const Ice::Current&)
+I1::opC1(Test::C1Ptr c1, const Ice::Current&)
 {
     return c1;
 }
@@ -181,41 +181,41 @@ I1::shutdown(const Ice::Current& current)
 // I2 implementation
 //
 Test::Inner::Inner2::S
-I2::opS(ICE_IN(Test::Inner::Inner2::S) s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
+I2::opS(Test::Inner::Inner2::S s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SSeq
-I2::opSSeq(ICE_IN(Test::Inner::Inner2::SSeq) s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
+I2::opSSeq(Test::Inner::Inner2::SSeq s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SMap
-I2::opSMap(ICE_IN(Test::Inner::Inner2::SMap) s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
+I2::opSMap(Test::Inner::Inner2::SMap s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::CPtr
-I2::opC(ICE_IN(Test::Inner::Inner2::CPtr) c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
+I2::opC(Test::Inner::Inner2::CPtr c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::Inner::Inner2::CSeq
-I2::opCSeq(ICE_IN(Test::Inner::Inner2::CSeq) c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
+I2::opCSeq(Test::Inner::Inner2::CSeq c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::Inner::Inner2::CMap
-I2::opCMap(ICE_IN(Test::Inner::Inner2::CMap) c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
+I2::opCMap(Test::Inner::Inner2::CMap c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -231,41 +231,41 @@ I2::shutdown(const Ice::Current& current)
 // I3 implementation
 //
 Test::Inner::Inner2::S
-I3::opS(ICE_IN(Test::Inner::Inner2::S) s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
+I3::opS(Test::Inner::Inner2::S s1, Test::Inner::Inner2::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SSeq
-I3::opSSeq(ICE_IN(Test::Inner::Inner2::SSeq) s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
+I3::opSSeq(Test::Inner::Inner2::SSeq s1, Test::Inner::Inner2::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::SMap
-I3::opSMap(ICE_IN(Test::Inner::Inner2::SMap) s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
+I3::opSMap(Test::Inner::Inner2::SMap s1, Test::Inner::Inner2::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::Inner::Inner2::CPtr
-I3::opC(ICE_IN(Test::Inner::Inner2::CPtr) c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
+I3::opC(Test::Inner::Inner2::CPtr c1, Test::Inner::Inner2::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::Inner::Inner2::CSeq
-I3::opCSeq(ICE_IN(Test::Inner::Inner2::CSeq) c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
+I3::opCSeq(Test::Inner::Inner2::CSeq c1, Test::Inner::Inner2::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 Test::Inner::Inner2::CMap
-I3::opCMap(ICE_IN(Test::Inner::Inner2::CMap) c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
+I3::opCMap(Test::Inner::Inner2::CMap c1, Test::Inner::Inner2::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -281,42 +281,42 @@ I3::shutdown(const Ice::Current& current)
 // I4 implementation
 //
 Test::S
-I4::opS(ICE_IN(Test::S) s1, Test::S& s2, const Ice::Current&)
+I4::opS(Test::S s1, Test::S& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SSeq
-I4::opSSeq(ICE_IN(Test::SSeq) s1, Test::SSeq& s2, const Ice::Current&)
+I4::opSSeq(Test::SSeq s1, Test::SSeq& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::SMap
-I4::opSMap(ICE_IN(Test::SMap) s1, Test::SMap& s2, const Ice::Current&)
+I4::opSMap(Test::SMap s1, Test::SMap& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
 }
 
 Test::CPtr
-I4::opC(ICE_IN(Test::CPtr) c1, Test::CPtr& c2, const Ice::Current&)
+I4::opC(Test::CPtr c1, Test::CPtr& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CSeq
-I4::opCSeq(ICE_IN(Test::CSeq) c1, Test::CSeq& c2, const Ice::Current&)
+I4::opCSeq(Test::CSeq c1, Test::CSeq& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
 }
 
 Test::CMap
-I4::opCMap(ICE_IN(Test::CMap) c1, Test::CMap& c2, const Ice::Current&)
+I4::opCMap(Test::CMap c1, Test::CMap& c2, const Ice::Current&)
 {
     c2 = c1;
     return c1;
@@ -334,10 +334,10 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(I1), Ice::stringToIdentity("i1"));
-    adapter->add(ICE_MAKE_SHARED(I2), Ice::stringToIdentity("i2"));
-    adapter->add(ICE_MAKE_SHARED(I3), Ice::stringToIdentity("i3"));
-    adapter->add(ICE_MAKE_SHARED(I4), Ice::stringToIdentity("i4"));
+    adapter->add(std::make_shared<I1>(), Ice::stringToIdentity("i1"));
+    adapter->add(std::make_shared<I2>(), Ice::stringToIdentity("i2"));
+    adapter->add(std::make_shared<I3>(), Ice::stringToIdentity("i3"));
+    adapter->add(std::make_shared<I4>(), Ice::stringToIdentity("i4"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/servantLocator/Collocated.cpp
+++ b/cpp/test/Ice/servantLocator/Collocated.cpp
@@ -47,8 +47,8 @@ public:
     {
         if(activate)
         {
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-            current.adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
+            current.adapter->addServantLocator(make_shared<ServantLocatorI>(""), "");
+            current.adapter->addServantLocator(make_shared<ServantLocatorI>("category"), "category");
         }
         else
         {
@@ -75,10 +75,10 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, ""), "");
-    adapter->addServantLocator(ICE_MAKE_SHARED(ServantLocatorI, "category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->addServantLocator(make_shared<ServantLocatorI>(""), "");
+    adapter->addServantLocator(make_shared<ServantLocatorI>("category"), "category");
+    adapter->add(make_shared<TestI>(), Ice::stringToIdentity("asm"));
+    adapter->add(make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
 
     Test::TestIntfPrxPtr allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/servantLocator/Server.cpp
+++ b/cpp/test/Ice/servantLocator/Server.cpp
@@ -77,8 +77,8 @@ Server::run(int argc, char** argv)
 
     adapter->addServantLocator(make_shared<ServantLocatorI>(""), "");
     adapter->addServantLocator(make_shared<ServantLocatorI>("category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("asm"));
+    adapter->add(std::make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
     adapter->activate();
     serverReady();
     adapter->waitForDeactivate();

--- a/cpp/test/Ice/servantLocator/ServerAMD.cpp
+++ b/cpp/test/Ice/servantLocator/ServerAMD.cpp
@@ -77,8 +77,8 @@ ServerAMD::run(int argc, char** argv)
 
     adapter->addServantLocator(make_shared<ServantLocatorAMDI>(""), "");
     adapter->addServantLocator(make_shared<ServantLocatorAMDI>("category"), "category");
-    adapter->add(ICE_MAKE_SHARED(TestAMDI), Ice::stringToIdentity("asm"));
-    adapter->add(ICE_MAKE_SHARED(TestActivationI), Ice::stringToIdentity("test/activation"));
+    adapter->add(std::make_shared<TestAMDI>(), Ice::stringToIdentity("asm"));
+    adapter->add(std::make_shared<TestActivationI>(), Ice::stringToIdentity("test/activation"));
     adapter->activate();
     serverReady();
     adapter->waitForDeactivate();

--- a/cpp/test/Ice/services/AllTests.cpp
+++ b/cpp/test/Ice/services/AllTests.cpp
@@ -58,7 +58,7 @@ public:
 
     int run(int, char*[])
     {
-        _factory = ICE_MAKE_SHARED(Glacier2::SessionFactoryHelper, ICE_MAKE_SHARED(SessionCallbackI));
+        _factory = make_shared<Glacier2::SessionFactoryHelper>(make_shared<SessionCallbackI>());
         return EXIT_SUCCESS;
     }
 
@@ -107,7 +107,7 @@ allTests(Test::TestHelper* helper)
         }
 
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("subscriber" ,"tcp");
-        Ice::ObjectPrxPtr subscriber = adapter->addWithUUID(ICE_MAKE_SHARED(ClockI));
+        Ice::ObjectPrxPtr subscriber = adapter->addWithUUID(std::make_shared<ClockI>());
         adapter->activate();
         assert(!topic);
         cout << "ok" << endl;

--- a/cpp/test/Ice/slicing/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/slicing/exceptions/AllTests.cpp
@@ -35,7 +35,7 @@ class RelayI : public Relay
         ex.b = "base";
         ex.kp = "preserved";
         ex.kpd = "derived";
-        ex.p1 = ICE_MAKE_SHARED(PreservedClass, "bc", "pc");
+        ex.p1 = make_shared<PreservedClass>("bc", "pc");
         ex.p2 = ex.p1;
         throw ex;
     }
@@ -46,7 +46,7 @@ class RelayI : public Relay
         ex.b = "base";
         ex.kp = "preserved";
         ex.kpd = "derived";
-        ex.p1 = ICE_MAKE_SHARED(PreservedClass, "bc", "pc");
+        ex.p1 = make_shared<PreservedClass>("bc", "pc");
         ex.p2 = ex.p1;
         throw ex;
     }
@@ -684,7 +684,7 @@ allTests(Test::TestHelper* helper)
     }
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("");
-    RelayPrxPtr relay = ICE_UNCHECKED_CAST(RelayPrx, adapter->addWithUUID(ICE_MAKE_SHARED(RelayI)));
+    RelayPrxPtr relay = ICE_UNCHECKED_CAST(RelayPrx, adapter->addWithUUID(make_shared<RelayI>()));
     adapter->activate();
     test->ice_getConnection()->setAdapter(adapter);
     try

--- a/cpp/test/Ice/slicing/exceptions/Server.cpp
+++ b/cpp/test/Ice/slicing/exceptions/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     properties->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("Test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
@@ -23,7 +23,7 @@ ServerAMD::run(int argc, char** argv)
     properties->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity("Test"));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/slicing/exceptions/TestI.cpp
+++ b/cpp/test/Ice/slicing/exceptions/TestI.cpp
@@ -6,6 +6,7 @@
 #include <Ice/Ice.h>
 #include <TestHelper.h>
 
+using namespace std;
 using namespace Test;
 
 TestI::TestI()
@@ -166,7 +167,7 @@ TestI::knownPreservedAsKnownPreserved(const ::Ice::Current&)
 }
 
 void
-TestI::relayKnownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayKnownPreservedAsBase(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->knownPreservedAsBase();
@@ -174,7 +175,7 @@ TestI::relayKnownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
 }
 
 void
-TestI::relayKnownPreservedAsKnownPreserved(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayKnownPreservedAsKnownPreserved(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->knownPreservedAsKnownPreserved();
@@ -188,7 +189,7 @@ TestI::unknownPreservedAsBase(const ::Ice::Current&)
     ex.b = "base";
     ex.kp = "preserved";
     ex.kpd = "derived";
-    ex.p1 = ICE_MAKE_SHARED(SPreservedClass, "bc", "spc");
+    ex.p1 = make_shared<SPreservedClass>("bc", "spc");
     ex.p2 = ex.p1;
     throw ex;
 }
@@ -200,13 +201,13 @@ TestI::unknownPreservedAsKnownPreserved(const ::Ice::Current&)
     ex.b = "base";
     ex.kp = "preserved";
     ex.kpd = "derived";
-    ex.p1 = ICE_MAKE_SHARED(SPreservedClass, "bc", "spc");
+    ex.p1 = make_shared<SPreservedClass>("bc", "spc");
     ex.p2 = ex.p1;
     throw ex;
 }
 
 void
-TestI::relayUnknownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayUnknownPreservedAsBase(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->unknownPreservedAsBase();
@@ -214,7 +215,7 @@ TestI::relayUnknownPreservedAsBase(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& 
 }
 
 void
-TestI::relayUnknownPreservedAsKnownPreserved(ICE_IN(RelayPrxPtr) r, const ::Ice::Current& c)
+TestI::relayUnknownPreservedAsKnownPreserved(RelayPrxPtr r, const ::Ice::Current& c)
 {
     RelayPrxPtr p = ICE_UNCHECKED_CAST(RelayPrx, c.con->createProxy(r->ice_getIdentity()));
     p->unknownPreservedAsKnownPreserved();

--- a/cpp/test/Ice/slicing/exceptions/TestI.h
+++ b/cpp/test/Ice/slicing/exceptions/TestI.h
@@ -33,14 +33,14 @@ public:
     virtual void knownPreservedAsBase(const ::Ice::Current&);
     virtual void knownPreservedAsKnownPreserved(const ::Ice::Current&);
 
-    virtual void relayKnownPreservedAsBase(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
-    virtual void relayKnownPreservedAsKnownPreserved(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
+    virtual void relayKnownPreservedAsBase(Test::RelayPrxPtr, const ::Ice::Current&);
+    virtual void relayKnownPreservedAsKnownPreserved(Test::RelayPrxPtr, const ::Ice::Current&);
 
     virtual void unknownPreservedAsBase(const ::Ice::Current&);
     virtual void unknownPreservedAsKnownPreserved(const ::Ice::Current&);
 
-    virtual void relayUnknownPreservedAsBase(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
-    virtual void relayUnknownPreservedAsKnownPreserved(ICE_IN(::Test::RelayPrxPtr), const ::Ice::Current&);
+    virtual void relayUnknownPreservedAsBase(Test::RelayPrxPtr, const ::Ice::Current&);
+    virtual void relayUnknownPreservedAsKnownPreserved(Test::RelayPrxPtr, const ::Ice::Current&);
 
     virtual void shutdown(const ::Ice::Current&);
 };

--- a/cpp/test/Ice/slicing/objects/AllTests.cpp
+++ b/cpp/test/Ice/slicing/objects/AllTests.cpp
@@ -15,7 +15,7 @@ namespace
 void breakCycles(Ice::ValuePtr);
 
 template<typename T>
-void breakCycles(const vector<ICE_SHARED_PTR<T>>& s)
+void breakCycles(const vector<shared_ptr<T>>& s)
 {
     for(auto e : s)
     {
@@ -24,7 +24,7 @@ void breakCycles(const vector<ICE_SHARED_PTR<T>>& s)
 }
 
 template<typename K, typename V>
-void breakCycles(const map<K, ICE_SHARED_PTR<V>>& d)
+void breakCycles(const map<K, shared_ptr<V>>& d)
 {
     for(auto e : d)
     {
@@ -32,7 +32,7 @@ void breakCycles(const map<K, ICE_SHARED_PTR<V>>& d)
     }
 }
 
-void breakCycles(ICE_SHARED_PTR<Ice::Value> o)
+void breakCycles(shared_ptr<Ice::Value> o)
 {
     if(ICE_DYNAMIC_CAST(D1, o))
     {
@@ -623,7 +623,7 @@ public:
     BDict rbdict;
     BDict obdict;
 };
-ICE_DEFINE_PTR(CallbackPtr, Callback);
+using CallbackPtr = std::shared_ptr<Callback>;
 
 class PNodeI : public virtual PNode
 {
@@ -1426,10 +1426,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1475,10 +1475,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1525,10 +1525,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1576,10 +1576,10 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d1 = ICE_MAKE_SHARED(D1);
+            D1Ptr d1 = std::make_shared<D1>();
             d1->sb = "D1.sb";
             d1->sd1 = "D1.sd1";
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->pb = d1;
             d3->sb = "D3.sb";
             d3->sd3 = "D3.sd3";
@@ -1752,17 +1752,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            BPtr b1 = ICE_MAKE_SHARED(B);
+            BPtr b1 = std::make_shared<B>();
             b1->sb = "B.sb(1)";
             b1->pb = b1;
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = b1;
 
-            BPtr b2 = ICE_MAKE_SHARED(B);
+            BPtr b2 = std::make_shared<B>();
             b2->sb = "B.sb(2)";
             b2->pb = b1;
 
@@ -1788,17 +1788,17 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            BPtr b1 = ICE_MAKE_SHARED(B);
+            BPtr b1 = std::make_shared<B>();
             b1->sb = "B.sb(1)";
             b1->pb = b1;
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = b1;
 
-            BPtr b2 = ICE_MAKE_SHARED(B);
+            BPtr b2 = std::make_shared<B>();
             b2->sb = "B.sb(2)";
             b2->pb = b1;
 
@@ -1824,18 +1824,18 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d11 = ICE_MAKE_SHARED(D1);
+            D1Ptr d11 = std::make_shared<D1>();
             d11->sb = "D1.sb(1)";
             d11->pb = d11;
             d11->sd1 = "D1.sd1(1)";
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = d11;
 
-            D1Ptr d12 = ICE_MAKE_SHARED(D1);
+            D1Ptr d12 = std::make_shared<D1>();
             d12->sb = "D1.sb(2)";
             d12->pb = d12;
             d12->sd1 = "D1.sd1(2)";
@@ -1864,18 +1864,18 @@ allTests(Test::TestHelper* helper)
     {
         try
         {
-            D1Ptr d11 = ICE_MAKE_SHARED(D1);
+            D1Ptr d11 = std::make_shared<D1>();
             d11->sb = "D1.sb(1)";
             d11->pb = d11;
             d11->sd1 = "D1.sd1(1)";
 
-            D3Ptr d3 = ICE_MAKE_SHARED(D3);
+            D3Ptr d3 = std::make_shared<D3>();
             d3->sb = "D3.sb";
             d3->pb = d3;
             d3->sd3 = "D3.sd3";
             d3->pd3 = d11;
 
-            D1Ptr d12 = ICE_MAKE_SHARED(D1);
+            D1Ptr d12 = std::make_shared<D1>();
             d12->sb = "D1.sb(2)";
             d12->pb = d12;
             d12->sd1 = "D1.sd1(2)";
@@ -1905,30 +1905,30 @@ allTests(Test::TestHelper* helper)
         {
             SS3 ss;
             {
-                BPtr ss1b = ICE_MAKE_SHARED(B);
+                BPtr ss1b = std::make_shared<B>();
                 ss1b->sb = "B.sb";
                 ss1b->pb = ss1b;
 
-                D1Ptr ss1d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss1d1 = std::make_shared<D1>();
                 ss1d1->sb = "D1.sb";
                 ss1d1->sd1 = "D1.sd1";
                 ss1d1->pb = ss1b;
 
-                D3Ptr ss1d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss1d3 = std::make_shared<D3>();
                 ss1d3->sb = "D3.sb";
                 ss1d3->sd3 = "D3.sd3";
                 ss1d3->pb = ss1b;
 
-                BPtr ss2b = ICE_MAKE_SHARED(B);
+                BPtr ss2b = std::make_shared<B>();
                 ss2b->sb = "B.sb";
                 ss2b->pb = ss1b;
 
-                D1Ptr ss2d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss2d1 = std::make_shared<D1>();
                 ss2d1->sb = "D1.sb";
                 ss2d1->sd1 = "D1.sd1";
                 ss2d1->pb = ss2b;
 
-                D3Ptr ss2d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss2d3 = std::make_shared<D3>();
                 ss2d3->sb = "D3.sb";
                 ss2d3->sd3 = "D3.sd3";
                 ss2d3->pb = ss2b;
@@ -1939,12 +1939,12 @@ allTests(Test::TestHelper* helper)
                 ss2d1->pd1 = ss1d3;
                 ss2d3->pd3 = ss1d1;
 
-                SS1Ptr ss1 = ICE_MAKE_SHARED(SS1);
+                SS1Ptr ss1 = std::make_shared<SS1>();
                 ss1->s.push_back(ss1b);
                 ss1->s.push_back(ss1d1);
                 ss1->s.push_back(ss1d3);
 
-                SS2Ptr ss2 = ICE_MAKE_SHARED(SS2);
+                SS2Ptr ss2 = std::make_shared<SS2>();
                 ss2->s.push_back(ss2b);
                 ss2->s.push_back(ss2d1);
                 ss2->s.push_back(ss2d3);
@@ -1998,30 +1998,30 @@ allTests(Test::TestHelper* helper)
         {
             SS3 ss;
             {
-                BPtr ss1b = ICE_MAKE_SHARED(B);
+                BPtr ss1b = std::make_shared<B>();
                 ss1b->sb = "B.sb";
                 ss1b->pb = ss1b;
 
-                D1Ptr ss1d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss1d1 = std::make_shared<D1>();
                 ss1d1->sb = "D1.sb";
                 ss1d1->sd1 = "D1.sd1";
                 ss1d1->pb = ss1b;
 
-                D3Ptr ss1d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss1d3 = std::make_shared<D3>();
                 ss1d3->sb = "D3.sb";
                 ss1d3->sd3 = "D3.sd3";
                 ss1d3->pb = ss1b;
 
-                BPtr ss2b = ICE_MAKE_SHARED(B);
+                BPtr ss2b = std::make_shared<B>();
                 ss2b->sb = "B.sb";
                 ss2b->pb = ss1b;
 
-                D1Ptr ss2d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr ss2d1 = std::make_shared<D1>();
                 ss2d1->sb = "D1.sb";
                 ss2d1->sd1 = "D1.sd1";
                 ss2d1->pb = ss2b;
 
-                D3Ptr ss2d3 = ICE_MAKE_SHARED(D3);
+                D3Ptr ss2d3 = std::make_shared<D3>();
                 ss2d3->sb = "D3.sb";
                 ss2d3->sd3 = "D3.sd3";
                 ss2d3->pb = ss2b;
@@ -2032,12 +2032,12 @@ allTests(Test::TestHelper* helper)
                 ss2d1->pd1 = ss1d3;
                 ss2d3->pd3 = ss1d1;
 
-                SS1Ptr ss1 = ICE_MAKE_SHARED(SS1);
+                SS1Ptr ss1 = std::make_shared<SS1>();
                 ss1->s.push_back(ss1b);
                 ss1->s.push_back(ss1d1);
                 ss1->s.push_back(ss1d3);
 
-                SS2Ptr ss2 = ICE_MAKE_SHARED(SS2);
+                SS2Ptr ss2 = std::make_shared<SS2>();
                 ss2->s.push_back(ss2b);
                 ss2->s.push_back(ss2d1);
                 ss2->s.push_back(ss2d3);
@@ -2096,7 +2096,7 @@ allTests(Test::TestHelper* helper)
             {
                 ostringstream s;
                 s << "D1." << i;
-                D1Ptr d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr d1 = std::make_shared<D1>();
                 d1->sb = s.str();
                 d1->pb = d1;
                 d1->sd1 = s.str();
@@ -2157,7 +2157,7 @@ allTests(Test::TestHelper* helper)
             {
                 ostringstream s;
                 s << "D1." << i;
-                D1Ptr d1 = ICE_MAKE_SHARED(D1);
+                D1Ptr d1 = std::make_shared<D1>();
                 d1->sb = s.str();
                 d1->pb = d1;
                 d1->sd1 = s.str();
@@ -2426,7 +2426,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server knows the most-derived class PDerived.
         //
-        PDerivedPtr pd = ICE_MAKE_SHARED(PDerived);
+        PDerivedPtr pd = std::make_shared<PDerived>();
         pd->pi = 3;
         pd->ps = "preserved";
         pd->pb = pd;
@@ -2449,7 +2449,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server only knows the base (non-preserved) type, so the object is sliced.
         //
-        PCUnknownPtr pu = ICE_MAKE_SHARED(PCUnknown);
+        PCUnknownPtr pu = std::make_shared<PCUnknown>();
         pu->pi = 3;
         pu->pu = "preserved";
         PBasePtr r = test->exchangePBase(pu);
@@ -2469,7 +2469,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type Preserved. The object will be sliced to
         // Preserved for the 1.0 encoding; otherwise it should be returned intact.
         //
-        PCDerivedPtr pcd = ICE_MAKE_SHARED(PCDerived);
+        PCDerivedPtr pcd = std::make_shared<PCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
         PBasePtr r = test->exchangePBase(pcd);
@@ -2499,7 +2499,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type CompactPDerived. The object will be sliced to
         // CompactPDerived for the 1.0 encoding; otherwise it should be returned intact.
         //
-        CompactPCDerivedPtr pcd = ICE_MAKE_SHARED(CompactPCDerived);
+        CompactPCDerivedPtr pcd = std::make_shared<CompactPCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
         PBasePtr r = test->exchangePBase(pcd);
@@ -2529,7 +2529,7 @@ allTests(Test::TestHelper* helper)
         // Send an object that will have multiple preserved slices in the server.
         // The object will be sliced to Preserved for the 1.0 encoding.
         //
-        PCDerived3Ptr pcd = ICE_MAKE_SHARED(PCDerived3);
+        PCDerived3Ptr pcd = std::make_shared<PCDerived3>();
         pcd->pi = 3;
         //
         // Sending more than 254 objects exercises the encoding for object ids.
@@ -2537,7 +2537,7 @@ allTests(Test::TestHelper* helper)
         int i;
         for(i = 0; i < 300; ++i)
         {
-            PCDerived2Ptr p2 = ICE_MAKE_SHARED(PCDerived2);
+            PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
             p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;
@@ -2612,7 +2612,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server knows the most-derived class PDerived.
         //
-        PDerivedPtr pd = ICE_MAKE_SHARED(PDerived);
+        PDerivedPtr pd = std::make_shared<PDerived>();
         pd->pi = 3;
         pd->ps = "preserved";
         pd->ps = "preserved";
@@ -2638,7 +2638,7 @@ allTests(Test::TestHelper* helper)
         //
         // Server only knows the base (non-preserved) type, so the object is sliced.
         //
-        PCUnknownPtr pu = ICE_MAKE_SHARED(PCUnknown);
+        PCUnknownPtr pu = std::make_shared<PCUnknown>();
         pu->pi = 3;
         pu->pu = "preserved";
         try
@@ -2661,7 +2661,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type Preserved. The object will be sliced to
         // Preserved for the 1.0 encoding; otherwise it should be returned intact.
         //
-        PCDerivedPtr pcd = ICE_MAKE_SHARED(PCDerived);
+        PCDerivedPtr pcd = std::make_shared<PCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
         if(test->ice_getEncodingVersion() == Ice::Encoding_1_0)
@@ -2691,7 +2691,7 @@ allTests(Test::TestHelper* helper)
         // Server only knows the intermediate type CompactPDerived. The object will be sliced to
         // CompactPDerived for the 1.0 encoding; otherwise it should be returned intact.
         //
-        CompactPCDerivedPtr pcd = ICE_MAKE_SHARED(CompactPCDerived);
+        CompactPCDerivedPtr pcd = std::make_shared<CompactPCDerived>();
         pcd->pi = 3;
         pcd->pbs.push_back(pcd);
 
@@ -2722,14 +2722,14 @@ allTests(Test::TestHelper* helper)
         // Send an object that will have multiple preserved slices in the server.
         // The object will be sliced to Preserved for the 1.0 encoding.
         //
-        PCDerived3Ptr pcd = ICE_MAKE_SHARED(PCDerived3);
+        PCDerived3Ptr pcd = std::make_shared<PCDerived3>();
         pcd->pi = 3;
         //
         // Sending more than 254 objects exercises the encoding for object ids.
         //
         for(int i = 0; i < 300; ++i)
         {
-            PCDerived2Ptr p2 = ICE_MAKE_SHARED(PCDerived2);
+            PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
             p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;

--- a/cpp/test/Ice/slicing/objects/Server.cpp
+++ b/cpp/test/Ice/slicing/objects/Server.cpp
@@ -24,7 +24,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/slicing/objects/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/objects/ServerAMD.cpp
@@ -24,7 +24,7 @@ ServerAMD::run(int argc, char** argv)
     communicator->getProperties()->setProperty("Ice.Warn.Dispatch", "0");
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint() + " -t 2000");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(TestI);
+    Ice::ObjectPtr object = std::make_shared<TestI>();
     adapter->add(object, Ice::stringToIdentity("Test"));
     adapter->activate();
     serverReady();

--- a/cpp/test/Ice/slicing/objects/TestI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestI.cpp
@@ -15,7 +15,7 @@ namespace
 void breakCycles(Ice::ValuePtr);
 
 template<typename T>
-void breakCycles(const vector<ICE_SHARED_PTR<T>>& s)
+void breakCycles(const vector<shared_ptr<T>>& s)
 {
     for(auto e : s)
     {
@@ -24,7 +24,7 @@ void breakCycles(const vector<ICE_SHARED_PTR<T>>& s)
 }
 
 template<typename K, typename V>
-void breakCycles(const map<K, ICE_SHARED_PTR<V>>& d)
+void breakCycles(const map<K, shared_ptr<V>>& d)
 {
     for(auto e : d)
     {
@@ -143,7 +143,7 @@ TestI::~TestI()
 Ice::ValuePtr
 TestI::SBaseAsObject(const ::Ice::Current&)
 {
-    SBasePtr sb = ICE_MAKE_SHARED(SBase);
+    SBasePtr sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
     return sb;
 }
@@ -151,7 +151,7 @@ TestI::SBaseAsObject(const ::Ice::Current&)
 SBasePtr
 TestI::SBaseAsSBase(const ::Ice::Current&)
 {
-    SBasePtr sb = ICE_MAKE_SHARED(SBase);
+    SBasePtr sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
     return sb;
 }
@@ -159,7 +159,7 @@ TestI::SBaseAsSBase(const ::Ice::Current&)
 SBasePtr
 TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
 {
-    SBSKnownDerivedPtr sbskd = ICE_MAKE_SHARED(SBSKnownDerived);
+    SBSKnownDerivedPtr sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
     sbskd->sbskd = "SBSKnownDerived.sbskd";
     return sbskd;
@@ -168,7 +168,7 @@ TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
 SBSKnownDerivedPtr
 TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
 {
-    SBSKnownDerivedPtr sbskd = ICE_MAKE_SHARED(SBSKnownDerived);
+    SBSKnownDerivedPtr sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
     sbskd->sbskd = "SBSKnownDerived.sbskd";
     return sbskd;
@@ -177,7 +177,7 @@ TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
 SBasePtr
 TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
 {
-    SBSUnknownDerivedPtr sbsud = ICE_MAKE_SHARED(SBSUnknownDerived);
+    SBSUnknownDerivedPtr sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
     sbsud->sbsud = "SBSUnknownDerived.sbsud";
     return sbsud;
@@ -186,7 +186,7 @@ TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
 SBasePtr
 TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
 {
-    SBSUnknownDerivedPtr sbsud = ICE_MAKE_SHARED(SBSUnknownDerived);
+    SBSUnknownDerivedPtr sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
     sbsud->sbsud = "SBSUnknownDerived.sbsud";
     return sbsud;
@@ -195,7 +195,7 @@ TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
 Ice::ValuePtr
 TestI::SUnknownAsObject(const ::Ice::Current&)
 {
-    SUnknownPtr su = ICE_MAKE_SHARED(SUnknown);
+    SUnknownPtr su = make_shared<SUnknown>();
     su->su = "SUnknown.su";
     su->cycle = su;
     _values.push_back(su);
@@ -203,7 +203,7 @@ TestI::SUnknownAsObject(const ::Ice::Current&)
 }
 
 void
-TestI::checkSUnknown(ICE_IN(Ice::ValuePtr) obj, const ::Ice::Current& current)
+TestI::checkSUnknown(Ice::ValuePtr obj, const ::Ice::Current& current)
 {
     SUnknownPtr su = ICE_DYNAMIC_CAST(SUnknown, obj);
     if(current.encoding == Ice::Encoding_1_0)
@@ -221,7 +221,7 @@ TestI::checkSUnknown(ICE_IN(Ice::ValuePtr) obj, const ::Ice::Current& current)
 BPtr
 TestI::oneElementCycle(const ::Ice::Current&)
 {
-    BPtr b = ICE_MAKE_SHARED(B);
+    BPtr b = make_shared<B>();
     b->sb = "B1.sb";
     b->pb = b;
     _values.push_back(b);
@@ -231,9 +231,9 @@ TestI::oneElementCycle(const ::Ice::Current&)
 BPtr
 TestI::twoElementCycle(const ::Ice::Current&)
 {
-    BPtr b1 = ICE_MAKE_SHARED(B);
+    BPtr b1 = make_shared<B>();
     b1->sb = "B1.sb";
-    BPtr b2 = ICE_MAKE_SHARED(B);
+    BPtr b2 = make_shared<B>();
     b2->sb = "B2.sb";
     b2->pb = b1;
     b1->pb = b2;
@@ -244,10 +244,10 @@ TestI::twoElementCycle(const ::Ice::Current&)
 BPtr
 TestI::D1AsB(const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -261,10 +261,10 @@ TestI::D1AsB(const ::Ice::Current&)
 D1Ptr
 TestI::D1AsD1(const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -278,10 +278,10 @@ TestI::D1AsD1(const ::Ice::Current&)
 BPtr
 TestI::D2AsB(const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = make_shared<D1>();
     d1->pb = d2;
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
@@ -295,10 +295,10 @@ TestI::D2AsB(const ::Ice::Current&)
 void
 TestI::paramTest1(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 {
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
     d1->sd1 = "D1.sd1";
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->pb = d1;
     d2->sb = "D2.sb";
     d2->sd2 = "D2.sd2";
@@ -320,26 +320,26 @@ TestI::paramTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 BPtr
 TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->sb = "D2.sb (p1 1)";
     d2->pb = 0;
     d2->sd2 = "D2.sd2 (p1 1)";
     p1 = d2;
 
-    D1Ptr d1 = ICE_MAKE_SHARED(D1);
+    D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb (p1 2)";
     d1->pb = 0;
     d1->sd1 = "D1.sd2 (p1 2)";
     d1->pd1 = 0;
     d2->pd2 = d1;
 
-    D2Ptr d4 = ICE_MAKE_SHARED(D2);
+    D2Ptr d4 = make_shared<D2>();
     d4->sb = "D2.sb (p2 1)";
     d4->pb = 0;
     d4->sd2 = "D2.sd2 (p2 1)";
     p2 = d4;
 
-    D1Ptr d3 = ICE_MAKE_SHARED(D1);
+    D1Ptr d3 = make_shared<D1>();
     d3->sb = "D1.sb (p2 2)";
     d3->pb = 0;
     d3->sd1 = "D1.sd2 (p2 2)";
@@ -357,12 +357,12 @@ TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 BPtr
 TestI::paramTest4(BPtr& p1, const ::Ice::Current&)
 {
-    D4Ptr d4 = ICE_MAKE_SHARED(D4);
+    D4Ptr d4 = make_shared<D4>();
     d4->sb = "D4.sb (1)";
     d4->pb = 0;
-    d4->p1 = ICE_MAKE_SHARED(B);
+    d4->p1 = make_shared<B>();
     d4->p1->sb = "B.sb (1)";
-    d4->p2 = ICE_MAKE_SHARED(B);
+    d4->p2 = make_shared<B>();
     d4->p2->sb = "B.sb (2)";
     p1 = d4;
     _values.push_back(d4);
@@ -386,7 +386,7 @@ TestI::returnTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 }
 
 BPtr
-TestI::returnTest3(ICE_IN(BPtr) p1, ICE_IN(BPtr) p2, const ::Ice::Current&)
+TestI::returnTest3(BPtr p1, BPtr p2, const ::Ice::Current&)
 {
     _values.push_back(p1);
     _values.push_back(p2);
@@ -394,7 +394,7 @@ TestI::returnTest3(ICE_IN(BPtr) p1, ICE_IN(BPtr) p2, const ::Ice::Current&)
 }
 
 SS3
-TestI::sequenceTest(ICE_IN(SS1Ptr) p1, ICE_IN(SS2Ptr) p2, const ::Ice::Current&)
+TestI::sequenceTest(SS1Ptr p1, SS2Ptr p2, const ::Ice::Current&)
 {
     SS3 ss;
     ss.c1 = p1;
@@ -405,13 +405,13 @@ TestI::sequenceTest(ICE_IN(SS1Ptr) p1, ICE_IN(SS2Ptr) p2, const ::Ice::Current&)
 }
 
 Test::BDict
-TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
+TestI::dictionaryTest(BDict bin, BDict& bout, const ::Ice::Current&)
 {
     int i;
     for(i = 0; i < 10; ++i)
     {
         BPtr b = bin.find(i)->second;
-        D2Ptr d2 = ICE_MAKE_SHARED(D2);
+        D2Ptr d2 = make_shared<D2>();
         d2->sb = b->sb;
         d2->pb = b->pb;
         d2->sd2 = "D2";
@@ -424,7 +424,7 @@ TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
     {
         std::ostringstream s;
         s << "D1." << i * 20;
-        D1Ptr d1 = ICE_MAKE_SHARED(D1);
+        D1Ptr d1 = make_shared<D1>();
         d1->sb = s.str();
         d1->pb = (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second);
         d1->sd1 = s.str();
@@ -436,7 +436,7 @@ TestI::dictionaryTest(ICE_IN(BDict) bin, BDict& bout, const ::Ice::Current&)
 }
 
 Test::PBasePtr
-TestI::exchangePBase(ICE_IN(Test::PBasePtr) pb, const Ice::Current&)
+TestI::exchangePBase(Test::PBasePtr pb, const Ice::Current&)
 {
     _values.push_back(pb);
     return pb;
@@ -445,7 +445,7 @@ TestI::exchangePBase(ICE_IN(Test::PBasePtr) pb, const Ice::Current&)
 Test::PreservedPtr
 TestI::PBSUnknownAsPreserved(const Ice::Current& current)
 {
-    PSUnknownPtr r = ICE_MAKE_SHARED(PSUnknown);
+    PSUnknownPtr r = make_shared<PSUnknown>();
     r->pi = 5;
     r->ps = "preserved";
     r->psu = "unknown";
@@ -456,13 +456,13 @@ TestI::PBSUnknownAsPreserved(const Ice::Current& current)
         // 1.0 encoding doesn't support unmarshaling unknown classes even if referenced
         // from unread slice.
         //
-        r->cl = ICE_MAKE_SHARED(MyClass, 15);
+        r->cl = make_shared<MyClass>(15);
     }
     return r;
 }
 
 void
-TestI::checkPBSUnknown(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknown(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknownPtr pu =  ICE_DYNAMIC_CAST(PSUnknown, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -487,20 +487,20 @@ TestI::PBSUnknownAsPreservedWithGraphAsync(function<void(const shared_ptr<Test::
                                             function<void(exception_ptr)>,
                                             const Ice::Current&)
 {
-    PSUnknownPtr r = ICE_MAKE_SHARED(PSUnknown);
+    PSUnknownPtr r = make_shared<PSUnknown>();
     r->pi = 5;
     r->ps = "preserved";
     r->psu = "unknown";
-    r->graph = ICE_MAKE_SHARED(PNode);
-    r->graph->next = ICE_MAKE_SHARED(PNode);
-    r->graph->next->next = ICE_MAKE_SHARED(PNode);
+    r->graph = make_shared<PNode>();
+    r->graph->next = make_shared<PNode>();
+    r->graph->next->next = make_shared<PNode>();
     r->graph->next->next->next = r->graph;
     response(r);
     r->graph->next->next->next = 0; // Break the cycle.
 }
 
 void
-TestI::checkPBSUnknownWithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknownWithGraph(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknownPtr pu = ICE_DYNAMIC_CAST(PSUnknown, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -527,7 +527,7 @@ TestI::PBSUnknown2AsPreservedWithGraphAsync(function<void(const shared_ptr<Test:
                                              function<void(exception_ptr)>,
                                              const Ice::Current&)
 {
-    PSUnknown2Ptr r = ICE_MAKE_SHARED(PSUnknown2);
+    PSUnknown2Ptr r = make_shared<PSUnknown2>();
     r->pi = 5;
     r->ps = "preserved";
     r->pb = r;
@@ -536,7 +536,7 @@ TestI::PBSUnknown2AsPreservedWithGraphAsync(function<void(const shared_ptr<Test:
 }
 
 void
-TestI::checkPBSUnknown2WithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Current& current)
+TestI::checkPBSUnknown2WithGraph(Test::PreservedPtr p, const Ice::Current& current)
 {
     PSUnknown2Ptr pu = ICE_DYNAMIC_CAST(PSUnknown2, p);
     if(current.encoding == Ice::Encoding_1_0)
@@ -556,7 +556,7 @@ TestI::checkPBSUnknown2WithGraph(ICE_IN(Test::PreservedPtr) p, const Ice::Curren
 }
 
 Test::PNodePtr
-TestI::exchangePNode(ICE_IN(Test::PNodePtr) pn, const Ice::Current&)
+TestI::exchangePNode(Test::PNodePtr pn, const Ice::Current&)
 {
     _values.push_back(pn);
     return pn;
@@ -567,7 +567,7 @@ TestI::throwBaseAsBase(const ::Ice::Current&)
 {
     BaseException be;
     be.sbe = "sbe";
-    be.pb = ICE_MAKE_SHARED(B);
+    be.pb = make_shared<B>();
     be.pb->sb = "sb";
     be.pb->pb = be.pb;
     _values.push_back(be.pb);
@@ -579,11 +579,11 @@ TestI::throwDerivedAsBase(const ::Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
-    de.pb = ICE_MAKE_SHARED(B);
+    de.pb = make_shared<B>();
     de.pb->sb = "sb1";
     de.pb->pb = de.pb;
     de.sde = "sde1";
-    de.pd1 = ICE_MAKE_SHARED(D1);
+    de.pd1 = make_shared<D1>();
     de.pd1->sb = "sb2";
     de.pd1->pb = de.pd1;
     de.pd1->sd1 = "sd2";
@@ -598,11 +598,11 @@ TestI::throwDerivedAsDerived(const ::Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
-    de.pb = ICE_MAKE_SHARED(B);
+    de.pb = make_shared<B>();
     de.pb->sb = "sb1";
     de.pb->pb = de.pb;
     de.sde = "sde1";
-    de.pd1 = ICE_MAKE_SHARED(D1);
+    de.pd1 = make_shared<D1>();
     de.pd1->sb = "sb2";
     de.pd1->pb = de.pd1;
     de.pd1->sd1 = "sd2";
@@ -615,7 +615,7 @@ TestI::throwDerivedAsDerived(const ::Ice::Current&)
 void
 TestI::throwUnknownDerivedAsBase(const ::Ice::Current&)
 {
-    D2Ptr d2 = ICE_MAKE_SHARED(D2);
+    D2Ptr d2 = make_shared<D2>();
     d2->sb = "sb d2";
     d2->pb = d2;
     d2->sd2 = "sd2 d2";
@@ -635,7 +635,7 @@ TestI::throwPreservedExceptionAsync(function<void()>,
                                      const ::Ice::Current&)
 {
     PSUnknownException ue;
-    ue.p = ICE_MAKE_SHARED(PSUnknown2);
+    ue.p = make_shared<PSUnknown2>();
     ue.p->pi = 5;
     ue.p->ps = "preserved";
     ue.p->pb = ue.p;
@@ -653,8 +653,8 @@ TestI::throwPreservedExceptionAsync(function<void()>,
 void
 TestI::useForward(ForwardPtr& f, const ::Ice::Current&)
 {
-    f = ICE_MAKE_SHARED(Forward);
-    f->h = ICE_MAKE_SHARED(Hidden);
+    f = make_shared<Forward>();
+    f->h = make_shared<Hidden>();
     f->h->f = f;
     _values.push_back(f);
 }

--- a/cpp/test/Ice/slicing/objects/TestI.h
+++ b/cpp/test/Ice/slicing/objects/TestI.h
@@ -24,7 +24,7 @@ public:
     virtual ::Test::SBasePtr SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&);
 
     virtual ::Ice::ValuePtr SUnknownAsObject(const ::Ice::Current&);
-    virtual void checkSUnknown(ICE_IN(Ice::ValuePtr) object, const ::Ice::Current&);
+    virtual void checkSUnknown(Ice::ValuePtr object, const ::Ice::Current&);
 
     virtual ::Test::BPtr oneElementCycle(const ::Ice::Current&);
     virtual ::Test::BPtr twoElementCycle(const ::Ice::Current&);
@@ -40,28 +40,28 @@ public:
 
     virtual ::Test::BPtr returnTest1(::Test::BPtr&, ::Test::BPtr&, const ::Ice::Current&);
     virtual ::Test::BPtr returnTest2(::Test::BPtr&, ::Test::BPtr&, const ::Ice::Current&);
-    virtual ::Test::BPtr returnTest3(ICE_IN(::Test::BPtr), ICE_IN(::Test::BPtr), const ::Ice::Current&);
+    virtual ::Test::BPtr returnTest3(::Test::BPtr, ::Test::BPtr, const ::Ice::Current&);
 
-    virtual ::Test::SS3 sequenceTest(ICE_IN(::Test::SS1Ptr), ICE_IN(::Test::SS2Ptr), const ::Ice::Current&);
+    virtual ::Test::SS3 sequenceTest(::Test::SS1Ptr, ::Test::SS2Ptr, const ::Ice::Current&);
 
-    virtual ::Test::BDict dictionaryTest(ICE_IN(::Test::BDict), ::Test::BDict&, const ::Ice::Current&);
+    virtual ::Test::BDict dictionaryTest(::Test::BDict, ::Test::BDict&, const ::Ice::Current&);
 
-    virtual ::Test::PBasePtr exchangePBase(ICE_IN(::Test::PBasePtr), const ::Ice::Current&);
+    virtual ::Test::PBasePtr exchangePBase(::Test::PBasePtr, const ::Ice::Current&);
 
     virtual ::Test::PreservedPtr PBSUnknownAsPreserved(const ::Ice::Current&);
-    virtual void checkPBSUnknown(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknown(::Test::PreservedPtr, const ::Ice::Current&);
 
     virtual void PBSUnknownAsPreservedWithGraphAsync(std::function<void(const std::shared_ptr<Test::Preserved>&)>,
                                                       std::function<void(std::exception_ptr)>,
                                                       const ::Ice::Current&);
-    virtual void checkPBSUnknownWithGraph(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknownWithGraph(::Test::PreservedPtr, const ::Ice::Current&);
 
     virtual void PBSUnknown2AsPreservedWithGraphAsync(std::function<void(const std::shared_ptr<Test::Preserved>&)>,
                                                        std::function<void(std::exception_ptr)>,
                                                        const ::Ice::Current&);
-    virtual void checkPBSUnknown2WithGraph(ICE_IN(::Test::PreservedPtr), const ::Ice::Current&);
+    virtual void checkPBSUnknown2WithGraph(::Test::PreservedPtr, const ::Ice::Current&);
 
-    virtual ::Test::PNodePtr exchangePNode(ICE_IN(::Test::PNodePtr), const ::Ice::Current&);
+    virtual ::Test::PNodePtr exchangePNode(::Test::PNodePtr, const ::Ice::Current&);
 
     virtual void throwBaseAsBase(const ::Ice::Current&);
     virtual void throwDerivedAsBase(const ::Ice::Current&);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -56,7 +56,7 @@ public:
 
     virtual void _iceRead(Ice::InputStream* in)
     {
-        obj = ICE_MAKE_SHARED(MyClass);
+        obj = std::make_shared<MyClass>();
         obj->_iceRead(in);
         called = true;
     }
@@ -298,7 +298,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        OptionalClassPtr o = ICE_MAKE_SHARED(OptionalClass);
+        OptionalClassPtr o = std::make_shared<OptionalClass>();
         o->bo = false;
         o->by = 5;
         o->sh = static_cast<Ice::Short>(4);
@@ -326,7 +326,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator, Ice::Encoding_1_0);
-        OptionalClassPtr o = ICE_MAKE_SHARED(OptionalClass);
+        OptionalClassPtr o = std::make_shared<OptionalClass>();
         o->bo = false;
         o->by = 5;
         o->sh = static_cast<Ice::Short>(4);
@@ -661,7 +661,7 @@ allTests(Test::TestHelper* helper)
         MyClassS arr;
         for(int i = 0; i < 4; ++i)
         {
-            MyClassPtr c = ICE_MAKE_SHARED(MyClass);
+            MyClassPtr c = std::make_shared<MyClass>();
             c->c = c;
             c->o = c;
             c->s.e = ICE_ENUM(MyEnum, enum2);
@@ -804,7 +804,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr obj = std::make_shared<MyClass>();
         obj->s.e = ICE_ENUM(MyEnum, enum2);
         shared_ptr<TestObjectWriter> writer = make_shared<TestObjectWriter>(obj);
         out.write(writer);
@@ -815,7 +815,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        MyClassPtr obj = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr obj = std::make_shared<MyClass>();
         obj->s.e = ICE_ENUM(MyEnum, enum2);
         shared_ptr<TestObjectWriter> writer = make_shared<TestObjectWriter>(obj);
         out.write(writer);
@@ -839,7 +839,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyException ex;
-        MyClassPtr c = ICE_MAKE_SHARED(MyClass);
+        MyClassPtr c = std::make_shared<MyClass>();
         c->c = c;
         c->o = c;
         c->s.e = ICE_ENUM(MyEnum, enum2);
@@ -974,9 +974,9 @@ allTests(Test::TestHelper* helper)
 
     {
         StringMyClassD dict;
-        dict["key1"] = ICE_MAKE_SHARED(MyClass);
+        dict["key1"] = std::make_shared<MyClass>();
         dict["key1"]->s.e = ICE_ENUM(MyEnum, enum2);
-        dict["key2"] = ICE_MAKE_SHARED(MyClass);
+        dict["key2"] = std::make_shared<MyClass>();
         dict["key2"]->s.e = ICE_ENUM(MyEnum, enum3);
         Ice::OutputStream out(communicator);
         out.write(dict);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -264,12 +264,12 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(MyEnum, enum3));
+        out.write(MyEnum::enum3);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         MyEnum e;
         in.read(e);
-        test(e == ICE_ENUM(MyEnum, enum3));
+        test(e == MyEnum::enum3);
     }
 
     {
@@ -283,7 +283,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(MyEnum, enum2);
+        s.e = MyEnum::enum2;
         s.p = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test:default"));
         out.write(s);
         out.finished(data);
@@ -581,10 +581,10 @@ allTests(Test::TestHelper* helper)
 
     {
         MyEnumS arr;
-        arr.push_back(ICE_ENUM(MyEnum, enum3));
-        arr.push_back(ICE_ENUM(MyEnum, enum2));
-        arr.push_back(ICE_ENUM(MyEnum, enum1));
-        arr.push_back(ICE_ENUM(MyEnum, enum2));
+        arr.push_back(MyEnum::enum3);
+        arr.push_back(MyEnum::enum2);
+        arr.push_back(MyEnum::enum1);
+        arr.push_back(MyEnum::enum2);
 
         Ice::OutputStream out(communicator);
         out.write(arr);
@@ -622,7 +622,7 @@ allTests(Test::TestHelper* helper)
             s.f = 5.0;
             s.d = 6.0;
             s.str = "7";
-            s.e = ICE_ENUM(MyEnum, enum2);
+            s.e = MyEnum::enum2;
             s.p = ICE_UNCHECKED_CAST(MyInterfacePrx, communicator->stringToProxy("test:default"));
             arr.push_back(s);
         }
@@ -664,7 +664,7 @@ allTests(Test::TestHelper* helper)
             MyClassPtr c = std::make_shared<MyClass>();
             c->c = c;
             c->o = c;
-            c->s.e = ICE_ENUM(MyEnum, enum2);
+            c->s.e = MyEnum::enum2;
 
             c->seq1.push_back(true);
             c->seq1.push_back(false);
@@ -706,9 +706,9 @@ allTests(Test::TestHelper* helper)
             c->seq8.push_back("string3");
             c->seq8.push_back("string4");
 
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum3));
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum2));
-            c->seq9.push_back(ICE_ENUM(MyEnum, enum1));
+            c->seq9.push_back(MyEnum::enum3);
+            c->seq9.push_back(MyEnum::enum2);
+            c->seq9.push_back(MyEnum::enum1);
 
             c->d["hi"] = c;
             arr.push_back(c);
@@ -728,7 +728,7 @@ allTests(Test::TestHelper* helper)
             test(arr2[j]);
             test(arr2[j]->c == arr2[j]);
             test(arr2[j]->o == arr2[j]);
-            test(arr2[j]->s.e == ICE_ENUM(MyEnum, enum2));
+            test(arr2[j]->s.e == MyEnum::enum2);
             test(arr2[j]->seq1 == arr[j]->seq1);
             test(arr2[j]->seq2 == arr[j]->seq2);
             test(arr2[j]->seq3 == arr[j]->seq3);
@@ -765,7 +765,7 @@ allTests(Test::TestHelper* helper)
             {
                 test(arr2S[j][k]->c == arr2S[j][k]);
                 test(arr2S[j][k]->o == arr2S[j][k]);
-                test(arr2S[j][k]->s.e == ICE_ENUM(MyEnum, enum2));
+                test(arr2S[j][k]->s.e == MyEnum::enum2);
                 test(arr2S[j][k]->seq1 == arr[k]->seq1);
                 test(arr2S[j][k]->seq2 == arr[k]->seq2);
                 test(arr2S[j][k]->seq3 == arr[k]->seq3);
@@ -805,7 +805,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyClassPtr obj = std::make_shared<MyClass>();
-        obj->s.e = ICE_ENUM(MyEnum, enum2);
+        obj->s.e = MyEnum::enum2;
         shared_ptr<TestObjectWriter> writer = make_shared<TestObjectWriter>(obj);
         out.write(writer);
         out.writePendingValues();
@@ -816,7 +816,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::OutputStream out(communicator);
         MyClassPtr obj = std::make_shared<MyClass>();
-        obj->s.e = ICE_ENUM(MyEnum, enum2);
+        obj->s.e = MyEnum::enum2;
         shared_ptr<TestObjectWriter> writer = make_shared<TestObjectWriter>(obj);
         out.write(writer);
         out.writePendingValues();
@@ -832,7 +832,7 @@ allTests(Test::TestHelper* helper)
         test(reader);
         test(reader->called);
         test(reader->obj);
-        test(reader->obj->s.e == ICE_ENUM(MyEnum, enum2));
+        test(reader->obj->s.e == MyEnum::enum2);
         factoryWrapper.clear();
     }
 
@@ -842,7 +842,7 @@ allTests(Test::TestHelper* helper)
         MyClassPtr c = std::make_shared<MyClass>();
         c->c = c;
         c->o = c;
-        c->s.e = ICE_ENUM(MyEnum, enum2);
+        c->s.e = MyEnum::enum2;
 
         c->seq1.push_back(true);
         c->seq1.push_back(false);
@@ -884,9 +884,9 @@ allTests(Test::TestHelper* helper)
         c->seq8.push_back("string3");
         c->seq8.push_back("string4");
 
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum3));
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum2));
-        c->seq9.push_back(ICE_ENUM(MyEnum, enum1));
+        c->seq9.push_back(MyEnum::enum3);
+        c->seq9.push_back(MyEnum::enum2);
+        c->seq9.push_back(MyEnum::enum1);
 
         ex.c = c;
 
@@ -975,9 +975,9 @@ allTests(Test::TestHelper* helper)
     {
         StringMyClassD dict;
         dict["key1"] = std::make_shared<MyClass>();
-        dict["key1"]->s.e = ICE_ENUM(MyEnum, enum2);
+        dict["key1"]->s.e = MyEnum::enum2;
         dict["key2"] = std::make_shared<MyClass>();
-        dict["key2"]->s.e = ICE_ENUM(MyEnum, enum3);
+        dict["key2"]->s.e = MyEnum::enum3;
         Ice::OutputStream out(communicator);
         out.write(dict);
         out.writePendingValues();
@@ -987,18 +987,18 @@ allTests(Test::TestHelper* helper)
         in.read(dict2);
         in.readPendingValues();
         test(dict2.size() == dict.size());
-        test(dict2["key1"] && (dict2["key1"]->s.e == ICE_ENUM(MyEnum, enum2)));
-        test(dict2["key2"] && (dict2["key2"]->s.e == ICE_ENUM(MyEnum, enum3)));
+        test(dict2["key1"] && (dict2["key1"]->s.e == MyEnum::enum2));
+        test(dict2["key2"] && (dict2["key2"]->s.e == MyEnum::enum3));
     }
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(Sub::NestedEnum, nestedEnum3));
+        out.write(Sub::NestedEnum::nestedEnum3);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         NestedEnum e;
         in.read(e);
-        test(e == ICE_ENUM(Sub::NestedEnum, nestedEnum3));
+        test(e == Sub::NestedEnum::nestedEnum3);
     }
 
     {
@@ -1012,7 +1012,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(Sub::NestedEnum, nestedEnum2);
+        s.e = Sub::NestedEnum::nestedEnum2;
         out.write(s);
         out.finished(data);
         Ice::InputStream in(communicator, data);
@@ -1043,12 +1043,12 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        out.write(ICE_ENUM(NestedEnum2, nestedEnum4));
+        out.write(NestedEnum2::nestedEnum4);
         out.finished(data);
         Ice::InputStream in(communicator, data);
         NestedEnum2 e;
         in.read(e);
-        test(e == ICE_ENUM(NestedEnum2, nestedEnum4));
+        test(e == NestedEnum2::nestedEnum4);
     }
 
     {
@@ -1062,7 +1062,7 @@ allTests(Test::TestHelper* helper)
         s.f = 5.0;
         s.d = 6.0;
         s.str = "7";
-        s.e = ICE_ENUM(NestedEnum2, nestedEnum5);
+        s.e = NestedEnum2::nestedEnum5;
         out.write(s);
         out.finished(data);
         Ice::InputStream in(communicator, data);

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -137,12 +137,12 @@ Client::run(int argc, char** argv)
         Ice::Identity ident = Ice::stringToIdentity(identStr);
         test(ident.name == msg);
         test(ident.category == "cat");
-        test(identityToString(ident, Ice::ICE_ENUM(ToStringMode, Unicode)) == identStr);
+        test(identityToString(ident, Ice::ToStringMode::Unicode) == identStr);
 
-        identStr = identityToString(ident, Ice::ICE_ENUM(ToStringMode, ASCII));
+        identStr = identityToString(ident, Ice::ToStringMode::ASCII);
         test(identStr == "cat/tu me fends le c\\u0153ur!");
         test(Ice::stringToIdentity(identStr) == ident);
-        identStr = identityToString(ident, Ice::ICE_ENUM(ToStringMode, Compat));
+        identStr = identityToString(ident, Ice::ToStringMode::Compat);
         test(identStr == "cat/tu me fends le c\\305\\223ur!");
         test(Ice::stringToIdentity(identStr) == ident);
 

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -149,7 +149,7 @@ Client::run(int argc, char** argv)
         cout << "ok" << endl;
     }
 
-    Ice::setProcessStringConverter(ICE_NULLPTR);
+    Ice::setProcessStringConverter(nullptr);
     Ice::setProcessWstringConverter(Ice::createUnicodeWstringConverter());
 
     string propValue = "Ice:createStringConverter";

--- a/cpp/test/Ice/stringConverter/Server.cpp
+++ b/cpp/test/Ice/stringConverter/Server.cpp
@@ -15,13 +15,13 @@ class MyObjectI : public Test::MyObject
 {
 public:
 
-    virtual wstring widen(ICE_IN(string) msg, const Ice::Current&)
+    virtual wstring widen(string msg, const Ice::Current&)
     {
         return stringToWstring(msg, Ice::getProcessStringConverter(),
                                Ice::getProcessWstringConverter());
     }
 
-    virtual string narrow(ICE_IN(wstring) wmsg, const Ice::Current&)
+    virtual string narrow(wstring wmsg, const Ice::Current&)
     {
         return wstringToString(wmsg, Ice::getProcessStringConverter(),
                                Ice::getProcessWstringConverter());
@@ -46,7 +46,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(MyObjectI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<MyObjectI>(), Ice::stringToIdentity("test"));
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/threadPoolPriority/Server.cpp
+++ b/cpp/test/Ice/threadPoolPriority/Server.cpp
@@ -50,7 +50,7 @@ Server::run(int argc, char** argv)
 #endif
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(PriorityI, adapter);
+    Ice::ObjectPtr object = make_shared<PriorityI>(adapter);
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/threadPoolPriority/ServerCustomThreadPool.cpp
+++ b/cpp/test/Ice/threadPoolPriority/ServerCustomThreadPool.cpp
@@ -54,7 +54,7 @@ ServerCustomThreadPool::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ThreadPool.ThreadPriority", "50");
 #endif
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPtr object = ICE_MAKE_SHARED(PriorityI, adapter);
+    Ice::ObjectPtr object = make_shared<PriorityI>(adapter);
     adapter->add(object, Ice::stringToIdentity("test"));
     adapter->activate();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -307,7 +307,7 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrxPtr& control
         TimeoutPrxPtr to = ICE_UNCHECKED_CAST(TimeoutPrx, obj->ice_timeout(250));
         Ice::ConnectionPtr connection = connect(to);
         controller->holdAdapter(-1);
-        connection->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        connection->close(Ice::ConnectionClose::GracefullyWithWait);
         try
         {
             connection->getInfo(); // getInfo() doesn't throw in the closing state.

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -461,7 +461,7 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrxPtr& control
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TimeoutCollocated");
         adapter->activate();
 
-        timeout = ICE_UNCHECKED_CAST(TimeoutPrx, adapter->addWithUUID(ICE_MAKE_SHARED(TimeoutI)));
+        timeout = ICE_UNCHECKED_CAST(TimeoutPrx, adapter->addWithUUID(std::make_shared<TimeoutI>()));
         timeout = timeout->ice_invocationTimeout(100);
         try
         {

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -52,11 +52,11 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(TimeoutI), Ice::stringToIdentity("timeout"));
+    adapter->add(make_shared<TimeoutI>(), Ice::stringToIdentity("timeout"));
     adapter->activate();
 
     Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
-    controllerAdapter->add(ICE_MAKE_SHARED(ControllerI, adapter), Ice::stringToIdentity("controller"));
+    controllerAdapter->add(make_shared<ControllerI>(adapter), Ice::stringToIdentity("controller"));
     controllerAdapter->activate();
 
     serverReady();

--- a/cpp/test/Ice/timeout/TestI.cpp
+++ b/cpp/test/Ice/timeout/TestI.cpp
@@ -37,7 +37,7 @@ TimeoutI::op(const Ice::Current&)
 }
 
 void
-TimeoutI::sendData(ICE_IN(Test::ByteSeq), const Ice::Current&)
+TimeoutI::sendData(Test::ByteSeq, const Ice::Current&)
 {
 }
 

--- a/cpp/test/Ice/timeout/TestI.h
+++ b/cpp/test/Ice/timeout/TestI.h
@@ -12,7 +12,7 @@ class TimeoutI : public virtual Test::Timeout
 public:
 
     virtual void op(const Ice::Current&);
-    virtual void sendData(ICE_IN(Test::ByteSeq), const Ice::Current&);
+    virtual void sendData(Test::ByteSeq, const Ice::Current&);
     virtual void sleep(Ice::Int, const Ice::Current&);
 };
 

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -112,7 +112,7 @@ allTests(Test::TestHelper* helper)
         {
             test(seq.size() > 16384);
         }
-        obj->ice_getConnection()->close(ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        obj->ice_getConnection()->close(ConnectionClose::GracefullyWithWait);
         communicator->getProperties()->setProperty("Ice.UDP.SndSize", "64000");
         seq.resize(50000);
         try

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -52,7 +52,7 @@ private:
 
     int _replies;
 };
-ICE_DEFINE_SHARED_PTR(PingReplyIPtr, PingReplyI);
+using PingReplyIPtr = std::shared_ptr<PingReplyI>;
 
 void
 allTests(Test::TestHelper* helper)
@@ -60,7 +60,7 @@ allTests(Test::TestHelper* helper)
     Ice::CommunicatorPtr communicator = helper->communicator();
     communicator->getProperties()->setProperty("ReplyAdapter.Endpoints", "udp");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("ReplyAdapter");
-    PingReplyIPtr replyI = ICE_MAKE_SHARED(PingReplyI);
+    PingReplyIPtr replyI = std::make_shared<PingReplyI>();
     PingReplyPrxPtr reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     adapter->activate();
 
@@ -84,7 +84,7 @@ allTests(Test::TestHelper* helper)
 
         // If the 3 datagrams were not received within the 2 seconds, we try again to
         // receive 3 new datagrams using a new object. We give up after 5 retries.
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     test(ret);
@@ -175,7 +175,7 @@ allTests(Test::TestHelper* helper)
         {
             break; // Success
         }
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     if(!ret)
@@ -205,7 +205,7 @@ allTests(Test::TestHelper* helper)
 
         // If the 3 datagrams were not received within the 2 seconds, we try again to
         // receive 3 new datagrams using a new object. We give up after 5 retries.
-        replyI = ICE_MAKE_SHARED(PingReplyI);
+        replyI = std::make_shared<PingReplyI>();
         reply = ICE_UNCHECKED_CAST(PingReplyPrx, adapter->addWithUUID(replyI))->ice_datagram();
     }
     test(ret);

--- a/cpp/test/Ice/udp/Server.cpp
+++ b/cpp/test/Ice/udp/Server.cpp
@@ -29,14 +29,14 @@ Server::run(int argc, char** argv)
 
     communicator->getProperties()->setProperty("ControlAdapter.Endpoints", getTestEndpoint(num, "tcp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("ControlAdapter");
-    adapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("control"));
+    adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("control"));
     adapter->activate();
 
     if(num == 0)
     {
         communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(num, "udp"));
         Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter");
-        adapter2->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        adapter2->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         adapter2->activate();
     }
 
@@ -60,7 +60,7 @@ Server::run(int argc, char** argv)
     try
     {
         Ice::ObjectAdapterPtr mcastAdapter = communicator->createObjectAdapter("McastTestAdapter");
-        mcastAdapter->add(ICE_MAKE_SHARED(TestIntfI), Ice::stringToIdentity("test"));
+        mcastAdapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
         mcastAdapter->activate();
     }
     catch(const Ice::SocketException&)

--- a/cpp/test/Ice/udp/TestI.cpp
+++ b/cpp/test/Ice/udp/TestI.cpp
@@ -10,7 +10,7 @@ using namespace std;
 using namespace Ice;
 
 void
-TestIntfI::ping(ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
+TestIntfI::ping(Test::PingReplyPrxPtr reply, const Current&)
 {
     try
     {
@@ -23,7 +23,7 @@ TestIntfI::ping(ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
 }
 
 void
-TestIntfI::sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr) reply, const Current&)
+TestIntfI::sendByteSeq(Test::ByteSeq, Test::PingReplyPrxPtr reply, const Current&)
 {
     try
     {
@@ -36,7 +36,7 @@ TestIntfI::sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr) repl
 }
 
 void
-TestIntfI::pingBiDir(ICE_IN(Ice::Identity) id, const Ice::Current& current)
+TestIntfI::pingBiDir(Ice::Identity id, const Ice::Current& current)
 {
     try
     {

--- a/cpp/test/Ice/udp/TestI.h
+++ b/cpp/test/Ice/udp/TestI.h
@@ -11,9 +11,9 @@ class TestIntfI : public Test::TestIntf
 {
 public:
 
-    virtual void ping(ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
-    virtual void sendByteSeq(ICE_IN(Test::ByteSeq), ICE_IN(Test::PingReplyPrxPtr), const Ice::Current&);
-    virtual void pingBiDir(ICE_IN(Ice::Identity), const Ice::Current&);
+    virtual void ping(Test::PingReplyPrxPtr, const Ice::Current&);
+    virtual void sendByteSeq(Test::ByteSeq, Test::PingReplyPrxPtr, const Ice::Current&);
+    virtual void pingBiDir(Ice::Identity, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 };
 

--- a/cpp/test/IceBox/admin/Service.cpp
+++ b/cpp/test/IceBox/admin/Service.cpp
@@ -39,7 +39,7 @@ create(const shared_ptr<Communicator>& communicator)
 
 ServiceI::ServiceI(const CommunicatorPtr& serviceManagerCommunicator)
 {
-    TestFacetIPtr facet = ICE_MAKE_SHARED(TestFacetI);
+    TestFacetIPtr facet = std::make_shared<TestFacetI>();
 
     //
     // Install a custom admin facet.

--- a/cpp/test/IceBox/admin/TestI.h
+++ b/cpp/test/IceBox/admin/TestI.h
@@ -22,6 +22,6 @@ private:
 
     Ice::PropertyDict _changes;
 };
-ICE_DEFINE_SHARED_PTR(TestFacetIPtr, TestFacetI);
+using TestFacetIPtr = std::shared_ptr<TestFacetI>;
 
 #endif

--- a/cpp/test/IceBox/configuration/Service.cpp
+++ b/cpp/test/IceBox/configuration/Service.cpp
@@ -49,7 +49,7 @@ void
 ServiceI::start(const string& name, const CommunicatorPtr& communicator, const StringSeq& args)
 {
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter(name + "OA");
-    adapter->add(ICE_MAKE_SHARED(TestI, args), stringToIdentity("test"));
+    adapter->add(make_shared<TestI>(args), stringToIdentity("test"));
     adapter->activate();
 }
 

--- a/cpp/test/IceBox/configuration/TestI.cpp
+++ b/cpp/test/IceBox/configuration/TestI.cpp
@@ -12,7 +12,7 @@ TestI::TestI(const Ice::StringSeq& args) : _args(args)
 }
 
 std::string
-TestI::getProperty(ICE_IN(std::string) name, const Ice::Current& current)
+TestI::getProperty(std::string name, const Ice::Current& current)
 {
     return current.adapter->getCommunicator()->getProperties()->getProperty(name);
 }

--- a/cpp/test/IceBox/configuration/TestI.h
+++ b/cpp/test/IceBox/configuration/TestI.h
@@ -13,7 +13,7 @@ public:
 
     TestI(const Ice::StringSeq&);
 
-    virtual std::string getProperty(ICE_IN(std::string), const Ice::Current&);
+    virtual std::string getProperty(std::string, const Ice::Current&);
     virtual Ice::StringSeq getArgs(const Ice::Current&);
 
 private:

--- a/cpp/test/IceDiscovery/simple/Server.cpp
+++ b/cpp/test/IceDiscovery/simple/Server.cpp
@@ -39,7 +39,7 @@ Server::run(int argc, char** argv)
     {
         ostringstream os;
         os << "controller" << num;
-        adapter->add(ICE_MAKE_SHARED(ControllerI), Ice::stringToIdentity(os.str()));
+        adapter->add(std::make_shared<ControllerI>(), Ice::stringToIdentity(os.str()));
     }
     adapter->activate();
 

--- a/cpp/test/IceDiscovery/simple/TestI.cpp
+++ b/cpp/test/IceDiscovery/simple/TestI.cpp
@@ -16,9 +16,9 @@ TestIntfI::getAdapterId(const Ice::Current& current)
 }
 
 void
-ControllerI::activateObjectAdapter(ICE_IN(string) name,
-                                   ICE_IN(string) adapterId,
-                                   ICE_IN(string) replicaGroupId,
+ControllerI::activateObjectAdapter(string name,
+                                   string adapterId,
+                                   string replicaGroupId,
                                    const Ice::Current& current)
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
@@ -31,23 +31,23 @@ ControllerI::activateObjectAdapter(ICE_IN(string) name,
 }
 
 void
-ControllerI::deactivateObjectAdapter(ICE_IN(string) name, const Ice::Current&)
+ControllerI::deactivateObjectAdapter(string name, const Ice::Current&)
 {
     _adapters[name]->destroy();
     _adapters.erase(name);
 }
 
 void
-ControllerI::addObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Current&)
+ControllerI::addObject(string oaName, string id, const Ice::Current&)
 {
     assert(_adapters[oaName]);
     Ice::Identity identity;
     identity.name = id;
-    _adapters[oaName]->add(ICE_MAKE_SHARED(TestIntfI), identity);
+    _adapters[oaName]->add(make_shared<TestIntfI>(), identity);
 }
 
 void
-ControllerI::removeObject(ICE_IN(string) oaName, ICE_IN(string) id, const Ice::Current&)
+ControllerI::removeObject(string oaName, string id, const Ice::Current&)
 {
     assert(_adapters[oaName]);
     Ice::Identity identity;

--- a/cpp/test/IceDiscovery/simple/TestI.h
+++ b/cpp/test/IceDiscovery/simple/TestI.h
@@ -18,11 +18,11 @@ class ControllerI : public Test::Controller
 {
 public:
 
-    virtual void activateObjectAdapter(ICE_IN(std::string), ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void deactivateObjectAdapter(ICE_IN(std::string), const Ice::Current&);
+    virtual void activateObjectAdapter(std::string, std::string, std::string, const Ice::Current&);
+    virtual void deactivateObjectAdapter(std::string, const Ice::Current&);
 
-    virtual void addObject(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void removeObject(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
+    virtual void addObject(std::string, std::string, const Ice::Current&);
+    virtual void removeObject(std::string, std::string, const Ice::Current&);
 
     virtual void shutdown(const Ice::Current&);
 

--- a/cpp/test/IceGrid/activation/AllTests.cpp
+++ b/cpp/test/IceGrid/activation/AllTests.cpp
@@ -102,7 +102,7 @@ allTests(Test::TestHelper* helper)
 
     adminSession->ice_getConnection()->setACM(registry->getACMTimeout(),
                                          IceUtil::None,
-                                         Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                                         Ice::ACMHeartbeat::HeartbeatAlways);
 
     shared_ptr<IceGrid::AdminPrx> admin = adminSession->getAdmin();
     test(admin);

--- a/cpp/test/IceGrid/activation/Server.cpp
+++ b/cpp/test/IceGrid/activation/Server.cpp
@@ -37,7 +37,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    TestIPtr testI = ICE_MAKE_SHARED(TestI);
+    TestIPtr testI = std::make_shared<TestI>();
     adapter->add(testI, Ice::stringToIdentity(properties->getProperty("Ice.Admin.ServerId")));
 
     int delay = properties->getPropertyAsInt("ActivationDelay");

--- a/cpp/test/IceGrid/activation/TestI.h
+++ b/cpp/test/IceGrid/activation/TestI.h
@@ -22,5 +22,5 @@ private:
 
     bool _failed;
 };
-ICE_DEFINE_PTR(TestIPtr, TestI);
+using TestIPtr = std::shared_ptr<TestI>;
 #endif

--- a/cpp/test/IceGrid/deployer/AllTests.cpp
+++ b/cpp/test/IceGrid/deployer/AllTests.cpp
@@ -374,7 +374,7 @@ allTests(Test::TestHelper* helper)
 
     session->ice_getConnection()->setACM(registry->getACMTimeout(),
                                          IceUtil::None,
-                                         Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                                         Ice::ACMHeartbeat::HeartbeatAlways);
 
     shared_ptr<AdminPrx> admin = session->getAdmin();
     test(admin);

--- a/cpp/test/IceGrid/distribution/AllTests.cpp
+++ b/cpp/test/IceGrid/distribution/AllTests.cpp
@@ -25,7 +25,7 @@ allTests(Test::TestHelper* helper)
 
     session->ice_getConnection()->setACM(registry->getACMTimeout(),
                                          IceUtil::None,
-                                         Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                                         Ice::ACMHeartbeat::HeartbeatAlways);
 
     shared_ptr<AdminPrx> admin = session->getAdmin();
     test(admin);

--- a/cpp/test/IceGrid/simple/AllTests.cpp
+++ b/cpp/test/IceGrid/simple/AllTests.cpp
@@ -305,7 +305,7 @@ allTestsWithDeploy(Test::TestHelper* helper)
 
     IceGrid::AdminSessionPrxPtr session = registry->createAdminSession("foo", "bar");
 
-    session->ice_getConnection()->setACM(registry->getACMTimeout(), IceUtil::None, Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+    session->ice_getConnection()->setACM(registry->getACMTimeout(), IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
 
     IceGrid::AdminPrxPtr admin = session->getAdmin();
     test(admin);

--- a/cpp/test/IceGrid/simple/Server.cpp
+++ b/cpp/test/IceGrid/simple/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     string id = communicator->getProperties()->getPropertyWithDefault("Identity", "test");
-    adapter->add(ICE_MAKE_SHARED(TestI), Ice::stringToIdentity(id));
+    adapter->add(std::make_shared<TestI>(), Ice::stringToIdentity(id));
 
     try
     {

--- a/cpp/test/IceGrid/update/AllTests.cpp
+++ b/cpp/test/IceGrid/update/AllTests.cpp
@@ -68,7 +68,7 @@ allTests(Test::TestHelper* helper)
 
     session->ice_getConnection()->setACM(registry->getACMTimeout(),
                                          IceUtil::None,
-                                         Ice::ICE_ENUM(ACMHeartbeat, HeartbeatAlways));
+                                         Ice::ACMHeartbeat::HeartbeatAlways);
 
     shared_ptr<AdminPrx> admin = session->getAdmin();
     test(admin);

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -818,7 +818,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->certs.size() == 2);
             test(info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+            test(getTrustError(info) == IceSSL::TrustError::NoError);
 
             test(ICE_TARGET_EQUAL_TO(caCert, info->certs[1]));
             test(ICE_TARGET_EQUAL_TO(serverCert, info->certs[0]));
@@ -1028,7 +1028,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->verified);
             test(getHost(info) == "localhost");
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+            test(getTrustError(info) == IceSSL::TrustError::NoError);
 
             fact->destroyServer(server);
             comm->destroy();
@@ -1048,7 +1048,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
@@ -1072,7 +1072,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             if(isCatalinaOrGreater || isIOS13OrGreater)
             {
                 test(!info->verified);
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+                test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             }
             else
             {
@@ -1099,7 +1099,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
@@ -1121,7 +1121,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             test(getHost(info) == "localhost");
 
             fact->destroyServer(server);
@@ -1146,7 +1146,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+            test(getTrustError(info) == IceSSL::TrustError::NoError);
             test(getHost(info) == "127.0.0.1");
 
             fact->destroyServer(server);
@@ -1167,7 +1167,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             test(getHost(info) == "127.0.0.1");
 
             fact->destroyServer(server);
@@ -1193,7 +1193,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, HostNameMismatch));
+            test(getTrustError(info) == IceSSL::TrustError::HostNameMismatch);
             test(getHost(info) == "127.0.0.1");
             fact->destroyServer(server);
             comm->destroy();
@@ -1394,7 +1394,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
             test(info->certs.size() == 1);
             test(!info->verified);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, PartialChain));
+            test(getTrustError(info) == IceSSL::TrustError::PartialChain);
         }
         catch(const Ice::LocalException& ex)
         {
@@ -1416,10 +1416,10 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
 #ifdef ICE_USE_OPENSSL
             test(info->certs.size() == 2); // TODO: Fix OpenSSL
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, UntrustedRoot));
+            test(getTrustError(info) == IceSSL::TrustError::UntrustedRoot);
 #else
             test(info->certs.size() == 1);
-            test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, PartialChain));
+            test(getTrustError(info) == IceSSL::TrustError::PartialChain);
 #endif
             test(!info->verified);
         }
@@ -1446,10 +1446,10 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
                 info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
 #if defined(ICE_USE_SCHANNEL)
                 test(info->certs.size() == 1); // SChannel never sends the root certificate
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, PartialChain));
+                test(getTrustError(info) == IceSSL::TrustError::PartialChain);
 #else
                 test(info->certs.size() == 2);
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, UntrustedRoot));
+                test(getTrustError(info) == IceSSL::TrustError::UntrustedRoot);
 #endif
                 test(!info->verified);
 
@@ -1483,7 +1483,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
                 info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
                 test(info->certs.size() == 2);
                 test(info->verified);
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+                test(getTrustError(info) == IceSSL::TrustError::NoError);
             }
             catch(const Ice::LocalException& ex)
             {
@@ -1549,7 +1549,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
                 info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
                 test(info->certs.size() == 3);
                 test(info->verified);
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+                test(getTrustError(info) == IceSSL::TrustError::NoError);
             }
             catch(const Ice::LocalException& ex)
             {
@@ -1598,7 +1598,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
                 info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
                 test(info->certs.size() == 4);
                 test(info->verified);
-                test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+                test(getTrustError(info) == IceSSL::TrustError::NoError);
             }
             catch(const Ice::LocalException& ex)
             {
@@ -1812,7 +1812,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         //
         verifier->reset();
         verifier->returnValue(false);
-        server->ice_getConnection()->close(Ice::ICE_SCOPED_ENUM(ConnectionClose, GracefullyWithWait));
+        server->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
         try
         {
             server->ice_ping();
@@ -2205,7 +2205,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(!info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, InvalidTime));
+        test(getTrustError(info) == IceSSL::TrustError::InvalidTime);
 
         fact->destroyServer(server);
         comm->destroy();
@@ -3726,7 +3726,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         test(info->verified);
         fact->destroyServer(server);
         comm->destroy();
@@ -3748,7 +3748,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         test(info->verified);
         fact->destroyServer(server);
         comm->destroy();
@@ -3769,7 +3769,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         // Revoked certificate is accpeted because IceSSL.RevocationCheck=0 disable revocation checks
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         test(info->verified);
         fact->destroyServer(server);
         comm->destroy();
@@ -3791,7 +3791,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(!info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, Revoked));
+        test(getTrustError(info) == IceSSL::TrustError::Revoked);
 
         fact->destroyServer(server);
         comm->destroy();
@@ -3817,7 +3817,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(!info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, Revoked));
+        test(getTrustError(info) == IceSSL::TrustError::Revoked);
 
         fact->destroyServer(server);
         comm->destroy();
@@ -3841,7 +3841,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
 
         fact->destroyServer(server);
         comm->destroy();
@@ -3872,7 +3872,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         test(info->verified);
 
         fact->destroyServer(server);
@@ -3910,7 +3910,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         test(info->verified);
         fact->destroyServer(server);
         comm->destroy();
@@ -3933,7 +3933,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(!info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, Revoked));
+        test(getTrustError(info) == IceSSL::TrustError::Revoked);
         fact->destroyServer(server);
         comm->destroy();
 
@@ -3956,7 +3956,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, NoError));
+        test(getTrustError(info) == IceSSL::TrustError::NoError);
         fact->destroyServer(server);
         comm->destroy();
 #   endif
@@ -3978,7 +3978,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         server->ice_ping();
         info = ICE_DYNAMIC_CAST(IceSSL::ConnectionInfo, server->ice_getConnection()->getInfo());
         test(!info->verified);
-        test(getTrustError(info) == IceSSL::ICE_ENUM(TrustError, RevocationStatusUnknown));
+        test(getTrustError(info) == IceSSL::TrustError::RevocationStatusUnknown);
         fact->destroyServer(server);
         comm->destroy();
 

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -287,7 +287,7 @@ private:
     string _password;
     int _count;
 };
-ICE_DEFINE_PTR(PasswordPromptIPtr, PasswordPromptI);
+using PasswordPromptIPtr = std::shared_ptr<PasswordPromptI>;
 
 class CertificateVerifierI final
 {
@@ -386,7 +386,7 @@ private:
     bool _invoked;
     bool _hadCert;
 };
-ICE_DEFINE_PTR(CertificateVerifierIPtr, CertificateVerifierI);
+using CertificateVerifierIPtr = std::shared_ptr<CertificateVerifierI>;
 
 int keychainN = 0;
 
@@ -530,7 +530,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 #ifdef __APPLE__
     vector<char> s(256);
     size_t size = s.size();
-    int ret = sysctlbyname("kern.osrelease", &s[0], &size, ICE_NULLPTR, 0);
+    int ret = sysctlbyname("kern.osrelease", &s[0], &size, nullptr, 0);
     if(ret == 0)
     {
         // version format is x.y.z
@@ -1772,7 +1772,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         CommunicatorPtr comm = initialize(initData);
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, comm->getPluginManager()->getPlugin("IceSSL"));
         test(plugin);
-        CertificateVerifierIPtr verifier = ICE_MAKE_SHARED(CertificateVerifierI);
+        CertificateVerifierIPtr verifier = make_shared<CertificateVerifierI>();
 
         plugin->setCertificateVerifier([verifier](const shared_ptr<IceSSL::ConnectionInfo>& infoP)
                                        { return verifier->verify(infoP); });
@@ -1844,7 +1844,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         CommunicatorPtr comm = initialize(initData);
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, comm->getPluginManager()->getPlugin("IceSSL"));
         test(plugin);
-        CertificateVerifierIPtr verifier = ICE_MAKE_SHARED(CertificateVerifierI);
+        CertificateVerifierIPtr verifier = make_shared<CertificateVerifierI>();
 
         plugin->setCertificateVerifier([verifier](const shared_ptr<IceSSL::ConnectionInfo>& infoP)
                                        { return verifier->verify(infoP); });
@@ -2352,7 +2352,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         PluginManagerPtr pm = comm->getPluginManager();
         IceSSL::PluginPtr plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, pm->getPlugin("IceSSL"));
         test(plugin);
-        PasswordPromptIPtr prompt = ICE_MAKE_SHARED(PasswordPromptI, "client");
+        PasswordPromptIPtr prompt = make_shared<PasswordPromptI>("client");
 
         plugin->setPasswordPrompt([prompt]{ return prompt->getPassword(); });
         pm->initializePlugins();
@@ -2384,7 +2384,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         pm = comm->getPluginManager();
         plugin = ICE_DYNAMIC_CAST(IceSSL::Plugin, pm->getPlugin("IceSSL"));
         test(plugin);
-        prompt = ICE_MAKE_SHARED(PasswordPromptI, "invalid");
+        prompt = make_shared<PasswordPromptI>("invalid");
 
         plugin->setPasswordPrompt([prompt]{ return prompt->getPassword(); });
         try

--- a/cpp/test/IceSSL/configuration/Server.cpp
+++ b/cpp/test/IceSSL/configuration/Server.cpp
@@ -39,7 +39,7 @@ Server::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint("tcp"));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     Ice::Identity id = Ice::stringToIdentity("factory");
-    adapter->add(ICE_MAKE_SHARED(ServerFactoryI, testdir), id);
+    adapter->add(make_shared<ServerFactoryI>(testdir), id);
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/IceSSL/configuration/TestI.cpp
+++ b/cpp/test/IceSSL/configuration/TestI.cpp
@@ -33,7 +33,7 @@ ServerI::noCert(const Ice::Current& c)
 }
 
 void
-ServerI::checkCert(ICE_IN(string) subjectDN, ICE_IN(string) issuerDN, const Ice::Current& c)
+ServerI::checkCert(string subjectDN, string issuerDN, const Ice::Current& c)
 {
     try
     {
@@ -50,7 +50,7 @@ ServerI::checkCert(ICE_IN(string) subjectDN, ICE_IN(string) issuerDN, const Ice:
 }
 
 void
-ServerI::checkCipher(ICE_IN(string) cipher, const Ice::Current& c)
+ServerI::checkCipher(string cipher, const Ice::Current& c)
 {
     try
     {
@@ -74,7 +74,7 @@ ServerFactoryI::ServerFactoryI(const string& defaultDir) : _defaultDir(defaultDi
 }
 
 Test::ServerPrxPtr
-ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
+ServerFactoryI::createServer(Test::Properties props, const Current&)
 {
     InitializationData initData;
     initData.properties = createProperties();
@@ -86,7 +86,7 @@ ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
 
     CommunicatorPtr communicator = initialize(initData);
     ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints("ServerAdapter", "ssl");
-    ServerIPtr server = ICE_MAKE_SHARED(ServerI, communicator);
+    ServerIPtr server = make_shared<ServerI>(communicator);
     ObjectPrxPtr obj = adapter->addWithUUID(server);
     _servers[obj->ice_getIdentity()] = server;
     adapter->activate();
@@ -95,7 +95,7 @@ ServerFactoryI::createServer(ICE_IN(Test::Properties) props, const Current&)
 }
 
 void
-ServerFactoryI::destroyServer(ICE_IN(Test::ServerPrxPtr) srv, const Ice::Current&)
+ServerFactoryI::destroyServer(Test::ServerPrxPtr srv, const Ice::Current&)
 {
     map<Identity, ServerIPtr>::iterator p = _servers.find(srv->ice_getIdentity());
     if(p != _servers.end())

--- a/cpp/test/IceSSL/configuration/TestI.h
+++ b/cpp/test/IceSSL/configuration/TestI.h
@@ -14,8 +14,8 @@ public:
     ServerI(const Ice::CommunicatorPtr&);
 
     virtual void noCert(const Ice::Current&);
-    virtual void checkCert(ICE_IN(std::string), ICE_IN(std::string), const Ice::Current&);
-    virtual void checkCipher(ICE_IN(std::string), const Ice::Current&);
+    virtual void checkCert(std::string, std::string, const Ice::Current&);
+    virtual void checkCipher(std::string, const Ice::Current&);
 
     void destroy();
 
@@ -23,7 +23,7 @@ private:
 
     Ice::CommunicatorPtr _communicator;
 };
-ICE_DEFINE_SHARED_PTR(ServerIPtr, ServerI);
+using ServerIPtr = std::shared_ptr<ServerI>;
 
 class ServerFactoryI : public Test::ServerFactory
 {
@@ -31,8 +31,8 @@ public:
 
     ServerFactoryI(const std::string&);
 
-    virtual Test::ServerPrxPtr createServer(ICE_IN(Test::Properties), const Ice::Current&);
-    virtual void destroyServer(ICE_IN(Test::ServerPrxPtr), const Ice::Current&);
+    virtual Test::ServerPrxPtr createServer(Test::Properties, const Ice::Current&);
+    virtual void destroyServer(Test::ServerPrxPtr, const Ice::Current&);
     virtual void shutdown(const Ice::Current&);
 
 private:

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -108,7 +108,7 @@ private:
     IceUtil::Time _scheduledTime;
     int _count;
 };
-ICE_DEFINE_PTR(TestTaskPtr, TestTask);
+using TestTaskPtr = std::shared_ptr<TestTask>;
 
 class DestroyTask : public IceUtil::TimerTask, IceUtil::Monitor<IceUtil::Mutex>
 {
@@ -145,7 +145,7 @@ private:
     IceUtil::TimerPtr _timer;
     bool _run;
 };
-ICE_DEFINE_PTR(DestroyTaskPtr, DestroyTask);
+using DestroyTaskPtr = std::shared_ptr<DestroyTask>;
 
 class Client : public Test::TestHelper
 {
@@ -163,7 +163,7 @@ Client::run(int, char*[])
         IceUtil::TimerPtr timer = new IceUtil::Timer();
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = make_shared<TestTask>();
             timer->schedule(task, IceUtil::Time());
             task->waitForRun();
             task->clear();
@@ -185,7 +185,7 @@ Client::run(int, char*[])
         }
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = make_shared<TestTask>();
             test(!timer->cancel(task));
             timer->schedule(task, IceUtil::Time::seconds(1));
             test(!task->hasRun() && timer->cancel(task) && !task->hasRun());
@@ -199,7 +199,7 @@ Client::run(int, char*[])
             IceUtil::Time start = IceUtil::Time::now(IceUtil::Time::Monotonic) + IceUtil::Time::milliSeconds(500);
             for(int i = 0; i < 20; ++i)
             {
-                tasks.push_back(ICE_MAKE_SHARED(TestTask, IceUtil::Time::milliSeconds(500 + i * 50)));
+                tasks.push_back(make_shared<TestTask>(IceUtil::Time::milliSeconds(500 + i * 50)));
             }
 
             IceUtilInternal::shuffle(tasks.begin(), tasks.end());
@@ -227,7 +227,7 @@ Client::run(int, char*[])
         }
 
         {
-            TestTaskPtr task = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr task = make_shared<TestTask>();
             timer->scheduleRepeated(task, IceUtil::Time::milliSeconds(20));
             IceUtil::ThreadControl::sleep(IceUtil::Time::milliSeconds(500));
             test(task->hasRun());
@@ -247,7 +247,7 @@ Client::run(int, char*[])
     {
         {
             IceUtil::TimerPtr timer = new IceUtil::Timer();
-            DestroyTaskPtr destroyTask = ICE_MAKE_SHARED(DestroyTask, timer);
+            DestroyTaskPtr destroyTask = make_shared<DestroyTask>(timer);
             timer->schedule(destroyTask, IceUtil::Time());
             destroyTask->waitForRun();
             try
@@ -261,7 +261,7 @@ Client::run(int, char*[])
         }
         {
             IceUtil::TimerPtr timer = new IceUtil::Timer();
-            TestTaskPtr testTask = ICE_MAKE_SHARED(TestTask);
+            TestTaskPtr testTask = make_shared<TestTask>();
             timer->schedule(testTask, IceUtil::Time());
             timer->destroy();
             try

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -111,19 +111,19 @@ void testtypes(const Ice::CommunicatorPtr& communicator)
         ICE_UNCHECKED_CAST(_cpp_and::breakPrx, communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
     int d2;
     d->_cpp_case(0, d2);
-    _cpp_and::breakPtr d1 = ICE_MAKE_SHARED(breakI);
+    _cpp_and::breakPtr d1 = std::make_shared<breakI>();
 
     _cpp_and::charPrxPtr e =
         ICE_UNCHECKED_CAST(_cpp_and::charPrx, communicator->stringToProxy("hello:tcp -h 127.0.0.1 -p 12010"));
     e->_cpp_explicit();
-    _cpp_and::charPtr e1 = ICE_MAKE_SHARED(charI);
+    _cpp_and::charPtr e1 = std::make_shared<charI>();
 
-    _cpp_and::switchPtr f1 = ICE_MAKE_SHARED(switchI);
+    _cpp_and::switchPtr f1 = std::make_shared<switchI>();
 
     _cpp_and::doPrxPtr g;
     g->_cpp_case(0, d2);
     g->_cpp_explicit();
-    _cpp_and::doPtr g1 = ICE_MAKE_SHARED(doI);
+    _cpp_and::doPtr g1 = std::make_shared<doI>();
 
     _cpp_and::_cpp_extern h;
     _cpp_and::_cpp_for i;
@@ -135,7 +135,7 @@ void testtypes(const Ice::CommunicatorPtr& communicator)
     k._cpp_signed = 2;
 
     // TODO: reenable once bug #1617 is fixed.
-    // _cpp_and::friendPtr l = ICE_MAKE_SHARED(friendI);
+    // _cpp_and::friendPtr l = std::make_shared<friendI>();
 
     const int m  = _cpp_and::_cpp_template;
     test(m == _cpp_and::_cpp_template);
@@ -156,7 +156,7 @@ Client::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", "default");
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    adapter->add(ICE_MAKE_SHARED(charI), Ice::stringToIdentity("test"));
+    adapter->add(std::make_shared<charI>(), Ice::stringToIdentity("test"));
     adapter->activate();
 
     cout << "Testing operation name... " << flush;

--- a/cpp/test/Slice/macros/Client.cpp
+++ b/cpp/test/Slice/macros/Client.cpp
@@ -20,11 +20,11 @@ void
 Client::run(int, char**)
 {
     cout << "testing Slice predefined macros... " << flush;
-    DefaultPtr d = ICE_MAKE_SHARED(Default);
+    DefaultPtr d = std::make_shared<Default>();
     test(d->x == 10);
     test(d->y == 10);
 
-    CppOnlyPtr c = ICE_MAKE_SHARED(CppOnly);
+    CppOnlyPtr c = std::make_shared<CppOnly>();
     test(c->lang == "cpp");
     test(c->version == ICE_INT_VERSION);
     cout << "ok" << endl;

--- a/cpp/test/Slice/structure/Client.cpp
+++ b/cpp/test/Slice/structure/Client.cpp
@@ -34,7 +34,7 @@ allTests(const Ice::CommunicatorPtr& communicator)
     def_s2.il.push_back(3);
     def_s2.sd["abc"] = "def";
     def_s2.s = {"name"};
-    def_s2.cls = ICE_MAKE_SHARED(C, 5);
+    def_s2.cls = make_shared<C>(5);
     def_s2.prx = communicator->stringToProxy("test");
     cout << "ok" << endl;
 }

--- a/cpp/test/include/TestHelper.h
+++ b/cpp/test/include/TestHelper.h
@@ -47,7 +47,7 @@ public:
     virtual void serverReady() = 0;
     virtual void communicatorInitialized(const Ice::CommunicatorPtr&) = 0;
 };
-ICE_DEFINE_PTR(ControllerHelperPtr, ControllerHelper);
+using ControllerHelperPtr = std::shared_ptr<ControllerHelper>;
 
 #if defined(ICE_OS_UWP) || (TARGET_OS_IPHONE != 0)
 
@@ -107,7 +107,7 @@ public:
     createTestProperties(int&, char*[]);
 
     Ice::CommunicatorPtr
-    initialize(int& argc, char* argv[], const Ice::PropertiesPtr& properties = ICE_NULLPTR);
+    initialize(int& argc, char* argv[], const Ice::PropertiesPtr& properties = nullptr);
 
     Ice::CommunicatorPtr initialize(int&, char*[], const Ice::InitializationData&);
 

--- a/cpp/test/ios/controller/Bundle/ControllerI.mm
+++ b/cpp/test/ios/controller/Bundle/ControllerI.mm
@@ -340,7 +340,7 @@ ProcessControllerI::start(string testSuite, string exe, StringSeq args, const Ic
     // test on arm64 devices with a debug Ice libraries which require lots of stack space.
     //
     helper->start(768 * 1024);
-    return ICE_UNCHECKED_CAST(ProcessPrx, c.adapter->addWithUUID(ICE_MAKE_SHARED(ProcessI, _controller, helper.get())));
+    return ICE_UNCHECKED_CAST(ProcessPrx, c.adapter->addWithUUID(make_shared<ProcessI>(_controller, helper.get())));
 }
 
 string
@@ -372,7 +372,7 @@ ControllerI::ControllerI(id<ControllerView> controller, NSString* ipv4, NSString
     ident.category = "iPhoneOS";
 #endif
     ident.name = [[[NSBundle mainBundle] bundleIdentifier] UTF8String];
-    adapter->add(ICE_MAKE_SHARED(ProcessControllerI, controller, ipv4, ipv6), ident);
+    adapter->add(make_shared<ProcessControllerI>(controller, ipv4, ipv6), ident);
     adapter->activate();
 }
 

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -535,7 +535,7 @@ IcePHP::connectionInit(void)
     zend_declare_property_null(connectionInfoClassEntry, "underlying", sizeof("underlying") - 1, ZEND_ACC_PUBLIC);
 
     // Register the IPConnectionInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "IPConnectionInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "IPConnectionInfo", nullptr);
     ce.create_object = handleConnectionInfoAlloc;
     ipConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, connectionInfoClassEntry);
     zend_declare_property_string(
@@ -554,14 +554,14 @@ IcePHP::connectionInit(void)
     zend_declare_property_long(ipConnectionInfoClassEntry, "remotePort", sizeof("remotePort") - 1, 0, ZEND_ACC_PUBLIC);
 
     // Register the TCPConnectionInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "TCPConnectionInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "TCPConnectionInfo", nullptr);
     ce.create_object = handleConnectionInfoAlloc;
     tcpConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, ipConnectionInfoClassEntry);
     zend_declare_property_long(tcpConnectionInfoClassEntry, "rcvSize", sizeof("rcvSize") - 1, 0, ZEND_ACC_PUBLIC);
     zend_declare_property_long(tcpConnectionInfoClassEntry, "sndSize", sizeof("sndSize") - 1, 0, ZEND_ACC_PUBLIC);
 
     // Register the UDPConnectionInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "UDPConnectionInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "UDPConnectionInfo", nullptr);
     ce.create_object = handleConnectionInfoAlloc;
     udpConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, ipConnectionInfoClassEntry);
     zend_declare_property_string(
@@ -573,13 +573,13 @@ IcePHP::connectionInit(void)
     zend_declare_property_long(udpConnectionInfoClassEntry, "mcastPort", sizeof("mcastPort") - 1, 0, ZEND_ACC_PUBLIC);
 
     // Register the WSConnectionInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "WSConnectionInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "WSConnectionInfo", nullptr);
     ce.create_object = handleConnectionInfoAlloc;
     wsConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, connectionInfoClassEntry);
     zend_declare_property_string(wsConnectionInfoClassEntry, "headers", sizeof("headers") - 1, "", ZEND_ACC_PUBLIC);
 
     // Register the SSLConnectionInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "SSLConnectionInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "SSLConnectionInfo", nullptr);
     ce.create_object = handleConnectionInfoAlloc;
     sslConnectionInfoClassEntry = zend_register_internal_class_ex(&ce, connectionInfoClassEntry);
     zend_declare_property_string(sslConnectionInfoClassEntry, "cipher", sizeof("cipher") - 1, "", ZEND_ACC_PUBLIC);

--- a/php/src/Endpoint.cpp
+++ b/php/src/Endpoint.cpp
@@ -251,7 +251,7 @@ IcePHP::endpointInit(void)
     zend_declare_property_null(endpointInfoClassEntry, "underlying", sizeof("underlying") - 1, ZEND_ACC_PUBLIC);
 
     // Define the IPEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "IPEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "IPEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     ipEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, endpointInfoClassEntry);
     zend_declare_property_string(ipEndpointInfoClassEntry, "host", sizeof("host") - 1, "", ZEND_ACC_PUBLIC);
@@ -264,12 +264,12 @@ IcePHP::endpointInit(void)
         ZEND_ACC_PUBLIC);
 
     // Define the TCPEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "TCPEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "TCPEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     tcpEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, ipEndpointInfoClassEntry);
 
     // Define the UDPEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "UDPEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "UDPEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     udpEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, ipEndpointInfoClassEntry);
     zend_declare_property_string(
@@ -281,13 +281,13 @@ IcePHP::endpointInit(void)
     zend_declare_property_long(udpEndpointInfoClassEntry, "mcastTtl", sizeof("mcastTtl") - 1, 0, ZEND_ACC_PUBLIC);
 
     // Define the WSEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "WSEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "WSEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     wsEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, endpointInfoClassEntry);
     zend_declare_property_string(wsEndpointInfoClassEntry, "resource", sizeof("resource") - 1, "", ZEND_ACC_PUBLIC);
 
     // Define the OpaqueEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "OpaqueEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "OpaqueEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     opaqueEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, endpointInfoClassEntry);
     zend_declare_property_null(
@@ -297,7 +297,7 @@ IcePHP::endpointInit(void)
     zend_declare_property_null(opaqueEndpointInfoClassEntry, "rawBytes", sizeof("rawBytes") - 1, ZEND_ACC_PUBLIC);
 
     // Define the SSLEndpointInfo class.
-    INIT_NS_CLASS_ENTRY(ce, "Ice", "SSLEndpointInfo", ICE_NULLPTR);
+    INIT_NS_CLASS_ENTRY(ce, "Ice", "SSLEndpointInfo", nullptr);
     ce.create_object = handleEndpointInfoAlloc;
     sslEndpointInfoClassEntry = zend_register_internal_class_ex(&ce, endpointInfoClassEntry);
 

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -106,10 +106,10 @@ static struct PyModuleDef iceModule =
     "The Internet Communications Engine.",
     -1,
     methods,
-    ICE_NULLPTR,
-    ICE_NULLPTR,
-    ICE_NULLPTR,
-    ICE_NULLPTR
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr
 };
 
 #if defined(__GNUC__)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -109,13 +109,13 @@ versionToString(PyObject* args, const char* type)
     PyObject* p;
     if(!PyArg_ParseTuple(args, STRCAST("O!"), versionType, &p))
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     T v;
     if(!getVersion<T>(p, v))
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     string s;
@@ -126,7 +126,7 @@ versionToString(PyObject* args, const char* type)
     catch(const Ice::Exception& ex)
     {
         IcePy::setPythonException(ex);
-        return ICE_NULLPTR;
+        return nullptr;
     }
     return createString(s);
 }
@@ -137,7 +137,7 @@ stringToVersion(PyObject* args, const char* type)
     char* str;
     if(!PyArg_ParseTuple(args, STRCAST("s"), &str))
     {
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     T v;
@@ -148,7 +148,7 @@ stringToVersion(PyObject* args, const char* type)
     catch(const Ice::Exception& ex)
     {
         IcePy::setPythonException(ex);
-        return ICE_NULLPTR;
+        return nullptr;
     }
 
     return createVersion<T>(v, type);


### PR DESCRIPTION
This is a first PR for removing C++ helper macros, mostly automated with a python script and regexp.