### PR TITLE
Cleanup virtual modifier in transport classes

### DIFF
--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -40,25 +40,25 @@ class ICE_API IPEndpointI : public EndpointI, public std::enable_shared_from_thi
 {
 public:
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const override;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
-    virtual Ice::Short type() const;
-    virtual const std::string& protocol() const;
-    virtual bool secure() const;
+    Ice::EndpointInfoPtr getInfo() const noexcept override;
+    Ice::Short type() const override;
+    const std::string& protocol() const override;
+    bool secure() const override;
 
-    virtual const std::string& connectionId() const;
-    virtual EndpointIPtr connectionId(const ::std::string&) const;
+    const std::string& connectionId() const override;
+    EndpointIPtr connectionId(const ::std::string&) const override;
 
-    virtual void connectors_async(Ice::EndpointSelectionType, const EndpointI_connectorsPtr&) const;
-    virtual std::vector<EndpointIPtr> expandIfWildcard() const;
-    virtual std::vector<EndpointIPtr> expandHost(EndpointIPtr&) const;
-    virtual bool equivalent(const EndpointIPtr&) const;
-    virtual ::Ice::Int hash() const;
-    virtual std::string options() const;
+    void connectors_async(Ice::EndpointSelectionType, const EndpointI_connectorsPtr&) const override;
+    std::vector<EndpointIPtr> expandIfWildcard() const override;
+    std::vector<EndpointIPtr> expandHost(EndpointIPtr&) const override;
+    bool equivalent(const EndpointIPtr&) const override;
+    ::Ice::Int hash() const override;
+    std::string options() const override;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const override;
+    bool operator<(const Ice::Endpoint&) const override;
 
     virtual std::vector<ConnectorPtr> connectors(const std::vector<Address>&, const NetworkProxyPtr&) const;
 
@@ -73,7 +73,7 @@ protected:
 
     friend class EndpointHostResolver;
 
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    bool checkOption(const std::string&, const std::string&, const std::string&) override;
 
     virtual ConnectorPtr createConnector(const Address& address, const NetworkProxyPtr&) const = 0;
     virtual IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const = 0;
@@ -95,7 +95,7 @@ private:
     mutable std::mutex _hashMutex;
 };
 
-class ICE_API EndpointHostResolver : public IceUtil::Thread
+class ICE_API EndpointHostResolver final : public IceUtil::Thread
 {
 public:
 
@@ -105,7 +105,7 @@ public:
                  const EndpointI_connectorsPtr&);
     void destroy();
 
-    virtual void run();
+    void run() final;
     void updateObserver();
 
 private:

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -18,22 +18,22 @@ NetworkProxy::~NetworkProxy()
 namespace
 {
 
-class SOCKSNetworkProxy : public NetworkProxy
+class SOCKSNetworkProxy final : public NetworkProxy
 {
 public:
 
     SOCKSNetworkProxy(const string&, int);
     SOCKSNetworkProxy(const Address&);
 
-    virtual void beginWrite(const Address&, Buffer&);
-    virtual SocketOperation endWrite(Buffer&);
-    virtual void beginRead(Buffer&);
-    virtual SocketOperation endRead(Buffer&);
-    virtual void finish(Buffer&, Buffer&);
-    virtual NetworkProxyPtr resolveHost(ProtocolSupport) const;
-    virtual Address getAddress() const;
-    virtual string getName() const;
-    virtual ProtocolSupport getProtocolSupport() const;
+    void beginWrite(const Address&, Buffer&) final;
+    SocketOperation endWrite(Buffer&) final;
+    void beginRead(Buffer&) final;
+    SocketOperation endRead(Buffer&) final;
+    void finish(Buffer&, Buffer&) final;
+    NetworkProxyPtr resolveHost(ProtocolSupport) const final;
+    Address getAddress() const final;
+    string getName() const final;
+    ProtocolSupport getProtocolSupport() const final;
 
 private:
 
@@ -42,22 +42,22 @@ private:
     Address _address;
 };
 
-class HTTPNetworkProxy : public NetworkProxy
+class HTTPNetworkProxy final : public NetworkProxy
 {
 public:
 
     HTTPNetworkProxy(const string&, int);
     HTTPNetworkProxy(const Address&, ProtocolSupport);
 
-    virtual void beginWrite(const Address&, Buffer&);
-    virtual SocketOperation endWrite(Buffer&);
-    virtual void beginRead(Buffer&);
-    virtual SocketOperation endRead(Buffer&);
-    virtual void finish(Buffer&, Buffer&);
-    virtual NetworkProxyPtr resolveHost(ProtocolSupport) const;
-    virtual Address getAddress() const;
-    virtual string getName() const;
-    virtual ProtocolSupport getProtocolSupport() const;
+    void beginWrite(const Address&, Buffer&) final;
+    SocketOperation endWrite(Buffer&) final;
+    void beginRead(Buffer&) final;
+    SocketOperation endRead(Buffer&) final;
+    void finish(Buffer&, Buffer&) final;
+    NetworkProxyPtr resolveHost(ProtocolSupport) const final;
+    Address getAddress() const final;
+    string getName() const final;
+    ProtocolSupport getProtocolSupport() const final;
 
 private:
 

--- a/cpp/src/Ice/TcpAcceptor.h
+++ b/cpp/src/Ice/TcpAcceptor.h
@@ -15,28 +15,28 @@ namespace IceInternal
 
 class TcpEndpoint;
 
-class TcpAcceptor : public Acceptor, public NativeInfo, public std::enable_shared_from_this<TcpAcceptor>
+class TcpAcceptor final : public Acceptor, public NativeInfo, public std::enable_shared_from_this<TcpAcceptor>
 {
 public:
 
     TcpAcceptor(const TcpEndpointIPtr&, const ProtocolInstancePtr&, const std::string&, int);
-    virtual ~TcpAcceptor();
-    virtual NativeInfoPtr getNativeInfo();
+    ~TcpAcceptor();
+    NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)
-    virtual AsyncInfo* getAsyncInfo(SocketOperation);
+    AsyncInfo* getAsyncInfo(SocketOperation) final;
 #endif
 
-    virtual void close();
-    virtual EndpointIPtr listen();
+    void close() final;
+    EndpointIPtr listen() final;
 #if defined(ICE_USE_IOCP)
-    virtual void startAccept();
-    virtual void finishAccept();
+    void startAccept() final;
+    void finishAccept() final;
 #endif
 
-    virtual TransceiverPtr accept();
-    virtual std::string protocol() const;
-    virtual std::string toString() const;
-    virtual std::string toDetailedString() const;
+    TransceiverPtr accept() final;
+    std::string protocol() const final;
+    std::string toString() const final;
+    std::string toDetailedString() const final;
 
     int effectivePort() const;
 

--- a/cpp/src/Ice/TcpConnector.h
+++ b/cpp/src/Ice/TcpConnector.h
@@ -13,20 +13,20 @@
 namespace IceInternal
 {
 
-class TcpConnector : public Connector
+class TcpConnector final : public Connector
 {
 public:
 
     TcpConnector(const ProtocolInstancePtr&, const Address&, const NetworkProxyPtr&, const Address&, Ice::Int,
                  const std::string&);
-    virtual ~TcpConnector();
-    virtual TransceiverPtr connect();
+    ~TcpConnector();
+    TransceiverPtr connect() final;
 
-    virtual Ice::Short type() const;
-    virtual std::string toString() const;
+    Ice::Short type() const final;
+    std::string toString() const final;
 
-    virtual bool operator==(const Connector&) const;
-    virtual bool operator<(const Connector&) const;
+    bool operator==(const Connector&) const final;
+    bool operator<(const Connector&) const final;
 
 private:
 

--- a/cpp/src/Ice/TcpEndpointI.h
+++ b/cpp/src/Ice/TcpEndpointI.h
@@ -13,7 +13,7 @@
 namespace IceInternal
 {
 
-class TcpEndpointI : public IPEndpointI
+class TcpEndpointI final : public IPEndpointI
 {
 public:
 
@@ -22,34 +22,34 @@ public:
     TcpEndpointI(const ProtocolInstancePtr&);
     TcpEndpointI(const ProtocolInstancePtr&, Ice::InputStream*);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
 
-    virtual Ice::Int timeout() const;
-    virtual EndpointIPtr timeout(Ice::Int) const;
-    virtual bool compress() const;
-    virtual EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
+    Ice::Int timeout() const final;
+    EndpointIPtr timeout(Ice::Int) const final;
+    bool compress() const final;
+    EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
 
-    virtual TransceiverPtr transceiver() const;
-    virtual AcceptorPtr acceptor(const std::string&) const;
-    virtual std::string options() const;
+    TransceiverPtr transceiver() const final;
+    AcceptorPtr acceptor(const std::string&) const final;
+    std::string options() const final;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
     TcpEndpointIPtr endpoint(const TcpAcceptorPtr&) const;
 
     using IPEndpointI::connectionId;
 
 protected:
 
-    virtual void hashInit(Ice::Int&) const;
-    virtual void fillEndpointInfo(Ice::IPEndpointInfo*) const;
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    void hashInit(Ice::Int&) const final;
+    void fillEndpointInfo(Ice::IPEndpointInfo*) const final;
+    bool checkOption(const std::string&, const std::string&, const std::string&) final;
 
-    virtual ConnectorPtr createConnector(const Address&, const NetworkProxyPtr&) const;
-    virtual IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const;
+    ConnectorPtr createConnector(const Address&, const NetworkProxyPtr&) const final;
+    IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const final;
 
 private:
 
@@ -60,20 +60,20 @@ private:
     const bool _compress;
 };
 
-class TcpEndpointFactory : public EndpointFactory
+class TcpEndpointFactory final : public EndpointFactory
 {
 public:
 
     TcpEndpointFactory(const ProtocolInstancePtr&);
-    virtual ~TcpEndpointFactory();
+    ~TcpEndpointFactory();
 
-    virtual Ice::Short type() const;
-    virtual std::string protocol() const;
-    virtual EndpointIPtr create(std::vector<std::string>&, bool) const;
-    virtual EndpointIPtr read(Ice::InputStream*) const;
-    virtual void destroy();
+    Ice::Short type() const final;
+    std::string protocol() const final;
+    EndpointIPtr create(std::vector<std::string>&, bool) const final;
+    EndpointIPtr read(Ice::InputStream*) const final;
+    void destroy() final;
 
-    virtual EndpointFactoryPtr clone(const ProtocolInstancePtr&) const;
+    EndpointFactoryPtr clone(const ProtocolInstancePtr&) const final;
 
 private:
 

--- a/cpp/src/Ice/UdpConnector.h
+++ b/cpp/src/Ice/UdpConnector.h
@@ -13,21 +13,21 @@
 namespace IceInternal
 {
 
-class UdpConnector : public Connector
+class UdpConnector final : public Connector
 {
 public:
 
     UdpConnector(const ProtocolInstancePtr&, const Address&, const Address&, const std::string&, int,
                  const std::string&);
 
-    virtual ~UdpConnector();
-    virtual TransceiverPtr connect();
+    ~UdpConnector();
+    TransceiverPtr connect() final;
 
-    virtual Ice::Short type() const;
-    virtual std::string toString() const;
+    Ice::Short type() const final;
+    std::string toString() const final;
 
-    virtual bool operator==(const Connector&) const;
-    virtual bool operator<(const Connector&) const;
+    bool operator==(const Connector&) const final;
+    bool operator<(const Connector&) const final;
 
 private:
 

--- a/cpp/src/Ice/UdpEndpointI.h
+++ b/cpp/src/Ice/UdpEndpointI.h
@@ -13,7 +13,7 @@
 namespace IceInternal
 {
 
-class UdpEndpointI : public IPEndpointI
+class UdpEndpointI final : public IPEndpointI
 {
 public:
 
@@ -22,37 +22,37 @@ public:
     UdpEndpointI(const ProtocolInstancePtr&);
     UdpEndpointI(const ProtocolInstancePtr&, Ice::InputStream*);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
 
-    virtual Ice::Int timeout() const;
-    virtual EndpointIPtr timeout(Ice::Int) const;
-    virtual bool compress() const;
-    virtual EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
+    Ice::Int timeout() const final;
+    EndpointIPtr timeout(Ice::Int) const final;
+    bool compress() const final;
+    EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
 
-    virtual TransceiverPtr transceiver() const;
-    virtual AcceptorPtr acceptor(const std::string&) const;
-    virtual std::string options() const;
+    TransceiverPtr transceiver() const final;
+    AcceptorPtr acceptor(const std::string&) const final;
+    std::string options() const final;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
     UdpEndpointIPtr endpoint(const UdpTransceiverPtr&) const;
 
     using IPEndpointI::connectionId;
 
-    virtual void initWithOptions(std::vector<std::string>&, bool);
+    void initWithOptions(std::vector<std::string>&, bool) final;
 
 protected:
 
-    virtual void hashInit(Ice::Int&) const;
-    virtual void fillEndpointInfo(Ice::IPEndpointInfo*) const;
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    void hashInit(Ice::Int&) const final;
+    void fillEndpointInfo(Ice::IPEndpointInfo*) const final;
+    bool checkOption(const std::string&, const std::string&, const std::string&) final;
 
-    virtual ConnectorPtr createConnector(const Address&, const NetworkProxyPtr&) const;
-    virtual IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const;
+    ConnectorPtr createConnector(const Address&, const NetworkProxyPtr&) const final;
+    IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const final;
 
 private:
 
@@ -65,20 +65,20 @@ private:
     const bool _compress;
 };
 
-class UdpEndpointFactory : public EndpointFactory
+class UdpEndpointFactory final : public EndpointFactory
 {
 public:
 
     UdpEndpointFactory(const ProtocolInstancePtr&);
-    virtual ~UdpEndpointFactory();
+    ~UdpEndpointFactory();
 
-    virtual Ice::Short type() const;
-    virtual std::string protocol() const;
-    virtual EndpointIPtr create(std::vector<std::string>&, bool) const;
-    virtual EndpointIPtr read(Ice::InputStream*) const;
-    virtual void destroy();
+    Ice::Short type() const final;
+    std::string protocol() const final;
+    EndpointIPtr create(std::vector<std::string>&, bool) const final;
+    EndpointIPtr read(Ice::InputStream*) const final;
+    void destroy() final;
 
-    virtual EndpointFactoryPtr clone(const ProtocolInstancePtr&) const;
+    EndpointFactoryPtr clone(const ProtocolInstancePtr&) const final;
 
 private:
 

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -15,7 +15,7 @@
 namespace IceInternal
 {
 
-class WSEndpoint : public EndpointI, public std::enable_shared_from_this<WSEndpoint>
+class WSEndpoint final : public EndpointI, public std::enable_shared_from_this<WSEndpoint>
 {
 public:
 
@@ -23,38 +23,38 @@ public:
     WSEndpoint(const ProtocolInstancePtr&, const EndpointIPtr&, std::vector<std::string>&);
     WSEndpoint(const ProtocolInstancePtr&, const EndpointIPtr&, Ice::InputStream*);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
-    virtual Ice::Short type() const;
-    virtual const std::string& protocol() const;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
+    Ice::Short type() const final;
+    const std::string& protocol() const final;
 
-    virtual Ice::Int timeout() const;
-    virtual EndpointIPtr timeout(Ice::Int) const;
-    virtual const std::string& connectionId() const;
-    virtual EndpointIPtr connectionId(const ::std::string&) const;
-    virtual bool compress() const;
-    virtual EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
-    virtual bool secure() const;
+    Ice::Int timeout() const final;
+    EndpointIPtr timeout(Ice::Int) const final;
+    const std::string& connectionId() const final;
+    EndpointIPtr connectionId(const ::std::string&) const final;
+    bool compress() const final;
+    EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
+    bool secure() const final;
 
-    virtual TransceiverPtr transceiver() const;
-    virtual void connectors_async(Ice::EndpointSelectionType, const EndpointI_connectorsPtr&) const;
-    virtual AcceptorPtr acceptor(const std::string&) const;
-    virtual std::vector<EndpointIPtr> expandIfWildcard() const;
-    virtual std::vector<EndpointIPtr> expandHost(EndpointIPtr&) const;
-    virtual bool equivalent(const EndpointIPtr&) const;
-    virtual ::Ice::Int hash() const;
-    virtual std::string options() const;
+    TransceiverPtr transceiver() const final;
+    void connectors_async(Ice::EndpointSelectionType, const EndpointI_connectorsPtr&) const final;
+    AcceptorPtr acceptor(const std::string&) const final;
+    std::vector<EndpointIPtr> expandIfWildcard() const final;
+    std::vector<EndpointIPtr> expandHost(EndpointIPtr&) const final;
+    bool equivalent(const EndpointIPtr&) const final;
+    ::Ice::Int hash() const final;
+    std::string options() const final;
 
     WSEndpointPtr endpoint(const EndpointIPtr&) const;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
 protected:
 
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    bool checkOption(const std::string&, const std::string&, const std::string&);
 
 private:
 
@@ -66,18 +66,18 @@ private:
     const std::string _resource;
 };
 
-class ICE_API WSEndpointFactory : public EndpointFactoryWithUnderlying
+class ICE_API WSEndpointFactory final : public EndpointFactoryWithUnderlying
 {
 public:
 
     WSEndpointFactory(const ProtocolInstancePtr&, Ice::Short);
 
-    virtual EndpointFactoryPtr cloneWithUnderlying(const ProtocolInstancePtr&, Ice::Short) const;
+    EndpointFactoryPtr cloneWithUnderlying(const ProtocolInstancePtr&, Ice::Short) const final;
 
 protected:
 
-    virtual EndpointIPtr createWithUnderlying(const EndpointIPtr&, std::vector<std::string>&, bool) const;
-    virtual EndpointIPtr readWithUnderlying(const EndpointIPtr&, Ice::InputStream*) const;
+    EndpointIPtr createWithUnderlying(const EndpointIPtr&, std::vector<std::string>&, bool) const final;
+    EndpointIPtr readWithUnderlying(const EndpointIPtr&, Ice::InputStream*) const final;
 };
 
 }

--- a/cpp/src/Ice/ios/StreamAcceptor.h
+++ b/cpp/src/Ice/ios/StreamAcceptor.h
@@ -14,25 +14,24 @@ namespace IceObjC
 class StreamEndpointI;
 typedef ::std::shared_ptr<StreamEndpointI> StreamEndpointIPtr;
 
-class StreamAcceptor : public IceInternal::Acceptor, public IceInternal::NativeInfo
+class StreamAcceptor final : public IceInternal::Acceptor, public IceInternal::NativeInfo
 {
 public:
 
-    virtual IceInternal::NativeInfoPtr getNativeInfo();
-    virtual void close();
-    virtual IceInternal::EndpointIPtr listen();
-    virtual IceInternal::TransceiverPtr accept();
-    virtual std::string protocol() const;
-    virtual std::string toString() const;
-    virtual std::string toDetailedString() const;
+    StreamAcceptor(const StreamEndpointIPtr&, const InstancePtr&, const std::string&, int);
+    ~StreamAcceptor();
+
+    IceInternal::NativeInfoPtr getNativeInfo() final;
+    void close() final;
+    IceInternal::EndpointIPtr listen() final;
+    IceInternal::TransceiverPtr accept() final;
+    std::string protocol() const final;
+    std::string toString() const final;
+    std::string toDetailedString() const final;
 
     int effectivePort() const;
 
 private:
-
-    StreamAcceptor(const StreamEndpointIPtr&, const InstancePtr&, const std::string&, int);
-    virtual ~StreamAcceptor();
-    friend class StreamEndpointI;
 
     StreamEndpointIPtr _endpoint;
     InstancePtr _instance;

--- a/cpp/src/Ice/ios/StreamEndpointI.h
+++ b/cpp/src/Ice/ios/StreamEndpointI.h
@@ -66,7 +66,7 @@ using StreamAcceptorPtr = std::shared_ptr<StreamAcceptor>;
 class StreamEndpointI;
 using StreamEndpointIPtr = std::shared_ptr<StreamEndpointI>;
 
-class StreamEndpointI : public IceInternal::IPEndpointI
+class StreamEndpointI final : public IceInternal::IPEndpointI
 {
 public:
 
@@ -75,27 +75,27 @@ public:
     StreamEndpointI(const InstancePtr&);
     StreamEndpointI(const InstancePtr&, Ice::InputStream*);
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
 
-    virtual Ice::Int timeout() const;
-    virtual IceInternal::EndpointIPtr timeout(Ice::Int) const;
-    virtual bool compress() const;
-    virtual IceInternal::EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
-    virtual bool secure() const;
+    Ice::Int timeout() const final;
+    IceInternal::EndpointIPtr timeout(Ice::Int) const final;
+    bool compress() const final;
+    IceInternal::EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
+    bool secure() const final;
 
-    virtual void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const;
-    virtual IceInternal::TransceiverPtr transceiver() const;
-    virtual IceInternal::AcceptorPtr acceptor(const std::string&) const;
-    virtual std::string options() const;
+    void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const final;
+    IceInternal::TransceiverPtr transceiver() const final;
+    IceInternal::AcceptorPtr acceptor(const std::string&) const final;
+    std::string options() const final;
 
     std::shared_ptr<StreamEndpointI> shared_from_this()
     {
         return std::static_pointer_cast<StreamEndpointI>(IceInternal::IPEndpointI::shared_from_this());
     }
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
     StreamEndpointIPtr endpoint(const StreamAcceptorPtr&) const;
 
@@ -103,13 +103,13 @@ public:
 
 protected:
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
-    virtual void hashInit(Ice::Int&) const;
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    void streamWriteImpl(Ice::OutputStream*) const final;
+    void hashInit(Ice::Int&) const final;
+    bool checkOption(const std::string&, const std::string&, const std::string&) final;
 
-    virtual IceInternal::ConnectorPtr createConnector(const IceInternal::Address&,
-                                                      const IceInternal::NetworkProxyPtr&) const;
-    virtual IceInternal::IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const;
+    IceInternal::ConnectorPtr createConnector(const IceInternal::Address&,
+                                              const IceInternal::NetworkProxyPtr&) const final;
+    IceInternal::IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const final;
 
 private:
 
@@ -122,21 +122,21 @@ private:
     const bool _compress;
 };
 
-class StreamEndpointFactory : public IceInternal::EndpointFactory
+class StreamEndpointFactory final : public IceInternal::EndpointFactory
 {
 public:
 
     StreamEndpointFactory(const InstancePtr&);
 
-    virtual ~StreamEndpointFactory();
+    ~StreamEndpointFactory() final;
 
-    virtual Ice::Short type() const;
-    virtual std::string protocol() const;
-    virtual IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const;
-    virtual IceInternal::EndpointIPtr read(Ice::InputStream*) const;
-    virtual void destroy();
+    Ice::Short type() const final;
+    std::string protocol() const final;
+    IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const final;
+    IceInternal::EndpointIPtr read(Ice::InputStream*) const final;
+    void destroy() final;
 
-    virtual IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const;
+    IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const final;
 
 private:
 

--- a/cpp/src/IceBT/EndpointI.h
+++ b/cpp/src/IceBT/EndpointI.h
@@ -16,7 +16,7 @@
 namespace IceBT
 {
 
-class EndpointI : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
+class EndpointI final : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
 {
 public:
 
@@ -25,32 +25,32 @@ public:
     EndpointI(const InstancePtr&);
     EndpointI(const InstancePtr&, Ice::InputStream*);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
-    virtual Ice::Short type() const;
-    virtual const std::string& protocol() const;
-    virtual Ice::Int timeout() const;
-    virtual IceInternal::EndpointIPtr timeout(Ice::Int) const;
-    virtual const std::string& connectionId() const;
-    virtual IceInternal::EndpointIPtr connectionId(const std::string&) const;
-    virtual bool compress() const;
-    virtual IceInternal::EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
-    virtual bool secure() const;
-    virtual IceInternal::TransceiverPtr transceiver() const;
-    virtual void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const;
-    virtual IceInternal::AcceptorPtr acceptor(const std::string&) const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const;
-    virtual bool equivalent(const IceInternal::EndpointIPtr&) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
+    Ice::Short type() const final;
+    const std::string& protocol() const final;
+    Ice::Int timeout() const final;
+    IceInternal::EndpointIPtr timeout(Ice::Int) const final;
+    const std::string& connectionId() const final;
+    IceInternal::EndpointIPtr connectionId(const std::string&) const final;
+    bool compress() const final;
+    IceInternal::EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
+    bool secure() const final;
+    IceInternal::TransceiverPtr transceiver() const final;
+    void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const final;
+    IceInternal::AcceptorPtr acceptor(const std::string&) const final;
+    std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const final;
+    std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const final;
+    bool equivalent(const IceInternal::EndpointIPtr&) const final;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
-    virtual Ice::Int hash() const;
+    Ice::Int hash() const final;
 
-    virtual std::string options() const;
+    std::string options() const final;
 
-    Ice::EndpointInfoPtr getInfo() const noexcept;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
 
     void initWithOptions(std::vector<std::string>&, bool);
 
@@ -72,36 +72,36 @@ private:
     const Ice::Int _hashValue;
 };
 
-class EndpointInfoI : public EndpointInfo
+class EndpointInfoI final : public EndpointInfo
 {
 public:
 
     EndpointInfoI(const EndpointIPtr&);
-    virtual ~EndpointInfoI();
+    ~EndpointInfoI();
 
-    virtual Ice::Short type() const noexcept;
-    virtual bool datagram() const noexcept;
-    virtual bool secure() const noexcept;
+    Ice::Short type() const noexcept final;
+    bool datagram() const noexcept final;
+    bool secure() const noexcept final;
 
 private:
 
     const EndpointIPtr _endpoint;
 };
 
-class EndpointFactoryI : public IceInternal::EndpointFactory
+class EndpointFactoryI  final : public IceInternal::EndpointFactory
 {
 public:
 
     EndpointFactoryI(const InstancePtr&);
-    virtual ~EndpointFactoryI();
+    ~EndpointFactoryI();
 
-    virtual Ice::Short type() const;
-    virtual std::string protocol() const;
-    virtual IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const;
-    virtual IceInternal::EndpointIPtr read(Ice::InputStream*) const;
-    virtual void destroy();
+    Ice::Short type() const final;
+    std::string protocol() const final;
+    IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const final;
+    IceInternal::EndpointIPtr read(Ice::InputStream*) const final;
+    void destroy();
 
-    virtual IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const;
+    IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const final;
 
 private:
 

--- a/cpp/src/IceIAP/EndpointI.h
+++ b/cpp/src/IceIAP/EndpointI.h
@@ -15,7 +15,7 @@ namespace IceObjC
 class iAPEndpointI;
 typedef ::std::shared_ptr<iAPEndpointI> iAPEndpointIPtr;
 
-class iAPEndpointI : public IceInternal::EndpointI, public std::enable_shared_from_this<iAPEndpointI>
+class iAPEndpointI final : public IceInternal::EndpointI, public std::enable_shared_from_this<iAPEndpointI>
 {
 public:
 
@@ -24,37 +24,37 @@ public:
     iAPEndpointI(const IceInternal::ProtocolInstancePtr&);
     iAPEndpointI(const IceInternal::ProtocolInstancePtr&, Ice::InputStream*);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
-    virtual Ice::Short type() const;
-    virtual const std::string& protocol() const;
-    virtual bool datagram() const;
-    virtual bool secure() const;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
+    Ice::Short type() const final;
+    const std::string& protocol() const final;
+    bool datagram() const final;
+    bool secure() const final;
 
-    virtual Ice::Int timeout() const;
-    virtual IceInternal::EndpointIPtr timeout(Ice::Int) const;
-    virtual const std::string& connectionId() const;
-    virtual IceInternal::EndpointIPtr connectionId(const std::string&) const;
-    virtual bool compress() const;
-    virtual IceInternal::EndpointIPtr compress(bool) const;
+    Ice::Int timeout() const final;
+    IceInternal::EndpointIPtr timeout(Ice::Int) const final;
+    const std::string& connectionId() const final;
+    IceInternal::EndpointIPtr connectionId(const std::string&) const final;
+    bool compress() const final;
+    IceInternal::EndpointIPtr compress(bool) const final;
 
-    virtual IceInternal::TransceiverPtr transceiver() const;
-    virtual void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const;
-    virtual IceInternal::AcceptorPtr acceptor(const std::string&) const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const;
-    virtual bool equivalent(const IceInternal::EndpointIPtr&) const;
+    IceInternal::TransceiverPtr transceiver() const final;
+    void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const final;
+    IceInternal::AcceptorPtr acceptor(const std::string&) const final;
+    std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const final;
+    std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const final;
+    bool equivalent(const IceInternal::EndpointIPtr&) const final;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
-    virtual std::string options() const;
-    virtual ::Ice::Int hash() const;
+    std::string options() const final;
+    ::Ice::Int hash() const final;
 
 private:
 
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    bool checkOption(const std::string&, const std::string&, const std::string&) final;
 
     //
     // All members are const, because endpoints are immutable.
@@ -69,21 +69,21 @@ private:
     const bool _compress;
 };
 
-class iAPEndpointFactory : public IceInternal::EndpointFactory
+class iAPEndpointFactory final : public IceInternal::EndpointFactory
 {
 public:
 
     iAPEndpointFactory(const IceInternal::ProtocolInstancePtr&);
 
-    virtual ~iAPEndpointFactory();
+    ~iAPEndpointFactory();
 
-    virtual Ice::Short type() const;
-    virtual std::string protocol() const;
-    virtual IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const;
-    virtual IceInternal::EndpointIPtr read(Ice::InputStream*) const;
-    virtual void destroy();
+    Ice::Short type() const final;
+    std::string protocol() const final;
+    IceInternal::EndpointIPtr create(std::vector<std::string>&, bool) const final;
+    IceInternal::EndpointIPtr read(Ice::InputStream*) const final;
+    void destroy() final;
 
-    virtual IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const;
+    IceInternal::EndpointFactoryPtr clone(const IceInternal::ProtocolInstancePtr&) const final;
 
 private:
 

--- a/cpp/src/IceSSL/AcceptorI.h
+++ b/cpp/src/IceSSL/AcceptorI.h
@@ -15,27 +15,27 @@
 namespace IceSSL
 {
 
-class AcceptorI : public IceInternal::Acceptor, public IceInternal::NativeInfo
+class AcceptorI final : public IceInternal::Acceptor, public IceInternal::NativeInfo
 {
 public:
 
     AcceptorI(const EndpointIPtr&, const InstancePtr&, const IceInternal::AcceptorPtr&, const std::string&);
-    virtual ~AcceptorI();
-    virtual IceInternal::NativeInfoPtr getNativeInfo();
+    ~AcceptorI();
+    IceInternal::NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)
-    virtual IceInternal::AsyncInfo* getAsyncInfo(IceInternal::SocketOperation);
+    IceInternal::AsyncInfo* getAsyncInfo(IceInternal::SocketOperation) final;
 #endif
 
-    virtual void close();
-    virtual IceInternal::EndpointIPtr listen();
+    void close() final;
+    IceInternal::EndpointIPtr listen() final;
 #if defined(ICE_USE_IOCP)
-    virtual void startAccept();
-    virtual void finishAccept();
+    void startAccept() final;
+    void finishAccept() final;
 #endif
-    virtual IceInternal::TransceiverPtr accept();
-    virtual std::string protocol() const;
-    virtual std::string toString() const;
-    virtual std::string toDetailedString() const;
+    IceInternal::TransceiverPtr accept() final;
+    std::string protocol() const final;
+    std::string toString() const final;
+    std::string toDetailedString() const final;
 
 private:
 

--- a/cpp/src/IceSSL/ConnectorI.h
+++ b/cpp/src/IceSSL/ConnectorI.h
@@ -16,19 +16,19 @@ namespace IceSSL
 
 class EndpointI;
 
-class ConnectorI : public IceInternal::Connector
+class ConnectorI final : public IceInternal::Connector
 {
 public:
 
     ConnectorI(const InstancePtr&, const IceInternal::ConnectorPtr&, const std::string&);
-    virtual ~ConnectorI();
-    virtual IceInternal::TransceiverPtr connect();
+    ~ConnectorI();
+    IceInternal::TransceiverPtr connect() final;
 
-    virtual Ice::Short type() const;
-    virtual std::string toString() const;
+    Ice::Short type() const final;
+    std::string toString() const final;
 
-    virtual bool operator==(const IceInternal::Connector&) const;
-    virtual bool operator<(const IceInternal::Connector&) const;
+    bool operator==(const IceInternal::Connector&) const final;
+    bool operator<(const IceInternal::Connector&) const final;
 
 private:
 

--- a/cpp/src/IceSSL/EndpointI.h
+++ b/cpp/src/IceSSL/EndpointI.h
@@ -16,44 +16,44 @@
 namespace IceSSL
 {
 
-class EndpointI : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
+class EndpointI final : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
 {
 public:
 
     EndpointI(const InstancePtr&, const IceInternal::EndpointIPtr&);
 
-    virtual void streamWriteImpl(Ice::OutputStream*) const;
+    void streamWriteImpl(Ice::OutputStream*) const final;
 
-    virtual Ice::EndpointInfoPtr getInfo() const noexcept;
-    virtual Ice::Short type() const;
-    virtual const std::string& protocol() const;
+    Ice::EndpointInfoPtr getInfo() const noexcept final;
+    Ice::Short type() const final;
+    const std::string& protocol() const final;
 
-    virtual Ice::Int timeout() const;
-    virtual IceInternal::EndpointIPtr timeout(Ice::Int) const;
-    virtual const std::string& connectionId() const;
-    virtual IceInternal::EndpointIPtr connectionId(const ::std::string&) const;
-    virtual bool compress() const;
-    virtual IceInternal::EndpointIPtr compress(bool) const;
-    virtual bool datagram() const;
-    virtual bool secure() const;
+    Ice::Int timeout() const final;
+    IceInternal::EndpointIPtr timeout(Ice::Int) const final;
+    const std::string& connectionId() const final;
+    IceInternal::EndpointIPtr connectionId(const ::std::string&) const final;
+    bool compress() const final;
+    IceInternal::EndpointIPtr compress(bool) const final;
+    bool datagram() const final;
+    bool secure() const final;
 
-    virtual IceInternal::TransceiverPtr transceiver() const;
-    virtual void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const;
-    virtual IceInternal::AcceptorPtr acceptor(const std::string&) const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const;
-    virtual std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const;
-    virtual bool equivalent(const IceInternal::EndpointIPtr&) const;
-    virtual ::Ice::Int hash() const;
-    virtual std::string options() const;
+    IceInternal::TransceiverPtr transceiver() const final;
+    void connectors_async(Ice::EndpointSelectionType, const IceInternal::EndpointI_connectorsPtr&) const final;
+    IceInternal::AcceptorPtr acceptor(const std::string&) const final;
+    std::vector<IceInternal::EndpointIPtr> expandIfWildcard() const final;
+    std::vector<IceInternal::EndpointIPtr> expandHost(IceInternal::EndpointIPtr&) const final;
+    bool equivalent(const IceInternal::EndpointIPtr&) const final;
+    ::Ice::Int hash() const final;
+    std::string options() const final;
 
     EndpointIPtr endpoint(const IceInternal::EndpointIPtr&) const;
 
-    virtual bool operator==(const Ice::Endpoint&) const;
-    virtual bool operator<(const Ice::Endpoint&) const;
+    bool operator==(const Ice::Endpoint&) const final;
+    bool operator<(const Ice::Endpoint&) const final;
 
 protected:
 
-    virtual bool checkOption(const std::string&, const std::string&, const std::string&);
+    bool checkOption(const std::string&, const std::string&, const std::string&) final;
 
 private:
 
@@ -64,23 +64,23 @@ private:
     const IceInternal::EndpointIPtr _delegate;
 };
 
-class EndpointFactoryI : public IceInternal::EndpointFactoryWithUnderlying
+class EndpointFactoryI final : public IceInternal::EndpointFactoryWithUnderlying
 {
 public:
 
     EndpointFactoryI(const InstancePtr&, Ice::Short);
 
-    virtual void destroy();
+    void destroy() final;
 
-    virtual IceInternal::EndpointFactoryPtr
-    cloneWithUnderlying(const IceInternal::ProtocolInstancePtr&, Ice::Short) const;
+    IceInternal::EndpointFactoryPtr
+    cloneWithUnderlying(const IceInternal::ProtocolInstancePtr&, Ice::Short) const final;
 
 protected:
 
-    virtual IceInternal::EndpointIPtr
-    createWithUnderlying(const IceInternal::EndpointIPtr&, std::vector<std::string>&, bool) const;
-    virtual IceInternal::EndpointIPtr
-    readWithUnderlying(const IceInternal::EndpointIPtr&, Ice::InputStream*) const;
+    IceInternal::EndpointIPtr
+    createWithUnderlying(const IceInternal::EndpointIPtr&, std::vector<std::string>&, bool) const final;
+    IceInternal::EndpointIPtr
+    readWithUnderlying(const IceInternal::EndpointIPtr&, Ice::InputStream*) const final;
 
 private:
 

--- a/cpp/src/IceSSL/Instance.cpp
+++ b/cpp/src/IceSSL/Instance.cpp
@@ -15,10 +15,6 @@ IceSSL::Instance::Instance(const SSLEnginePtr& engine, Short type, const string&
 {
 }
 
-IceSSL::Instance::~Instance()
-{
-}
-
 bool
 IceSSL::Instance::initialized() const
 {

--- a/cpp/src/IceSSL/Instance.h
+++ b/cpp/src/IceSSL/Instance.h
@@ -12,15 +12,13 @@
 namespace IceSSL
 {
 
-class ICESSL_API Instance : public IceInternal::ProtocolInstance
+class ICESSL_API Instance final : public IceInternal::ProtocolInstance
 {
 public:
 
     Instance(const SSLEnginePtr&, Ice::Short, const std::string&);
-    virtual ~Instance();
 
-    SSLEnginePtr
-    engine() const
+    SSLEnginePtr engine() const
     {
         return _engine;
     }


### PR DESCRIPTION
This PR cleanups the usage of `virtual` modifier in transport classes.