### PR TITLE
Replace Connection::StartCallback with std::function base callbacks

### DIFF
--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1058,7 +1058,16 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::nextConnector()
                     << _iter->connector->toString();
             }
             Ice::ConnectionIPtr connection = _factory->createConnection(_iter->connector->connect(), *_iter);
-            connection->start(shared_from_this());
+            auto self = shared_from_this();
+            connection->start(
+                [self](ConnectionIPtr conn)
+                {
+                    self->connectionStartCompleted(std::move(conn));
+                },
+                [self](ConnectionIPtr conn, exception_ptr ex)
+                {
+                    self->connectionStartFailed(std::move(conn), ex);
+                });
         }
         catch(const Ice::LocalException& ex)
         {
@@ -1513,7 +1522,16 @@ IceInternal::IncomingConnectionFactory::message(ThreadPoolCurrent& current)
 
     assert(connection);
 
-    connection->start(shared_from_this());
+    auto self = shared_from_this();
+    connection->start(
+        [self](ConnectionIPtr conn)
+        {
+            self->connectionStartCompleted(std::move(conn));
+        },
+        [self](ConnectionIPtr conn, exception_ptr ex)
+        {
+            self->connectionStartFailed(std::move(conn), ex);
+        });
 }
 
 void
@@ -1702,7 +1720,7 @@ IceInternal::IncomingConnectionFactory::initialize()
             const_cast<EndpointIPtr&>(_endpoint) = _transceiver->bind();
             ConnectionIPtr connection(ConnectionI::create(_adapter->getCommunicator(), _instance, 0, _transceiver, 0,
                                                           _endpoint, _adapter));
-            connection->start(0);
+            connection->start(nullptr, nullptr);
             _connections.insert(connection);
         }
         else

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1059,7 +1059,7 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::nextConnector()
             }
             Ice::ConnectionIPtr connection = _factory->createConnection(_iter->connector->connect(), *_iter);
             auto self = shared_from_this();
-            connection->start(
+            connection->startAsync(
                 [self](ConnectionIPtr conn)
                 {
                     self->connectionStartCompleted(std::move(conn));
@@ -1523,7 +1523,7 @@ IceInternal::IncomingConnectionFactory::message(ThreadPoolCurrent& current)
     assert(connection);
 
     auto self = shared_from_this();
-    connection->start(
+    connection->startAsync(
         [self](ConnectionIPtr conn)
         {
             self->connectionStartCompleted(std::move(conn));
@@ -1720,7 +1720,7 @@ IceInternal::IncomingConnectionFactory::initialize()
             const_cast<EndpointIPtr&>(_endpoint) = _transceiver->bind();
             ConnectionIPtr connection(ConnectionI::create(_adapter->getCommunicator(), _instance, 0, _transceiver, 0,
                                                           _endpoint, _adapter));
-            connection->start(nullptr, nullptr);
+            connection->startAsync(nullptr, nullptr);
             _connections.insert(connection);
         }
         else

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -81,9 +81,7 @@ private:
         EndpointIPtr endpoint;
     };
 
-    class ConnectCallback final :
-        public Ice::ConnectionI::StartCallback,
-        public std::enable_shared_from_this<ConnectCallback>
+    class ConnectCallback final : public std::enable_shared_from_this<ConnectCallback>
     {
     public:
 
@@ -167,7 +165,7 @@ private:
     std::condition_variable _conditionVariable;
 };
 
-class IncomingConnectionFactory final : public EventHandler, public Ice::ConnectionI::StartCallback
+class IncomingConnectionFactory final : public EventHandler
 {
 public:
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -388,7 +388,7 @@ Ice::ConnectionI::OutgoingMessage::completed(std::exception_ptr ex)
 }
 
 void
-Ice::ConnectionI::start(
+Ice::ConnectionI::startAsync(
     function<void(Ice::ConnectionIPtr)> connectionStartCompleted,
     function<void(Ice::ConnectionIPtr, exception_ptr)> connectionStartFailed)
 {

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -60,14 +60,21 @@ class DispatchCall : public DispatchWorkItem
 {
 public:
 
-    DispatchCall(const ConnectionIPtr& connection, const ConnectionI::StartCallbackPtr& startCB,
-                 const vector<ConnectionI::OutgoingMessage>& sentCBs, Byte compress, Int requestId,
-                 Int invokeNum, const ServantManagerPtr& servantManager, const ObjectAdapterPtr& adapter,
-                 const OutgoingAsyncBasePtr& outAsync, const HeartbeatCallback& heartbeatCallback,
-                 InputStream& stream) :
+    DispatchCall(
+        const ConnectionIPtr& connection,
+        function<void (ConnectionIPtr)> connectionStartCompleted,
+        const vector<ConnectionI::OutgoingMessage>& sentCBs,
+        Byte compress,
+        Int requestId,
+        Int invokeNum,
+        const ServantManagerPtr& servantManager,
+        const ObjectAdapterPtr& adapter,
+        const OutgoingAsyncBasePtr& outAsync,
+        const HeartbeatCallback& heartbeatCallback,
+        InputStream& stream) :
         DispatchWorkItem(connection),
         _connection(connection),
-        _startCB(startCB),
+        _connectionStartCompleted(std::move(connectionStartCompleted)),
         _sentCBs(sentCBs),
         _compress(compress),
         _requestId(requestId),
@@ -84,14 +91,14 @@ public:
     virtual void
     run()
     {
-        _connection->dispatch(_startCB, _sentCBs, _compress, _requestId, _invokeNum, _servantManager, _adapter,
+        _connection->dispatch(_connectionStartCompleted, _sentCBs, _compress, _requestId, _invokeNum, _servantManager, _adapter,
                               _outAsync, _heartbeatCallback, _stream);
     }
 
 private:
 
     const ConnectionIPtr _connection;
-    const ConnectionI::StartCallbackPtr _startCB;
+    const function<void(Ice::ConnectionIPtr)> _connectionStartCompleted;
     const vector<ConnectionI::OutgoingMessage> _sentCBs;
     const Byte _compress;
     const Int _requestId;
@@ -381,7 +388,9 @@ Ice::ConnectionI::OutgoingMessage::completed(std::exception_ptr ex)
 }
 
 void
-Ice::ConnectionI::start(const StartCallbackPtr& callback)
+Ice::ConnectionI::start(
+    function<void(Ice::ConnectionIPtr)> connectionStartCompleted,
+    function<void(Ice::ConnectionIPtr, exception_ptr)> connectionStartFailed)
 {
     try
     {
@@ -394,9 +403,10 @@ Ice::ConnectionI::start(const StartCallbackPtr& callback)
 
         if(!initialize() || !validate())
         {
-            if(callback)
+            if(connectionStartCompleted && connectionStartFailed)
             {
-                _startCallback = callback;
+                _connectionStartCompleted = std::move(connectionStartCompleted);
+                _connectionStartFailed = std::move(connectionStartFailed);
                 return;
             }
 
@@ -420,9 +430,9 @@ Ice::ConnectionI::start(const StartCallbackPtr& callback)
     catch(const Ice::LocalException&)
     {
         exception(current_exception());
-        if(callback)
+        if(connectionStartFailed)
         {
-            callback->connectionStartFailed(shared_from_this(), current_exception());
+            connectionStartFailed(shared_from_this(), current_exception());
             return;
         }
         else
@@ -432,9 +442,9 @@ Ice::ConnectionI::start(const StartCallbackPtr& callback)
         }
     }
 
-    if(callback)
+    if(connectionStartCompleted)
     {
-        callback->connectionStartCompleted(shared_from_this());
+        connectionStartCompleted(shared_from_this());
     }
 }
 
@@ -1410,7 +1420,7 @@ Ice::ConnectionI::finishAsync(SocketOperation operation)
 void
 Ice::ConnectionI::message(ThreadPoolCurrent& current)
 {
-    StartCallbackPtr startCB;
+    function<void(ConnectionIPtr)> connectionStartCompleted;
     vector<OutgoingMessage> sentCBs;
     Byte compress = 0;
     Int requestId = 0;
@@ -1581,13 +1591,12 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                 // We start out in holding state.
                 //
                 setState(StateHolding);
-                if(_startCallback)
+                if(_connectionStartCompleted)
                 {
-                    swap(_startCallback, startCB);
-                    if(startCB)
-                    {
-                        ++dispatchCount;
-                    }
+                    connectionStartCompleted = std::move(_connectionStartCompleted);
+                    ++dispatchCount;
+                    _connectionStartCompleted = nullptr;
+                    _connectionStartFailed = nullptr;
                 }
             }
             else
@@ -1680,27 +1689,56 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
 
 // dispatchFromThisThread dispatches to the correct DispatchQueue
 #ifdef ICE_SWIFT
-    _threadPool->dispatchFromThisThread(make_shared<DispatchCall>(shared_from_this(), startCB, sentCBs, compress, requestId,
-                                                         invokeNum, servantManager, adapter, outAsync,
-                                                         heartbeatCallback, current.stream));
+    _threadPool->dispatchFromThisThread(
+        make_shared<DispatchCall>(
+                shared_from_this(),
+                std::move(connectionStartCompleted),
+                sentCBs,
+                compress,
+                requestId,
+                invokeNum,
+                servantManager,
+                adapter,
+                outAsync,
+                heartbeatCallback,
+                current.stream));
 #else
     if(!_dispatcher) // Optimization, call dispatch() directly if there's no dispatcher.
     {
-        dispatch(startCB, sentCBs, compress, requestId, invokeNum, servantManager, adapter, outAsync, heartbeatCallback,
-                 current.stream);
+        dispatch(
+            connectionStartCompleted,
+            sentCBs,
+            compress,
+            requestId,
+            invokeNum,
+            servantManager,
+            adapter,
+            outAsync,
+            heartbeatCallback,
+            current.stream);
     }
     else
     {
-        _threadPool->dispatchFromThisThread(make_shared<DispatchCall>(shared_from_this(), startCB, sentCBs, compress, requestId,
-                                                             invokeNum, servantManager, adapter, outAsync,
-                                                             heartbeatCallback, current.stream));
+        _threadPool->dispatchFromThisThread(
+            make_shared<DispatchCall>(
+                shared_from_this(),
+                std::move(connectionStartCompleted),
+                sentCBs,
+                compress,
+                requestId,
+                invokeNum,
+                servantManager,
+                adapter,
+                outAsync,
+                heartbeatCallback,
+                current.stream));
 
     }
 #endif
 }
 
 void
-ConnectionI::dispatch(const StartCallbackPtr& startCB, const vector<OutgoingMessage>& sentCBs,
+ConnectionI::dispatch(function<void(ConnectionIPtr)> connectionStartCompleted, const vector<OutgoingMessage>& sentCBs,
                       Byte compress, Int requestId, Int invokeNum, const ServantManagerPtr& servantManager,
                       const ObjectAdapterPtr& adapter, const OutgoingAsyncBasePtr& outAsync,
                       const HeartbeatCallback& heartbeatCallback, InputStream& stream)
@@ -1711,9 +1749,9 @@ ConnectionI::dispatch(const StartCallbackPtr& startCB, const vector<OutgoingMess
     // Notify the factory that the connection establishment and
     // validation has completed.
     //
-    if(startCB)
+    if(connectionStartCompleted)
     {
-        startCB->connectionStartCompleted(shared_from_this());
+        connectionStartCompleted(shared_from_this());
         ++dispatchedCount;
     }
 
@@ -1837,7 +1875,12 @@ Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
     // to call code that will potentially block (this avoids promoting a new leader and
     // unecessary thread creation, especially if this is called on shutdown).
     //
-    if(!_startCallback && _sendStreams.empty() && _asyncRequests.empty() && !_closeCallback && !_heartbeatCallback)
+    if(!_connectionStartCompleted &&
+       !_connectionStartFailed &&
+       _sendStreams.empty() &&
+       _asyncRequests.empty() &&
+       !_closeCallback &&
+       !_heartbeatCallback)
     {
         finish(close);
         return;
@@ -1927,12 +1970,12 @@ Ice::ConnectionI::finish(bool close)
         }
     }
 
-    if(_startCallback)
+    if(_connectionStartFailed)
     {
         assert(_exception);
-
-        _startCallback->connectionStartFailed(shared_from_this(), _exception);
-        _startCallback = 0;
+        _connectionStartFailed(shared_from_this(), _exception);
+        _connectionStartFailed = nullptr;
+        _connectionStartCompleted = nullptr;
     }
 
     if(!_sendStreams.empty())
@@ -2185,7 +2228,8 @@ Ice::ConnectionI::create(const CommunicatorPtr& communicator,
 
 Ice::ConnectionI::~ConnectionI()
 {
-    assert(!_startCallback);
+    assert(!_connectionStartCompleted);
+    assert(!_connectionStartFailed);
     assert(!_closeCallback);
     assert(!_heartbeatCallback);
     assert(_state == StateFinished);

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -126,7 +126,7 @@ public:
         CommunicatorDestroyed
     };
 
-    void start(
+    void startAsync(
         std::function<void(ConnectionIPtr)>,
         std::function<void(Ice::ConnectionIPtr, std::exception_ptr)>);
     void activate();

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -120,22 +120,15 @@ public:
 #endif
     };
 
-    class StartCallback
-    {
-    public:
-
-        virtual void connectionStartCompleted(const ConnectionIPtr&) = 0;
-        virtual void connectionStartFailed(const ConnectionIPtr&, std::exception_ptr) = 0;
-    };
-    using StartCallbackPtr = ::std::shared_ptr<StartCallback>;
-
     enum DestructionReason
     {
         ObjectAdapterDeactivated,
         CommunicatorDestroyed
     };
 
-    void start(const StartCallbackPtr&);
+    void start(
+        std::function<void(ConnectionIPtr)>,
+        std::function<void(Ice::ConnectionIPtr, std::exception_ptr)>);
     void activate();
     void hold();
     void destroy(DestructionReason);
@@ -215,8 +208,13 @@ public:
 
     void exception(std::exception_ptr);
 
-    void dispatch(const StartCallbackPtr&, const std::vector<OutgoingMessage>&, Byte, Int, Int,
-                  const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&,
+    void dispatch(std::function<void(ConnectionIPtr)>,
+                  const std::vector<OutgoingMessage>&,
+                  Byte,
+                  Int,
+                  Int,
+                  const IceInternal::ServantManagerPtr&,
+                  const ObjectAdapterPtr&,
                   const IceInternal::OutgoingAsyncBasePtr&,
                   const HeartbeatCallback&,
                   Ice::InputStream&);
@@ -311,7 +309,8 @@ private:
     const IceUtil::TimerTaskPtr _readTimeout;
     bool _readTimeoutScheduled;
 
-    StartCallbackPtr _startCallback;
+    std::function<void(ConnectionIPtr)> _connectionStartCompleted;
+    std::function<void(ConnectionIPtr, std::exception_ptr)> _connectionStartFailed;
 
     const bool _warn;
     const bool _warnUdp;


### PR DESCRIPTION
This PR replaces Connection::StartCallback with std::function base callbacks.

I will remove ConnectCallback in a follow up PR.

I also want to remove DispatchCall, but it requires to make InputStream movable. (for a follow-up PR)