### PR TITLE
Remove generation of unused OpNameResult structs in C++

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2687,7 +2687,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     }
 
     H << nl << deprecateSymbol << "::std::future<" << futureT << "> " << name << "Async" << spar << inParamsDecl
-        << contextDecl << epar << "const;";
+        << contextDecl << epar << " const;";
 
     C << sp;
     C << nl << "::std::future<" << futureTAbsolute << ">";


### PR DESCRIPTION
I replaced them by tuples in a previous PR but forgot to remove their generation.