### PR TITLE
Using string_view for operation names

### DIFF
--- a/cpp/include/Ice/BatchRequestInterceptor.h
+++ b/cpp/include/Ice/BatchRequestInterceptor.h
@@ -37,7 +37,7 @@ public:
      * Obtains the name of the operation.
      * @return The operation name.
      */
-    virtual const std::string& getOperation() const = 0;
+    virtual std::string_view getOperation() const = 0;
 
     /**
      * Obtains the proxy on which the batch request was invoked.

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -369,7 +369,7 @@ public:
      * @param ctx The context specified by the user.
      * @return The invocation observer to instrument the invocation.
      */
-    virtual InvocationObserverPtr getInvocationObserver(const std::optional<Ice::ObjectPrx>& prx, const ::std::string& operation, const ::Ice::Context& ctx) = 0;
+    virtual InvocationObserverPtr getInvocationObserver(const std::optional<Ice::ObjectPrx>& prx, std::string_view operation, const ::Ice::Context& ctx) = 0;
 
     /**
      * This method should return a dispatch observer for the given dispatch. The Ice run-time calls this method each

--- a/cpp/include/Ice/ObserverHelper.h
+++ b/cpp/include/Ice/ObserverHelper.h
@@ -117,12 +117,12 @@ class ICE_API InvocationObserver : public ObserverHelperT<Ice::Instrumentation::
 {
 public:
 
-    InvocationObserver(const Ice::ObjectPrx&, const std::string&, const Ice::Context&);
-    InvocationObserver(Instance*, const std::string&);
+    InvocationObserver(const Ice::ObjectPrx& proxy, std::string_view operation, const Ice::Context& context);
+    InvocationObserver(Instance* instance, std::string_view operation);
     InvocationObserver() = default;
 
-    void attach(const Ice::ObjectPrx&, const std::string&, const Ice::Context&);
-    void attach(Instance*, const std::string&);
+    void attach(const Ice::ObjectPrx&, std::string_view operation, const Ice::Context&);
+    void attach(Instance*, std::string_view operation);
 
     void retried()
     {

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -197,7 +197,7 @@ public:
 
     OutgoingAsync(Ice::ObjectPrx, bool);
 
-    void prepare(const std::string&, Ice::OperationMode, const Ice::Context&);
+    void prepare(std::string_view operation, Ice::OperationMode mode, const Ice::Context& context);
 
     virtual bool sent();
     virtual bool response();
@@ -206,8 +206,8 @@ public:
     virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*);
 
     void abort(std::exception_ptr);
-    void invoke(const std::string&);
-    void invoke(const std::string&, Ice::OperationMode, Ice::FormatType, const Ice::Context&,
+    void invoke(std::string_view);
+    void invoke(std::string_view, Ice::OperationMode, Ice::FormatType, const Ice::Context&,
                 std::function<void(Ice::OutputStream*)>);
     void throwUserException();
 
@@ -324,7 +324,7 @@ public:
     using OutgoingAsync::OutgoingAsync;
 
     void
-    invoke(const std::string& operation,
+    invoke(std::string_view operation,
            Ice::OperationMode mode,
            Ice::FormatType format,
            const Ice::Context& ctx,
@@ -342,7 +342,7 @@ public:
     }
 
     void
-    invoke(const std::string& operation,
+    invoke(std::string_view operation,
            Ice::OperationMode mode,
            Ice::FormatType format,
            const Ice::Context& ctx,
@@ -368,7 +368,7 @@ public:
     using OutgoingAsync::OutgoingAsync;
 
     void
-    invoke(const std::string& operation,
+    invoke(std::string_view operation,
            Ice::OperationMode mode,
            Ice::FormatType format,
            const Ice::Context& ctx,
@@ -480,7 +480,7 @@ public:
     }
 
     void
-    invoke(const std::string& operation,
+    invoke(std::string_view operation,
            Ice::OperationMode mode,
            Ice::FormatType format,
            const Ice::Context& ctx,

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -483,7 +483,7 @@ public:
      * exception, it throws it directly.
      */
     bool
-    ice_invoke(const std::string& operation,
+    ice_invoke(std::string_view operation,
                Ice::OperationMode mode,
                const std::vector<Byte>& inParams,
                std::vector<Ice::Byte>& outParams,
@@ -498,7 +498,7 @@ public:
      * @return The future object for the invocation.
      */
     std::future<std::tuple<bool, std::vector<Ice::Byte>>>
-    ice_invokeAsync(const std::string& operation,
+    ice_invokeAsync(std::string_view operation,
                     Ice::OperationMode mode,
                     const std::vector<Byte>& inParams,
                     const Ice::Context& context = Ice::noExplicitContext) const;
@@ -515,7 +515,7 @@ public:
      * @return A function that can be called to cancel the invocation locally.
      */
     std::function<void()>
-    ice_invokeAsync(const std::string& operation,
+    ice_invokeAsync(std::string_view operation,
                     Ice::OperationMode mode,
                     const std::vector<Ice::Byte>& inParams,
                     std::function<void(bool, std::vector<Ice::Byte>)> response,
@@ -536,7 +536,7 @@ public:
      * exception, it throws it directly.
      */
     bool
-    ice_invoke(const std::string& operation,
+    ice_invoke(std::string_view operation,
                Ice::OperationMode mode,
                const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
                std::vector<Ice::Byte>& outParams,
@@ -551,7 +551,7 @@ public:
      * @return The future object for the invocation.
      */
     std::future<std::tuple<bool, std::vector<Ice::Byte>>>
-    ice_invokeAsync(const std::string& operation,
+    ice_invokeAsync(std::string_view operation,
                     Ice::OperationMode mode,
                     const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
                     const Ice::Context& context = Ice::noExplicitContext) const;
@@ -568,7 +568,7 @@ public:
      * @return A function that can be called to cancel the invocation locally.
      */
     std::function<void()>
-    ice_invokeAsync(const std::string& operation,
+    ice_invokeAsync(std::string_view operation,
                     Ice::OperationMode mode,
                     const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
                     std::function<void(bool, std::pair<const Ice::Byte*, const Ice::Byte*>)> response,

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -17,47 +17,31 @@ namespace
 
 const int udpOverhead = 20 + 8;
 
-class BatchRequestI : public Ice::BatchRequest
+class BatchRequestI final : public Ice::BatchRequest
 {
 public:
-
-    BatchRequestI(BatchRequestQueue& queue, const Ice::ObjectPrx& proxy, const string& operation, int size) :
-        _queue(queue), _proxy(proxy), _operation(operation), _size(size)
+    BatchRequestI(BatchRequestQueue& queue, const Ice::ObjectPrx& proxy, string_view operation, int size)
+        : _queue(queue),
+          _proxy(proxy),
+          _operation(operation),
+          _size(size)
     {
     }
 
-    virtual void
-    enqueue() const
-    {
-        _queue.enqueueBatchRequest(_proxy);
-    }
+    void enqueue() const final { _queue.enqueueBatchRequest(_proxy); }
 
-    virtual int
-    getSize() const
-    {
-        return _size;
-    }
+    int getSize() const final { return _size; }
 
-    virtual const std::string&
-    getOperation() const
-    {
-        return _operation;
-    }
+    string_view getOperation() const { return _operation; }
 
-    virtual const Ice::ObjectPrx&
-    getProxy() const
-    {
-        return _proxy;
-    }
+    const Ice::ObjectPrx& getProxy() const final { return _proxy; }
 
 private:
-
     BatchRequestQueue& _queue;
     const Ice::ObjectPrx& _proxy;
-    const std::string& _operation;
+    const string_view _operation;
     const int _size;
 };
-
 }
 
 BatchRequestQueue::BatchRequestQueue(const InstancePtr& instance, bool datagram) :
@@ -100,7 +84,7 @@ BatchRequestQueue::prepareBatchRequest(OutputStream* os)
 void
 BatchRequestQueue::finishBatchRequest(OutputStream* os,
                                       const Ice::ObjectPrx& proxy,
-                                      const std::string& operation)
+                                      string_view operation)
 {
     //
     // No need for synchronization, no other threads are supposed

--- a/cpp/src/Ice/BatchRequestQueue.h
+++ b/cpp/src/Ice/BatchRequestQueue.h
@@ -23,7 +23,7 @@ public:
     BatchRequestQueue(const InstancePtr&, bool);
 
     void prepareBatchRequest(Ice::OutputStream*);
-    void finishBatchRequest(Ice::OutputStream*, const Ice::ObjectPrx&, const std::string&);
+    void finishBatchRequest(Ice::OutputStream*, const Ice::ObjectPrx&, std::string_view);
     void abortBatchRequest(Ice::OutputStream*);
 
     int swap(Ice::OutputStream*, bool&);

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -146,7 +146,7 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
 }
 
 void
-CommunicatorFlushBatchAsync::invoke(const string& operation, CompressBatch compressBatch)
+CommunicatorFlushBatchAsync::invoke(string_view operation, CompressBatch compressBatch)
 {
     _observer.attach(_instance.get(), operation);
     _instance->outgoingConnectionFactory()->flushAsyncBatchRequests(shared_from_this(), compressBatch);
@@ -377,13 +377,6 @@ Ice::CommunicatorI::postToClientThreadPool(function<void()> call)
     _instance->clientThreadPool()->dispatch(call);
 }
 
-namespace
-{
-
-const ::std::string flushBatchRequests_name = "flushBatchRequests";
-
-}
-
 ::std::function<void()>
 Ice::CommunicatorI::flushBatchRequestsAsync(CompressBatch compress,
                                             function<void(exception_ptr)> ex,
@@ -401,7 +394,8 @@ Ice::CommunicatorI::flushBatchRequestsAsync(CompressBatch compress,
         }
     };
     auto outAsync = make_shared<CommunicatorFlushBatchLambda>(_instance, ex, sent);
-    outAsync->invoke(flushBatchRequests_name, compress);
+    static constexpr string_view operationName = "flushBatchRequests";
+    outAsync->invoke(operationName, compress);
     return [outAsync]() { outAsync->cancel(); };
 }
 

--- a/cpp/src/Ice/CommunicatorI.h
+++ b/cpp/src/Ice/CommunicatorI.h
@@ -28,7 +28,7 @@ public:
     CommunicatorFlushBatchAsync(const InstancePtr&);
 
     void flushConnection(const Ice::ConnectionIPtr&, Ice::CompressBatch);
-    void invoke(const std::string&, Ice::CompressBatch);
+    void invoke(std::string_view, Ice::CompressBatch);
 
     std::shared_ptr<CommunicatorFlushBatchAsync> shared_from_this()
     {

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -362,7 +362,7 @@ public:
         }
     };
     static Attributes attributes;
-    InvocationHelper(const optional<ObjectPrx>& proxy, const string& op, const Context& ctx) :
+    InvocationHelper(const optional<ObjectPrx>& proxy, string_view op, const Context& ctx) :
         _proxy(proxy), _operation(op), _context(ctx)
     {
     }
@@ -472,7 +472,7 @@ public:
         }
     }
 
-    const string&
+    string_view
     getOperation() const
     {
         return _operation;
@@ -481,7 +481,7 @@ public:
 private:
 
     const optional<ObjectPrx>& _proxy;
-    const string& _operation;
+    string_view _operation;
     const Context& _context;
     mutable string _id;
 };
@@ -1024,7 +1024,7 @@ CommunicatorObserverI::getThreadObserver(const string& parent,
 }
 
 InvocationObserverPtr
-CommunicatorObserverI::getInvocationObserver(const optional<ObjectPrx>& proxy, const string& op, const Context& ctx)
+CommunicatorObserverI::getInvocationObserver(const optional<ObjectPrx>& proxy, string_view op, const Context& ctx)
 {
     if(_invocations.isEnabled())
     {

--- a/cpp/src/Ice/InstrumentationI.h
+++ b/cpp/src/Ice/InstrumentationI.h
@@ -228,7 +228,7 @@ public:
                                                                       const Ice::Instrumentation::ThreadObserverPtr&);
 
     virtual Ice::Instrumentation::InvocationObserverPtr getInvocationObserver(const std::optional<Ice::ObjectPrx>&,
-                                                                              const std::string&,
+                                                                              std::string_view,
                                                                               const Ice::Context&);
 
     virtual Ice::Instrumentation::DispatchObserverPtr getDispatchObserver(const Ice::Current&, std::int32_t);

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -41,7 +41,7 @@ public:
 
     vector<RemoteLoggerPrx> log(const LogMessage&);
 
-    void deadRemoteLogger(const RemoteLoggerPrx&, const LoggerPtr&, exception_ptr, const string&);
+    void deadRemoteLogger(const RemoteLoggerPrx&, const LoggerPtr&, exception_ptr, std::string_view);
 
     int getTraceLevel() const
     {
@@ -548,7 +548,7 @@ void
 LoggerAdminI::deadRemoteLogger(const RemoteLoggerPrx& remoteLogger,
                                const LoggerPtr& logger,
                                std::exception_ptr ex,
-                               const string& operation)
+                               string_view operation)
 {
     //
     // No need to convert remoteLogger as we only use its identity

--- a/cpp/src/Ice/ObserverHelper.cpp
+++ b/cpp/src/Ice/ObserverHelper.cpp
@@ -11,7 +11,7 @@ using namespace std;
 using namespace Ice;
 using namespace Ice::Instrumentation;
 
-IceInternal::InvocationObserver::InvocationObserver(const Ice::ObjectPrx& proxy, const string& op, const Context& ctx)
+IceInternal::InvocationObserver::InvocationObserver(const Ice::ObjectPrx& proxy, string_view op, const Context& ctx)
 {
     const CommunicatorObserverPtr& obsv = proxy->_getReference()->getInstance()->initializationData().observer;
     if(!obsv)
@@ -21,7 +21,7 @@ IceInternal::InvocationObserver::InvocationObserver(const Ice::ObjectPrx& proxy,
     attach(obsv->getInvocationObserver(proxy, op, ctx));
 }
 
-IceInternal::InvocationObserver::InvocationObserver(IceInternal::Instance* instance, const string& op)
+IceInternal::InvocationObserver::InvocationObserver(IceInternal::Instance* instance, string_view op)
 {
     const CommunicatorObserverPtr& obsv = instance->initializationData().observer;
     if(!obsv)
@@ -33,7 +33,7 @@ IceInternal::InvocationObserver::InvocationObserver(IceInternal::Instance* insta
 }
 
 void
-IceInternal::InvocationObserver::attach(const Ice::ObjectPrx& proxy, const string& op, const Context& ctx)
+IceInternal::InvocationObserver::attach(const Ice::ObjectPrx& proxy, string_view op, const Context& ctx)
 {
     const CommunicatorObserverPtr& obsv = proxy->_getReference()->getInstance()->initializationData().observer;
     if(!obsv)
@@ -44,7 +44,7 @@ IceInternal::InvocationObserver::attach(const Ice::ObjectPrx& proxy, const strin
 }
 
 void
-IceInternal::InvocationObserver::attach(IceInternal::Instance* instance, const string& op)
+IceInternal::InvocationObserver::attach(IceInternal::Instance* instance, string_view op)
 {
     const CommunicatorObserverPtr& obsv = instance->initializationData().observer;
     if(!obsv)

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -638,7 +638,7 @@ OutgoingAsync::OutgoingAsync(ObjectPrx proxy, bool synchronous) :
 }
 
 void
-OutgoingAsync::prepare(const string& operation, OperationMode mode, const Context& context)
+OutgoingAsync::prepare(string_view operation, OperationMode mode, const Context& context)
 {
     checkSupportedProtocol(getCompatibleProtocol(_proxy._getReference()->getProtocol()));
 
@@ -886,7 +886,7 @@ OutgoingAsync::abort(std::exception_ptr ex)
 }
 
 void
-OutgoingAsync::invoke(const string& operation)
+OutgoingAsync::invoke(string_view operation)
 {
     if (_proxy._getReference()->isBatch())
     {
@@ -908,7 +908,7 @@ OutgoingAsync::invoke(const string& operation)
 }
 
 void
-OutgoingAsync::invoke(const string& operation,
+OutgoingAsync::invoke(string_view operation,
                       Ice::OperationMode mode,
                       Ice::FormatType format,
                       const Ice::Context& context,

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -17,19 +17,6 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-namespace
-{
-
-const string ice_ping_name = "ice_ping";
-const string ice_ids_name = "ice_ids";
-const string ice_id_name = "ice_id";
-const string ice_isA_name = "ice_isA";
-const string ice_invoke_name = "ice_invoke";
-const string ice_getConnection_name = "ice_getConnection";
-const string ice_flushBatchRequests_name = "ice_flushBatchRequests";
-
-}
-
 namespace IceInternal
 {
 
@@ -58,7 +45,7 @@ public:
     virtual AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool);
     virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*);
 
-    void invoke(const string&);
+    void invoke(string_view operation);
 
 private:
 
@@ -79,7 +66,7 @@ public:
 
     virtual Ice::ConnectionPtr getConnection() const;
 
-    void invoke(const string&);
+    void invoke(string_view operation);
 };
 
 class ProxyGetConnectionLambda : public ProxyGetConnection, public LambdaInvoke
@@ -145,7 +132,7 @@ public:
     using OutgoingAsync::OutgoingAsync;
 
     void
-    invoke(const std::string& operation,
+    invoke(string_view operation,
            Ice::OperationMode mode,
            const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
            const Ice::Context& context)
@@ -284,7 +271,7 @@ ProxyFlushBatchAsync::invokeCollocated(CollocatedRequestHandler* handler)
 }
 
 void
-ProxyFlushBatchAsync::invoke(const string& operation)
+ProxyFlushBatchAsync::invoke(string_view operation)
 {
     checkSupportedProtocol(getCompatibleProtocol(_proxy->_getReference()->getProtocol()));
     _observer.attach(_proxy, operation, noExplicitContext);
@@ -325,7 +312,7 @@ ProxyGetConnection::getConnection() const
 }
 
 void
-ProxyGetConnection::invoke(const string& operation)
+ProxyGetConnection::invoke(string_view operation)
 {
     _observer.attach(_proxy, operation, noExplicitContext);
     invokeImpl(true); // userThread = true
@@ -360,8 +347,9 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<OutgoingAsyncT<bool>>& outAsync,
                           string_view typeId,
                           const Context& ctx) const
 {
-    _checkTwowayOnly(ice_isA_name);
-    outAsync->invoke(ice_isA_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx,
+    static constexpr string_view operationName = "ice_isA";
+    _checkTwowayOnly(operationName);
+    outAsync->invoke(operationName, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx,
                      [&](Ice::OutputStream* os)
                      {
                          os->write(typeId, false);
@@ -395,7 +383,8 @@ Ice::ObjectPrx::ice_pingAsync(const Ice::Context& context) const
 void
 Ice::ObjectPrx::_iceI_ping(const shared_ptr<OutgoingAsyncT<void>>& outAsync, const Context& ctx) const
 {
-    outAsync->invoke(ice_ping_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr);
+    static constexpr string_view operationName = "ice_ping";
+    outAsync->invoke(operationName, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr);
 }
 
 vector<string>
@@ -424,8 +413,9 @@ Ice::ObjectPrx::ice_idsAsync(const Ice::Context& context) const
 void
 Ice::ObjectPrx::_iceI_ids(const shared_ptr<OutgoingAsyncT<vector<string>>>& outAsync, const Context& ctx) const
 {
-    _checkTwowayOnly(ice_ids_name);
-    outAsync->invoke(ice_ids_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
+    static constexpr string_view operationName = "ice_ids";
+    _checkTwowayOnly(operationName);
+    outAsync->invoke(operationName, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          vector<string> v;
@@ -459,8 +449,9 @@ Ice::ObjectPrx::ice_idAsync(const Ice::Context& context) const
 void
 Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, const Context& ctx) const
 {
-    _checkTwowayOnly(ice_id_name);
-    outAsync->invoke(ice_id_name, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
+    static constexpr string_view operationName = "ice_id";
+    _checkTwowayOnly(operationName);
+    outAsync->invoke(operationName, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr,
                      [](Ice::InputStream* stream)
                      {
                          string v;
@@ -469,7 +460,7 @@ Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, con
                      });
 }
 
-bool Ice::ObjectPrx::ice_invoke(const string &operation,
+bool Ice::ObjectPrx::ice_invoke(string_view operation,
                                 Ice::OperationMode mode,
                                 const vector<Byte> &inParams,
                                 vector<Ice::Byte> &outParams,
@@ -479,7 +470,7 @@ bool Ice::ObjectPrx::ice_invoke(const string &operation,
 }
 
 std::future<std::tuple<bool, vector<Byte>>>
-Ice::ObjectPrx::ice_invokeAsync(const string &operation,
+Ice::ObjectPrx::ice_invokeAsync(string_view operation,
                                 Ice::OperationMode mode,
                                 const vector<Byte> &inParams,
                                 const Ice::Context &context) const
@@ -488,7 +479,7 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 }
 
 std::function<void()>
-Ice::ObjectPrx::ice_invokeAsync(const string &operation,
+Ice::ObjectPrx::ice_invokeAsync(string_view operation,
                                 Ice::OperationMode mode,
                                 const vector<Ice::Byte> &inParams,
                                 std::function<void(bool, vector<Ice::Byte>)> response,
@@ -512,7 +503,7 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
     { outAsync->cancel(); };
 }
 
-bool Ice::ObjectPrx::ice_invoke(const string &operation,
+bool Ice::ObjectPrx::ice_invoke(string_view operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
                                 vector<Ice::Byte> &outParams,
@@ -528,7 +519,7 @@ bool Ice::ObjectPrx::ice_invoke(const string &operation,
 }
 
 std::future<std::tuple<bool, vector<Byte>>>
-Ice::ObjectPrx::ice_invokeAsync(const string &operation,
+Ice::ObjectPrx::ice_invokeAsync(string_view operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
                                 const Ice::Context &context) const
@@ -541,7 +532,7 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 }
 
 std::function<void()>
-Ice::ObjectPrx::ice_invokeAsync(const string &operation,
+Ice::ObjectPrx::ice_invokeAsync(string_view operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
                                 std::function<void(bool, std::pair<const Ice::Byte *, const Ice::Byte *>)> response,
@@ -595,7 +586,8 @@ std::future<std::shared_ptr<Ice::Connection>> Ice::ObjectPrx::ice_getConnectionA
 void
 Ice::ObjectPrx::_iceI_getConnection(const shared_ptr<ProxyGetConnection>& outAsync) const
 {
-    outAsync->invoke(ice_getConnection_name);
+    static constexpr string_view operationName = "ice_getConnection";
+    outAsync->invoke(operationName);
 }
 
 void Ice::ObjectPrx::ice_flushBatchRequests() const
@@ -644,5 +636,6 @@ std::future<void> Ice::ObjectPrx::ice_flushBatchRequestsAsync() const
 void
 Ice::ObjectPrx::_iceI_flushBatchRequests(const shared_ptr<ProxyFlushBatchAsync>& outAsync) const
 {
-    outAsync->invoke(ice_flushBatchRequests_name);
+    static constexpr string_view operationName = "ice_flushBatchRequests";
+    outAsync->invoke(operationName);
 }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2169,8 +2169,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         //
         C << sb;
 
-        // TODO: switch to string_view and constexpr.
-        C << nl << "static const ::std::string operationName = \"" << name << "\";";
+        C << nl << "static constexpr ::std::string_view operationName = \"" << name << "\";";
         C << sp;
 
         if(p->returnsData())
@@ -2289,8 +2288,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     C << inParamsImplDecl << ("const " + getUnqualified("::Ice::Context&", interfaceScope) + " context");
     C << epar << " const";
     C << sb;
-    // TODO: switch to string_view and constexpr.
-    C << nl << "static const ::std::string operationName = \"" << name << "\";";
+    C << nl << "static constexpr ::std::string_view operationName = \"" << name << "\";";
     C << sp;
     if(p->returnsData())
     {

--- a/cpp/test/Ice/metrics/InstrumentationI.h
+++ b/cpp/test/Ice/metrics/InstrumentationI.h
@@ -323,7 +323,7 @@ public:
    }
 
     virtual Ice::Instrumentation::InvocationObserverPtr
-    getInvocationObserver(const Ice::ObjectPrxPtr&, const std::string&, const Ice::Context&)
+    getInvocationObserver(const Ice::ObjectPrxPtr&, std::string_view, const Ice::Context&)
     {
         std::lock_guard lock(_mutex);
         if(!invocationObserver)

--- a/cpp/test/Ice/retry/InstrumentationI.cpp
+++ b/cpp/test/Ice/retry/InstrumentationI.cpp
@@ -105,7 +105,7 @@ public:
     }
 
     virtual Ice::Instrumentation::InvocationObserverPtr
-    getInvocationObserver(const Ice::ObjectPrxPtr&, const ::std::string&, const Ice::Context&)
+    getInvocationObserver(const Ice::ObjectPrxPtr&, std::string_view, const Ice::Context&)
     {
         return invocationObserver;
     }


### PR DESCRIPTION
This PR updates Ice C++ to pass operation names as string_view instead of const string&.

Interestingly, we never store these string into actual string instances (and this PR doesn't change that). I suspect this is not strictly correct: it works because the generated code uses static strings, but if you use the invokeAsync API with short-lived strings for your operation names, you could get a crash.
