### PR TITLE
Preliminary C++ proxy refactoring

### DIFF
--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -947,8 +947,7 @@ public:
         }
         else
         {
-            v = ::IceInternal::createProxy<T>();
-            v->_copyFrom(proxy);
+            v = std::make_shared<T>(*proxy);
         }
     }
 

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -79,12 +79,6 @@ typedef IceUtil::Handle<ProxyGetConnection> ProxyGetConnectionPtr;
 namespace IceInternal
 {
 
-template<typename P>
-::std::shared_ptr<P> createProxy()
-{
-    return ::std::shared_ptr<P>(new P());
-}
-
 inline ::std::pair<const Ice::Byte*, const Ice::Byte*>
 makePair(const Ice::ByteSeq& seq)
 {
@@ -278,7 +272,15 @@ class ICE_API ObjectPrx : public ::std::enable_shared_from_this<ObjectPrx>
 {
 public:
 
+    ObjectPrx() = default;
+    ObjectPrx(const ObjectPrx& other) noexcept;
     virtual ~ObjectPrx() = default;
+
+    /// \cond INTERNAL
+    ObjectPrx(const IceInternal::ReferencePtr& ref) noexcept : _reference(ref)
+    {
+    }
+    /// \endcond
 
     friend ICE_API bool operator<(const ObjectPrx&, const ObjectPrx&);
     friend ICE_API bool operator==(const ObjectPrx&, const ObjectPrx&);
@@ -1069,8 +1071,6 @@ public:
 
     const ::IceInternal::ReferencePtr& _getReference() const { return _reference; }
 
-    void _copyFrom(const std::shared_ptr<::Ice::ObjectPrx>&);
-
     int _handleException(const ::Ice::Exception&, const ::IceInternal::RequestHandlerPtr&, ::Ice::OperationMode,
                           bool, int&);
 
@@ -1107,20 +1107,14 @@ protected:
         return [outAsync]() { outAsync->cancel(); };
     }
 
-    virtual ::std::shared_ptr<ObjectPrx> _newInstance() const;
-    ObjectPrx() = default;
-    friend ::std::shared_ptr<ObjectPrx> IceInternal::createProxy<ObjectPrx>();
     /// \endcond
 
 private:
 
-    void setup(const ::IceInternal::ReferencePtr&);
-    friend class ::IceInternal::ProxyFactory;
-
-    ::IceInternal::ReferencePtr _reference;
+    const ::IceInternal::ReferencePtr _reference;
     ::IceInternal::RequestHandlerPtr _requestHandler;
     ::IceInternal::BatchRequestQueuePtr _batchRequestQueue;
-    IceUtil::Mutex _mutex;
+    mutable std::mutex _mutex;
 };
 
 inline bool
@@ -1163,7 +1157,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_context(const ::Ice::Context& context) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_context(context));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_context(context));
     }
 
     /**
@@ -1173,7 +1167,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_adapterId(const ::std::string& id) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_adapterId(id));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_adapterId(id));
     }
 
     /**
@@ -1183,7 +1177,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_endpoints(const ::Ice::EndpointSeq& endpoints) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_endpoints(endpoints));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_endpoints(endpoints));
     }
 
     /**
@@ -1193,7 +1187,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_locatorCacheTimeout(int timeout) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_locatorCacheTimeout(timeout));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_locatorCacheTimeout(timeout));
     }
 
     /**
@@ -1203,7 +1197,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_connectionCached(bool b) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_connectionCached(b));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_connectionCached(b));
     }
 
     /**
@@ -1213,7 +1207,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_endpointSelection(::Ice::EndpointSelectionType type) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_endpointSelection(type));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_endpointSelection(type));
     }
 
     /**
@@ -1224,7 +1218,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_secure(bool b) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_secure(b));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_secure(b));
     }
 
     /**
@@ -1236,7 +1230,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_preferSecure(bool b) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_preferSecure(b));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_preferSecure(b));
     }
 
     /**
@@ -1246,7 +1240,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_router(const ::std::shared_ptr<::Ice::RouterPrx>& router) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_router(router));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_router(router));
     }
 
     /**
@@ -1256,7 +1250,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_locator(const ::std::shared_ptr<::Ice::LocatorPrx>& locator) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_locator(locator));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_locator(locator));
     }
 
     /**
@@ -1266,7 +1260,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_collocationOptimized(bool b) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_collocationOptimized(b));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_collocationOptimized(b));
     }
 
     /**
@@ -1276,7 +1270,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_invocationTimeout(int timeout) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_invocationTimeout(timeout));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_invocationTimeout(timeout));
     }
 
     /**
@@ -1285,7 +1279,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_twoway() const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_twoway());
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_twoway());
     }
 
     /**
@@ -1294,7 +1288,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_oneway() const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_oneway());
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_oneway());
     }
 
     /**
@@ -1303,7 +1297,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_batchOneway() const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_batchOneway());
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_batchOneway());
     }
 
     /**
@@ -1312,7 +1306,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_datagram() const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_datagram());
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_datagram());
     }
 
     /**
@@ -1321,7 +1315,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_batchDatagram() const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_batchDatagram());
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_batchDatagram());
     }
 
     /**
@@ -1332,7 +1326,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_compress(bool b) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_compress(b));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_compress(b));
     }
 
     /**
@@ -1343,7 +1337,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_timeout(int timeout) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_timeout(timeout));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_timeout(timeout));
     }
 
     /**
@@ -1354,7 +1348,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_connectionId(const ::std::string& id) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_connectionId(id));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_connectionId(id));
     }
 
     /**
@@ -1365,7 +1359,7 @@ public:
      */
     ::std::shared_ptr<Prx> ice_fixed(const ::std::shared_ptr<::Ice::Connection>& connection) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_fixed(connection));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_fixed(connection));
     }
 
     /**
@@ -1376,14 +1370,8 @@ public:
      */
     ::std::shared_ptr<Prx> ice_encodingVersion(const ::Ice::EncodingVersion& version) const
     {
-        return ::std::dynamic_pointer_cast<Prx>(ObjectPrx::ice_encodingVersion(version));
+        return ::std::make_shared<Prx>(*ObjectPrx::ice_encodingVersion(version));
     }
-
-protected:
-
-    /// \cond INTERNAL
-    virtual ::std::shared_ptr<ObjectPrx> _newInstance() const = 0;
-    /// \endcond
 };
 
 ICE_API ::std::ostream& operator<<(::std::ostream&, const ::Ice::ObjectPrx&);
@@ -1494,8 +1482,7 @@ uncheckedCast(const ::std::shared_ptr<T>& b)
         r = ::std::dynamic_pointer_cast<P>(b);
         if(!r)
         {
-            r = IceInternal::createProxy<P>();
-            r->_copyFrom(b);
+            r = std::make_shared<P>(*b);
         }
     }
     return r;
@@ -1516,8 +1503,7 @@ uncheckedCast(const ::std::shared_ptr<T>& b, const std::string& f)
     ::std::shared_ptr<P> r;
     if(b)
     {
-        r = IceInternal::createProxy<P>();
-        r->_copyFrom(b->ice_facet(f));
+        r = std::make_shared<P>(*(b->ice_facet(f)));
     }
     return r;
 }
@@ -1540,8 +1526,7 @@ checkedCast(const ::std::shared_ptr<T>& b, const ::Ice::Context& context = Ice::
     {
         if(b->ice_isA(P::ice_staticId(), context))
         {
-            r = IceInternal::createProxy<P>();
-            r->_copyFrom(b);
+            r = std::make_shared<P>(*b);
         }
     }
     return r;
@@ -1569,8 +1554,7 @@ checkedCast(const ::std::shared_ptr<T>& b, const std::string& f, const ::Ice::Co
             ::std::shared_ptr<::Ice::ObjectPrx> bb = b->ice_facet(f);
             if(bb->ice_isA(P::ice_staticId(), context))
             {
-                r = IceInternal::createProxy<P>();
-                r->_copyFrom(bb);
+                r = std::make_shared<P>(*bb);
             }
         }
         catch(const Ice::FacetNotExistException&)

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -272,7 +272,6 @@ class ICE_API ObjectPrx : public ::std::enable_shared_from_this<ObjectPrx>
 {
 public:
 
-    ObjectPrx() = default;
     ObjectPrx(const ObjectPrx& other) noexcept;
     virtual ~ObjectPrx() = default;
 
@@ -281,9 +280,6 @@ public:
     {
     }
     /// \endcond
-
-    friend ICE_API bool operator<(const ObjectPrx&, const ObjectPrx&);
-    friend ICE_API bool operator==(const ObjectPrx&, const ObjectPrx&);
 
     /**
      * Obtains the communicator that created this proxy.
@@ -1089,6 +1085,9 @@ public:
 protected:
 
     /// \cond INTERNAL
+    // This constructor is never called; it allows Proxy's default constructor to compile.
+    ObjectPrx() = default;
+
     template<typename R, template<typename> class P = ::std::promise, typename Obj, typename Fn, typename... Args>
     auto _makePromiseOutgoing(bool sync, Obj obj, Fn fn, Args&&... args)
         -> decltype(std::declval<P<R>>().get_future())
@@ -1116,6 +1115,9 @@ private:
     ::IceInternal::BatchRequestQueuePtr _batchRequestQueue;
     mutable std::mutex _mutex;
 };
+
+ICE_API bool operator<(const ObjectPrx&, const ObjectPrx&);
+ICE_API bool operator==(const ObjectPrx&, const ObjectPrx&);
 
 inline bool
 operator>(const ObjectPrx& lhs, const ObjectPrx& rhs)
@@ -1372,6 +1374,12 @@ public:
     {
         return ::std::make_shared<Prx>(*ObjectPrx::ice_encodingVersion(version));
     }
+
+protected:
+
+    // This constructor never initializes the base classes since they are all virtual and Proxy is never the most
+    // derived class.
+    Proxy() = default;
 };
 
 ICE_API ::std::ostream& operator<<(::std::ostream&, const ::Ice::ObjectPrx&);

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -137,13 +137,13 @@ namespace Ice
 bool
 operator<(const ObjectPrx& lhs, const ObjectPrx& rhs)
 {
-    return lhs._reference < rhs._reference;
+    return lhs._getReference() < rhs._getReference();
 }
 
 bool
 operator==(const ObjectPrx& lhs, const ObjectPrx& rhs)
 {
-    return lhs._reference == rhs._reference;
+    return lhs._getReference() == rhs._getReference();
 }
 
 }

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -148,6 +148,12 @@ operator==(const ObjectPrx& lhs, const ObjectPrx& rhs)
 
 }
 
+Ice::ObjectPrx::ObjectPrx(const ObjectPrx& other) noexcept : _reference(other._reference)
+{
+    lock_guard lock(other._mutex);
+    _requestHandler = other._requestHandler;
+}
+
 void
 Ice::ObjectPrx::_iceI_isA(const shared_ptr<IceInternal::OutgoingAsyncT<bool>>& outAsync,
                           const string& typeId,
@@ -218,29 +224,20 @@ Ice::ObjectPrx::_checkTwowayOnly(const string& name) const
     }
 }
 
-shared_ptr<ObjectPrx>
-Ice::ObjectPrx::_newInstance() const
-{
-    return createProxy<ObjectPrx>();
-}
-
 ostream&
 Ice::operator<<(ostream& os, const Ice::ObjectPrx& p)
 {
     return os << p.ice_toString();
 }
 
-#define ICE_OBJECT_PRX Ice::ObjectPrx
-#define CONST_POINTER_CAST_OBJECT_PRX const_pointer_cast<ObjectPrx>(shared_from_this())
-
 Identity
-ICE_OBJECT_PRX::ice_getIdentity() const
+Ice::ObjectPrx::ice_getIdentity() const
 {
     return _reference->getIdentity();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_identity(const Identity& newIdentity) const
+Ice::ObjectPrx::ice_identity(const Identity& newIdentity) const
 {
     if(newIdentity.name.empty())
     {
@@ -248,74 +245,66 @@ ICE_OBJECT_PRX::ice_identity(const Identity& newIdentity) const
     }
     if(newIdentity == _reference->getIdentity())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        auto proxy = createProxy<ObjectPrx>();
-        proxy->setup(_reference->changeIdentity(newIdentity));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeIdentity(newIdentity));
     }
 }
 
 Context
-ICE_OBJECT_PRX::ice_getContext() const
+Ice::ObjectPrx::ice_getContext() const
 {
     return _reference->getContext()->getValue();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_context(const Context& newContext) const
+Ice::ObjectPrx::ice_context(const Context& newContext) const
 {
-    ObjectPrxPtr proxy = _newInstance();
-    proxy->setup(_reference->changeContext(newContext));
-    return proxy;
+    return make_shared<ObjectPrx>(_reference->changeContext(newContext));
 }
 
 const string&
-ICE_OBJECT_PRX::ice_getFacet() const
+Ice::ObjectPrx::ice_getFacet() const
 {
     return _reference->getFacet();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_facet(const string& newFacet) const
+Ice::ObjectPrx::ice_facet(const string& newFacet) const
 {
     if(newFacet == _reference->getFacet())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        auto proxy = createProxy<ObjectPrx>();
-        proxy->setup(_reference->changeFacet(newFacet));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeFacet(newFacet));
     }
 }
 
 string
-ICE_OBJECT_PRX::ice_getAdapterId() const
+Ice::ObjectPrx::ice_getAdapterId() const
 {
     return _reference->getAdapterId();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_adapterId(const string& newAdapterId) const
+Ice::ObjectPrx::ice_adapterId(const string& newAdapterId) const
 {
     if(newAdapterId == _reference->getAdapterId())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeAdapterId(newAdapterId));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeAdapterId(newAdapterId));
     }
 }
 
 EndpointSeq
-ICE_OBJECT_PRX::ice_getEndpoints() const
+Ice::ObjectPrx::ice_getEndpoints() const
 {
     vector<EndpointIPtr> endpoints = _reference->getEndpoints();
     EndpointSeq retSeq;
@@ -327,7 +316,7 @@ ICE_OBJECT_PRX::ice_getEndpoints() const
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_endpoints(const EndpointSeq& newEndpoints) const
+Ice::ObjectPrx::ice_endpoints(const EndpointSeq& newEndpoints) const
 {
     vector<EndpointIPtr> endpoints;
     for(EndpointSeq::const_iterator p = newEndpoints.begin(); p != newEndpoints.end(); ++p)
@@ -337,24 +326,22 @@ ICE_OBJECT_PRX::ice_endpoints(const EndpointSeq& newEndpoints) const
 
     if(endpoints == _reference->getEndpoints())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeEndpoints(endpoints));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeEndpoints(endpoints));
     }
 }
 
 Int
-ICE_OBJECT_PRX::ice_getLocatorCacheTimeout() const
+Ice::ObjectPrx::ice_getLocatorCacheTimeout() const
 {
     return _reference->getLocatorCacheTimeout();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_locatorCacheTimeout(Int newTimeout) const
+Ice::ObjectPrx::ice_locatorCacheTimeout(Int newTimeout) const
 {
     if(newTimeout < -1)
     {
@@ -364,196 +351,178 @@ ICE_OBJECT_PRX::ice_locatorCacheTimeout(Int newTimeout) const
     }
     if(newTimeout == _reference->getLocatorCacheTimeout())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeLocatorCacheTimeout(newTimeout));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeLocatorCacheTimeout(newTimeout));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isConnectionCached() const
+Ice::ObjectPrx::ice_isConnectionCached() const
 {
     return _reference->getCacheConnection();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_connectionCached(bool newCache) const
+Ice::ObjectPrx::ice_connectionCached(bool newCache) const
 {
     if(newCache == _reference->getCacheConnection())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeCacheConnection(newCache));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeCacheConnection(newCache));
     }
 }
 
 EndpointSelectionType
-ICE_OBJECT_PRX::ice_getEndpointSelection() const
+Ice::ObjectPrx::ice_getEndpointSelection() const
 {
     return _reference->getEndpointSelection();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_endpointSelection(EndpointSelectionType newType) const
+Ice::ObjectPrx::ice_endpointSelection(EndpointSelectionType newType) const
 {
     if(newType == _reference->getEndpointSelection())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeEndpointSelection(newType));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeEndpointSelection(newType));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isSecure() const
+Ice::ObjectPrx::ice_isSecure() const
 {
     return _reference->getSecure();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_secure(bool b) const
+Ice::ObjectPrx::ice_secure(bool b) const
 {
     if(b == _reference->getSecure())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeSecure(b));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeSecure(b));
     }
 }
 
 ::Ice::EncodingVersion
-ICE_OBJECT_PRX::ice_getEncodingVersion() const
+Ice::ObjectPrx::ice_getEncodingVersion() const
 {
     return _reference->getEncoding();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_encodingVersion(const ::Ice::EncodingVersion& encoding) const
+Ice::ObjectPrx::ice_encodingVersion(const ::Ice::EncodingVersion& encoding) const
 {
     if(encoding == _reference->getEncoding())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeEncoding(encoding));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeEncoding(encoding));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isPreferSecure() const
+Ice::ObjectPrx::ice_isPreferSecure() const
 {
     return _reference->getPreferSecure();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_preferSecure(bool b) const
+Ice::ObjectPrx::ice_preferSecure(bool b) const
 {
     if(b == _reference->getPreferSecure())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changePreferSecure(b));
-        return proxy;
+       return make_shared<ObjectPrx>(_reference->changePreferSecure(b));
     }
 }
 
 RouterPrxPtr
-ICE_OBJECT_PRX::ice_getRouter() const
+Ice::ObjectPrx::ice_getRouter() const
 {
     RouterInfoPtr ri = _reference->getRouterInfo();
     return ri ? ri->getRouter() : nullptr;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_router(const RouterPrxPtr& router) const
+Ice::ObjectPrx::ice_router(const RouterPrxPtr& router) const
 {
     ReferencePtr ref = _reference->changeRouter(router);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
 }
 
 LocatorPrxPtr
-ICE_OBJECT_PRX::ice_getLocator() const
+Ice::ObjectPrx::ice_getLocator() const
 {
     LocatorInfoPtr ri = _reference->getLocatorInfo();
     return ri ? ri->getLocator() : nullptr;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_locator(const LocatorPrxPtr& locator) const
+Ice::ObjectPrx::ice_locator(const LocatorPrxPtr& locator) const
 {
     ReferencePtr ref = _reference->changeLocator(locator);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isCollocationOptimized() const
+Ice::ObjectPrx::ice_isCollocationOptimized() const
 {
     return _reference->getCollocationOptimized();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_collocationOptimized(bool b) const
+Ice::ObjectPrx::ice_collocationOptimized(bool b) const
 {
     if(b == _reference->getCollocationOptimized())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeCollocationOptimized(b));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeCollocationOptimized(b));
     }
 }
 
 Int
-ICE_OBJECT_PRX::ice_getInvocationTimeout() const
+Ice::ObjectPrx::ice_getInvocationTimeout() const
 {
     return _reference->getInvocationTimeout();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_invocationTimeout(Int newTimeout) const
+Ice::ObjectPrx::ice_invocationTimeout(Int newTimeout) const
 {
     if(newTimeout < 1 && newTimeout != -1 && newTimeout != -2)
     {
@@ -563,145 +532,131 @@ ICE_OBJECT_PRX::ice_invocationTimeout(Int newTimeout) const
     }
     if(newTimeout == _reference->getInvocationTimeout())
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeInvocationTimeout(newTimeout));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeInvocationTimeout(newTimeout));
     }
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_twoway() const
+Ice::ObjectPrx::ice_twoway() const
 {
     if(_reference->getMode() == Reference::ModeTwoway)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeMode(Reference::ModeTwoway));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeMode(Reference::ModeTwoway));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isTwoway() const
+Ice::ObjectPrx::ice_isTwoway() const
 {
     return _reference->getMode() == Reference::ModeTwoway;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_oneway() const
+Ice::ObjectPrx::ice_oneway() const
 {
     if(_reference->getMode() == Reference::ModeOneway)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeMode(Reference::ModeOneway));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeMode(Reference::ModeOneway));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isOneway() const
+Ice::ObjectPrx::ice_isOneway() const
 {
     return _reference->getMode() == Reference::ModeOneway;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_batchOneway() const
+Ice::ObjectPrx::ice_batchOneway() const
 {
     if(_reference->getMode() == Reference::ModeBatchOneway)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeMode(Reference::ModeBatchOneway));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeMode(Reference::ModeBatchOneway));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isBatchOneway() const
+Ice::ObjectPrx::ice_isBatchOneway() const
 {
     return _reference->getMode() == Reference::ModeBatchOneway;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_datagram() const
+Ice::ObjectPrx::ice_datagram() const
 {
     if(_reference->getMode() == Reference::ModeDatagram)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeMode(Reference::ModeDatagram));
-        return proxy;
+        return make_shared<ObjectPrx>(_reference->changeMode(Reference::ModeDatagram));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isDatagram() const
+Ice::ObjectPrx::ice_isDatagram() const
 {
     return _reference->getMode() == Reference::ModeDatagram;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_batchDatagram() const
+Ice::ObjectPrx::ice_batchDatagram() const
 {
     if(_reference->getMode() == Reference::ModeBatchDatagram)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(_reference->changeMode(Reference::ModeBatchDatagram));
-        return proxy;
+       return make_shared<ObjectPrx>(_reference->changeMode(Reference::ModeBatchDatagram));
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isBatchDatagram() const
+Ice::ObjectPrx::ice_isBatchDatagram() const
 {
     return _reference->getMode() == Reference::ModeBatchDatagram;
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_compress(bool b) const
+Ice::ObjectPrx::ice_compress(bool b) const
 {
     ReferencePtr ref = _reference->changeCompress(b);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+       return make_shared<ObjectPrx>(ref);
     }
 }
 
 IceUtil::Optional<bool>
-ICE_OBJECT_PRX::ice_getCompress() const
+Ice::ObjectPrx::ice_getCompress() const
 {
     return _reference->getCompress();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_timeout(int t) const
+Ice::ObjectPrx::ice_timeout(int t) const
 {
     if(t < 1 && t != -1)
     {
@@ -712,46 +667,42 @@ ICE_OBJECT_PRX::ice_timeout(int t) const
     ReferencePtr ref = _reference->changeTimeout(t);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
 }
 
 IceUtil::Optional<int>
-ICE_OBJECT_PRX::ice_getTimeout() const
+Ice::ObjectPrx::ice_getTimeout() const
 {
     return _reference->getTimeout();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_connectionId(const string& id) const
+Ice::ObjectPrx::ice_connectionId(const string& id) const
 {
     ReferencePtr ref = _reference->changeConnectionId(id);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
 }
 
 string
-ICE_OBJECT_PRX::ice_getConnectionId() const
+Ice::ObjectPrx::ice_getConnectionId() const
 {
     return _reference->getConnectionId();
 }
 
 ObjectPrxPtr
-ICE_OBJECT_PRX::ice_fixed(const ::Ice::ConnectionPtr& connection) const
+Ice::ObjectPrx::ice_fixed(const ::Ice::ConnectionPtr& connection) const
 {
     if(!connection)
     {
@@ -765,28 +716,26 @@ ICE_OBJECT_PRX::ice_fixed(const ::Ice::ConnectionPtr& connection) const
     ReferencePtr ref = _reference->changeConnection(impl);
     if(ref == _reference)
     {
-        return CONST_POINTER_CAST_OBJECT_PRX;
+        return const_pointer_cast<ObjectPrx>(shared_from_this());
     }
     else
     {
-        ObjectPrxPtr proxy = _newInstance();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
 }
 
 bool
-ICE_OBJECT_PRX::ice_isFixed() const
+Ice::ObjectPrx::ice_isFixed() const
 {
     return FixedReferencePtr::dynamicCast(_reference);
 }
 
 ConnectionPtr
-ICE_OBJECT_PRX::ice_getCachedConnection() const
+Ice::ObjectPrx::ice_getCachedConnection() const
 {
     RequestHandlerPtr handler;
     {
-        IceUtil::Mutex::Lock sync(_mutex);
+        lock_guard lock(_mutex);
         handler =  _requestHandler;
     }
 
@@ -803,22 +752,8 @@ ICE_OBJECT_PRX::ice_getCachedConnection() const
     return 0;
 }
 
-void
-ICE_OBJECT_PRX::setup(const ReferencePtr& ref)
-{
-    //
-    // No need to synchronize "*this", as this operation is only
-    // called upon initialization.
-    //
-
-    assert(!_reference);
-    assert(!_requestHandler);
-
-    _reference = ref;
-}
-
 int
-ICE_OBJECT_PRX::_handleException(const Exception& ex,
+Ice::ObjectPrx::_handleException(const Exception& ex,
                                  const RequestHandlerPtr& handler,
                                  OperationMode mode,
                                  bool sent,
@@ -867,12 +802,12 @@ ICE_OBJECT_PRX::_handleException(const Exception& ex,
 }
 
 ::IceInternal::RequestHandlerPtr
-ICE_OBJECT_PRX::_getRequestHandler()
+Ice::ObjectPrx::_getRequestHandler()
 {
     RequestHandlerPtr handler;
     if(_reference->getCacheConnection())
     {
-        IceUtil::Mutex::Lock sync(_mutex);
+        lock_guard lock(_mutex);
         if(_requestHandler)
         {
             return _requestHandler;
@@ -882,9 +817,9 @@ ICE_OBJECT_PRX::_getRequestHandler()
 }
 
 IceInternal::BatchRequestQueuePtr
-ICE_OBJECT_PRX::_getBatchRequestQueue()
+Ice::ObjectPrx::_getBatchRequestQueue()
 {
-    IceUtil::Mutex::Lock sync(_mutex);
+    lock_guard lock(_mutex);
     if(!_batchRequestQueue)
     {
         _batchRequestQueue = _reference->getBatchRequestQueue();
@@ -893,11 +828,11 @@ ICE_OBJECT_PRX::_getBatchRequestQueue()
 }
 
 ::IceInternal::RequestHandlerPtr
-ICE_OBJECT_PRX::_setRequestHandler(const ::IceInternal::RequestHandlerPtr& handler)
+Ice::ObjectPrx::_setRequestHandler(const ::IceInternal::RequestHandlerPtr& handler)
 {
     if(_reference->getCacheConnection())
     {
-        IceUtil::Mutex::Lock sync(_mutex);
+        lock_guard lock(_mutex);
         if(!_requestHandler)
         {
             _requestHandler = handler;
@@ -908,12 +843,12 @@ ICE_OBJECT_PRX::_setRequestHandler(const ::IceInternal::RequestHandlerPtr& handl
 }
 
 void
-ICE_OBJECT_PRX::_updateRequestHandler(const ::IceInternal::RequestHandlerPtr& previous,
+Ice::ObjectPrx::_updateRequestHandler(const ::IceInternal::RequestHandlerPtr& previous,
                                       const ::IceInternal::RequestHandlerPtr& handler)
 {
     if(_reference->getCacheConnection() && previous)
     {
-        IceUtil::Mutex::Lock sync(_mutex);
+        lock_guard lock(_mutex);
         if(_requestHandler && _requestHandler.get() != handler.get())
         {
             //
@@ -928,22 +863,14 @@ ICE_OBJECT_PRX::_updateRequestHandler(const ::IceInternal::RequestHandlerPtr& pr
     }
 }
 
-void
-ICE_OBJECT_PRX::_copyFrom(const ObjectPrxPtr& from)
-{
-    IceUtil::Mutex::Lock sync(from->_mutex);
-    _reference = from->_reference;
-    _requestHandler = from->_requestHandler;
-}
-
 CommunicatorPtr
-ICE_OBJECT_PRX::ice_getCommunicator() const
+Ice::ObjectPrx::ice_getCommunicator() const
 {
     return _reference->getCommunicator();
 }
 
 string
-ICE_OBJECT_PRX::ice_toString() const
+Ice::ObjectPrx::ice_toString() const
 {
     //
     // Returns the stringified proxy. There's no need to convert the
@@ -954,13 +881,13 @@ ICE_OBJECT_PRX::ice_toString() const
 }
 
 Int
-ICE_OBJECT_PRX::_hash() const
+Ice::ObjectPrx::_hash() const
 {
     return _reference->hash();
 }
 
 void
-ICE_OBJECT_PRX::_write(OutputStream& os) const
+Ice::ObjectPrx::_write(OutputStream& os) const
 {
     os.write(_getReference()->getIdentity());
     _getReference()->streamWrite(&os);

--- a/cpp/src/Ice/ProxyFactory.cpp
+++ b/cpp/src/Ice/ProxyFactory.cpp
@@ -80,9 +80,7 @@ IceInternal::ProxyFactory::referenceToProxy(const ReferencePtr& ref) const
 {
     if(ref)
     {
-        auto proxy = createProxy<ObjectPrx>();
-        proxy->setup(ref);
-        return proxy;
+        return make_shared<ObjectPrx>(ref);
     }
     else
     {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -5800,12 +5800,12 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     string name = fixKwd(p->name());
     string scope = fixKwd(p->scope());
-    string scoped = fixKwd(p->scoped());
+    string scoped = fixKwd(p->scoped() + "Prx");
     InterfaceList bases = p->bases();
 
     H << sp;
     writeDocSummary(H, p);
-    H << nl << "class " << _dllClassExport << p->name() << "Prx : public virtual "
+    H << nl << "class " << _dllClassExport << p->name() << "Prx : public "
       << getUnqualified("::Ice::Proxy", scope) << "<" << fixKwd(p->name() + "Prx") << ", ";
     if(bases.empty())
     {
@@ -5847,8 +5847,6 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << " */";
     H << nl << _dllMemberExport << "static const ::std::string& ice_staticId();";
     H << sp;
-    H << nl << prx << "() = default;";
-    H << sp;
     H << nl << "explicit " << prx << "(const ::Ice::ObjectPrx& other) : ::Ice::ObjectPrx(other)";
     H << nl << "{";
     H << nl << "}";
@@ -5858,7 +5856,13 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "{";
     H << nl << "}";
     H << nl << "/// \\endcond";
-
+    H.dec();
+    H << sp << nl << "protected:";
+    H.inc();
+    H << sp;
+    H << nl << "/// \\cond INTERNAL";
+    H << nl << prx << "() = default;";
+    H << nl << "/// \\endcond";
     H << eb << ';';
 
     C << sp;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -5829,6 +5829,7 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     H.dec();
     H << nl << "public:";
     H.inc();
+
     return true;
 }
 
@@ -5845,29 +5846,21 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << " * @return The fully-scoped type ID.";
     H << nl << " */";
     H << nl << _dllMemberExport << "static const ::std::string& ice_staticId();";
-
-    H.dec();
-    H << sp << nl << "protected:";
-    H.inc();
+    H << sp;
+    H << nl << prx << "() = default;";
+    H << sp;
+    H << nl << "explicit " << prx << "(const ::Ice::ObjectPrx& other) : ::Ice::ObjectPrx(other)";
+    H << nl << "{";
+    H << nl << "}";
     H << sp;
     H << nl << "/// \\cond INTERNAL";
-    H << nl << getUnqualified(prx, scope) << "() = default;";
-    H << nl << "friend ::std::shared_ptr<" << getUnqualified(prx, scope) << "> IceInternal::createProxy<"
-      << getUnqualified(prx, scope) << ">();";
-    H << sp;
-    H << nl << _dllMemberExport << "virtual ::std::shared_ptr<" << getUnqualified("::Ice::ObjectPrx", scope)
-      << "> _newInstance() const override;";
+    H << nl << prx << "(const ::IceInternal::ReferencePtr& ref) : ::Ice::ObjectPrx(ref)";
+    H << nl << "{";
+    H << nl << "}";
     H << nl << "/// \\endcond";
+
     H << eb << ';';
 
-    C << sp;
-    C << nl << "/// \\cond INTERNAL";
-    C << nl << "::std::shared_ptr<::Ice::ObjectPrx>";
-    C << nl << scoped.substr(2) << "::_newInstance() const";
-    C << sb;
-    C << nl << "return ::IceInternal::createProxy<" << getUnqualified(prx, scope) << ">();";
-    C << eb;
-    C << nl << "/// \\endcond";
     C << sp;
     C << nl << "const ::std::string&" << nl << scoped.substr(2) << "::ice_staticId()";
     C << sb;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -5798,9 +5798,7 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
-    string name = fixKwd(p->name());
-    string scope = fixKwd(p->scope());
-    string scoped = fixKwd(p->scoped() + "Prx");
+    const string scope = fixKwd(p->scope());
     InterfaceList bases = p->bases();
 
     H << sp;
@@ -5836,9 +5834,8 @@ Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 void
 Slice::Gen::Cpp11ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
-    string prx = fixKwd(p->name() + "Prx");
+    const string prx = fixKwd(p->name() + "Prx");
     const string scoped = fixKwd(p->scoped() + "Prx");
-    const string scope = fixKwd(p->scope());
 
     H << sp;
     H << nl << "/**";


### PR DESCRIPTION
This preliminary Proxy refactoring makes ObjectPrx and derived classes more standard classes.

ObjectPrx's reference data member is now const and initialized by ObjectPrx's constructors.
