### PR TITLE
Remove Ice::Byte

### DIFF
--- a/cpp/include/Ice/Buffer.h
+++ b/cpp/include/Ice/Buffer.h
@@ -15,7 +15,7 @@ class ICE_API Buffer : private IceUtil::noncopyable
 public:
 
     Buffer() : i(b.begin()) { }
-    Buffer(const Ice::Byte* beg, const Ice::Byte* end) : b(beg, end), i(b.begin()) { }
+    Buffer(const std::uint8_t* beg, const std::uint8_t* end) : b(beg, end), i(b.begin()) { }
     Buffer(const std::vector<Ice::Byte>& v) : b(v), i(b.begin()) { }
     Buffer(Buffer& o, bool adopt) : b(o.b, adopt), i(b.begin()) { }
 
@@ -29,12 +29,12 @@ public:
         // Standard vector-like operations.
         //
 
-        typedef Ice::Byte value_type;
-        typedef Ice::Byte* iterator;
-        typedef const Ice::Byte* const_iterator;
-        typedef Ice::Byte& reference;
-        typedef const Ice::Byte& const_reference;
-        typedef Ice::Byte* pointer;
+        typedef std::uint8_t value_type;
+        typedef std::uint8_t* iterator;
+        typedef const std::uint8_t* const_iterator;
+        typedef std::uint8_t& reference;
+        typedef const std::uint8_t& const_reference;
+        typedef std::uint8_t* pointer;
         typedef size_t size_type;
 
         Container();

--- a/cpp/include/Ice/Buffer.h
+++ b/cpp/include/Ice/Buffer.h
@@ -16,7 +16,7 @@ public:
 
     Buffer() : i(b.begin()) { }
     Buffer(const std::uint8_t* beg, const std::uint8_t* end) : b(beg, end), i(b.begin()) { }
-    Buffer(const std::vector<Ice::Byte>& v) : b(v), i(b.begin()) { }
+    Buffer(const std::vector<std::uint8_t>& v) : b(v), i(b.begin()) { }
     Buffer(Buffer& o, bool adopt) : b(o.b, adopt), i(b.begin()) { }
 
     void swapBuffer(Buffer&);

--- a/cpp/include/Ice/Config.h
+++ b/cpp/include/Ice/Config.h
@@ -43,18 +43,6 @@ namespace Ice
 
 namespace IceInternal
 {
-}
-
-namespace Ice
-{
-
-/** The mapping for the Slice byte type. */
-typedef unsigned char Byte;
-
-}
-
-namespace IceInternal
-{
 
 ICE_API int getSystemErrno();
 

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -90,9 +90,9 @@ public:
 
     IconvStringConverter(const std::string&);
 
-    virtual Ice::Byte* toUTF8(const charT*, const charT*, Ice::UTF8Buffer&) const;
+    virtual std::uint8_t* toUTF8(const charT*, const charT*, Ice::UTF8Buffer&) const;
 
-    virtual void fromUTF8(const Ice::Byte*, const Ice::Byte*, std::basic_string<charT>&) const;
+    virtual void fromUTF8(const std::uint8_t*, const std::uint8_t*, std::basic_string<charT>&) const;
 
 private:
 
@@ -175,7 +175,7 @@ IconvStringConverter<charT>::getDescriptors() const
     return descriptorHolder.descriptor;
 }
 
-template<typename charT> Ice::Byte*
+template<typename charT> std::uint8_t*
 IconvStringConverter<charT>::toUTF8(const charT* sourceStart,
                                     const charT* sourceEnd,
                                     Ice::UTF8Buffer& buf) const
@@ -208,7 +208,7 @@ IconvStringConverter<charT>::toUTF8(const charT* sourceStart,
     {
         size_t howMany = std::max(inbytesleft, size_t(4));
         outbuf = reinterpret_cast<char*>(buf.getMoreBytes(howMany,
-                                                          reinterpret_cast<Ice::Byte*>(outbuf)));
+                                                          reinterpret_cast<std::uint8_t*>(outbuf)));
         count = iconv(cd, &inbuf, &inbytesleft, &outbuf, &howMany);
     } while(count == size_t(-1) && errno == E2BIG);
 
@@ -217,11 +217,11 @@ IconvStringConverter<charT>::toUTF8(const charT* sourceStart,
         throw Ice::IllegalConversionException(__FILE__, __LINE__,
                                               errno == 0 ? "Unknown error" : IceUtilInternal::errorToString(errno));
     }
-    return reinterpret_cast<Ice::Byte*>(outbuf);
+    return reinterpret_cast<std::uint8_t*>(outbuf);
 }
 
 template<typename charT> void
-IconvStringConverter<charT>::fromUTF8(const Ice::Byte* sourceStart, const Ice::Byte* sourceEnd,
+IconvStringConverter<charT>::fromUTF8(const std::uint8_t* sourceStart, const std::uint8_t* sourceEnd,
                                       std::basic_string<charT>& target) const
 {
     iconv_t cd = getDescriptors().first;
@@ -239,7 +239,7 @@ IconvStringConverter<charT>::fromUTF8(const Ice::Byte* sourceStart, const Ice::B
 #ifdef ICE_CONST_ICONV_INBUF
     const char* inbuf = reinterpret_cast<const char*>(sourceStart);
 #else
-    char* inbuf = reinterpret_cast<char*>(const_cast<Ice::Byte*>(sourceStart));
+    char* inbuf = reinterpret_cast<char*>(const_cast<std::uint8_t*>(sourceStart));
 #endif
     assert(sourceEnd > sourceStart);
     size_t inbytesleft = static_cast<size_t>(sourceEnd - sourceStart);

--- a/cpp/include/Ice/Incoming.h
+++ b/cpp/include/Ice/Incoming.h
@@ -75,7 +75,7 @@ public:
 
 protected:
 
-    IncomingBase(Instance*, ResponseHandler*, Ice::Connection*, const Ice::ObjectAdapterPtr&, bool, Ice::Byte, std::int32_t);
+    IncomingBase(Instance*, ResponseHandler*, Ice::Connection*, const Ice::ObjectAdapterPtr&, bool, std::uint8_t, std::int32_t);
     IncomingBase(IncomingBase&);
     IncomingBase(const IncomingBase&) = delete;
 
@@ -110,7 +110,7 @@ class ICE_API Incoming final : public IncomingBase
 {
 public:
 
-    Incoming(Instance*, ResponseHandler*, Ice::Connection*, const Ice::ObjectAdapterPtr&, bool, Ice::Byte, std::int32_t);
+    Incoming(Instance*, ResponseHandler*, Ice::Connection*, const Ice::ObjectAdapterPtr&, bool, std::uint8_t, std::int32_t);
 
     const Ice::Current& getCurrent()
     {

--- a/cpp/include/Ice/Incoming.h
+++ b/cpp/include/Ice/Incoming.h
@@ -67,7 +67,7 @@ public:
     Ice::OutputStream* startWriteParams();
     void endWriteParams();
     void writeEmptyParams();
-    void writeParamEncaps(const Ice::Byte*, std::int32_t, bool);
+    void writeParamEncaps(const std::uint8_t*, std::int32_t, bool);
     void setMarshaledResult(const Ice::MarshaledResult&);
 
     void response(bool);
@@ -92,7 +92,7 @@ protected:
     ::std::shared_ptr<void> _cookie;
     DispatchObserver _observer;
     bool _response;
-    Ice::Byte _compress;
+    std::uint8_t _compress;
     Ice::FormatType _format;
     Ice::OutputStream _os;
 
@@ -157,7 +157,7 @@ public:
     {
         _current.encoding = _is->skipEmptyEncapsulation();
     }
-    void readParamEncaps(const Ice::Byte*& v, std::int32_t& sz)
+    void readParamEncaps(const std::uint8_t*& v, std::int32_t& sz)
     {
         _current.encoding = _is->readEncapsulation(v, sz);
     }
@@ -167,7 +167,7 @@ private:
     friend class IncomingAsync;
 
     Ice::InputStream* _is;
-    Ice::Byte* _inParamPos;
+    std::uint8_t* _inParamPos;
 
     IncomingAsyncPtr _inAsync;
 };

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -79,7 +79,7 @@ public:
      * You can supply a communicator later by calling initialize().
      * @param bytes The encoded data.
      */
-    InputStream(const std::pair<const Byte*, const Byte*>& bytes);
+    InputStream(const std::pair<const std::uint8_t*, const std::uint8_t*>& bytes);
 
     /// \cond INTERNAL
     InputStream(IceInternal::Buffer&, bool = false);
@@ -103,7 +103,7 @@ public:
      * @param communicator The communicator to use for unmarshaling tasks.
      * @param bytes The encoded data.
      */
-    InputStream(const CommunicatorPtr& communicator, const std::pair<const Byte*, const Byte*>& bytes);
+    InputStream(const CommunicatorPtr& communicator, const std::pair<const std::uint8_t*, const std::uint8_t*>& bytes);
 
     /// \cond INTERNAL
     InputStream(const CommunicatorPtr& communicator, IceInternal::Buffer&, bool = false);
@@ -136,7 +136,7 @@ public:
      * @param version The encoding version used to encode the data to be unmarshaled.
      * @param bytes The encoded data.
      */
-    InputStream(const EncodingVersion& version, const std::pair<const Byte*, const Byte*>& bytes);
+    InputStream(const EncodingVersion& version, const std::pair<const std::uint8_t*, const std::uint8_t*>& bytes);
 
     /// \cond INTERNAL
     InputStream(const EncodingVersion&, IceInternal::Buffer&, bool = false);
@@ -164,7 +164,7 @@ public:
      * @param bytes The encoded data.
      */
     InputStream(const CommunicatorPtr& communicator, const EncodingVersion& version,
-                const std::pair<const Byte*, const Byte*>& bytes);
+                const std::pair<const std::uint8_t*, const std::uint8_t*>& bytes);
 
     /// \cond INTERNAL
     InputStream(const CommunicatorPtr&, const EncodingVersion&, IceInternal::Buffer&, bool = false);
@@ -475,7 +475,7 @@ public:
      * @param sz The number of bytes in the encapsulation.
      * @return encoding The encapsulation's encoding version.
      */
-    EncodingVersion readEncapsulation(const Byte*& v, std::int32_t& sz)
+    EncodingVersion readEncapsulation(const std::uint8_t*& v, std::int32_t& sz)
     {
         EncodingVersion encoding;
         v = i;
@@ -561,7 +561,7 @@ public:
      */
     std::int32_t readSize() // Inlined for performance reasons.
     {
-        Byte byte;
+        std::uint8_t byte;
         read(byte);
         unsigned char val = static_cast<unsigned char>(byte);
         if(val == 255)
@@ -602,7 +602,7 @@ public:
      * @param v A pointer into the internal marshaling buffer representing the start of the blob.
      * @param sz The number of bytes to read.
      */
-    void readBlob(const Byte*& v, Container::size_type sz)
+    void readBlob(const std::uint8_t*& v, Container::size_type sz)
     {
         if(sz > 0)
         {
@@ -753,7 +753,7 @@ public:
      * Reads a byte from the stream.
      * @param v The extracted byte.
      */
-    void read(Byte& v)
+    void read(std::uint8_t& v)
     {
         if(i >= b.end())
         {
@@ -773,7 +773,7 @@ public:
      * @param v A pair of pointers into the internal marshaling buffer representing the start and end of the
      * sequence elements.
      */
-    void read(std::pair<const Byte*, const Byte*>& v);
+    void read(std::pair<const std::uint8_t*, const std::uint8_t*>& v);
 
     /**
      * Reads a bool from the stream.
@@ -830,16 +830,16 @@ public:
         {
             throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
         }
-        const Byte* src = &(*i);
+        const std::uint8_t* src = &(*i);
         i += sizeof(std::int32_t);
 #ifdef ICE_BIG_ENDIAN
-        Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(std::int32_t) - 1;
+        std::uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(std::int32_t) - 1;
         *dest-- = *src++;
         *dest-- = *src++;
         *dest-- = *src++;
         *dest = *src;
 #else
-        Byte* dest = reinterpret_cast<Byte*>(&v);
+        std::uint8_t* dest = reinterpret_cast<Byte*>(&v);
         *dest++ = *src++;
         *dest++ = *src++;
         *dest++ = *src++;
@@ -1035,7 +1035,7 @@ public:
      */
     void skipSize()
     {
-        Byte bt;
+        std::uint8_t bt;
         read(bt);
         if(static_cast<unsigned char>(bt) == 255)
         {
@@ -1276,7 +1276,7 @@ private:
             IndexListList indirectionTables;
 
             // Slice attributes
-            Byte sliceFlags;
+            std::uint8_t sliceFlags;
             std::int32_t sliceSize;
             std::string typeId;
             int compactId;

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -70,7 +70,7 @@ public:
      * You can supply a communicator later by calling initialize().
      * @param bytes The encoded data.
      */
-    InputStream(const std::vector<Byte>& bytes);
+    InputStream(const std::vector<std::uint8_t>& bytes);
 
     /**
      * Constructs a stream using the latest encoding version but without a communicator.
@@ -96,7 +96,7 @@ public:
      * @param communicator The communicator to use for unmarshaling tasks.
      * @param bytes The encoded data.
      */
-    InputStream(const CommunicatorPtr& communicator, const std::vector<Byte>& bytes);
+    InputStream(const CommunicatorPtr& communicator, const std::vector<std::uint8_t>& bytes);
 
     /**
      * Constructs a stream using the communicator's default encoding version.
@@ -126,7 +126,7 @@ public:
      * @param version The encoding version used to encode the data to be unmarshaled.
      * @param bytes The encoded data.
      */
-    InputStream(const EncodingVersion& version, const std::vector<Byte>& bytes);
+    InputStream(const EncodingVersion& version, const std::vector<std::uint8_t>& bytes);
 
     /**
      * Constructs a stream using the given encoding version but without a communicator.
@@ -155,7 +155,7 @@ public:
      * @param version The encoding version used to encode the data to be unmarshaled.
      * @param bytes The encoded data.
      */
-    InputStream(const CommunicatorPtr& communicator, const EncodingVersion& version, const std::vector<Byte>& bytes);
+    InputStream(const CommunicatorPtr& communicator, const EncodingVersion& version, const std::vector<std::uint8_t>& bytes);
 
     /**
      * Constructs a stream using the given communicator and encoding version.
@@ -594,7 +594,7 @@ public:
      * @param bytes The vector to hold a copy of the bytes from the marshaling buffer.
      * @param sz The number of bytes to read.
      */
-    void readBlob(std::vector<Byte>& bytes, std::int32_t sz);
+    void readBlob(std::vector<std::uint8_t>& bytes, std::int32_t sz);
 
     /**
      * Reads a blob of bytes from the stream.
@@ -766,7 +766,7 @@ public:
      * Reads a sequence of bytes from the stream.
      * @param v A vector to hold a copy of the bytes.
      */
-    void read(std::vector<Byte>& v);
+    void read(std::vector<std::uint8_t>& v);
 
     /**
      * Reads a sequence of bytes from the stream.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -833,13 +833,13 @@ public:
         const std::uint8_t* src = &(*i);
         i += sizeof(std::int32_t);
 #ifdef ICE_BIG_ENDIAN
-        std::uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(std::int32_t) - 1;
+        std::uint8_t* dest = reinterpret_cast<std::uint8_t*>(&v) + sizeof(std::int32_t) - 1;
         *dest-- = *src++;
         *dest-- = *src++;
         *dest-- = *src++;
         *dest = *src;
 #else
-        std::uint8_t* dest = reinterpret_cast<Byte*>(&v);
+        std::uint8_t* dest = reinterpret_cast<std::uint8_t*>(&v);
         *dest++ = *src++;
         *dest++ = *src++;
         *dest++ = *src++;

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -176,7 +176,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(std::pair<const Byte*, const Byte*> inEncaps, std::vector<Byte>& outEncaps,
+    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps, std::vector<Byte>& outEncaps,
                             const Current& current) = 0;
 
     /// \cond INTERNAL
@@ -238,8 +238,8 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual void ice_invokeAsync(std::pair<const Byte*, const Byte*> inEncaps,
-                                 std::function<void(bool, const std::pair<const Byte*, const Byte*>&)> response,
+    virtual void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps,
+                                 std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> response,
                                  std::function<void(std::exception_ptr)> error,
                                  const Current& current) = 0;
     /// \cond INTERNAL

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -148,7 +148,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(std::vector<Byte> inEncaps, std::vector<Byte>& outEncaps, const Current& current) = 0;
+    virtual bool ice_invoke(std::vector<std::uint8_t> inEncaps, std::vector<std::uint8_t>& outEncaps, const Current& current) = 0;
 
     /// \cond INTERNAL
     virtual bool _iceDispatch(IceInternal::Incoming&, const Current&);
@@ -176,7 +176,7 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps, std::vector<Byte>& outEncaps,
+    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps, std::vector<std::uint8_t>& outEncaps,
                             const Current& current) = 0;
 
     /// \cond INTERNAL
@@ -206,8 +206,8 @@ public:
      * @throws UserException A user exception can be raised directly and the
      * run time will marshal it.
      */
-    virtual void ice_invokeAsync(std::vector<Byte> inEncaps,
-                                 std::function<void(bool, const std::vector<Byte>&)> response,
+    virtual void ice_invokeAsync(std::vector<std::uint8_t> inEncaps,
+                                 std::function<void(bool, const std::vector<std::uint8_t>&)> response,
                                  std::function<void(std::exception_ptr)> error,
                                  const Current& current) = 0;
 

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -224,7 +224,7 @@ public:
     {
         _os.writeEmptyEncapsulation(_encoding);
     }
-    void writeParamEncaps(const ::Ice::Byte* encaps, std::int32_t size)
+    void writeParamEncaps(const ::std::uint8_t* encaps, std::int32_t size)
     {
         if(size == 0)
         {

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -318,7 +318,7 @@ public:
         }
         else
         {
-            write(static_cast<Byte>(v));
+            write(static_cast<std::uint8_t>(v));
         }
     }
 
@@ -338,7 +338,7 @@ public:
         }
         else
         {
-            *dest = static_cast<Byte>(v);
+            *dest = static_cast<std::uint8_t>(v);
         }
     }
 
@@ -369,7 +369,7 @@ public:
      * Copies the specified blob of bytes to the stream without modification.
      * @param v The bytes to be copied.
      */
-    void writeBlob(const std::vector<Byte>& v);
+    void writeBlob(const std::vector<std::uint8_t>& v);
 
     /**
      * Copies the specified blob of bytes to the stream without modification.
@@ -569,7 +569,7 @@ public:
      */
     void write(bool v)
     {
-        b.push_back(static_cast<Byte>(v));
+        b.push_back(static_cast<std::uint8_t>(v));
     }
 
     /**
@@ -852,7 +852,7 @@ public:
      * Indicates that marshaling is complete. This function must only be called once.
      * @param v Filled with a copy of the encoded data.
      */
-    void finished(std::vector<Byte>& v);
+    void finished(std::vector<std::uint8_t>& v);
 
     /**
      * Indicates that marshaling is complete. This function must only be called once.

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -57,7 +57,7 @@ public:
      * stream will reallocate if the size of the marshaled data exceeds the application's buffer.
      */
     OutputStream(const CommunicatorPtr& communicator, const EncodingVersion& version,
-                 const std::pair<const Byte*, const Byte*>& bytes);
+                 const std::pair<const std::uint8_t*, const std::uint8_t*>& bytes);
 
     ~OutputStream()
     {
@@ -252,7 +252,7 @@ public:
      * @param v The start of the buffer.
      * @param sz The number of bytes to copy.
      */
-    void writeEncapsulation(const Byte* v, std::int32_t sz)
+    void writeEncapsulation(const std::uint8_t* v, std::int32_t sz)
     {
         if(sz < 6)
         {
@@ -376,7 +376,7 @@ public:
      * @param v The start of the buffer to be copied.
      * @param sz The number of bytes to be copied.
      */
-    void writeBlob(const Byte* v, Container::size_type sz)
+    void writeBlob(const std::uint8_t* v, Container::size_type sz)
     {
         if(sz > 0)
         {
@@ -551,7 +551,7 @@ public:
      * Writes a byte to the stream.
      * @param v The byte to write.
      */
-    void write(Byte v)
+    void write(std::uint8_t v)
     {
         b.push_back(v);
     }
@@ -561,7 +561,7 @@ public:
      * @param start The beginning of the sequence.
      * @param end The end of the sequence.
      */
-    void write(const Byte* start, const Byte* end);
+    void write(const std::uint8_t* start, const std::uint8_t* end);
 
     /**
      * Writes a boolean to the stream.
@@ -618,13 +618,13 @@ public:
     void write(std::int32_t v, Container::iterator dest)
     {
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(std::) - 1;
+        const std::uint8_t* src = reinterpret_cast<const std::uint8_t*>(&v) + sizeof(std::) - 1;
         *dest++ = *src--;
         *dest++ = *src--;
         *dest++ = *src--;
         *dest = *src;
 #else
-        const Byte* src = reinterpret_cast<const Byte*>(&v);
+        const std::uint8_t* src = reinterpret_cast<const std::uint8_t*>(&v);
         *dest++ = *src++;
         *dest++ = *src++;
         *dest++ = *src++;
@@ -859,7 +859,7 @@ public:
      * @return A pair of pointers into the internal marshaling buffer. These pointers are
      * valid for the lifetime of the stream.
      */
-    std::pair<const Byte*, const Byte*> finished();
+    std::pair<const std::uint8_t*, const std::uint8_t*> finished();
 
     /// \cond INTERNAL
     OutputStream(IceInternal::Instance*, const EncodingVersion&);
@@ -1028,7 +1028,7 @@ private:
             bool firstSlice;
 
             // Slice attributes
-            Byte sliceFlags;
+            std::uint8_t sliceFlags;
             Container::size_type writeSlice;    // Position of the slice data members
             Container::size_type sliceFlagsPos; // Position of the slice flags
             PtrToIndexMap indirectionMap;

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -313,7 +313,7 @@ public:
         assert(v >= 0);
         if(v > 254)
         {
-            write(Byte(255));
+            write(std::uint8_t(255));
             write(v);
         }
         else
@@ -333,7 +333,7 @@ public:
         assert(v >= 0);
         if(v > 254)
         {
-            *dest++ = Byte(255);
+            *dest++ = std::uint8_t(255);
             write(v, dest);
         }
         else

--- a/cpp/include/Ice/Protocol.h
+++ b/cpp/include/Ice/Protocol.h
@@ -15,12 +15,12 @@ namespace IceInternal
 // Size of the Ice protocol header
 //
 // Magic number (4 Bytes)
-// Protocol version major (Byte)
-// Protocol version minor (Byte)
-// Encoding version major (Byte)
-// Encoding version minor (Byte)
-// Message type (Byte)
-// Compression status (Byte)
+// Protocol version major (std::uint8_t)
+// Protocol version minor (std::uint8_t)
+// Encoding version major (std::uint8_t)
+// Encoding version minor (std::uint8_t)
+// Message type (std::uint8_t)
+// Compression status (std::uint8_t)
 // Message size (Int)
 //
 const ::std::int32_t headerSize = 14;

--- a/cpp/include/Ice/Protocol.h
+++ b/cpp/include/Ice/Protocol.h
@@ -28,34 +28,34 @@ const ::std::int32_t headerSize = 14;
 //
 // The magic number at the front of each message
 //
-extern const ::Ice::Byte magic[4];
+extern const ::std::uint8_t magic[4];
 
 //
 // The current Ice protocol, protocol encoding and encoding version
 //
-const ::Ice::Byte protocolMajor = 1;
-const ::Ice::Byte protocolMinor = 0;
-const ::Ice::Byte protocolEncodingMajor = 1;
-const ::Ice::Byte protocolEncodingMinor = 0;
+const ::std::uint8_t protocolMajor = 1;
+const ::std::uint8_t protocolMinor = 0;
+const ::std::uint8_t protocolEncodingMajor = 1;
+const ::std::uint8_t protocolEncodingMinor = 0;
 
-const ::Ice::Byte encodingMajor = 1;
-const ::Ice::Byte encodingMinor = 1;
+const ::std::uint8_t encodingMajor = 1;
+const ::std::uint8_t encodingMinor = 1;
 
 //
 // The Ice protocol message types
 //
-const ::Ice::Byte requestMsg = 0;
-const ::Ice::Byte requestBatchMsg = 1;
-const ::Ice::Byte replyMsg = 2;
-const ::Ice::Byte validateConnectionMsg = 3;
-const ::Ice::Byte closeConnectionMsg = 4;
+const ::std::uint8_t requestMsg = 0;
+const ::std::uint8_t requestBatchMsg = 1;
+const ::std::uint8_t replyMsg = 2;
+const ::std::uint8_t validateConnectionMsg = 3;
+const ::std::uint8_t closeConnectionMsg = 4;
 
 //
 // The request header, batch request header and reply header.
 //
-extern const ::Ice::Byte requestHdr[headerSize + sizeof(std::int32_t)];
-extern const ::Ice::Byte requestBatchHdr[headerSize + sizeof(std::int32_t)];
-extern const ::Ice::Byte replyHdr[headerSize];
+extern const ::std::uint8_t requestHdr[headerSize + sizeof(std::int32_t)];
+extern const ::std::uint8_t requestBatchHdr[headerSize + sizeof(std::int32_t)];
+extern const ::std::uint8_t replyHdr[headerSize];
 
 //
 // IPv4/IPv6 support enumeration.
@@ -67,7 +67,7 @@ enum ProtocolSupport
     EnableBoth
 };
 
-ICE_API void stringToMajorMinor(const ::std::string&, Ice::Byte&, Ice::Byte&);
+ICE_API void stringToMajorMinor(const ::std::string&, std::uint8_t&, std::uint8_t&);
 
 template<typename T> std::string
 versionToString(const T& v)
@@ -96,15 +96,15 @@ ICE_API void throwUnsupportedProtocolException(const char*, int, const Ice::Prot
 ICE_API void throwUnsupportedEncodingException(const char*, int, const Ice::EncodingVersion&,
                                                const Ice::EncodingVersion&);
 
-const ::Ice::Byte OPTIONAL_END_MARKER        = 0xFF;
+const ::std::uint8_t OPTIONAL_END_MARKER        = 0xFF;
 
-const ::Ice::Byte FLAG_HAS_TYPE_ID_STRING    = (1<<0);
-const ::Ice::Byte FLAG_HAS_TYPE_ID_INDEX     = (1<<1);
-const ::Ice::Byte FLAG_HAS_TYPE_ID_COMPACT   = (1<<0) | (1<<1);
-const ::Ice::Byte FLAG_HAS_OPTIONAL_MEMBERS  = (1<<2);
-const ::Ice::Byte FLAG_HAS_INDIRECTION_TABLE = (1<<3);
-const ::Ice::Byte FLAG_HAS_SLICE_SIZE        = (1<<4);
-const ::Ice::Byte FLAG_IS_LAST_SLICE         = (1<<5);
+const ::std::uint8_t FLAG_HAS_TYPE_ID_STRING    = (1<<0);
+const ::std::uint8_t FLAG_HAS_TYPE_ID_INDEX     = (1<<1);
+const ::std::uint8_t FLAG_HAS_TYPE_ID_COMPACT   = (1<<0) | (1<<1);
+const ::std::uint8_t FLAG_HAS_OPTIONAL_MEMBERS  = (1<<2);
+const ::std::uint8_t FLAG_HAS_INDIRECTION_TABLE = (1<<3);
+const ::std::uint8_t FLAG_HAS_SLICE_SIZE        = (1<<4);
+const ::std::uint8_t FLAG_IS_LAST_SLICE         = (1<<5);
 
 }
 

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -536,7 +536,7 @@ public:
     bool
     ice_invoke(const std::string& operation,
                Ice::OperationMode mode,
-               const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
+               const std::pair<const std::uint8_t*, const std::uint8_t*>& inParams,
                std::vector<Ice::Byte>& outParams,
                const Ice::Context& context = Ice::noExplicitContext) const;
 
@@ -551,7 +551,7 @@ public:
     std::future<std::tuple<bool, std::vector<Ice::Byte>>>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
-                    const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
+                    const std::pair<const std::uint8_t*, const std::uint8_t*>& inParams,
                     const Ice::Context& context = Ice::noExplicitContext) const;
 
     /**
@@ -568,8 +568,8 @@ public:
     std::function<void()>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
-                    const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
-                    std::function<void(bool, std::pair<const Ice::Byte*, const Ice::Byte*>)> response,
+                    const std::pair<const std::uint8_t*, const std::uint8_t*>& inParams,
+                    std::function<void(bool, std::pair<const std::uint8_t*, const std::uint8_t*>)> response,
                     std::function<void(std::exception_ptr)> ex = nullptr,
                     std::function<void(bool)> sent = nullptr,
                     const Ice::Context& context = Ice::noExplicitContext) const;

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -484,7 +484,7 @@ public:
     ice_invoke(const std::string& operation,
                Ice::OperationMode mode,
                const std::vector<std::uint8_t>& inParams,
-               std::vector<Ice::Byte>& outParams,
+               std::vector<std::uint8_t>& outParams,
                const Ice::Context& context = Ice::noExplicitContext) const;
 
     /**
@@ -495,7 +495,7 @@ public:
      * @param context The context map for the invocation.
      * @return The future object for the invocation.
      */
-    std::future<std::tuple<bool, std::vector<Ice::Byte>>>
+    std::future<std::tuple<bool, std::vector<std::uint8_t>>>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
                     const std::vector<std::uint8_t>& inParams,
@@ -515,8 +515,8 @@ public:
     std::function<void()>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
-                    const std::vector<Ice::Byte>& inParams,
-                    std::function<void(bool, std::vector<Ice::Byte>)> response,
+                    const std::vector<std::uint8_t>& inParams,
+                    std::function<void(bool, std::vector<std::uint8_t>)> response,
                     std::function<void(std::exception_ptr)> ex = nullptr,
                     std::function<void(bool)> sent = nullptr,
                     const Ice::Context& context = Ice::noExplicitContext) const;
@@ -537,7 +537,7 @@ public:
     ice_invoke(const std::string& operation,
                Ice::OperationMode mode,
                const std::pair<const std::uint8_t*, const std::uint8_t*>& inParams,
-               std::vector<Ice::Byte>& outParams,
+               std::vector<std::uint8_t>& outParams,
                const Ice::Context& context = Ice::noExplicitContext) const;
 
     /**
@@ -548,7 +548,7 @@ public:
      * @param context The context map for the invocation.
      * @return The future object for the invocation.
      */
-    std::future<std::tuple<bool, std::vector<Ice::Byte>>>
+    std::future<std::tuple<bool, std::vector<std::uint8_t>>>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
                     const std::pair<const std::uint8_t*, const std::uint8_t*>& inParams,

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -483,7 +483,7 @@ public:
     bool
     ice_invoke(const std::string& operation,
                Ice::OperationMode mode,
-               const std::vector<Byte>& inParams,
+               const std::vector<std::uint8_t>& inParams,
                std::vector<Ice::Byte>& outParams,
                const Ice::Context& context = Ice::noExplicitContext) const;
 
@@ -498,7 +498,7 @@ public:
     std::future<std::tuple<bool, std::vector<Ice::Byte>>>
     ice_invokeAsync(const std::string& operation,
                     Ice::OperationMode mode,
-                    const std::vector<Byte>& inParams,
+                    const std::vector<std::uint8_t>& inParams,
                     const Ice::Context& context = Ice::noExplicitContext) const;
 
     /**

--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -30,7 +30,7 @@ struct ICE_API SliceInfo
     /**
      * The encoded bytes for this slice, including the leading size integer.
      */
-    std::vector<Byte> bytes;
+    std::vector<std::uint8_t> bytes;
 
     /**
      * The class instances referenced by this slice.

--- a/cpp/include/IceSSL/Plugin.h
+++ b/cpp/include/IceSSL/Plugin.h
@@ -349,7 +349,7 @@ public:
      * Obtains the data associated with this extension.
      * @return The extension data.
      */
-    virtual std::vector<Ice::Byte> getData() const = 0;
+    virtual std::vector<std::uint8_t> getData() const = 0;
 };
 using X509ExtensionPtr = std::shared_ptr<X509Extension>;
 
@@ -379,13 +379,13 @@ public:
      * Obtains the authority key identifier.
      * @return The identifier.
      */
-    virtual std::vector<Ice::Byte> getAuthorityKeyIdentifier() const = 0;
+    virtual std::vector<std::uint8_t> getAuthorityKeyIdentifier() const = 0;
 
     /**
      * Obtains the subject key identifier.
      * @return The identifier.
      */
-    virtual std::vector<Ice::Byte> getSubjectKeyIdentifier() const = 0;
+    virtual std::vector<std::uint8_t> getSubjectKeyIdentifier() const = 0;
 
     /**
      * Verifies that this certificate was signed by the given certificate

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -221,8 +221,6 @@ private:
     const noncopyable& operator=(const noncopyable&);
 };
 
-typedef unsigned char Byte;
-
 //
 // Int64 typedef and ICE_INT64 macro for Int64 literal values
 //

--- a/cpp/include/IceUtil/StringConverter.h
+++ b/cpp/include/IceUtil/StringConverter.h
@@ -163,13 +163,13 @@ namespace IceUtilInternal
 //
 // Convert from UTF-8 to UTF-16/32
 //
-ICE_API std::vector<unsigned short> toUTF16(const std::vector<IceUtil::Byte>&);
-ICE_API std::vector<unsigned int> toUTF32(const std::vector<IceUtil::Byte>&);
+ICE_API std::vector<unsigned short> toUTF16(const std::vector<std::uint8_t>&);
+ICE_API std::vector<unsigned int> toUTF32(const std::vector<std::uint8_t>&);
 
 //
 // Convert from UTF-32 to UTF-8
 //
-ICE_API std::vector<IceUtil::Byte> fromUTF32(const std::vector<unsigned int>&);
+ICE_API std::vector<std::uint8_t> fromUTF32(const std::vector<unsigned int>&);
 
 }
 

--- a/cpp/include/IceUtil/StringConverter.h
+++ b/cpp/include/IceUtil/StringConverter.h
@@ -29,7 +29,7 @@ public:
      * @param firstUnused A pointer to the first unused byte.
      * @return A pointer to the beginning of the buffer.
      */
-    virtual Byte* getMoreBytes(size_t howMany, Byte* firstUnused) = 0;
+    virtual std::uint8_t* getMoreBytes(size_t howMany, std::uint8_t* firstUnused) = 0;
 
     virtual ~UTF8Buffer();
 };
@@ -50,12 +50,12 @@ public:
      * Returns a pointer to byte after the last written byte (which may be
      * past the last byte returned by getMoreBytes).
      */
-    virtual Byte* toUTF8(const charT* sourceStart, const charT* sourceEnd, UTF8Buffer& buf) const = 0;
+    virtual std::uint8_t* toUTF8(const charT* sourceStart, const charT* sourceEnd, UTF8Buffer& buf) const = 0;
 
     /**
      * Unmarshals a UTF-8 sequence into a basic_string.
      */
-    virtual void fromUTF8(const Byte* sourceStart, const Byte* sourceEnd, std::basic_string<charT>& target) const = 0;
+    virtual void fromUTF8(const std::uint8_t* sourceStart, const std::uint8_t* sourceEnd, std::basic_string<charT>& target) const = 0;
 
     virtual ~BasicStringConverter()
     {

--- a/cpp/src/Glacier2/Blobject.cpp
+++ b/cpp/src/Glacier2/Blobject.cpp
@@ -67,8 +67,8 @@ Glacier2::Blobject::updateObserver(const shared_ptr<Glacier2::Instrumentation::S
 
 void
 Glacier2::Blobject::invoke(ObjectPrx& proxy,
-                           const std::pair<const Byte*, const Byte*>& inParams,
-                           function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+                           const std::pair<const uint8_t*, const uint8_t*>& inParams,
+                           function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                            function<void(exception_ptr)> exception,
                            const Current& current)
 {
@@ -252,7 +252,7 @@ Glacier2::Blobject::invoke(ObjectPrx& proxy,
 
         try
         {
-            function<void(bool, pair<const Byte*, const Byte*>)> amiResponse = nullptr;
+            function<void(bool, pair<const uint8_t*, const uint8_t*>)> amiResponse = nullptr;
             function<void(bool)> amiSent = nullptr;
 
             if(proxy->ice_isTwoway())

--- a/cpp/src/Glacier2/Blobject.h
+++ b/cpp/src/Glacier2/Blobject.h
@@ -27,8 +27,8 @@ public:
 protected:
 
     void invoke(Ice::ObjectPrx&,
-                const std::pair<const Ice::Byte*, const Ice::Byte*>&,
-                std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+                const std::pair<const std::uint8_t*, const std::uint8_t*>&,
+                std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                 std::function<void(std::exception_ptr)>,
                 const Ice::Current&);
 

--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -24,8 +24,8 @@ Glacier2::ClientBlobject::ClientBlobject(shared_ptr<Instance>instance,
 }
 
 void
-Glacier2::ClientBlobject::ice_invokeAsync(pair<const Byte*, const Byte*> inParams,
-                                          function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+Glacier2::ClientBlobject::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                          function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                           function<void(exception_ptr)> error,
                                           const Current& current)
 {

--- a/cpp/src/Glacier2/ClientBlobject.h
+++ b/cpp/src/Glacier2/ClientBlobject.h
@@ -21,8 +21,8 @@ public:
     ClientBlobject(std::shared_ptr<Instance>, std::shared_ptr<FilterManager>, const Ice::Context&,
                    std::shared_ptr<RoutingTable>);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*> inEncaps,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> response,
                          std::function<void(std::exception_ptr)> error,
                          const Ice::Current& current) override;
 

--- a/cpp/src/Glacier2/RequestQueue.cpp
+++ b/cpp/src/Glacier2/RequestQueue.cpp
@@ -10,9 +10,9 @@ using namespace std;
 using namespace Ice;
 using namespace Glacier2;
 
-Glacier2::Request::Request(ObjectPrxPtr proxy, const std::pair<const Byte*, const Byte*>& inParams,
+Glacier2::Request::Request(ObjectPrxPtr proxy, const std::pair<const uint8_t*, const uint8_t*>& inParams,
                  const Current& current, bool forwardContext, const Ice::Context& sslContext,
-                 function<void(bool, pair<const Byte*, const Byte*>)> response,
+                 function<void(bool, pair<const uint8_t*, const uint8_t*>)> response,
                  function<void(exception_ptr)> exception) :
     _proxy(std::move(proxy)),
     _inParams(inParams.first, inParams.second),
@@ -30,11 +30,11 @@ Glacier2::Request::Request(ObjectPrxPtr proxy, const std::pair<const Byte*, cons
 }
 
 void
-Glacier2::Request::invoke(function<void(bool, pair<const Byte*, const Byte*>)>&& response,
+Glacier2::Request::invoke(function<void(bool, pair<const uint8_t*, const uint8_t*>)>&& response,
                           function<void(exception_ptr)>&& exception,
                           std::function<void(bool)>&& sent)
 {
-    pair<const Byte*, const Byte*> inPair;
+    pair<const uint8_t*, const uint8_t*> inPair;
     if(_inParams.size() == 0)
     {
         inPair.first = inPair.second = nullptr;
@@ -110,7 +110,7 @@ Glacier2::Request::override(const shared_ptr<Request>& other) const
 }
 
 void
-Glacier2::Request::response(bool ok, const pair<const Byte*, const Byte*>& outParams)
+Glacier2::Request::response(bool ok, const pair<const uint8_t*, const uint8_t*>& outParams)
 {
     assert(_proxy->ice_isTwoway());
     _response(ok, outParams);
@@ -216,7 +216,7 @@ Glacier2::RequestQueue::flushRequests()
             }
             auto self = shared_from_this();
             request->invoke(
-                [self, request](bool ok, const pair<const Byte*, const Byte*>& outParams)
+                [self, request](bool ok, const pair<const uint8_t*, const uint8_t*>& outParams)
                 {
                     self->response(ok, outParams, request);
                 },
@@ -266,7 +266,7 @@ Glacier2::RequestQueue::flush()
         auto request = *p;
 
         request->invoke(
-            [self, request](bool ok, const pair<const Byte*, const Byte*>& outParams)
+            [self, request](bool ok, const pair<const uint8_t*, const uint8_t*>& outParams)
             {
                 self->response(ok, outParams, request);
             },
@@ -302,7 +302,7 @@ Glacier2::RequestQueue::flush()
 }
 
 void
-Glacier2::RequestQueue::response(bool ok, const pair<const Byte*, const Byte*>& outParams, const shared_ptr<Request>& request)
+Glacier2::RequestQueue::response(bool ok, const pair<const uint8_t*, const uint8_t*>& outParams, const shared_ptr<Request>& request)
 {
     assert(request);
     request->response(ok, outParams);

--- a/cpp/src/Glacier2/RequestQueue.h
+++ b/cpp/src/Glacier2/RequestQueue.h
@@ -24,14 +24,14 @@ class Request
 public:
 
     Request(Ice::ObjectPrxPtr,
-            const std::pair<const Ice::Byte*, const Ice::Byte*>&,
+            const std::pair<const std::uint8_t*, const std::uint8_t*>&,
             const Ice::Current&,
             bool,
             const Ice::Context&,
-            std::function<void(bool, std::pair<const Ice::Byte*, const Ice::Byte*>)>,
+            std::function<void(bool, std::pair<const std::uint8_t*, const std::uint8_t*>)>,
             std::function<void(std::exception_ptr)>);
 
-    void invoke(std::function<void(bool, std::pair<const Ice::Byte*, const Ice::Byte*>)>&&,
+    void invoke(std::function<void(bool, std::pair<const std::uint8_t*, const std::uint8_t*>)>&&,
                 std::function<void(std::exception_ptr)>&&,
                 std::function<void(bool)>&& = nullptr);
     bool override(const std::shared_ptr<Request>&) const;
@@ -40,7 +40,7 @@ public:
 private:
 
     friend class RequestQueue;
-    void response(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&);
+    void response(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&);
     void exception(std::exception_ptr);
     void queued();
 
@@ -50,7 +50,7 @@ private:
     const bool _forwardContext;
     const Ice::Context _sslContext;
     const std::string _override;
-    std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)> _response;
+    std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> _response;
     std::function<void(std::exception_ptr)> _exception;
 };
 
@@ -71,7 +71,7 @@ private:
 
     void flush();
 
-    void response(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&, const std::shared_ptr<Request>&);
+    void response(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&, const std::shared_ptr<Request>&);
     void exception(std::exception_ptr, const std::shared_ptr<Request>&);
     void sent(bool, const std::shared_ptr<Request>&);
 

--- a/cpp/src/Glacier2/ServerBlobject.cpp
+++ b/cpp/src/Glacier2/ServerBlobject.cpp
@@ -14,8 +14,8 @@ Glacier2::ServerBlobject::ServerBlobject(shared_ptr<Instance> instance, shared_p
 }
 
 void
-Glacier2::ServerBlobject::ice_invokeAsync(pair<const Byte*, const Byte*> inParams,
-                                          function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+Glacier2::ServerBlobject::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                          function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                           function<void(exception_ptr)> error,
                                           const Current& current)
 {

--- a/cpp/src/Glacier2/ServerBlobject.h
+++ b/cpp/src/Glacier2/ServerBlobject.h
@@ -16,8 +16,8 @@ public:
 
     ServerBlobject(std::shared_ptr<Instance>, std::shared_ptr<Ice::Connection>);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*> inEncaps,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> response,
                          std::function<void(std::exception_ptr)> error,
                          const Ice::Current& current) override;
 };

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -176,10 +176,10 @@ BatchRequestQueue::swap(OutputStream* os, bool& compress)
 
     _conditionVariable.wait(lock, [this] { return !_batchStreamInUse || _batchStreamCanFlush; });
 
-    vector<Ice::Byte> lastRequest;
+    vector<uint8_t> lastRequest;
     if(_batchMarker < _batchStream.b.size())
     {
-        vector<Ice::Byte>(_batchStream.b.begin() + _batchMarker, _batchStream.b.end()).swap(lastRequest);
+        vector<uint8_t>(_batchStream.b.begin() + _batchMarker, _batchStream.b.end()).swap(lastRequest);
         _batchStream.b.resize(_batchMarker);
     }
 

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -191,7 +191,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
 }
 
 void
-CollocatedRequestHandler::sendResponse(int32_t requestId, OutputStream* os, Byte, bool amd)
+CollocatedRequestHandler::sendResponse(int32_t requestId, OutputStream* os, uint8_t, bool amd)
 {
     OutgoingAsyncBasePtr outAsync;
     {

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -52,7 +52,7 @@ private:
 void
 fillInValue(OutputStream* os, int pos, int32_t value)
 {
-    const Byte* p = reinterpret_cast<const Byte*>(&value);
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(&value);
 #ifdef ICE_BIG_ENDIAN
     reverse_copy(p, p + sizeof(std::int32_t), os->b.begin() + pos);
 #else

--- a/cpp/src/Ice/CollocatedRequestHandler.h
+++ b/cpp/src/Ice/CollocatedRequestHandler.h
@@ -39,7 +39,7 @@ public:
 
     virtual void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr);
 
-    virtual void sendResponse(std::int32_t, Ice::OutputStream*, Ice::Byte, bool);
+    virtual void sendResponse(std::int32_t, Ice::OutputStream*, std::uint8_t, bool);
     virtual void sendNoResponse();
     virtual bool systemException(std::int32_t, std::exception_ptr, bool);
     virtual void invokeException(std::int32_t, std::exception_ptr, int, bool);

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -840,7 +840,7 @@ public:
             _os.write(currentProtocol);
             _os.write(currentProtocolEncoding);
             _os.write(validateConnectionMsg);
-            _os.write(static_cast<Byte>(0)); // Compression status (always zero for validate connection).
+            _os.write(static_cast<uint8_t>(0)); // Compression status (always zero for validate connection).
             _os.write(headerSize); // Message size.
             _os.i = _os.b.begin();
 
@@ -2527,7 +2527,7 @@ Ice::ConnectionI::initiateShutdown()
         os.write(currentProtocol);
         os.write(currentProtocolEncoding);
         os.write(closeConnectionMsg);
-        os.write(static_cast<Byte>(1)); // compression status: compression supported but not used.
+        os.write(static_cast<uint8_t>(1)); // compression status: compression supported but not used.
         os.write(headerSize); // Message size.
 
         OutgoingMessage message(&os, false);
@@ -2563,7 +2563,7 @@ Ice::ConnectionI::sendHeartbeatNow()
         os.write(currentProtocol);
         os.write(currentProtocolEncoding);
         os.write(validateConnectionMsg);
-        os.write(static_cast<Byte>(0)); // Compression status (always zero for validate connection).
+        os.write(static_cast<uint8_t>(0)); // Compression status (always zero for validate connection).
         os.write(headerSize); // Message size.
         os.i = os.b.begin();
         try
@@ -2615,7 +2615,7 @@ Ice::ConnectionI::validate(SocketOperation operation)
                 _writeStream.write(currentProtocol);
                 _writeStream.write(currentProtocolEncoding);
                 _writeStream.write(validateConnectionMsg);
-                _writeStream.write(static_cast<Byte>(0)); // Compression status (always zero for validate connection).
+                _writeStream.write(static_cast<uint8_t>(0)); // Compression status (always zero for validate connection).
                 _writeStream.write(headerSize); // Message size.
                 _writeStream.i = _writeStream.b.begin();
                 traceSend(_writeStream, _logger, _traceLevels);

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -63,7 +63,7 @@ public:
         const ConnectionIPtr& connection,
         function<void (ConnectionIPtr)> connectionStartCompleted,
         const vector<ConnectionI::OutgoingMessage>& sentCBs,
-        Byte compress,
+        uint8_t compress,
         int32_t requestId,
         int32_t invokeNum,
         const ServantManagerPtr& servantManager,
@@ -98,7 +98,7 @@ private:
     const ConnectionIPtr _connection;
     const function<void(Ice::ConnectionIPtr)> _connectionStartCompleted;
     const vector<ConnectionI::OutgoingMessage> _sentCBs;
-    const Byte _compress;
+    const uint8_t _compress;
     const int32_t _requestId;
     const int32_t _invokeNum;
     const ServantManagerPtr _servantManager;
@@ -724,7 +724,7 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
         //
         // Fill in the request ID.
         //
-        const Byte* p = reinterpret_cast<const Byte*>(&requestId);
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(&requestId);
 #ifdef ICE_BIG_ENDIAN
         reverse_copy(p, p + sizeof(int32_t), os->b.begin() + headerSize);
 #else
@@ -733,7 +733,7 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
     }
     else if(batchRequestNum > 0)
     {
-        const Byte* p = reinterpret_cast<const Byte*>(&batchRequestNum);
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(&batchRequestNum);
 #ifdef ICE_BIG_ENDIAN
         reverse_copy(p, p + sizeof(int32_t), os->b.begin() + headerSize);
 #else
@@ -1121,7 +1121,7 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
 }
 
 void
-Ice::ConnectionI::sendResponse(int32_t, OutputStream* os, Byte compressFlag, bool /*amd*/)
+Ice::ConnectionI::sendResponse(int32_t, OutputStream* os, uint8_t compressFlag, bool /*amd*/)
 {
     std::unique_lock lock(_mutex);
     assert(_state > StateNotValidated);
@@ -1404,7 +1404,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
 {
     function<void(ConnectionIPtr)> connectionStartCompleted;
     vector<OutgoingMessage> sentCBs;
-    Byte compress = 0;
+    uint8_t compress = 0;
     int32_t requestId = 0;
     int32_t invokeNum = 0;
     ServantManagerPtr servantManager;
@@ -1494,7 +1494,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     }
 
                     _readStream.i = _readStream.b.begin();
-                    const Byte* m;
+                    const uint8_t* m;
                     _readStream.readBlob(m, static_cast<int32_t>(sizeof(magic)));
                     if(m[0] != magic[0] || m[1] != magic[1] || m[2] != magic[2] || m[3] != magic[3])
                     {
@@ -1507,9 +1507,9 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     _readStream.read(ev);
                     checkSupportedProtocolEncoding(ev);
 
-                    Byte messageType;
+                    uint8_t messageType;
                     _readStream.read(messageType);
-                    Byte compressByte;
+                    uint8_t compressByte;
                     _readStream.read(compressByte);
                     int32_t size;
                     _readStream.read(size);
@@ -1721,7 +1721,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
 
 void
 ConnectionI::dispatch(function<void(ConnectionIPtr)> connectionStartCompleted, const vector<OutgoingMessage>& sentCBs,
-                      Byte compress, int32_t requestId, int32_t invokeNum, const ServantManagerPtr& servantManager,
+                      uint8_t compress, int32_t requestId, int32_t invokeNum, const ServantManagerPtr& servantManager,
                       const ObjectAdapterPtr& adapter, const OutgoingAsyncBasePtr& outAsync,
                       const HeartbeatCallback& heartbeatCallback, InputStream& stream)
 {
@@ -2675,7 +2675,7 @@ Ice::ConnectionI::validate(SocketOperation operation)
 
             assert(_readStream.i == _readStream.b.end());
             _readStream.i = _readStream.b.begin();
-            Byte m[4];
+            uint8_t m[4];
             _readStream.read(m[0]);
             _readStream.read(m[1]);
             _readStream.read(m[2]);
@@ -2690,13 +2690,13 @@ Ice::ConnectionI::validate(SocketOperation operation)
             EncodingVersion ev;
             _readStream.read(ev);
             checkSupportedProtocolEncoding(ev);
-            Byte messageType;
+            uint8_t messageType;
             _readStream.read(messageType);
             if(messageType != validateConnectionMsg)
             {
                 throw ConnectionNotValidatedException(__FILE__, __LINE__);
             }
-            Byte compress;
+            uint8_t compress;
             _readStream.read(compress); // Ignore compression status for validate connection.
             int32_t size;
             _readStream.read(size);
@@ -2826,7 +2826,7 @@ Ice::ConnectionI::sendNextMessage(vector<OutgoingMessage>& callbacks)
                 // No compression, just fill in the message size.
                 //
                 int32_t sz = static_cast<int32_t>(message->stream->b.size());
-                const Byte* p = reinterpret_cast<const Byte*>(&sz);
+                const uint8_t* p = reinterpret_cast<const uint8_t*>(&sz);
 #ifdef ICE_BIG_ENDIAN
                 reverse_copy(p, p + sizeof(int32_t), message->stream->b.begin() + 10);
 #else
@@ -2966,7 +2966,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         // No compression, just fill in the message size.
         //
         int32_t sz = static_cast<int32_t>(message.stream->b.size());
-        const Byte* p = reinterpret_cast<const Byte*>(&sz);
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(&sz);
 #ifdef ICE_BIG_ENDIAN
         reverse_copy(p, p + sizeof(int32_t), message.stream->b.begin() + 10);
 #else
@@ -3079,7 +3079,7 @@ getBZ2Error(int bzError)
 void
 Ice::ConnectionI::doCompress(OutputStream& uncompressed, OutputStream& compressed)
 {
-    const Byte* p;
+    const uint8_t* p;
 
     //
     // Compress the message body, but not the header.
@@ -3104,7 +3104,7 @@ Ice::ConnectionI::doCompress(OutputStream& uncompressed, OutputStream& compresse
     // will also be in the header of the compressed stream.
     //
     int32_t compressedSize = static_cast<int32_t>(compressed.b.size());
-    p = reinterpret_cast<const Byte*>(&compressedSize);
+    p = reinterpret_cast<const uint8_t*>(&compressedSize);
 #ifdef ICE_BIG_ENDIAN
     reverse_copy(p, p + sizeof(int32_t), uncompressed.b.begin() + 10);
 #else
@@ -3116,7 +3116,7 @@ Ice::ConnectionI::doCompress(OutputStream& uncompressed, OutputStream& compresse
     // of the compressed stream.
     //
     int32_t uncompressedSize = static_cast<int32_t>(uncompressed.b.size());
-    p = reinterpret_cast<const Byte*>(&uncompressedSize);
+    p = reinterpret_cast<const uint8_t*>(&uncompressedSize);
 #ifdef ICE_BIG_ENDIAN
     reverse_copy(p, p + sizeof(int32_t), compressed.b.begin() + headerSize);
 #else
@@ -3163,7 +3163,7 @@ Ice::ConnectionI::doUncompress(InputStream& compressed, InputStream& uncompresse
 #endif
 
 SocketOperation
-Ice::ConnectionI::parseMessage(InputStream& stream, int32_t& invokeNum, int32_t& requestId, Byte& compress,
+Ice::ConnectionI::parseMessage(InputStream& stream, int32_t& invokeNum, int32_t& requestId, uint8_t& compress,
                                ServantManagerPtr& servantManager, ObjectAdapterPtr& adapter,
                                OutgoingAsyncBasePtr& outAsync, HeartbeatCallback& heartbeatCallback,
                                int& dispatchCount)
@@ -3186,7 +3186,7 @@ Ice::ConnectionI::parseMessage(InputStream& stream, int32_t& invokeNum, int32_t&
         //
         assert(stream.i == stream.b.end());
         stream.i = stream.b.begin() + 8;
-        Byte messageType;
+        uint8_t messageType;
         stream.read(messageType);
         stream.read(compress);
 
@@ -3385,7 +3385,7 @@ Ice::ConnectionI::parseMessage(InputStream& stream, int32_t& invokeNum, int32_t&
 }
 
 void
-Ice::ConnectionI::invokeAll(InputStream& stream, int32_t invokeNum, int32_t requestId, Byte compress,
+Ice::ConnectionI::invokeAll(InputStream& stream, int32_t invokeNum, int32_t requestId, uint8_t compress,
                             const ServantManagerPtr& servantManager, const ObjectAdapterPtr& adapter)
 {
     //

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -72,8 +72,8 @@ class ConnectionI : public Connection,
 
     private:
 
-        Ice::Byte* _readStreamPos;
-        Ice::Byte* _writeStreamPos;
+        std::uint8_t* _readStreamPos;
+        std::uint8_t* _writeStreamPos;
     };
 
 public:

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -169,7 +169,7 @@ public:
 
     virtual void asyncRequestCanceled(const IceInternal::OutgoingAsyncBasePtr&, std::exception_ptr);
 
-    virtual void sendResponse(std::int32_t, Ice::OutputStream*, Byte, bool);
+    virtual void sendResponse(std::int32_t, Ice::OutputStream*, std::uint8_t, bool);
     virtual void sendNoResponse();
     virtual bool systemException(std::int32_t, std::exception_ptr, bool);
     virtual void invokeException(std::int32_t, std::exception_ptr, int, bool);
@@ -209,7 +209,7 @@ public:
 
     void dispatch(std::function<void(ConnectionIPtr)>,
                   const std::vector<OutgoingMessage>&,
-                  Byte,
+                  std::uint8_t,
                   std::int32_t,
                   std::int32_t,
                   const IceInternal::ServantManagerPtr&,
@@ -269,7 +269,7 @@ private:
                                               IceInternal::ServantManagerPtr&, ObjectAdapterPtr&,
                                               IceInternal::OutgoingAsyncBasePtr&, HeartbeatCallback&, int&);
 
-    void invokeAll(Ice::InputStream&, std::int32_t, std::int32_t, Byte,
+    void invokeAll(Ice::InputStream&, std::int32_t, std::int32_t, std::uint8_t,
                    const IceInternal::ServantManagerPtr&, const ObjectAdapterPtr&);
 
     void scheduleTimeout(IceInternal::SocketOperation status);

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -265,7 +265,7 @@ private:
     void doUncompress(Ice::InputStream&, Ice::InputStream&);
 #endif
 
-    IceInternal::SocketOperation parseMessage(Ice::InputStream&, std::int32_t&, std::int32_t&, Byte&,
+    IceInternal::SocketOperation parseMessage(Ice::InputStream&, std::int32_t&, std::int32_t&, std::uint8_t&,
                                               IceInternal::ServantManagerPtr&, ObjectAdapterPtr&,
                                               IceInternal::OutgoingAsyncBasePtr&, HeartbeatCallback&, int&);
 

--- a/cpp/src/Ice/HttpParser.cpp
+++ b/cpp/src/Ice/HttpParser.cpp
@@ -25,10 +25,10 @@ IceInternal::HttpParser::HttpParser() :
 {
 }
 
-const Ice::Byte*
-IceInternal::HttpParser::isCompleteMessage(const Ice::Byte* begin, const Ice::Byte* end) const
+const uint8_t*
+IceInternal::HttpParser::isCompleteMessage(const uint8_t* begin, const uint8_t* end) const
 {
-    const Ice::Byte* p = begin;
+    const uint8_t* p = begin;
 
     //
     // Skip any leading CR-LF characters.
@@ -71,10 +71,10 @@ IceInternal::HttpParser::isCompleteMessage(const Ice::Byte* begin, const Ice::By
 }
 
 bool
-IceInternal::HttpParser::parse(const Ice::Byte* begin, const Ice::Byte* end)
+IceInternal::HttpParser::parse(const uint8_t* begin, const uint8_t* end)
 {
-    const Ice::Byte* p = begin;
-    const Ice::Byte* start = 0;
+    const uint8_t* p = begin;
+    const uint8_t* start = 0;
     const string::value_type CR = '\r';
     const string::value_type LF = '\n';
 

--- a/cpp/src/Ice/HttpParser.h
+++ b/cpp/src/Ice/HttpParser.h
@@ -40,9 +40,9 @@ public:
         TypeResponse
     };
 
-    const Ice::Byte* isCompleteMessage(const Ice::Byte*, const Ice::Byte*) const;
+    const std::uint8_t* isCompleteMessage(const std::uint8_t*, const std::uint8_t*) const;
 
-    bool parse(const Ice::Byte*, const Ice::Byte*);
+    bool parse(const std::uint8_t*, const std::uint8_t*);
 
     Type type() const;
 

--- a/cpp/src/Ice/Incoming.cpp
+++ b/cpp/src/Ice/Incoming.cpp
@@ -41,7 +41,7 @@ Ice::MarshaledResult::MarshaledResult(const Ice::Current& current) :
 
 IceInternal::IncomingBase::IncomingBase(Instance* instance, ResponseHandler* responseHandler,
                                         Ice::Connection* connection, const ObjectAdapterPtr& adapter,
-                                        bool response, Byte compress, int32_t requestId) :
+                                        bool response, uint8_t compress, int32_t requestId) :
     _response(response),
     _compress(compress),
     _format(Ice::FormatType::DefaultFormat),
@@ -111,7 +111,7 @@ IncomingBase::writeEmptyParams()
 }
 
 void
-IncomingBase::writeParamEncaps(const Byte* v, int32_t sz, bool ok)
+IncomingBase::writeParamEncaps(const uint8_t* v, int32_t sz, bool ok)
 {
     if(!ok)
     {
@@ -504,7 +504,7 @@ IceInternal::IncomingBase::handleException(std::exception_ptr exc, bool amd)
 }
 
 IceInternal::Incoming::Incoming(Instance* instance, ResponseHandler* responseHandler, Ice::Connection* connection,
-                                const ObjectAdapterPtr& adapter, bool response, Byte compress, int32_t requestId) :
+                                const ObjectAdapterPtr& adapter, bool response, uint8_t compress, int32_t requestId) :
     IncomingBase(instance, responseHandler, connection, adapter, response, compress, requestId),
     _inParamPos(0)
 {
@@ -579,7 +579,7 @@ IceInternal::Incoming::invoke(const ServantManagerPtr& servantManager, InputStre
 
     _is->read(_current.operation, false);
 
-    Byte b;
+    uint8_t b;
     _is->read(b);
     _current.mode = static_cast<OperationMode>(b);
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -513,11 +513,11 @@ Ice::InputStream::read(int16_t& v)
     const uint8_t* src = &(*i);
     i += sizeof(int16_t);
 #ifdef ICE_BIG_ENDIAN
-    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int16_t) - 1;
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v) + sizeof(int16_t) - 1;
     *dest-- = *src++;
     *dest = *src;
 #else
-    uint8_t* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v);
     *dest++ = *src++;
     *dest = *src;
 #endif
@@ -534,7 +534,7 @@ Ice::InputStream::read(vector<int16_t>& v)
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int16_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&v[0]) + sizeof(int16_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -542,7 +542,7 @@ Ice::InputStream::read(vector<int16_t>& v)
             dest += 2 * sizeof(int16_t);
         }
 #else
-        copy(begin, i, reinterpret_cast<Byte*>(&v[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&v[0]));
 #endif
     }
     else
@@ -571,7 +571,7 @@ Ice::InputStream::read(pair<const short*, const short*>& v)
         i += sz * static_cast<int>(sizeof(int16_t));
 #  ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int16_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&result[0]) + sizeof(int16_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -579,7 +579,7 @@ Ice::InputStream::read(pair<const short*, const short*>& v)
             dest += 2 * sizeof(int16_t);
         }
 #  else
-        copy(begin, i, reinterpret_cast<Byte*>(&result[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&result[0]));
 #  endif
 #endif
     }
@@ -600,7 +600,7 @@ Ice::InputStream::read(vector<int32_t>& v)
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int32_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&v[0]) + sizeof(int32_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -610,7 +610,7 @@ Ice::InputStream::read(vector<int32_t>& v)
             dest += 2 * sizeof(int32_t);
         }
 #else
-        copy(begin, i, reinterpret_cast<Byte*>(&v[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&v[0]));
 #endif
     }
     else
@@ -640,7 +640,7 @@ Ice::InputStream::read(pair<const int32_t*, const int32_t*>& v)
         i += sz * static_cast<int>(sizeof(int32_t));
 #  ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int32_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&result[0]) + sizeof(int32_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -650,7 +650,7 @@ Ice::InputStream::read(pair<const int32_t*, const int32_t*>& v)
             dest += 2 * sizeof(int32_t);
         }
 #  else
-        copy(begin, i, reinterpret_cast<Byte*>(&result[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&result[0]));
 #  endif
 #endif
     }
@@ -670,7 +670,7 @@ Ice::InputStream::read(int64_t& v)
     const uint8_t* src = &(*i);
     i += sizeof(int64_t);
 #ifdef ICE_BIG_ENDIAN
-    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v) + sizeof(int64_t) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
@@ -680,7 +680,7 @@ Ice::InputStream::read(int64_t& v)
     *dest-- = *src++;
     *dest = *src;
 #else
-    uint8_t* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -703,7 +703,7 @@ Ice::InputStream::read(vector<int64_t>& v)
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int64_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&v[0]) + sizeof(int64_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -717,7 +717,7 @@ Ice::InputStream::read(vector<int64_t>& v)
             dest += 2 * sizeof(int64_t);
         }
 #else
-        copy(begin, i, reinterpret_cast<Byte*>(&v[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&v[0]));
 #endif
     }
     else
@@ -747,7 +747,7 @@ Ice::InputStream::read(pair<const int64_t*, const int64_t*>& v)
         i += sz * static_cast<int>(sizeof(int64_t));
 #  ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int64_t) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&result[0]) + sizeof(int64_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -761,7 +761,7 @@ Ice::InputStream::read(pair<const int64_t*, const int64_t*>& v)
             dest += 2 * sizeof(int64_t);
         }
 #  else
-        copy(begin, i, reinterpret_cast<Byte*>(&result[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&result[0]));
 #  endif
 #endif
     }
@@ -781,13 +781,13 @@ Ice::InputStream::read(float& v)
     const uint8_t* src = &(*i);
     i += sizeof(float);
 #ifdef ICE_BIG_ENDIAN
-    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(float) - 1;
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v) + sizeof(float) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest = *src;
 #else
-    uint8_t* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -806,7 +806,7 @@ Ice::InputStream::read(vector<float>& v)
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(float) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&v[0]) + sizeof(float) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -816,7 +816,7 @@ Ice::InputStream::read(vector<float>& v)
             dest += 2 * sizeof(float);
         }
 #else
-        copy(begin, i, reinterpret_cast<Byte*>(&v[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&v[0]));
 #endif
     }
     else
@@ -846,7 +846,7 @@ Ice::InputStream::read(pair<const float*, const float*>& v)
         i += sz * static_cast<int>(sizeof(float));
 #  ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(float) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&result[0]) + sizeof(float) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -856,7 +856,7 @@ Ice::InputStream::read(pair<const float*, const float*>& v)
             dest += 2 * sizeof(float);
         }
 #  else
-        copy(begin, i, reinterpret_cast<Byte*>(&result[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&result[0]));
 #  endif
 #endif
     }
@@ -876,7 +876,7 @@ Ice::InputStream::read(double& v)
     const uint8_t* src = &(*i);
     i += sizeof(double);
 #ifdef ICE_BIG_ENDIAN
-    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(double) - 1;
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v) + sizeof(double) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
@@ -886,7 +886,7 @@ Ice::InputStream::read(double& v)
     *dest-- = *src++;
     *dest = *src;
 #else
-    uint8_t* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -909,7 +909,7 @@ Ice::InputStream::read(vector<double>& v)
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(double) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&v[0]) + sizeof(double) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -923,7 +923,7 @@ Ice::InputStream::read(vector<double>& v)
             dest += 2 * sizeof(double);
         }
 #else
-        copy(begin, i, reinterpret_cast<Byte*>(&v[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&v[0]));
 #endif
     }
     else
@@ -953,7 +953,7 @@ Ice::InputStream::read(pair<const double*, const double*>& v)
         i += sz * static_cast<int>(sizeof(double));
 #  ifdef ICE_BIG_ENDIAN
         const uint8_t* src = &(*begin);
-        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(double) - 1;
+        uint8_t* dest = reinterpret_cast<uint8_t*>(&result[0]) + sizeof(double) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -967,7 +967,7 @@ Ice::InputStream::read(pair<const double*, const double*>& v)
             dest += 2 * sizeof(double);
         }
 #  else
-        copy(begin, i, reinterpret_cast<Byte*>(&result[0]));
+        copy(begin, i, reinterpret_cast<uint8_t*>(&result[0]));
 #  endif
 #endif
     }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -37,7 +37,7 @@ Ice::InputStream::InputStream()
     initialize(currentEncoding);
 }
 
-Ice::InputStream::InputStream(const vector<Byte>& v) :
+Ice::InputStream::InputStream(const vector<uint8_t>& v) :
     Buffer(v)
 {
     initialize(currentEncoding);
@@ -60,7 +60,7 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator)
     initialize(communicator);
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<Byte>& v) :
+Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<uint8_t>& v) :
     Buffer(v)
 {
     initialize(communicator);
@@ -83,7 +83,7 @@ Ice::InputStream::InputStream(const EncodingVersion& encoding)
     initialize(encoding);
 }
 
-Ice::InputStream::InputStream(const EncodingVersion& encoding, const vector<Byte>& v) :
+Ice::InputStream::InputStream(const EncodingVersion& encoding, const vector<uint8_t>& v) :
     Buffer(v)
 {
     initialize(encoding);
@@ -107,7 +107,7 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const Encodin
 }
 
 Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const EncodingVersion& encoding,
-                              const vector<Byte>& v) :
+                              const vector<uint8_t>& v) :
     Buffer(v)
 {
     initialize(communicator, encoding);
@@ -387,7 +387,7 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
 }
 
 void
-Ice::InputStream::readBlob(vector<Byte>& v, int32_t sz)
+Ice::InputStream::readBlob(vector<uint8_t>& v, int32_t sz)
 {
     if(sz > 0)
     {
@@ -395,7 +395,7 @@ Ice::InputStream::readBlob(vector<Byte>& v, int32_t sz)
         {
             throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
         }
-        vector<Byte>(i, i + sz).swap(v);
+        vector<uint8_t>(i, i + sz).swap(v);
         i += sz;
     }
     else
@@ -2300,11 +2300,11 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
         // Don't include the optional member end marker. It will be re-written by
         // endSlice when the sliced data is re-written.
         //
-        vector<Byte>(start, _stream->i - 1).swap(info->bytes);
+        vector<uint8_t>(start, _stream->i - 1).swap(info->bytes);
     }
     else
     {
-        vector<Byte>(start, _stream->i).swap(info->bytes);
+        vector<uint8_t>(start, _stream->i).swap(info->bytes);
     }
 
     _current->indirectionTables.push_back(IndexList());

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -405,7 +405,7 @@ Ice::InputStream::readBlob(vector<uint8_t>& v, int32_t sz)
 }
 
 void
-Ice::InputStream::read(std::vector<Ice::Byte>& v)
+Ice::InputStream::read(std::vector<uint8_t>& v)
 {
     std::pair<const uint8_t*, const uint8_t*> p;
     read(p);

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -407,7 +407,7 @@ Ice::InputStream::readBlob(vector<Byte>& v, int32_t sz)
 void
 Ice::InputStream::read(std::vector<Ice::Byte>& v)
 {
-    std::pair<const Ice::Byte*, const Ice::Byte*> p;
+    std::pair<const uint8_t*, const uint8_t*> p;
     read(p);
     if(p.first != p.second)
     {

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -43,7 +43,7 @@ Ice::InputStream::InputStream(const vector<Byte>& v) :
     initialize(currentEncoding);
 }
 
-Ice::InputStream::InputStream(const pair<const Byte*, const Byte*>& p) :
+Ice::InputStream::InputStream(const pair<const uint8_t*, const uint8_t*>& p) :
     Buffer(p.first, p.second)
 {
     initialize(currentEncoding);
@@ -66,7 +66,7 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<
     initialize(communicator);
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const pair<const Byte*, const Byte*>& p) :
+Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const pair<const uint8_t*, const uint8_t*>& p) :
     Buffer(p.first, p.second)
 {
     initialize(communicator);
@@ -89,7 +89,7 @@ Ice::InputStream::InputStream(const EncodingVersion& encoding, const vector<Byte
     initialize(encoding);
 }
 
-Ice::InputStream::InputStream(const EncodingVersion& encoding, const pair<const Byte*, const Byte*>& p) :
+Ice::InputStream::InputStream(const EncodingVersion& encoding, const pair<const uint8_t*, const uint8_t*>& p) :
     Buffer(p.first, p.second)
 {
     initialize(encoding);
@@ -114,7 +114,7 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const Encodin
 }
 
 Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const EncodingVersion& encoding,
-                              const pair<const Byte*, const Byte*>& p) :
+                              const pair<const uint8_t*, const uint8_t*>& p) :
     Buffer(p.first, p.second)
 {
     initialize(communicator, encoding);
@@ -421,7 +421,7 @@ Ice::InputStream::read(std::vector<Ice::Byte>& v)
 }
 
 void
-Ice::InputStream::read(pair<const Byte*, const Byte*>& v)
+Ice::InputStream::read(pair<const uint8_t*, const uint8_t*>& v)
 {
     int32_t sz = readAndCheckSeqSize(1);
     if(sz > 0)
@@ -510,14 +510,14 @@ Ice::InputStream::read(int16_t& v)
     {
         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    const Byte* src = &(*i);
+    const uint8_t* src = &(*i);
     i += sizeof(int16_t);
 #ifdef ICE_BIG_ENDIAN
-    Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(int16_t) - 1;
+    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int16_t) - 1;
     *dest-- = *src++;
     *dest = *src;
 #else
-    Byte* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<Byte*>(&v);
     *dest++ = *src++;
     *dest = *src;
 #endif
@@ -533,8 +533,8 @@ Ice::InputStream::read(vector<int16_t>& v)
         i += sz * static_cast<int>(sizeof(int16_t));
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int16_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int16_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -570,8 +570,8 @@ Ice::InputStream::read(pair<const short*, const short*>& v)
         Container::iterator begin = i;
         i += sz * static_cast<int>(sizeof(int16_t));
 #  ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int16_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int16_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -599,8 +599,8 @@ Ice::InputStream::read(vector<int32_t>& v)
         i += sz * static_cast<int>(sizeof(int32_t));
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int32_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int32_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -639,8 +639,8 @@ Ice::InputStream::read(pair<const int32_t*, const int32_t*>& v)
         Container::iterator begin = i;
         i += sz * static_cast<int>(sizeof(int32_t));
 #  ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int32_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int32_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -667,10 +667,10 @@ Ice::InputStream::read(int64_t& v)
     {
         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    const Byte* src = &(*i);
+    const uint8_t* src = &(*i);
     i += sizeof(int64_t);
 #ifdef ICE_BIG_ENDIAN
-    Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
+    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
@@ -680,7 +680,7 @@ Ice::InputStream::read(int64_t& v)
     *dest-- = *src++;
     *dest = *src;
 #else
-    Byte* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<Byte*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -702,8 +702,8 @@ Ice::InputStream::read(vector<int64_t>& v)
         i += sz * static_cast<int>(sizeof(int64_t));
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int64_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(int64_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -746,8 +746,8 @@ Ice::InputStream::read(pair<const int64_t*, const int64_t*>& v)
         Container::iterator begin = i;
         i += sz * static_cast<int>(sizeof(int64_t));
 #  ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int64_t) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(int64_t) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -778,16 +778,16 @@ Ice::InputStream::read(float& v)
     {
         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    const Byte* src = &(*i);
+    const uint8_t* src = &(*i);
     i += sizeof(float);
 #ifdef ICE_BIG_ENDIAN
-    Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(float) - 1;
+    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(float) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest = *src;
 #else
-    Byte* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<Byte*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -805,8 +805,8 @@ Ice::InputStream::read(vector<float>& v)
         i += sz * static_cast<int>(sizeof(float));
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(float) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(float) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -845,8 +845,8 @@ Ice::InputStream::read(pair<const float*, const float*>& v)
         Container::iterator begin = i;
         i += sz * static_cast<int>(sizeof(float));
 #  ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(float) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(float) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -873,10 +873,10 @@ Ice::InputStream::read(double& v)
     {
         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
-    const Byte* src = &(*i);
+    const uint8_t* src = &(*i);
     i += sizeof(double);
 #ifdef ICE_BIG_ENDIAN
-    Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(double) - 1;
+    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(double) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
@@ -886,7 +886,7 @@ Ice::InputStream::read(double& v)
     *dest-- = *src++;
     *dest = *src;
 #else
-    Byte* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<Byte*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -908,8 +908,8 @@ Ice::InputStream::read(vector<double>& v)
         i += sz * static_cast<int>(sizeof(double));
         v.resize(static_cast<size_t>(sz));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(double) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&v[0]) + sizeof(double) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -952,8 +952,8 @@ Ice::InputStream::read(pair<const double*, const double*>& v)
         Container::iterator begin = i;
         i += sz * static_cast<int>(sizeof(double));
 #  ifdef ICE_BIG_ENDIAN
-        const Byte* src = &(*begin);
-        Byte* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(double) - 1;
+        const uint8_t* src = &(*begin);
+        uint8_t* dest = reinterpret_cast<Byte*>(&result[0]) + sizeof(double) - 1;
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest-- = *src++;
@@ -1193,7 +1193,7 @@ Ice::InputStream::readEnum(int32_t maxValue)
     {
         if(maxValue < 127)
         {
-            Byte value;
+            uint8_t value;
             read(value);
             return value;
         }
@@ -1238,7 +1238,7 @@ Ice::InputStream::readOptImpl(int32_t readTag, OptionalFormat expectedFormat)
             return false; // End of encapsulation also indicates end of optionals.
         }
 
-        Byte v;
+        uint8_t v;
         read(v);
         if(v == OPTIONAL_END_MARKER)
         {
@@ -1343,7 +1343,7 @@ Ice::InputStream::skipOptionals()
             return; // End of encapsulation also indicates end of optionals.
         }
 
-        Byte v;
+        uint8_t v;
         read(v);
         if(v == OPTIONAL_END_MARKER)
         {

--- a/cpp/src/Ice/NetworkProxy.cpp
+++ b/cpp/src/Ice/NetworkProxy.cpp
@@ -86,23 +86,23 @@ SOCKSNetworkProxy::beginWrite(const Address& addr, Buffer& buf)
     //
     buf.b.resize(9);
     buf.i = buf.b.begin();
-    Ice::Byte* dest = &buf.b[0];
+    uint8_t* dest = &buf.b[0];
     *dest++ = 0x04; // SOCKS version 4.
     *dest++ = 0x01; // Command, establish a TCP/IP stream connection
 
-    const Ice::Byte* src;
+    const uint8_t* src;
 
     //
     // Port (already in big-endian order)
     //
-    src = reinterpret_cast<const Ice::Byte*>(&addr.saIn.sin_port);
+    src = reinterpret_cast<const uint8_t*>(&addr.saIn.sin_port);
     *dest++ = *src++;
     *dest++ = *src;
 
     //
     // IPv4 address (already in big-endian order)
     //
-    src = reinterpret_cast<const Ice::Byte*>(&addr.saIn.sin_addr.s_addr);
+    src = reinterpret_cast<const uint8_t*>(&addr.saIn.sin_addr.s_addr);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -145,9 +145,9 @@ SOCKSNetworkProxy::finish(Buffer& readBuffer, Buffer&)
         throw Ice::UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
 
-    const Ice::Byte* src = &(*readBuffer.i);
-    const Ice::Byte b1 = *src++;
-    const Ice::Byte b2 = *src++;
+    const uint8_t* src = &(*readBuffer.i);
+    const uint8_t b1 = *src++;
+    const uint8_t b2 = *src++;
     if(b1 != 0x00 || b2 != 0x5a)
     {
         throw Ice::ConnectFailedException(__FILE__, __LINE__);
@@ -229,7 +229,7 @@ HTTPNetworkProxy::endRead(Buffer& buf)
     // Check if we received the full HTTP response, if not, continue
     // reading otherwise we're done.
     //
-    const Ice::Byte* end = HttpParser().isCompleteMessage(buf.b.begin(), buf.i);
+    const uint8_t* end = HttpParser().isCompleteMessage(buf.b.begin(), buf.i);
     if(!end && buf.i == buf.b.end())
     {
         //

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -231,7 +231,7 @@ Ice::Object::_iceCheckMode(OperationMode expected, OperationMode received)
 bool
 Ice::Blobject::_iceDispatch(Incoming& in, const Current& current)
 {
-    const Byte* inEncaps;
+    const uint8_t* inEncaps;
     int32_t sz;
     in.readParamEncaps(inEncaps, sz);
     vector<Byte> outEncaps;
@@ -250,7 +250,7 @@ Ice::Blobject::_iceDispatch(Incoming& in, const Current& current)
 bool
 Ice::BlobjectArray::_iceDispatch(Incoming& in, const Current& current)
 {
-    pair<const Byte*, const Byte*> inEncaps;
+    pair<const uint8_t*, const uint8_t*> inEncaps;
     int32_t sz;
     in.readParamEncaps(inEncaps.first, sz);
     inEncaps.second = inEncaps.first + sz;
@@ -270,7 +270,7 @@ Ice::BlobjectArray::_iceDispatch(Incoming& in, const Current& current)
 bool
 Ice::BlobjectAsync::_iceDispatch(Incoming& in, const Current& current)
 {
-    const Byte* inEncaps;
+    const uint8_t* inEncaps;
     int32_t sz;
     in.readParamEncaps(inEncaps, sz);
     auto async = IncomingAsync::create(in);
@@ -294,13 +294,13 @@ Ice::BlobjectAsync::_iceDispatch(Incoming& in, const Current& current)
 bool
 Ice::BlobjectArrayAsync::_iceDispatch(Incoming& in, const Current& current)
 {
-    pair<const Byte*, const Byte*> inEncaps;
+    pair<const uint8_t*, const uint8_t*> inEncaps;
     int32_t sz;
     in.readParamEncaps(inEncaps.first, sz);
     inEncaps.second = inEncaps.first + sz;
     auto async = IncomingAsync::create(in);
     ice_invokeAsync(inEncaps,
-                    [async](bool ok, const pair<const Byte*, const Byte*>& outE)
+                    [async](bool ok, const pair<const uint8_t*, const uint8_t*>& outE)
                     {
                         async->writeParamEncaps(outE.first, static_cast<int32_t>(outE.second - outE.first), ok);
                         async->completed();

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -234,8 +234,8 @@ Ice::Blobject::_iceDispatch(Incoming& in, const Current& current)
     const uint8_t* inEncaps;
     int32_t sz;
     in.readParamEncaps(inEncaps, sz);
-    vector<Byte> outEncaps;
-    bool ok = ice_invoke(vector<Byte>(inEncaps, inEncaps + sz), outEncaps, current);
+    vector<uint8_t> outEncaps;
+    bool ok = ice_invoke(vector<uint8_t>(inEncaps, inEncaps + sz), outEncaps, current);
     if(outEncaps.empty())
     {
         in.writeParamEncaps(0, 0, ok);
@@ -254,7 +254,7 @@ Ice::BlobjectArray::_iceDispatch(Incoming& in, const Current& current)
     int32_t sz;
     in.readParamEncaps(inEncaps.first, sz);
     inEncaps.second = inEncaps.first + sz;
-    vector<Byte> outEncaps;
+    vector<uint8_t> outEncaps;
     bool ok = ice_invoke(inEncaps, outEncaps, current);
     if(outEncaps.empty())
     {
@@ -274,8 +274,8 @@ Ice::BlobjectAsync::_iceDispatch(Incoming& in, const Current& current)
     int32_t sz;
     in.readParamEncaps(inEncaps, sz);
     auto async = IncomingAsync::create(in);
-    ice_invokeAsync(vector<Byte>(inEncaps, inEncaps + sz),
-                    [async](bool ok, const vector<Byte>& outEncaps)
+    ice_invokeAsync(vector<uint8_t>(inEncaps, inEncaps + sz),
+                    [async](bool ok, const vector<uint8_t>& outEncaps)
                     {
                         if(outEncaps.empty())
                         {

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -42,7 +42,7 @@ IceInternal::OpaqueEndpointI::OpaqueEndpointI(int16_t type, InputStream* s) : _t
 {
     _rawEncoding = s->getEncoding();
     int32_t sz = s->getEncapsulationSize();
-    s->readBlob(const_cast<vector<Byte>&>(_rawBytes), sz);
+    s->readBlob(const_cast<vector<uint8_t>&>(_rawBytes), sz);
 }
 
 namespace
@@ -371,7 +371,7 @@ IceInternal::OpaqueEndpointI::checkOption(const string& option, const string& ar
                 throw EndpointParseException(__FILE__, __LINE__, os.str());
             }
         }
-        const_cast<vector<Byte>&>(_rawBytes) = Base64::decode(argument);
+        const_cast<vector<uint8_t>&>(_rawBytes) = Base64::decode(argument);
         return true;
     }
 

--- a/cpp/src/Ice/OpaqueEndpointI.h
+++ b/cpp/src/Ice/OpaqueEndpointI.h
@@ -61,7 +61,7 @@ private:
     //
     std::int16_t _type;
     Ice::EncodingVersion _rawEncoding; // The encoding used for _rawBytes
-    const std::vector<Ice::Byte> _rawBytes;
+    const std::vector<std::uint8_t> _rawBytes;
 };
 
 }

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -725,7 +725,7 @@ OutgoingAsync::response()
         _childObserver.detach();
     }
 
-    Byte replyStatus;
+    uint8_t replyStatus;
     try
     {
         _is.read(replyStatus);

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -676,7 +676,7 @@ OutgoingAsync::prepare(const string& operation, OperationMode mode, const Contex
 
     _os.write(operation, false);
 
-    _os.write(static_cast<Byte>(_mode));
+    _os.write(static_cast<uint8_t>(_mode));
 
     if(&context != &Ice::noExplicitContext)
     {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -1160,7 +1160,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(string_view typeId, int compactId
         _current->sliceFlags |= FLAG_IS_LAST_SLICE; // This is the last slice.
     }
 
-    _stream->write(Byte(0)); // Placeholder for the slice flags
+    _stream->write(std::uint8_t(0)); // Placeholder for the slice flags
 
     //
     // For instance slices, encode the flag and the type ID either as a

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -33,7 +33,7 @@ public:
     {
     }
 
-    Ice::Byte* getMoreBytes(size_t howMany, Ice::Byte* firstUnused)
+    uint8_t* getMoreBytes(size_t howMany, uint8_t* firstUnused)
     {
         assert(howMany > 0);
 
@@ -837,7 +837,7 @@ Ice::OutputStream::finished()
 {
     if(b.empty())
     {
-        return pair<const Byte*, const Byte*>(reinterpret_cast<Ice::Byte*>(0), reinterpret_cast<Ice::Byte*>(0));
+        return pair<const Byte*, const Byte*>(reinterpret_cast<uint8_t*>(0), reinterpret_cast<uint8_t*>(0));
     }
     else
     {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -90,7 +90,7 @@ Ice::OutputStream::OutputStream(const CommunicatorPtr& communicator, const Encod
 }
 
 Ice::OutputStream::OutputStream(const CommunicatorPtr& communicator, const EncodingVersion& encoding,
-                                const pair<const Byte*, const Byte*>& buf) :
+                                const pair<const uint8_t*, const uint8_t*>& buf) :
     Buffer(buf.first, buf.second),
     _closure(0),
     _currentEncaps(0)
@@ -248,7 +248,7 @@ Ice::OutputStream::writeBlob(const vector<Byte>& v)
 }
 
 void
-Ice::OutputStream::write(const Byte* begin, const Byte* end)
+Ice::OutputStream::write(const uint8_t* begin, const uint8_t* end)
 {
     int32_t sz = static_cast<int32_t>(end - begin);
     writeSize(sz);
@@ -317,13 +317,13 @@ Ice::OutputStream::write(int16_t v)
 {
     Container::size_type pos = b.size();
     resize(pos + sizeof(int16_t));
-    Byte* dest = &b[pos];
+    uint8_t* dest = &b[pos];
 #ifdef ICE_BIG_ENDIAN
-    const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(int16_t) - 1;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v) + sizeof(int16_t) - 1;
     *dest++ = *src--;
     *dest = *src;
 #else
-    const Byte* src = reinterpret_cast<const Byte*>(&v);
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v);
     *dest++ = *src++;
     *dest = *src;
 #endif
@@ -339,8 +339,8 @@ Ice::OutputStream::write(const int16_t* begin, const int16_t* end)
         Container::size_type pos = b.size();
         resize(pos + static_cast<size_t>(sz) * sizeof(int16_t));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(begin) + sizeof(int16_t) - 1;
-        Byte* dest = &(*(b.begin() + pos));
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(begin) + sizeof(int16_t) - 1;
+        uint8_t* dest = &(*(b.begin() + pos));
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest++ = *src--;
@@ -348,7 +348,7 @@ Ice::OutputStream::write(const int16_t* begin, const int16_t* end)
             src += 2 * sizeof(int16_t);
         }
 #else
-        memcpy(&b[pos], reinterpret_cast<const Byte*>(begin), static_cast<size_t>(sz) * sizeof(int16_t));
+        memcpy(&b[pos], reinterpret_cast<const uint8_t*>(begin), static_cast<size_t>(sz) * sizeof(int16_t));
 #endif
     }
 }
@@ -363,8 +363,8 @@ Ice::OutputStream::write(const int32_t* begin, const int32_t* end)
         Container::size_type pos = b.size();
         resize(pos + static_cast<size_t>(sz) * sizeof(int32_t));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(begin) + sizeof(int32_t) - 1;
-        Byte* dest = &(*(b.begin() + pos));
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(begin) + sizeof(int32_t) - 1;
+        uint8_t* dest = &(*(b.begin() + pos));
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest++ = *src--;
@@ -374,7 +374,7 @@ Ice::OutputStream::write(const int32_t* begin, const int32_t* end)
             src += 2 * sizeof(int32_t);
         }
 #else
-        memcpy(&b[pos], reinterpret_cast<const Byte*>(begin), static_cast<size_t>(sz) * sizeof(int32_t));
+        memcpy(&b[pos], reinterpret_cast<const uint8_t*>(begin), static_cast<size_t>(sz) * sizeof(int32_t));
 #endif
     }
 }
@@ -384,9 +384,9 @@ Ice::OutputStream::write(int64_t v)
 {
     Container::size_type pos = b.size();
     resize(pos + sizeof(int64_t));
-    Byte* dest = &b[pos];
+    uint8_t* dest = &b[pos];
 #ifdef ICE_BIG_ENDIAN
-    const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(Long) - 1;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v) + sizeof(Long) - 1;
     *dest++ = *src--;
     *dest++ = *src--;
     *dest++ = *src--;
@@ -396,7 +396,7 @@ Ice::OutputStream::write(int64_t v)
     *dest++ = *src--;
     *dest = *src;
 #else
-    const Byte* src = reinterpret_cast<const Byte*>(&v);
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -418,8 +418,8 @@ Ice::OutputStream::write(const int64_t* begin, const int64_t* end)
         Container::size_type pos = b.size();
         resize(pos + static_cast<size_t>(sz) * sizeof(int64_t));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(begin) + sizeof(int64_t) - 1;
-        Byte* dest = &(*(b.begin() + pos));
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(begin) + sizeof(int64_t) - 1;
+        uint8_t* dest = &(*(b.begin() + pos));
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest++ = *src--;
@@ -433,7 +433,7 @@ Ice::OutputStream::write(const int64_t* begin, const int64_t* end)
             src += 2 * sizeof(int64_t);
         }
 #else
-        memcpy(&b[pos], reinterpret_cast<const Byte*>(begin), static_cast<size_t>(sz) * sizeof(int64_t));
+        memcpy(&b[pos], reinterpret_cast<const uint8_t*>(begin), static_cast<size_t>(sz) * sizeof(int64_t));
 #endif
     }
 }
@@ -443,15 +443,15 @@ Ice::OutputStream::write(float v)
 {
     Container::size_type pos = b.size();
     resize(pos + sizeof(float));
-    Byte* dest = &b[pos];
+    uint8_t* dest = &b[pos];
 #ifdef ICE_BIG_ENDIAN
-    const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(float) - 1;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v) + sizeof(float) - 1;
     *dest++ = *src--;
     *dest++ = *src--;
     *dest++ = *src--;
     *dest = *src;
 #else
-    const Byte* src = reinterpret_cast<const Byte*>(&v);
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -469,8 +469,8 @@ Ice::OutputStream::write(const float* begin, const float* end)
         Container::size_type pos = b.size();
         resize(pos + static_cast<size_t>(sz) * sizeof(float));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(begin) + sizeof(float) - 1;
-        Byte* dest = &(*(b.begin() + pos));
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(begin) + sizeof(float) - 1;
+        uint8_t* dest = &(*(b.begin() + pos));
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest++ = *src--;
@@ -480,7 +480,7 @@ Ice::OutputStream::write(const float* begin, const float* end)
             src += 2 * sizeof(float);
         }
 #else
-        memcpy(&b[pos], reinterpret_cast<const Byte*>(begin), static_cast<size_t>(sz) * sizeof(float));
+        memcpy(&b[pos], reinterpret_cast<const uint8_t*>(begin), static_cast<size_t>(sz) * sizeof(float));
 #endif
     }
 }
@@ -490,9 +490,9 @@ Ice::OutputStream::write(double v)
 {
     Container::size_type pos = b.size();
     resize(pos + sizeof(double));
-    Byte* dest = &b[pos];
+    uint8_t* dest = &b[pos];
 #ifdef ICE_BIG_ENDIAN
-    const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(double) - 1;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v) + sizeof(double) - 1;
     *dest++ = *src--;
     *dest++ = *src--;
     *dest++ = *src--;
@@ -502,7 +502,7 @@ Ice::OutputStream::write(double v)
     *dest++ = *src--;
     *dest = *src;
 #else
-    const Byte* src = reinterpret_cast<const Byte*>(&v);
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -524,8 +524,8 @@ Ice::OutputStream::write(const double* begin, const double* end)
         Container::size_type pos = b.size();
         resize(pos + static_cast<size_t>(sz) * sizeof(double));
 #ifdef ICE_BIG_ENDIAN
-        const Byte* src = reinterpret_cast<const Byte*>(begin) + sizeof(double) - 1;
-        Byte* dest = &(*(b.begin() + pos));
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(begin) + sizeof(double) - 1;
+        uint8_t* dest = &(*(b.begin() + pos));
         for(int j = 0 ; j < sz ; ++j)
         {
             *dest++ = *src--;
@@ -539,7 +539,7 @@ Ice::OutputStream::write(const double* begin, const double* end)
             src += 2 * sizeof(double);
         }
 #else
-        memcpy(&b[pos], reinterpret_cast<const Byte*>(begin), static_cast<size_t>(sz) * sizeof(double));
+        memcpy(&b[pos], reinterpret_cast<const uint8_t*>(begin), static_cast<size_t>(sz) * sizeof(double));
 #endif
     }
 }
@@ -574,7 +574,7 @@ Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = nullptr;
+        uint8_t* lastByte = nullptr;
         bool converted = false;
         if(_instance)
         {
@@ -686,7 +686,7 @@ Ice::OutputStream::write(wstring_view v)
         size_t firstIndex = b.size();
         StreamUTF8BufferI buffer(*this);
 
-        Byte* lastByte = nullptr;
+        uint8_t* lastByte = nullptr;
 
         // Note: wstringConverter is never null; when set to null, get returns the default unicode wstring converter
         if(_instance)
@@ -811,7 +811,7 @@ Ice::OutputStream::writeOptImpl(int32_t tag, OptionalFormat type)
         return false; // Optional members aren't supported with the 1.0 encoding.
     }
 
-    Byte v = static_cast<Byte>(type);
+    uint8_t v = static_cast<Byte>(type);
     if(tag < 30)
     {
         v |= static_cast<Byte>(tag << 3);
@@ -832,16 +832,16 @@ Ice::OutputStream::finished(vector<Byte>& bytes)
     vector<Byte>(b.begin(), b.end()).swap(bytes);
 }
 
-pair<const Byte*, const Byte*>
+pair<const uint8_t*, const uint8_t*>
 Ice::OutputStream::finished()
 {
     if(b.empty())
     {
-        return pair<const Byte*, const Byte*>(reinterpret_cast<uint8_t*>(0), reinterpret_cast<uint8_t*>(0));
+        return pair<const uint8_t*, const uint8_t*>(reinterpret_cast<uint8_t*>(0), reinterpret_cast<uint8_t*>(0));
     }
     else
     {
-        return pair<const Byte*, const Byte*>(&b[0], &b[0] + b.size());
+        return pair<const uint8_t*, const uint8_t*>(&b[0], &b[0] + b.size());
     }
 }
 
@@ -995,7 +995,7 @@ Ice::OutputStream::EncapsEncoder10::endSlice()
     // Write the slice length.
     //
     int32_t sz = static_cast<int32_t>(_stream->b.size() - _writeSlice + sizeof(int32_t));
-    Byte* dest = &(*(_stream->b.begin() + _writeSlice - sizeof(int32_t)));
+    uint8_t* dest = &(*(_stream->b.begin() + _writeSlice - sizeof(int32_t)));
     _stream->write(sz, dest);
 }
 
@@ -1229,7 +1229,7 @@ Ice::OutputStream::EncapsEncoder11::endSlice()
     if(_current->sliceFlags & FLAG_HAS_SLICE_SIZE)
     {
         int32_t sz = static_cast<int32_t>(_stream->b.size() - _current->writeSlice + sizeof(int32_t));
-        Byte* dest = &(*(_stream->b.begin() + _current->writeSlice - sizeof(int32_t)));
+        uint8_t* dest = &(*(_stream->b.begin() + _current->writeSlice - sizeof(int32_t)));
         _stream->write(sz, dest);
     }
 
@@ -1257,7 +1257,7 @@ Ice::OutputStream::EncapsEncoder11::endSlice()
     //
     // Finally, update the slice flags.
     //
-    Byte* dest = &(*(_stream->b.begin() + _current->sliceFlagsPos));
+    uint8_t* dest = &(*(_stream->b.begin() + _current->sliceFlagsPos));
     *dest = _current->sliceFlags;
 }
 

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -237,7 +237,7 @@ Ice::OutputStream::writePendingValues()
 }
 
 void
-Ice::OutputStream::writeBlob(const vector<Byte>& v)
+Ice::OutputStream::writeBlob(const vector<uint8_t>& v)
 {
     if(!v.empty())
     {
@@ -283,7 +283,7 @@ struct WriteBoolHelper
     {
         for(size_t idx = 0; idx < static_cast<size_t>(sz); ++idx)
         {
-            b[pos + idx] = static_cast<Byte>(*(begin + idx));
+            b[pos + idx] = static_cast<uint8_t>(*(begin + idx));
         }
     }
 };
@@ -779,7 +779,7 @@ Ice::OutputStream::writeEnum(int32_t v, int32_t maxValue)
     {
         if(maxValue < 127)
         {
-            write(static_cast<Byte>(v));
+            write(static_cast<uint8_t>(v));
         }
         else if(maxValue < 32767)
         {
@@ -811,10 +811,10 @@ Ice::OutputStream::writeOptImpl(int32_t tag, OptionalFormat type)
         return false; // Optional members aren't supported with the 1.0 encoding.
     }
 
-    uint8_t v = static_cast<Byte>(type);
+    uint8_t v = static_cast<uint8_t>(type);
     if(tag < 30)
     {
-        v |= static_cast<Byte>(tag << 3);
+        v |= static_cast<uint8_t>(tag << 3);
         write(v);
     }
     else
@@ -827,9 +827,9 @@ Ice::OutputStream::writeOptImpl(int32_t tag, OptionalFormat type)
 }
 
 void
-Ice::OutputStream::finished(vector<Byte>& bytes)
+Ice::OutputStream::finished(vector<uint8_t>& bytes)
 {
-    vector<Byte>(b.begin(), b.end()).swap(bytes);
+    vector<uint8_t>(b.begin(), b.end()).swap(bytes);
 }
 
 pair<const uint8_t*, const uint8_t*>

--- a/cpp/src/Ice/Protocol.cpp
+++ b/cpp/src/Ice/Protocol.cpp
@@ -8,9 +8,9 @@
 namespace IceInternal
 {
 
-const Ice::Byte magic[] = { 0x49, 0x63, 0x65, 0x50 };   // 'I', 'c', 'e', 'P'
+const uint8_t magic[] = { 0x49, 0x63, 0x65, 0x50 };   // 'I', 'c', 'e', 'P'
 
-const Ice::Byte requestHdr[] =
+const uint8_t requestHdr[] =
 {
     magic[0],
     magic[1],
@@ -26,7 +26,7 @@ const Ice::Byte requestHdr[] =
     0, 0, 0, 0 // Request id (placeholder)
 };
 
-const Ice::Byte requestBatchHdr[] =
+const uint8_t requestBatchHdr[] =
 {
     magic[0],
     magic[1],
@@ -42,7 +42,7 @@ const Ice::Byte requestBatchHdr[] =
     0, 0, 0, 0  // Number of requests in batch (placeholder)
 };
 
-const Ice::Byte replyHdr[] =
+const uint8_t replyHdr[] =
 {
     magic[0],
     magic[1],
@@ -58,7 +58,7 @@ const Ice::Byte replyHdr[] =
 };
 
 void
-stringToMajorMinor(const std::string& str, Ice::Byte& major, Ice::Byte& minor)
+stringToMajorMinor(const std::string& str, uint8_t& major, uint8_t& minor)
 {
     std::string::size_type pos = str.find_first_of(".");
     if(pos == std::string::npos)

--- a/cpp/src/Ice/Protocol.cpp
+++ b/cpp/src/Ice/Protocol.cpp
@@ -85,8 +85,8 @@ stringToMajorMinor(const std::string& str, uint8_t& major, uint8_t& minor)
         throw Ice::VersionParseException(__FILE__, __LINE__, "range error in version `" + str + "'");
     }
 
-    major = static_cast<Ice::Byte>(majVersion);
-    minor = static_cast<Ice::Byte>(minVersion);
+    major = static_cast<uint8_t>(majVersion);
+    minor = static_cast<uint8_t>(minVersion);
 }
 
 void

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -472,7 +472,7 @@ Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, con
 bool Ice::ObjectPrx::ice_invoke(const string &operation,
                                 Ice::OperationMode mode,
                                 const vector<uint8_t> &inParams,
-                                vector<Ice::Byte> &outParams,
+                                vector<uint8_t> &outParams,
                                 const Ice::Context &context) const
 {
     return ice_invoke(operation, mode, makePair(inParams), outParams, context);
@@ -490,8 +490,8 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 std::function<void()>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
-                                const vector<Ice::Byte> &inParams,
-                                std::function<void(bool, vector<Ice::Byte>)> response,
+                                const vector<uint8_t> &inParams,
+                                std::function<void(bool, vector<uint8_t>)> response,
                                 std::function<void(std::exception_ptr)> ex,
                                 std::function<void(bool)> sent,
                                 const Ice::Context &context) const
@@ -515,7 +515,7 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 bool Ice::ObjectPrx::ice_invoke(const string &operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const uint8_t *, const uint8_t *> &inParams,
-                                vector<Ice::Byte> &outParams,
+                                vector<uint8_t> &outParams,
                                 const Ice::Context &context) const
 {
     using Outgoing = InvokePromiseOutgoing<std::tuple<bool, vector<uint8_t>>>;

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -33,7 +33,7 @@ const string ice_flushBatchRequests_name = "ice_flushBatchRequests";
 namespace IceInternal
 {
 
-inline std::pair<const Ice::Byte*, const Ice::Byte*>
+inline std::pair<const uint8_t*, const uint8_t*>
 makePair(const Ice::ByteSeq& seq)
 {
     if(seq.empty())
@@ -147,12 +147,12 @@ public:
     void
     invoke(const std::string& operation,
            Ice::OperationMode mode,
-           const std::pair<const Ice::Byte*, const Ice::Byte*>& inParams,
+           const std::pair<const uint8_t*, const uint8_t*>& inParams,
            const Ice::Context& context)
     {
         _read = [](bool ok, Ice::InputStream* stream)
         {
-            const Ice::Byte* encaps;
+            const uint8_t* encaps;
             std::int32_t sz;
             stream->readEncapsulation(encaps, sz);
             return R { ok, { encaps, encaps + sz } };
@@ -514,7 +514,7 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 
 bool Ice::ObjectPrx::ice_invoke(const string &operation,
                                 Ice::OperationMode mode,
-                                const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
+                                const std::pair<const uint8_t *, const uint8_t *> &inParams,
                                 vector<Ice::Byte> &outParams,
                                 const Ice::Context &context) const
 {
@@ -530,7 +530,7 @@ bool Ice::ObjectPrx::ice_invoke(const string &operation,
 std::future<std::tuple<bool, vector<Byte>>>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
-                                const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
+                                const std::pair<const uint8_t *, const uint8_t *> &inParams,
                                 const Ice::Context &context) const
 {
     using Outgoing =
@@ -543,13 +543,13 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
 std::function<void()>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
-                                const std::pair<const Ice::Byte *, const Ice::Byte *> &inParams,
-                                std::function<void(bool, std::pair<const Ice::Byte *, const Ice::Byte *>)> response,
+                                const std::pair<const uint8_t *, const uint8_t *> &inParams,
+                                std::function<void(bool, std::pair<const uint8_t *, const uint8_t *>)> response,
                                 std::function<void(std::exception_ptr)> ex,
                                 std::function<void(bool)> sent,
                                 const Ice::Context &context) const
 {
-    using Result = ::std::tuple<bool, ::std::pair<const ::Ice::Byte *, const ::Ice::Byte *>>;
+    using Result = ::std::tuple<bool, ::std::pair<const ::uint8_t *, const ::uint8_t *>>;
     using Outgoing = ::IceInternal::InvokeLambdaOutgoing<Result>;
 
     ::std::function<void(Result &&)> r;

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -518,7 +518,7 @@ bool Ice::ObjectPrx::ice_invoke(string_view operation,
     return success;
 }
 
-std::future<std::tuple<bool, vector<Byte>>>
+std::future<std::tuple<bool, vector<uint8_t>>>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const uint8_t *, const uint8_t *> &inParams,

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -471,17 +471,17 @@ Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, con
 
 bool Ice::ObjectPrx::ice_invoke(const string &operation,
                                 Ice::OperationMode mode,
-                                const vector<Byte> &inParams,
+                                const vector<uint8_t> &inParams,
                                 vector<Ice::Byte> &outParams,
                                 const Ice::Context &context) const
 {
     return ice_invoke(operation, mode, makePair(inParams), outParams, context);
 }
 
-std::future<std::tuple<bool, vector<Byte>>>
+std::future<std::tuple<bool, vector<uint8_t>>>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
-                                const vector<Byte> &inParams,
+                                const vector<uint8_t> &inParams,
                                 const Ice::Context &context) const
 {
     return ice_invokeAsync(operation, mode, makePair(inParams), context);
@@ -496,11 +496,11 @@ Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 std::function<void(bool)> sent,
                                 const Ice::Context &context) const
 {
-    using Outgoing = InvokeLambdaOutgoing<std::tuple<bool, vector<Byte>>>;
-    std::function<void(std::tuple<bool, vector<Byte>> &&)> r;
+    using Outgoing = InvokeLambdaOutgoing<std::tuple<bool, vector<uint8_t>>>;
+    std::function<void(std::tuple<bool, vector<uint8_t>> &&)> r;
     if (response)
     {
-        r = [response = std::move(response)](std::tuple<bool, vector<Byte>>&& result)
+        r = [response = std::move(response)](std::tuple<bool, vector<uint8_t>>&& result)
         {
             auto [success, outParams] = std::move(result);
             response(success, std::move(outParams));
@@ -518,7 +518,7 @@ bool Ice::ObjectPrx::ice_invoke(const string &operation,
                                 vector<Ice::Byte> &outParams,
                                 const Ice::Context &context) const
 {
-    using Outgoing = InvokePromiseOutgoing<std::tuple<bool, vector<Byte>>>;
+    using Outgoing = InvokePromiseOutgoing<std::tuple<bool, vector<uint8_t>>>;
     auto outAsync = std::make_shared<Outgoing>(*this, true);
     outAsync->invoke(operation, mode, inParams, context);
     auto result = outAsync->getFuture().get();
@@ -527,14 +527,14 @@ bool Ice::ObjectPrx::ice_invoke(const string &operation,
     return success;
 }
 
-std::future<std::tuple<bool, vector<Byte>>>
+std::future<std::tuple<bool, vector<uint8_t>>>
 Ice::ObjectPrx::ice_invokeAsync(const string &operation,
                                 Ice::OperationMode mode,
                                 const std::pair<const uint8_t *, const uint8_t *> &inParams,
                                 const Ice::Context &context) const
 {
     using Outgoing =
-        ::IceInternal::InvokePromiseOutgoing<::std::tuple<bool, vector<Byte>>>;
+        ::IceInternal::InvokePromiseOutgoing<::std::tuple<bool, vector<uint8_t>>>;
     auto outAsync = ::std::make_shared<Outgoing>(*this, false);
     outAsync->invoke(operation, mode, inParams, context);
     return outAsync->getFuture();

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -157,7 +157,7 @@ IceInternal::Reference::streamWrite(OutputStream* s) const
         s->write(&_facet, &_facet + 1);
     }
 
-    s->write(static_cast<Byte>(_mode));
+    s->write(static_cast<uint8_t>(_mode));
 
     s->write(_secure);
 

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -533,7 +533,7 @@ IceInternal::ReferenceFactory::create(const Identity& ident, InputStream* s)
         facet.swap(facetPath[0]);
     }
 
-    Byte modeAsByte;
+    uint8_t modeAsByte;
     s->read(modeAsByte);
     Reference::Mode mode = static_cast<Reference::Mode>(modeAsByte);
     if(mode < 0 || mode > Reference::ModeLast)

--- a/cpp/src/Ice/ReplyStatus.h
+++ b/cpp/src/Ice/ReplyStatus.h
@@ -10,14 +10,14 @@
 namespace IceInternal
 {
 
-static const Ice::Byte replyOK = 0;
-static const Ice::Byte replyUserException = 1;
-static const Ice::Byte replyObjectNotExist = 2;
-static const Ice::Byte replyFacetNotExist = 3;
-static const Ice::Byte replyOperationNotExist = 4;
-static const Ice::Byte replyUnknownLocalException = 5;
-static const Ice::Byte replyUnknownUserException = 6;
-static const Ice::Byte replyUnknownException = 7;
+static const std::uint8_t replyOK = 0;
+static const std::uint8_t replyUserException = 1;
+static const std::uint8_t replyObjectNotExist = 2;
+static const std::uint8_t replyFacetNotExist = 3;
+static const std::uint8_t replyOperationNotExist = 4;
+static const std::uint8_t replyUnknownLocalException = 5;
+static const std::uint8_t replyUnknownUserException = 6;
+static const std::uint8_t replyUnknownException = 7;
 
 }
 

--- a/cpp/src/Ice/ResponseHandler.h
+++ b/cpp/src/Ice/ResponseHandler.h
@@ -24,7 +24,7 @@ class ResponseHandler : public EnableSharedFromThis<ResponseHandler>
 {
 public:
 
-    virtual void sendResponse(std::int32_t, Ice::OutputStream*, Ice::Byte, bool) = 0;
+    virtual void sendResponse(std::int32_t, Ice::OutputStream*, std::uint8_t, bool) = 0;
     virtual void sendNoResponse() = 0;
     virtual bool systemException(std::int32_t, std::exception_ptr, bool) = 0;
     virtual void invokeException(std::int32_t, std::exception_ptr, int, bool) = 0;

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -48,7 +48,7 @@ printIdentityFacetOperation(ostream& s, InputStream& stream)
 }
 
 static string
-getMessageTypeAsString(Byte type)
+getMessageTypeAsString(uint8_t type)
 {
     switch(type)
     {
@@ -72,7 +72,7 @@ printRequestHeader(ostream& s, InputStream& stream)
 {
     printIdentityFacetOperation(s, stream);
 
-    Byte mode;
+    uint8_t mode;
     stream.read(mode);
     s << "\nmode = " << static_cast<int>(mode) << ' ';
     switch(static_cast<OperationMode>(mode))
@@ -126,31 +126,31 @@ printRequestHeader(ostream& s, InputStream& stream)
 static Byte
 printHeader(ostream& s, InputStream& stream)
 {
-    Byte magicNumber;
+    uint8_t magicNumber;
     stream.read(magicNumber);   // Don't bother printing the magic number
     stream.read(magicNumber);
     stream.read(magicNumber);
     stream.read(magicNumber);
 
-    Byte pMajor;
-    Byte pMinor;
+    uint8_t pMajor;
+    uint8_t pMinor;
     stream.read(pMajor);
     stream.read(pMinor);
 //    s << "\nprotocol version = " << static_cast<unsigned>(pMajor)
 //      << "." << static_cast<unsigned>(pMinor);
 
-    Byte eMajor;
-    Byte eMinor;
+    uint8_t eMajor;
+    uint8_t eMinor;
     stream.read(eMajor);
     stream.read(eMinor);
 //    s << "\nencoding version = " << static_cast<unsigned>(eMajor)
 //      << "." << static_cast<unsigned>(eMinor);
 
-    Byte type;
+    uint8_t type;
     stream.read(type);
     s << "\nmessage type = "  << static_cast<int>(type) << " (" << getMessageTypeAsString(type) << ')';
 
-    Byte compress;
+    uint8_t compress;
     stream.read(compress);
     s << "\ncompression status = "  << static_cast<int>(compress) << ' ';
 
@@ -223,7 +223,7 @@ printReply(ostream& s, InputStream& stream)
     stream.read(requestId);
     s << "\nrequest id = " << requestId;
 
-    Byte replyStatus;
+    uint8_t replyStatus;
     stream.read(replyStatus);
     s << "\nreply status = " << static_cast<int>(replyStatus) << ' ';
     switch(replyStatus)
@@ -332,7 +332,7 @@ printReply(ostream& s, InputStream& stream)
 static Byte
 printMessage(ostream& s, InputStream& stream)
 {
-    Byte type = printHeader(s, stream);
+    uint8_t type = printHeader(s, stream);
 
     switch(type)
     {
@@ -403,7 +403,7 @@ IceInternal::traceSend(const OutputStream& str, const LoggerPtr& logger, const T
         is.i = is.b.begin();
 
         ostringstream s;
-        Byte type = printMessage(s, is);
+        uint8_t type = printMessage(s, is);
 
         logger->trace(tl->protocolCat, "sending " + getMessageTypeAsString(type) + " " + s.str());
     }
@@ -419,7 +419,7 @@ IceInternal::traceRecv(const InputStream& str, const LoggerPtr& logger, const Tr
         stream.i = stream.b.begin();
 
         ostringstream s;
-        Byte type = printMessage(s, stream);
+        uint8_t type = printMessage(s, stream);
 
         logger->trace(tl->protocolCat, "received " + getMessageTypeAsString(type) + " " + s.str());
         stream.i = p;

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -123,7 +123,7 @@ printRequestHeader(ostream& s, InputStream& stream)
     }
 }
 
-static Byte
+static uint8_t
 printHeader(ostream& s, InputStream& stream)
 {
     uint8_t magicNumber;
@@ -329,7 +329,7 @@ printReply(ostream& s, InputStream& stream)
     }
 }
 
-static Byte
+static uint8_t
 printMessage(ostream& s, InputStream& stream)
 {
     uint8_t type = printHeader(s, stream);

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -69,7 +69,7 @@ IceInternal::UdpEndpointI::UdpEndpointI(const ProtocolInstancePtr& instance, Inp
 {
     if(s->getEncoding() == Ice::Encoding_1_0)
     {
-        Ice::Byte b;
+        uint8_t b;
         s->read(b);
         s->read(b);
         s->read(b);
@@ -398,7 +398,7 @@ IceInternal::UdpEndpointI::checkOption(const string& option, const string& argum
         }
         try
         {
-            Ice::Byte major, minor;
+            uint8_t major, minor;
             IceInternal::stringToMajorMinor(argument, major, minor);
             if(major != 1 || minor != 0)
             {

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -59,13 +59,13 @@ const string _wsUUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 //
 // Rename to avoid conflict with OS 10.10 htonll
 //
-void ice_htonll(int64_t v, Byte* dest)
+void ice_htonll(int64_t v, uint8_t* dest)
 {
     //
     // Transfer a 64-bit integer in network (big-endian) order.
     //
 #ifdef ICE_BIG_ENDIAN
-    const Byte* src = reinterpret_cast<const Byte*>(&v);
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -75,7 +75,7 @@ void ice_htonll(int64_t v, Byte* dest)
     *dest++ = *src++;
     *dest = *src;
 #else
-    const Byte* src = reinterpret_cast<const Byte*>(&v) + sizeof(int64_t) - 1;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(&v) + sizeof(int64_t) - 1;
     *dest++ = *src--;
     *dest++ = *src--;
     *dest++ = *src--;
@@ -90,7 +90,7 @@ void ice_htonll(int64_t v, Byte* dest)
 //
 // Rename to avoid conflict with OS 10.10 nlltoh
 //
-int64_t ice_nlltoh(const Byte* src)
+int64_t ice_nlltoh(const uint8_t* src)
 {
     int64_t v;
 
@@ -98,7 +98,7 @@ int64_t ice_nlltoh(const Byte* src)
     // Extract a 64-bit integer in network (big-endian) order.
     //
 #ifdef ICE_BIG_ENDIAN
-    Byte* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<Byte*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -108,7 +108,7 @@ int64_t ice_nlltoh(const Byte* src)
     *dest++ = *src++;
     *dest = *src;
 #else
-    Byte* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
+    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;
@@ -1656,7 +1656,7 @@ IceInternal::WSTransceiver::readBuffered(IceInternal::Buffer::Container::size_ty
 }
 
 void
-IceInternal::WSTransceiver::prepareWriteHeader(Byte opCode, IceInternal::Buffer::Container::size_type payloadLength)
+IceInternal::WSTransceiver::prepareWriteHeader(uint8_t opCode, IceInternal::Buffer::Container::size_type payloadLength)
 {
     //
     // We need to prepare the frame header.

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -236,7 +236,7 @@ IceInternal::WSTransceiver::initialize(Buffer& readBuffer, Buffer& writeBuffer)
                 //
                 // Check if we have enough data for a complete message.
                 //
-                const Ice::Byte* p = _parser->isCompleteMessage(&_readBuffer.b[0], _readBuffer.i);
+                const uint8_t* p = _parser->isCompleteMessage(&_readBuffer.b[0], _readBuffer.i);
                 if(!p)
                 {
                     if(_readBuffer.i < _readBuffer.b.end())

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -98,7 +98,7 @@ int64_t ice_nlltoh(const uint8_t* src)
     // Extract a 64-bit integer in network (big-endian) order.
     //
 #ifdef ICE_BIG_ENDIAN
-    uint8_t* dest = reinterpret_cast<Byte*>(&v);
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v);
     *dest++ = *src++;
     *dest++ = *src++;
     *dest++ = *src++;
@@ -108,7 +108,7 @@ int64_t ice_nlltoh(const uint8_t* src)
     *dest++ = *src++;
     *dest = *src;
 #else
-    uint8_t* dest = reinterpret_cast<Byte*>(&v) + sizeof(int64_t) - 1;
+    uint8_t* dest = reinterpret_cast<uint8_t*>(&v) + sizeof(int64_t) - 1;
     *dest-- = *src++;
     *dest-- = *src++;
     *dest-- = *src++;

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1667,21 +1667,21 @@ IceInternal::WSTransceiver::prepareWriteHeader(uint8_t opCode, IceInternal::Buff
     //
     // Set the opcode - this is the one and only data frame.
     //
-    *_writeBuffer.i++ = static_cast<Byte>(opCode | FLAG_FINAL);
+    *_writeBuffer.i++ = static_cast<uint8_t>(opCode | FLAG_FINAL);
 
     //
     // Set the payload length.
     //
     if(payloadLength <= 125)
     {
-        *_writeBuffer.i++ = static_cast<Byte>(payloadLength);
+        *_writeBuffer.i++ = static_cast<uint8_t>(payloadLength);
     }
     else if(payloadLength > 125 && payloadLength <= USHRT_MAX)
     {
         //
         // Use an extra 16 bits to encode the payload length.
         //
-        *_writeBuffer.i++ = static_cast<Byte>(126);
+        *_writeBuffer.i++ = static_cast<uint8_t>(126);
         *reinterpret_cast<uint16_t*>(_writeBuffer.i) = htons(static_cast<uint16_t>(payloadLength));
         _writeBuffer.i += 2;
     }
@@ -1690,7 +1690,7 @@ IceInternal::WSTransceiver::prepareWriteHeader(uint8_t opCode, IceInternal::Buff
         //
         // Use an extra 64 bits to encode the payload length.
         //
-        *_writeBuffer.i++ = static_cast<Byte>(127);
+        *_writeBuffer.i++ = static_cast<uint8_t>(127);
         ice_htonll(static_cast<int64_t>(payloadLength), _writeBuffer.i);
         _writeBuffer.i += 8;
     }

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -133,7 +133,7 @@ private:
     bool _closingInitiator;
     int _closingReason;
 
-    std::vector<Ice::Byte> _pingPayload;
+    std::vector<std::uint8_t> _pingPayload;
 };
 
 }

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -62,7 +62,7 @@ private:
     bool postWrite(Buffer&);
 
     bool readBuffered(Buffer::Container::size_type);
-    void prepareWriteHeader(Ice::Byte, Buffer::Container::size_type);
+    void prepareWriteHeader(std::uint8_t, Buffer::Container::size_type);
 
     friend class WSConnector;
     friend class WSAcceptor;

--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -24,8 +24,8 @@ struct QueuedDispatch final
     // The pointers in p refer to the Ice marshaling buffer and won't remain valid after
     // ice_invokeAsync completes, so we have to make a copy of the in parameters
     //
-    QueuedDispatch(pair<const Byte*, const Byte*> p,
-                   function<void(bool, const pair<const Byte*, const Byte*>&)>&& r,
+    QueuedDispatch(pair<const uint8_t*, const uint8_t*> p,
+                   function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>&& r,
                    function<void(exception_ptr)>&& e,
                    const Current& c) :
         inParams(p.first, p.second), response(std::move(r)), error(std::move(e)), current(c)
@@ -38,7 +38,7 @@ struct QueuedDispatch final
     QueuedDispatch(const QueuedDispatch&) = delete;
 
     const vector<Byte> inParams;
-    function<void(bool, const pair<const Byte*, const Byte*>&)> response;
+    function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response;
     function<void(exception_ptr)> error;
     const Current current;
 };
@@ -103,15 +103,15 @@ public:
     void outgoingException(exception_ptr);
 
     void closed(const shared_ptr<Connection>&);
-    void dispatch(pair<const Byte*, const Byte*>,
-                  function<void(bool, const pair<const Byte*, const Byte*>&)>,
+    void dispatch(pair<const uint8_t*, const uint8_t*>,
+                  function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>,
                   function<void(exception_ptr)>,
                   const Current&);
 private:
 
     void send(const shared_ptr<Connection>&,
-              pair<const Byte*, const Byte*>,
-              function<void(bool, const pair<const Byte*, const Byte*>&)>,
+              pair<const uint8_t*, const uint8_t*>,
+              function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>,
               function<void(exception_ptr)>,
               const Current& current);
 
@@ -141,8 +141,8 @@ public:
 
     BridgeI(shared_ptr<ObjectAdapter> adapter, ObjectPrxPtr target);
 
-    void ice_invokeAsync(pair<const Byte*, const Byte*> inEncaps,
-                         function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+    void ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inEncaps,
+                         function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                          function<void(exception_ptr)> error,
                          const Current& current) override;
 
@@ -312,8 +312,8 @@ BridgeConnection::closed(const shared_ptr<Connection>& con)
 }
 
 void
-BridgeConnection::dispatch(pair<const Byte*, const Byte*> inParams,
-                           function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+BridgeConnection::dispatch(pair<const uint8_t*, const uint8_t*> inParams,
+                           function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                            function<void(exception_ptr)> error,
                            const Current& current)
 {
@@ -343,8 +343,8 @@ BridgeConnection::dispatch(pair<const Byte*, const Byte*> inParams,
 
 void
 BridgeConnection::send(const shared_ptr<Connection>& dest,
-                       pair<const Byte*, const Byte*> inParams,
-                       function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+                       pair<const uint8_t*, const uint8_t*> inParams,
+                       function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                        function<void(exception_ptr)> error,
                        const Current& current)
 {
@@ -386,8 +386,8 @@ BridgeI::BridgeI(shared_ptr<ObjectAdapter> adapter, ObjectPrxPtr target) :
 }
 
 void
-BridgeI::ice_invokeAsync(pair<const Byte*, const Byte*> inParams,
-                         function<void(bool, const pair<const Byte*, const Byte*>&)> response,
+BridgeI::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                         function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                          function<void(exception_ptr)> error,
                          const Current& current)
 {

--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -37,7 +37,7 @@ struct QueuedDispatch final
     // Make sure we don't copy this struct by accident
     QueuedDispatch(const QueuedDispatch&) = delete;
 
-    const vector<Byte> inParams;
+    const vector<uint8_t> inParams;
     function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response;
     function<void(exception_ptr)> error;
     const Current current;

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -478,8 +478,8 @@ struct Codec<T, IceContext, Ice::OutputStream>
 {
     static void read(T& t, const MDB_val& val, const IceContext& ctx)
     {
-        std::pair<const Ice::Byte*, const Ice::Byte*> p(static_cast<const Ice::Byte*>(val.mv_data),
-                                                        static_cast<const Ice::Byte*>(val.mv_data) + val.mv_size);
+        std::pair<const std::uint8_t*, const std::uint8_t*> p(static_cast<const std::uint8_t*>(val.mv_data),
+                                                        static_cast<const std::uint8_t*>(val.mv_data) + val.mv_size);
         Ice::InputStream in(ctx.communicator, ctx.encoding, p);
         in.read(t);
     }
@@ -495,8 +495,8 @@ struct Codec<T, IceContext, Ice::OutputStream>
     static bool write(const T& t, MDB_val& val, const IceContext& ctx)
     {
         const size_t limit = val.mv_size;
-        std::pair<Ice::Byte*, Ice::Byte*> p(reinterpret_cast<Ice::Byte*>(val.mv_data),
-                                            reinterpret_cast<Ice::Byte*>(val.mv_data) + limit);
+        std::pair<std::uint8_t*, std::uint8_t*> p(reinterpret_cast<std::uint8_t*>(val.mv_data),
+                                            reinterpret_cast<std::uint8_t*>(val.mv_data) + limit);
         Ice::OutputStream stream(ctx.communicator, ctx.encoding, p);
         stream.write(t);
         val.mv_size = stream.b.size();

--- a/cpp/src/IceGrid/AdminCallbackRouter.cpp
+++ b/cpp/src/IceGrid/AdminCallbackRouter.cpp
@@ -34,8 +34,8 @@ AdminCallbackRouter::removeMapping(const string& category)
 }
 
 void
-AdminCallbackRouter::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                                     function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+AdminCallbackRouter::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                     function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                      function<void(exception_ptr)> exception,
                                      const Ice::Current& current)
 {

--- a/cpp/src/IceGrid/AdminCallbackRouter.h
+++ b/cpp/src/IceGrid/AdminCallbackRouter.h
@@ -24,8 +24,8 @@ public:
     void addMapping(const std::string&, const std::shared_ptr<Ice::Connection>&);
     void removeMapping(const std::string&);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                          std::function<void(std::exception_ptr)>,
                          const Ice::Current& current) override;
 

--- a/cpp/src/IceGrid/AdminRouter.cpp
+++ b/cpp/src/IceGrid/AdminRouter.cpp
@@ -14,8 +14,8 @@ IceGrid::AdminRouter::AdminRouter(const shared_ptr<TraceLevels>& traceLevels) :
 
 void
 IceGrid::AdminRouter::invokeOnTarget(const Ice::ObjectPrxPtr& target,
-                                     const pair<const Ice::Byte*, const Ice::Byte*>& inParams,
-                                     function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)>&& response,
+                                     const pair<const uint8_t*, const uint8_t*>& inParams,
+                                     function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>&& response,
                                      function<void(exception_ptr)>&& exception,
                                      const Ice::Current& current)
 {

--- a/cpp/src/IceGrid/AdminRouter.h
+++ b/cpp/src/IceGrid/AdminRouter.h
@@ -21,8 +21,8 @@ protected:
     AdminRouter(const std::shared_ptr<TraceLevels>&);
 
     void invokeOnTarget(const Ice::ObjectPrxPtr&,
-                        const std::pair<const Ice::Byte*, const Ice::Byte*>&,
-                        std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>&&,
+                        const std::pair<const std::uint8_t*, const std::uint8_t*>&,
+                        std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>&&,
                         std::function<void(std::exception_ptr)>&&,
                         const Ice::Current&);
 

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -29,8 +29,8 @@ public:
     }
 
     void
-    ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                    function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+    ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                    function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                     function<void(exception_ptr)> exception, const Ice::Current& current) override
     {
         _proxy->ice_invokeAsync(current.operation, current.mode, inParams,

--- a/cpp/src/IceGrid/NodeAdminRouter.cpp
+++ b/cpp/src/IceGrid/NodeAdminRouter.cpp
@@ -18,8 +18,8 @@ NodeServerAdminRouter::NodeServerAdminRouter(const shared_ptr<NodeI>& node) :
 }
 
 void
-NodeServerAdminRouter::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                                       function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+NodeServerAdminRouter::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                       function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                        function<void(exception_ptr)> exception,
                                        const Ice::Current& current)
 {

--- a/cpp/src/IceGrid/NodeAdminRouter.h
+++ b/cpp/src/IceGrid/NodeAdminRouter.h
@@ -20,8 +20,8 @@ public:
 
     NodeServerAdminRouter(const std::shared_ptr<NodeI>&);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                          std::function<void(std::exception_ptr)>,
                          const Ice::Current& current) override;
 

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -20,7 +20,7 @@ public:
 
     SynchronizationCallbackI(const shared_ptr<RegistryServerAdminRouter>& adminRouter,
                              const pair<const Byte*, const Byte*>& inParams,
-                             function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+                             function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                              function<void(exception_ptr)> exception,
                              const Current& current) :
         _adminRouter(adminRouter),
@@ -48,7 +48,7 @@ public:
 private:
 
     const shared_ptr<RegistryServerAdminRouter> _adminRouter;
-    function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> _response;
+    function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> _response;
     function<void(exception_ptr)> _exception;
     const vector<Byte> _inParams;
     const Current _current;
@@ -63,8 +63,8 @@ RegistryServerAdminRouter::RegistryServerAdminRouter(const shared_ptr<Database>&
 }
 
 void
-RegistryServerAdminRouter::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                                       function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+RegistryServerAdminRouter::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                       function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                        function<void(exception_ptr)> exception,
                                        const Ice::Current& current)
 {
@@ -112,8 +112,8 @@ RegistryNodeAdminRouter::RegistryNodeAdminRouter(const string& collocNodeName, c
 }
 
 void
-RegistryNodeAdminRouter::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                                       function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+RegistryNodeAdminRouter::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                       function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                        function<void(exception_ptr)> exception,
                                        const Ice::Current& current)
 {
@@ -163,8 +163,8 @@ RegistryReplicaAdminRouter::RegistryReplicaAdminRouter(const string& name,
 }
 
 void
-RegistryReplicaAdminRouter::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                                       function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+RegistryReplicaAdminRouter::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                                       function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                        function<void(exception_ptr)> exception,
                                        const Ice::Current& current)
 {

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -19,7 +19,7 @@ class SynchronizationCallbackI final : public SynchronizationCallback
 public:
 
     SynchronizationCallbackI(const shared_ptr<RegistryServerAdminRouter>& adminRouter,
-                             const pair<const Byte*, const Byte*>& inParams,
+                             const pair<const uint8_t*, const uint8_t*>& inParams,
                              function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                              function<void(exception_ptr)> exception,
                              const Current& current) :

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -50,7 +50,7 @@ private:
     const shared_ptr<RegistryServerAdminRouter> _adminRouter;
     function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> _response;
     function<void(exception_ptr)> _exception;
-    const vector<Byte> _inParams;
+    const vector<uint8_t> _inParams;
     const Current _current;
 };
 

--- a/cpp/src/IceGrid/RegistryAdminRouter.h
+++ b/cpp/src/IceGrid/RegistryAdminRouter.h
@@ -18,8 +18,8 @@ public:
 
     RegistryServerAdminRouter(const std::shared_ptr<Database>&);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                          std::function<void(std::exception_ptr)>,
                          const Ice::Current& current) override;
 
@@ -34,8 +34,8 @@ public:
 
     RegistryNodeAdminRouter(const std::string&, const std::shared_ptr<Database>&);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                          std::function<void(std::exception_ptr)>,
                          const Ice::Current& current) override;
 
@@ -51,8 +51,8 @@ public:
 
     RegistryReplicaAdminRouter(const std::string&, const std::shared_ptr<Database>&);
 
-    void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                         std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                         std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                          std::function<void(std::exception_ptr)>,
                          const Ice::Current& current) override;
 

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -41,7 +41,7 @@ namespace IceGrid
 void
 chownRecursive(const string& path, uid_t uid, gid_t gid)
 {
-    vector<vector<Ice::Byte> > namelist;
+    vector<vector<uint8_t> > namelist;
     DIR* d;
     if((d = opendir(path.c_str())) == 0)
     {

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -19,7 +19,7 @@ namespace
 {
 
 class LocatorI; // Forward declaration
-typedef std::pair<function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)>,
+typedef std::pair<function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>,
                   function<void(exception_ptr)>> AMDCallback;
 
 class Request : public std::enable_shared_from_this<Request>
@@ -29,7 +29,7 @@ public:
     Request(LocatorI* locator,
             const string& operation,
             Ice::OperationMode mode,
-            const pair<const Ice::Byte*, const Ice::Byte*>& inParams,
+            const pair<const uint8_t*, const uint8_t*>& inParams,
             const Ice::Context& ctx,
             const AMDCallback& amdCB) :
         _locator(locator),
@@ -42,7 +42,7 @@ public:
     }
 
     void invoke(const Ice::LocatorPrxPtr&);
-    void response(bool, const pair<const Ice::Byte*, const Ice::Byte*>&);
+    void response(bool, const pair<const uint8_t*, const uint8_t*>&);
     void exception(std::exception_ptr);
 
 protected:
@@ -68,8 +68,8 @@ public:
     LocatorI(const string&, const LookupPrxPtr&, const Ice::PropertiesPtr&, const string&, const Ice::LocatorPrxPtr&);
     void setLookupReply(const LookupReplyPrxPtr&);
 
-    virtual void ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*>,
-                                 function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    virtual void ice_invokeAsync(pair<const uint8_t*, const uint8_t*>,
+                                 function<void(bool, const pair<const uint8_t*, const uint8_t*>&)>,
                                  function<void(exception_ptr)>,
                                  const Ice::Current&);
 
@@ -327,7 +327,7 @@ Request::invoke(const Ice::LocatorPrxPtr& l)
             l->ice_invokeAsync(_operation, _mode, _inParams,
                                [self](bool ok, vector<Ice::Byte> outParams)
                                {
-                                   pair<const Ice::Byte*, const Ice::Byte*> outPair;
+                                   pair<const uint8_t*, const uint8_t*> outPair;
                                    if(outParams.empty())
                                    {
                                        outPair.first = outPair.second = 0;
@@ -359,7 +359,7 @@ Request::invoke(const Ice::LocatorPrxPtr& l)
 }
 
 void
-Request::response(bool ok, const pair<const Ice::Byte*, const Ice::Byte*>& outParams)
+Request::response(bool ok, const pair<const uint8_t*, const uint8_t*>& outParams)
 {
     _amdCB.first(ok, outParams);
 }
@@ -477,8 +477,8 @@ LocatorI::setLookupReply(const LookupReplyPrxPtr& lookupReply)
 }
 
 void
-LocatorI::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inParams,
-                          function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> responseCB,
+LocatorI::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inParams,
+                          function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> responseCB,
                           function<void(exception_ptr)> exceptionCB,
                           const Ice::Current& current)
 {

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -325,7 +325,7 @@ Request::invoke(const Ice::LocatorPrxPtr& l)
         {
             auto self = shared_from_this();
             l->ice_invokeAsync(_operation, _mode, _inParams,
-                               [self](bool ok, vector<Ice::Byte> outParams)
+                               [self](bool ok, vector<uint8_t> outParams)
                                {
                                    pair<const uint8_t*, const uint8_t*> outPair;
                                    if(outParams.empty())

--- a/cpp/src/IcePatch2/FileServerI.cpp
+++ b/cpp/src/IcePatch2/FileServerI.cpp
@@ -70,7 +70,7 @@ IcePatch2::FileServerI::getFileCompressedAsync(
     string pa,
     int32_t pos,
     int32_t num,
-    function<void(const pair<const ::Ice::Byte*, const ::Ice::Byte*>& returnValue)> response,
+    function<void(const pair<const ::uint8_t*, const ::uint8_t*>& returnValue)> response,
     function<void(exception_ptr)> exception,
     const Current&) const
 {
@@ -98,7 +98,7 @@ IcePatch2::FileServerI::getLargeFileCompressedAsync(
     string pa,
     int64_t pos,
     int32_t num,
-    function<void(const pair<const ::Ice::Byte*, const ::Ice::Byte*>& returnValue)> response,
+    function<void(const pair<const ::uint8_t*, const ::uint8_t*>& returnValue)> response,
     function<void(exception_ptr)> exception,
     const Current&) const
 {

--- a/cpp/src/IcePatch2/FileServerI.cpp
+++ b/cpp/src/IcePatch2/FileServerI.cpp
@@ -80,11 +80,11 @@ IcePatch2::FileServerI::getFileCompressedAsync(
         getFileCompressedInternal(std::move(pa), pos, num, buffer, false);
         if(buffer.empty())
         {
-            response(make_pair<const Byte*, const Byte*>(0, 0));
+            response(make_pair<const uint8_t*, const uint8_t*>(0, 0));
         }
         else
         {
-            response(make_pair<const Byte*, const Byte*>(&buffer[0], &buffer[0] + buffer.size()));
+            response(make_pair<const uint8_t*, const uint8_t*>(&buffer[0], &buffer[0] + buffer.size()));
         }
     }
     catch(const std::exception&)
@@ -108,11 +108,11 @@ IcePatch2::FileServerI::getLargeFileCompressedAsync(
         getFileCompressedInternal(std::move(pa), pos, num, buffer, true);
         if(buffer.empty())
         {
-            response(make_pair<const Byte*, const Byte*>(0, 0));
+            response(make_pair<const uint8_t*, const uint8_t*>(0, 0));
         }
         else
         {
-            response(make_pair<const Byte*, const Byte*>(&buffer[0], &buffer[0] + buffer.size()));
+            response(make_pair<const uint8_t*, const uint8_t*>(&buffer[0], &buffer[0] + buffer.size()));
         }
 
     }

--- a/cpp/src/IcePatch2/FileServerI.cpp
+++ b/cpp/src/IcePatch2/FileServerI.cpp
@@ -76,7 +76,7 @@ IcePatch2::FileServerI::getFileCompressedAsync(
 {
     try
     {
-        vector<Byte> buffer;
+        vector<uint8_t> buffer;
         getFileCompressedInternal(std::move(pa), pos, num, buffer, false);
         if(buffer.empty())
         {
@@ -104,7 +104,7 @@ IcePatch2::FileServerI::getLargeFileCompressedAsync(
 {
     try
     {
-        vector<Byte> buffer;
+        vector<uint8_t> buffer;
         getFileCompressedInternal(std::move(pa), pos, num, buffer, true);
         if(buffer.empty())
         {
@@ -127,7 +127,7 @@ IcePatch2::FileServerI::getFileCompressedInternal(
     std::string pa,
     int64_t pos,
     int32_t num,
-    vector<Byte>& buffer,
+    vector<uint8_t>& buffer,
     bool largeFile) const
 {
     if(IceUtilInternal::isAbsolutePath(pa))

--- a/cpp/src/IcePatch2/FileServerI.h
+++ b/cpp/src/IcePatch2/FileServerI.h
@@ -30,7 +30,7 @@ public:
         std::string,
         std::int32_t,
         std::int32_t,
-        std::function<void(const std::pair<const Ice::Byte*, const Ice::Byte*>& returnValue)>,
+        std::function<void(const std::pair<const std::uint8_t*, const std::uint8_t*>& returnValue)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) const;
 
@@ -38,7 +38,7 @@ public:
         std::string,
         std::int64_t,
         std::int32_t,
-        std::function<void(const std::pair<const Ice::Byte*, const Ice::Byte*>& returnValue)>,
+        std::function<void(const std::pair<const std::uint8_t*, const std::uint8_t*>& returnValue)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) const;
 

--- a/cpp/src/IcePatch2/FileServerI.h
+++ b/cpp/src/IcePatch2/FileServerI.h
@@ -49,7 +49,7 @@ private:
         std::string,
         std::int64_t,
         std::int32_t,
-        std::vector<Ice::Byte>&,
+        std::vector<std::uint8_t>&,
         bool) const;
 
     const std::string _dataDir;

--- a/cpp/src/IcePatch2Lib/ClientUtil.cpp
+++ b/cpp/src/IcePatch2Lib/ClientUtil.cpp
@@ -848,7 +848,7 @@ void getFileCompressed(
             path,
             static_cast<int32_t>(pos),
             chunkSize,
-            [cb](std::pair<const Byte*, const Byte*> result) { cb->complete(ByteSeq(result.first, result.second)); },
+            [cb](std::pair<const uint8_t*, const uint8_t*> result) { cb->complete(ByteSeq(result.first, result.second)); },
             [cb](exception_ptr exception) { cb->exception(exception); });
     }
     else
@@ -857,7 +857,7 @@ void getFileCompressed(
             path,
             pos,
             chunkSize,
-            [cb](std::pair<const Byte*, const Byte*> result) { cb->complete(ByteSeq(result.first, result.second)); },
+            [cb](std::pair<const uint8_t*, const uint8_t*> result) { cb->complete(ByteSeq(result.first, result.second)); },
             [cb](exception_ptr exception) { cb->exception(exception); });
     }
 }

--- a/cpp/src/IcePatch2Lib/Util.cpp
+++ b/cpp/src/IcePatch2Lib/Util.cpp
@@ -827,7 +827,7 @@ getFileInfoSeqInternal(const string& basePath, const string& relPath, int compre
             }
             else
             {
-                fill(bytesSHA.begin(), bytesSHA.end(), Byte(0));
+                fill(bytesSHA.begin(), bytesSHA.end(), uint8_t(0));
             }
             info.checksum.swap(bytesSHA);
 
@@ -888,7 +888,7 @@ getFileInfoSeqInternal(const string& basePath, const string& relPath, int compre
             if(relPath.size() == 0 && buf.st_size == 0)
             {
                 bytesSHA.resize(20);
-                fill(bytesSHA.begin(), bytesSHA.end(), Byte(0));
+                fill(bytesSHA.begin(), bytesSHA.end(), uint8_t(0));
             }
             else
             {
@@ -1227,7 +1227,7 @@ IcePatch2Internal::getFileTree0(const LargeFileInfoSeq& infoSeq, FileTree0& tree
         }
         else
         {
-            fill(tree1.checksum.begin(), tree1.checksum.end(), Byte(0));
+            fill(tree1.checksum.begin(), tree1.checksum.end(), uint8_t(0));
         }
 
         copy(tree1.checksum.begin(), tree1.checksum.end(), c0);
@@ -1239,6 +1239,6 @@ IcePatch2Internal::getFileTree0(const LargeFileInfoSeq& infoSeq, FileTree0& tree
     }
     else
     {
-        fill(tree0.checksum.begin(), tree0.checksum.end(), Byte(0));
+        fill(tree0.checksum.begin(), tree0.checksum.end(), uint8_t(0));
     }
 }

--- a/cpp/src/IcePatch2Lib/Util.cpp
+++ b/cpp/src/IcePatch2Lib/Util.cpp
@@ -196,7 +196,7 @@ IcePatch2Internal::stringToBytes(const string& str)
             }
         }
 
-        bytes.push_back(static_cast<Byte>(byte));
+        bytes.push_back(static_cast<uint8_t>(byte));
     }
 
     return bytes;

--- a/cpp/src/IcePatch2Lib/Util.cpp
+++ b/cpp/src/IcePatch2Lib/Util.cpp
@@ -596,7 +596,7 @@ IcePatch2Internal::compressBytesToFile(const string& pa, const ByteSeq& bytes, i
         throw runtime_error(reason);
     }
 
-    BZ2_bzWrite(&bzError, bzFile, const_cast<Byte*>(&bytes[static_cast<size_t>(pos)]),
+    BZ2_bzWrite(&bzError, bzFile, const_cast<uint8_t*>(&bytes[static_cast<size_t>(pos)]),
                 static_cast<int>(bytes.size()) - pos);
     if(bzError != BZ_OK)
     {
@@ -895,7 +895,7 @@ getFileInfoSeqInternal(const string& basePath, const string& relPath, int compre
                 IceInternal::SHA1 hasher;
                 if(relPath.size() != 0)
                 {
-                    hasher.update(reinterpret_cast<const IceUtil::Byte*>(relPath.c_str()), relPath.size());
+                    hasher.update(reinterpret_cast<const uint8_t*>(relPath.c_str()), relPath.size());
                 }
 
                 if(buf.st_size != 0)
@@ -956,7 +956,7 @@ getFileInfoSeqInternal(const string& basePath, const string& relPath, int compre
                         bytesLeft -= static_cast<unsigned int>(bytes.size());
                         if(doCompress)
                         {
-                            BZ2_bzWrite(&bzError, bzFile, const_cast<Byte*>(&bytes[0]), static_cast<int>(bytes.size()));
+                            BZ2_bzWrite(&bzError, bzFile, const_cast<uint8_t*>(&bytes[0]), static_cast<int>(bytes.size()));
                             if(bzError != BZ_OK)
                             {
                                 string reason = "BZ2_bzWrite failed";
@@ -971,7 +971,7 @@ getFileInfoSeqInternal(const string& basePath, const string& relPath, int compre
                             }
                         }
 
-                        hasher.update(reinterpret_cast<IceUtil::Byte*>(&bytes[0]), bytes.size());
+                        hasher.update(reinterpret_cast<uint8_t*>(&bytes[0]), bytes.size());
                     }
 
                     IceUtilInternal::close(fd);

--- a/cpp/src/IcePatch2Lib/Util.cpp
+++ b/cpp/src/IcePatch2Lib/Util.cpp
@@ -662,7 +662,7 @@ IcePatch2Internal::decompressFile(const string& pa)
         }
 
         const int32_t numBZ2 = 64 * 1024;
-        Byte bytesBZ2[numBZ2];
+        uint8_t bytesBZ2[numBZ2];
 
         while(bzError != BZ_STREAM_END)
         {

--- a/cpp/src/IceSSL/OpenSSLCertificateI.cpp
+++ b/cpp/src/IceSSL/OpenSSLCertificateI.cpp
@@ -207,7 +207,7 @@ public:
     ~OpenSSLX509ExtensionI();
     virtual bool isCritical() const;
     virtual string getOID() const;
-    virtual vector<Ice::Byte> getData() const;
+    virtual vector<uint8_t> getData() const;
 
 private:
 
@@ -227,8 +227,8 @@ public:
 
     virtual bool operator==(const IceSSL::Certificate&) const;
 
-    virtual vector<Ice::Byte> getAuthorityKeyIdentifier() const;
-    virtual vector<Ice::Byte> getSubjectKeyIdentifier() const;
+    virtual vector<uint8_t> getAuthorityKeyIdentifier() const;
+    virtual vector<uint8_t> getSubjectKeyIdentifier() const;
     virtual bool verify(const IceSSL::CertificatePtr&) const;
     virtual string encode() const;
 
@@ -285,10 +285,10 @@ OpenSSLX509ExtensionI::getOID() const
     return _oid;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 OpenSSLX509ExtensionI::getData() const
 {
-    vector<Ice::Byte> data;
+    vector<uint8_t> data;
     ASN1_OCTET_STRING* buffer = X509_EXTENSION_get_data(_extension);
     assert(buffer);
     data.resize(buffer->length);
@@ -327,10 +327,10 @@ OpenSSLCertificateI::operator==(const IceSSL::Certificate& r) const
     return X509_cmp(_cert, p->_cert) == 0;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 OpenSSLCertificateI::getAuthorityKeyIdentifier() const
 {
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
     int index = X509_get_ext_by_NID(_cert, NID_authority_key_identifier, -1);
     if(index >= 0)
     {
@@ -350,10 +350,10 @@ OpenSSLCertificateI::getAuthorityKeyIdentifier() const
     return keyid;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 OpenSSLCertificateI::getSubjectKeyIdentifier() const
 {
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
     int index = X509_get_ext_by_NID(_cert, NID_subject_key_identifier, -1);
     if(index >= 0)
     {

--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -230,11 +230,11 @@ certificateAltNames(CERT_INFO* certInfo, LPCSTR altNameOID)
                         // IPv4 address
                         //
                         ostringstream os;
-                        Byte* src = reinterpret_cast<Byte*>(entry->IPAddress.pbData);
+                        uint8_t* src = reinterpret_cast<Byte*>(entry->IPAddress.pbData);
                         for(int j = 0; j < 4;)
                         {
                             int value = 0;
-                            Byte* dest = reinterpret_cast<Byte*>(&value);
+                            uint8_t* dest = reinterpret_cast<Byte*>(&value);
                             *dest = *src++;
                             os << value;
                             if(++j < 4)

--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -48,7 +48,7 @@ public:
     SCHannelX509ExtensionI(CERT_EXTENSION , const string&, const CertInfoHolderPtr&);
     virtual bool isCritical() const;
     virtual string getOID() const;
-    virtual vector<Ice::Byte> getData() const;
+    virtual vector<uint8_t> getData() const;
 
 private:
 
@@ -68,8 +68,8 @@ public:
 
     virtual bool operator==(const IceSSL::Certificate&) const;
 
-    virtual vector<Ice::Byte> getAuthorityKeyIdentifier() const;
-    virtual vector<Ice::Byte> getSubjectKeyIdentifier() const;
+    virtual vector<uint8_t> getAuthorityKeyIdentifier() const;
+    virtual vector<uint8_t> getSubjectKeyIdentifier() const;
     virtual bool verify(const CertificatePtr&) const;
     virtual string encode() const;
 
@@ -282,10 +282,10 @@ SCHannelX509ExtensionI::getOID() const
     return _oid;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 SCHannelX509ExtensionI::getData() const
 {
-    vector<Ice::Byte> data;
+    vector<uint8_t> data;
     data.resize(_extension.Value.cbData);
     memcpy(&data[0], _extension.Value.pbData, _extension.Value.cbData);
     return data;
@@ -340,10 +340,10 @@ SChannelCertificateI::operator==(const IceSSL::Certificate& r) const
     return CertCompareCertificate(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, _certInfo, p->_certInfo) != 0;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 SChannelCertificateI::getAuthorityKeyIdentifier() const
 {
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
     PCERT_EXTENSION extension = CertFindExtension(szOID_AUTHORITY_KEY_IDENTIFIER2, _certInfo->cExtension,
                                                   _certInfo->rgExtension);
     if(extension)
@@ -366,10 +366,10 @@ SChannelCertificateI::getAuthorityKeyIdentifier() const
     return keyid;
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 SChannelCertificateI::getSubjectKeyIdentifier() const
 {
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
     PCERT_EXTENSION extension = CertFindExtension(szOID_SUBJECT_KEY_IDENTIFIER, _certInfo->cExtension,
                                                   _certInfo->rgExtension);
     if(extension)

--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -230,11 +230,11 @@ certificateAltNames(CERT_INFO* certInfo, LPCSTR altNameOID)
                         // IPv4 address
                         //
                         ostringstream os;
-                        uint8_t* src = reinterpret_cast<Byte*>(entry->IPAddress.pbData);
+                        uint8_t* src = reinterpret_cast<uint8_t*>(entry->IPAddress.pbData);
                         for(int j = 0; j < 4;)
                         {
                             int value = 0;
-                            uint8_t* dest = reinterpret_cast<Byte*>(&value);
+                            uint8_t* dest = reinterpret_cast<uint8_t*>(&value);
                             *dest = *src++;
                             os << value;
                             if(++j < 4)

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -597,7 +597,7 @@ SChannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
         // If we have filled the buffer or if nothing left to read from
         // the read buffer, we're done.
         //
-        Byte* i = buffer.i + length;
+        uint8_t* i = buffer.i + length;
         if(i == buffer.b.end() || _readBuffer.i == _readBuffer.b.begin())
         {
             break;

--- a/cpp/src/IceSSL/SChannelTransceiverI.cpp
+++ b/cpp/src/IceSSL/SChannelTransceiverI.cpp
@@ -654,7 +654,7 @@ SChannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
             if(dataBuffer->cbBuffer > remaining)
             {
                 _readUnprocessed.b.resize(dataBuffer->cbBuffer - remaining);
-                memcpy(_readUnprocessed.b.begin(), reinterpret_cast<Byte*>(dataBuffer->pvBuffer) + remaining,
+                memcpy(_readUnprocessed.b.begin(), reinterpret_cast<uint8_t*>(dataBuffer->pvBuffer) + remaining,
                     dataBuffer->cbBuffer - remaining);
             }
         }

--- a/cpp/src/IceSSL/SecureTransportCertificateI.cpp
+++ b/cpp/src/IceSSL/SecureTransportCertificateI.cpp
@@ -258,8 +258,8 @@ public:
 
     virtual bool operator==(const IceSSL::Certificate&) const;
 
-    virtual vector<Ice::Byte> getAuthorityKeyIdentifier() const;
-    virtual vector<Ice::Byte> getSubjectKeyIdentifier() const;
+    virtual vector<uint8_t> getAuthorityKeyIdentifier() const;
+    virtual vector<uint8_t> getSubjectKeyIdentifier() const;
     virtual bool verify(const IceSSL::CertificatePtr&) const;
     virtual string encode() const;
 
@@ -439,13 +439,13 @@ SecureTransportCertificateI::operator==(const IceSSL::Certificate& r) const
     return CFEqual(_cert.get(), p->_cert.get());
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 SecureTransportCertificateI::getAuthorityKeyIdentifier() const
 {
 #ifdef ICE_USE_SECURE_TRANSPORT_IOS
     throw Ice::FeatureNotSupportedException(__FILE__, __LINE__);
 #else // macOS
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
 
     UniqueRef<CFDictionaryRef> property(getCertificateProperty(_cert.get(), kSecOIDAuthorityKeyIdentifier));
     if(property)
@@ -479,13 +479,13 @@ SecureTransportCertificateI::getAuthorityKeyIdentifier() const
 #endif
 }
 
-vector<Ice::Byte>
+vector<uint8_t>
 SecureTransportCertificateI::getSubjectKeyIdentifier() const
 {
 #ifdef ICE_USE_SECURE_TRANSPORT_IOS
     throw Ice::FeatureNotSupportedException(__FILE__, __LINE__);
 #else // macOS
-    vector<Ice::Byte> keyid;
+    vector<uint8_t> keyid;
     UniqueRef<CFDictionaryRef> property(getCertificateProperty(_cert.get(), kSecOIDSubjectKeyIdentifier));
     if(property)
     {

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.cpp
@@ -659,7 +659,7 @@ IceSSL::SecureTransport::TransceiverI::writeRaw(const char* data, size_t* length
 
     try
     {
-        IceInternal::Buffer buf(reinterpret_cast<const Ice::Byte*>(data), reinterpret_cast<const Ice::Byte*>(data) + *length);
+        IceInternal::Buffer buf(reinterpret_cast<const uint8_t*>(data), reinterpret_cast<const uint8_t*>(data) + *length);
         IceInternal::SocketOperation op = _delegate->write(buf);
         if(op == IceInternal::SocketOperationWrite)
         {
@@ -692,7 +692,7 @@ IceSSL::SecureTransport::TransceiverI::readRaw(char* data, size_t* length) const
 
     try
     {
-        IceInternal::Buffer buf(reinterpret_cast<Ice::Byte*>(data), reinterpret_cast<Ice::Byte*>(data) + *length);
+        IceInternal::Buffer buf(reinterpret_cast<uint8_t*>(data), reinterpret_cast<uint8_t*>(data) + *length);
         IceInternal::SocketOperation op = _delegate->read(buf);
         if(op == IceInternal::SocketOperationRead)
         {

--- a/cpp/src/IceSSL/SecureTransportTransceiverI.h
+++ b/cpp/src/IceSSL/SecureTransportTransceiverI.h
@@ -69,7 +69,7 @@ private:
         SSLWantWrite = 0x2
     };
 
-    mutable Ice::Byte _tflags;
+    mutable std::uint8_t _tflags;
     size_t _maxSendPacketSize;
     size_t _maxRecvPacketSize;
     std::string _cipher;

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -174,9 +174,9 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
 
             fs.seekg(0, ios::beg);
 
-            vector<Ice::Byte> buf;
+            vector<uint8_t> buf;
             buf.reserve(static_cast<size_t>(fileSize));
-            buf.insert(buf.begin(), istream_iterator<Ice::Byte>(fs), istream_iterator<Ice::Byte>());
+            buf.insert(buf.begin(), istream_iterator<uint8_t>(fs), istream_iterator<uint8_t>());
 
             fs.close();
 

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -48,7 +48,7 @@ public:
 
     bool
     ice_invoke(pair<const uint8_t*, const uint8_t*> inParams,
-               vector<Ice::Byte>&,
+               vector<uint8_t>&,
                const Ice::Current& current) override
     {
         // Use cached reads.
@@ -296,7 +296,7 @@ SubscriberTwoway::flush()
         {
             auto self = static_pointer_cast<SubscriberTwoway>(shared_from_this());
             _obj->ice_invokeAsync(e.op, e.mode, e.data,
-                [self](bool, vector<Ice::Byte>)
+                [self](bool, vector<uint8_t>)
                 {
                     self->completed();
                 },

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -47,7 +47,7 @@ public:
     }
 
     bool
-    ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inParams,
+    ice_invoke(pair<const uint8_t*, const uint8_t*> inParams,
                vector<Ice::Byte>&,
                const Ice::Current& current) override
     {

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -41,7 +41,7 @@ public:
     }
 
     bool
-    ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inParams,
+    ice_invoke(pair<const uint8_t*, const uint8_t*> inParams,
                Ice::ByteSeq&,
                const Ice::Current& current) override
     {

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -33,7 +33,7 @@ public:
     }
 
     bool
-    ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inParams, Ice::ByteSeq&, const Ice::Current& current) override
+    ice_invoke(pair<const uint8_t*, const uint8_t*> inParams, Ice::ByteSeq&, const Ice::Current& current) override
     {
         // Use cached reads.
         EventData event = { current.operation, current.mode, Ice::ByteSeq(), current.ctx };

--- a/cpp/src/IceUtil/ConsoleUtil.cpp
+++ b/cpp/src/IceUtil/ConsoleUtil.cpp
@@ -49,8 +49,8 @@ ConsoleUtil::toConsoleEncoding(const string& message) const
 
         // Then from UTF-8 to console CP
         string consoleString;
-        _consoleConverter->fromUTF8(reinterpret_cast<const IceUtil::Byte* > (u8s.data()),
-                                    reinterpret_cast<const IceUtil::Byte*>(u8s.data() + u8s.size()),
+        _consoleConverter->fromUTF8(reinterpret_cast<const uint8_t* > (u8s.data()),
+                                    reinterpret_cast<const uint8_t*>(u8s.data() + u8s.size()),
                                     consoleString);
 
         return consoleString;

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -83,7 +83,7 @@ public:
             const size_t chunkSize = std::max<size_t>(static_cast<size_t>(sourceEnd - sourceStart) * factor, 4);
             ++factor; // at the next round, we'll allocate more bytes per remaining source character
 
-            targetStart = reinterpret_cast<char*>(buffer.getMoreBytes(chunkSize, reinterpret_cast<Byte*>(targetNext)));
+            targetStart = reinterpret_cast<char*>(buffer.getMoreBytes(chunkSize, reinterpret_cast<uint8_t*>(targetNext)));
             targetEnd = targetStart + chunkSize;
             targetNext = targetStart;
 
@@ -128,7 +128,7 @@ public:
             sourceStart = sourceNext;
         } while (more);
 
-        return reinterpret_cast<Byte*>(targetNext);
+        return reinterpret_cast<uint8_t*>(targetNext);
     }
 
     virtual void fromUTF8(const uint8_t* sourceStart, const uint8_t* sourceEnd, wstring& target) const
@@ -198,7 +198,7 @@ public:
             _buffer.resize(bytesUsed + howMany);
         }
 
-        return const_cast<Byte*>(reinterpret_cast<const uint8_t*>(_buffer.data())) + bytesUsed;
+        return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(_buffer.data())) + bytesUsed;
     }
 
     void swap(string& other, const uint8_t* tail)
@@ -462,7 +462,7 @@ WindowsStringConverter::WindowsStringConverter(unsigned int cp) :
 {
 }
 
-Byte*
+uint8_t*
 WindowsStringConverter::toUTF8(const char* sourceStart, const char* sourceEnd, UTF8Buffer& buffer) const
 {
     //

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -47,7 +47,7 @@ class UnicodeWstringConverter : public WstringConverter
 {
 public:
 
-    virtual Byte* toUTF8(const wchar_t* sourceStart, const wchar_t* sourceEnd, UTF8Buffer& buffer) const
+    virtual uint8_t* toUTF8(const wchar_t* sourceStart, const wchar_t* sourceEnd, UTF8Buffer& buffer) const
     {
         //
         // Max bytes for a character encoding in UTF-8 is 4,
@@ -131,7 +131,7 @@ public:
         return reinterpret_cast<Byte*>(targetNext);
     }
 
-    virtual void fromUTF8(const Byte* sourceStart, const Byte* sourceEnd, wstring& target) const
+    virtual void fromUTF8(const uint8_t* sourceStart, const uint8_t* sourceEnd, wstring& target) const
     {
         const size_t sourceSize = static_cast<size_t>(sourceEnd - sourceStart);
 
@@ -185,12 +185,12 @@ public:
     //
     // Returns the first unused byte in the resized buffer
     //
-    Byte* getMoreBytes(size_t howMany, Byte* firstUnused)
+    uint8_t* getMoreBytes(size_t howMany, uint8_t* firstUnused)
     {
         size_t bytesUsed = 0;
         if(firstUnused != 0)
         {
-            bytesUsed = static_cast<size_t>(firstUnused - reinterpret_cast<const Byte*>(_buffer.data()));
+            bytesUsed = static_cast<size_t>(firstUnused - reinterpret_cast<const uint8_t*>(_buffer.data()));
         }
 
         if(_buffer.size() < howMany + bytesUsed)
@@ -198,13 +198,13 @@ public:
             _buffer.resize(bytesUsed + howMany);
         }
 
-        return const_cast<Byte*>(reinterpret_cast<const Byte*>(_buffer.data())) + bytesUsed;
+        return const_cast<Byte*>(reinterpret_cast<const uint8_t*>(_buffer.data())) + bytesUsed;
     }
 
-    void swap(string& other, const Byte* tail)
+    void swap(string& other, const uint8_t* tail)
     {
-        assert(tail >= reinterpret_cast<const Byte*>(_buffer.data()));
-        _buffer.resize(static_cast<size_t>(tail - reinterpret_cast<const Byte*>(_buffer.data())));
+        assert(tail >= reinterpret_cast<const uint8_t*>(_buffer.data()));
+        _buffer.resize(static_cast<size_t>(tail - reinterpret_cast<const uint8_t*>(_buffer.data())));
         other.swap(_buffer);
     }
 
@@ -272,7 +272,7 @@ IceUtil::wstringToString(const wstring& v, const StringConverterPtr& converter, 
         // First convert to UTF-8 narrow string.
         //
         UTF8BufferI buffer;
-        Byte* last = wConverterWithDefault->toUTF8(v.data(), v.data() + v.size(), buffer);
+        uint8_t* last = wConverterWithDefault->toUTF8(v.data(), v.data() + v.size(), buffer);
         buffer.swap(target, last);
 
         //
@@ -282,8 +282,8 @@ IceUtil::wstringToString(const wstring& v, const StringConverterPtr& converter, 
         if(converter)
         {
             string tmp;
-            converter->fromUTF8(reinterpret_cast<const Byte*>(target.data()),
-                                reinterpret_cast<const Byte*>(target.data() + target.size()), tmp);
+            converter->fromUTF8(reinterpret_cast<const uint8_t*>(target.data()),
+                                reinterpret_cast<const uint8_t*>(target.data() + target.size()), tmp);
             tmp.swap(target);
         }
     }
@@ -304,7 +304,7 @@ IceUtil::stringToWstring(const string& v, const StringConverterPtr& converter, c
         if(converter)
         {
             UTF8BufferI buffer;
-            Byte* last = converter->toUTF8(v.data(), v.data() + v.size(), buffer);
+            uint8_t* last = converter->toUTF8(v.data(), v.data() + v.size(), buffer);
             buffer.swap(tmp, last);
         }
         else
@@ -317,8 +317,8 @@ IceUtil::stringToWstring(const string& v, const StringConverterPtr& converter, c
         //
         // Convert from UTF-8 to the wide string encoding
         //
-        wConverterWithDefault->fromUTF8(reinterpret_cast<const Byte*>(tmp.data()),
-                                        reinterpret_cast<const Byte*>(tmp.data() + tmp.size()), target);
+        wConverterWithDefault->fromUTF8(reinterpret_cast<const uint8_t*>(tmp.data()),
+                                        reinterpret_cast<const uint8_t*>(tmp.data() + tmp.size()), target);
 
     }
     return target;
@@ -332,7 +332,7 @@ IceUtil::nativeToUTF8(const string& str, const IceUtil::StringConverterPtr& conv
         return str;
     }
     UTF8BufferI buffer;
-    Byte* last = converter->toUTF8(str.data(), str.data() + str.size(), buffer);
+    uint8_t* last = converter->toUTF8(str.data(), str.data() + str.size(), buffer);
     string result;
     buffer.swap(result, last);
     return result;
@@ -346,8 +346,8 @@ IceUtil::UTF8ToNative(const string& str, const IceUtil::StringConverterPtr& conv
         return str;
     }
     string tmp;
-    converter->fromUTF8(reinterpret_cast<const Byte*>(str.data()),
-                        reinterpret_cast<const Byte*>(str.data() + str.size()), tmp);
+    converter->fromUTF8(reinterpret_cast<const uint8_t*>(str.data()),
+                        reinterpret_cast<const uint8_t*>(str.data() + str.size()), tmp);
     return tmp;
 }
 
@@ -425,8 +425,8 @@ IceUtilInternal::fromUTF32(const vector<unsigned int>& source)
             Convert::byte_string bs = convert.to_bytes(reinterpret_cast<const Char32T*>(&source.front()),
                                                        reinterpret_cast<const Char32T*>(&source.front() + source.size()));
 
-            result = vector<Byte>(reinterpret_cast<const Byte*>(bs.data()),
-                                  reinterpret_cast<const Byte*>(bs.data()) + bs.length());
+            result = vector<Byte>(reinterpret_cast<const uint8_t*>(bs.data()),
+                                  reinterpret_cast<const uint8_t*>(bs.data()) + bs.length());
         }
         catch(const std::range_error& ex)
         {
@@ -449,9 +449,9 @@ public:
 
     explicit WindowsStringConverter(unsigned int);
 
-    virtual Byte* toUTF8(const char*, const char*, UTF8Buffer&) const;
+    virtual uint8_t* toUTF8(const char*, const char*, UTF8Buffer&) const;
 
-    virtual void fromUTF8(const Byte*, const Byte*, string& target) const;
+    virtual void fromUTF8(const uint8_t*, const uint8_t*, string& target) const;
 
 private:
     unsigned int _cp;
@@ -507,7 +507,7 @@ WindowsStringConverter::toUTF8(const char* sourceStart, const char* sourceEnd, U
 }
 
 void
-WindowsStringConverter::fromUTF8(const Byte* sourceStart, const Byte* sourceEnd, string& target) const
+WindowsStringConverter::fromUTF8(const uint8_t* sourceStart, const uint8_t* sourceEnd, string& target) const
 {
     if(sourceStart == sourceEnd)
     {

--- a/cpp/src/IceUtil/StringConverter.cpp
+++ b/cpp/src/IceUtil/StringConverter.cpp
@@ -355,7 +355,7 @@ typedef char16_t Char16T;
 typedef char32_t Char32T;
 
 vector<unsigned short>
-IceUtilInternal::toUTF16(const vector<Byte>& source)
+IceUtilInternal::toUTF16(const vector<uint8_t>& source)
 {
     vector<unsigned short> result;
     if(!source.empty())
@@ -383,7 +383,7 @@ IceUtilInternal::toUTF16(const vector<Byte>& source)
 }
 
 vector<unsigned int>
-IceUtilInternal::toUTF32(const vector<Byte>& source)
+IceUtilInternal::toUTF32(const vector<uint8_t>& source)
 {
     vector<unsigned int> result;
     if(!source.empty())
@@ -409,10 +409,10 @@ IceUtilInternal::toUTF32(const vector<Byte>& source)
     return result;
 }
 
-vector<Byte>
+vector<uint8_t>
 IceUtilInternal::fromUTF32(const vector<unsigned int>& source)
 {
-    vector<Byte> result;
+    vector<uint8_t> result;
     if(!source.empty())
     {
         assert(sizeof(Char32T) == sizeof(unsigned int));
@@ -425,7 +425,7 @@ IceUtilInternal::fromUTF32(const vector<unsigned int>& source)
             Convert::byte_string bs = convert.to_bytes(reinterpret_cast<const Char32T*>(&source.front()),
                                                        reinterpret_cast<const Char32T*>(&source.front() + source.size()));
 
-            result = vector<Byte>(reinterpret_cast<const uint8_t*>(bs.data()),
+            result = vector<uint8_t>(reinterpret_cast<const uint8_t*>(bs.data()),
                                   reinterpret_cast<const uint8_t*>(bs.data()) + bs.length());
         }
         catch(const std::range_error& ex)

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -17,7 +17,7 @@ namespace
 {
 
 char
-toHexDigit(Byte b)
+toHexDigit(uint8_t b)
 {
     assert(b < 16);
     if(b < 10)
@@ -38,7 +38,7 @@ addContinuationByte(string::iterator& p, string::iterator end, unsigned int code
         throw IllegalArgumentException(__FILE__, __LINE__, "UTF-8 sequence too short");
     }
 
-    Byte b = static_cast<Byte>(*p++);
+    uint8_t b = static_cast<Byte>(*p++);
 
     if((b >> 6) != 2)
     {
@@ -55,7 +55,7 @@ appendUniversalName(char c, string::iterator& p, string::iterator end, string& r
 {
     unsigned int codePoint;
 
-    Byte b = static_cast<Byte>(c);
+    uint8_t b = static_cast<Byte>(c);
     if((b >> 5) == 0x06)
     {
         // 2 bytes

--- a/cpp/src/IceUtil/StringUtil.cpp
+++ b/cpp/src/IceUtil/StringUtil.cpp
@@ -38,7 +38,7 @@ addContinuationByte(string::iterator& p, string::iterator end, unsigned int code
         throw IllegalArgumentException(__FILE__, __LINE__, "UTF-8 sequence too short");
     }
 
-    uint8_t b = static_cast<Byte>(*p++);
+    uint8_t b = static_cast<uint8_t>(*p++);
 
     if((b >> 6) != 2)
     {
@@ -55,7 +55,7 @@ appendUniversalName(char c, string::iterator& p, string::iterator end, string& r
 {
     unsigned int codePoint;
 
-    uint8_t b = static_cast<Byte>(c);
+    uint8_t b = static_cast<uint8_t>(c);
     if((b >> 5) == 0x06)
     {
         // 2 bytes
@@ -89,7 +89,7 @@ appendUniversalName(char c, string::iterator& p, string::iterator end, string& r
         result.append("\\U");
         for(int j = 7; j >= 0; j--)
         {
-            result.push_back(toHexDigit(static_cast<Byte>((codePoint >> (j * 4)) & 0x0F)));
+            result.push_back(toHexDigit(static_cast<uint8_t>((codePoint >> (j * 4)) & 0x0F)));
         }
     }
     else
@@ -97,7 +97,7 @@ appendUniversalName(char c, string::iterator& p, string::iterator end, string& r
         result.append("\\u");
         for(int j = 3; j >= 0; j--)
         {
-            result.push_back(toHexDigit(static_cast<Byte>((codePoint >> (j * 4)) & 0x0F)));
+            result.push_back(toHexDigit(static_cast<uint8_t>((codePoint >> (j * 4)) & 0x0F)));
         }
     }
 }

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -267,9 +267,9 @@ run(const Ice::StringSeq& args)
 
             fs.seekg(0, ios::beg);
 
-            vector<Ice::Byte> buf;
+            vector<uint8_t> buf;
             buf.reserve(static_cast<size_t>(fileSize));
-            buf.insert(buf.begin(), istream_iterator<Ice::Byte>(fs), istream_iterator<Ice::Byte>());
+            buf.insert(buf.begin(), istream_iterator<uint8_t>(fs), istream_iterator<uint8_t>());
 
             fs.close();
 

--- a/cpp/src/iceserviceinstall/ServiceInstaller.h
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.h
@@ -61,7 +61,7 @@ private:
     std::string _glacier2InstanceName;
 
     SID* _sid;
-    std::vector<IceUtil::Byte> _sidBuffer;
+    std::vector<std::uint8_t> _sidBuffer;
 
     std::string _sidName;
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1421,7 +1421,7 @@ allTests(Test::TestHelper* helper, bool collocated)
                 seq.resize(1024 * 10);
                 for(Ice::ByteSeq::iterator q = seq.begin(); q != seq.end(); ++q)
                 {
-                    *q = static_cast<Ice::Byte>(IceUtilInternal::random(255));
+                    *q = static_cast<uint8_t>(IceUtilInternal::random(255));
                 }
 
                 //

--- a/cpp/test/Ice/background/AllTests.cpp
+++ b/cpp/test/Ice/background/AllTests.cpp
@@ -1248,7 +1248,7 @@ readWriteTests(const ConfigurationPtr& configuration,
     seq.resize(10024); // Make sure the request doesn't compress too well.
     for(Ice::ByteSeq::iterator p = seq.begin(); p != seq.end(); ++p)
     {
-        *p = static_cast<Ice::Byte>(IceUtilInternal::random(255));
+        *p = static_cast<uint8_t>(IceUtilInternal::random(255));
     }
 
     // Fill up the receive and send buffers

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -209,7 +209,7 @@ allTests(Test::TestHelper* helper)
         int i = 0;
         for(MyByteSeq::iterator p = in.begin(); p != in.end(); ++p)
         {
-            *p = static_cast<Ice::Byte>('1' + i++);
+            *p = static_cast<uint8_t>('1' + i++);
         }
 
         MyByteSeq out;
@@ -674,7 +674,7 @@ allTests(Test::TestHelper* helper)
             int i = 0;
             for(MyByteSeq::iterator p = in.begin(); p != in.end(); ++p)
             {
-                *p = static_cast<Ice::Byte>('1' + i++);
+                *p = static_cast<uint8_t>('1' + i++);
             }
 
             auto r = t->opMyByteSeqAsync(in).get();
@@ -999,8 +999,8 @@ allTests(Test::TestHelper* helper)
                             [&](pair<const uint8_t*, const uint8_t*> ret,
                                 pair<const uint8_t*, const uint8_t*> out)
                             {
-                                test(arrayRangeEquals<Ice::Byte>(out, inPair));
-                                test(arrayRangeEquals<Ice::Byte>(ret, inPair));
+                                test(arrayRangeEquals<uint8_t>(out, inPair));
+                                test(arrayRangeEquals<uint8_t>(ret, inPair));
                                 done.set_value(true);
                             },
                             [&](std::exception_ptr)
@@ -1105,7 +1105,7 @@ allTests(Test::TestHelper* helper)
         promise<bool> done;
 
         t->opByteSeqAsync(in,
-                          [&](deque<Ice::Byte> ret, deque<Ice::Byte> out)
+                          [&](deque<uint8_t> ret, deque<uint8_t> out)
                           {
                               test(ret == out);
                               test(ret == in);
@@ -1130,7 +1130,7 @@ allTests(Test::TestHelper* helper)
         promise<bool> done;
 
         t->opByteListAsync(in,
-                           [&](list<Ice::Byte> ret, list<Ice::Byte> out)
+                           [&](list<uint8_t> ret, list<uint8_t> out)
                            {
                                test(ret == out);
                                test(ret == in);
@@ -1149,7 +1149,7 @@ allTests(Test::TestHelper* helper)
         int i = 0;
         for(MyByteSeq::iterator p = in.begin(); p != in.end(); ++p)
         {
-            *p = static_cast<Ice::Byte>('1' + i++);
+            *p = static_cast<uint8_t>('1' + i++);
         }
 
         promise<bool> done;
@@ -1555,7 +1555,7 @@ allTests(Test::TestHelper* helper)
         t->opOutArrayByteSeqAsync(in,
                                   [&](pair<const uint8_t*, const uint8_t*> out)
                                   {
-                                      test(arrayRangeEquals<Ice::Byte>(
+                                      test(arrayRangeEquals<uint8_t>(
                                                make_pair<const uint8_t*>(&in[0], &in[0] + in.size()), out));
                                       done.set_value(true);
                                   },

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -177,29 +177,29 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        deque< ::Ice::Byte> in(5);
+        deque<uint8_t> in(5);
         in[0] = '1';
         in[1] = '2';
         in[2] = '3';
         in[3] = '4';
         in[4] = '5';
 
-        deque< ::Ice::Byte> out;
-        deque< ::Ice::Byte> ret = t->opByteSeq(in, out);
+        deque<uint8_t> out;
+        deque<uint8_t> ret = t->opByteSeq(in, out);
         test(out == in);
         test(ret == in);
     }
 
     {
-        list< ::Ice::Byte> in;
+        list<uint8_t> in;
         in.push_back('1');
         in.push_back('2');
         in.push_back('3');
         in.push_back('4');
         in.push_back('5');
 
-        list< ::Ice::Byte> out;
-        list< ::Ice::Byte> ret = t->opByteList(in, out);
+        list<uint8_t> out;
+        list<uint8_t> ret = t->opByteList(in, out);
         test(out == in);
         test(ret == in);
     }
@@ -644,7 +644,7 @@ allTests(Test::TestHelper* helper)
         }
 
         {
-            deque< ::Ice::Byte> in(5);
+            deque<uint8_t> in(5);
             in[0] = '1';
             in[1] = '2';
             in[2] = '3';
@@ -657,7 +657,7 @@ allTests(Test::TestHelper* helper)
         }
 
         {
-            list< ::Ice::Byte> in;
+            list<uint8_t> in;
             in.push_back('1');
             in.push_back('2');
             in.push_back('3');
@@ -1095,7 +1095,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        deque< ::Ice::Byte> in(5);
+        deque<uint8_t> in(5);
         in[0] = '1';
         in[1] = '2';
         in[2] = '3';
@@ -1120,7 +1120,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        list< ::Ice::Byte> in;
+        list<uint8_t> in;
         in.push_back('1');
         in.push_back('2');
         in.push_back('3');

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -515,7 +515,7 @@ allTests(Test::TestHelper* helper)
         test(retBS == inBS);
 
         Test::BufferStruct bs;
-        bs.byteBuf.setAndInit(new Ice::Byte[10], 10);
+        bs.byteBuf.setAndInit(new uint8_t[10], 10);
         bs.boolBuf.setAndInit(new bool[10], 10);
         bs.shortBuf.setAndInit(new int16_t[10], 10);
         bs.intBuf.setAndInit(new int32_t[10], 10);

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -107,7 +107,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Test::ByteList in;
-        Ice::Byte inArray[5];
+        uint8_t inArray[5];
         inArray[0] = '1';
         in.push_back(inArray[0]);
         inArray[1] = '2';
@@ -118,7 +118,7 @@ allTests(Test::TestHelper* helper)
         in.push_back(inArray[3]);
         inArray[4] = '5';
         in.push_back(inArray[4]);
-        pair<const Ice::Byte*, const Ice::Byte*> inPair(inArray, inArray + 5);
+        pair<const uint8_t*, const uint8_t*> inPair(inArray, inArray + 5);
 
         Test::ByteList out;
         Test::ByteList ret = t->opByteArray(inPair, out);
@@ -579,7 +579,7 @@ allTests(Test::TestHelper* helper)
 
         {
             Test::ByteList in;
-            Ice::Byte inArray[5];
+            uint8_t inArray[5];
             inArray[0] = '1';
             in.push_back(inArray[0]);
             inArray[1] = '2';
@@ -590,7 +590,7 @@ allTests(Test::TestHelper* helper)
             in.push_back(inArray[3]);
             inArray[4] = '5';
             in.push_back(inArray[4]);
-            pair<const Ice::Byte*, const Ice::Byte*> inPair(inArray, inArray + 5);
+            pair<const uint8_t*, const uint8_t*> inPair(inArray, inArray + 5);
 
             auto r = t->opByteArrayAsync(inPair).get();
             test(std::get<1>(r) == in);
@@ -985,19 +985,19 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        Ice::Byte in[5];
+        uint8_t in[5];
         in[0] = '1';
         in[1] = '2';
         in[2] = '3';
         in[3] = '4';
         in[4] = '5';
-        pair<const Ice::Byte*, const Ice::Byte*> inPair(in, in + 5);
+        pair<const uint8_t*, const uint8_t*> inPair(in, in + 5);
 
         promise<bool> done;
 
         t->opByteArrayAsync(inPair,
-                            [&](pair<const Ice::Byte*, const Ice::Byte*> ret,
-                                pair<const Ice::Byte*, const Ice::Byte*> out)
+                            [&](pair<const uint8_t*, const uint8_t*> ret,
+                                pair<const uint8_t*, const uint8_t*> out)
                             {
                                 test(arrayRangeEquals<Ice::Byte>(out, inPair));
                                 test(arrayRangeEquals<Ice::Byte>(ret, inPair));
@@ -1553,10 +1553,10 @@ allTests(Test::TestHelper* helper)
         promise<bool> done;
 
         t->opOutArrayByteSeqAsync(in,
-                                  [&](pair<const Ice::Byte*, const Ice::Byte*> out)
+                                  [&](pair<const uint8_t*, const uint8_t*> out)
                                   {
                                       test(arrayRangeEquals<Ice::Byte>(
-                                               make_pair<const Ice::Byte*>(&in[0], &in[0] + in.size()), out));
+                                               make_pair<const uint8_t*>(&in[0], &in[0] + in.size()), out));
                                       done.set_value(true);
                                   },
                                   [&](std::exception_ptr)

--- a/cpp/test/Ice/custom/MyByteSeq.cpp
+++ b/cpp/test/Ice/custom/MyByteSeq.cpp
@@ -16,7 +16,7 @@ MyByteSeq::MyByteSeq(size_t size)
 {
     if(_size != 0)
     {
-        _data = new Ice::Byte[_size];
+        _data = new uint8_t[_size];
     }
 }
 
@@ -25,7 +25,7 @@ MyByteSeq::MyByteSeq(const MyByteSeq& seq)
     _size = seq._size;
     if(_size != 0)
     {
-        _data = new Ice::Byte[_size];
+        _data = new uint8_t[_size];
         memcpy(_data, seq._data, _size);
     }
     else
@@ -77,7 +77,7 @@ MyByteSeq::operator=(const MyByteSeq& rhs)
     _size = rhs._size;
     if(_size != 0)
     {
-        _data = new Ice::Byte[_size];
+        _data = new uint8_t[_size];
         memcpy(_data, rhs._data, _size);
     }
 }

--- a/cpp/test/Ice/custom/MyByteSeq.cpp
+++ b/cpp/test/Ice/custom/MyByteSeq.cpp
@@ -49,7 +49,7 @@ void
 MyByteSeq::swap(MyByteSeq& seq)
 {
     size_t tmpSize = seq._size;
-    Ice::Byte* tmpData = seq._data;
+    uint8_t* tmpData = seq._data;
     seq._size = _size;
     seq._data = _data;
     _size = tmpSize;

--- a/cpp/test/Ice/custom/MyByteSeq.h
+++ b/cpp/test/Ice/custom/MyByteSeq.h
@@ -11,10 +11,10 @@ class MyByteSeq
 {
 public:
 
-    typedef Ice::Byte* iterator;
-    typedef Ice::Byte* const_iterator;
+    typedef std::uint8_t* iterator;
+    typedef std::uint8_t* const_iterator;
 
-    typedef Ice::Byte value_type;
+    typedef std::uint8_t value_type;
 
     MyByteSeq();
     MyByteSeq(size_t);
@@ -31,7 +31,7 @@ public:
 private:
 
     size_t _size;
-    Ice::Byte* _data;
+    std::uint8_t* _data;
 };
 
 #endif

--- a/cpp/test/Ice/custom/StringConverterI.cpp
+++ b/cpp/test/Ice/custom/StringConverterI.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace Ice;
 
-Byte*
+uint8_t*
 Test::StringConverterI::toUTF8(const char* sourceStart, const char* sourceEnd, UTF8Buffer& buffer) const
 {
     size_t size = static_cast<size_t>(sourceEnd - sourceStart);
@@ -34,7 +34,7 @@ Test::StringConverterI::fromUTF8(const uint8_t* sourceStart, const uint8_t* sour
     }
 }
 
-Byte*
+uint8_t*
 Test::WstringConverterI::toUTF8(const wchar_t* sourceStart, const wchar_t* sourceEnd, UTF8Buffer& buffer) const
 {
     wstring ws(sourceStart, sourceEnd);

--- a/cpp/test/Ice/custom/StringConverterI.cpp
+++ b/cpp/test/Ice/custom/StringConverterI.cpp
@@ -16,7 +16,7 @@ Test::StringConverterI::toUTF8(const char* sourceStart, const char* sourceEnd, U
 
     for(size_t i = 0; i < size; ++i)
     {
-        targetStart[i] = static_cast<Byte>(tolower(sourceStart[i]));
+        targetStart[i] = static_cast<uint8_t>(tolower(sourceStart[i]));
     }
 
     return targetEnd;
@@ -46,7 +46,7 @@ Test::WstringConverterI::toUTF8(const wchar_t* sourceStart, const wchar_t* sourc
 
     for(size_t i = 0; i < size; ++i)
     {
-        targetStart[i] = static_cast<Byte>(tolower(s[i]));
+        targetStart[i] = static_cast<uint8_t>(tolower(s[i]));
     }
     return targetEnd;
 }

--- a/cpp/test/Ice/custom/StringConverterI.cpp
+++ b/cpp/test/Ice/custom/StringConverterI.cpp
@@ -11,8 +11,8 @@ Byte*
 Test::StringConverterI::toUTF8(const char* sourceStart, const char* sourceEnd, UTF8Buffer& buffer) const
 {
     size_t size = static_cast<size_t>(sourceEnd - sourceStart);
-    Byte* targetStart = buffer.getMoreBytes(size, 0);
-    Byte* targetEnd = targetStart + size;
+    uint8_t* targetStart = buffer.getMoreBytes(size, 0);
+    uint8_t* targetEnd = targetStart + size;
 
     for(size_t i = 0; i < size; ++i)
     {
@@ -23,7 +23,7 @@ Test::StringConverterI::toUTF8(const char* sourceStart, const char* sourceEnd, U
 }
 
 void
-Test::StringConverterI::fromUTF8(const Byte* sourceStart, const Byte* sourceEnd,
+Test::StringConverterI::fromUTF8(const uint8_t* sourceStart, const uint8_t* sourceEnd,
                                  string& target) const
 {
     size_t size = static_cast<size_t>(sourceEnd - sourceStart);
@@ -41,8 +41,8 @@ Test::WstringConverterI::toUTF8(const wchar_t* sourceStart, const wchar_t* sourc
     string s = wstringToString(ws);
 
     size_t size = s.size();
-    Byte* targetStart = buffer.getMoreBytes(size, 0);
-    Byte* targetEnd = targetStart + size;
+    uint8_t* targetStart = buffer.getMoreBytes(size, 0);
+    uint8_t* targetEnd = targetStart + size;
 
     for(size_t i = 0; i < size; ++i)
     {
@@ -52,7 +52,7 @@ Test::WstringConverterI::toUTF8(const wchar_t* sourceStart, const wchar_t* sourc
 }
 
 void
-Test::WstringConverterI::fromUTF8(const Byte* sourceStart, const Byte* sourceEnd,
+Test::WstringConverterI::fromUTF8(const uint8_t* sourceStart, const uint8_t* sourceEnd,
                                   wstring& target) const
 {
     string s(sourceStart, sourceEnd);

--- a/cpp/test/Ice/custom/StringConverterI.h
+++ b/cpp/test/Ice/custom/StringConverterI.h
@@ -19,8 +19,8 @@ class StringConverterI : public Ice::StringConverter
 {
 public:
 
-    virtual Ice::Byte* toUTF8(const char*, const char*, Ice::UTF8Buffer&) const;
-    virtual void fromUTF8(const Ice::Byte* sourceStart, const Ice::Byte* sourceEnd,
+    virtual std::uint8_t* toUTF8(const char*, const char*, Ice::UTF8Buffer&) const;
+    virtual void fromUTF8(const std::uint8_t* sourceStart, const std::uint8_t* sourceEnd,
                           std::string& target) const;
 };
 
@@ -28,8 +28,8 @@ class WstringConverterI : public Ice::WstringConverter
 {
 public:
 
-    virtual Ice::Byte* toUTF8(const wchar_t*, const wchar_t*, Ice::UTF8Buffer&) const;
-    virtual void fromUTF8(const Ice::Byte* sourceStart, const Ice::Byte* sourceEnd,
+    virtual std::uint8_t* toUTF8(const wchar_t*, const wchar_t*, Ice::UTF8Buffer&) const;
+    virtual void fromUTF8(const std::uint8_t* sourceStart, const std::uint8_t* sourceEnd,
                           std::wstring& target) const;
 
 };

--- a/cpp/test/Ice/custom/Test.ice
+++ b/cpp/test/Ice/custom/Test.ice
@@ -20,7 +20,7 @@ sequence<BoolList> BoolListSeq;
 ["cpp:type:std::list<std::deque<bool> >"] sequence<["cpp:type:std::deque<bool>"] BoolSeq> BoolDequeList;
 
 sequence<byte> ByteSeq;
-["cpp:type:std::list< ::Ice::Byte>"] sequence<byte> ByteList;
+["cpp:type:std::list<std::uint8_t>"] sequence<byte> ByteList;
 
 ["cpp:type:std::list< ::Test::ByteList>"] sequence<ByteList> ByteListList;
 sequence<ByteList> ByteListSeq;
@@ -108,7 +108,7 @@ class DictClass
 ["cpp:type:Test::CustomBuffer<int64_t>"] sequence<long> LongBuffer;
 ["cpp:type:Test::CustomBuffer<float>"] sequence<float> FloatBuffer;
 ["cpp:type:Test::CustomBuffer<double>"] sequence<double> DoubleBuffer;
-["cpp:type:Test::CustomBuffer<Ice::Byte>"] sequence<byte> ByteBuffer;
+["cpp:type:Test::CustomBuffer<std::uint8_t>"] sequence<byte> ByteBuffer;
 struct BufferStruct
 {
     ByteBuffer byteBuf;
@@ -139,9 +139,9 @@ interface TestIntf
     ["cpp:array"] BoolDequeList opBoolDequeListArray(["cpp:array"] BoolDequeList inSeq,
                                                 out ["cpp:array"] BoolDequeList outSeq);
 
-    ["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq
-    opByteSeq(["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq inSeq,
-              out ["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq outSeq);
+    ["cpp:type:std::deque<std::uint8_t>"] ByteSeq
+    opByteSeq(["cpp:type:std::deque<std::uint8_t>"] ByteSeq inSeq,
+              out ["cpp:type:std::deque<std::uint8_t>"] ByteSeq outSeq);
 
     ByteList opByteList(ByteList inSeq, out ByteList outSeq);
 

--- a/cpp/test/Ice/custom/TestAMD.ice
+++ b/cpp/test/Ice/custom/TestAMD.ice
@@ -18,7 +18,7 @@ sequence<BoolList> BoolListSeq;
 ["cpp:type:std::list< ::Test::BoolSeq>"] sequence<BoolSeq> BoolSeqList;
 
 sequence<byte> ByteSeq;
-["cpp:type:std::list< ::Ice::Byte>"] sequence<byte> ByteList;
+["cpp:type:std::list<std::uint8_t>"] sequence<byte> ByteList;
 
 ["cpp:type:std::list< ::Test::ByteList>"] sequence<ByteList> ByteListList;
 sequence<ByteList> ByteListSeq;
@@ -106,7 +106,7 @@ class DictClass
 ["cpp:type:Test::CustomBuffer<int64_t>"] sequence<long> LongBuffer;
 ["cpp:type:Test::CustomBuffer<float>"] sequence<float> FloatBuffer;
 ["cpp:type:Test::CustomBuffer<double>"] sequence<double> DoubleBuffer;
-["cpp:type:Test::CustomBuffer<Ice::Byte>"] sequence<byte> ByteBuffer;
+["cpp:type:Test::CustomBuffer<std::uint8_t>"] sequence<byte> ByteBuffer;
 struct BufferStruct
 {
     ByteBuffer byteBuf;
@@ -133,9 +133,9 @@ struct BufferStruct
 
     BoolList opBoolList(BoolList inSeq, out BoolList outSeq);
 
-    ["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq
-    opByteSeq(["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq inSeq,
-              out ["cpp:type:std::deque< ::Ice::Byte>"] ByteSeq outSeq);
+    ["cpp:type:std::deque<std::uint8_t>"] ByteSeq
+    opByteSeq(["cpp:type:std::deque<std::uint8_t>"] ByteSeq inSeq,
+              out ["cpp:type:std::deque<std::uint8_t>"] ByteSeq outSeq);
 
     ByteList opByteList(ByteList inSeq, out ByteList outSeq);
 

--- a/cpp/test/Ice/custom/TestAMDI.cpp
+++ b/cpp/test/Ice/custom/TestAMDI.cpp
@@ -58,8 +58,8 @@ TestIntfI::opBoolListAsync(Test::BoolList in,
 }
 
 void
-TestIntfI::opByteSeqAsync(std::deque<Ice::Byte> in,
-                          std::function<void(const std::deque<Ice::Byte>&, const std::deque<Ice::Byte>&)> response,
+TestIntfI::opByteSeqAsync(std::deque<uint8_t> in,
+                          std::function<void(const std::deque<uint8_t>&, const std::deque<uint8_t>&)> response,
                           std::function<void(std::exception_ptr)>, const Ice::Current&)
 {
     response(in, in);

--- a/cpp/test/Ice/custom/TestAMDI.cpp
+++ b/cpp/test/Ice/custom/TestAMDI.cpp
@@ -24,9 +24,9 @@ TestIntfI::opBoolArrayAsync(std::pair<const bool*, const bool*> in,
 }
 
 void
-TestIntfI::opByteArrayAsync(std::pair<const Ice::Byte*, const Ice::Byte*> in,
-                            std::function<void(const std::pair<const Ice::Byte*, const Ice::Byte*>&,
-                                                const std::pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+TestIntfI::opByteArrayAsync(std::pair<const uint8_t*, const uint8_t*> in,
+                            std::function<void(const std::pair<const uint8_t*, const uint8_t*>&,
+                                                const std::pair<const uint8_t*, const uint8_t*>&)> response,
                             std::function<void(std::exception_ptr)>, const Ice::Current&)
 {
     response(in, in);
@@ -201,7 +201,7 @@ TestIntfI::opCListAsync(Test::CList in,
 
 void
 TestIntfI::opOutArrayByteSeqAsync(Test::ByteSeq in,
-                                  std::function<void(const std::pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+                                  std::function<void(const std::pair<const uint8_t*, const uint8_t*>&)> response,
                                   std::function<void(std::exception_ptr)>, const Ice::Current&)
 {
     response(std::make_pair(in.data(), in.data() + in.size()));

--- a/cpp/test/Ice/custom/TestAMDI.h
+++ b/cpp/test/Ice/custom/TestAMDI.h
@@ -18,9 +18,9 @@ public:
                           std::function<void(const ::Test::BoolSeq&, const ::Test::BoolSeq&)>,
                           std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void opByteArrayAsync(std::pair<const ::Ice::Byte*, const ::Ice::Byte*>,
-                          std::function<void(const std::pair<const ::Ice::Byte*, const ::Ice::Byte*>&,
-                                              const std::pair<const ::Ice::Byte*, const ::Ice::Byte*>&)>,
+    void opByteArrayAsync(std::pair<const ::std::uint8_t*, const ::std::uint8_t*>,
+                          std::function<void(const std::pair<const ::std::uint8_t*, const ::std::uint8_t*>&,
+                                              const std::pair<const ::std::uint8_t*, const ::std::uint8_t*>&)>,
                           std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
     void opVariableArrayAsync(std::pair<const ::Test::Variable*, const ::Test::Variable*>,
@@ -110,7 +110,7 @@ public:
                       std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
     void opOutArrayByteSeqAsync(::Test::ByteSeq,
-                                std::function<void(const std::pair<const ::Ice::Byte*, const ::Ice::Byte*>&)>,
+                                std::function<void(const std::pair<const ::std::uint8_t*, const ::std::uint8_t*>&)>,
                                 std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
     void opIntStringDictAsync(::Test::IntStringDict,

--- a/cpp/test/Ice/custom/TestAMDI.h
+++ b/cpp/test/Ice/custom/TestAMDI.h
@@ -35,8 +35,8 @@ public:
                          std::function<void(const ::Test::BoolList&, const ::Test::BoolList&)>,
                          std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void opByteSeqAsync(std::deque< ::Ice::Byte>,
-                        std::function<void(const std::deque< ::Ice::Byte>&, const std::deque< ::Ice::Byte>&)>,
+    void opByteSeqAsync(std::deque< std::uint8_t>,
+                        std::function<void(const std::deque< std::uint8_t>&, const std::deque< std::uint8_t>&)>,
                         std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
     void opByteListAsync(::Test::ByteList,

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -24,7 +24,7 @@ TestIntfI::opBoolArray(std::pair<const bool*, const bool*> inSeq,
 }
 
 Test::ByteList
-TestIntfI::opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*> inSeq,
+TestIntfI::opByteArray(std::pair<const uint8_t*, const uint8_t*> inSeq,
                        Test::ByteList& outSeq,
                        const Ice::Current&)
 {

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -113,18 +113,18 @@ TestIntfI::opBoolDequeListRange(Test::BoolDequeList inSeq, Test::BoolDequeList& 
     return outSeq;
 }
 
-std::deque< ::Ice::Byte>
-TestIntfI::opByteSeq(std::deque< ::Ice::Byte> inSeq,
-                     std::deque< ::Ice::Byte>& outSeq,
+std::deque< uint8_t>
+TestIntfI::opByteSeq(std::deque< uint8_t> inSeq,
+                     std::deque< uint8_t>& outSeq,
                      const Ice::Current&)
 {
     outSeq = inSeq;
     return inSeq;
 }
 
-std::list< ::Ice::Byte>
-TestIntfI::opByteList(std::list< ::Ice::Byte> inSeq,
-                      std::list< ::Ice::Byte>& outSeq,
+std::list< uint8_t>
+TestIntfI::opByteList(std::list< uint8_t> inSeq,
+                      std::list< uint8_t>& outSeq,
                       const Ice::Current&)
 {
     outSeq = inSeq;

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -19,7 +19,7 @@ public:
                                       Test::BoolSeq&,
                                       const Ice::Current&);
 
-    virtual Test::ByteList opByteArray(std::pair<const Ice::Byte*, const Ice::Byte*>,
+    virtual Test::ByteList opByteArray(std::pair<const std::uint8_t*, const std::uint8_t*>,
                                        Test::ByteList&,
                                        const Ice::Current&);
 

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -56,12 +56,12 @@ public:
     virtual ::Test::BoolDequeList opBoolDequeListRange(::Test::BoolDequeList,
                                                        ::Test::BoolDequeList&, const ::Ice::Current&);
 
-    virtual std::deque< ::Ice::Byte> opByteSeq(std::deque< ::Ice::Byte>,
-                                               std::deque< ::Ice::Byte>&,
+    virtual std::deque< std::uint8_t> opByteSeq(std::deque< std::uint8_t>,
+                                               std::deque< std::uint8_t>&,
                                                const Ice::Current&);
 
-    virtual std::list< ::Ice::Byte> opByteList(std::list< ::Ice::Byte>,
-                                               std::list< ::Ice::Byte>&,
+    virtual std::list< std::uint8_t> opByteList(std::list< std::uint8_t>,
+                                               std::list< std::uint8_t>&,
                                                const Ice::Current&);
 
     virtual MyByteSeq opMyByteSeq(MyByteSeq,

--- a/cpp/test/Ice/dispatcher/AllTests.cpp
+++ b/cpp/test/Ice/dispatcher/AllTests.cpp
@@ -192,7 +192,7 @@ allTests(Test::TestHelper* helper)
         seq.resize(1024); // Make sure the request doesn't compress too well.
         for(Ice::ByteSeq::iterator q = seq.begin(); q != seq.end(); ++q)
         {
-            *q = static_cast<Ice::Byte>(IceUtilInternal::random(255));
+            *q = static_cast<uint8_t>(IceUtilInternal::random(255));
         }
 
         vector<shared_ptr<promise<void>>> completed;

--- a/cpp/test/Ice/echo/BlobjectI.cpp
+++ b/cpp/test/Ice/echo/BlobjectI.cpp
@@ -36,8 +36,8 @@ BlobjectI::flushBatch()
 }
 
 void
-BlobjectI::ice_invokeAsync(std::vector<Ice::Byte> inEncaps,
-                           std::function<void(bool, const std::vector<Ice::Byte>&)> response,
+BlobjectI::ice_invokeAsync(std::vector<uint8_t> inEncaps,
+                           std::function<void(bool, const std::vector<uint8_t>&)> response,
                            std::function<void(std::exception_ptr)> ex,
                            const Ice::Current& current)
 {
@@ -63,16 +63,16 @@ BlobjectI::ice_invokeAsync(std::vector<Ice::Byte> inEncaps,
 
         if(_batchProxy)
         {
-            vector<Ice::Byte> out;
+            vector<uint8_t> out;
             obj->ice_invoke(current.operation, current.mode, inEncaps, out, current.ctx);
-            response(true, vector<Ice::Byte>());
+            response(true, vector<uint8_t>());
         }
         else
         {
             obj->ice_oneway()->ice_invokeAsync(current.operation, current.mode, inEncaps,
-                                               [](bool, const std::vector<Ice::Byte>&) { assert(0); },
+                                               [](bool, const std::vector<uint8_t>&) { assert(0); },
                                                ex,
-                                               [&](bool) { response(true, vector<Ice::Byte>()); },
+                                               [&](bool) { response(true, vector<uint8_t>()); },
                                                current.ctx);
         }
     }

--- a/cpp/test/Ice/echo/BlobjectI.h
+++ b/cpp/test/Ice/echo/BlobjectI.h
@@ -17,8 +17,8 @@ public:
     void flushBatch();
     void setConnection(const Ice::ConnectionPtr&);
 
-    virtual void ice_invokeAsync(std::vector<Ice::Byte>,
-                                 std::function<void(bool, const std::vector<Ice::Byte>&)>,
+    virtual void ice_invokeAsync(std::vector<std::uint8_t>,
+                                 std::function<void(bool, const std::vector<std::uint8_t>&)>,
                                  std::function<void(std::exception_ptr)>,
                                  const Ice::Current&) override;
 

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -63,7 +63,7 @@ allTests(Test::TestHelper* helper)
         }
 
         // ice_invoke with array mapping
-        pair<const ::Ice::Byte*, const ::Ice::Byte*> inPair(&inEncaps[0], &inEncaps[0] + inEncaps.size());
+        pair<const ::uint8_t*, const ::uint8_t*> inPair(&inEncaps[0], &inEncaps[0] + inEncaps.size());
         if(cl->ice_invoke("opString", Ice::OperationMode::Normal, inPair, outEncaps))
         {
             Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
@@ -255,7 +255,7 @@ allTests(Test::TestHelper* helper)
         auto inPair = make_pair(inEncaps.data(), inEncaps.data() + inEncaps.size());
 
         cl->ice_invokeAsync("opString", Ice::OperationMode::Normal, inPair,
-            [&](bool ok, pair<const Ice::Byte*, const Ice::Byte*> outParams)
+            [&](bool ok, pair<const uint8_t*, const uint8_t*> outParams)
             {
                 vector<Ice::Byte>(outParams.first, outParams.second).swap(outEncaps);
                 completed.set_value(ok);

--- a/cpp/test/Ice/invoke/AllTests.cpp
+++ b/cpp/test/Ice/invoke/AllTests.cpp
@@ -118,7 +118,7 @@ allTests(Test::TestHelper* helper)
     {
         Ice::ByteSeq inEncaps;
         batchOneway->ice_invokeAsync("opOneway", Ice::OperationMode::Normal, inEncaps,
-            [](bool, const vector<Ice::Byte>)
+            [](bool, const vector<uint8_t>)
             {
                 test(false);
             },
@@ -198,7 +198,7 @@ allTests(Test::TestHelper* helper)
         out.finished(inEncaps);
 
         cl->ice_invokeAsync("opString", Ice::OperationMode::Normal, inEncaps,
-            [&](bool ok, vector<Ice::Byte> outParams)
+            [&](bool ok, vector<uint8_t> outParams)
             {
                 outEncaps = std::move(outParams);
                 completed.set_value(ok);
@@ -257,7 +257,7 @@ allTests(Test::TestHelper* helper)
         cl->ice_invokeAsync("opString", Ice::OperationMode::Normal, inPair,
             [&](bool ok, pair<const uint8_t*, const uint8_t*> outParams)
             {
-                vector<Ice::Byte>(outParams.first, outParams.second).swap(outEncaps);
+                vector<uint8_t>(outParams.first, outParams.second).swap(outEncaps);
                 completed.set_value(ok);
             },
             [&](exception_ptr ex)
@@ -313,7 +313,7 @@ allTests(Test::TestHelper* helper)
         Ice::ByteSeq inEncaps, outEncaps;
 
         cl->ice_invokeAsync("opException", Ice::OperationMode::Normal, inEncaps,
-            [&](bool ok, vector<Ice::Byte> outParams)
+            [&](bool ok, vector<uint8_t> outParams)
             {
                 outEncaps = std::move(outParams);
                 completed.set_value(ok);

--- a/cpp/test/Ice/invoke/BlobjectI.cpp
+++ b/cpp/test/Ice/invoke/BlobjectI.cpp
@@ -10,7 +10,7 @@
 using namespace std;
 
 bool
-invokeInternal(Ice::InputStream& in, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
+invokeInternal(Ice::InputStream& in, vector<uint8_t>& outEncaps, const Ice::Current& current)
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();
     Ice::OutputStream out(communicator);
@@ -79,14 +79,14 @@ invokeInternal(Ice::InputStream& in, vector<Ice::Byte>& outEncaps, const Ice::Cu
 }
 
 bool
-BlobjectI::ice_invoke(vector<Ice::Byte> inEncaps, vector<Ice::Byte>& outEncaps, const Ice::Current& current)
+BlobjectI::ice_invoke(vector<uint8_t> inEncaps, vector<uint8_t>& outEncaps, const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);
     return invokeInternal(in, outEncaps, current);
 }
 
 bool
-BlobjectArrayI::ice_invoke(pair<const uint8_t*, const uint8_t*> inEncaps, vector<Ice::Byte>& outEncaps,
+BlobjectArrayI::ice_invoke(pair<const uint8_t*, const uint8_t*> inEncaps, vector<uint8_t>& outEncaps,
                            const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);
@@ -94,13 +94,13 @@ BlobjectArrayI::ice_invoke(pair<const uint8_t*, const uint8_t*> inEncaps, vector
 }
 
 void
-BlobjectAsyncI::ice_invokeAsync(vector<Ice::Byte> inEncaps,
-                                function<void(bool, const vector<Ice::Byte>&)> response,
+BlobjectAsyncI::ice_invokeAsync(vector<uint8_t> inEncaps,
+                                function<void(bool, const vector<uint8_t>&)> response,
                                 function<void(exception_ptr)>,
                                 const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), inEncaps);
-    vector<Ice::Byte> outEncaps;
+    vector<uint8_t> outEncaps;
     bool ok = invokeInternal(in, outEncaps, current);
     response(ok, outEncaps);
 }
@@ -112,7 +112,7 @@ BlobjectArrayAsyncI::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inEnca
                                      const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), inEncaps);
-    vector<Ice::Byte> outEncaps;
+    vector<uint8_t> outEncaps;
     bool ok = invokeInternal(in, outEncaps, current);
     pair<const uint8_t*, const uint8_t*> outPair(static_cast<const uint8_t*>(nullptr), static_cast<const uint8_t*>(nullptr));
     if(outEncaps.size() != 0)

--- a/cpp/test/Ice/invoke/BlobjectI.cpp
+++ b/cpp/test/Ice/invoke/BlobjectI.cpp
@@ -86,7 +86,7 @@ BlobjectI::ice_invoke(vector<Ice::Byte> inEncaps, vector<Ice::Byte>& outEncaps, 
 }
 
 bool
-BlobjectArrayI::ice_invoke(pair<const Ice::Byte*, const Ice::Byte*> inEncaps, vector<Ice::Byte>& outEncaps,
+BlobjectArrayI::ice_invoke(pair<const uint8_t*, const uint8_t*> inEncaps, vector<Ice::Byte>& outEncaps,
                            const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), current.encoding, inEncaps);
@@ -106,15 +106,15 @@ BlobjectAsyncI::ice_invokeAsync(vector<Ice::Byte> inEncaps,
 }
 
 void
-BlobjectArrayAsyncI::ice_invokeAsync(pair<const Ice::Byte*, const Ice::Byte*> inEncaps,
-                                     function<void(bool, const pair<const Ice::Byte*, const Ice::Byte*>&)> response,
+BlobjectArrayAsyncI::ice_invokeAsync(pair<const uint8_t*, const uint8_t*> inEncaps,
+                                     function<void(bool, const pair<const uint8_t*, const uint8_t*>&)> response,
                                      function<void(exception_ptr)>,
                                      const Ice::Current& current)
 {
     Ice::InputStream in(current.adapter->getCommunicator(), inEncaps);
     vector<Ice::Byte> outEncaps;
     bool ok = invokeInternal(in, outEncaps, current);
-    pair<const Ice::Byte*, const Ice::Byte*> outPair(static_cast<const Ice::Byte*>(nullptr), static_cast<const Ice::Byte*>(nullptr));
+    pair<const uint8_t*, const uint8_t*> outPair(static_cast<const uint8_t*>(nullptr), static_cast<const uint8_t*>(nullptr));
     if(outEncaps.size() != 0)
     {
         outPair.first = &outEncaps[0];

--- a/cpp/test/Ice/invoke/BlobjectI.h
+++ b/cpp/test/Ice/invoke/BlobjectI.h
@@ -18,7 +18,7 @@ class BlobjectArrayI : public Ice::BlobjectArray
 {
 public:
 
-    virtual bool ice_invoke(std::pair<const Ice::Byte*, const Ice::Byte*>, std::vector<Ice::Byte>&,
+    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*>, std::vector<Ice::Byte>&,
                             const Ice::Current&);
 };
 
@@ -36,8 +36,8 @@ class BlobjectArrayAsyncI : public Ice::BlobjectArrayAsync
 {
 public:
 
-    virtual void ice_invokeAsync(std::pair<const Ice::Byte*, const Ice::Byte*>,
-                                 std::function<void(bool, const std::pair<const Ice::Byte*, const Ice::Byte*>&)>,
+    virtual void ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*>,
+                                 std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)>,
                                  std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
 };

--- a/cpp/test/Ice/invoke/BlobjectI.h
+++ b/cpp/test/Ice/invoke/BlobjectI.h
@@ -11,14 +11,14 @@ class BlobjectI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<std::uint8_t>, std::vector<std::uint8_t>&, const Ice::Current&);
 };
 
 class BlobjectArrayI : public Ice::BlobjectArray
 {
 public:
 
-    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*>, std::vector<Ice::Byte>&,
+    virtual bool ice_invoke(std::pair<const std::uint8_t*, const std::uint8_t*>, std::vector<std::uint8_t>&,
                             const Ice::Current&);
 };
 
@@ -26,8 +26,8 @@ class BlobjectAsyncI : public Ice::BlobjectAsync
 {
 public:
 
-    virtual void ice_invokeAsync(std::vector<Ice::Byte>,
-                                 std::function<void(bool, const std::vector<Ice::Byte>&)>,
+    virtual void ice_invokeAsync(std::vector<std::uint8_t>,
+                                 std::function<void(bool, const std::vector<std::uint8_t>&)>,
                                  std::function<void(std::exception_ptr)>,
                                  const Ice::Current&);
 };

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -314,8 +314,8 @@ InitialI::opM(Test::MPtr v1, Test::MPtr& v2, const Ice::Current&)
 }
 
 bool
-UnexpectedObjectExceptionTestI::ice_invoke(std::vector<Ice::Byte>,
-                                           std::vector<Ice::Byte>& outParams,
+UnexpectedObjectExceptionTestI::ice_invoke(std::vector<uint8_t>,
+                                           std::vector<uint8_t>& outParams,
                                            const Ice::Current& current)
 {
     Ice::CommunicatorPtr communicator = current.adapter->getCommunicator();

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -124,7 +124,7 @@ class UnexpectedObjectExceptionTestI : public Ice::Blobject
 {
 public:
 
-    virtual bool ice_invoke(std::vector<Ice::Byte>, std::vector<Ice::Byte>&, const Ice::Current&);
+    virtual bool ice_invoke(std::vector<std::uint8_t>, std::vector<std::uint8_t>&, const Ice::Current&);
 };
 using UnexpectedObjectExceptionTestIPtr = std::shared_ptr<UnexpectedObjectExceptionTestI>;
 

--- a/cpp/test/Ice/operations/Oneways.cpp
+++ b/cpp/test/Ice/operations/Oneways.cpp
@@ -63,7 +63,7 @@ oneways(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     }
 
     {
-        Ice::Byte b;
+        uint8_t b;
 
         try
         {

--- a/cpp/test/Ice/operations/Oneways.cpp
+++ b/cpp/test/Ice/operations/Oneways.cpp
@@ -67,7 +67,7 @@ oneways(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
 
         try
         {
-            p->opByte(Ice::Byte(0xff), Ice::Byte(0x0f), b);
+            p->opByte(uint8_t(0xff), uint8_t(0x0f), b);
             test(false);
         }
         catch(const Ice::TwowayOnlyException&)

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -182,7 +182,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
     {
         try
         {
-            p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
+            p->opByteAsync(uint8_t(0xff), uint8_t(0x0f),
                 [](uint8_t, uint8_t)
                 {
                     test(false);

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -183,7 +183,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
         try
         {
             p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
-                [](Ice::Byte, Ice::Byte)
+                [](Ice::Byte, uint8_t)
                 {
                     test(false);
                 });

--- a/cpp/test/Ice/operations/OnewaysAMI.cpp
+++ b/cpp/test/Ice/operations/OnewaysAMI.cpp
@@ -183,7 +183,7 @@ onewaysAMI(const Ice::CommunicatorPtr&, const Test::MyClassPrxPtr& proxy)
         try
         {
             p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
-                [](Ice::Byte, uint8_t)
+                [](uint8_t, uint8_t)
                 {
                     test(false);
                 });

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -93,7 +93,7 @@ MyDerivedClassI::opVoidAsync(function<void()> response,
 void
 MyDerivedClassI::opByteAsync(uint8_t p1,
                              uint8_t p2,
-                             function<void(Ice::Byte, uint8_t)> response,
+                             function<void(uint8_t, uint8_t)> response,
                              function<void(exception_ptr)>,
                              const Ice::Current&)
 {

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -91,9 +91,9 @@ MyDerivedClassI::opVoidAsync(function<void()> response,
 }
 
 void
-MyDerivedClassI::opByteAsync(Ice::Byte p1,
-                             Ice::Byte p2,
-                             function<void(Ice::Byte, Ice::Byte)> response,
+MyDerivedClassI::opByteAsync(uint8_t p1,
+                             uint8_t p2,
+                             function<void(Ice::Byte, uint8_t)> response,
                              function<void(exception_ptr)>,
                              const Ice::Current&)
 {
@@ -751,8 +751,8 @@ MyDerivedClassI::opDerivedAsync(function<void()> response,
 }
 
 void
-MyDerivedClassI::opByte1Async(Ice::Byte b,
-                              function<void(Ice::Byte)> response,
+MyDerivedClassI::opByte1Async(uint8_t b,
+                              function<void(uint8_t)> response,
                               function<void(exception_ptr)>,
                               const Ice::Current&)
 {

--- a/cpp/test/Ice/operations/TestAMDI.h
+++ b/cpp/test/Ice/operations/TestAMDI.h
@@ -33,8 +33,8 @@ public:
                              ::std::function<void(std::exception_ptr)>,
                              const Ice::Current&);
 
-    virtual void opByteAsync(Ice::Byte, Ice::Byte,
-                             ::std::function<void(Ice::Byte, std::uint8_t)>,
+    virtual void opByteAsync(std::uint8_t, std::uint8_t,
+                             ::std::function<void(std::uint8_t, std::uint8_t)>,
                              ::std::function<void(std::exception_ptr)>,
                              const Ice::Current&);
 
@@ -297,7 +297,7 @@ public:
                                 ::std::function<void(std::exception_ptr)>,
                                 const Ice::Current&);
 
-    virtual void opByte1Async(Ice::Byte,
+    virtual void opByte1Async(std::uint8_t,
                               ::std::function<void(std::uint8_t)>,
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);

--- a/cpp/test/Ice/operations/TestAMDI.h
+++ b/cpp/test/Ice/operations/TestAMDI.h
@@ -34,7 +34,7 @@ public:
                              const Ice::Current&);
 
     virtual void opByteAsync(Ice::Byte, Ice::Byte,
-                             ::std::function<void(Ice::Byte, Ice::Byte)>,
+                             ::std::function<void(Ice::Byte, std::uint8_t)>,
                              ::std::function<void(std::exception_ptr)>,
                              const Ice::Current&);
 
@@ -298,7 +298,7 @@ public:
                                 const Ice::Current&);
 
     virtual void opByte1Async(Ice::Byte,
-                              ::std::function<void(Ice::Byte)>,
+                              ::std::function<void(std::uint8_t)>,
                               ::std::function<void(std::exception_ptr)>,
                               const Ice::Current&);
 

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -63,7 +63,7 @@ MyDerivedClassI::opVoid(const Ice::Current& current)
     test(current.mode == OperationMode::Normal);
 }
 
-uint8_tce::Byte
+uint8_t
 MyDerivedClassI::opByte(uint8_t p1,
                         uint8_t p2,
                         uint8_t& p3,
@@ -659,7 +659,7 @@ MyDerivedClassI::opDerived(const Ice::Current&)
 {
 }
 
-uint8_tce::Byte
+uint8_t
 MyDerivedClassI::opByte1(uint8_t b, const Ice::Current&)
 {
     return b;

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -63,10 +63,10 @@ MyDerivedClassI::opVoid(const Ice::Current& current)
     test(current.mode == OperationMode::Normal);
 }
 
-Ice::Byte
-MyDerivedClassI::opByte(Ice::Byte p1,
-                        Ice::Byte p2,
-                        Ice::Byte& p3,
+uint8_tce::Byte
+MyDerivedClassI::opByte(uint8_t p1,
+                        uint8_t p2,
+                        uint8_t& p3,
                         const Ice::Current&)
 {
     p3 = p1 ^ p2;
@@ -659,8 +659,8 @@ MyDerivedClassI::opDerived(const Ice::Current&)
 {
 }
 
-Ice::Byte
-MyDerivedClassI::opByte1(Ice::Byte b, const Ice::Current&)
+uint8_tce::Byte
+MyDerivedClassI::opByte1(uint8_t b, const Ice::Current&)
 {
     return b;
 }

--- a/cpp/test/Ice/operations/TestI.h
+++ b/cpp/test/Ice/operations/TestI.h
@@ -27,9 +27,9 @@ public:
 
     virtual void opVoid(const Ice::Current&);
 
-    virtual Ice::Byte opByte(Ice::Byte,
+    virtual std::uint8_t opByte(Ice::Byte,
                              Ice::Byte,
-                             Ice::Byte&,
+                             std::uint8_t&,
                              const Ice::Current&);
 
     virtual bool opBool(bool,
@@ -262,7 +262,7 @@ public:
 
     virtual void opDerived(const Ice::Current&);
 
-    virtual Ice::Byte opByte1(Ice::Byte, const Ice::Current&);
+    virtual std::uint8_t opByte1(Ice::Byte, const Ice::Current&);
 
     virtual std::int16_t opShort1(std::int16_t, const Ice::Current&);
 

--- a/cpp/test/Ice/operations/TestI.h
+++ b/cpp/test/Ice/operations/TestI.h
@@ -27,8 +27,8 @@ public:
 
     virtual void opVoid(const Ice::Current&);
 
-    virtual std::uint8_t opByte(Ice::Byte,
-                             Ice::Byte,
+    virtual std::uint8_t opByte(std::uint8_t,
+                             std::uint8_t,
                              std::uint8_t&,
                              const Ice::Current&);
 
@@ -262,7 +262,7 @@ public:
 
     virtual void opDerived(const Ice::Current&);
 
-    virtual std::uint8_t opByte1(Ice::Byte, const Ice::Current&);
+    virtual std::uint8_t opByte1(std::uint8_t, const Ice::Current&);
 
     virtual std::int16_t opShort1(std::int16_t, const Ice::Current&);
 

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -255,9 +255,9 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         uint8_t b;
         uint8_t r;
 
-        r = p->opByte(Ice::Byte(0xff), Ice::Byte(0x0f), b);
-        test(b == Ice::Byte(0xf0));
-        test(r == Ice::Byte(0xff));
+        r = p->opByte(uint8_t(0xff), uint8_t(0x0f), b);
+        test(b == uint8_t(0xf0));
+        test(r == uint8_t(0xff));
     }
 
     {
@@ -390,34 +390,34 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::ByteS bsi1;
         Test::ByteS bsi2;
 
-        bsi1.push_back(Ice::Byte(0x01));
-        bsi1.push_back(Ice::Byte(0x11));
-        bsi1.push_back(Ice::Byte(0x12));
-        bsi1.push_back(Ice::Byte(0x22));
+        bsi1.push_back(uint8_t(0x01));
+        bsi1.push_back(uint8_t(0x11));
+        bsi1.push_back(uint8_t(0x12));
+        bsi1.push_back(uint8_t(0x22));
 
-        bsi2.push_back(Ice::Byte(0xf1));
-        bsi2.push_back(Ice::Byte(0xf2));
-        bsi2.push_back(Ice::Byte(0xf3));
-        bsi2.push_back(Ice::Byte(0xf4));
+        bsi2.push_back(uint8_t(0xf1));
+        bsi2.push_back(uint8_t(0xf2));
+        bsi2.push_back(uint8_t(0xf3));
+        bsi2.push_back(uint8_t(0xf4));
 
         Test::ByteS bso;
         Test::ByteS rso;
 
         rso = p->opByteS(bsi1, bsi2, bso);
         test(bso.size() == 4);
-        test(bso[0] == Ice::Byte(0x22));
-        test(bso[1] == Ice::Byte(0x12));
-        test(bso[2] == Ice::Byte(0x11));
-        test(bso[3] == Ice::Byte(0x01));
+        test(bso[0] == uint8_t(0x22));
+        test(bso[1] == uint8_t(0x12));
+        test(bso[2] == uint8_t(0x11));
+        test(bso[3] == uint8_t(0x01));
         test(rso.size() == 8);
-        test(rso[0] == Ice::Byte(0x01));
-        test(rso[1] == Ice::Byte(0x11));
-        test(rso[2] == Ice::Byte(0x12));
-        test(rso[3] == Ice::Byte(0x22));
-        test(rso[4] == Ice::Byte(0xf1));
-        test(rso[5] == Ice::Byte(0xf2));
-        test(rso[6] == Ice::Byte(0xf3));
-        test(rso[7] == Ice::Byte(0xf4));
+        test(rso[0] == uint8_t(0x01));
+        test(rso[1] == uint8_t(0x11));
+        test(rso[2] == uint8_t(0x12));
+        test(rso[3] == uint8_t(0x22));
+        test(rso[4] == uint8_t(0xf1));
+        test(rso[5] == uint8_t(0xf2));
+        test(rso[6] == uint8_t(0xf3));
+        test(rso[7] == uint8_t(0xf4));
     }
 
     {
@@ -553,14 +553,14 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::ByteSS bsi2;
         bsi2.resize(2);
 
-        bsi1[0].push_back(Ice::Byte(0x01));
-        bsi1[0].push_back(Ice::Byte(0x11));
-        bsi1[0].push_back(Ice::Byte(0x12));
-        bsi1[1].push_back(Ice::Byte(0xff));
+        bsi1[0].push_back(uint8_t(0x01));
+        bsi1[0].push_back(uint8_t(0x11));
+        bsi1[0].push_back(uint8_t(0x12));
+        bsi1[1].push_back(uint8_t(0xff));
 
-        bsi2[0].push_back(Ice::Byte(0x0e));
-        bsi2[1].push_back(Ice::Byte(0xf2));
-        bsi2[1].push_back(Ice::Byte(0xf1));
+        bsi2[0].push_back(uint8_t(0x0e));
+        bsi2[1].push_back(uint8_t(0xf2));
+        bsi2[1].push_back(uint8_t(0xf1));
 
         Test::ByteSS bso;
         Test::ByteSS rso;
@@ -568,23 +568,23 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         rso = p->opByteSS(bsi1, bsi2, bso);
         test(bso.size() == 2);
         test(bso[0].size() == 1);
-        test(bso[0][0] == Ice::Byte(0xff));
+        test(bso[0][0] == uint8_t(0xff));
         test(bso[1].size() == 3);
-        test(bso[1][0] == Ice::Byte(0x01));
-        test(bso[1][1] == Ice::Byte(0x11));
-        test(bso[1][2] == Ice::Byte(0x12));
+        test(bso[1][0] == uint8_t(0x01));
+        test(bso[1][1] == uint8_t(0x11));
+        test(bso[1][2] == uint8_t(0x12));
         test(rso.size() == 4);
         test(rso[0].size() == 3);
-        test(rso[0][0] == Ice::Byte(0x01));
-        test(rso[0][1] == Ice::Byte(0x11));
-        test(rso[0][2] == Ice::Byte(0x12));
+        test(rso[0][0] == uint8_t(0x01));
+        test(rso[0][1] == uint8_t(0x11));
+        test(rso[0][2] == uint8_t(0x12));
         test(rso[1].size() == 1);
-        test(rso[1][0] == Ice::Byte(0xff));
+        test(rso[1][0] == uint8_t(0xff));
         test(rso[2].size() == 1);
-        test(rso[2][0] == Ice::Byte(0x0e));
+        test(rso[2][0] == uint8_t(0x0e));
         test(rso[3].size() == 2);
-        test(rso[3][0] == Ice::Byte(0xf2));
-        test(rso[3][1] == Ice::Byte(0xf1));
+        test(rso[3][0] == uint8_t(0xf2));
+        test(rso[3][1] == uint8_t(0xf1));
     }
 
     {
@@ -1309,15 +1309,15 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
         Test::ByteS si2;
         Test::ByteS si3;
 
-        si1.push_back(Ice::Byte(0x01));
-        si1.push_back(Ice::Byte(0x11));
-        si2.push_back(Ice::Byte(0x12));
-        si3.push_back(Ice::Byte(0xf2));
-        si3.push_back(Ice::Byte(0xf3));
+        si1.push_back(uint8_t(0x01));
+        si1.push_back(uint8_t(0x11));
+        si2.push_back(uint8_t(0x12));
+        si3.push_back(uint8_t(0xf2));
+        si3.push_back(uint8_t(0xf3));
 
-        sdi1[Ice::Byte(0x01)] = si1;
-        sdi1[Ice::Byte(0x22)] = si2;
-        sdi2[Ice::Byte(0xf1)] = si3;
+        sdi1[uint8_t(0x01)] = si1;
+        sdi1[uint8_t(0x22)] = si2;
+        sdi2[uint8_t(0xf1)] = si3;
 
         try
         {
@@ -1326,14 +1326,14 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
 
             test(_do == sdi2);
             test(ro.size() == 3);
-            test(ro[Ice::Byte(0x01)].size() == 2);
-            test(ro[Ice::Byte(0x01)][0] == Ice::Byte(0x01));
-            test(ro[Ice::Byte(0x01)][1] == Ice::Byte(0x11));
-            test(ro[Ice::Byte(0x22)].size() == 1);
-            test(ro[Ice::Byte(0x22)][0] == Ice::Byte(0x12));
-            test(ro[Ice::Byte(0xf1)].size() == 2);
-            test(ro[Ice::Byte(0xf1)][0] == Ice::Byte(0xf2));
-            test(ro[Ice::Byte(0xf1)][1] == Ice::Byte(0xf3));
+            test(ro[uint8_t(0x01)].size() == 2);
+            test(ro[uint8_t(0x01)][0] == uint8_t(0x01));
+            test(ro[uint8_t(0x01)][1] == uint8_t(0x11));
+            test(ro[uint8_t(0x22)].size() == 1);
+            test(ro[uint8_t(0x22)][0] == uint8_t(0x12));
+            test(ro[uint8_t(0xf1)].size() == 2);
+            test(ro[uint8_t(0xf1)][0] == uint8_t(0xf2));
+            test(ro[uint8_t(0xf1)][1] == uint8_t(0xf3));
         }
         catch(const Ice::OperationNotExistException&)
         {

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -252,8 +252,8 @@ twoways(const Ice::CommunicatorPtr& communicator, Test::TestHelper*, const Test:
     }
 
     {
-        Ice::Byte b;
-        Ice::Byte r;
+        uint8_t b;
+        uint8_t r;
 
         r = p->opByte(Ice::Byte(0xff), Ice::Byte(0x0f), b);
         test(b == Ice::Byte(0xf0));

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -114,8 +114,8 @@ public:
 
     void opByte(uint8_t r, uint8_t b)
     {
-        test(b == Ice::Byte(0xf0));
-        test(r == Ice::Byte(0xff));
+        test(b == uint8_t(0xf0));
+        test(r == uint8_t(0xff));
         called();
     }
 
@@ -203,19 +203,19 @@ public:
     void opByteS(const Test::ByteS& rso, const Test::ByteS& bso)
     {
         test(bso.size() == 4);
-        test(bso[0] == Ice::Byte(0x22));
-        test(bso[1] == Ice::Byte(0x12));
-        test(bso[2] == Ice::Byte(0x11));
-        test(bso[3] == Ice::Byte(0x01));
+        test(bso[0] == uint8_t(0x22));
+        test(bso[1] == uint8_t(0x12));
+        test(bso[2] == uint8_t(0x11));
+        test(bso[3] == uint8_t(0x01));
         test(rso.size() == 8);
-        test(rso[0] == Ice::Byte(0x01));
-        test(rso[1] == Ice::Byte(0x11));
-        test(rso[2] == Ice::Byte(0x12));
-        test(rso[3] == Ice::Byte(0x22));
-        test(rso[4] == Ice::Byte(0xf1));
-        test(rso[5] == Ice::Byte(0xf2));
-        test(rso[6] == Ice::Byte(0xf3));
-        test(rso[7] == Ice::Byte(0xf4));
+        test(rso[0] == uint8_t(0x01));
+        test(rso[1] == uint8_t(0x11));
+        test(rso[2] == uint8_t(0x12));
+        test(rso[3] == uint8_t(0x22));
+        test(rso[4] == uint8_t(0xf1));
+        test(rso[5] == uint8_t(0xf2));
+        test(rso[6] == uint8_t(0xf3));
+        test(rso[7] == uint8_t(0xf4));
         called();
     }
 
@@ -294,23 +294,23 @@ public:
     {
         test(bso.size() == 2);
         test(bso[0].size() == 1);
-        test(bso[0][0] == Ice::Byte(0xff));
+        test(bso[0][0] == uint8_t(0xff));
         test(bso[1].size() == 3);
-        test(bso[1][0] == Ice::Byte(0x01));
-        test(bso[1][1] == Ice::Byte(0x11));
-        test(bso[1][2] == Ice::Byte(0x12));
+        test(bso[1][0] == uint8_t(0x01));
+        test(bso[1][1] == uint8_t(0x11));
+        test(bso[1][2] == uint8_t(0x12));
         test(rso.size() == 4);
         test(rso[0].size() == 3);
-        test(rso[0][0] == Ice::Byte(0x01));
-        test(rso[0][1] == Ice::Byte(0x11));
-        test(rso[0][2] == Ice::Byte(0x12));
+        test(rso[0][0] == uint8_t(0x01));
+        test(rso[0][1] == uint8_t(0x11));
+        test(rso[0][2] == uint8_t(0x12));
         test(rso[1].size() == 1);
-        test(rso[1][0] == Ice::Byte(0xff));
+        test(rso[1][0] == uint8_t(0xff));
         test(rso[2].size() == 1);
-        test(rso[2][0] == Ice::Byte(0x0e));
+        test(rso[2][0] == uint8_t(0x0e));
         test(rso[3].size() == 2);
-        test(rso[3][0] == Ice::Byte(0xf2));
-        test(rso[3][1] == Ice::Byte(0xf1));
+        test(rso[3][0] == uint8_t(0xf2));
+        test(rso[3][1] == uint8_t(0xf1));
         called();
     }
 
@@ -767,22 +767,22 @@ public:
     void opByteByteSD(const Test::ByteByteSD& ro, const Test::ByteByteSD& _do)
     {
         test(_do.size() == 1);
-        test(_do.find(Ice::Byte(0xf1)) != _do.end());
-        test(_do.find(Ice::Byte(0xf1))->second.size() == 2);
-        test(_do.find(Ice::Byte(0xf1))->second[0] == 0xf2);
-        test(_do.find(Ice::Byte(0xf1))->second[1] == 0xf3);
+        test(_do.find(uint8_t(0xf1)) != _do.end());
+        test(_do.find(uint8_t(0xf1))->second.size() == 2);
+        test(_do.find(uint8_t(0xf1))->second[0] == 0xf2);
+        test(_do.find(uint8_t(0xf1))->second[1] == 0xf3);
         test(ro.size() == 3);
-        test(ro.find(Ice::Byte(0x01)) != ro.end());
-        test(ro.find(Ice::Byte(0x01))->second.size() == 2);
-        test(ro.find(Ice::Byte(0x01))->second[0] == Ice::Byte(0x01));
-        test(ro.find(Ice::Byte(0x01))->second[1] == Ice::Byte(0x11));
-        test(ro.find(Ice::Byte(0x22)) != ro.end());
-        test(ro.find(Ice::Byte(0x22))->second.size() == 1);
-        test(ro.find(Ice::Byte(0x22))->second[0] == Ice::Byte(0x12));
-        test(ro.find(Ice::Byte(0xf1)) != ro.end());
-        test(ro.find(Ice::Byte(0xf1))->second.size() == 2);
-        test(ro.find(Ice::Byte(0xf1))->second[0] == Ice::Byte(0xf2));
-        test(ro.find(Ice::Byte(0xf1))->second[1] == Ice::Byte(0xf3));
+        test(ro.find(uint8_t(0x01)) != ro.end());
+        test(ro.find(uint8_t(0x01))->second.size() == 2);
+        test(ro.find(uint8_t(0x01))->second[0] == uint8_t(0x01));
+        test(ro.find(uint8_t(0x01))->second[1] == uint8_t(0x11));
+        test(ro.find(uint8_t(0x22)) != ro.end());
+        test(ro.find(uint8_t(0x22))->second.size() == 1);
+        test(ro.find(uint8_t(0x22))->second[0] == uint8_t(0x12));
+        test(ro.find(uint8_t(0xf1)) != ro.end());
+        test(ro.find(uint8_t(0xf1))->second.size() == 2);
+        test(ro.find(uint8_t(0xf1))->second[0] == uint8_t(0xf2));
+        test(ro.find(uint8_t(0xf1))->second[1] == uint8_t(0xf3));
         called();
     }
 
@@ -1104,7 +1104,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         CallbackPtr cb = make_shared<Callback>();
-        p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
+        p->opByteAsync(uint8_t(0xff), uint8_t(0x0f),
             [&](uint8_t b1, uint8_t b2)
             {
                 cb->opByte(b1, b2);
@@ -1203,15 +1203,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteS bsi1;
         Test::ByteS bsi2;
 
-        bsi1.push_back(Ice::Byte(0x01));
-        bsi1.push_back(Ice::Byte(0x11));
-        bsi1.push_back(Ice::Byte(0x12));
-        bsi1.push_back(Ice::Byte(0x22));
+        bsi1.push_back(uint8_t(0x01));
+        bsi1.push_back(uint8_t(0x11));
+        bsi1.push_back(uint8_t(0x12));
+        bsi1.push_back(uint8_t(0x22));
 
-        bsi2.push_back(Ice::Byte(0xf1));
-        bsi2.push_back(Ice::Byte(0xf2));
-        bsi2.push_back(Ice::Byte(0xf3));
-        bsi2.push_back(Ice::Byte(0xf4));
+        bsi2.push_back(uint8_t(0xf1));
+        bsi2.push_back(uint8_t(0xf2));
+        bsi2.push_back(uint8_t(0xf3));
+        bsi2.push_back(uint8_t(0xf4));
 
         CallbackPtr cb = make_shared<Callback>();
         p->opByteSAsync(bsi1, bsi2,
@@ -1318,14 +1318,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteSS bsi2;
         bsi2.resize(2);
 
-        bsi1[0].push_back(Ice::Byte(0x01));
-        bsi1[0].push_back(Ice::Byte(0x11));
-        bsi1[0].push_back(Ice::Byte(0x12));
-        bsi1[1].push_back(Ice::Byte(0xff));
+        bsi1[0].push_back(uint8_t(0x01));
+        bsi1[0].push_back(uint8_t(0x11));
+        bsi1[0].push_back(uint8_t(0x12));
+        bsi1[1].push_back(uint8_t(0xff));
 
-        bsi2[0].push_back(Ice::Byte(0x0e));
-        bsi2[1].push_back(Ice::Byte(0xf2));
-        bsi2[1].push_back(Ice::Byte(0xf1));
+        bsi2[0].push_back(uint8_t(0x0e));
+        bsi2[1].push_back(uint8_t(0xf2));
+        bsi2[1].push_back(uint8_t(0xf1));
 
         CallbackPtr cb = make_shared<Callback>();
         p->opByteSSAsync(bsi1, bsi2,
@@ -1776,15 +1776,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteS si2;
         Test::ByteS si3;
 
-        si1.push_back(Ice::Byte(0x01));
-        si1.push_back(Ice::Byte(0x11));
-        si2.push_back(Ice::Byte(0x12));
-        si3.push_back(Ice::Byte(0xf2));
-        si3.push_back(Ice::Byte(0xf3));
+        si1.push_back(uint8_t(0x01));
+        si1.push_back(uint8_t(0x11));
+        si2.push_back(uint8_t(0x12));
+        si3.push_back(uint8_t(0xf2));
+        si3.push_back(uint8_t(0xf3));
 
-        sdi1[Ice::Byte(0x01)] = si1;
-        sdi1[Ice::Byte(0x22)] = si2;
-        sdi2[Ice::Byte(0xf1)] = si3;
+        sdi1[uint8_t(0x01)] = si1;
+        sdi1[uint8_t(0x22)] = si2;
+        sdi2[uint8_t(0xf1)] = si3;
 
         CallbackPtr cb = make_shared<Callback>();
         p->opByteByteSDAsync(sdi1, sdi2,
@@ -2382,7 +2382,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
 
     {
         CallbackPtr cb = make_shared<Callback>();
-        auto f = p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f));
+        auto f = p->opByteAsync(uint8_t(0xff), uint8_t(0x0f));
         try
         {
             auto r = f.get();
@@ -2545,15 +2545,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteS bsi1;
         Test::ByteS bsi2;
 
-        bsi1.push_back(Ice::Byte(0x01));
-        bsi1.push_back(Ice::Byte(0x11));
-        bsi1.push_back(Ice::Byte(0x12));
-        bsi1.push_back(Ice::Byte(0x22));
+        bsi1.push_back(uint8_t(0x01));
+        bsi1.push_back(uint8_t(0x11));
+        bsi1.push_back(uint8_t(0x12));
+        bsi1.push_back(uint8_t(0x22));
 
-        bsi2.push_back(Ice::Byte(0xf1));
-        bsi2.push_back(Ice::Byte(0xf2));
-        bsi2.push_back(Ice::Byte(0xf3));
-        bsi2.push_back(Ice::Byte(0xf4));
+        bsi2.push_back(uint8_t(0xf1));
+        bsi2.push_back(uint8_t(0xf2));
+        bsi2.push_back(uint8_t(0xf3));
+        bsi2.push_back(uint8_t(0xf4));
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteSAsync(bsi1, bsi2);
@@ -2700,14 +2700,14 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteSS bsi2;
         bsi2.resize(2);
 
-        bsi1[0].push_back(Ice::Byte(0x01));
-        bsi1[0].push_back(Ice::Byte(0x11));
-        bsi1[0].push_back(Ice::Byte(0x12));
-        bsi1[1].push_back(Ice::Byte(0xff));
+        bsi1[0].push_back(uint8_t(0x01));
+        bsi1[0].push_back(uint8_t(0x11));
+        bsi1[0].push_back(uint8_t(0x12));
+        bsi1[1].push_back(uint8_t(0xff));
 
-        bsi2[0].push_back(Ice::Byte(0x0e));
-        bsi2[1].push_back(Ice::Byte(0xf2));
-        bsi2[1].push_back(Ice::Byte(0xf1));
+        bsi2[0].push_back(uint8_t(0x0e));
+        bsi2[1].push_back(uint8_t(0xf2));
+        bsi2[1].push_back(uint8_t(0xf1));
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteSSAsync(bsi1, bsi2);
@@ -3234,15 +3234,15 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
         Test::ByteS si2;
         Test::ByteS si3;
 
-        si1.push_back(Ice::Byte(0x01));
-        si1.push_back(Ice::Byte(0x11));
-        si2.push_back(Ice::Byte(0x12));
-        si3.push_back(Ice::Byte(0xf2));
-        si3.push_back(Ice::Byte(0xf3));
+        si1.push_back(uint8_t(0x01));
+        si1.push_back(uint8_t(0x11));
+        si2.push_back(uint8_t(0x12));
+        si3.push_back(uint8_t(0xf2));
+        si3.push_back(uint8_t(0xf3));
 
-        sdi1[Ice::Byte(0x01)] = si1;
-        sdi1[Ice::Byte(0x22)] = si2;
-        sdi2[Ice::Byte(0xf1)] = si3;
+        sdi1[uint8_t(0x01)] = si1;
+        sdi1[uint8_t(0x22)] = si2;
+        sdi2[uint8_t(0xf1)] = si3;
 
         CallbackPtr cb = make_shared<Callback>();
         auto f = p->opByteByteSDAsync(sdi1, sdi2);

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -112,7 +112,7 @@ public:
         called();
     }
 
-    void opByte(Ice::Byte r, Ice::Byte b)
+    void opByte(uint8_t r, uint8_t b)
     {
         test(b == Ice::Byte(0xf0));
         test(r == Ice::Byte(0xff));
@@ -1105,7 +1105,7 @@ twowaysAMI(const Ice::CommunicatorPtr& communicator, const Test::MyClassPrxPtr& 
     {
         CallbackPtr cb = make_shared<Callback>();
         p->opByteAsync(Ice::Byte(0xff), Ice::Byte(0x0f),
-            [&](Ice::Byte b1, Ice::Byte b2)
+            [&](uint8_t b1, uint8_t b2)
             {
                 cb->opByte(b1, b2);
             },

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -345,7 +345,7 @@ allTests(Test::TestHelper* helper, bool)
     test(!oon->a);
 
     MultiOptionalPtr mo1 = make_shared<MultiOptional>();
-    mo1->a = static_cast<Ice::Byte>(15);
+    mo1->a = static_cast<uint8_t>(15);
     mo1->b = true;
     mo1->c = static_cast<int16_t>(19);
     mo1->d = 78;
@@ -408,7 +408,7 @@ allTests(Test::TestHelper* helper, bool)
     MultiOptionalPtr mo3 = make_shared<MultiOptional>();
     *mo3 = *mo2;
 
-    test(mo3->a == static_cast<Ice::Byte>(15));
+    test(mo3->a == static_cast<uint8_t>(15));
     test(mo3->b == true);
     test(mo3->c == static_cast<short>(19));
     test(mo3->d == 78);
@@ -445,12 +445,12 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing comparison operators... " << flush;
 
-    test(mo1->a == static_cast<Ice::Byte>(15) && static_cast<Ice::Byte>(15) == mo1->a &&
-        mo1->a != static_cast<Ice::Byte>(16) && static_cast<Ice::Byte>(16) != mo1->a);
-    test(mo1->a < static_cast<Ice::Byte>(16) && mo1->a > static_cast<Ice::Byte>(14) &&
-        mo1->a <= static_cast<Ice::Byte>(15) && mo1->a >= static_cast<Ice::Byte>(15) &&
-        mo1->a <= static_cast<Ice::Byte>(16) && mo1->a >= static_cast<Ice::Byte>(14));
-    test(mo1->a > optional<Ice::Byte>() && optional<Ice::Byte>() < mo1->a);
+    test(mo1->a == static_cast<uint8_t>(15) && static_cast<uint8_t>(15) == mo1->a &&
+        mo1->a != static_cast<uint8_t>(16) && static_cast<uint8_t>(16) != mo1->a);
+    test(mo1->a < static_cast<uint8_t>(16) && mo1->a > static_cast<uint8_t>(14) &&
+        mo1->a <= static_cast<uint8_t>(15) && mo1->a >= static_cast<uint8_t>(15) &&
+        mo1->a <= static_cast<uint8_t>(16) && mo1->a >= static_cast<uint8_t>(14));
+    test(mo1->a > optional<uint8_t>() && optional<uint8_t>() < mo1->a);
     test(14 > optional<int>() && optional<int>() < 14);
 
     test(mo1->h == string("test") && string("test") == mo1->h && mo1->h != string("testa") && string("testa") != mo1->h);
@@ -941,9 +941,9 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing optional parameters... " << flush;
     {
-        optional<Ice::Byte> p1;
-        optional<Ice::Byte> p3;
-        optional<Ice::Byte> p2 = initial->opByte(p1, p3);
+        optional<uint8_t> p1;
+        optional<uint8_t> p3;
+        optional<uint8_t> p2 = initial->opByte(p1, p3);
         test(!p2 && !p3);
 
         const uint8_t bval = 56;
@@ -963,7 +963,7 @@ allTests(Test::TestHelper* helper, bool)
         in.read(1, p2);
         in.read(3, p3);
 
-        optional<Ice::Byte> p4 = static_cast<Ice::Byte>(0x08);
+        optional<uint8_t> p4 = static_cast<uint8_t>(0x08);
         in.read(89, p4);
 
         in.endEncapsulation();
@@ -1391,7 +1391,7 @@ allTests(Test::TestHelper* helper, bool)
         optional<ByteSeq> p2 = initial->opByteSeq(p1, p3);
         test(!p2 && !p3);
 
-        vector<Ice::Byte> bs(100);
+        vector<uint8_t> bs(100);
         fill(bs.begin(), bs.end(), 56);
         p1 = toArrayRange(bs);
         p2 = initial->opByteSeq(p1, p3);

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -946,7 +946,7 @@ allTests(Test::TestHelper* helper, bool)
         optional<Ice::Byte> p2 = initial->opByte(p1, p3);
         test(!p2 && !p3);
 
-        const Ice::Byte bval = 56;
+        const uint8_t bval = 56;
 
         p1 = bval;
         p2 = initial->opByte(p1, p3);
@@ -1386,7 +1386,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "testing optional parameters and custom sequences... " << flush;
     {
-        optional<std::pair<const Ice::Byte*, const Ice::Byte*> > p1;
+        optional<std::pair<const uint8_t*, const uint8_t*> > p1;
         optional<ByteSeq> p3;
         optional<ByteSeq> p2 = initial->opByteSeq(p1, p3);
         test(!p2 && !p3);

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -185,8 +185,8 @@ InitialI::opMyInterfaceProxyAsync(optional<::MyInterfacePrx> p1,
 }
 
 void
-InitialI::opByteSeqAsync(optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>> p1,
-                              ::std::function<void(const optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>>&, const optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>>&)> response,
+InitialI::opByteSeqAsync(optional<::std::pair<const ::uint8_t*, const ::uint8_t*>> p1,
+                              ::std::function<void(const optional<::std::pair<const ::uint8_t*, const ::uint8_t*>>&, const optional<::std::pair<const ::uint8_t*, const ::uint8_t*>>&)> response,
                               ::std::function<void(::std::exception_ptr)>, const Ice::Current&)
 {
     response(p1, p1);

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -73,8 +73,8 @@ InitialI::opRequiredExceptionAsync(optional<int> a, optional<::std::string> b, o
 }
 
 void
-InitialI::opByteAsync(optional<::Ice::Byte> p1,
-                      ::std::function<void(const optional<::Ice::Byte>&, const optional<::Ice::Byte>&)> response,
+InitialI::opByteAsync(optional<uint8_t> p1,
+                      ::std::function<void(const optional<uint8_t>&, const optional<uint8_t>&)> response,
                       ::std::function<void(::std::exception_ptr)>, const Ice::Current&)
 {
     response(p1, p1);

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -32,8 +32,8 @@ public:
                                           ::std::function<void()>,
                                           ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void opByteAsync(std::optional<::Ice::Byte>,
-                             ::std::function<void(const std::optional<::Ice::Byte>&, const std::optional<::Ice::Byte>&)>,
+    virtual void opByteAsync(std::optional<std::uint8_t>,
+                             ::std::function<void(const std::optional<std::uint8_t>&, const std::optional<std::uint8_t>&)>,
                              ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
     virtual void opBoolAsync(std::optional<bool>,

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -88,8 +88,8 @@ public:
                                          ::std::function<void(const std::optional<::Test::MyInterfacePrx>&, const std::optional<::Test::MyInterfacePrx>&)>,
                                          ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void opByteSeqAsync(std::optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>>,
-                                ::std::function<void(const std::optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>>&, const std::optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*>>&)>,
+    virtual void opByteSeqAsync(std::optional<::std::pair<const ::std::uint8_t*, const ::std::uint8_t*>>,
+                                ::std::function<void(const std::optional<::std::pair<const ::std::uint8_t*, const ::std::uint8_t*>>&, const std::optional<::std::pair<const ::std::uint8_t*, const ::std::uint8_t*>>&)>,
                                 ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
     virtual void opBoolSeqAsync(std::optional<::std::pair<const bool*, const bool*>>,

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -182,7 +182,7 @@ InitialI::opMyInterfaceProxy(optional<MyInterfacePrx> p1, optional<MyInterfacePr
 }
 
 optional<Test::ByteSeq>
-InitialI::opByteSeq(optional<pair<const Ice::Byte*, const Ice::Byte*> > p1, optional<Test::ByteSeq>& p3,
+InitialI::opByteSeq(optional<pair<const uint8_t*, const uint8_t*> > p1, optional<Test::ByteSeq>& p3,
                     const Current&)
 {
     if(p1)

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -83,8 +83,8 @@ InitialI::opRequiredException(optional<int32_t> a,
     throw ex;
 }
 
-optional<Ice::Byte>
-InitialI::opByte(optional<Ice::Byte> p1, optional<Ice::Byte>& p3, const Current&)
+optional<uint8_t>
+InitialI::opByte(optional<uint8_t> p1, optional<uint8_t>& p3, const Current&)
 {
     p3 = p1;
     return p1;

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -31,8 +31,8 @@ public:
                                      std::optional<Test::OneOptionalPtr>,
                                      const Ice::Current&);
 
-    virtual std::optional<::Ice::Byte> opByte(std::optional<::Ice::Byte>,
-                                                   std::optional<::Ice::Byte>&,
+    virtual std::optional<std::uint8_t> opByte(std::optional<std::uint8_t>,
+                                                   std::optional<std::uint8_t>&,
                                                    const ::Ice::Current&);
 
     virtual std::optional<bool> opBool(std::optional<bool>, std::optional<bool>&,

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -87,7 +87,7 @@ public:
                                                                           const ::Ice::Current&);
 
     virtual std::optional<::Test::ByteSeq> opByteSeq(
-        std::optional<::std::pair<const ::Ice::Byte*, const ::Ice::Byte*> >,
+        std::optional<::std::pair<const ::std::uint8_t*, const ::std::uint8_t*> >,
         std::optional<::Test::ByteSeq>&,
         const ::Ice::Current&);
 

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -987,11 +987,11 @@ allTests(Test::TestHelper* helper)
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
         out.endEncapsulation();
-        vector<Ice::Byte> inEncaps;
+        vector<uint8_t> inEncaps;
         out.finished(inEncaps);
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
-        vector<Ice::Byte> outEncaps;
+        vector<uint8_t> outEncaps;
         cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }
@@ -1008,11 +1008,11 @@ allTests(Test::TestHelper* helper)
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
         out.endEncapsulation();
-        vector<Ice::Byte> inEncaps;
+        vector<uint8_t> inEncaps;
         out.finished(inEncaps);
         inEncaps[4] = version.major;
         inEncaps[5] = version.minor;
-        vector<Ice::Byte> outEncaps;
+        vector<uint8_t> outEncaps;
         cl->ice_invoke("ice_ping", Ice::OperationMode::Normal, inEncaps, outEncaps);
         test(false);
     }

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -134,7 +134,7 @@ allTests(Test::TestHelper* helper)
         std::bind(&MyClassFactoryWrapper::create, &factoryWrapper, std::placeholders::_1);
     communicator->getValueFactoryManager()->add(f, MyClass::ice_staticId());
 
-    vector<Ice::Byte> data;
+    vector<uint8_t> data;
 
     //
     // Test the stream API.
@@ -142,7 +142,7 @@ allTests(Test::TestHelper* helper)
     cout << "testing primitive types... " << flush;
 
     {
-        vector<Ice::Byte> byte;
+        vector<uint8_t> byte;
         Ice::InputStream in(communicator, byte);
     }
 
@@ -154,7 +154,7 @@ allTests(Test::TestHelper* helper)
         out.finished(data);
         pair<const uint8_t*, const uint8_t*> d = out.finished();
         test(d.second - d.first == static_cast<int>(data.size()));
-        test(vector<Ice::Byte>(d.first, d.second) == data);
+        test(vector<uint8_t>(d.first, d.second) == data);
 
         Ice::InputStream in(communicator, data);
         in.startEncapsulation();
@@ -165,7 +165,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        vector<Ice::Byte> byte;
+        vector<uint8_t> byte;
         Ice::InputStream in(communicator, byte);
         try
         {
@@ -1098,7 +1098,7 @@ allTests(Test::TestHelper* helper)
         uint8_t buf[128];
         pair<uint8_t*, uint8_t*> p(&buf[0], &buf[0] + sizeof(buf));
         Ice::OutputStream out(communicator, Ice::currentEncoding, p);
-        vector<Ice::Byte> v;
+        vector<uint8_t> v;
         v.resize(127);
         out.write(v);
         test(out.pos() == 128); // 127 bytes + leading size (1 byte)
@@ -1108,7 +1108,7 @@ allTests(Test::TestHelper* helper)
         uint8_t buf[128];
         pair<uint8_t*, uint8_t*> p(&buf[0], &buf[0] + sizeof(buf));
         Ice::OutputStream out(communicator, Ice::currentEncoding, p);
-        vector<Ice::Byte> v;
+        vector<uint8_t> v;
         v.resize(127);
         ::memset(&v[0], 0xFF, v.size());
         out.write(v);
@@ -1118,7 +1118,7 @@ allTests(Test::TestHelper* helper)
         out.finished(data);
 
         Ice::InputStream in(communicator, data);
-        vector<Ice::Byte> v2;
+        vector<uint8_t> v2;
         in.read(v2);
         test(v2.size() == 127);
         test(v == v2); // Make sure the original buffer was preserved.

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -1112,7 +1112,7 @@ allTests(Test::TestHelper* helper)
         v.resize(127);
         ::memset(&v[0], 0xFF, v.size());
         out.write(v);
-        out.write(Ice::Byte(0xFF)); // This extra byte should make the stream reallocate.
+        out.write(uint8_t(0xFF)); // This extra byte should make the stream reallocate.
         test(out.pos() == 129); // 127 bytes + leading size (1 byte) + 1 byte
         test(out.b.begin() != buf); // Verify the stream was reallocated.
         out.finished(data);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -152,7 +152,7 @@ allTests(Test::TestHelper* helper)
         out.write(true);
         out.endEncapsulation();
         out.finished(data);
-        pair<const Ice::Byte*, const Ice::Byte*> d = out.finished();
+        pair<const uint8_t*, const uint8_t*> d = out.finished();
         test(d.second - d.first == static_cast<int>(data.size()));
         test(vector<Ice::Byte>(d.first, d.second) == data);
 
@@ -190,10 +190,10 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        out.write((Ice::Byte)1);
+        out.write((uint8_t)1);
         out.finished(data);
         Ice::InputStream in(communicator, data);
-        Ice::Byte v;
+        uint8_t v;
         in.read(v);
         test(v == 1);
     }
@@ -1095,8 +1095,8 @@ allTests(Test::TestHelper* helper)
     // Test marshaling to user-supplied buffer.
     //
     {
-        Ice::Byte buf[128];
-        pair<Ice::Byte*, Ice::Byte*> p(&buf[0], &buf[0] + sizeof(buf));
+        uint8_t buf[128];
+        pair<uint8_t*, uint8_t*> p(&buf[0], &buf[0] + sizeof(buf));
         Ice::OutputStream out(communicator, Ice::currentEncoding, p);
         vector<Ice::Byte> v;
         v.resize(127);
@@ -1105,8 +1105,8 @@ allTests(Test::TestHelper* helper)
         test(out.b.begin() == buf); // Verify the stream hasn't reallocated.
     }
     {
-        Ice::Byte buf[128];
-        pair<Ice::Byte*, Ice::Byte*> p(&buf[0], &buf[0] + sizeof(buf));
+        uint8_t buf[128];
+        pair<uint8_t*, uint8_t*> p(&buf[0], &buf[0] + sizeof(buf));
         Ice::OutputStream out(communicator, Ice::currentEncoding, p);
         vector<Ice::Byte> v;
         v.resize(127);

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -44,10 +44,10 @@ using namespace std;
 using namespace Ice;
 
 string
-toHexString(vector<Ice::Byte> data)
+toHexString(vector<uint8_t> data)
 {
     ostringstream os;
-    for(vector<Ice::Byte>::const_iterator i = data.begin(); i != data.end();)
+    for(vector<uint8_t>::const_iterator i = data.begin(); i != data.end();)
     {
         unsigned char c = *i;
         os.fill('0');

--- a/cpp/test/IceUtil/unicode/Client.cpp
+++ b/cpp/test/IceUtil/unicode/Client.cpp
@@ -209,8 +209,8 @@ main(int argc, char* argv[])
 
         cout << "testing IceUtilInternal::toUTF16, toUTF32 and fromUTF32... ";
 
-        vector<Byte> u8 = vector<Byte>(reinterpret_cast<const Byte*>(ns.data()),
-                                       reinterpret_cast<const Byte*>(ns.data() + ns.length()));
+        vector<Byte> u8 = vector<Byte>(reinterpret_cast<const uint8_t*>(ns.data()),
+                                       reinterpret_cast<const uint8_t*>(ns.data() + ns.length()));
 
         vector<unsigned short> u16 = IceUtilInternal::toUTF16(u8);
         test(u16.size() == 4);

--- a/cpp/test/IceUtil/unicode/Client.cpp
+++ b/cpp/test/IceUtil/unicode/Client.cpp
@@ -209,7 +209,7 @@ main(int argc, char* argv[])
 
         cout << "testing IceUtilInternal::toUTF16, toUTF32 and fromUTF32... ";
 
-        vector<Byte> u8 = vector<Byte>(reinterpret_cast<const uint8_t*>(ns.data()),
+        vector<uint8_t> u8 = vector<uint8_t>(reinterpret_cast<const uint8_t*>(ns.data()),
                                        reinterpret_cast<const uint8_t*>(ns.data() + ns.length()));
 
         vector<unsigned short> u16 = IceUtilInternal::toUTF16(u8);
@@ -225,7 +225,7 @@ main(int argc, char* argv[])
         test(u32[1] == 0x20ac);
         test(u32[2] == 0x10437);
 
-        vector<Byte> nu8 = IceUtilInternal::fromUTF32(u32);
+        vector<uint8_t> nu8 = IceUtilInternal::fromUTF32(u32);
         test(nu8 == u8);
 
         cout << "ok" << endl;

--- a/matlab/src/Endpoint.cpp
+++ b/matlab/src/Endpoint.cpp
@@ -92,7 +92,7 @@ createInfo(const shared_ptr<Ice::EndpointInfo>& info)
     if(opaqueInfo)
     {
         mxSetFieldByNumber(r, 0, Field::RawEncoding, createEncodingVersion(opaqueInfo->rawEncoding));
-        Ice::Byte* p = &opaqueInfo->rawBytes[0];
+        uint8_t* p = &opaqueInfo->rawBytes[0];
         mxSetFieldByNumber(r, 0, Field::RawBytes, createByteArray(p, p + opaqueInfo->rawBytes.size()));
     }
 

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -23,8 +23,8 @@ public:
     virtual void sent();
 
     void finished(const std::shared_ptr<Ice::Communicator>&, const Ice::EncodingVersion&, bool,
-                  std::pair<const Ice::Byte*, const Ice::Byte*>);
-    void getResults(bool&, pair<const Ice::Byte*, const Ice::Byte*>&);
+                  std::pair<const uint8_t*, const uint8_t*>);
+    void getResults(bool&, pair<const uint8_t*, const uint8_t*>&);
 
 protected:
 
@@ -67,7 +67,7 @@ InvocationFuture::exception(exception_ptr e)
 
 void
 InvocationFuture::finished(const std::shared_ptr<Ice::Communicator>& /*communicator*/,
-                           const Ice::EncodingVersion& /*encoding*/, bool b, pair<const Ice::Byte*, const Ice::Byte*> p)
+                           const Ice::EncodingVersion& /*encoding*/, bool b, pair<const uint8_t*, const uint8_t*> p)
 {
     lock_guard<mutex> lock(_mutex);
     _ok = b;
@@ -82,7 +82,7 @@ InvocationFuture::finished(const std::shared_ptr<Ice::Communicator>& /*communica
 }
 
 void
-InvocationFuture::getResults(bool& ok, pair<const Ice::Byte*, const Ice::Byte*>& p)
+InvocationFuture::getResults(bool& ok, pair<const uint8_t*, const uint8_t*>& p)
 {
     lock_guard<mutex> lock(_mutex);
     assert(_twoway);
@@ -192,8 +192,8 @@ Ice_ObjectPrx_read(void* communicator, mxArray* encoding, mxArray* buf, int star
 {
     assert(!mxIsEmpty(buf));
 
-    pair<const Ice::Byte*, const Ice::Byte*> p;
-    p.first = reinterpret_cast<Ice::Byte*>(mxGetData(buf)) + start;
+    pair<const uint8_t*, const uint8_t*> p;
+    p.first = reinterpret_cast<uint8_t*>(mxGetData(buf)) + start;
     p.second = p.first + size;
 
     try
@@ -231,7 +231,7 @@ Ice_ObjectPrx_write(void* proxy, void* communicator, mxArray* encoding)
 
         Ice::OutputStream out(comm, enc);
         out.write(prx);
-        pair<const Ice::Byte*, const Ice::Byte*> p = out.finished();
+        pair<const uint8_t*, const uint8_t*> p = out.finished();
 
         assert(p.second > p.first);
         return createResultValue(createByteArray(p.first, p.second));
@@ -245,10 +245,10 @@ Ice_ObjectPrx_write(void* proxy, void* communicator, mxArray* encoding)
 mxArray*
 Ice_ObjectPrx_ice_invoke(void* self, const char* op, int m, mxArray* inParams, unsigned int size, mxArray* context)
 {
-    pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
+    pair<const uint8_t*, const uint8_t*> params(0, 0);
     if(!mxIsEmpty(inParams))
     {
-        params.first = reinterpret_cast<Ice::Byte*>(mxGetData(inParams));
+        params.first = reinterpret_cast<uint8_t*>(mxGetData(inParams));
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
@@ -276,10 +276,10 @@ Ice_ObjectPrx_ice_invoke(void* self, const char* op, int m, mxArray* inParams, u
 mxArray*
 Ice_ObjectPrx_ice_invokeNC(void* self, const char* op, int m, mxArray* inParams, unsigned int size)
 {
-    pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
+    pair<const uint8_t*, const uint8_t*> params(0, 0);
     if(!mxIsEmpty(inParams))
     {
-        params.first = reinterpret_cast<Ice::Byte*>(mxGetData(inParams));
+        params.first = reinterpret_cast<uint8_t*>(mxGetData(inParams));
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
@@ -307,10 +307,10 @@ Ice_ObjectPrx_ice_invokeAsync(void* self, const char* op, int m, mxArray* inPara
                               mxArray* context, void** future)
 {
     const auto proxy = restoreProxy(self);
-    pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
+    pair<const uint8_t*, const uint8_t*> params(0, 0);
     if(!mxIsEmpty(inParams))
     {
-        params.first = reinterpret_cast<Ice::Byte*>(mxGetData(inParams));
+        params.first = reinterpret_cast<uint8_t*>(mxGetData(inParams));
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
@@ -325,7 +325,7 @@ Ice_ObjectPrx_ice_invokeAsync(void* self, const char* op, int m, mxArray* inPara
         getStringMap(context, ctx);
         function<void()> token = proxy->ice_invokeAsync(
             op, mode, params,
-            [proxy, f](bool ok, pair<const Ice::Byte*, const Ice::Byte*> outParams)
+            [proxy, f](bool ok, pair<const uint8_t*, const uint8_t*> outParams)
             {
                 f->finished(proxy->ice_getCommunicator(), proxy->ice_getEncodingVersion(), ok, outParams);
             },
@@ -352,10 +352,10 @@ mxArray*
 Ice_ObjectPrx_ice_invokeAsyncNC(void* self, const char* op, int m, mxArray* inParams, unsigned int size, void** future)
 {
     const auto proxy = restoreProxy(self);
-    pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
+    pair<const uint8_t*, const uint8_t*> params(0, 0);
     if(!mxIsEmpty(inParams))
     {
-        params.first = reinterpret_cast<Ice::Byte*>(mxGetData(inParams));
+        params.first = reinterpret_cast<uint8_t*>(mxGetData(inParams));
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
@@ -368,7 +368,7 @@ Ice_ObjectPrx_ice_invokeAsyncNC(void* self, const char* op, int m, mxArray* inPa
     {
         function<void()> token = proxy->ice_invokeAsync(
             op, mode, params,
-            [proxy, f](bool ok, pair<const Ice::Byte*, const Ice::Byte*> outParams)
+            [proxy, f](bool ok, pair<const uint8_t*, const uint8_t*> outParams)
             {
                 f->finished(proxy->ice_getCommunicator(),
                             proxy->ice_getEncodingVersion(), ok, outParams);
@@ -1176,7 +1176,7 @@ Ice_InvocationFuture_results(void* self)
     }
 
     bool ok;
-    pair<const Ice::Byte*, const Ice::Byte*> p;
+    pair<const uint8_t*, const uint8_t*> p;
     f->getResults(ok, p);
     mxArray* params = 0;
     if(p.second > p.first)

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -35,7 +35,7 @@ private:
     const bool _twoway;
     State _state;
     bool _ok; // True for success, false for user exception.
-    vector<Ice::Byte> _data;
+    vector<uint8_t> _data;
 };
 
 InvocationFuture::InvocationFuture(bool twoway, bool batch) :
@@ -75,7 +75,7 @@ InvocationFuture::finished(const std::shared_ptr<Ice::Communicator>& /*communica
     _token = nullptr;
     if(p.second > p.first)
     {
-        vector<Ice::Byte> data(p.first, p.second); // Makes a copy.
+        vector<uint8_t> data(p.first, p.second); // Makes a copy.
         _data.swap(data); // Avoids another copy.
     }
     _cond.notify_all();
@@ -252,7 +252,7 @@ Ice_ObjectPrx_ice_invoke(void* self, const char* op, int m, mxArray* inParams, u
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
-    vector<Ice::Byte> v;
+    vector<uint8_t> v;
 
     try
     {
@@ -283,7 +283,7 @@ Ice_ObjectPrx_ice_invokeNC(void* self, const char* op, int m, mxArray* inParams,
         params.second = params.first + size;
     }
     auto mode = static_cast<Ice::OperationMode>(m);
-    vector<Ice::Byte> v;
+    vector<uint8_t> v;
 
     try
     {

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -30,7 +30,7 @@ replace(string s, string patt, string val)
 }
 
 void
-getMajorMinor(mxArray* p, Ice::Byte& major, Ice::Byte& minor)
+getMajorMinor(mxArray* p, uint8_t& major, uint8_t& minor)
 {
     auto maj = mxGetProperty(p, 0, "major");
     assert(maj);
@@ -112,10 +112,10 @@ IceMatlab::createBool(bool v)
 }
 
 mxArray*
-IceMatlab::createByte(Ice::Byte v)
+IceMatlab::createByte(uint8_t v)
 {
     auto r = mxCreateNumericMatrix(1, 1, mxUINT8_CLASS, mxREAL);
-    auto p = reinterpret_cast<Ice::Byte*>(mxGetPr(r));
+    auto p = reinterpret_cast<uint8_t*>(mxGetPr(r));
     *p = v;
     return r;
 }
@@ -587,10 +587,10 @@ IceMatlab::getStringList(mxArray* m, vector<string>& v)
 }
 
 mxArray*
-IceMatlab::createByteArray(const Ice::Byte* begin, const Ice::Byte* end)
+IceMatlab::createByteArray(const uint8_t* begin, const uint8_t* end)
 {
     mxArray* r = mxCreateUninitNumericMatrix(1, end - begin, mxUINT8_CLASS, mxREAL);
-    memcpy(reinterpret_cast<Ice::Byte*>(mxGetData(r)), begin, end - begin);
+    memcpy(reinterpret_cast<uint8_t*>(mxGetData(r)), begin, end - begin);
     return r;
 }
 

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -38,14 +38,14 @@ getMajorMinor(mxArray* p, uint8_t& major, uint8_t& minor)
     {
         throw std::invalid_argument("major is not a scalar");
     }
-    major = static_cast<Ice::Byte>(mxGetScalar(maj));
+    major = static_cast<uint8_t>(mxGetScalar(maj));
     auto min = mxGetProperty(p, 0, "minor");
     assert(min);
     if(!mxIsScalar(min))
     {
         throw std::invalid_argument("minor is not a scalar");
     }
-    minor = static_cast<Ice::Byte>(mxGetScalar(min));
+    minor = static_cast<uint8_t>(mxGetScalar(min));
 }
 
 }
@@ -595,7 +595,7 @@ IceMatlab::createByteArray(const uint8_t* begin, const uint8_t* end)
 }
 
 mxArray*
-IceMatlab::createByteList(const vector<Ice::Byte>& bytes)
+IceMatlab::createByteList(const vector<uint8_t>& bytes)
 {
     auto r = mxCreateCellMatrix(1, static_cast<int>(bytes.size()));
     mwIndex i = 0;

--- a/matlab/src/Util.h
+++ b/matlab/src/Util.h
@@ -42,7 +42,7 @@ mxArray* createOptionalValue(bool, mxArray*);
 mxArray* createStringList(const std::vector<std::string>&);
 void getStringList(mxArray*, std::vector<std::string>&);
 mxArray* createByteArray(const std::uint8_t*, const std::uint8_t*);
-mxArray* createByteList(const std::vector<Ice::Byte>&);
+mxArray* createByteList(const std::vector<std::uint8_t>&);
 mxArray* createCertificateList(const std::vector<IceSSL::CertificatePtr>&);
 
 std::string idToClass(const std::string&);

--- a/matlab/src/Util.h
+++ b/matlab/src/Util.h
@@ -19,7 +19,7 @@ mxArray* createStringFromUTF8(const std::string&);
 std::string getStringFromUTF16(mxArray*);
 mxArray* createEmpty();
 mxArray* createBool(bool);
-mxArray* createByte(Ice::Byte);
+mxArray* createByte(std::uint8_t);
 mxArray* createShort(short);
 mxArray* createInt(int);
 mxArray* createLong(long long);
@@ -41,7 +41,7 @@ mxArray* createResultException(mxArray*);
 mxArray* createOptionalValue(bool, mxArray*);
 mxArray* createStringList(const std::vector<std::string>&);
 void getStringList(mxArray*, std::vector<std::string>&);
-mxArray* createByteArray(const Ice::Byte*, const Ice::Byte*);
+mxArray* createByteArray(const std::uint8_t*, const std::uint8_t*);
 mxArray* createByteList(const std::vector<Ice::Byte>&);
 mxArray* createCertificateList(const std::vector<IceSSL::CertificatePtr>&);
 

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -115,9 +115,9 @@ protected:
 
     OperationIPtr _op;
 
-    bool prepareRequest(int, zval*, Ice::OutputStream*, pair<const Ice::Byte*, const Ice::Byte*>&);
-    void unmarshalResults(int, zval*, zval*, const pair<const Ice::Byte*, const Ice::Byte*>&);
-    void unmarshalException(zval*, const pair<const Ice::Byte*, const Ice::Byte*>&);
+    bool prepareRequest(int, zval*, Ice::OutputStream*, pair<const uint8_t*, const uint8_t*>&);
+    void unmarshalResults(int, zval*, zval*, const pair<const uint8_t*, const uint8_t*>&);
+    void unmarshalException(zval*, const pair<const uint8_t*, const uint8_t*>&);
     bool validateException(const ExceptionInfoPtr&) const;
     void checkTwowayOnly(const Ice::ObjectPrx&) const;
 };
@@ -381,7 +381,7 @@ IcePHP::TypedInvocation::prepareRequest(
     int argc,
     zval* args,
     Ice::OutputStream* os,
-    pair<const Ice::Byte*, const Ice::Byte*>& params)
+    pair<const uint8_t*, const uint8_t*>& params)
 {
     // Verify that the expected number of arguments are supplied. The context argument is optional.
     if(argc != _op->numParams && argc != _op->numParams + 1)
@@ -475,7 +475,7 @@ IcePHP::TypedInvocation::unmarshalResults(
     int argc,
     zval* args,
     zval* ret,
-    const pair<const Ice::Byte*, const Ice::Byte*>& bytes)
+    const pair<const uint8_t*, const uint8_t*>& bytes)
 {
     Ice::InputStream is(_communicator->getCommunicator(), bytes);
 
@@ -559,7 +559,7 @@ IcePHP::TypedInvocation::unmarshalResults(
 }
 
 void
-IcePHP::TypedInvocation::unmarshalException(zval* zex, const pair<const Ice::Byte*, const Ice::Byte*>& bytes)
+IcePHP::TypedInvocation::unmarshalException(zval* zex, const pair<const uint8_t*, const uint8_t*>& bytes)
 {
     Ice::InputStream is(_communicator->getCommunicator(), bytes);
 
@@ -662,7 +662,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
     }
 
     Ice::OutputStream os(_prx->ice_getCommunicator());
-    pair<const Ice::Byte*, const Ice::Byte*> params;
+    pair<const uint8_t*, const uint8_t*> params;
     if (!prepareRequest(ZEND_NUM_ARGS(), args, &os, params))
     {
         return;
@@ -703,7 +703,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
             if(!status)
             {
                 // Unmarshal a user exception.
-                pair<const Ice::Byte*, const Ice::Byte*> rb(0, 0);
+                pair<const uint8_t*, const uint8_t*> rb(0, 0);
                 if(!result.empty())
                 {
                     rb.first = &result[0];
@@ -721,7 +721,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
             else if(!_op->outParams.empty() || _op->returnType)
             {
                 // Unmarshal the results.
-                pair<const Ice::Byte*, const Ice::Byte*> rb(0, 0);
+                pair<const uint8_t*, const uint8_t*> rb(0, 0);
                 if(!result.empty())
                 {
                     rb.first = &result[0];

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -684,7 +684,7 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
         checkTwowayOnly(_prx);
 
         // Invoke the operation.
-        vector<Ice::Byte> result;
+        vector<uint8_t> result;
         bool status;
         {
             if(hasCtx)

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -869,7 +869,7 @@ IcePHP::PrimitiveInfo::unmarshal(
     }
     case PrimitiveInfo::KindByte:
     {
-        Ice::Byte val;
+        uint8_t val;
         is->read(val);
         ZVAL_LONG(&zv, val & 0xff);
         break;
@@ -1820,9 +1820,9 @@ IcePHP::SequenceInfo::unmarshalPrimitiveSequence(
     }
     case PrimitiveInfo::KindByte:
     {
-        pair<const Ice::Byte*, const Ice::Byte*> pr;
+        pair<const uint8_t*, const uint8_t*> pr;
         is->read(pr);
-        for (const Ice::Byte* p = pr.first; p != pr.second; ++p)
+        for (const uint8_t* p = pr.first; p != pr.second; ++p)
         {
             add_next_index_long(&zv, *p & 0xff);
         }

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -396,12 +396,12 @@ IcePHP::StreamUtil::getSlicedDataMember(zval* obj, ObjectMap* objectMap)
 #   pragma clang diagnostic push
 #   pragma clang diagnostic ignored "-Wshadow"
 #endif
-                vector<Ice::Byte>::size_type i = 0;
+                vector<uint8_t>::size_type i = 0;
                 ZEND_HASH_FOREACH_VAL(barr, e)
                 {
                     long l = static_cast<long>(Z_LVAL_P(e));
                     assert(l >= 0 && l <= 255);
-                    info->bytes[i++] = static_cast<Ice::Byte>(l);
+                    info->bytes[i++] = static_cast<uint8_t>(l);
                 }
                 ZEND_HASH_FOREACH_END();
 #if defined(__clang__)
@@ -757,7 +757,7 @@ IcePHP::PrimitiveInfo::marshal(zval* zv, Ice::OutputStream* os, ObjectMap*, bool
         assert(Z_TYPE_P(zv) == IS_LONG);
         long val = static_cast<long>(Z_LVAL_P(zv));
         assert(val >= 0 && val <= 255); // validate() should have caught this.
-        os->write(static_cast<Ice::Byte>(val));
+        os->write(static_cast<uint8_t>(val));
         break;
     }
     case PrimitiveInfo::KindShort:
@@ -1625,7 +1625,7 @@ IcePHP::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, zval*
             }
             long l = static_cast<long>(Z_LVAL_P(val));
             assert(l >= 0 && l <= 255);
-            seq[i++] = static_cast<Ice::Byte>(l);
+            seq[i++] = static_cast<uint8_t>(l);
         }
         ZEND_HASH_FOREACH_END();
 

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -99,7 +99,7 @@ getVersion(zval* zv, T& v, const char* type)
         invalidArgument("version major must be a value between 0 and 255");
         return false;
     }
-    v.major = static_cast<Ice::Byte>(m);
+    v.major = static_cast<uint8_t>(m);
 
     m = static_cast<long>(Z_LVAL_P(&minorVal));
     if(m < 0 || m > 255)
@@ -107,7 +107,7 @@ getVersion(zval* zv, T& v, const char* type)
         invalidArgument("version minor must be a value between 0 and 255");
         return false;
     }
-    v.minor = static_cast<Ice::Byte>(m);
+    v.minor = static_cast<uint8_t>(m);
 
     return true;
 }

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -151,7 +151,7 @@ protected:
     bool _done;
     PyObject* _future;
     bool _ok;
-    vector<Ice::Byte> _results;
+    vector<uint8_t> _results;
     PyObject* _exception;
 };
 using AsyncInvocationPtr = shared_ptr<AsyncInvocation>;
@@ -1695,7 +1695,7 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
         //
         // Invoke the operation.
         //
-        vector<Ice::Byte> result;
+        vector<uint8_t> result;
         bool status;
         Ice::Context ctx;
         if(pyctx != Py_None)
@@ -1948,7 +1948,7 @@ IcePy::AsyncInvocation::response(bool ok, const pair<const uint8_t*, const uint8
         // The future hasn't been created yet, which means invoke() is still running. Save the results for later.
         //
         _ok = ok;
-        vector<Ice::Byte> v(results.first, results.second);
+        vector<uint8_t> v(results.first, results.second);
         _results.swap(v);
         _done = true;
         return;
@@ -2235,7 +2235,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 
     try
     {
-        vector<Ice::Byte> out;
+        vector<uint8_t> out;
 
         bool ok;
         Ice::Context context;

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -534,7 +534,7 @@ IcePy::StreamUtil::getSlicedDataMember(PyObject* obj, ObjectMap* objectMap)
                 Py_ssize_t strsz;
                 assert(PyBytes_Check(bytes.get()));
                 PyBytes_AsStringAndSize(bytes.get(), &str, &strsz);
-                vector<Ice::Byte> vtmp(reinterpret_cast<Ice::Byte*>(str), reinterpret_cast<Ice::Byte*>(str + strsz));
+                vector<Ice::Byte> vtmp(reinterpret_cast<uint8_t*>(str), reinterpret_cast<uint8_t*>(str + strsz));
                 info->bytes.swap(vtmp);
 
                 PyObjectHandle instances = getAttr(s.get(), "instances", false);
@@ -917,7 +917,7 @@ IcePy::PrimitiveInfo::unmarshal(Ice::InputStream* is, const UnmarshalCallbackPtr
     }
     case PrimitiveInfo::KindByte:
     {
-        Ice::Byte val;
+        uint8_t val;
         is->read(val);
         PyObjectHandle p = PyLong_FromLong(val);
         cb->unmarshaled(p.get(), target, closure);
@@ -1800,7 +1800,7 @@ IcePy::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, PyObje
                     throw AbortMarshaling();
                 }
             }
-            const Ice::Byte* b = reinterpret_cast<const Ice::Byte*>(pybuf.buf);
+            const uint8_t* b = reinterpret_cast<const uint8_t*>(pybuf.buf);
             Py_ssize_t sz = pybuf.len;
 
             switch(pi->kind)
@@ -1813,8 +1813,8 @@ IcePy::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, PyObje
                 }
                 case PrimitiveInfo::KindByte:
                 {
-                    os->write(reinterpret_cast<const Ice::Byte*>(b),
-                              reinterpret_cast<const Ice::Byte*>(b + sz));
+                    os->write(reinterpret_cast<const uint8_t*>(b),
+                              reinterpret_cast<const uint8_t*>(b + sz));
                     break;
                 }
                 case PrimitiveInfo::KindShort:
@@ -1902,7 +1902,7 @@ IcePy::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, PyObje
             assert(PyBytes_Check(p));
             char* str;
             PyBytes_AsStringAndSize(p, &str, &sz);
-            os->write(reinterpret_cast<const Ice::Byte*>(str), reinterpret_cast<const Ice::Byte*>(str + sz));
+            os->write(reinterpret_cast<const uint8_t*>(str), reinterpret_cast<const uint8_t*>(str + sz));
         }
         else
         {
@@ -2174,7 +2174,7 @@ IcePy::SequenceInfo::unmarshalPrimitiveSequence(const PrimitiveInfoPtr& pi, Ice:
     }
     case PrimitiveInfo::KindByte:
     {
-        pair<const Ice::Byte*, const Ice::Byte*> p;
+        pair<const uint8_t*, const uint8_t*> p;
         is->read(p);
         int sz = static_cast<int>(p.second - p.first);
         if(sm->factory)
@@ -2627,7 +2627,7 @@ IcePy::CustomInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* /*obje
     char* str;
     Py_ssize_t sz;
     PyBytes_AsStringAndSize(obj.get(), &str, &sz);
-    os->write(reinterpret_cast<const Ice::Byte*>(str), reinterpret_cast<const Ice::Byte*>(str + sz));
+    os->write(reinterpret_cast<const uint8_t*>(str), reinterpret_cast<const uint8_t*>(str + sz));
 }
 
 void
@@ -2637,7 +2637,7 @@ IcePy::CustomInfo::unmarshal(Ice::InputStream* is, const UnmarshalCallbackPtr& c
     //
     // Unmarshal the raw byte sequence.
     //
-    pair<const Ice::Byte*, const Ice::Byte*> seq;
+    pair<const uint8_t*, const uint8_t*> seq;
     is->read(seq);
     int sz = static_cast<int>(seq.second - seq.first);
 

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -534,7 +534,7 @@ IcePy::StreamUtil::getSlicedDataMember(PyObject* obj, ObjectMap* objectMap)
                 Py_ssize_t strsz;
                 assert(PyBytes_Check(bytes.get()));
                 PyBytes_AsStringAndSize(bytes.get(), &str, &strsz);
-                vector<Ice::Byte> vtmp(reinterpret_cast<uint8_t*>(str), reinterpret_cast<uint8_t*>(str + strsz));
+                vector<uint8_t> vtmp(reinterpret_cast<uint8_t*>(str), reinterpret_cast<uint8_t*>(str + strsz));
                 info->bytes.swap(vtmp);
 
                 PyObjectHandle instances = getAttr(s.get(), "instances", false);
@@ -835,7 +835,7 @@ IcePy::PrimitiveInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap*, bo
         long val = PyLong_AsLong(p);
         assert(!PyErr_Occurred()); // validate() should have caught this.
         assert(val >= 0 && val <= 255); // validate() should have caught this.
-        os->write(static_cast<Ice::Byte>(val));
+        os->write(static_cast<uint8_t>(val));
         break;
     }
     case PrimitiveInfo::KindShort:
@@ -1925,7 +1925,7 @@ IcePy::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, PyObje
                                  static_cast<int>(i));
                     throw AbortMarshaling();
                 }
-                seq[static_cast<size_t>(i)] = static_cast<Ice::Byte>(val);
+                seq[static_cast<size_t>(i)] = static_cast<uint8_t>(val);
             }
             os->write(seq);
         }

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -53,7 +53,7 @@ getVersion(PyObject* p, T& v)
             PyErr_Format(PyExc_ValueError, STRCAST("version major must be a value between 0 and 255"));
             return false;
         }
-        v.major = static_cast<Ice::Byte>(m);
+        v.major = static_cast<uint8_t>(m);
     }
     else
     {
@@ -74,7 +74,7 @@ getVersion(PyObject* p, T& v)
             PyErr_Format(PyExc_ValueError, STRCAST("version minor must be a value between 0 and 255"));
             return false;
         }
-        v.minor = static_cast<Ice::Byte>(m);
+        v.minor = static_cast<uint8_t>(m);
     }
     else
     {

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -69,7 +69,7 @@ private:
 
     void convertParams(VALUE, ParamInfoList&, long, bool&);
     ParamInfoPtr convertParam(VALUE, long);
-    void prepareRequest(const Ice::ObjectPrx&, VALUE, Ice::OutputStream*, pair<const Ice::Byte*, const Ice::Byte*>&);
+    void prepareRequest(const Ice::ObjectPrx&, VALUE, Ice::OutputStream*, pair<const uint8_t*, const uint8_t*>&);
     VALUE unmarshalResults(const vector<Ice::Byte>&, const Ice::CommunicatorPtr&);
     VALUE unmarshalException(const vector<Ice::Byte>&, const Ice::CommunicatorPtr&);
     bool validateException(VALUE) const;
@@ -283,7 +283,7 @@ IceRuby::OperationI::invoke(const Ice::ObjectPrx& proxy, VALUE args, VALUE hctx)
     // Marshal the input parameters to a byte sequence.
     //
     Ice::OutputStream os(communicator);
-    pair<const Ice::Byte*, const Ice::Byte*> params;
+    pair<const uint8_t*, const uint8_t*> params;
     prepareRequest(proxy, args, &os, params);
 
     if(!_deprecateMessage.empty())
@@ -396,9 +396,9 @@ IceRuby::OperationI::prepareRequest(
     const Ice::ObjectPrx& proxy,
     VALUE args,
     Ice::OutputStream* os,
-    pair<const Ice::Byte*, const Ice::Byte*>& params)
+    pair<const uint8_t*, const uint8_t*>& params)
 {
-    params.first = params.second = static_cast<const Ice::Byte*>(0);
+    params.first = params.second = static_cast<const uint8_t*>(0);
 
     //
     // Validate the number of arguments.

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -70,8 +70,8 @@ private:
     void convertParams(VALUE, ParamInfoList&, long, bool&);
     ParamInfoPtr convertParam(VALUE, long);
     void prepareRequest(const Ice::ObjectPrx&, VALUE, Ice::OutputStream*, pair<const uint8_t*, const uint8_t*>&);
-    VALUE unmarshalResults(const vector<Ice::Byte>&, const Ice::CommunicatorPtr&);
-    VALUE unmarshalException(const vector<Ice::Byte>&, const Ice::CommunicatorPtr&);
+    VALUE unmarshalResults(const vector<uint8_t>&, const Ice::CommunicatorPtr&);
+    VALUE unmarshalException(const vector<uint8_t>&, const Ice::CommunicatorPtr&);
     bool validateException(VALUE) const;
     void checkTwowayOnly(const Ice::ObjectPrx&) const;
 };
@@ -473,7 +473,7 @@ IceRuby::OperationI::prepareRequest(
 }
 
 VALUE
-IceRuby::OperationI::unmarshalResults(const vector<Ice::Byte>& bytes, const Ice::CommunicatorPtr& communicator)
+IceRuby::OperationI::unmarshalResults(const vector<uint8_t>& bytes, const Ice::CommunicatorPtr& communicator)
 {
     int numResults = static_cast<int>(_outParams.size());
     if(_returnType)
@@ -555,7 +555,7 @@ IceRuby::OperationI::unmarshalResults(const vector<Ice::Byte>& bytes, const Ice:
 }
 
 VALUE
-IceRuby::OperationI::unmarshalException(const vector<Ice::Byte>& bytes, const Ice::CommunicatorPtr& communicator)
+IceRuby::OperationI::unmarshalException(const vector<uint8_t>& bytes, const Ice::CommunicatorPtr& communicator)
 {
     Ice::InputStream is(communicator, bytes);
 

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -358,7 +358,7 @@ IceRuby::StreamUtil::getSlicedDataMember(VALUE obj, ValueMap* valueMap)
                 const long len = RSTRING_LEN(bytes);
                 if(str != 0 && len != 0)
                 {
-                    vector<Ice::Byte> vtmp(reinterpret_cast<const uint8_t*>(str),
+                    vector<uint8_t> vtmp(reinterpret_cast<const uint8_t*>(str),
                                            reinterpret_cast<const uint8_t*>(str + len));
                     info->bytes.swap(vtmp);
                 }
@@ -554,7 +554,7 @@ IceRuby::PrimitiveInfo::marshal(VALUE p, Ice::OutputStream* os, ValueMap*, bool)
         long i = getInteger(p);
         if(i >= 0 && i <= 255)
         {
-            os->write(static_cast<Ice::Byte>(i));
+            os->write(static_cast<uint8_t>(i));
             break;
         }
         throw RubyException(rb_eTypeError, "value is out of range for a byte");
@@ -1434,7 +1434,7 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
                 {
                     throw RubyException(rb_eTypeError, "invalid value for element %ld of sequence<byte>", i);
                 }
-                seq[static_cast<size_t>(i)] = static_cast<Ice::Byte>(val);
+                seq[static_cast<size_t>(i)] = static_cast<uint8_t>(val);
             }
             os->write(seq);
         }

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -358,8 +358,8 @@ IceRuby::StreamUtil::getSlicedDataMember(VALUE obj, ValueMap* valueMap)
                 const long len = RSTRING_LEN(bytes);
                 if(str != 0 && len != 0)
                 {
-                    vector<Ice::Byte> vtmp(reinterpret_cast<const Ice::Byte*>(str),
-                                           reinterpret_cast<const Ice::Byte*>(str + len));
+                    vector<Ice::Byte> vtmp(reinterpret_cast<const uint8_t*>(str),
+                                           reinterpret_cast<const uint8_t*>(str + len));
                     info->bytes.swap(vtmp);
                 }
 
@@ -640,7 +640,7 @@ IceRuby::PrimitiveInfo::unmarshal(Ice::InputStream* is, const UnmarshalCallbackP
     }
     case PrimitiveInfo::KindByte:
     {
-        Ice::Byte b;
+        uint8_t b;
         is->read(b);
         val = callRuby(rb_int2inum, b);
         break;
@@ -1420,7 +1420,7 @@ IceRuby::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, VALU
             }
             else
             {
-                os->write(reinterpret_cast<const Ice::Byte*>(s), reinterpret_cast<const Ice::Byte*>(s + len));
+                os->write(reinterpret_cast<const uint8_t*>(s), reinterpret_cast<const uint8_t*>(s + len));
             }
         }
         else
@@ -1568,7 +1568,7 @@ IceRuby::SequenceInfo::unmarshalPrimitiveSequence(const PrimitiveInfoPtr& pi, Ic
     }
     case PrimitiveInfo::KindByte:
     {
-        pair<const Ice::Byte*, const Ice::Byte*> p;
+        pair<const uint8_t*, const uint8_t*> p;
         is->read(p);
         result = callRuby(rb_str_new, reinterpret_cast<const char*>(p.first), static_cast<long>(p.second - p.first));
         break;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -378,13 +378,13 @@ IceRuby::stringSeqToArray(const vector<string>& seq)
 }
 
 VALUE
-IceRuby::createNumSeq(const vector<Ice::Byte>& v)
+IceRuby::createNumSeq(const vector<uint8_t>& v)
 {
     volatile VALUE result = createArray(v.size());
     long i = 0;
     if(v.size() > 0)
     {
-        for(vector<Ice::Byte>::const_iterator p = v.begin(); p != v.end(); ++p, ++i)
+        for(vector<uint8_t>::const_iterator p = v.begin(); p != v.end(); ++p, ++i)
         {
             RARRAY_ASET(result, i, INT2FIX(*p));
         }

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -97,7 +97,7 @@ VALUE stringSeqToArray(const std::vector<std::string>&);
 // Convert a vector of std::uint8_t into a Ruby array of numbers.
 // May raise RubyException.
 //
-VALUE createNumSeq(const std::vector<Ice::Byte>&);
+VALUE createNumSeq(const std::vector<std::uint8_t>&);
 
 //
 // Convert a Ruby hash to Ice::Context. Returns true on success

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -94,7 +94,7 @@ bool arrayToStringSeq(VALUE, std::vector<std::string>&);
 VALUE stringSeqToArray(const std::vector<std::string>&);
 
 //
-// Convert a vector of Ice::Byte into a Ruby array of numbers.
+// Convert a vector of std::uint8_t into a Ruby array of numbers.
 // May raise RubyException.
 //
 VALUE createNumSeq(const std::vector<Ice::Byte>&);

--- a/swift/src/IceImpl/BlobjectFacade.h
+++ b/swift/src/IceImpl/BlobjectFacade.h
@@ -48,8 +48,8 @@ public:
     }
 
     virtual void
-    ice_invokeAsync(std::pair<const Byte*, const Byte*> inEncaps,
-                    std::function<void(bool, const std::pair<const Byte*, const Byte*>&)> response,
+    ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps,
+                    std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> response,
                     std::function<void(std::exception_ptr)> error,
                     const Ice::Current& current);
 

--- a/swift/src/IceImpl/BlobjectFacade.mm
+++ b/swift/src/IceImpl/BlobjectFacade.mm
@@ -9,13 +9,13 @@
 #import "Connection.h"
 
 void
-BlobjectFacade::ice_invokeAsync(std::pair<const Byte*, const Byte*> inEncaps,
-                                std::function<void(bool, const std::pair<const Byte*, const Byte*>&)> response,
+BlobjectFacade::ice_invokeAsync(std::pair<const uint8_t*, const uint8_t*> inEncaps,
+                                std::function<void(bool, const std::pair<const uint8_t*, const uint8_t*>&)> response,
                                 std::function<void(std::exception_ptr)> error,
                                 const Ice::Current& current)
 {
     ICEBlobjectResponse responseCallback = ^(bool ok, const void* outParams, long count) {
-        const Ice::Byte* start = static_cast<const Ice::Byte*>(outParams);
+        const uint8_t* start = static_cast<const uint8_t*>(outParams);
         response(ok, std::make_pair(start, start + static_cast<size_t>(count)));
     };
 
@@ -29,7 +29,7 @@ BlobjectFacade::ice_invokeAsync(std::pair<const Byte*, const Byte*> inEncaps,
     @autoreleasepool
     {
         [_facade facadeInvoke:adapter
-                    inEncapsBytes:const_cast<Ice::Byte*>(inEncaps.first)
+                    inEncapsBytes:const_cast<uint8_t*>(inEncaps.first)
                     inEncapsCount:static_cast<long>(inEncaps.second - inEncaps.first)
                               con:con
                              name:toNSString(current.id.name) category:toNSString(current.id.category)

--- a/swift/src/IceImpl/BlobjectFacade.mm
+++ b/swift/src/IceImpl/BlobjectFacade.mm
@@ -9,13 +9,13 @@
 #import "Connection.h"
 
 void
-BlobjectFacade::ice_invokeAsync(std::pair<const uint8_t*, const uint8_t*> inEncaps,
-                                std::function<void(bool, const std::pair<const uint8_t*, const uint8_t*>&)> response,
+BlobjectFacade::ice_invokeAsync(std::pair<const std::uint8_t*, const std::uint8_t*> inEncaps,
+                                std::function<void(bool, const std::pair<const std::uint8_t*, const std::uint8_t*>&)> response,
                                 std::function<void(std::exception_ptr)> error,
                                 const Ice::Current& current)
 {
     ICEBlobjectResponse responseCallback = ^(bool ok, const void* outParams, long count) {
-        const uint8_t* start = static_cast<const uint8_t*>(outParams);
+        const std::uint8_t* start = static_cast<const std::uint8_t*>(outParams);
         response(ok, std::make_pair(start, start + static_cast<size_t>(count)));
     };
 
@@ -29,13 +29,13 @@ BlobjectFacade::ice_invokeAsync(std::pair<const uint8_t*, const uint8_t*> inEnca
     @autoreleasepool
     {
         [_facade facadeInvoke:adapter
-                    inEncapsBytes:const_cast<uint8_t*>(inEncaps.first)
+                    inEncapsBytes:const_cast<std::uint8_t*>(inEncaps.first)
                     inEncapsCount:static_cast<long>(inEncaps.second - inEncaps.first)
                               con:con
                              name:toNSString(current.id.name) category:toNSString(current.id.category)
                             facet:toNSString(current.facet)
                         operation:toNSString(current.operation)
-                             mode:static_cast<uint8_t>(current.mode)
+                             mode:static_cast<std::uint8_t>(current.mode)
                           context:toNSDictionary(current.ctx)
                         requestId:current.requestId
                     encodingMajor:current.encoding.major

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -216,7 +216,7 @@
     }
 }
 
--(BOOL) flushBatchRequests:(uint8_t)compress error:(NSError**)error
+-(BOOL) flushBatchRequests:(std::uint8_t)compress error:(NSError**)error
 {
     try
     {
@@ -230,7 +230,7 @@
     }
 }
 
--(void) flushBatchRequestsAsync:(uint8_t)compress
+-(void) flushBatchRequestsAsync:(std::uint8_t)compress
                       exception:(void (^)(NSError*))exception
                            sent:(void (^_Nullable)(bool))sent
 {
@@ -399,16 +399,16 @@
     }
 }
 
--(void) getDefaultEncoding:(uint8_t*)major minor:(uint8_t*)minor
+-(void) getDefaultEncoding:(std::uint8_t*)major minor:(std::uint8_t*)minor
 {
     auto defaultEncoding = IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultEncoding;
     *major = defaultEncoding.major;
     *minor = defaultEncoding.minor;
 }
 
--(uint8_t) getDefaultFormat
+-(std::uint8_t) getDefaultFormat
 {
-    return static_cast<uint8_t>(IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat);
+    return static_cast<std::uint8_t>(IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat);
 }
 
 -(id<ICEBlobjectFacade>) facetToFacade:(const std::shared_ptr<Ice::Object>&) servant

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -16,7 +16,7 @@
     return std::static_pointer_cast<Ice::Connection>(self.cppObject);
 }
 
--(void) close:(uint8_t)mode
+-(void) close:(std::uint8_t)mode
 {
     self.connection->close(Ice::ConnectionClose(mode));
 }
@@ -62,7 +62,7 @@
     return [ICEEndpoint getHandle:endpoint];
 }
 
--(BOOL) flushBatchRequests:(uint8_t)compress error:(NSError**)error
+-(BOOL) flushBatchRequests:(std::uint8_t)compress error:(NSError**)error
 {
     try
     {
@@ -76,7 +76,7 @@
     }
 }
 
--(void) flushBatchRequestsAsync:(uint8_t)compress
+-(void) flushBatchRequestsAsync:(std::uint8_t)compress
                       exception:(void (^)(NSError*))exception
                            sent:(void (^_Nullable)(bool))sent
 {
@@ -223,12 +223,12 @@
     self.connection->setACM(opTimeout, opClose, opHeartbeat);
 }
 
--(void) getACM:(int32_t*)timeout close:(uint8_t*)close heartbeat:(uint8_t*)heartbeat
+-(void) getACM:(int32_t*)timeout close:(std::uint8_t*)close heartbeat:(std::uint8_t*)heartbeat
 {
     auto acm = self.connection->getACM();
     *timeout = acm.timeout;
-    *close = static_cast<uint8_t>(acm.close);
-    *heartbeat = static_cast<uint8_t>(acm.heartbeat);
+    *close = static_cast<std::uint8_t>(acm.close);
+    *heartbeat = static_cast<std::uint8_t>(acm.heartbeat);
 }
 
 -(NSString*) type

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -175,7 +175,7 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
 
 +(NSString*) identityToString:(NSString*)name
                               category:(NSString*)category
-                                  mode:(uint8_t)mode
+                                  mode:(std::uint8_t)mode
 {
     Ice::Identity identity{fromNSString(name), fromNSString(category)};
     return toNSString(Ice::identityToString(identity, static_cast<Ice::ToStringMode>(mode)));

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -204,12 +204,12 @@
     }
 }
 
--(uint8_t) ice_getEndpointSelection
+-(std::uint8_t) ice_getEndpointSelection
 {
-    return static_cast<uint8_t>(_prx->ice_getEndpointSelection());
+    return static_cast<std::uint8_t>(_prx->ice_getEndpointSelection());
 }
 
--(instancetype) ice_endpointSelection:(uint8_t)type error:(NSError**)error
+-(instancetype) ice_endpointSelection:(std::uint8_t)type error:(NSError**)error
 {
     try
     {
@@ -223,7 +223,7 @@
     }
 }
 
--(instancetype) ice_encodingVersion:(uint8_t)major minor:(uint8_t)minor
+-(instancetype) ice_encodingVersion:(std::uint8_t)major minor:(std::uint8_t)minor
 {
     Ice::EncodingVersion encoding{major, minor};
 
@@ -231,7 +231,7 @@
     return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
 }
 
--(void) ice_getEncodingVersion:(uint8_t*)major minor:(uint8_t*)minor
+-(void) ice_getEncodingVersion:(std::uint8_t*)major minor:(std::uint8_t*)minor
 {
     Ice::EncodingVersion v = _prx->ice_getEncodingVersion();
     *major = v.major;
@@ -565,14 +565,14 @@
 
 +(id) ice_read:(NSData*)data
   communicator:(ICECommunicator*)communicator
- encodingMajor:(uint8_t)major
- encodingMinor:(uint8_t)minor
+ encodingMajor:(std::uint8_t)major
+ encodingMinor:(std::uint8_t)minor
      bytesRead:(NSInteger*)bytesRead
          error:(NSError**)error
 {
 
-    std::pair<const uint8_t*, const uint8_t*> p;
-    p.first = static_cast<const uint8_t*>(data.bytes);
+    std::pair<const std::uint8_t*, const std::uint8_t*> p;
+    p.first = static_cast<const std::uint8_t*>(data.bytes);
     p.second = p.first + data.length;
 
     auto comm = [communicator communicator];
@@ -602,8 +602,8 @@
 }
 
 -(void) ice_write:(id<ICEOutputStreamHelper>)os
-    encodingMajor:(uint8_t)encodingMajor
-    encodingMinor:(uint8_t)encodingMinor
+    encodingMajor:(std::uint8_t)encodingMajor
+    encodingMinor:(std::uint8_t)encodingMinor
 {
     //
     // Marshal a proxy into a stream and return the encoded bytes.
@@ -617,14 +617,14 @@
 }
 
 -(BOOL) invoke:(NSString* _Nonnull)op
-          mode:(uint8_t)mode
+          mode:(std::uint8_t)mode
       inParams:(NSData*)inParams
        context:(NSDictionary* _Nullable)context
       response:(void (^)(bool, void*, long))response
          error:(NSError**)error
 {
-    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
-    params.first = static_cast<const uint8_t*>(inParams.bytes);
+    std::pair<const std::uint8_t*, const std::uint8_t*> params(0, 0);
+    params.first = static_cast<const std::uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -634,7 +634,7 @@
         {
             fromNSDictionary(context, ctx);
         }
-        std::vector<uint8_t> outParams;
+        std::vector<std::uint8_t> outParams;
 
         // We use a std::promise and invokeAsync to avoid making an extra copy of the outParam buffer
         // and to avoid calling PromiseKit wait. PromiseKit issues a warning if wait() is called on the main thread.
@@ -642,13 +642,13 @@
         std::promise<void> p;
 
         _prx->ice_invokeAsync(fromNSString(op), static_cast<Ice::OperationMode>(mode), params,
-                              [response, &p](bool ok, std::pair<const uint8_t*, const uint8_t*> outParams)
+                              [response, &p](bool ok, std::pair<const std::uint8_t*, const std::uint8_t*> outParams)
                               {
                                   // We need an autorelease pool as the unmarshaling (in the response) can
                                   // create autorelease objects, typically when unmarshaling proxies
                                   @autoreleasepool
                                   {
-                                      response(ok, const_cast<uint8_t*>(outParams.first),
+                                      response(ok, const_cast<std::uint8_t*>(outParams.first),
                                                static_cast<long>(outParams.second - outParams.first));
                                   }
                                   p.set_value();
@@ -671,13 +671,13 @@
 }
 
 -(BOOL) onewayInvoke:(NSString*)op
-                mode:(uint8_t)mode
+                mode:(std::uint8_t)mode
             inParams:(NSData*)inParams
              context:(NSDictionary*)context
                error:(NSError**)error
 {
-    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
-    params.first = static_cast<const uint8_t*>(inParams.bytes);
+    std::pair<const std::uint8_t*, const std::uint8_t*> params(0, 0);
+    params.first = static_cast<const std::uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -688,7 +688,7 @@
             fromNSDictionary(context, ctx);
         }
 
-        std::vector<uint8_t> ignored;
+        std::vector<std::uint8_t> ignored;
         _prx->ice_invoke(fromNSString(op), static_cast<Ice::OperationMode>(mode), params, ignored,
                          context ? ctx : Ice::noExplicitContext);
         return YES;
@@ -701,15 +701,15 @@
 }
 
 -(void) invokeAsync:(NSString* _Nonnull)op
-               mode:(uint8_t)mode
+               mode:(std::uint8_t)mode
            inParams:(NSData*)inParams
             context:(NSDictionary* _Nullable)context
            response:(void (^)(bool, void*, long))response
           exception:(void (^)(NSError*))exception
                sent:(void (^_Nullable)(bool))sent
 {
-    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
-    params.first = static_cast<const uint8_t*>(inParams.bytes);
+    std::pair<const std::uint8_t*, const std::uint8_t*> params(0, 0);
+    params.first = static_cast<const std::uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -721,7 +721,7 @@
         }
 
         _prx->ice_invokeAsync(fromNSString(op), static_cast<Ice::OperationMode>(mode), params,
-                                            [response](bool ok, std::pair<const uint8_t*, const uint8_t*> outParams)
+                                            [response](bool ok, std::pair<const std::uint8_t*, const std::uint8_t*> outParams)
                                             {
                                                 // We need an autorelease pool in case the unmarshaling creates auto
                                                 // release objects, and in case the application attaches a handler to
@@ -729,7 +729,7 @@
                                                 // executes response)
                                                 @autoreleasepool
                                                 {
-                                                    response(ok, const_cast<uint8_t*>(outParams.first),
+                                                    response(ok, const_cast<std::uint8_t*>(outParams.first),
                                                              static_cast<long>(outParams.second - outParams.first));
                                                 }
                                             },

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -571,8 +571,8 @@
          error:(NSError**)error
 {
 
-    std::pair<const Ice::Byte*, const Ice::Byte*> p;
-    p.first = static_cast<const Ice::Byte*>(data.bytes);
+    std::pair<const uint8_t*, const uint8_t*> p;
+    p.first = static_cast<const uint8_t*>(data.bytes);
     p.second = p.first + data.length;
 
     auto comm = [communicator communicator];
@@ -623,8 +623,8 @@
       response:(void (^)(bool, void*, long))response
          error:(NSError**)error
 {
-    std::pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
-    params.first = static_cast<const Ice::Byte*>(inParams.bytes);
+    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
+    params.first = static_cast<const uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -634,7 +634,7 @@
         {
             fromNSDictionary(context, ctx);
         }
-        std::vector<Ice::Byte> outParams;
+        std::vector<uint8_t> outParams;
 
         // We use a std::promise and invokeAsync to avoid making an extra copy of the outParam buffer
         // and to avoid calling PromiseKit wait. PromiseKit issues a warning if wait() is called on the main thread.
@@ -642,13 +642,13 @@
         std::promise<void> p;
 
         _prx->ice_invokeAsync(fromNSString(op), static_cast<Ice::OperationMode>(mode), params,
-                              [response, &p](bool ok, std::pair<const Ice::Byte*, const Ice::Byte*> outParams)
+                              [response, &p](bool ok, std::pair<const uint8_t*, const uint8_t*> outParams)
                               {
                                   // We need an autorelease pool as the unmarshaling (in the response) can
                                   // create autorelease objects, typically when unmarshaling proxies
                                   @autoreleasepool
                                   {
-                                      response(ok, const_cast<Ice::Byte*>(outParams.first),
+                                      response(ok, const_cast<uint8_t*>(outParams.first),
                                                static_cast<long>(outParams.second - outParams.first));
                                   }
                                   p.set_value();
@@ -676,8 +676,8 @@
              context:(NSDictionary*)context
                error:(NSError**)error
 {
-    std::pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
-    params.first = static_cast<const Ice::Byte*>(inParams.bytes);
+    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
+    params.first = static_cast<const uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -688,7 +688,7 @@
             fromNSDictionary(context, ctx);
         }
 
-        std::vector<Ice::Byte> ignored;
+        std::vector<uint8_t> ignored;
         _prx->ice_invoke(fromNSString(op), static_cast<Ice::OperationMode>(mode), params, ignored,
                          context ? ctx : Ice::noExplicitContext);
         return YES;
@@ -708,8 +708,8 @@
           exception:(void (^)(NSError*))exception
                sent:(void (^_Nullable)(bool))sent
 {
-    std::pair<const Ice::Byte*, const Ice::Byte*> params(0, 0);
-    params.first = static_cast<const Ice::Byte*>(inParams.bytes);
+    std::pair<const uint8_t*, const uint8_t*> params(0, 0);
+    params.first = static_cast<const uint8_t*>(inParams.bytes);
     params.second = params.first + inParams.length;
 
     try
@@ -721,7 +721,7 @@
         }
 
         _prx->ice_invokeAsync(fromNSString(op), static_cast<Ice::OperationMode>(mode), params,
-                                            [response](bool ok, std::pair<const Ice::Byte*, const Ice::Byte*> outParams)
+                                            [response](bool ok, std::pair<const uint8_t*, const uint8_t*> outParams)
                                             {
                                                 // We need an autorelease pool in case the unmarshaling creates auto
                                                 // release objects, and in case the application attaches a handler to
@@ -729,7 +729,7 @@
                                                 // executes response)
                                                 @autoreleasepool
                                                 {
-                                                    response(ok, const_cast<Ice::Byte*>(outParams.first),
+                                                    response(ok, const_cast<uint8_t*>(outParams.first),
                                                              static_cast<long>(outParams.second - outParams.first));
                                                 }
                                             },


### PR DESCRIPTION
This PR removes Ice::Byte and replaces it by `std::uint8_t`.