### PR TITLE
Remove unused getReference functions

### DIFF
--- a/cpp/src/Ice/CollocatedRequestHandler.h
+++ b/cpp/src/Ice/CollocatedRequestHandler.h
@@ -46,8 +46,6 @@ public:
     virtual bool systemException(Ice::Int, std::exception_ptr, bool);
     virtual void invokeException(Ice::Int, std::exception_ptr, int, bool);
 
-    const ReferencePtr& getReference() const { return _reference; } // Inlined for performances.
-
     virtual Ice::ConnectionIPtr getConnection();
     virtual Ice::ConnectionIPtr waitForConnection();
 

--- a/cpp/src/Ice/RequestHandler.h
+++ b/cpp/src/Ice/RequestHandler.h
@@ -58,8 +58,6 @@ public:
 
     virtual AsyncStatus sendAsyncRequest(const ProxyOutgoingAsyncBasePtr&) = 0;
 
-    const ReferencePtr& getReference() const { return _reference; } // Inlined for performances.
-
     virtual Ice::ConnectionIPtr getConnection() = 0;
     virtual Ice::ConnectionIPtr waitForConnection() = 0;
 


### PR DESCRIPTION
This PR removes two unused inline functions.