### PR TITLE
Update Timer implementation to use std::mutex

### DIFF
--- a/cpp/include/IceUtil/Timer.h
+++ b/cpp/include/IceUtil/Timer.h
@@ -6,11 +6,11 @@
 #define ICE_UTIL_TIMER_H
 
 #include <IceUtil/Thread.h>
-#include <IceUtil/Monitor.h>
 #include <IceUtil/Time.h>
 
 #include <set>
 #include <map>
+#include <mutex>
 #include <functional>
 
 namespace IceUtil
@@ -97,7 +97,8 @@ protected:
         inline bool operator<(const Token& r) const;
     };
 
-    IceUtil::Monitor<IceUtil::Mutex> _monitor;
+    std::mutex _mutex;
+    std::condition_variable _conditionVariable;
     bool _destroyed;
     std::set<Token> _tokens;
 


### PR DESCRIPTION
This PR updates Timer implementation to use `std::mutex` and `std::condition_variable`. Removes the last use of `IceUtil::Mutex` and `IceUtil::Monitor` from the souces.