### PR TITLE
Remove IceInternal::getSystemErrno

### DIFF
--- a/cpp/include/Ice/Config.h
+++ b/cpp/include/Ice/Config.h
@@ -30,22 +30,4 @@
 #   include <dispatch/dispatch.h>
 #endif
 
-//
-// Define the Ice and IceInternal namespace, so that we can use the following
-// everywhere in our code:
-//
-// using namespace Ice;
-// using namespace IceInternal;
-//
-namespace Ice
-{
-}
-
-namespace IceInternal
-{
-
-ICE_API int getSystemErrno();
-
-}
-
 #endif

--- a/cpp/include/Ice/LocalException.h
+++ b/cpp/include/Ice/LocalException.h
@@ -1539,7 +1539,7 @@ public:
      * @param file The file name in which the exception was raised, typically __FILE__.
      * @param line The line number at which the exception was raised, typically __LINE__.
      */
-    SyscallException(const char *file, int line);
+    ICE_MEMBER(ICE_API) SyscallException(const char *file, int line);
 
     /**
      * One-shot constructor to initialize all data members.

--- a/cpp/include/Ice/LocalException.h
+++ b/cpp/include/Ice/LocalException.h
@@ -1535,12 +1535,11 @@ public:
 
     /**
      * The file and line number are required for all local exceptions.
+     * The error code is filled automatically with the value of the current error code.
      * @param file The file name in which the exception was raised, typically __FILE__.
      * @param line The line number at which the exception was raised, typically __LINE__.
      */
-    SyscallException(const char* file, int line) : LocalExceptionHelper<SyscallException, LocalException>(file, line)
-    {
-    }
+    SyscallException(const char *file, int line);
 
     /**
      * One-shot constructor to initialize all data members.
@@ -1710,24 +1709,14 @@ public:
     FileException(const FileException&) = default;
 
     /**
-     * The file and line number are required for all local exceptions.
-     * @param file The file name in which the exception was raised, typically __FILE__.
-     * @param line The line number at which the exception was raised, typically __LINE__.
-     */
-    FileException(const char* file, int line) : LocalExceptionHelper<FileException, SyscallException>(file, line)
-    {
-    }
-
-    /**
      * One-shot constructor to initialize all data members.
      * The file and line number are required for all local exceptions.
      * @param file The file name in which the exception was raised, typically __FILE__.
      * @param line The line number at which the exception was raised, typically __LINE__.
-     * @param error The error number describing the system exception.
      * @param path The path of the file responsible for the error.
      */
-    FileException(const char* file, int line, int error, const ::std::string& path) :
-        LocalExceptionHelper<FileException, SyscallException>(file, line, error),
+    FileException(const char* file, int line, const ::std::string& path) :
+        LocalExceptionHelper<FileException, SyscallException>(file, line),
         path(path)
     {
     }

--- a/cpp/include/IceUtil/Exception.h
+++ b/cpp/include/IceUtil/Exception.h
@@ -184,33 +184,6 @@ private:
 };
 
 /**
- * This exception indicates the failure of a system call.
- * \headerfile Ice/Ice.h
- */
-class ICE_API SyscallException : public ExceptionHelper<SyscallException>
-{
-public:
-
-    SyscallException(const char*, int, int);
-
-    virtual std::string ice_id() const;
-    virtual void ice_print(std::ostream&) const;
-
-    /**
-     * Provides the error number returned by the system call.
-     * @return The error number.
-     */
-    int error() const;
-
-private:
-
-    const int _error;
-};
-
-template<typename E>
-using SyscallExceptionHelper = ExceptionHelper<E, SyscallException>;
-
-/**
  * This exception indicates the failure to lock a file.
  * \headerfile Ice/Ice.h
  */

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -356,6 +356,17 @@ Ice::OperationNotExistException::ice_print(ostream& out) const
     printFailedRequestData(out, *this);
 }
 
+Ice::SyscallException::SyscallException(const char* file, int line) :
+    LocalExceptionHelper<SyscallException, LocalException>(file, line),
+#ifdef _WIN32
+    error(GetLastError())
+#else
+    error(errno)
+#endif
+{
+
+}
+
 void
 Ice::SyscallException::ice_print(ostream& out) const
 {

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -946,7 +946,7 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                     FILE* file = IceUtilInternal::freopen(stdOutFilename, "a", stdout);
                     if(file == 0)
                     {
-                        throw FileException(__FILE__, __LINE__, getSystemErrno(), stdOutFilename);
+                        throw FileException(__FILE__, __LINE__, stdOutFilename);
                     }
                 }
 
@@ -955,7 +955,7 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                     FILE* file = IceUtilInternal::freopen(stdErrFilename, "a", stderr);
                     if(file == 0)
                     {
-                        throw FileException(__FILE__, __LINE__, getSystemErrno(), stdErrFilename);
+                        throw FileException(__FILE__, __LINE__, stdErrFilename);
                     }
                 }
 
@@ -995,17 +995,17 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
 
                     if(setgid(pw->pw_gid) == -1)
                     {
-                        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+                        throw SyscallException(__FILE__, __LINE__);
                     }
 
                     if(initgroups(pw->pw_name, static_cast<int>(pw->pw_gid)) == -1)
                     {
-                        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+                        throw SyscallException(__FILE__, __LINE__);
                     }
 
                     if(setuid(pw->pw_uid) == -1)
                     {
-                        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+                        throw SyscallException(__FILE__, __LINE__);
                     }
                 }
 #endif

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -55,20 +55,6 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-#ifdef _WIN32
-int
-IceInternal::getSystemErrno()
-{
-    return GetLastError();
-}
-#else
-int
-IceInternal::getSystemErrno()
-{
-    return errno;
-}
-#endif
-
 namespace
 {
 
@@ -2063,7 +2049,7 @@ IceInternal::createPipe(SOCKET fds[2])
 
     if(::pipe(fds) != 0)
     {
-        throw SyscallException(__FILE__, __LINE__, getSocketErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     try

--- a/cpp/src/Ice/PropertiesI.cpp
+++ b/cpp/src/Ice/PropertiesI.cpp
@@ -393,7 +393,7 @@ Ice::PropertiesI::load(const std::string& file)
         ifstream in(IceUtilInternal::streamFilename(file).c_str());
         if(!in)
         {
-            throw FileException(__FILE__, __LINE__, getSystemErrno(), file);
+            throw FileException(__FILE__, __LINE__, file);
         }
 
         string line;

--- a/cpp/src/Ice/SHA1.cpp
+++ b/cpp/src/Ice/SHA1.cpp
@@ -6,7 +6,7 @@
 
 #if defined(_WIN32)
 #   include <Wincrypt.h>
-#   include <IceUtil/Exception.h>
+#   include <Ice/LocalException.h>
 #elif defined(__APPLE__)
 #   include <CommonCrypto/CommonDigest.h>
 #else
@@ -16,7 +16,6 @@
 #endif
 
 using namespace std;
-using namespace IceUtil;
 
 namespace IceInternal
 {

--- a/cpp/src/Ice/SHA1.cpp
+++ b/cpp/src/Ice/SHA1.cpp
@@ -64,12 +64,12 @@ IceInternal::SHA1::Hasher::Hasher() :
 {
     if(!CryptAcquireContext(&_ctx, 0, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__, GetLastError());
+        throw IceUtil::SyscallException(__FILE__, __LINE__);
     }
 
     if(!CryptCreateHash(_ctx, CALG_SHA1, 0, 0, &_hash))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__, GetLastError());
+        throw IceUtil::SyscallException(__FILE__, __LINE__);
     }
 }
 
@@ -103,7 +103,7 @@ IceInternal::SHA1::Hasher::update(const unsigned char* data, size_t length)
 #if defined(_WIN32)
     if(!CryptHashData(_hash, data, static_cast<DWORD>(length), 0))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__, GetLastError());
+        throw IceUtil::SyscallException(__FILE__, __LINE__);
     }
 #elif defined(__APPLE__)
     CC_SHA1_Update(&_ctx, reinterpret_cast<const void*>(data), static_cast<CC_LONG>(length));
@@ -120,7 +120,7 @@ IceInternal::SHA1::Hasher::finalize(vector<unsigned char>& md)
     DWORD length = SHA_DIGEST_LENGTH;
     if(!CryptGetHashParam(_hash, HP_HASHVAL, &md[0], &length, 0))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__, GetLastError());
+        throw IceUtil::SyscallException(__FILE__, __LINE__);
     }
 #elif defined(__APPLE__)
     md.resize(CC_SHA1_DIGEST_LENGTH);

--- a/cpp/src/Ice/SHA1.cpp
+++ b/cpp/src/Ice/SHA1.cpp
@@ -64,12 +64,12 @@ IceInternal::SHA1::Hasher::Hasher() :
 {
     if(!CryptAcquireContext(&_ctx, 0, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__);
+        throw Ice::SyscallException(__FILE__, __LINE__);
     }
 
     if(!CryptCreateHash(_ctx, CALG_SHA1, 0, 0, &_hash))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__);
+        throw Ice::SyscallException(__FILE__, __LINE__);
     }
 }
 
@@ -103,7 +103,7 @@ IceInternal::SHA1::Hasher::update(const unsigned char* data, size_t length)
 #if defined(_WIN32)
     if(!CryptHashData(_hash, data, static_cast<DWORD>(length), 0))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__);
+        throw Ice::SyscallException(__FILE__, __LINE__);
     }
 #elif defined(__APPLE__)
     CC_SHA1_Update(&_ctx, reinterpret_cast<const void*>(data), static_cast<CC_LONG>(length));
@@ -120,7 +120,7 @@ IceInternal::SHA1::Hasher::finalize(vector<unsigned char>& md)
     DWORD length = SHA_DIGEST_LENGTH;
     if(!CryptGetHashParam(_hash, HP_HASHVAL, &md[0], &length, 0))
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__);
+        throw Ice::SyscallException(__FILE__, __LINE__);
     }
 #elif defined(__APPLE__)
     md.resize(CC_SHA1_DIGEST_LENGTH);

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -197,7 +197,7 @@ public:
         _source = RegisterEventSourceW(0, stringToWstring(mangleSource(source), _stringConverter).c_str());
         if(_source == 0)
         {
-            throw SyscallException(__FILE__, __LINE__, GetLastError());
+            throw SyscallException(__FILE__, __LINE__);
         }
     }
 
@@ -233,7 +233,7 @@ public:
         if(!GetModuleFileNameW(_module, path, _MAX_PATH))
         {
             RegCloseKey(hKey);
-            throw SyscallException(__FILE__, __LINE__, GetLastError());
+            throw SyscallException(__FILE__, __LINE__);
         }
 
         //
@@ -1603,7 +1603,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
         //
         if(setsid() == -1)
         {
-            throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
 
         //
@@ -1618,7 +1618,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
         pid = fork();
         if(pid < 0)
         {
-            throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
         if(pid != 0)
         {
@@ -1632,7 +1632,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
             //
             if(chdir("/") != 0)
             {
-                throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+                throw SyscallException(__FILE__, __LINE__);
             }
         }
 
@@ -1648,7 +1648,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
             int fdMax = static_cast<int>(sysconf(_SC_OPEN_MAX));
             if(fdMax <= 0)
             {
-                throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+                throw SyscallException(__FILE__, __LINE__);
             }
 
             for(int i = 0; i < fdMax; ++i)
@@ -1708,7 +1708,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
             assert(fd == 0);
             if(fd != 0)
             {
-                throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+                throw SyscallException(__FILE__, __LINE__);
             }
             if(stdOut.empty())
             {
@@ -1716,7 +1716,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
                 assert(fd == 1);
                 if(fd != 1)
                 {
-                    throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+                    throw SyscallException(__FILE__, __LINE__);
                 }
             }
             if(stdErr.empty())
@@ -1725,7 +1725,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
                 assert(fd == 2);
                 if(fd != 2)
                 {
-                    throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+                    throw SyscallException(__FILE__, __LINE__);
                 }
             }
         }

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -46,6 +46,25 @@ using namespace IceGrid;
 
 #define ICE_STRING(X) #X
 
+namespace
+{
+
+#ifdef _WIN32
+int
+getSystemErrno()
+{
+    return GetLastError();
+}
+#else
+int
+getSystemErrno()
+{
+    return errno;
+}
+#endif
+
+}
+
 namespace IceGrid
 {
 
@@ -299,14 +318,14 @@ Activator::Activator(const shared_ptr<TraceLevels>& traceLevels) :
 
     if(_hIntr == nullptr)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
 
     }
 #else
     int fds[2];
     if(pipe(fds) != 0)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
     _fdIntrRead = fds[0];
     _fdIntrWrite = fds[1];
@@ -653,7 +672,7 @@ Activator::activate(const string& name,
     char* grouplist = getgrset(pw->pw_name);
     if(grouplist == 0)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
     vector<string> grps;
     if(IceUtilInternal::splitString(grouplist, ",", grps))
@@ -699,13 +718,13 @@ Activator::activate(const string& name,
     int fds[2];
     if(pipe(fds) != 0)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     int errorFds[2];
     if(pipe(errorFds) != 0)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     //
@@ -722,7 +741,7 @@ Activator::activate(const string& name,
     pid_t pid = fork();
     if(pid == -1)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     if(pid == 0) // Child process.
@@ -1009,7 +1028,7 @@ Activator::sendSignal(const string& name, int signal)
         }
         else if(GetLastError() != ERROR_INVALID_PARAMETER) // Process with pid doesn't exist anymore.
         {
-            throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
     }
     else if(signal == SIGKILL)
@@ -1017,7 +1036,7 @@ Activator::sendSignal(const string& name, int signal)
         HANDLE hnd = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
         if(hnd == nullptr)
         {
-            throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
 
         TerminateProcess(hnd, 0); // We use 0 for the exit code to make sure it's not considered as a crash.
@@ -1038,7 +1057,7 @@ Activator::sendSignal(const string& name, int signal)
     int ret = ::kill(static_cast<pid_t>(pid), signal);
     if(ret != 0 && getSystemErrno() != ESRCH)
     {
-        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     if(_traceLevels->activator > 1)
@@ -1191,7 +1210,7 @@ Activator::terminationListener()
         DWORD ret = WaitForSingleObject(_hIntr, INFINITE);
         if(ret == WAIT_FAILED)
         {
-            throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
         clearInterrupt();
 
@@ -1294,7 +1313,7 @@ Activator::terminationListener()
             }
 #endif
 
-            throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
 
         vector<Process> terminated;
@@ -1346,7 +1365,7 @@ Activator::terminationListener()
                 {
                     if(errno != EAGAIN || message.empty())
                     {
-                        throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+                        throw SyscallException(__FILE__, __LINE__);
                     }
 
                     ++p;
@@ -1431,7 +1450,7 @@ Activator::setInterrupt()
     ssize_t sz = write(_fdIntrWrite, &c, 1);
     if(sz == -1)
     {
-        throw SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+        throw SyscallException(__FILE__, __LINE__);
     }
 #endif
 }
@@ -1463,7 +1482,7 @@ Activator::waitPid(pid_t processPid)
                     ++nRetry;
                     continue;
                 }
-                throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+                throw SyscallException(__FILE__, __LINE__);
             }
             assert(pid == processPid);
             break;
@@ -1472,7 +1491,7 @@ Activator::waitPid(pid_t processPid)
         pid_t pid = waitpid(processPid, &status, 0);
         if(pid < 0)
         {
-            throw SyscallException(__FILE__, __LINE__, getSystemErrno());
+            throw SyscallException(__FILE__, __LINE__);
         }
         assert(pid == processPid);
 #endif

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -97,11 +97,11 @@ setNoIndexingAttribute(const string& path)
     DWORD attrs = GetFileAttributesW(wpath.c_str());
     if(attrs == INVALID_FILE_ATTRIBUTES)
     {
-        throw FileException(__FILE__, __LINE__, IceInternal::getSystemErrno(), path);
+        throw FileException(__FILE__, __LINE__, path);
     }
     if(!SetFileAttributesW(wpath.c_str(), attrs | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED))
     {
-        throw FileException(__FILE__, __LINE__, IceInternal::getSystemErrno(), path);
+        throw FileException(__FILE__, __LINE__, path);
     }
 }
 #endif
@@ -328,7 +328,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
     {
         if(!IceUtilInternal::directoryExists(dataPath))
         {
-            FileException ex(__FILE__, __LINE__, IceInternal::getSystemErrno(), dataPath);
+            FileException ex(__FILE__, __LINE__, dataPath);
             ServiceError err(this);
             err << "property `IceGrid.Node.Data' is set to an invalid path:\n" << ex;
             return false;

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -177,7 +177,7 @@ PlatformInfo::PlatformInfo(const string& prefix,
     size_t sz = sizeof(_nProcessorThreads);
     if(sysctl(ncpu, 2, &_nProcessorThreads, &sz, 0, 0) == -1)
     {
-        throw Ice::SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+        throw Ice::SyscallException(__FILE__, __LINE__);
     }
 #else
     _nProcessorThreads = static_cast<int>(sysconf(_SC_NPROCESSORS_ONLN));

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -347,7 +347,7 @@ RegistryI::startImpl()
     {
         if(!IceUtilInternal::directoryExists(dbPath))
         {
-            Ice::SyscallException ex(__FILE__, __LINE__, IceInternal::getSystemErrno());
+            Ice::SyscallException ex(__FILE__, __LINE__);
             Ice::Error out(_communicator->getLogger());
             out << "property `IceGrid.Registry.LMDB.Path' is set to an invalid path:\n" << ex;
             return false;

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -2519,7 +2519,7 @@ ServerI::checkAndUpdateUser(const shared_ptr<InternalServerDescriptor>& desc, bo
         }
         if(!success)
         {
-            throw Ice::SyscallException(__FILE__, __LINE__, IceInternal::getSystemErrno());
+            throw Ice::SyscallException(__FILE__, __LINE__);
         }
         if(user != string(&buf[0]))
         {

--- a/cpp/src/IceSSL/SecureTransportEngine.cpp
+++ b/cpp/src/IceSSL/SecureTransportEngine.cpp
@@ -58,7 +58,7 @@ RegExp::RegExp(const string& regexp)
     int err = regcomp(&_preg, regexp.c_str(), REG_EXTENDED | REG_NOSUB);
     if(err)
     {
-        throw IceUtil::SyscallException(__FILE__, __LINE__, err);
+        throw SyscallException(__FILE__, __LINE__, err);
     }
 }
 

--- a/cpp/src/IceUtil/UUID.cpp
+++ b/cpp/src/IceUtil/UUID.cpp
@@ -45,67 +45,43 @@ inline void bytesToHex(unsigned char* bytes, size_t len, char*& hexBuffer)
 string
 IceUtil::generateUUID()
 {
-#if defined(_WIN32)
+struct UUID
+{
+    unsigned char timeLow[4];
+    unsigned char timeMid[2];
+    unsigned char timeHighAndVersion[2];
+    unsigned char clockSeqHiAndReserved;
+    unsigned char clockSeqLow;
+    unsigned char node[6];
+};
+UUID uuid;
 
-    UUID uuid;
-    RPC_STATUS ret = UuidCreate(&uuid);
-    if(ret != RPC_S_OK && ret != RPC_S_UUID_LOCAL_ONLY && ret != RPC_S_UUID_NO_ADDRESS)
-    {
-        throw SyscallException(__FILE__, __LINE__);
-    }
+assert(sizeof(UUID) == 16);
 
-    unsigned char* str;
+// Get a random sequence of bytes.
+char* buffer = reinterpret_cast<char*>(&uuid);
+IceUtilInternal::generateRandom(buffer, sizeof(UUID));
 
-    ret = UuidToString(&uuid, &str);
-    if(ret != RPC_S_OK)
-    {
-        throw SyscallException(__FILE__, __LINE__);
-    }
-    string result = reinterpret_cast<char*>(str);
+// Adjust the bits that say "version 4" UUID
+uuid.timeHighAndVersion[0] &= 0x0F;
+uuid.timeHighAndVersion[0] |= (4 << 4);
+uuid.clockSeqHiAndReserved &= 0x3F;
+uuid.clockSeqHiAndReserved |= 0x80;
 
-    RpcStringFree(&str);
-    return result;
+// Convert to a UUID string
+char uuidString[16 * 2 + 4 + 1]; // 16 bytes, 4 '-' and a final '\0'
+char* uuidIndex = uuidString;
+bytesToHex(uuid.timeLow, sizeof(uuid.timeLow), uuidIndex);
+*uuidIndex++ = '-';
+bytesToHex(uuid.timeMid, sizeof(uuid.timeMid), uuidIndex);
+*uuidIndex++ = '-';
+bytesToHex(uuid.timeHighAndVersion, sizeof(uuid.timeHighAndVersion), uuidIndex);
+*uuidIndex++ = '-';
+bytesToHex(&uuid.clockSeqHiAndReserved, sizeof(uuid.clockSeqHiAndReserved), uuidIndex);
+bytesToHex(&uuid.clockSeqLow, sizeof(uuid.clockSeqLow), uuidIndex);
+*uuidIndex++ = '-';
+bytesToHex(uuid.node, sizeof(uuid.node), uuidIndex);
+*uuidIndex = '\0';
 
-#else
-    struct UUID
-    {
-        unsigned char timeLow[4];
-        unsigned char timeMid[2];
-        unsigned char timeHighAndVersion[2];
-        unsigned char clockSeqHiAndReserved;
-        unsigned char clockSeqLow;
-        unsigned char node[6];
-    };
-    UUID uuid;
-
-    assert(sizeof(UUID) == 16);
-
-    // Get a random sequence of bytes.
-    char* buffer = reinterpret_cast<char*>(&uuid);
-    IceUtilInternal::generateRandom(buffer, sizeof(UUID));
-
-    // Adjust the bits that say "version 4" UUID
-    uuid.timeHighAndVersion[0] &= 0x0F;
-    uuid.timeHighAndVersion[0] |= (4 << 4);
-    uuid.clockSeqHiAndReserved &= 0x3F;
-    uuid.clockSeqHiAndReserved |= 0x80;
-
-    // Convert to a UUID string
-    char uuidString[16 * 2 + 4 + 1]; // 16 bytes, 4 '-' and a final '\0'
-    char* uuidIndex = uuidString;
-    bytesToHex(uuid.timeLow, sizeof(uuid.timeLow), uuidIndex);
-    *uuidIndex++ = '-';
-    bytesToHex(uuid.timeMid, sizeof(uuid.timeMid), uuidIndex);
-    *uuidIndex++ = '-';
-    bytesToHex(uuid.timeHighAndVersion, sizeof(uuid.timeHighAndVersion), uuidIndex);
-    *uuidIndex++ = '-';
-    bytesToHex(&uuid.clockSeqHiAndReserved, sizeof(uuid.clockSeqHiAndReserved), uuidIndex);
-    bytesToHex(&uuid.clockSeqLow, sizeof(uuid.clockSeqLow), uuidIndex);
-    *uuidIndex++ = '-';
-    bytesToHex(uuid.node, sizeof(uuid.node), uuidIndex);
-    *uuidIndex = '\0';
-
-    return uuidString;
-
-#endif
+return uuidString;
 }

--- a/cpp/src/IceUtil/UUID.cpp
+++ b/cpp/src/IceUtil/UUID.cpp
@@ -51,7 +51,7 @@ IceUtil::generateUUID()
     RPC_STATUS ret = UuidCreate(&uuid);
     if(ret != RPC_S_OK && ret != RPC_S_UUID_LOCAL_ONLY && ret != RPC_S_UUID_NO_ADDRESS)
     {
-        throw SyscallException(__FILE__, __LINE__, GetLastError());
+        throw SyscallException(__FILE__, __LINE__);
     }
 
     unsigned char* str;
@@ -59,7 +59,7 @@ IceUtil::generateUUID()
     ret = UuidToString(&uuid, &str);
     if(ret != RPC_S_OK)
     {
-        throw SyscallException(__FILE__, __LINE__, GetLastError());
+        throw SyscallException(__FILE__, __LINE__);
     }
     string result = reinterpret_cast<char*>(str);
 

--- a/cpp/src/IceUtil/UUID.cpp
+++ b/cpp/src/IceUtil/UUID.cpp
@@ -41,43 +41,43 @@ inline void bytesToHex(unsigned char* bytes, size_t len, char*& hexBuffer)
 string
 IceUtil::generateUUID()
 {
-struct UUID
-{
-    unsigned char timeLow[4];
-    unsigned char timeMid[2];
-    unsigned char timeHighAndVersion[2];
-    unsigned char clockSeqHiAndReserved;
-    unsigned char clockSeqLow;
-    unsigned char node[6];
-};
-UUID uuid;
+    struct UUID
+    {
+        unsigned char timeLow[4];
+        unsigned char timeMid[2];
+        unsigned char timeHighAndVersion[2];
+        unsigned char clockSeqHiAndReserved;
+        unsigned char clockSeqLow;
+        unsigned char node[6];
+    };
+    UUID uuid;
 
-assert(sizeof(UUID) == 16);
+    assert(sizeof(UUID) == 16);
 
-// Get a random sequence of bytes.
-char* buffer = reinterpret_cast<char*>(&uuid);
-IceUtilInternal::generateRandom(buffer, sizeof(UUID));
+    // Get a random sequence of bytes.
+    char* buffer = reinterpret_cast<char*>(&uuid);
+    IceUtilInternal::generateRandom(buffer, sizeof(UUID));
 
-// Adjust the bits that say "version 4" UUID
-uuid.timeHighAndVersion[0] &= 0x0F;
-uuid.timeHighAndVersion[0] |= (4 << 4);
-uuid.clockSeqHiAndReserved &= 0x3F;
-uuid.clockSeqHiAndReserved |= 0x80;
+    // Adjust the bits that say "version 4" UUID
+    uuid.timeHighAndVersion[0] &= 0x0F;
+    uuid.timeHighAndVersion[0] |= (4 << 4);
+    uuid.clockSeqHiAndReserved &= 0x3F;
+    uuid.clockSeqHiAndReserved |= 0x80;
 
-// Convert to a UUID string
-char uuidString[16 * 2 + 4 + 1]; // 16 bytes, 4 '-' and a final '\0'
-char* uuidIndex = uuidString;
-bytesToHex(uuid.timeLow, sizeof(uuid.timeLow), uuidIndex);
-*uuidIndex++ = '-';
-bytesToHex(uuid.timeMid, sizeof(uuid.timeMid), uuidIndex);
-*uuidIndex++ = '-';
-bytesToHex(uuid.timeHighAndVersion, sizeof(uuid.timeHighAndVersion), uuidIndex);
-*uuidIndex++ = '-';
-bytesToHex(&uuid.clockSeqHiAndReserved, sizeof(uuid.clockSeqHiAndReserved), uuidIndex);
-bytesToHex(&uuid.clockSeqLow, sizeof(uuid.clockSeqLow), uuidIndex);
-*uuidIndex++ = '-';
-bytesToHex(uuid.node, sizeof(uuid.node), uuidIndex);
-*uuidIndex = '\0';
+    // Convert to a UUID string
+    char uuidString[16 * 2 + 4 + 1]; // 16 bytes, 4 '-' and a final '\0'
+    char* uuidIndex = uuidString;
+    bytesToHex(uuid.timeLow, sizeof(uuid.timeLow), uuidIndex);
+    *uuidIndex++ = '-';
+    bytesToHex(uuid.timeMid, sizeof(uuid.timeMid), uuidIndex);
+    *uuidIndex++ = '-';
+    bytesToHex(uuid.timeHighAndVersion, sizeof(uuid.timeHighAndVersion), uuidIndex);
+    *uuidIndex++ = '-';
+    bytesToHex(&uuid.clockSeqHiAndReserved, sizeof(uuid.clockSeqHiAndReserved), uuidIndex);
+    bytesToHex(&uuid.clockSeqLow, sizeof(uuid.clockSeqLow), uuidIndex);
+    *uuidIndex++ = '-';
+    bytesToHex(uuid.node, sizeof(uuid.node), uuidIndex);
+    *uuidIndex = '\0';
 
-return uuidString;
+    return uuidString;
 }

--- a/cpp/src/IceUtil/UUID.cpp
+++ b/cpp/src/IceUtil/UUID.cpp
@@ -4,14 +4,10 @@
 
 #include <IceUtil/UUID.h>
 #include <IceUtil/Exception.h>
-// On Windows, we use Windows's RPC UUID generator. On other platforms, we use a high quality random number generator
+// We use a high quality random number generator
 // (std::random_device) to generate "version 4" UUIDs, as described in
 // http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-00.txt
-#ifdef _WIN32
-#   include <rpc.h>
-#else
-#   include <IceUtil/Random.h>
-#endif
+#include <IceUtil/Random.h>
 
 using namespace std;
 

--- a/cpp/src/IceUtil/UtilException.cpp
+++ b/cpp/src/IceUtil/UtilException.cpp
@@ -655,34 +655,6 @@ IceUtil::IllegalConversionException::reason() const
     return _reason;
 }
 
-IceUtil::SyscallException::SyscallException(const char* file, int line, int err ):
-    ExceptionHelper<SyscallException>(file, line),
-    _error(err)
-{
-}
-
-void
-IceUtil::SyscallException::ice_print(ostream& os) const
-{
-    Exception::ice_print(os);
-    if(_error != 0)
-    {
-        os << ":\nsyscall exception: " << IceUtilInternal::errorToString(_error);
-    }
-}
-
-string
-IceUtil::SyscallException::ice_id() const
-{
-    return "::IceUtil::SyscallException";
-}
-
-int
-IceUtil::SyscallException::error() const
-{
-    return _error;
-}
-
 IceUtil::FileLockException::FileLockException(const char* file, int line, int err, const string& path):
     ExceptionHelper<FileLockException>(file, line),
     _error(err),


### PR DESCRIPTION
IceInternal::getSystemErrno (which returns the current error number) was defined in `Ice/Config.h` but implemented `Ice/Network.cpp`. It was only used when throwing two local exceptions and in some IceGrid activator code.

EDIT: I've also removed the generateUUID windows specific code. This removes the special `IceUtil::SyscallException`
