### PR TITLE
C#: add /opt/homebrew/bin/slice2cs to zeroc.ice.net.props

### DIFF
--- a/csharp/msbuild/zeroc.ice.net.props
+++ b/csharp/msbuild/zeroc.ice.net.props
@@ -28,6 +28,12 @@
                         <IceToolsPath>/usr/local/bin</IceToolsPath>
                     </PropertyGroup>
                 </When>
+                <!-- For Homebrew on macOS with Apple Silicon   -->
+                <When Condition="Exists('/opt/homebrew/bin/slice2cs')">
+                    <PropertyGroup>
+                        <IceToolsPath>/opt/homebrew/bin/slice2cs</IceToolsPath>
+                    </PropertyGroup>
+                </When>
             </Choose>
         </When>
     </Choose>

--- a/csharp/msbuild/zeroc.ice.net.props
+++ b/csharp/msbuild/zeroc.ice.net.props
@@ -31,7 +31,7 @@
                 <!-- For Homebrew on macOS with Apple Silicon   -->
                 <When Condition="Exists('/opt/homebrew/bin/slice2cs')">
                     <PropertyGroup>
-                        <IceToolsPath>/opt/homebrew/bin/slice2cs</IceToolsPath>
+                        <IceToolsPath>/opt/homebrew/bin</IceToolsPath>
                     </PropertyGroup>
                 </When>
             </Choose>


### PR DESCRIPTION
This PR adds `/opt/homebrew/bin/slice2cs` (the default install location for brew on Apple Silicon) to `zeroc.ice.net.props`.  I was going to conditionally check for macOS, but decided against it as I don't see the benefit. 