### PR TITLE
Restore catch (exception_ptr)

### DIFF
--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -206,6 +206,10 @@ OutgoingAsyncBase::invokeResponse()
                 handleInvokeException(current_exception(), this);
             }
         }
+        catch (std::exception_ptr eptr)
+        {
+            rethrow_exception(eptr);
+        }
     }
     catch(const std::exception& ex)
     {


### PR DESCRIPTION
This PR restores a `catch (exception_ptr)` from OutgoingAsync, that I removed by mistake in a previous PR.

You can see the original code here:
https://github.com/zeroc-ice/ice/blob/900b4bc98e271fe7cfd32978ab74d84454d85c03/cpp/src/Ice/OutgoingAsync.cpp#L219

I removed this code because I thought it was a typo. But it's not, since we actually throw the exception_ptr from the generated code:

https://github.com/zeroc-ice/ice/blob/be34214ac075cac67a700b7a93b181ddcc03d374/cpp/src/slice2cpp/Gen.cpp#L2884

This is apparently about getting a better warning message. The test suite does not verify this better warning - which explains why my removal seemed ok.

I don't find this code path elegant. If we want to keep it, we should add a comment.