### PR TITLE
Simplify RouterInfo API

### DIFF
--- a/cpp/src/Ice/ConnectRequestHandler.cpp
+++ b/cpp/src/Ice/ConnectRequestHandler.cpp
@@ -135,7 +135,7 @@ ConnectRequestHandler::setConnection(const Ice::ConnectionIPtr& connection, bool
     {
         auto self = shared_from_this();
         if (!ri->addProxyAsync(
-                _reference->getInstance()->proxyFactory()->referenceToProxy(_reference),
+                _reference,
                 [self] { self->addedProxy(); },
                 [self](exception_ptr ex) { self->setException(ex); }))
         {

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -164,7 +164,7 @@ IceInternal::RouterInfo::getClientEndpointsAsync(
     _router->getClientProxyAsync(
         [self, response](const Ice::ObjectPrxPtr& proxy, optional<bool> hasRoutingTable)
         {
-            response(self->setClientEndpoints(proxy, hasRoutingTable ? hasRoutingTable.value() : true));
+            response(self->setClientEndpoints(proxy, hasRoutingTable.value_or(true)));
         },
         ex);
 }

--- a/cpp/src/Ice/RouterInfo.h
+++ b/cpp/src/Ice/RouterInfo.h
@@ -50,15 +50,6 @@ class RouterInfo final : public std::enable_shared_from_this<RouterInfo>
 {
 public:
 
-    class GetClientEndpointsCallback
-    {
-    public:
-
-        virtual void setEndpoints(const std::vector<EndpointIPtr>&) = 0;
-        virtual void setException(std::exception_ptr) = 0;
-    };
-    using GetClientEndpointsCallbackPtr = std::shared_ptr<GetClientEndpointsCallback>;
-
     RouterInfo(const Ice::RouterPrxPtr&);
 
     void destroy();
@@ -73,11 +64,12 @@ public:
         //
         return _router;
     }
-    void getClientProxyResponse(const Ice::ObjectPrxPtr&, const std::optional<bool>&,
-                                const GetClientEndpointsCallbackPtr&);
-    void getClientProxyException(std::exception_ptr, const GetClientEndpointsCallbackPtr&);
+
     std::vector<EndpointIPtr> getClientEndpoints();
-    void getClientEndpoints(const GetClientEndpointsCallbackPtr&);
+
+    void getClientEndpointsAsync(
+        std::function<void(std::vector<EndpointIPtr>)> response,
+        std::function<void(std::exception_ptr)> ex);
 
     std::vector<EndpointIPtr> getServerEndpoints();
 
@@ -91,14 +83,10 @@ public:
 
     void clearCache(const ReferencePtr&);
 
-    //
-    // The following methods need to be public for access by AMI callbacks.
-    //
-    std::vector<EndpointIPtr> setClientEndpoints(const Ice::ObjectPrxPtr&, bool);
-
 private:
 
     void addAndEvictProxies(const Ice::Identity&, const Ice::ObjectProxySeq&);
+    std::vector<EndpointIPtr> setClientEndpoints(const Ice::ObjectPrxPtr&, bool);
 
     const Ice::RouterPrxPtr _router;
     std::vector<EndpointIPtr> _clientEndpoints;

--- a/cpp/src/Ice/RouterInfo.h
+++ b/cpp/src/Ice/RouterInfo.h
@@ -82,7 +82,7 @@ public:
     std::vector<EndpointIPtr> getServerEndpoints();
 
     bool addProxyAsync(
-        const Ice::ObjectPrxPtr& proxy,
+        const ReferencePtr& proxy,
         std::function<void()> response,
         std::function<void(std::exception_ptr)> ex);
 
@@ -95,9 +95,10 @@ public:
     // The following methods need to be public for access by AMI callbacks.
     //
     std::vector<EndpointIPtr> setClientEndpoints(const Ice::ObjectPrxPtr&, bool);
-    void addAndEvictProxies(const Ice::ObjectPrxPtr&, const Ice::ObjectProxySeq&);
 
 private:
+
+    void addAndEvictProxies(const Ice::Identity&, const Ice::ObjectProxySeq&);
 
     const Ice::RouterPrxPtr _router;
     std::vector<EndpointIPtr> _clientEndpoints;


### PR DESCRIPTION
This PR simplifies the API of addProxyAsync and removes the GetClientEndpointsCallback callback.