### PR TITLE
Fix build failure

### DIFF
--- a/matlab/src/msbuild/ice/ice.vcxproj
+++ b/matlab/src/msbuild/ice/ice.vcxproj
@@ -32,10 +32,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>..\..\..\lib\$(Platform)\$(Configuration)\</OutDir>
     <TargetExt>.mexw64</TargetExt>
+    <TargetName>ice</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>..\..\..\lib\$(Platform)\$(Configuration)\</OutDir>
     <TargetExt>.mexw64</TargetExt>
+    <TargetName>ice</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/matlab/src/msbuild/icethunk/icethunk.vcxproj
+++ b/matlab/src/msbuild/icethunk/icethunk.vcxproj
@@ -30,10 +30,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>..\..\..\lib\$(Platform)\$(Configuration)\</OutDir>
     <TargetExt>.dll</TargetExt>
+    <TargetName>icethunk</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>..\..\..\lib\$(Platform)\$(Configuration)\</OutDir>
     <TargetExt>.dll</TargetExt>
+    <TargetName>icethunk</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
The default target names for C++ dlls include the so version. The MATLAB mex and thunk files should not include the version. This PR updates the projects to override the default target names.