### PR TITLE
Refactor slice2cpp visitors

### DIFF
--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -138,10 +138,11 @@ private:
         void visitModuleEnd(const ModulePtr&) final;
         bool visitStructStart(const StructPtr&) final;
         void visitStructEnd(const StructPtr&) final;
-        void visitDataMember(const DataMemberPtr&) final;
-
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
         bool visitClassDefStart(const ClassDefPtr&) final;
         void visitClassDefEnd(const ClassDefPtr&) final;
+        void visitDataMember(const DataMemberPtr&) final;
 
     private:
 
@@ -160,45 +161,19 @@ private:
         std::list<int> _useWstringHist;
     };
 
-    class ExceptionVisitor final : private ::IceUtil::noncopyable, public ParserVisitor
-    {
-    public:
-        ExceptionVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
-
-        bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
-        bool visitExceptionStart(const ExceptionPtr&) final;
-        void visitExceptionEnd(const ExceptionPtr&) final;
-        void visitDataMember(const DataMemberPtr&) final;
-
-        // Otherwise we visit their data members.
-        bool visitClassDefStart(const ClassDefPtr&) final { return false; }
-        bool visitStructStart(const StructPtr&) final { return false; }
-
-    private:
-
-        ::IceUtilInternal::Output& H;
-        ::IceUtilInternal::Output& C;
-
-        std::string _dllExport;
-        std::string _dllClassExport;
-        std::string _dllMemberExport;
-        bool _doneStaticSymbol;
-        int _useWstring;
-        std::list<int> _useWstringHist;
-    };
-
-    class InterfaceVisitor : private ::IceUtil::noncopyable, public ParserVisitor
+    // Generates the server-side classes that applications use to implement Ice objects.
+    class InterfaceVisitor final : public ParserVisitor
     {
     public:
 
         InterfaceVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        InterfaceVisitor(const InterfaceVisitor&) = delete;
 
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-        virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
-        virtual void visitOperation(const OperationPtr&);
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
     private:
 
@@ -210,7 +185,7 @@ private:
         std::list<int> _useWstringHist;
     };
 
-    // Generates StreamHelper template specializations for enums, structs, classes and exceptions.
+    // Generates internal StreamHelper template specializations for enums, structs, classes and exceptions.
     class StreamVisitor final : public ParserVisitor
     {
     public:
@@ -230,8 +205,6 @@ private:
 
         ::IceUtilInternal::Output& H;
     };
-
-private:
 
     class MetaDataVisitor : public ParserVisitor
     {

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -11,7 +11,7 @@
 namespace Slice
 {
 
-class Gen : private ::IceUtil::noncopyable
+class Gen
 {
 public:
 
@@ -22,9 +22,10 @@ public:
         const std::string&,
         const std::vector<std::string>&,
         const std::string&,
-        const std::string&,
-        bool);
+        const std::string&);
     ~Gen();
+
+    Gen(const Gen&) = delete;
 
     void generate(const UnitPtr&);
     void closeOutput();
@@ -63,26 +64,56 @@ private:
     std::vector<std::string> _includePaths;
     std::string _dllExport;
     std::string _dir;
-    bool _implCpp11;
 
     // Visitors
 
-    class DeclVisitor : private ::IceUtil::noncopyable, public ParserVisitor
+    // Generates forward declarations for classes, proxies and structs. Also generates using for sequences and
+    // dictionaries, enum definitions and constants.
+    class ForwardDeclVisitor final : public ParserVisitor
     {
     public:
 
-        DeclVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        ForwardDeclVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&);
+        ForwardDeclVisitor(const ForwardDeclVisitor&) = delete;
 
-        virtual bool visitUnitStart(const UnitPtr&);
-        virtual void visitUnitEnd(const UnitPtr&);
+        bool visitUnitStart(const UnitPtr&) final;
+        void visitUnitEnd(const UnitPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        void visitClassDecl(const ClassDeclPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final; // TODO: move
+        bool visitStructStart(const StructPtr&) final;
+        void visitInterfaceDecl(const InterfaceDeclPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final; // TODO: move
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+        void visitSequence(const SequencePtr&);
+        void visitDictionary(const DictionaryPtr&);
+        void visitEnum(const EnumPtr&);
+        void visitConst(const ConstPtr&);
+
+    private:
+
+        ::IceUtilInternal::Output& H;
+        ::IceUtilInternal::Output& C; // TODO: probably not needed
+
+        int _useWstring;
+        std::list<int> _useWstringHist;
+    };
+
+    // The second code-generation visitor. We need to generate the proxies early because fields (in structs, classes
+    // and exceptions) can use fields and these fields must see complete proxy types.
+    class ProxyVisitor : public ParserVisitor
+    {
+    public:
+
+        ProxyVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        ProxyVisitor(const ProxyVisitor&) = delete;
+
         virtual bool visitModuleStart(const ModulePtr&);
         virtual void visitModuleEnd(const ModulePtr&);
-        virtual void visitClassDecl(const ClassDeclPtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&);
-        virtual bool visitStructStart(const StructPtr&);
-        virtual void visitInterfaceDecl(const InterfaceDeclPtr&);
         virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-        virtual bool visitExceptionStart(const ExceptionPtr&);
+        virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
         virtual void visitOperation(const OperationPtr&);
 
     private:
@@ -91,24 +122,6 @@ private:
         ::IceUtilInternal::Output& C;
 
         std::string _dllExport;
-    };
-
-    class TypesVisitor : private ::IceUtil::noncopyable, public ParserVisitor
-    {
-    public:
-
-        TypesVisitor(::IceUtilInternal::Output&);
-
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual void visitSequence(const SequencePtr&);
-        virtual void visitDictionary(const DictionaryPtr&);
-        virtual void visitEnum(const EnumPtr&);
-        virtual void visitConst(const ConstPtr&);
-
-    private:
-
-        ::IceUtilInternal::Output& H;
         int _useWstring;
         std::list<int> _useWstringHist;
     };
@@ -160,28 +173,6 @@ private:
         std::string _dllClassExport;
         std::string _dllMemberExport;
         bool _doneStaticSymbol;
-        int _useWstring;
-        std::list<int> _useWstringHist;
-    };
-
-    class ProxyVisitor : private ::IceUtil::noncopyable, public ParserVisitor
-    {
-    public:
-
-        ProxyVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
-
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-        virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
-        virtual void visitOperation(const OperationPtr&);
-
-    private:
-
-        ::IceUtilInternal::Output& H;
-        ::IceUtilInternal::Output& C;
-
-        std::string _dllExport;
         int _useWstring;
         std::list<int> _useWstringHist;
     };
@@ -262,48 +253,6 @@ private:
         ::IceUtilInternal::Output& H;
         ::IceUtilInternal::Output& C;
         std::string _dllExport;
-    };
-
-    class CompatibilityVisitor : private ::IceUtil::noncopyable, public ParserVisitor
-    {
-    public:
-
-        CompatibilityVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
-
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual void visitClassDecl(const ClassDeclPtr&);
-        virtual void visitInterfaceDecl(const InterfaceDeclPtr&);
-
-    private:
-
-        ::IceUtilInternal::Output& H;
-        std::string _dllExport;
-    };
-
-    class ImplVisitor : private ::IceUtil::noncopyable, public ParserVisitor
-    {
-    public:
-
-        ImplVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
-
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-
-    private:
-
-        ::IceUtilInternal::Output& H;
-        ::IceUtilInternal::Output& C;
-
-        std::string _dllExport;
-        int _useWstring;
-        std::list<int> _useWstringHist;
-
-        //
-        // Get the default value returned for a type
-        //
-        std::string defaultValue(const TypePtr&, const std::string&, const StringList&) const;
     };
 
 private:

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -177,29 +177,6 @@ private:
         std::list<int> _useWstringHist;
     };
 
-    class ObjectVisitor : public ParserVisitor
-    {
-    public:
-
-        ObjectVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
-
-    protected:
-
-        bool emitBaseInitializers(const ClassDefPtr&);
-        void emitOneShotConstructor(const ClassDefPtr&);
-        void emitDataMember(const DataMemberPtr&);
-
-        ::IceUtilInternal::Output& H;
-        ::IceUtilInternal::Output& C;
-
-        std::string _dllExport;
-        std::string _dllClassExport;
-        std::string _dllMemberExport;
-        bool _doneStaticSymbol;
-        int _useWstring;
-        std::list<int> _useWstringHist;
-    };
-
     class InterfaceVisitor : private ::IceUtil::noncopyable, public ParserVisitor
     {
     public:
@@ -222,31 +199,50 @@ private:
         std::list<int> _useWstringHist;
     };
 
-    class ValueVisitor : private ::IceUtil::noncopyable, public ObjectVisitor
+    class ValueVisitor final : public ParserVisitor
     {
     public:
 
         ValueVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        ValueVisitor(const ValueVisitor&) = delete;
 
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&);
-        virtual void visitClassDefEnd(const ClassDefPtr&);
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+
+    private:
+
+        bool emitBaseInitializers(const ClassDefPtr&);
+        void emitOneShotConstructor(const ClassDefPtr&);
+        void emitDataMember(const DataMemberPtr&);
+
+        ::IceUtilInternal::Output& H;
+        ::IceUtilInternal::Output& C;
+
+        std::string _dllExport;
+        std::string _dllClassExport;
+        std::string _dllMemberExport;
+        bool _doneStaticSymbol;
+        int _useWstring;
+        std::list<int> _useWstringHist;
     };
 
-    class StreamVisitor : private ::IceUtil::noncopyable, public ParserVisitor
+    // Generates StreamHelper template specializations for enums, structs, classes and exceptions.
+    class StreamVisitor final : public ParserVisitor
     {
     public:
 
         StreamVisitor(::IceUtilInternal::Output&, ::IceUtilInternal::Output&, const std::string&);
+        StreamVisitor(const StreamVisitor&) = delete;
 
-        virtual bool visitModuleStart(const ModulePtr&);
-        virtual void visitModuleEnd(const ModulePtr&);
-        virtual bool visitStructStart(const StructPtr&);
-        virtual bool visitClassDefStart(const ClassDefPtr&);
-        virtual bool visitExceptionStart(const ExceptionPtr&);
-        virtual void visitExceptionEnd(const ExceptionPtr&);
-        virtual void visitEnum(const EnumPtr&);
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+        void visitEnum(const EnumPtr&);
 
     private:
 

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -56,7 +56,6 @@ usage(const string& n)
         "--source-ext EXT         Use EXT instead of the default `cpp' extension.\n"
         "--add-header HDR[,GUARD] Add #include for HDR (with guard GUARD) to generated source file.\n"
         "--include-dir DIR        Use DIR as the header include directory in source files.\n"
-        "--impl-c++11             Generate sample implementations for C++11 mapping.\n"
         "--dll-export SYMBOL      Use SYMBOL for DLL exports\n"
         "                         deprecated: use instead [[\"cpp:dll-export:SYMBOL\"]] metadata.\n"
         ;
@@ -79,7 +78,6 @@ compile(const vector<string>& argv)
     opts.addOpt("", "include-dir", IceUtilInternal::Options::NeedArg);
     opts.addOpt("", "output-dir", IceUtilInternal::Options::NeedArg);
     opts.addOpt("", "dll-export", IceUtilInternal::Options::NeedArg);
-    opts.addOpt("", "impl-c++11");
     opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceUtilInternal::Options::NeedArg, "");
@@ -145,8 +143,6 @@ compile(const vector<string>& argv)
     string output = opts.optArg("output-dir");
 
     string dllExport = opts.optArg("dll-export");
-
-    bool implCpp11 = opts.isSet("impl-c++11");
 
     bool depend = opts.isSet("depend");
 
@@ -289,7 +285,7 @@ compile(const vector<string>& argv)
                     try
                     {
                         Gen gen(icecpp->getBaseName(), headerExtension, sourceExtension, extraHeaders, include,
-                                includePaths, dllExport, output, implCpp11);
+                                includePaths, dllExport, output);
                         gen.generate(u);
                     }
                     catch(const Slice::FileException& ex)


### PR DESCRIPTION
This PR refactors the visitors used by slice2cpp. It doesn't change the generated code except for:
 - some minor reordering
 - we no longer generate forward declarations for server-side interfaces (we don't need them)

This PR also removes the --impl option from slice2cpp.
