### PR TITLE
Rework -std flag on Linux/macos

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux \
     && sudo dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \
     && sudo apt update \
-    && sudo apt-get install -y python3 ruby-full \
+    && sudo apt-get install -y python3 python3-dev python3-passlib ruby-full \
     && sudo apt-get install -y libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev libmcpp-dev libssl-dev libsystemd-dev \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -133,7 +133,7 @@ $3/%.o: $1/%.mm
 $3/%.o: $1/%.mm
 	$(E) "Compiling [$8-$9] $$<"
 	$(Q)$(or $($8_cxx),$(platform_cxx)) $(CXXFLAGS) $(call depend-cppflags,$3/$$*.Td,$$@)\
-	$(strip $6) $(CPPFLAGS) -std=c++17 -c $$< -o $$@
+	$(strip $6) $(CPPFLAGS) -c $$< -o $$@
 	$(Q)$(MV) $3/$$*.Td $3/$$*.mm.d
 endif
 

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -42,9 +42,13 @@ ifeq ($(MAXWARN),yes)
     cppflags	+=  -Wweak-vtables
 endif
 
-# -Wshadow issues false warnings with clang 3.x (Apple LLVM 9.0)
-ifeq ($(shell clang -v 2>&1 | sed -ne 's/.*version \([0-9]*\)\.\([0-9]*\).*/\1\2/p'),90)
-    cppflags    := $(filter-out -Wshadow -Wshadow-all,$(cppflags))
+clang_version = $(shell clang -dumpversion 2>&1 | cut -f1 -d\.)
+
+# We use -std=c++20 with clang 15.0 and later.
+ifeq ($(shell test $(clang_version) -ge 15 && echo yes),yes)
+    cppflags    += -std=c++20
+else
+    cppflags    += -std=c++17
 endif
 
 nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -140,10 +140,10 @@ shared_ldflags      = $(if $(filter-out program,$($1_target)),\
 cppflags        = -Wall -Wextra -Wredundant-decls -Wshadow -Wdeprecated -Werror -pthread $(if $(filter yes,$(OPTIMIZE)),-DNDEBUG,-g)
 ldflags         = -pthread
 
-# -Wshadow is too strict with gcc 4
-ifeq ($(shell $(CXX) -dumpversion | cut -f1 -d\.),4)
-    cppflags    := $(filter-out -Wshadow,$(cppflags))
-endif
+gcc_version = $(shell $(CXX) -dumpversion 2>&1 | cut -f1 -d\.)
+
+# As of GCC 13.4, https://gcc.gnu.org/projects/cxx-status.html#cxx20 still describes C++20 support as "experimental".
+cppflags       += -std=c++17
 
 nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations
 nounusedparameter-cppflags    := -Wno-unused-parameter

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -17,9 +17,6 @@ ifeq ($(os),Darwin)
 include         $(lang_srcdir)/config/Make.xcodesdk.rules
 endif
 
-# We assume Make.rules.$(os) defines cppflags.
-cppflags                += -std=c++17
-
 # Validate platforms and configs
 $(eval $(call validate-config))
 
@@ -78,7 +75,7 @@ define make-cpp-src-project
 ifeq ($(filter all cpp,$(ICE_BIN_DIST)),)
 $1_slicecompiler        := slice2cpp
 $1_sliceflags           += -I$(slicedir)
-$1_cppflags             += -Isrc -I$1/generated -I$(includedir) -I$(includedir)/generated -DICE_BUILDING_SRC -std=c++17
+$1_cppflags             += -Isrc -I$1/generated -I$(includedir) -I$(includedir)/generated -DICE_BUILDING_SRC
 $(make-project)
 srcs:: $1
 endif

--- a/cpp/include/IceBT/ConnectionInfo.h
+++ b/cpp/include/IceBT/ConnectionInfo.h
@@ -5,6 +5,7 @@
 #ifndef __IceBT_ConnectionInfo_h__
 #define __IceBT_ConnectionInfo_h__
 
+#include <IceUtil/PushDisableWarnings.h>
 #include <Ice/ProxyF.h>
 #include <Ice/ObjectF.h>
 #include <Ice/ValueF.h>
@@ -130,4 +131,5 @@ using ConnectionInfoPtr = ::std::shared_ptr<ConnectionInfo>;
 }
 /// \endcond
 
+#include <IceUtil/PopDisableWarnings.h>
 #endif

--- a/cpp/include/IceBT/EndpointInfo.h
+++ b/cpp/include/IceBT/EndpointInfo.h
@@ -5,6 +5,7 @@
 #ifndef __IceBT_EndpointInfo_h__
 #define __IceBT_EndpointInfo_h__
 
+#include <IceUtil/PushDisableWarnings.h>
 #include <Ice/ProxyF.h>
 #include <Ice/ObjectF.h>
 #include <Ice/ValueF.h>
@@ -89,4 +90,5 @@ using EndpointInfoPtr = ::std::shared_ptr<EndpointInfo>;
 }
 /// \endcond
 
+#include <IceUtil/PopDisableWarnings.h>
 #endif

--- a/cpp/include/IceBT/Types.h
+++ b/cpp/include/IceBT/Types.h
@@ -5,6 +5,7 @@
 #ifndef __IceBT_Types_h__
 #define __IceBT_Types_h__
 
+#include <IceUtil/PushDisableWarnings.h>
 #include <Ice/ProxyF.h>
 #include <Ice/ObjectF.h>
 #include <Ice/ValueF.h>
@@ -90,4 +91,5 @@ public:
 
 }
 
+#include <IceUtil/PopDisableWarnings.h>
 #endif

--- a/cpp/include/IceIAP/ConnectionInfo.h
+++ b/cpp/include/IceIAP/ConnectionInfo.h
@@ -5,6 +5,7 @@
 #ifndef __IceIAP_ConnectionInfo_h__
 #define __IceIAP_ConnectionInfo_h__
 
+#include <IceUtil/PushDisableWarnings.h>
 #include <Ice/ProxyF.h>
 #include <Ice/ObjectF.h>
 #include <Ice/ValueF.h>
@@ -115,4 +116,5 @@ using ConnectionInfoPtr = ::std::shared_ptr<ConnectionInfo>;
 }
 /// \endcond
 
+#include <IceUtil/PopDisableWarnings.h>
 #endif

--- a/cpp/include/IceIAP/EndpointInfo.h
+++ b/cpp/include/IceIAP/EndpointInfo.h
@@ -5,6 +5,7 @@
 #ifndef __IceIAP_EndpointInfo_h__
 #define __IceIAP_EndpointInfo_h__
 
+#include <IceUtil/PushDisableWarnings.h>
 #include <Ice/ProxyF.h>
 #include <Ice/ObjectF.h>
 #include <Ice/ValueF.h>
@@ -104,4 +105,5 @@ using EndpointInfoPtr = ::std::shared_ptr<EndpointInfo>;
 }
 /// \endcond
 
+#include <IceUtil/PopDisableWarnings.h>
 #endif

--- a/cpp/src/IceBT/TransceiverI.h
+++ b/cpp/src/IceBT/TransceiverI.h
@@ -10,7 +10,6 @@
 #include <IceBT/StreamSocket.h>
 
 #include <Ice/Transceiver.h>
-#include <Ice/UniquePtr.h>
 
 namespace IceBT
 {
@@ -51,7 +50,7 @@ private:
     std::string _addr;
     std::string _uuid;
     bool _needConnect;
-    IceInternal::UniquePtr<Ice::Exception> _exception;
+    std::unique_ptr<Ice::Exception> _exception;
     IceUtil::Monitor<IceUtil::Mutex> _lock;
 
     void connectCompleted(int, const ConnectionPtr&);

--- a/cpp/test/ios/controller/C++ Test Controller.xcodeproj/project.pbxproj
+++ b/cpp/test/ios/controller/C++ Test Controller.xcodeproj/project.pbxproj
@@ -547,7 +547,7 @@
 		1440D8701E0186FF00CF7ED3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
@@ -586,7 +586,7 @@
 		1440D8711E0186FF00CF7ED3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
@@ -625,7 +625,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -658,7 +658,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -795,7 +795,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
 				INFOPLIST_FILE = Classes/Info.plist;
@@ -824,7 +824,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
 				INFOPLIST_FILE = Classes/Info.plist;
@@ -852,7 +852,7 @@
 		14E3982F1E01B14B00A89291 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;
@@ -891,7 +891,7 @@
 		14E398301E01B14B00A89291 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = U4TBVKNQ7F;

--- a/php/config/Make.rules
+++ b/php/config/Make.rules
@@ -50,7 +50,7 @@ ifneq ($(shell type $(PHP_CONFIG) > /dev/null 2>&1 && echo 0),0)
 $(error $(PHP_CONFIG) not found review your PHP installation and ensure $(PHP_CONFIG) is in your PATH)
 endif
 
-php_cppflags            = -std=c++17 $(shell $(PHP_CONFIG) --includes)
+php_cppflags            = $(shell $(PHP_CONFIG) --includes)
 
 ifeq ($(os),Darwin)
     php_cppflags        := $(php_cppflags) -Wno-unused-parameter -Wno-missing-field-initializers

--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -22,7 +22,7 @@ ifeq ($(os),Linux)
    cppflags   := $(filter-out -Wredundant-decls,$(cppflags))
 endif
 
-python_cppflags         := -std=c++17 $(or $(PYTHON_CPPFLAGS),$(shell $(python-config) --cflags))
+python_cppflags         := $(or $(PYTHON_CPPFLAGS),$(shell $(python-config) --cflags))
 python_ldflags          := $(or $(PYTHON_LDLFLAGS),$(shell $(python-config) --ldflags))
 
 # Use .so as default value --extension-suffix is not supported by python-config in all platforms

--- a/ruby/config/Make.rules
+++ b/ruby/config/Make.rules
@@ -15,7 +15,7 @@ ruby-call = $(shell $(RUBY) -e 'require "rbconfig"; puts RbConfig::expand("$1")'
 
 # Ruby compiler flags
 platform_cxx    := $(call ruby-call, $$(CXX))
-ruby_cppflags   := -std=c++17 -I$(call ruby-call,$$(rubyhdrdir))
+ruby_cppflags   := -I$(call ruby-call,$$(rubyhdrdir))
 ruby_config_dir := $(call ruby-call,$$(includedir)/$$(arch)/ruby-$$(ruby_version))
 ruby_arch       := $(call ruby-call,$$(arch))
 ifeq ($(wildcard $(ruby_config_dir)/ruby/config.h),)

--- a/swift/Rakefile
+++ b/swift/Rakefile
@@ -737,7 +737,7 @@ def target_set_common_build_settings(target, product, platform, plist: nil, swif
         config.build_settings["GCC_SYMBOLS_PRIVATE_EXTERN"] = "YES"
         config.build_settings["ENABLE_TESTABILITY"] = "NO"
         config.build_settings["GCC_TREAT_WARNINGS_AS_ERRORS"] = "YES"
-        config.build_settings["CLANG_CXX_LANGUAGE_STANDARD"] = "c++17"
+        config.build_settings["CLANG_CXX_LANGUAGE_STANDARD"] = "c++20"
         config.build_settings["CURRENT_PROJECT_VERSION"] = $projectVersion
         config.build_settings["DYLIB_CURRENT_VERSION"] = $projectVersion
         config.build_settings["DYLIB_COMPATIBILITY_VERSION"] = "0"


### PR DESCRIPTION
This PR moves where we set -std on Linux and macos to the per-platform Make configuration file, and sets -std=c++20 on macOS with clang 15 and greater. It keeps -std=c++17 on Linux and for older versions of clang on macos.

This PR also fixes a few build issues.

Partial fix for #1624.
