### PR TITLE
Another fix for Slice compiler directory creation

### DIFF
--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -703,14 +703,14 @@ Slice::JavaOutput::openClass(const string& cls, const string& prefix, const stri
             int err = IceUtilInternal::mkdir(path, 0777);
             // If slice2java is run concurrently, it's possible that another instance of slice2java has already
             // created the directory.
-            if (err == EEXIST && IceUtilInternal::directoryExists(path))
+            if (err == 0 || (errno == EEXIST && IceUtilInternal::directoryExists(path)))
             {
-                // Directory already exists, ignore the error
+                // Directory successfully created or already exists.
             }
-            else if(err != 0)
+            else
             {
                 ostringstream os;
-                os << "cannot create directory `" << path << "': " << IceUtilInternal::errorToString(err);
+                os << "cannot create directory `" << path << "': " << IceUtilInternal::errorToString(errno);
                 throw FileException(__FILE__, __LINE__, os.str());
             }
             FileTracker::instance()->addDirectory(path);

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -236,14 +236,14 @@ openClass(const string& abs, const string& dir, IceUtilInternal::Output& out)
             int err = IceUtilInternal::mkdir(path, 0777);
             // If slice2matlab is run concurrently, it's possible that another instance of slice2matlab has already
             // created the directory.
-            if (err == EEXIST && IceUtilInternal::directoryExists(path))
+            if (err == 0 || (errno == EEXIST && IceUtilInternal::directoryExists(path)))
             {
-                // Directory already exists, ignore the error
+                // Directory successfully created or already exists.
             }
-            else if(err != 0)
+            else
             {
                 ostringstream os;
-                os << "cannot create directory `" << path << "': " << IceUtilInternal::errorToString(err);
+                os << "cannot create directory `" << path << "': " << IceUtilInternal::errorToString(errno);
                 throw FileException(__FILE__, __LINE__, os.str());
             }
             FileTracker::instance()->addDirectory(path);


### PR DESCRIPTION
The previous fix for #1846 was incorrect, `mkdir` and `_mkdir` return `-1` on error and set errno. My previous fix was incorrectly comparing the return value against `EEXIST`