### PR TITLE
Update / cleanup slice2cpp

### DIFF
--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -761,9 +761,9 @@ Slice::fixKwd(const string& name)
 }
 
 void
-Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, int typeCtx)
+Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op)
 {
-    writeMarshalUnmarshalParams(out, params, op, true, typeCtx);
+    writeMarshalUnmarshalParams(out, params, op, true, 0);
 }
 
 void

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -101,12 +101,10 @@ writeParamAllocateCode(Output& out, const TypePtr& type, bool optional, const st
 
 void
 writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const OperationPtr& op, bool marshal,
-                            bool prepend, int typeCtx, const string& customStream = "", const string& retP = "",
-                            const string& obj = "")
+                            bool prepend, int typeCtx, const string& customStream = "", const string& retP = "")
 {
     string prefix = prepend ? paramPrefix : "";
     string returnValueS = retP.empty() ? string("ret") : retP;
-    string objPrefix = obj.empty() ? obj : obj + ".";
 
     string stream = customStream;
     if(stream.empty())
@@ -152,22 +150,22 @@ writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const Oper
             if (tuple)
             {
                 auto index = std::distance(params.begin(), std::find(params.begin(), params.end(), *p)) + retOffset;
-                out << "::std::get<" + std::to_string(index) + ">(" + obj + ")";
+                out << "::std::get<" + std::to_string(index) + ">(v)";
             }
             else
             {
-                out << objPrefix + fixKwd(prefix + (*p)->name());
+                out << fixKwd(prefix + (*p)->name());
             }
         }
         if(op && op->returnType() && !op->returnIsOptional())
         {
             if (tuple)
             {
-                out << "::std::get<0>(" + obj + ")";
+                out << "::std::get<0>(v)";
             }
             else
             {
-                out << objPrefix + returnValueS;
+                out << returnValueS;
             }
         }
         out << epar << ";";
@@ -237,11 +235,11 @@ writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const Oper
                 {
                     if (tuple)
                     {
-                        out << "::std::get<0>(" + obj + ")";
+                        out << "::std::get<0>(v)";
                     }
                     else
                     {
-                        out << objPrefix + returnValueS;
+                        out << returnValueS;
                     }
                     checkReturnType = false;
                 }
@@ -249,22 +247,22 @@ writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const Oper
                 if (tuple)
                 {
                     auto index = std::distance(params.begin(), std::find(params.begin(), params.end(), *p)) + retOffset;
-                    out << "::std::get<" + std::to_string(index) + ">(" + obj + ")";
+                    out << "::std::get<" + std::to_string(index) + ">(v)";
                 }
                 else
                 {
-                    out << objPrefix + fixKwd(prefix + (*p)->name());
+                    out << fixKwd(prefix + (*p)->name());
                 }
             }
             if(checkReturnType)
             {
                 if (tuple)
                 {
-                    out << "::std::get<0>(" + obj + ")";
+                    out << "::std::get<0>(v)";
                 }
                 else
                 {
-                    out << objPrefix + returnValueS;
+                    out << returnValueS;
                 }
             }
         }
@@ -771,17 +769,15 @@ Slice::fixKwd(const string& name)
 }
 
 void
-Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, bool prepend, int typeCtx,
-                        const string& customStream, const string& retP)
+Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, int typeCtx)
 {
-    writeMarshalUnmarshalParams(out, params, op, true, prepend, typeCtx, customStream, retP);
+    writeMarshalUnmarshalParams(out, params, op, true, /*prepend*/ true, typeCtx, "");
 }
 
 void
-Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, bool prepend, int typeCtx,
-                          const string& customStream, const string& retP, const string& obj)
+Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, bool prepend, int typeCtx)
 {
-    writeMarshalUnmarshalParams(out, params, op, false, prepend, typeCtx, customStream, retP, obj);
+    writeMarshalUnmarshalParams(out, params, op, false, prepend, typeCtx, "", "");
 }
 
 void

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -505,7 +505,7 @@ Slice::inputTypeToString(const TypePtr& type, bool optional, const string& scope
         "const ::std::shared_ptr<::Ice::Value>&"
     };
 
-    typeCtx |= TypeContextInParam;
+    typeCtx |= (TypeContextAcceptViewParam | TypeContextAcceptArrayParam);
 
     if(optional)
     {
@@ -1012,7 +1012,7 @@ Slice::findMetaData(const StringList& metaData, int typeCtx)
             {
                 string ss = str.substr(prefix.size());
 
-                if(typeCtx & TypeContextInParam)
+                if(typeCtx & TypeContextAcceptViewParam)
                 {
                     if(ss.find("view-type:") == 0)
                     {
@@ -1025,7 +1025,7 @@ Slice::findMetaData(const StringList& metaData, int typeCtx)
                     return str.substr(pos + 1);
                 }
             }
-            else if(typeCtx & TypeContextInParam)
+            else if(typeCtx & TypeContextAcceptArrayParam)
             {
                 string ss = str.substr(prefix.size());
                 if(ss == "array")

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -100,11 +100,13 @@ writeParamAllocateCode(Output& out, const TypePtr& type, bool optional, const st
 }
 
 void
-writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const OperationPtr& op, bool marshal, int typeCtx)
+writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const OperationPtr& op, bool marshal)
 {
     const string returnValueS = "ret";
     const string stream = marshal ? "ostr" : "istr";
-    bool tuple = (typeCtx & TypeContextTuple) != 0;
+
+    // True when unmarshaling a tuple response.
+    bool tuple = !marshal && op && (params.size() + (op->returnType() ? 1 : 0)) > 1;
 
     //
     // Marshal non optional parameters.
@@ -763,13 +765,13 @@ Slice::fixKwd(const string& name)
 void
 Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op)
 {
-    writeMarshalUnmarshalParams(out, params, op, true, 0);
+    writeMarshalUnmarshalParams(out, params, op, true);
 }
 
 void
-Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, int typeCtx)
+Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op)
 {
-    writeMarshalUnmarshalParams(out, params, op, false, typeCtx);
+    writeMarshalUnmarshalParams(out, params, op, false);
 }
 
 void

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -775,8 +775,6 @@ Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const Operat
 void
 Slice::writeAllocateCode(Output& out, const ParamDeclList& params, const OperationPtr& op, const string& clScope, int typeCtx)
 {
-    const string returnValueS = "ret";
-
     for(ParamDeclList::const_iterator p = params.begin(); p != params.end(); ++p)
     {
         writeParamAllocateCode(out, (*p)->type(), (*p)->optional(), clScope, fixKwd(paramPrefix + (*p)->name()),
@@ -785,7 +783,7 @@ Slice::writeAllocateCode(Output& out, const ParamDeclList& params, const Operati
 
     if(op && op->returnType())
     {
-        writeParamAllocateCode(out, op->returnType(), op->returnIsOptional(), clScope, returnValueS, op->getMetaData(),
+        writeParamAllocateCode(out, op->returnType(), op->returnIsOptional(), clScope, "ret", op->getMetaData(),
                                typeCtx);
     }
 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -773,19 +773,13 @@ Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const Operat
 }
 
 void
-Slice::writeAllocateCode(Output& out, const ParamDeclList& params, const OperationPtr& op, bool prepend,
-                         const string& clScope, int typeCtx, const string& customRet)
+Slice::writeAllocateCode(Output& out, const ParamDeclList& params, const OperationPtr& op, const string& clScope, int typeCtx)
 {
-    string prefix = prepend ? paramPrefix : "";
-    string returnValueS = customRet;
-    if(returnValueS.empty())
-    {
-        returnValueS = "ret";
-    }
+    const string returnValueS = "ret";
 
     for(ParamDeclList::const_iterator p = params.begin(); p != params.end(); ++p)
     {
-        writeParamAllocateCode(out, (*p)->type(), (*p)->optional(), clScope, fixKwd(prefix + (*p)->name()),
+        writeParamAllocateCode(out, (*p)->type(), (*p)->optional(), clScope, fixKwd(paramPrefix + (*p)->name()),
                                (*p)->getMetaData(), typeCtx);
     }
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -1092,22 +1092,3 @@ Slice::inWstringModule(const SequencePtr& seq)
     }
     return false;
 }
-
-string
-Slice::getDataMemberRef(const DataMemberPtr& p)
-{
-    string name = fixKwd(p->name());
-    if(!p->optional())
-    {
-        return name;
-    }
-
-    if(dynamic_pointer_cast<Builtin>(p->type()))
-    {
-        return "*" + name;
-    }
-    else
-    {
-        return "(*" + name + ")";
-    }
-}

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -100,18 +100,10 @@ writeParamAllocateCode(Output& out, const TypePtr& type, bool optional, const st
 }
 
 void
-writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const OperationPtr& op, bool marshal,
-                            bool prepend, int typeCtx, const string& customStream = "", const string& retP = "")
+writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const OperationPtr& op, bool marshal, int typeCtx)
 {
-    string prefix = prepend ? paramPrefix : "";
-    string returnValueS = retP.empty() ? string("ret") : retP;
-
-    string stream = customStream;
-    if(stream.empty())
-    {
-        stream = marshal ? "ostr" : "istr";
-    }
-
+    const string returnValueS = "ret";
+    const string stream = marshal ? "ostr" : "istr";
     bool tuple = (typeCtx & TypeContextTuple) != 0;
 
     //
@@ -154,7 +146,7 @@ writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const Oper
             }
             else
             {
-                out << fixKwd(prefix + (*p)->name());
+                out << fixKwd(paramPrefix + (*p)->name());
             }
         }
         if(op && op->returnType() && !op->returnIsOptional())
@@ -251,7 +243,7 @@ writeMarshalUnmarshalParams(Output& out, const ParamDeclList& params, const Oper
                 }
                 else
                 {
-                    out << fixKwd(prefix + (*p)->name());
+                    out << fixKwd(paramPrefix + (*p)->name());
                 }
             }
             if(checkReturnType)
@@ -771,13 +763,13 @@ Slice::fixKwd(const string& name)
 void
 Slice::writeMarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, int typeCtx)
 {
-    writeMarshalUnmarshalParams(out, params, op, true, /*prepend*/ true, typeCtx, "");
+    writeMarshalUnmarshalParams(out, params, op, true, typeCtx);
 }
 
 void
-Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, bool prepend, int typeCtx)
+Slice::writeUnmarshalCode(Output& out, const ParamDeclList& params, const OperationPtr& op, int typeCtx)
 {
-    writeMarshalUnmarshalParams(out, params, op, false, prepend, typeCtx, "", "");
+    writeMarshalUnmarshalParams(out, params, op, false, typeCtx);
 }
 
 void

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -22,8 +22,8 @@ void printHeader(::IceUtilInternal::Output&);
 void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
-const int TypeContextAcceptArrayParam = 1;
-const int TypeContextAcceptViewParam = 2;
+const int TypeContextUnmarshalParamZeroCopy = 1;
+const int TypeContextMarshalParam = 2;
 const int TypeContextUseWstring = 4;
 
 bool isMovable(const TypePtr&);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -64,7 +64,6 @@ bool findMetaData(const std::string&, const StringList&, std::string&);
 std::string findMetaData(const StringList&, int = 0);
 bool inWstringModule(const SequencePtr&);
 
-std::string getDataMemberRef(const DataMemberPtr&);
 }
 
 #endif

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -23,10 +23,7 @@ void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
 const int TypeContextInParam = 1;
-const int TypeContextArrayParam = 2;
-const int TypeContextViewParam = 4;
 const int TypeContextUseWstring = 16;
-const int TypeContextTuple = 32;
 
 bool isMovable(const TypePtr&);
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -23,6 +23,8 @@ void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
 const int TypeContextInParam = 1;
+const int TypeContextArrayParam = 2;
+const int TypeContextViewParam = 4;
 const int TypeContextUseWstring = 16;
 const int TypeContextTuple = 32;
 
@@ -46,10 +48,6 @@ std::string opFormatTypeToString(const OperationPtr&);
 
 std::string fixKwd(const std::string&);
 
-void writeMarshalUnmarshalCode(::IceUtilInternal::Output&, const TypePtr&, bool, int, const std::string&,
-                               bool, const StringList& = StringList(), int = 0, const std::string& = "",
-                               bool = true, const std::string& = "");
-
 void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool,
                       int = 0, const std::string& = "", const std::string& = "");
 void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, int = 0,
@@ -57,7 +55,6 @@ void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const 
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, const std::string&,
                        int = 0, const std::string& = "");
 
-void writeMarshalUnmarshalDataMemberInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, bool);
 void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 void writeStreamHelpers(::IceUtilInternal::Output&, const ContainedPtr&, DataMemberList, bool);
 void writeIceTuple(::IceUtilInternal::Output&, DataMemberList, int);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -49,7 +49,7 @@ std::string opFormatTypeToString(const OperationPtr&);
 std::string fixKwd(const std::string&);
 
 void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&);
-void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
+void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&);
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, const std::string&, int);
 
 void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberList&, bool, bool);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -48,7 +48,7 @@ std::string opFormatTypeToString(const OperationPtr&);
 
 std::string fixKwd(const std::string&);
 
-void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
+void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&);
 void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, const std::string&, int);
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -29,11 +29,18 @@ const int TypeContextTuple = 32;
 bool isMovable(const TypePtr&);
 
 std::string getUnqualified(const std::string&, const std::string&);
-std::string typeToString(const TypePtr&, const std::string& = "", const StringList& = StringList(), int = 0);
+
+// Gets the C++ type for a Slice parameter or field.
 std::string typeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
-std::string returnTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+
+// TODO: find a better name.
+// Gets the C++ type for a Slice parameter to be marshaled.
 std::string inputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+
+// TODO: find a better name.
+// Gets the C++ type for a Slice out parameter when mapped to a C++ out parameter.
 std::string outputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+
 std::string operationModeToString(Operation::Mode);
 std::string opFormatTypeToString(const OperationPtr&);
 
@@ -50,7 +57,6 @@ void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const 
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, const std::string&,
                        int = 0, const std::string& = "");
 
-void writeEndCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool = false);
 void writeMarshalUnmarshalDataMemberInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberPtr&, bool);
 void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 void writeStreamHelpers(::IceUtilInternal::Output&, const ContainedPtr&, DataMemberList, bool);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -23,9 +23,6 @@ void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
 const int TypeContextInParam = 1;
-const int TypeContextAMIEnd = 2;
-const int TypeContextAMIPrivateEnd = 4;
-const int TypeContextAMICallPrivateEnd = 8;
 const int TypeContextUseWstring = 16;
 const int TypeContextTuple = 32;
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -48,10 +48,8 @@ std::string opFormatTypeToString(const OperationPtr&);
 
 std::string fixKwd(const std::string&);
 
-void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool,
-                      int = 0, const std::string& = "", const std::string& = "");
-void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, int = 0,
-                        const std::string& = "", const std::string& = "", const std::string& = "");
+void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
+void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, int = 0);
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, const std::string&,
                        int = 0, const std::string& = "");
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -50,8 +50,7 @@ std::string fixKwd(const std::string&);
 
 void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
 void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
-void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, const std::string&,
-                       int = 0, const std::string& = "");
+void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, const std::string&, int);
 
 void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 void writeStreamHelpers(::IceUtilInternal::Output&, const ContainedPtr&, DataMemberList, bool);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -49,7 +49,7 @@ std::string opFormatTypeToString(const OperationPtr&);
 std::string fixKwd(const std::string&);
 
 void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
-void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, int = 0);
+void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, int = 0);
 void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, bool, const std::string&,
                        int = 0, const std::string& = "");
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -7,6 +7,7 @@
 
 #include <Slice/Parser.h>
 #include <IceUtil/OutputUtil.h>
+#include "TypeContext.h"
 
 namespace Slice
 {
@@ -22,24 +23,20 @@ void printHeader(::IceUtilInternal::Output&);
 void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
-const int TypeContextUnmarshalParamZeroCopy = 1;
-const int TypeContextMarshalParam = 2;
-const int TypeContextUseWstring = 4;
-
 bool isMovable(const TypePtr&);
 
 std::string getUnqualified(const std::string&, const std::string&);
 
 // Gets the C++ type for a Slice parameter or field.
-std::string typeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+std::string typeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), TypeContext = TypeContext::None);
 
 // TODO: find a better name.
 // Gets the C++ type for a Slice parameter to be marshaled.
-std::string inputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+std::string inputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), TypeContext = TypeContext::None);
 
 // TODO: find a better name.
 // Gets the C++ type for a Slice out parameter when mapped to a C++ out parameter.
-std::string outputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), int = 0);
+std::string outputTypeToString(const TypePtr&, bool, const std::string& = "", const StringList& = StringList(), TypeContext = TypeContext::None);
 
 std::string operationModeToString(Operation::Mode);
 std::string opFormatTypeToString(const OperationPtr&);
@@ -48,15 +45,15 @@ std::string fixKwd(const std::string&);
 
 void writeMarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&);
 void writeUnmarshalCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&);
-void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, const std::string&, int);
+void writeAllocateCode(::IceUtilInternal::Output&, const ParamDeclList&, const OperationPtr&, const std::string&, TypeContext);
 
 void writeMarshalUnmarshalAllInHolder(IceUtilInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 void writeStreamHelpers(::IceUtilInternal::Output&, const ContainedPtr&, DataMemberList, bool);
-void writeIceTuple(::IceUtilInternal::Output&, DataMemberList, int);
+void writeIceTuple(::IceUtilInternal::Output&, DataMemberList, TypeContext);
 
 bool findMetaData(const std::string&, const ClassDeclPtr&, std::string&);
 bool findMetaData(const std::string&, const StringList&, std::string&);
-std::string findMetaData(const StringList&, int = 0);
+std::string findMetaData(const StringList&, TypeContext = TypeContext::None);
 bool inWstringModule(const SequencePtr&);
 
 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -22,8 +22,9 @@ void printHeader(::IceUtilInternal::Output&);
 void printVersionCheck(::IceUtilInternal::Output&);
 void printDllExportStuff(::IceUtilInternal::Output&, const std::string&);
 
-const int TypeContextInParam = 1;
-const int TypeContextUseWstring = 16;
+const int TypeContextAcceptArrayParam = 1;
+const int TypeContextAcceptViewParam = 2;
+const int TypeContextUseWstring = 4;
 
 bool isMovable(const TypePtr&);
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1964,7 +1964,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << "," << nl << "[](" << getUnqualified("::Ice::InputStream*", interfaceScope) << " istr)";
         C << sb;
 
-        writeAllocateCode(C, outParams, p, true, interfaceScope, _useWstring);
+        writeAllocateCode(C, outParams, p, interfaceScope, _useWstring);
         writeUnmarshalCode(C, outParams, p, _useWstring);
 
         if(p->returnsClasses(false))
@@ -3137,7 +3137,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     if(!inParams.empty())
     {
         C << nl << "auto istr = inS.startReadParams();";
-        writeAllocateCode(C, inParams, 0, true, interfaceScope, _useWstring | TypeContextInParam);
+        writeAllocateCode(C, inParams, 0, interfaceScope, _useWstring | TypeContextInParam);
         writeUnmarshalCode(C, inParams, 0, _useWstring | TypeContextInParam);
         if(p->sendsClasses(false))
         {
@@ -3162,7 +3162,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         }
         else
         {
-            writeAllocateCode(C, outParams, 0, true, interfaceScope, _useWstring);
+            writeAllocateCode(C, outParams, 0, interfaceScope, _useWstring);
             if(ret)
             {
                 C << nl << retS << " ret = ";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1646,7 +1646,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     vector<string> inParamsImpl;
 
     vector<string> futureOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring);
-    vector<string> lambdaOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring | TypeContextInParam);
+    vector<string> lambdaOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring | TypeContextAcceptArrayParam);
 
     const string futureImplPrefix = "_iceI_";
     const string lambdaImplPrefix = futureOutParams == lambdaOutParams ? "_iceI_" : "_iceIL_";
@@ -1785,7 +1785,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     const string responseParam = escapeParam(inParams, "response");
     const string exParam = escapeParam(inParams, "ex");
     const string sentParam = escapeParam(inParams, "sent");
-    const string lambdaResponse = createLambdaResponse(p, _useWstring | TypeContextInParam);
+    const string lambdaResponse = createLambdaResponse(p, _useWstring | TypeContextAcceptArrayParam);
 
     H << sp;
     if(comment)
@@ -2998,10 +2998,9 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 
         if(!isOutParam)
         {
-            // TODO: We need the TypeContextInParam for the view types.
             params.push_back(typeToString(type, (*q)->optional(), interfaceScope, (*q)->getMetaData(),
-                                          _useWstring | TypeContextInParam) + " " + paramName);
-            args.push_back(condMove(isMovable(type) && !isOutParam, paramPrefix + (*q)->name()));
+                                          _useWstring | TypeContextAcceptArrayParam) + " " + paramName);
+            args.push_back(condMove(isMovable(type), paramPrefix + (*q)->name()));
         }
         else
         {
@@ -3137,7 +3136,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     if(!inParams.empty())
     {
         C << nl << "auto istr = inS.startReadParams();";
-        writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContextInParam);
+        writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContextAcceptArrayParam);
         writeUnmarshalCode(C, inParams, nullptr);
         if(p->sendsClasses(false))
         {
@@ -3162,7 +3161,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         }
         else
         {
-            writeAllocateCode(C, outParams, 0, interfaceScope, _useWstring);
+            writeAllocateCode(C, outParams, nullptr, interfaceScope, _useWstring);
             if(ret)
             {
                 C << nl << retS << " ret = ";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1945,7 +1945,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << sb;
         C << nl << returnT << " v;";
 
-        writeUnmarshalCode(C, outParams, p, _useWstring | TypeContextTuple);
+        writeUnmarshalCode(C, outParams, p, TypeContextTuple);
 
         if(p->returnsClasses(false))
         {
@@ -1965,7 +1965,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << sb;
 
         writeAllocateCode(C, outParams, p, interfaceScope, _useWstring);
-        writeUnmarshalCode(C, outParams, p, _useWstring);
+        writeUnmarshalCode(C, outParams, p);
 
         if(p->returnsClasses(false))
         {
@@ -3137,8 +3137,8 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     if(!inParams.empty())
     {
         C << nl << "auto istr = inS.startReadParams();";
-        writeAllocateCode(C, inParams, 0, interfaceScope, _useWstring | TypeContextInParam);
-        writeUnmarshalCode(C, inParams, 0, _useWstring | TypeContextInParam);
+        writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContextInParam);
+        writeUnmarshalCode(C, inParams, nullptr);
         if(p->sendsClasses(false))
         {
             C << nl << "istr->readPendingValues();";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -193,7 +193,7 @@ writeInParamsLambda(IceUtilInternal::Output& C, const OperationPtr& p, const Par
     {
         C << "[&](" << getUnqualified("::Ice::OutputStream*", scope) << " ostr)";
         C << sb;
-        writeMarshalCode(C, inParams, nullptr, TypeContextInParam);
+        writeMarshalCode(C, inParams, nullptr);
         if(p->sendsClasses(false))
         {
             C << nl << "ostr->writePendingValues();";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -180,6 +180,7 @@ toDllMemberExport(const string& dllExport)
     }
 }
 
+// Marshals the parameters of an outgoing request.
 void
 writeInParamsLambda(IceUtilInternal::Output& C, const OperationPtr& p, const ParamDeclList& inParams,
                     const string& scope)
@@ -192,7 +193,7 @@ writeInParamsLambda(IceUtilInternal::Output& C, const OperationPtr& p, const Par
     {
         C << "[&](" << getUnqualified("::Ice::OutputStream*", scope) << " ostr)";
         C << sb;
-        writeMarshalCode(C, inParams, 0, true, TypeContextInParam);
+        writeMarshalCode(C, inParams, nullptr, TypeContextInParam);
         if(p->sendsClasses(false))
         {
             C << nl << "ostr->writePendingValues();";
@@ -1943,8 +1944,8 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << "," << nl << "[](" << getUnqualified("::Ice::InputStream*", interfaceScope) << " istr)";
         C << sb;
         C << nl << returnT << " v;";
-        // The "ret" parameter (the one before last) is not used with tuples.
-        writeUnmarshalCode(C, outParams, p, false, _useWstring | TypeContextTuple, "", "", "v");
+
+        writeUnmarshalCode(C, outParams, p, false, _useWstring | TypeContextTuple);
 
         if(p->returnsClasses(false))
         {
@@ -3082,7 +3083,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C.dec();
         C << sb;
         C << nl << "ostr->startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";
-        writeMarshalCode(C, outParams, p, true, 0, "ostr");
+        writeMarshalCode(C, outParams, p);
         if(p->returnsClasses(false))
         {
             C << nl << "ostr->writePendingValues();";
@@ -3183,7 +3184,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             if(ret || !outParams.empty())
             {
                 C << nl << "auto ostr = inS.startWriteParams();";
-                writeMarshalCode(C, outParams, p, true);
+                writeMarshalCode(C, outParams, p);
                 if(p->returnsClasses(false))
                 {
                     C << nl << "ostr->writePendingValues();";
@@ -3205,7 +3206,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             C << nl << "auto responseCB = [inA]" << spar << responseParamsDecl << epar;
             C << sb;
             C << nl << "auto ostr = inA->startWriteParams();";
-            writeMarshalCode(C, outParams, p, true);
+            writeMarshalCode(C, outParams, p);
             if(p->returnsClasses(false))
             {
                 C << nl << "ostr->writePendingValues();";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1646,7 +1646,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     vector<string> inParamsImpl;
 
     vector<string> futureOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring);
-    vector<string> lambdaOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring | TypeContextAcceptArrayParam);
+    vector<string> lambdaOutParams = createOutgoingAsyncParams(p, interfaceScope, _useWstring | TypeContextUnmarshalParamZeroCopy);
 
     const string futureImplPrefix = "_iceI_";
     const string lambdaImplPrefix = futureOutParams == lambdaOutParams ? "_iceI_" : "_iceIL_";
@@ -1785,7 +1785,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     const string responseParam = escapeParam(inParams, "response");
     const string exParam = escapeParam(inParams, "ex");
     const string sentParam = escapeParam(inParams, "sent");
-    const string lambdaResponse = createLambdaResponse(p, _useWstring | TypeContextAcceptArrayParam);
+    const string lambdaResponse = createLambdaResponse(p, _useWstring | TypeContextUnmarshalParamZeroCopy);
 
     H << sp;
     if(comment)
@@ -2999,7 +2999,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         if(!isOutParam)
         {
             params.push_back(typeToString(type, (*q)->optional(), interfaceScope, (*q)->getMetaData(),
-                                          _useWstring | TypeContextAcceptArrayParam) + " " + paramName);
+                                          _useWstring | TypeContextUnmarshalParamZeroCopy) + " " + paramName);
             args.push_back(condMove(isMovable(type), paramPrefix + (*q)->name()));
         }
         else
@@ -3136,7 +3136,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     if(!inParams.empty())
     {
         C << nl << "auto istr = inS.startReadParams();";
-        writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContextAcceptArrayParam);
+        writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContextUnmarshalParamZeroCopy);
         writeUnmarshalCode(C, inParams, nullptr);
         if(p->sendsClasses(false))
         {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1934,7 +1934,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
     C << "," << nl;
     throwUserExceptionLambda(C, p->throws(), interfaceScope);
 
-    if(outgoingAsyncParams.size() > 1)
+    if (outgoingAsyncParams.size() > 1)
     {
         //
         // Generate a read method if there are more than one ret/out parameter. If there's
@@ -1945,7 +1945,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << sb;
         C << nl << returnT << " v;";
 
-        writeUnmarshalCode(C, outParams, p, TypeContextTuple);
+        writeUnmarshalCode(C, outParams, p);
 
         if(p->returnsClasses(false))
         {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -574,7 +574,7 @@ createOutgoingAsyncParams(const OperationPtr& p, const string& scope, int typeCo
     TypePtr ret = p->returnType();
     if (ret)
     {
-        elements.push_back(returnTypeToString(ret, p->returnIsOptional(), scope, p->getMetaData(), typeContext));
+        elements.push_back(typeToString(ret, p->returnIsOptional(), scope, p->getMetaData(), typeContext));
     }
     for (const auto& param : p->outParameters())
     {
@@ -1353,7 +1353,7 @@ Slice::Gen::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
     string scope = fixKwd(p->scope());
     TypePtr type = p->type();
     int typeCtx = _useWstring;
-    string s = typeToString(type, scope, p->typeMetaData(), typeCtx);
+    string s = typeToString(type, false, scope, p->typeMetaData(), typeCtx);
     StringList metaData = p->getMetaData();
 
     string seqType = findMetaData(metaData, _useWstring);
@@ -1388,8 +1388,8 @@ Slice::Gen::ForwardDeclVisitor::visitDictionary(const DictionaryPtr& p)
         //
         TypePtr keyType = p->keyType();
         TypePtr valueType = p->valueType();
-        string ks = typeToString(keyType, scope, p->keyMetaData(), typeCtx);
-        string vs = typeToString(valueType, scope, p->valueMetaData(), typeCtx);
+        string ks = typeToString(keyType, false, scope, p->keyMetaData(), typeCtx);
+        string vs = typeToString(valueType, false, scope, p->valueMetaData(), typeCtx);
 
         H << nl << "using " << name << " = ::std::map<" << ks << ", " << vs << ">;";
     }
@@ -1409,7 +1409,7 @@ Slice::Gen::ForwardDeclVisitor::visitConst(const ConstPtr& p)
     H << sp;
     writeDocSummary(H, p);
     H << nl << (isConstexprType(p->type()) ? "constexpr " : "const ")
-      << typeToString(p->type(), scope, p->typeMetaData(), _useWstring) << " " << fixKwd(p->name())
+      << typeToString(p->type(), false, scope, p->typeMetaData(), _useWstring) << " " << fixKwd(p->name())
       << " = ";
     writeConstantValue(H, p->type(), p->valueType(), p->value(), _useWstring, p->typeMetaData(),
                        scope);
@@ -1632,8 +1632,8 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     TypePtr ret = p->returnType();
 
     bool retIsOpt = p->returnIsOptional();
-    string retS = returnTypeToString(ret, retIsOpt, interfaceScope, p->getMetaData(), _useWstring);
-    string retSImpl = returnTypeToString(ret, retIsOpt, "", p->getMetaData(), _useWstring);
+    string retS = ret ? typeToString(ret, retIsOpt, interfaceScope, p->getMetaData(), _useWstring) : "void";
+    string retSImpl = ret ? typeToString(ret, retIsOpt, "", p->getMetaData(), _useWstring) : "void";
 
     // All parameters
     vector<string> paramsDecl;
@@ -1867,8 +1867,8 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
     TypePtr ret = p->returnType();
 
     bool retIsOpt = p->returnIsOptional();
-    string retS = returnTypeToString(ret, retIsOpt, interfaceScope, p->getMetaData(), _useWstring);
-    string retSImpl = returnTypeToString(ret, retIsOpt, "", p->getMetaData(), _useWstring);
+    string retS = ret ? typeToString(ret, retIsOpt, interfaceScope, p->getMetaData(), _useWstring) : "void";
+    string retSImpl = ret ? typeToString(ret, retIsOpt, "", p->getMetaData(), _useWstring) : "void";
 
     vector<string> inParamsS;
     vector<string> inParamsImplDecl;
@@ -2976,7 +2976,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     }
 
     string retS;
-    if(amd)
+    if (amd || !ret)
     {
         retS = "void";
     }
@@ -2986,7 +2986,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     }
     else
     {
-        retS = returnTypeToString(ret, p->returnIsOptional(), interfaceScope, p->getMetaData(), _useWstring);
+        retS = typeToString(ret, p->returnIsOptional(), interfaceScope, p->getMetaData(), _useWstring);
     }
 
     for(ParamDeclList::iterator q = paramList.begin(); q != paramList.end(); ++q)

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1945,7 +1945,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << sb;
         C << nl << returnT << " v;";
 
-        writeUnmarshalCode(C, outParams, p, false, _useWstring | TypeContextTuple);
+        writeUnmarshalCode(C, outParams, p, _useWstring | TypeContextTuple);
 
         if(p->returnsClasses(false))
         {
@@ -1965,7 +1965,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << sb;
 
         writeAllocateCode(C, outParams, p, true, interfaceScope, _useWstring);
-        writeUnmarshalCode(C, outParams, p, true, _useWstring);
+        writeUnmarshalCode(C, outParams, p, _useWstring);
 
         if(p->returnsClasses(false))
         {
@@ -3138,7 +3138,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     {
         C << nl << "auto istr = inS.startReadParams();";
         writeAllocateCode(C, inParams, 0, true, interfaceScope, _useWstring | TypeContextInParam);
-        writeUnmarshalCode(C, inParams, 0, true, _useWstring | TypeContextInParam);
+        writeUnmarshalCode(C, inParams, 0, _useWstring | TypeContextInParam);
         if(p->sendsClasses(false))
         {
             C << nl << "istr->readPendingValues();";

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -7,6 +7,7 @@
 
 #include "Slice/Parser.h"
 #include "IceUtil/OutputUtil.h"
+#include "TypeContext.h"
 
 namespace Slice
 {
@@ -30,8 +31,8 @@ public:
     void generate(const UnitPtr&);
     void closeOutput();
 
-    static int setUseWstring(ContainedPtr, std::list<int>&, int);
-    static int resetUseWstring(std::list<int>&);
+    static TypeContext setUseWstring(ContainedPtr, std::list<TypeContext>&, TypeContext);
+    static TypeContext resetUseWstring(std::list<TypeContext>&);
 
 private:
 
@@ -90,8 +91,8 @@ private:
 
         ::IceUtilInternal::Output& H;
 
-        int _useWstring;
-        std::list<int> _useWstringHist;
+        TypeContext _useWstring;
+        std::list<TypeContext> _useWstringHist;
     };
 
     // Generates the code that registers the default class and exception factories.
@@ -137,8 +138,8 @@ private:
         ::IceUtilInternal::Output& C;
 
         std::string _dllExport;
-        int _useWstring;
-        std::list<int> _useWstringHist;
+        TypeContext _useWstring;
+        std::list<TypeContext> _useWstringHist;
     };
 
     // Generates code for definitions with data members - structs, classes and exceptions.
@@ -172,8 +173,8 @@ private:
         std::string _dllClassExport;
         std::string _dllMemberExport;
         bool _doneStaticSymbol;
-        int _useWstring;
-        std::list<int> _useWstringHist;
+        TypeContext _useWstring;
+        std::list<TypeContext> _useWstringHist;
     };
 
     // Generates the server-side classes that applications use to implement Ice objects.
@@ -196,8 +197,8 @@ private:
         ::IceUtilInternal::Output& C;
 
         std::string _dllExport;
-        int _useWstring;
-        std::list<int> _useWstringHist;
+        TypeContext _useWstring;
+        std::list<TypeContext> _useWstringHist;
     };
 
     // Generates internal StreamHelper template specializations for enums, structs, classes and exceptions.

--- a/cpp/src/slice2cpp/TypeContext.h
+++ b/cpp/src/slice2cpp/TypeContext.h
@@ -1,0 +1,36 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#ifndef TYPE_CONTEXT_H
+#define TYPE_CONTEXT_H
+
+#include <cstdint>
+#include <type_traits>
+
+namespace Slice
+{
+    enum class TypeContext : std::uint8_t
+    {
+        None = 0,
+        UseWstring = 1,
+        MarshalParam = 2,
+        UnmarshalParamZeroCopy = 4
+    };
+
+    inline constexpr TypeContext operator|(TypeContext lhs, TypeContext rhs) noexcept
+    {
+        return static_cast<TypeContext>(
+            static_cast<std::underlying_type_t<TypeContext>>(lhs) |
+            static_cast<std::underlying_type_t<TypeContext>>(rhs));
+    }
+
+    inline constexpr TypeContext operator&(TypeContext lhs, TypeContext rhs) noexcept
+    {
+        return static_cast<TypeContext>(
+            static_cast<std::underlying_type_t<TypeContext>>(lhs) &
+            static_cast<std::underlying_type_t<TypeContext>>(rhs));
+    }
+}
+
+#endif

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -130,7 +130,7 @@ InitialI::opDoubleAsync(optional<double> p1,
 
 void
 InitialI::opStringAsync(optional<::std::string> p1,
-                             ::std::function<void(const optional<::std::string>&, const optional<::std::string>&)> response,
+                             ::std::function<void(const optional<::std::string_view>&, const optional<::std::string_view>&)> response,
                              ::std::function<void(::std::exception_ptr)>, const Ice::Current&)
 {
     response(p1, p1);

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -61,7 +61,7 @@ public:
                                ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
     virtual void opStringAsync(std::optional<::std::string>,
-                               ::std::function<void(const std::optional<::std::string>&, const std::optional<::std::string>&)>,
+                               ::std::function<void(const std::optional<::std::string_view>&, const std::optional<::std::string_view>&)>,
                                ::std::function<void(::std::exception_ptr)>, const Ice::Current&) override;
 
     virtual void opMyEnumAsync(std::optional<::Test::MyEnum>,


### PR DESCRIPTION
This PR converts the TypeContext into an enum, removes several TypeContext values, and split "InParam" into 2 values (MarshalParam and UnmarshalParamZeroCopy).

It also updates the mapping for Slice optional string parameter: it's now mapped to a std::optional<string_view> when marshaled.

Fixes #1849.
Fixes #1856.