### PR TITLE
Update C++ code generation

### DIFF
--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -27,6 +27,7 @@ const int TypeContextAMIEnd = 2;
 const int TypeContextAMIPrivateEnd = 4;
 const int TypeContextAMICallPrivateEnd = 8;
 const int TypeContextUseWstring = 16;
+const int TypeContextTuple = 32;
 const int TypeContextCpp11 = 64;
 
 bool isMovable(const TypePtr&);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2498,12 +2498,6 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "{";
     H << nl << "}";
 
-    // Copy constructor
-    H << sp;
-    H << nl << prx << "(const " << prx << "& other) : ::Ice::ObjectPrx(other)";
-    H << nl << "{";
-    H << nl << "}";
-
     H << sp;
     H << nl << "/// \\cond INTERNAL";
     H << nl << prx << "(const ::IceInternal::ReferencePtr& ref) : ::Ice::ObjectPrx(ref)";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -911,17 +911,28 @@ Slice::Gen::generate(const UnitPtr& p)
         DeclVisitor declVisitor(H, C, _dllExport);
         p->visit(&declVisitor, false);
 
-        TypesVisitor typesVisitor(H, C, _dllExport);
+        // All types except structs, classes, exceptions and proxies.
+        TypesVisitor typesVisitor(H);
         p->visit(&typesVisitor, false);
 
+        StructVisitor structVisitor(H);
+        p->visit(&structVisitor, false);
+
+        // TODO: we need the interface visitor before the proxy visitor because proxy functions can reference structs
+        // defined in the mapping server-side class. We should fix that.
         InterfaceVisitor interfaceVisitor(H, C, _dllExport);
         p->visit(&interfaceVisitor, false);
 
+        // We need to define proxy types before they can be used as struct and class fields
+        ProxyVisitor proxyVisitor(H, C, _dllExport);
+        p->visit(&proxyVisitor, false);
+
+        // Classes can use proxies and structs.
         ValueVisitor valueVisitor(H, C, _dllExport);
         p->visit(&valueVisitor, false);
 
-        ProxyVisitor proxyVisitor(H, C, _dllExport);
-        p->visit(&proxyVisitor, false);
+        ExceptionVisitor exceptionVisitor(H, C, _dllExport);
+        p->visit(&exceptionVisitor, false);
 
         StreamVisitor streamVisitor(H, C, _dllExport);
         p->visit(&streamVisitor, false);
@@ -1705,6 +1716,13 @@ Slice::Gen::DeclVisitor::visitClassDefStart(const ClassDefPtr& p)
     return true;
 }
 
+bool
+Slice::Gen::DeclVisitor::visitStructStart(const StructPtr& p)
+{
+    H << nl << "struct " << fixKwd(p->name()) << ';';
+    return false;
+}
+
 void
 Slice::Gen::DeclVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 {
@@ -1772,9 +1790,8 @@ Slice::Gen::DeclVisitor::visitOperation(const OperationPtr& p)
     C << nl << "const ::std::string " << flatName << " = \"" << p->name() << "\";";
 }
 
-Slice::Gen::TypesVisitor::TypesVisitor(Output& h, Output& c, const string& dllExport) :
-    H(h), C(c), _dllExport(dllExport), _dllClassExport(toDllClassExport(dllExport)),
-    _dllMemberExport(toDllMemberExport(dllExport)), _doneStaticSymbol(false), _useWstring(false)
+Slice::Gen::TypesVisitor::TypesVisitor(Output& h) :
+    H(h), _useWstring(false)
 {
 }
 
@@ -1792,24 +1809,250 @@ Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitModuleEnd(const ModulePtr& p)
+Slice::Gen::TypesVisitor::visitModuleEnd(const ModulePtr&)
 {
-    // TODO: this is not a good check, as it includes local structs and probably structs defined in included files.
-    if(p->hasStructs())
+    H << sp << nl << '}';
+    _useWstring = resetUseWstring(_useWstringHist);
+}
+
+void
+Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
+{
+    bool unscoped = findMetaData(p->getMetaData(), TypeContextCpp11) == "%unscoped";
+    H << sp;
+    writeDocSummary(H, p);
+    H << nl << "enum ";
+    if(!unscoped)
     {
-        H << sp << nl << "using Ice::operator<;";
-        H << nl << "using Ice::operator<=;";
-        H << nl << "using Ice::operator>;";
-        H << nl << "using Ice::operator>=;";
-        H << nl << "using Ice::operator==;";
-        H << nl << "using Ice::operator!=;";
+        H << "class ";
     }
+    H << fixKwd(p->name());
+    if(!unscoped && p->maxValue() <= 0xFF)
+    {
+        H << " : unsigned char";
+    }
+    H << sb;
+
+    EnumeratorList enumerators = p->enumerators();
+    //
+    // Check if any of the enumerators were assigned an explicit value.
+    //
+    const bool explicitValue = p->explicitValue();
+    for(EnumeratorList::const_iterator en = enumerators.begin(); en != enumerators.end();)
+    {
+        writeDocSummary(H, *en);
+        H << nl << fixKwd((*en)->name());
+        //
+        // If any of the enumerators were assigned an explicit value, we emit
+        // an explicit value for *all* enumerators.
+        //
+        if(explicitValue)
+        {
+            H << " = " << int64ToString((*en)->value());
+        }
+        if(++en != enumerators.end())
+        {
+            H << ',';
+        }
+    }
+    H << eb << ';';
+}
+
+void
+Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
+{
+    string name = fixKwd(p->name());
+    string scope = fixKwd(p->scope());
+    TypePtr type = p->type();
+    int typeCtx = _useWstring;
+    string s = typeToString(type, scope, p->typeMetaData(), typeCtx | TypeContextCpp11);
+    StringList metaData = p->getMetaData();
+
+    string seqType = findMetaData(metaData, _useWstring);
+    H << sp;
+    writeDocSummary(H, p);
+
+    if(!seqType.empty())
+    {
+        H << nl << "using " << name << " = " << seqType << ';';
+    }
+    else
+    {
+        H << nl << "using " << name << " = ::std::vector<" << s << ">;";
+    }
+}
+
+void
+Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
+{
+    string name = fixKwd(p->name());
+    string scope = fixKwd(p->scope());
+    string dictType = findMetaData(p->getMetaData());
+    int typeCtx = _useWstring;
+
+    H << sp;
+    writeDocSummary(H, p);
+
+    if(dictType.empty())
+    {
+        //
+        // A default std::map dictionary
+        //
+        TypePtr keyType = p->keyType();
+        TypePtr valueType = p->valueType();
+        string ks = typeToString(keyType, scope, p->keyMetaData(), typeCtx | TypeContextCpp11);
+        string vs = typeToString(valueType, scope, p->valueMetaData(), typeCtx | TypeContextCpp11);
+
+        H << nl << "using " << name << " = ::std::map<" << ks << ", " << vs << ">;";
+    }
+    else
+    {
+        //
+        // A custom dictionary
+        //
+        H << nl << "using " << name << " = " << dictType << ';';
+    }
+}
+
+void
+Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
+{
+    const string scope = fixKwd(p->scope());
+    H << sp;
+    writeDocSummary(H, p);
+    H << nl << (isConstexprType(p->type()) ? "constexpr " : "const ")
+      << typeToString(p->type(), scope, p->typeMetaData(), _useWstring | TypeContextCpp11) << " " << fixKwd(p->name())
+      << " = ";
+    writeConstantValue(H, p->type(), p->valueType(), p->value(), _useWstring | TypeContextCpp11, p->typeMetaData(),
+                       scope);
+    H << ';';
+}
+
+Slice::Gen::StructVisitor::StructVisitor(Output& h) :
+    H(h), _useWstring(false)
+{
+}
+
+bool
+Slice::Gen::StructVisitor::visitModuleStart(const ModulePtr& p)
+{
+    // TODO: this most likely includes structs in included files, which is not what we want here.
+    if(!p->hasStructs())
+    {
+        return false;
+    }
+
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    H << sp << nl << "namespace " << fixKwd(p->name()) << nl << '{';
+    return true;
+}
+
+void
+Slice::Gen::StructVisitor::visitModuleEnd(const ModulePtr&)
+{
+    H << sp << nl << "using Ice::operator<;";
+    H << nl << "using Ice::operator<=;";
+    H << nl << "using Ice::operator>;";
+    H << nl << "using Ice::operator>=;";
+    H << nl << "using Ice::operator==;";
+    H << nl << "using Ice::operator!=;";
     H << sp << nl << '}';
     _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::Gen::StructVisitor::visitStructStart(const StructPtr& p)
+{
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+
+    H << sp;
+    writeDocSummary(H, p);
+    H << nl << "struct " << fixKwd(p->name());
+    H << sb;
+
+    return true;
+}
+
+void
+Slice::Gen::StructVisitor::visitStructEnd(const StructPtr& p)
+{
+    H << sp;
+    H << nl << "/**";
+    H << nl << " * Obtains a tuple containing all of the struct's data members.";
+    H << nl << " * @return The data members in a tuple.";
+    H << nl << " */";
+    writeIceTuple(H, p->dataMembers(), _useWstring | TypeContextCpp11);
+    H << eb << ';';
+    _useWstring = resetUseWstring(_useWstringHist);
+}
+
+void
+Slice::Gen::StructVisitor::visitDataMember(const DataMemberPtr& p)
+{
+    // TODO: avoid duplication with class and exception visitors.
+
+    //
+    // Use an empty scope to get full qualified names from calls to typeToString.
+    //
+    const string scope = "";
+    string name = fixKwd(p->name());
+    writeDocSummary(H, p);
+    H << nl << typeToString(p->type(), p->optional(), scope, p->getMetaData(), _useWstring | TypeContextCpp11)
+      << ' ' << name;
+
+    string defaultValue = p->defaultValue();
+    if(!defaultValue.empty())
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+        if(p->optional() && builtin->kind() == Builtin::KindString)
+        {
+            //
+            // = "<string literal>" doesn't work for optional<std::string>
+            //
+            H << '{';
+            writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring | TypeContextCpp11,
+                               p->getMetaData(), scope);
+            H << '}';
+        }
+        else
+        {
+            H << " = ";
+            writeConstantValue(H, p->type(), p->defaultValueType(), defaultValue, _useWstring | TypeContextCpp11,
+                               p->getMetaData(), scope);
+        }
+    }
+
+    H << ';';
+}
+
+Slice::Gen::ExceptionVisitor::ExceptionVisitor(Output& h, Output& c, const string& dllExport) :
+    H(h), C(c), _dllExport(dllExport), _dllClassExport(toDllClassExport(dllExport)),
+    _dllMemberExport(toDllMemberExport(dllExport)), _doneStaticSymbol(false), _useWstring(false)
+{
+}
+
+bool
+Slice::Gen::ExceptionVisitor::visitModuleStart(const ModulePtr& p)
+{
+    if(!p->hasExceptions())
+    {
+        return false;
+    }
+
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    H << sp << nl << "namespace " << fixKwd(p->name()) << nl << '{';
+    return true;
+}
+
+void
+Slice::Gen::ExceptionVisitor::visitModuleEnd(const ModulePtr&)
+{
+    H << sp << nl << '}';
+    _useWstring = resetUseWstring(_useWstringHist);
+}
+
+bool
+Slice::Gen::ExceptionVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
@@ -2016,7 +2259,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
+Slice::Gen::ExceptionVisitor::visitExceptionEnd(const ExceptionPtr& p)
 {
     string name = fixKwd(p->name());
     string scope = fixKwd(p->scope());
@@ -2092,34 +2335,8 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     _useWstring = resetUseWstring(_useWstringHist);
 }
 
-bool
-Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
-{
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
-
-    H << sp;
-    writeDocSummary(H, p);
-    H << nl << "struct " << fixKwd(p->name());
-    H << sb;
-
-    return true;
-}
-
 void
-Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
-{
-    H << sp;
-    H << nl << "/**";
-    H << nl << " * Obtains a tuple containing all of the struct's data members.";
-    H << nl << " * @return The data members in a tuple.";
-    H << nl << " */";
-    writeIceTuple(H, p->dataMembers(), _useWstring | TypeContextCpp11);
-    H << eb << ';';
-    _useWstring = resetUseWstring(_useWstringHist);
-}
-
-void
-Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
+Slice::Gen::ExceptionVisitor::visitDataMember(const DataMemberPtr& p)
 {
     //
     // Use an empty scope to get full qualified names from calls to typeToString.
@@ -2153,62 +2370,6 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     }
 
     H << ';';
-}
-
-void
-Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
-{
-    string name = fixKwd(p->name());
-    string scope = fixKwd(p->scope());
-    TypePtr type = p->type();
-    int typeCtx = _useWstring;
-    string s = typeToString(type, scope, p->typeMetaData(), typeCtx | TypeContextCpp11);
-    StringList metaData = p->getMetaData();
-
-    string seqType = findMetaData(metaData, _useWstring);
-    H << sp;
-    writeDocSummary(H, p);
-
-    if(!seqType.empty())
-    {
-        H << nl << "using " << name << " = " << seqType << ';';
-    }
-    else
-    {
-        H << nl << "using " << name << " = ::std::vector<" << s << ">;";
-    }
-}
-
-void
-Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
-{
-    string name = fixKwd(p->name());
-    string scope = fixKwd(p->scope());
-    string dictType = findMetaData(p->getMetaData());
-    int typeCtx = _useWstring;
-
-    H << sp;
-    writeDocSummary(H, p);
-
-    if(dictType.empty())
-    {
-        //
-        // A default std::map dictionary
-        //
-        TypePtr keyType = p->keyType();
-        TypePtr valueType = p->valueType();
-        string ks = typeToString(keyType, scope, p->keyMetaData(), typeCtx | TypeContextCpp11);
-        string vs = typeToString(valueType, scope, p->valueMetaData(), typeCtx | TypeContextCpp11);
-
-        H << nl << "using " << name << " = ::std::map<" << ks << ", " << vs << ">;";
-    }
-    else
-    {
-        //
-        // A custom dictionary
-        //
-        H << nl << "using " << name << " = " << dictType << ';';
-    }
 }
 
 Slice::Gen::ProxyVisitor::ProxyVisitor(Output& h, Output& c, const string& dllExport) :
@@ -2294,6 +2455,13 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "explicit " << prx << "(const ::Ice::ObjectPrx& other) : ::Ice::ObjectPrx(other)";
     H << nl << "{";
     H << nl << "}";
+
+    // Copy constructor
+    H << sp;
+    H << nl << prx << "(const " << prx << "& other) : ::Ice::ObjectPrx(other)";
+    H << nl << "{";
+    H << nl << "}";
+
     H << sp;
     H << nl << "/// \\cond INTERNAL";
     H << nl << prx << "(const ::IceInternal::ReferencePtr& ref) : ::Ice::ObjectPrx(ref)";
@@ -2331,6 +2499,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     bool retIsOpt = p->returnIsOptional();
     string retS = returnTypeToString(ret, retIsOpt, interfaceScope, p->getMetaData(), _useWstring | TypeContextCpp11);
+    string retSImpl = returnTypeToString(ret, retIsOpt, "", p->getMetaData(), _useWstring | TypeContextCpp11);
 
     vector<string> params;
     vector<string> paramsDecl;
@@ -2408,8 +2577,8 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     string scoped = fixKwd(interface->scope() + interface->name() + "Prx" + "::").substr(2);
 
     const string contextParam = escapeParam(paramList, "context");
-    const string contextDecl = "const " + getUnqualified("::Ice::Context&", interfaceScope) + " " + contextParam + " = " +
-        getUnqualified("::Ice::noExplicitContext", interfaceScope);
+    const string contextDef = "const " + getUnqualified("::Ice::Context&", interfaceScope) + " " + contextParam;
+    const string contextDecl = contextDef + " = " + getUnqualified("::Ice::noExplicitContext", interfaceScope);
 
     string futureT;
     if(futureOutParams.empty())
@@ -2441,49 +2610,55 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         postParams.push_back(contextDoc);
         writeOpDocSummary(H, p, comment, OpDocAllParams, true, StringList(), postParams, comment->returns());
     }
-    H << nl << deprecateSymbol << retS << ' ' << fixKwd(name) << spar << paramsDecl << contextDecl << epar;
-    H << sb;
-    H << nl;
-    if(futureOutParams.size() == 1)
+    H << nl << deprecateSymbol << _dllMemberExport << retS << ' ' << fixKwd(name)
+        << spar << paramsDecl << contextDecl << epar << ";";
+
+    C << sp;
+    C << nl << retSImpl << nl
+        << scoped << fixKwd(name) << spar << paramsDecl << contextDef << epar;
+    C << sb;
+    C << nl;
+    if (futureOutParams.size() == 1)
     {
         if(ret)
         {
-            H << "return ";
+            C << "return ";
         }
         else
         {
-            H << fixKwd((*outParams.begin())->name()) << " = ";
+            C << fixKwd((*outParams.begin())->name()) << " = ";
         }
     }
-    else if(futureOutParams.size() > 1)
+    else if (futureOutParams.size() > 1)
     {
-        H << "auto _result = ";
+        C << "auto _result = ";
     }
 
-    H << "_makePromiseOutgoing<" << futureT << ">";
+    C << "_makePromiseOutgoing<" << futureT << ">";
 
-    H << spar << "true, this" << "&" + interface->name() + "Prx::_iceI_" + name;
-    for(ParamDeclList::const_iterator q = inParams.begin(); q != inParams.end(); ++q)
+    C << spar << "true, this" << "&" + interface->name() + "Prx::_iceI_" + name;
+    for (ParamDeclList::const_iterator q = inParams.begin(); q != inParams.end(); ++q)
     {
-        H << fixKwd((*q)->name());
+        C << fixKwd((*q)->name());
     }
-    H << contextParam << epar << ".get();";
-    if(futureOutParams.size() > 1)
+    C << contextParam << epar << ".get();";
+    if (futureOutParams.size() > 1)
     {
-        for(ParamDeclList::const_iterator q = outParams.begin(); q != outParams.end(); ++q)
+        for (ParamDeclList::const_iterator q = outParams.begin(); q != outParams.end(); ++q)
         {
-            H << nl << fixKwd((*q)->name()) << " = ";
-            H << condMove(isMovable((*q)->type()), "_result." + fixKwd((*q)->name())) + ";";
+            C << nl << fixKwd((*q)->name()) << " = ";
+            C << condMove(isMovable((*q)->type()), "_result." + fixKwd((*q)->name())) + ";";
         }
         if(ret)
         {
-            H << nl << "return " + condMove(isMovable(ret), "_result." + returnValueS) + ";";
+            C << nl << "return " + condMove(isMovable(ret), "_result." + returnValueS) + ";";
         }
     }
-    H << eb;
+    C << eb;
 
     //
     // Promise based asynchronous operation
+    // TODO: remove template P and move implementation out of line
     //
     H << sp;
     if(comment)
@@ -2555,36 +2730,40 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     H << "::std::function<void" << spar << lambdaOutParams << epar << "> " << responseParam << ",";
     H << nl << "::std::function<void(::std::exception_ptr)> " << exParam << " = nullptr,";
     H << nl << "::std::function<void(bool)> " << sentParam << " = nullptr,";
-    H << nl << contextDecl << ")" << string(lambdaCustomOut ? ";" : "");
+    H << nl << contextDecl << ");";
 
     H.restoreIndent();
+
+    // TODO: cleanup the code below to reduce duplication.
+
+    C << sp;
+    C << nl << "::std::function<void()>";
+    C << nl << scoped << name << "Async(";
+    C.useCurrentPosAsIndent();
+    if (!inParamsImplDecl.empty())
+    {
+        for (vector<string>::const_iterator q = inParamsImplDecl.begin(); q != inParamsImplDecl.end(); ++q)
+        {
+            if (q != inParamsImplDecl.begin())
+            {
+                C << " ";
+            }
+            C << *q << ",";
+        }
+        C << nl;
+    }
+
+    C << "::std::function<void " << spar << lambdaOutParams << epar << "> response,";
+    C << nl << "::std::function<void(::std::exception_ptr)> ex,";
+    C << nl << "::std::function<void(bool)> sent,";
+    C << nl << "const ::Ice::Context& context)";
+    C.restoreIndent();
+
     if(lambdaCustomOut)
     {
         //
         // "Custom" implementation in .cpp file
         //
-
-        C << sp;
-        C << nl << "::std::function<void()>";
-        C << nl << scoped << name << "Async(";
-        C.useCurrentPosAsIndent();
-        if(!inParamsImplDecl.empty())
-        {
-            for(vector<string>::const_iterator q = inParamsImplDecl.begin(); q != inParamsImplDecl.end(); ++q)
-            {
-                if(q != inParamsImplDecl.begin())
-                {
-                    C << " ";
-                }
-                C << *q << ",";
-            }
-            C << nl;
-        }
-        C << "::std::function<void " << spar << lambdaOutParams << epar << "> response,";
-        C << nl << "::std::function<void(::std::exception_ptr)> ex,";
-        C << nl << "::std::function<void(bool)> sent,";
-        C << nl << "const ::Ice::Context& context)";
-        C.restoreIndent();
         C << sb;
         if(p->returnsData())
         {
@@ -2644,40 +2823,40 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     else
     {
         //
-        // Simple implementation directly in header file
+        // Simple implementation in .cpp file
         //
 
-        H << sb;
+        C << sb;
         if(futureOutParams.size() > 1)
         {
-            H << nl << "auto _responseCb = [response](" << futureT << "&& _result)";
-            H << sb;
-            H << nl << responseParam << spar;
+            C << nl << "auto _responseCb = [response](" << futureT << "&& _result)";
+            C << sb;
+            C << nl << responseParam << spar;
 
             if(ret)
             {
-                H << condMove(isMovable(ret), string("_result.") + returnValueS);
+                C << condMove(isMovable(ret), string("_result.") + returnValueS);
             }
             for(ParamDeclList::const_iterator q = outParams.begin(); q != outParams.end(); ++q)
             {
-                H << condMove(isMovable((*q)->type()), "_result." + fixKwd((*q)->name()));
+                C << condMove(isMovable((*q)->type()), "_result." + fixKwd((*q)->name()));
             }
-            H << epar << ";" << eb << ";";
+            C << epar << ";" << eb << ";";
         }
 
-        H << nl << "return _makeLambdaOutgoing<" << futureT << ">" << spar;
+        C << nl << "return _makeLambdaOutgoing<" << futureT << ">" << spar;
 
-        H << "std::move(" + (futureOutParams.size() > 1 ? "_responseCb" : responseParam) + ")"
-          << "std::move(" + exParam + ")"
-          << "std::move(" + sentParam + ")"
+        C << "std::move(" + (futureOutParams.size() > 1 ? string("_responseCb") : "response") + ")"
+          << "std::move(ex)"
+          << "std::move(sent)"
           << "this";
-        H << string("&" + getUnqualified(scoped, interfaceScope.substr(2)) + "_iceI_" + name);
+        C << string("&" + getUnqualified(scoped, interfaceScope.substr(2)) + "_iceI_" + name);
         for(ParamDeclList::const_iterator q = inParams.begin(); q != inParams.end(); ++q)
         {
-            H << fixKwd((*q)->name());
+            C << paramPrefix + (*q)->name();
         }
-        H << contextParam << epar << ";";
-        H << eb;
+        C << "context" << epar << ";";
+        C << eb;
     }
 
     //
@@ -2767,78 +2946,6 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     C << nl << "/// \\endcond";
 }
 
-void
-Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
-{
-    bool unscoped = findMetaData(p->getMetaData(), TypeContextCpp11) == "%unscoped";
-    H << sp;
-    writeDocSummary(H, p);
-    H << nl << "enum ";
-    if(!unscoped)
-    {
-        H << "class ";
-    }
-    H << fixKwd(p->name());
-    if(!unscoped && p->maxValue() <= 0xFF)
-    {
-        H << " : unsigned char";
-    }
-    H << sb;
-
-    EnumeratorList enumerators = p->enumerators();
-    //
-    // Check if any of the enumerators were assigned an explicit value.
-    //
-    const bool explicitValue = p->explicitValue();
-    for(EnumeratorList::const_iterator en = enumerators.begin(); en != enumerators.end();)
-    {
-        writeDocSummary(H, *en);
-        H << nl << fixKwd((*en)->name());
-        //
-        // If any of the enumerators were assigned an explicit value, we emit
-        // an explicit value for *all* enumerators.
-        //
-        if(explicitValue)
-        {
-            H << " = " << int64ToString((*en)->value());
-        }
-        if(++en != enumerators.end())
-        {
-            H << ',';
-        }
-    }
-    H << eb << ';';
-}
-
-void
-Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
-{
-    const string scope = fixKwd(p->scope());
-    H << sp;
-    writeDocSummary(H, p);
-    H << nl << (isConstexprType(p->type()) ? "constexpr " : "const ")
-      << typeToString(p->type(), scope, p->typeMetaData(), _useWstring | TypeContextCpp11) << " " << fixKwd(p->name())
-      << " = ";
-    writeConstantValue(H, p->type(), p->valueType(), p->value(), _useWstring | TypeContextCpp11, p->typeMetaData(),
-                       scope);
-    H << ';';
-}
-
-void
-Slice::Gen::TypesVisitor::emitUpcall(const ExceptionPtr& base, const string& call, const string& scope)
-{
-    C << nl;
-    if(base)
-    {
-        C << getUnqualified(fixKwd(base->scoped()), scope);
-    }
-    else
-    {
-        getUnqualified("::Ice::UserException", scope);
-    }
-    C << call;
-}
-
 Slice::Gen::ObjectVisitor::ObjectVisitor(::IceUtilInternal::Output& h,
                                          ::IceUtilInternal::Output& c,
                                          const std::string& dllExport) :
@@ -2888,36 +2995,6 @@ Slice::Gen::ObjectVisitor::emitDataMember(const DataMemberPtr& p)
         }
     }
     H << ";";
-}
-
-void
-Slice::Gen::InterfaceVisitor::emitUpcall(const ClassDefPtr& base, const string& call, const string& scope)
-{
-    C << nl;
-    if(base)
-    {
-        C << getUnqualified(fixKwd(base->scoped()), scope);
-    }
-    else
-    {
-        C << getUnqualified("::Ice::Object", scope);
-    }
-    C << call;
-}
-
-void
-Slice::Gen::ValueVisitor::emitUpcall(const ClassDefPtr& base, const string& call, const string& scope)
-{
-    C << nl;
-    if(base)
-    {
-        C << getUnqualified(fixKwd(base->scoped()), scope);
-    }
-    else
-    {
-        C << getUnqualified("::Ice::Value", scope);
-    }
-    C << call;
 }
 
 Slice::Gen::InterfaceVisitor::InterfaceVisitor(::IceUtilInternal::Output& h,
@@ -3013,7 +3090,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     H << nl << " * @param current The Current object for the invocation.";
     H << nl << " * @return True if this object supports the interface, false, otherwise.";
     H << nl << " */";
-    H << nl << "virtual bool ice_isA(::std::string id, const " << getUnqualified("::Ice::Current&", scope)
+    H << nl << "bool ice_isA(::std::string id, const " << getUnqualified("::Ice::Current&", scope)
       << " current) const override;";
         H << sp;
     H << nl << "/**";
@@ -3022,7 +3099,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     H << nl << " * @return A list of fully-scoped type IDs.";
     H << nl << " */";
     H << nl
-      << "virtual ::std::vector<::std::string> ice_ids(const " << getUnqualified("::Ice::Current&", scope)
+      << "::std::vector<::std::string> ice_ids(const " << getUnqualified("::Ice::Current&", scope)
       << " current) const override;";
         H << sp;
     H << nl << "/**";
@@ -3030,7 +3107,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     H << nl << " * @param current The Current object for the invocation.";
     H << nl << " * @return A fully-scoped type ID.";
     H << nl << " */";
-    H << nl << "virtual ::std::string ice_id(const " << getUnqualified("::Ice::Current&", scope)
+    H << nl << "::std::string ice_id(const " << getUnqualified("::Ice::Current&", scope)
       << " current) const override;";
         H << sp;
     H << nl << "/**";
@@ -3968,7 +4045,9 @@ Slice::Gen::CompatibilityVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
     string scoped = fixKwd(p->scoped());
 
     H << sp << nl << "using " << p->name() << "Ptr = ::std::shared_ptr<" << name << ">;";
-    H << nl << "using " << p->name() << "PrxPtr = ::std::shared_ptr<" << p->name() << "Prx>;";
+
+    // TODO: remove and update code that relies on these PrxPtr
+    H << sp << nl << "using " << p->name() << "PrxPtr = ::std::shared_ptr<" << p->name() << "Prx>;";
 }
 
 Slice::Gen::ImplVisitor::ImplVisitor(Output& h, Output& c, const string& dllExport) :

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -630,6 +630,8 @@ emitOpNameResult(IceUtilInternal::Output& H, const OperationPtr& p, int useWstri
 string
 createResultType(const OperationPtr& p, const string& scope, int useWstring)
 {
+    assert(useWstring == 0 || useWstring == TypeContextUseWstring);
+
     TypePtr ret = p->returnType();
     string retS = returnTypeToString(ret, p->returnIsOptional(), scope, p->getMetaData(),
                                      useWstring | TypeContextCpp11);
@@ -646,9 +648,9 @@ createResultType(const OperationPtr& p, const string& scope, int useWstring)
         {
             out << retS;
         }
-        for (ParamDeclList::iterator q = outParams.begin(); q != outParams.end(); ++q)
+        for (const auto& param : outParams)
         {
-            out << typeToString((*q)->type(), (*q)->optional(), scope, (*q)->getMetaData(), useWstring | TypeContextCpp11);
+            out << typeToString(param->type(), param->optional(), scope, param->getMetaData(), useWstring | TypeContextCpp11);
         }
         out << eabrk;
         return os.str();
@@ -659,8 +661,8 @@ createResultType(const OperationPtr& p, const string& scope, int useWstring)
     }
     else if (outParams.size() == 1)
     {
-        auto q = outParams.begin();
-        return typeToString((*q)->type(), (*q)->optional(), scope, (*q)->getMetaData(), useWstring | TypeContextCpp11);
+        const auto& param = outParams.front();
+        return typeToString(param->type(), param->optional(), scope, param->getMetaData(), useWstring | TypeContextCpp11);
     }
     else
     {
@@ -2697,16 +2699,16 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         writeOpDocSummary(H, p, comment, OpDocInParams, false, StringList(), postParams, returns);
     }
 
-    H << nl << deprecateSymbol << "std::future<" << futureT << "> " << name << "Async" << spar << inParamsDecl
+    H << nl << deprecateSymbol << "::std::future<" << futureT << "> " << name << "Async" << spar << inParamsDecl
         << contextDecl << epar << ";";
 
     C << sp;
-    C << nl << "std::future<" << futureTAbsolute << ">";
+    C << nl << "::std::future<" << futureTAbsolute << ">";
     C << nl;
     C << scoped << name << "Async" << spar << inParamsImplDecl << "const ::Ice::Context& context" << epar;
 
     C << sb;
-    C << nl << "return _makePromiseOutgoing<" << futureT << ", std::promise>" << spar;
+    C << nl << "return _makePromiseOutgoing<" << futureT << ", ::std::promise>" << spar;
     C << "false, this" << string("&" + interface->name() + "Prx::_iceI_" + name);
     for(ParamDeclList::const_iterator q = inParams.begin(); q != inParams.end(); ++q)
     {

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -79,6 +79,7 @@ private:
         virtual void visitModuleEnd(const ModulePtr&);
         virtual void visitClassDecl(const ClassDeclPtr&);
         virtual bool visitClassDefStart(const ClassDefPtr&);
+        virtual bool visitStructStart(const StructPtr&);
         virtual void visitInterfaceDecl(const InterfaceDeclPtr&);
         virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
         virtual bool visitExceptionStart(const ExceptionPtr&);
@@ -96,24 +97,61 @@ private:
     {
     public:
 
-        TypesVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        TypesVisitor(::IceUtilInternal::Output&);
 
         virtual bool visitModuleStart(const ModulePtr&);
         virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&) { return false; }
-        virtual bool visitExceptionStart(const ExceptionPtr&);
-        virtual void visitExceptionEnd(const ExceptionPtr&);
-        virtual bool visitStructStart(const StructPtr&);
-        virtual void visitStructEnd(const StructPtr&);
         virtual void visitSequence(const SequencePtr&);
         virtual void visitDictionary(const DictionaryPtr&);
         virtual void visitEnum(const EnumPtr&);
         virtual void visitConst(const ConstPtr&);
-        virtual void visitDataMember(const DataMemberPtr&);
 
     private:
 
-        void emitUpcall(const ExceptionPtr&, const std::string&, const std::string&);
+        ::IceUtilInternal::Output& H;
+        int _useWstring;
+        std::list<int> _useWstringHist;
+    };
+
+    class StructVisitor final : private ::IceUtil::noncopyable, public ParserVisitor
+    {
+    public:
+
+        StructVisitor(::IceUtilInternal::Output&);
+
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitStructEnd(const StructPtr&) final;
+        void visitDataMember(const DataMemberPtr&) final;
+
+        // Otherwise we visit their data members.
+        bool visitClassDefStart(const ClassDefPtr&) final { return false; }
+        bool visitExceptionStart(const ExceptionPtr&) final { return false; }
+
+    private:
+
+        ::IceUtilInternal::Output& H;
+        int _useWstring;
+        std::list<int> _useWstringHist;
+    };
+
+    class ExceptionVisitor final : private ::IceUtil::noncopyable, public ParserVisitor
+    {
+    public:
+        ExceptionVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+        void visitDataMember(const DataMemberPtr&) final;
+
+        // Otherwise we visit their data members.
+        bool visitClassDefStart(const ClassDefPtr&) final { return false; }
+        bool visitStructStart(const StructPtr&) final { return false; }
+
+    private:
 
         ::IceUtilInternal::Output& H;
         ::IceUtilInternal::Output& C;
@@ -183,7 +221,6 @@ private:
         virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
         virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
         virtual void visitOperation(const OperationPtr&);
-        void emitUpcall(const ClassDefPtr&, const std::string&, const std::string&);
 
     private:
 
@@ -207,7 +244,6 @@ private:
         virtual void visitModuleEnd(const ModulePtr&);
         virtual bool visitClassDefStart(const ClassDefPtr&);
         virtual void visitClassDefEnd(const ClassDefPtr&);
-        void emitUpcall(const ClassDefPtr&, const std::string&, const std::string&);
     };
 
     class StreamVisitor : private ::IceUtil::noncopyable, public ParserVisitor

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -181,8 +181,7 @@ private:
         ::IceUtilInternal::Output& H;
         ::IceUtilInternal::Output& C;
 
-        std::string _dllClassExport;
-        std::string _dllMemberExport;
+        std::string _dllExport;
         int _useWstring;
         std::list<int> _useWstringHist;
     };
@@ -228,8 +227,6 @@ private:
         ::IceUtilInternal::Output& C;
 
         std::string _dllExport;
-        std::string _dllClassExport;
-        std::string _dllMemberExport;
         int _useWstring;
         std::list<int> _useWstringHist;
     };

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1594,7 +1594,7 @@ allTests(Test::TestHelper* helper, bool collocated)
     }
 
     {
-        cout << "testing result struct... " << flush;
+        cout << "testing result tuple... " << flush;
 
         auto q = Ice::uncheckedCast<Test::Outer::Inner::TestIntfPrx>(
             communicator->stringToProxy("test2:" + helper->getTestEndpoint()));
@@ -1622,8 +1622,9 @@ allTests(Test::TestHelper* helper, bool collocated)
 
         auto f = q->opAsync(1);
         auto r = f.get();
-        test(r.returnValue == r.j);
-        test(r.returnValue == 1);
+        // TODO: this is not really a good test as we could mix up the two values.
+        test(std::get<0>(r) == std::get<1>(r));
+        test(std::get<0>(r) == 1);
         cout << "ok" << endl;
     }
 

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -657,8 +657,8 @@ allTests(Test::TestHelper* helper)
     {
         Util::string_view in = "HELLO WORLD!";
         auto r = t->opStringAsync(in).get();
-        test(r.returnValue == r.outString);
-        test(r.returnValue == in);
+        test(std::get<0>(r) == std::get<1>(r));
+        test(std::get<0>(r) == in);
     }
     cout << "ok" << endl;
 
@@ -678,8 +678,8 @@ allTests(Test::TestHelper* helper)
             }
             pair<const Ice::Double*, const Ice::Double*> inPair(inArray, inArray + 5);
             auto r = t->opDoubleArrayAsync(inPair).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -697,8 +697,8 @@ allTests(Test::TestHelper* helper)
             pair<const bool*, const bool*> inPair(inArray, inArray + 5);
 
             auto r = t->opBoolArrayAsync(inPair).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -717,8 +717,8 @@ allTests(Test::TestHelper* helper)
             pair<const Ice::Byte*, const Ice::Byte*> inPair(inArray, inArray + 5);
 
             auto r = t->opByteArrayAsync(inPair).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -737,8 +737,8 @@ allTests(Test::TestHelper* helper)
             pair<const Test::Variable*, const Test::Variable*> inPair(inArray, inArray + 5);
 
             auto r = t->opVariableArrayAsync(inPair).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -749,8 +749,8 @@ allTests(Test::TestHelper* helper)
             in[3] = false;
             in[4] = true;
             auto r = t->opBoolRangeAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -762,8 +762,8 @@ allTests(Test::TestHelper* helper)
             in.push_back('5');
 
             auto r = t->opByteRangeAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -780,8 +780,8 @@ allTests(Test::TestHelper* helper)
             v.s = "STRINGS.";
             in.push_back(v);
             auto r = t->opVariableRangeAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -792,8 +792,8 @@ allTests(Test::TestHelper* helper)
             in.push_back('4');
             in.push_back('5');
             auto r = t->opByteRangeTypeAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -817,8 +817,8 @@ allTests(Test::TestHelper* helper)
             inSeq.push_back(v);
 
             auto r = t->opVariableRangeTypeAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -830,8 +830,8 @@ allTests(Test::TestHelper* helper)
             in[4] = true;
 
             auto r = t->opBoolSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -843,8 +843,8 @@ allTests(Test::TestHelper* helper)
             in.push_back(true);
 
             auto r = t->opBoolListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -856,8 +856,8 @@ allTests(Test::TestHelper* helper)
             in[4] = '5';
 
             auto r = t->opByteSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -869,8 +869,8 @@ allTests(Test::TestHelper* helper)
             in.push_back('5');
 
             auto r = t->opByteListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -882,8 +882,8 @@ allTests(Test::TestHelper* helper)
             }
 
             auto r = t->opMyByteSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -895,8 +895,8 @@ allTests(Test::TestHelper* helper)
             in[4] = "STRINGS.";
 
             auto r = t->opStringSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -908,8 +908,8 @@ allTests(Test::TestHelper* helper)
             in.push_back("STRINGS.");
 
             auto r = t->opStringListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -921,8 +921,8 @@ allTests(Test::TestHelper* helper)
             in[4].s = 5;
 
             auto r = t->opFixedSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -934,8 +934,8 @@ allTests(Test::TestHelper* helper)
             }
 
             auto r = t->opFixedListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -947,8 +947,8 @@ allTests(Test::TestHelper* helper)
             in[4].s = "STRINGS.";
 
             auto r = t->opVariableSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -966,8 +966,8 @@ allTests(Test::TestHelper* helper)
             in.push_back(v);
 
             auto r = t->opVariableListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -979,8 +979,8 @@ allTests(Test::TestHelper* helper)
             in[4]["E"] = "E";
 
             auto r = t->opStringStringDictSeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -998,8 +998,8 @@ allTests(Test::TestHelper* helper)
             in.push_back(ssd);
 
             auto r = t->opStringStringDictListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -1011,8 +1011,8 @@ allTests(Test::TestHelper* helper)
             in[4] = Test:: E::E3;
 
             auto r = t->opESeqAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -1024,8 +1024,8 @@ allTests(Test::TestHelper* helper)
             in.push_back(Test:: E::E3);
 
             auto r = t->opEListAsync(in).get();
-            test(r.outSeq == in);
-            test(r.returnValue == in);
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
         }
 
         {
@@ -1038,11 +1038,11 @@ allTests(Test::TestHelper* helper)
 
             auto r = t->opDPrxSeqAsync(in).get();
 
-            test(r.outSeq.size() == in.size());
-            test(r.returnValue.size() == in.size());
+            test(std::get<1>(r).size() == in.size());
+            test(std::get<0>(r).size() == in.size());
 
-            auto op = r.outSeq.begin();
-            auto rp = r.returnValue.begin();
+            auto op = std::get<1>(r).begin();
+            auto rp = std::get<0>(r).begin();
 
             for(auto i: in)
             {
@@ -1061,11 +1061,11 @@ allTests(Test::TestHelper* helper)
 
             auto r = t->opDPrxListAsync(in).get();
 
-            test(r.outSeq.size() == in.size());
-            test(r.returnValue.size() == in.size());
+            test(std::get<1>(r).size() == in.size());
+            test(std::get<0>(r).size() == in.size());
 
-            auto op = r.outSeq.begin();
-            auto rp = r.returnValue.begin();
+            auto op = std::get<1>(r).begin();
+            auto rp = std::get<0>(r).begin();
 
             for(auto i: in)
             {
@@ -1083,13 +1083,13 @@ allTests(Test::TestHelper* helper)
             in[4] = in[0];
 
             auto r = t->opCSeqAsync(in).get();
-            test(r.outSeq.size() == in.size());
-            test(r.returnValue.size() == in.size());
+            test(std::get<1>(r).size() == in.size());
+            test(std::get<0>(r).size() == in.size());
 
-            auto rp = r.returnValue.begin();
-            for(auto o: r.outSeq)
+            auto rp = std::get<0>(r).begin();
+            for(auto o: std::get<1>(r))
             {
-                test(o == r.outSeq[0]);
+                test(o == std::get<1>(r)[0]);
                 test(*rp++ == o);
             }
         }
@@ -1103,9 +1103,9 @@ allTests(Test::TestHelper* helper)
             in.push_back(make_shared<Test::C>());
 
             auto r = t->opCListAsync(in).get();
-            test(r.outSeq.size() == in.size());
-            test(r.returnValue.size() == in.size());
-            test(r.outSeq == r.returnValue);
+            test(std::get<1>(r).size() == in.size());
+            test(std::get<0>(r).size() == in.size());
+            test(std::get<1>(r) == std::get<0>(r));
         }
 
         {
@@ -1983,8 +1983,8 @@ allTests(Test::TestHelper* helper)
             idict[-1] = "MINUS ONE";
 
             auto r = t->opIntStringDictAsync(idict).get();
-            test(r.odict == idict);
-            test(r.returnValue == idict);
+            test(std::get<1>(r) == idict);
+            test(std::get<0>(r) == idict);
         }
 
         {
@@ -1996,9 +1996,9 @@ allTests(Test::TestHelper* helper)
             idict["MINUS ONE"] = -1;
 
             auto r = t->opVarDictAsync(idict).get();
-            test(r.odict == idict);
-            test(r.returnValue.size() == 1000);
-            for(auto i: r.returnValue)
+            test(std::get<1>(r) == idict);
+            test(std::get<0>(r).size() == 1000);
+            for(auto i: std::get<0>(r))
             {
                 test(i.second == i.first * i.first);
             }
@@ -2013,13 +2013,13 @@ allTests(Test::TestHelper* helper)
             idict[-1] = "MINUS ONE";
 
             auto r = t->opCustomIntStringDictAsync(idict).get();
-            test(r.odict.size() == idict.size());
+            test(std::get<1>(r).size() == idict.size());
 
-            test(r.odict == r.returnValue);
+            test(std::get<1>(r) == std::get<0>(r));
 
             for(auto i: idict)
             {
-                test(r.odict[i.first] == i.second);
+                test(std::get<1>(r)[i.first] == i.second);
             }
         }
 
@@ -2148,8 +2148,8 @@ allTests(Test::TestHelper* helper)
 
     {
         auto r = wsc1->opStringAsync(wstr).get();
-        test(r.s2 == wstr);
-        test(r.returnValue == wstr);
+        test(std::get<1>(r) == wstr);
+        test(std::get<0>(r) == wstr);
     }
 
     {
@@ -2176,8 +2176,8 @@ allTests(Test::TestHelper* helper)
 
     {
         auto r = wsc2->opStringAsync(wstr).get();
-        test(r.s2 == wstr);
-        test(r.returnValue == wstr);
+        test(std::get<1>(r) == wstr);
+        test(std::get<0>(r) == wstr);
     }
 
     {

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -2388,7 +2388,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByte(r.returnValue, r.p3);
+            cb->opByte(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2407,7 +2407,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opBool(r.returnValue, r.p3);
+            cb->opBool(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2426,7 +2426,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opShortIntLong(r.returnValue, r.p4, r.p5, r.p6);
+            cb->opShortIntLong(std::get<0>(r), std::get<1>(r), std::get<2>(r), std::get<3>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2445,7 +2445,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opFloatDouble(r.returnValue, r.p3, r.p4);
+            cb->opFloatDouble(std::get<0>(r), std::get<1>(r), std::get<2>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2464,7 +2464,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opString(r.returnValue, r.p3);
+            cb->opString(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2483,7 +2483,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyEnum(r.returnValue, r.p2);
+            cb->opMyEnum(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2502,7 +2502,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyClass(r.returnValue, r.p2, r.p3);
+            cb->opMyClass(std::get<0>(r), std::get<1>(r), std::get<2>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2530,7 +2530,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStruct(r.returnValue, r.p3);
+            cb->opStruct(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2562,7 +2562,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByteS(r.returnValue, r.p3);
+            cb->opByteS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2590,7 +2590,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opBoolS(r.returnValue, r.p3);
+            cb->opBoolS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2626,7 +2626,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opShortIntLongS(r.returnValue, r.p4, r.p5, r.p6);
+            cb->opShortIntLongS(std::get<0>(r), std::get<1>(r), std::get<2>(r), std::get<3>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2655,7 +2655,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opFloatDoubleS(r.returnValue, r.p3, r.p4);
+            cb->opFloatDoubleS(std::get<0>(r), std::get<1>(r), std::get<2>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2683,7 +2683,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringS(r.returnValue, r.p3);
+            cb->opStringS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2716,7 +2716,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByteSS(r.returnValue, r.p3);
+            cb->opByteSS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2747,7 +2747,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opFloatDoubleSS(r.returnValue, r.p3, r.p4);
+            cb->opFloatDoubleSS(std::get<0>(r), std::get<1>(r), std::get<2>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2777,7 +2777,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringSS(r.returnValue, r.p3);
+            cb->opStringSS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2804,7 +2804,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByteBoolD(r.returnValue, r.p3);
+            cb->opByteBoolD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2831,7 +2831,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opShortIntD(r.returnValue, r.p3);
+            cb->opShortIntD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2858,7 +2858,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opLongFloatD(r.returnValue, r.p3);
+            cb->opLongFloatD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2885,7 +2885,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringStringD(r.returnValue, r.p3);
+            cb->opStringStringD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2912,7 +2912,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringMyEnumD(r.returnValue, r.p3);
+            cb->opStringMyEnumD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2944,7 +2944,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyStructMyEnumD(r.returnValue, r.p3);
+            cb->opMyStructMyEnumD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -2983,7 +2983,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByteBoolDS(r.returnValue, r.p3);
+            cb->opByteBoolDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3021,7 +3021,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opShortIntDS(r.returnValue, r.p3);
+            cb->opShortIntDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3059,7 +3059,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opLongFloatDS(r.returnValue, r.p3);
+            cb->opLongFloatDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3097,7 +3097,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringStringDS(r.returnValue, r.p3);
+            cb->opStringStringDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3135,7 +3135,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringMyEnumDS(r.returnValue, r.p3);
+            cb->opStringMyEnumDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3171,7 +3171,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyEnumStringDS(r.returnValue, r.p3);
+            cb->opMyEnumStringDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3215,7 +3215,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyStructMyEnumDS(r.returnValue, r.p3);
+            cb->opMyStructMyEnumDS(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3251,7 +3251,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opByteByteSD(r.returnValue, r.p3);
+            cb->opByteByteSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3286,7 +3286,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opBoolBoolSD(r.returnValue, r.p3);
+            cb->opBoolBoolSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3324,7 +3324,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opShortShortSD(r.returnValue, r.p3);
+            cb->opShortShortSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3362,7 +3362,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opIntIntSD(r.returnValue, r.p3);
+            cb->opIntIntSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3400,7 +3400,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opLongLongSD(r.returnValue, r.p3);
+            cb->opLongLongSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3438,7 +3438,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringFloatSD(r.returnValue, r.p3);
+            cb->opStringFloatSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3476,7 +3476,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringDoubleSD(r.returnValue, r.p3);
+            cb->opStringDoubleSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3516,7 +3516,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opStringStringSD(r.returnValue, r.p3);
+            cb->opStringStringSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {
@@ -3555,7 +3555,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         try
         {
             auto r = f.get();
-            cb->opMyEnumMyEnumSD(r.returnValue, r.p3);
+            cb->opMyEnumMyEnumSD(std::get<0>(r), std::get<1>(r));
         }
         catch(const Ice::Exception& ex)
         {

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -82,47 +82,47 @@ allTests(Test::TestHelper* helper)
         s1.v = 0;
         {
             auto result = i->opSAsync(s1).get();
-            test(result.returnValue == s1);
-            test(result.s2 == s1);
+            test(std::get<0>(result) == s1);
+            test(std::get<1>(result) == s1);
         }
 
         Test::SSeq sseq1;
         sseq1.push_back(s1);
         {
             auto result = i->opSSeqAsync(sseq1).get();
-            test(result.returnValue == sseq1);
-            test(result.s2 == sseq1);
+            test(std::get<0>(result) == sseq1);
+            test(std::get<1>(result) == sseq1);
         }
 
         Test::SMap smap1;
         smap1["a"] = s1;
         {
             auto result = i->opSMapAsync(smap1).get();
-            test(result.returnValue == smap1);
-            test(result.s2 == smap1);
+            test(std::get<0>(result) == smap1);
+            test(std::get<1>(result) == smap1);
         }
 
         Test::CPtr c1 =  make_shared<Test::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(result.returnValue, c1));
-            test(Ice::targetEqualTo(result.c2, c1));
+            test(Ice::targetEqualTo(std::get<0>(result), c1));
+            test(Ice::targetEqualTo(std::get<1>(result), c1));
         }
 
         Test::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(result.returnValue[0], c1));
-            test(Ice::targetEqualTo(result.s2[0], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
         }
 
         Test::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(result.returnValue["a"], c1));
-            test(Ice::targetEqualTo(result.c2["a"], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
         }
 
         {
@@ -451,47 +451,47 @@ allTests(Test::TestHelper* helper)
         s1.v = 0;
         {
             auto result = i->opSAsync(s1).get();
-            test(result.returnValue == s1);
-            test(result.s2 == s1);
+            test(std::get<0>(result) == s1);
+            test(std::get<1>(result) == s1);
         }
 
         Test::Inner::Inner2::SSeq sseq1;
         sseq1.push_back(s1);
         {
             auto result = i->opSSeqAsync(sseq1).get();
-            test(result.returnValue == sseq1);
-            test(result.s2 == sseq1);
+            test(std::get<0>(result) == sseq1);
+            test(std::get<1>(result) == sseq1);
         }
 
         Test::Inner::Inner2::SMap smap1;
         smap1["a"] = s1;
         {
             auto result = i->opSMapAsync(smap1).get();
-            test(result.returnValue == smap1);
-            test(result.s2 == smap1);
+            test(std::get<0>(result) == smap1);
+            test(std::get<1>(result) == smap1);
         }
 
         Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(result.returnValue, c1));
-            test(Ice::targetEqualTo(result.c2, c1));
+            test(Ice::targetEqualTo(std::get<0>(result), c1));
+            test(Ice::targetEqualTo(std::get<1>(result), c1));
         }
 
         Test::Inner::Inner2::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(result.returnValue[0], c1));
-            test(Ice::targetEqualTo(result.c2[0], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
         }
 
         Test::Inner::Inner2::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(result.returnValue["a"], c1));
-            test(Ice::targetEqualTo(result.c2["a"], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
         }
     }
 
@@ -728,47 +728,47 @@ allTests(Test::TestHelper* helper)
         s1.v = 0;
         {
             auto result = i->opSAsync(s1).get();
-            test(result.returnValue == s1);
-            test(result.s2 == s1);
+            test(std::get<0>(result) == s1);
+            test(std::get<1>(result) == s1);
         }
 
         Test::Inner::Inner2::SSeq sseq1;
         sseq1.push_back(s1);
         {
             auto result = i->opSSeqAsync(sseq1).get();
-            test(result.returnValue == sseq1);
-            test(result.s2 == sseq1);
+            test(std::get<0>(result) == sseq1);
+            test(std::get<1>(result) == sseq1);
         }
 
         Test::Inner::Inner2::SMap smap1;
         smap1["a"] = s1;
         {
             auto result = i->opSMapAsync(smap1).get();
-            test(result.returnValue == smap1);
-            test(result.s2 == smap1);
+            test(std::get<0>(result) == smap1);
+            test(std::get<1>(result) == smap1);
         }
 
         Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(result.returnValue, c1));
-            test(Ice::targetEqualTo(result.c2, c1));
+            test(Ice::targetEqualTo(std::get<0>(result), c1));
+            test(Ice::targetEqualTo(std::get<1>(result), c1));
         }
 
         Test::Inner::Inner2::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(result.returnValue[0], c1));
-            test(Ice::targetEqualTo(result.c2[0], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
         }
 
         Test::Inner::Inner2::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(result.returnValue["a"], c1));
-            test(Ice::targetEqualTo(result.c2["a"], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
         }
     }
 
@@ -1005,47 +1005,47 @@ allTests(Test::TestHelper* helper)
         s1.v = 0;
         {
             auto result = i->opSAsync(s1).get();
-            test(result.returnValue == s1);
-            test(result.s2 == s1);
+            test(std::get<0>(result) == s1);
+            test(std::get<1>(result) == s1);
         }
 
         Test::SSeq sseq1;
         sseq1.push_back(s1);
         {
             auto result = i->opSSeqAsync(sseq1).get();
-            test(result.returnValue == sseq1);
-            test(result.s2 == sseq1);
+            test(std::get<0>(result) == sseq1);
+            test(std::get<1>(result) == sseq1);
         }
 
         Test::SMap smap1;
         smap1["a"] = s1;
         {
             auto result = i->opSMapAsync(smap1).get();
-            test(result.returnValue == smap1);
-            test(result.s2 == smap1);
+            test(std::get<0>(result) == smap1);
+            test(std::get<1>(result) == smap1);
         }
 
         Test::CPtr c1 = make_shared<Test::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(result.returnValue, c1));
-            test(Ice::targetEqualTo(result.c2, c1));
+            test(Ice::targetEqualTo(std::get<0>(result), c1));
+            test(Ice::targetEqualTo(std::get<1>(result), c1));
         }
 
         Test::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(result.returnValue[0], c1));
-            test(Ice::targetEqualTo(result.c2[0], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
         }
 
         Test::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(result.returnValue["a"], c1));
-            test(Ice::targetEqualTo(result.c2["a"], c1));
+            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
+            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
         }
     }
 

--- a/cpp/test/Ice/slicing/objects/AllTests.cpp
+++ b/cpp/test/Ice/slicing/objects/AllTests.cpp
@@ -1287,8 +1287,8 @@ allTests(Test::TestHelper* helper)
         try
         {
             auto result = f.get();
-            auto b1 = std::move(result.p1);
-            auto b2 = std::move(result.p2);
+            auto b1 = std::move(std::get<0>(result));
+            auto b2 = std::move(std::get<1>(result));
 
             test(b1);
             test(b1->ice_id() == "::Test::D1");
@@ -1372,10 +1372,10 @@ allTests(Test::TestHelper* helper)
         try
         {
             auto result = f.get();
-            test(result.returnValue == result.p1);
+            test(std::get<0>(result) == std::get<1>(result));
 
-            breakCycles(result.returnValue);
-            breakCycles(result.p1);
+            breakCycles(std::get<0>(result));
+            breakCycles(std::get<1>(result));
         }
         catch(...)
         {
@@ -1410,10 +1410,10 @@ allTests(Test::TestHelper* helper)
         try
         {
             auto result = f.get();
-            test(result.returnValue == result.p2);
+            test(std::get<0>(result) == std::get<1>(result));
 
-            breakCycles(result.returnValue);
-            breakCycles(result.p2);
+            breakCycles(std::get<0>(result));
+            breakCycles(std::get<1>(result));
         }
         catch(...)
         {
@@ -1662,9 +1662,9 @@ allTests(Test::TestHelper* helper)
         try
         {
             auto result = f.get();
-            auto ret = result.returnValue;
-            auto p1 = result.p1;
-            auto p2 = result.p2;
+            auto ret = std::get<0>(result);
+            auto p1 = std::get<1>(result);
+            auto p2 = std::get<2>(result);
 
             test(p1);
             test(p1->sb == "D2.sb (p1 1)");
@@ -1725,8 +1725,8 @@ allTests(Test::TestHelper* helper)
         try
         {
             auto result = f.get();
-            auto ret = std::move(result.returnValue);
-            auto b = std::move(result.p);
+            auto ret = std::move(std::get<0>(result));
+            auto b = std::move(std::get<1>(result));
 
             test(b);
             test(b->sb == "D4.sb (1)");
@@ -2165,8 +2165,8 @@ allTests(Test::TestHelper* helper)
             }
 
             auto result = test->dictionaryTestAsync(bin).get();
-            r = result.returnValue;
-            bout = result.bout;
+            r = std::get<0>(result);
+            bout = std::get<1>(result);
 
             test(bout.size() == 10);
             for(i = 0; i < 10; ++i)


### PR DESCRIPTION
This PR updates slice2cpp as follows:

- it moves all the generated code for proxies out-of-line
- it replaces the generated Result struct (used by the proxy future API and the implementation of the proxy sync API) by a tuple; this tuple starts with the return type (if any, at position 0) and is followed by the out param in declaration order.
- it removes the ability to use a promise other than std::promise for the proxy future API
- it changes the order of the generated declarations; in particular, proxies are now fully declared before structs and classes are declared
