### PR TITLE
Doxygen Fixes

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -897,7 +897,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -38,6 +38,7 @@ class Properties;
 
 }
 
+/// \cond INTERNAL
 namespace Ice
 {
 

--- a/cpp/include/Ice/Value.h
+++ b/cpp/include/Ice/Value.h
@@ -134,6 +134,7 @@ protected:
         Base::_iceReadImpl(is);
     }
 };
+/// \endcond
 
 }
 

--- a/cpp/include/IceUtil/Exception.h
+++ b/cpp/include/IceUtil/Exception.h
@@ -104,6 +104,8 @@ ICE_API std::ostream& operator<<(std::ostream&, const Exception&);
  * It implements ice_clone and ice_throw.
  * \headerfile Ice/Ice.h
  */
+// We generate a text graph, because the inheritance graph for this type has too many nodes.
+/// \inheritancegraph{TEXT}
 template<typename E, typename B = Exception>
 class ExceptionHelper : public B
 {

--- a/cpp/include/IceUtil/PopDisableWarnings.h
+++ b/cpp/include/IceUtil/PopDisableWarnings.h
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+/*! \file
+    \hideincludedbygraph
+*/
+
 // No pragma once as this file can be included several times in a translation
 // unit
 

--- a/cpp/include/IceUtil/PushDisableWarnings.h
+++ b/cpp/include/IceUtil/PushDisableWarnings.h
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+/*! \file
+    \hideincludedbygraph
+*/
+
 // No pragma once as this file can be included several times in a translation
 // unit
 

--- a/cpp/include/IceUtil/UndefSysMacros.h
+++ b/cpp/include/IceUtil/UndefSysMacros.h
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+/*! \file
+    \hideincludedbygraph
+*/
+
 #ifndef ICE_UTIL_UNDEF_SYS_MACROS_H
 #define ICE_UTIL_UNDEF_SYS_MACROS_H
 

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -907,7 +907,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which


### PR DESCRIPTION
This PR fixes some Doxygen warnings that were being ignoring in the builds,
and configured Doxygen to treat warnings and errors, so they'll cause the builds to fail in the future (in the good way).

These warnings were:
- some mismatched/missing `\cond` commands
- Doxygen generated graphs showing how files include each other.
Some of our 'utility' header files were included in so many places, we were getting warnings for them having too many graph nodes. I just disabled the graphs for those files, because nobody cares about them.
- The `ExceptionHelper` is a base class for ALOT of things. So we were getting a similar warning for too many nodes.
Since this is a type that we do actually care about, I set it to generate a text description, instead of a graph.
If we want, I can raise the max_node_limit to 114 (how many things inherit from this type).