### PR TITLE
Make _batchRequestQueue const

### DIFF
--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -522,9 +522,7 @@ public:
     virtual ~ObjectPrx() = default;
 
     /// \cond INTERNAL
-    ObjectPrx(const IceInternal::ReferencePtr& ref) noexcept : _reference(ref)
-    {
-    }
+    ObjectPrx(const IceInternal::ReferencePtr& ref) noexcept;
     /// \endcond
 
     /**
@@ -1162,7 +1160,7 @@ public:
     void _checkTwowayOnly(const ::std::string&) const;
 
     ::IceInternal::RequestHandlerPtr _getRequestHandler();
-    ::IceInternal::BatchRequestQueuePtr _getBatchRequestQueue();
+    ::IceInternal::BatchRequestQueuePtr _getBatchRequestQueue() const { return _batchRequestQueue; }
     ::IceInternal::RequestHandlerPtr _setRequestHandler(const ::IceInternal::RequestHandlerPtr&);
     void _updateRequestHandler(const ::IceInternal::RequestHandlerPtr&, const ::IceInternal::RequestHandlerPtr&);
 
@@ -1225,9 +1223,9 @@ private:
     IceInternal::ReferencePtr _timeout(int) const;
     IceInternal::ReferencePtr _twoway() const;
 
-    const ::IceInternal::ReferencePtr _reference;
+    const IceInternal::ReferencePtr _reference;
     ::IceInternal::RequestHandlerPtr _requestHandler;
-    ::IceInternal::BatchRequestQueuePtr _batchRequestQueue;
+    const IceInternal::BatchRequestQueuePtr _batchRequestQueue;
     mutable std::mutex _mutex;
 };
 

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -149,9 +149,13 @@ operator==(const ObjectPrx& lhs, const ObjectPrx& rhs)
 
 }
 
-Ice::ObjectPrx::ObjectPrx(const ObjectPrx& other) noexcept :
-    enable_shared_from_this<ObjectPrx>(), // the copy is independent of other
-    _reference(other._reference)
+Ice::ObjectPrx::ObjectPrx(const ReferencePtr& ref) noexcept :
+    _reference(ref),
+    _batchRequestQueue(ref->isBatch() ? _reference->getBatchRequestQueue() : nullptr)
+{
+}
+
+Ice::ObjectPrx::ObjectPrx(const ObjectPrx& other) noexcept : ObjectPrx(other._reference)
 {
     lock_guard lock(other._mutex);
     _requestHandler = other._requestHandler;
@@ -499,17 +503,6 @@ Ice::ObjectPrx::_getRequestHandler()
         }
     }
     return _reference->getRequestHandler(shared_from_this());
-}
-
-IceInternal::BatchRequestQueuePtr
-Ice::ObjectPrx::_getBatchRequestQueue()
-{
-    lock_guard lock(_mutex);
-    if(!_batchRequestQueue)
-    {
-        _batchRequestQueue = _reference->getBatchRequestQueue();
-    }
-    return _batchRequestQueue;
 }
 
 ::IceInternal::RequestHandlerPtr

--- a/cpp/src/Ice/Reference.h
+++ b/cpp/src/Ice/Reference.h
@@ -59,6 +59,7 @@ public:
     };
 
     Mode getMode() const { return _mode; }
+    bool isBatch() const { return _mode == ModeBatchOneway || _mode == ModeBatchDatagram; }
     bool getSecure() const { return _secure; }
     const Ice::ProtocolVersion& getProtocol() const { return _protocol; }
     const Ice::EncodingVersion& getEncoding() const { return _encoding; }


### PR DESCRIPTION
This is a small update to Proxy to make its _bachRequestQueue data member const.