### PR TITLE
Add noexcept / final to OutgoingAsync classes

### DIFF
--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -33,8 +33,14 @@ public:
 
 protected:
 
-    virtual bool handleSent(bool, bool) = 0;
-    virtual bool handleException(std::exception_ptr) = 0;
+    // Returns true if handleInvokeSent handles sent callbacks.
+    virtual bool handleSent(bool done, bool alreadySent) noexcept = 0;
+
+    // Returns true if handleInvokeException handles exception callbacks.
+    virtual bool handleException(std::exception_ptr) noexcept = 0;
+
+    // Returns true if handleInvokeResponse handles response callbacks.
+    // This function can unmarshal the response and throw an exception.
     virtual bool handleResponse(bool) = 0;
 
     virtual void handleInvokeSent(bool, OutgoingAsyncBase*) const = 0;
@@ -256,13 +262,13 @@ public:
 
 protected:
 
-    virtual bool handleSent(bool, bool) override;
-    virtual bool handleException(std::exception_ptr) override;
-    virtual bool handleResponse(bool) override;
+    bool handleSent(bool, bool) noexcept final;
+    bool handleException(std::exception_ptr) noexcept final;
+    bool handleResponse(bool) final;
 
-    virtual void handleInvokeSent(bool, OutgoingAsyncBase*) const override;
-    virtual void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const override;
-    virtual void handleInvokeResponse(bool, OutgoingAsyncBase*) const override;
+    void handleInvokeSent(bool, OutgoingAsyncBase*) const final;
+    void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const final;
+    void handleInvokeResponse(bool, OutgoingAsyncBase*) const final;
 
     std::function<void(std::exception_ptr)> _exception;
     std::function<void(bool)> _sent;
@@ -278,42 +284,40 @@ public:
 
 protected:
 
-    std::promise<R> _promise;
-    std::function<void(bool)> _response;
-
-private:
-
-    virtual bool handleSent(bool, bool) override
+    bool handleSent(bool, bool) noexcept override
     {
         return false;
     }
 
-    virtual bool handleException(std::exception_ptr ex) override
+    bool handleException(std::exception_ptr ex) noexcept final
     {
         _promise.set_exception(ex);
         return false;
     }
 
-    virtual bool handleResponse(bool ok) override
+    bool handleResponse(bool ok) final
     {
         _response(ok);
         return false;
     }
 
-    virtual void handleInvokeSent(bool, OutgoingAsyncBase*) const override
+    void handleInvokeSent(bool, OutgoingAsyncBase*) const final
     {
         assert(false);
     }
 
-    virtual void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const override
+    void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const final
     {
         assert(false);
     }
 
-    virtual void handleInvokeResponse(bool, OutgoingAsyncBase*) const override
+    void handleInvokeResponse(bool, OutgoingAsyncBase*) const final
     {
         assert(false);
     }
+
+    std::promise<R> _promise;
+    std::function<void(bool)> _response;
 };
 
 template<typename T>
@@ -549,7 +553,7 @@ public:
         };
     }
 
-    virtual bool handleSent(bool done, bool) override
+    bool handleSent(bool done, bool) noexcept final
     {
         if(done)
         {

--- a/cpp/src/Ice/CommunicatorI.cpp
+++ b/cpp/src/Ice/CommunicatorI.cpp
@@ -41,7 +41,7 @@ CommunicatorFlushBatchAsync::CommunicatorFlushBatchAsync(const InstancePtr& inst
 void
 CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::CompressBatch compressBatch)
 {
-    class FlushBatch : public OutgoingAsyncBase
+    class FlushBatch final : public OutgoingAsyncBase
     {
     public:
 
@@ -75,32 +75,32 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
             return _parentObserver;
         }
 
-        virtual bool handleSent(bool, bool)
+        bool handleSent(bool, bool) noexcept final
         {
             return false;
         }
 
-        virtual bool handleException(std::exception_ptr)
+        bool handleException(std::exception_ptr) noexcept final
         {
             return false;
         }
 
-        virtual bool handleResponse(bool)
+        bool handleResponse(bool) final
         {
             return false;
         }
 
-        virtual void handleInvokeSent(bool, OutgoingAsyncBase*) const
+        void handleInvokeSent(bool, OutgoingAsyncBase*) const final
         {
             assert(false);
         }
 
-        virtual void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const
+        void handleInvokeException(std::exception_ptr, OutgoingAsyncBase*) const final
         {
             assert(false);
         }
 
-        virtual void handleInvokeResponse(bool, OutgoingAsyncBase*) const
+        void handleInvokeResponse(bool, OutgoingAsyncBase*) const final
         {
             assert(false);
         }

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -955,13 +955,13 @@ OutgoingAsync::throwUserException()
 }
 
 bool
-LambdaInvoke::handleSent(bool, bool alreadySent)
+LambdaInvoke::handleSent(bool, bool alreadySent) noexcept
 {
     return _sent != nullptr && !alreadySent; // Invoke the sent callback only if not already invoked.
 }
 
 bool
-LambdaInvoke::handleException(std::exception_ptr)
+LambdaInvoke::handleException(std::exception_ptr) noexcept
 {
     return _exception != nullptr; // Invoke the callback
 }

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -117,7 +117,7 @@ public:
 
     using ProxyFlushBatchAsync::ProxyFlushBatchAsync;
 
-    virtual bool handleSent(bool, bool) override
+    bool handleSent(bool, bool) noexcept override
     {
         this->_promise.set_value();
         return false;
@@ -219,7 +219,7 @@ public:
         };
     }
 
-    virtual bool handleSent(bool done, bool) override
+    bool handleSent(bool done, bool) noexcept override
     {
         if(done)
         {


### PR DESCRIPTION
This PR updates the handle{Invoke}{Sent|Exception|Response} functions.