### PR TITLE
ConnectCallback cleanup

### DIFF
--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -1137,12 +1137,6 @@ IceInternal::OutgoingConnectionFactory::ConnectCallback::removeFromPending()
 }
 
 bool
-IceInternal::OutgoingConnectionFactory::ConnectCallback::operator<(const ConnectCallback& rhs) const
-{
-    return this < &rhs;
-}
-
-bool
 IceInternal::OutgoingConnectionFactory::ConnectCallback::connectionStartFailedImpl(std::exception_ptr ex)
 {
     bool communicatorDestroyed = false;

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -111,8 +111,6 @@ private:
         bool removeConnectors(const std::vector<ConnectorInfo>&);
         void removeFromPending();
 
-        bool operator<(const ConnectCallback&) const;
-
     private:
 
         bool connectionStartFailedImpl(std::exception_ptr);
@@ -154,7 +152,7 @@ private:
     const FactoryACMMonitorPtr _monitor;
     bool _destroyed;
 
-    using ConnectCallbackSet = std::set<ConnectCallbackPtr, Ice::TargetCompare<ConnectCallbackPtr, std::less>>;
+    using ConnectCallbackSet = std::set<ConnectCallbackPtr>;
 
     std::multimap<ConnectorPtr, Ice::ConnectionIPtr, Ice::TargetCompare<ConnectorPtr, std::less>> _connections;
     std::map<ConnectorPtr, ConnectCallbackSet, Ice::TargetCompare<ConnectorPtr, std::less>> _pending;


### PR DESCRIPTION
This PR removes the `ConnectCallback::operator<`, it is not required. We can use the operator provided by shared_ptr as we just want to compare pointers.