### PR TITLE
Remove deprecated IcePatch2 API

### DIFF
--- a/cpp/src/IcePatch2/FileServerI.cpp
+++ b/cpp/src/IcePatch2/FileServerI.cpp
@@ -25,16 +25,6 @@ IcePatch2::FileServerI::FileServerI(const std::string& dataDir, const LargeFileI
     getFileTree0(infoSeq, tree0);
 }
 
-FileInfoSeq
-IcePatch2::FileServerI::getFileInfoSeq(int32_t node0, const Current& c) const
-{
-   LargeFileInfoSeq largeFiles = getLargeFileInfoSeq(node0, c);
-   FileInfoSeq files;
-   files.resize(largeFiles.size());
-   transform(largeFiles.begin(), largeFiles.end(), files.begin(), toFileInfo);
-   return files;
-}
-
 LargeFileInfoSeq
 IcePatch2::FileServerI::getLargeFileInfoSeq(int32_t node0, const Current&) const
 {
@@ -63,34 +53,6 @@ ByteSeq
 IcePatch2::FileServerI::getChecksum(const Current&) const
 {
     return _tree0.checksum;
-}
-
-void
-IcePatch2::FileServerI::getFileCompressedAsync(
-    string pa,
-    int32_t pos,
-    int32_t num,
-    function<void(const pair<const ::uint8_t*, const ::uint8_t*>& returnValue)> response,
-    function<void(exception_ptr)> exception,
-    const Current&) const
-{
-    try
-    {
-        vector<uint8_t> buffer;
-        getFileCompressedInternal(std::move(pa), pos, num, buffer, false);
-        if(buffer.empty())
-        {
-            response(make_pair<const uint8_t*, const uint8_t*>(0, 0));
-        }
-        else
-        {
-            response(make_pair<const uint8_t*, const uint8_t*>(&buffer[0], &buffer[0] + buffer.size()));
-        }
-    }
-    catch(const std::exception&)
-    {
-        exception(current_exception());
-    }
 }
 
 void

--- a/cpp/src/IcePatch2Lib/ClientUtil.cpp
+++ b/cpp/src/IcePatch2Lib/ClientUtil.cpp
@@ -90,7 +90,6 @@ private:
     LargeFileInfoSeq _removeFiles;
 
     FILE* _log;
-    bool _useSmallFileAPI;
 };
 
 Decompressor::Decompressor(const string& dataDir) :
@@ -199,8 +198,7 @@ PatcherI::PatcherI(const CommunicatorPtr& communicator, const PatcherFeedbackPtr
     _thorough(communicator->getProperties()->getPropertyAsIntWithDefault("IcePatch2Client.Thorough", 0) > 0),
     _chunkSize(communicator->getProperties()->getPropertyAsIntWithDefault("IcePatch2Client.ChunkSize", 100)),
     _remove(communicator->getProperties()->getPropertyAsIntWithDefault("IcePatch2Client.Remove", 1)),
-    _log(0),
-    _useSmallFileAPI(false)
+    _log(0)
 {
     const char* clientProxyProperty = "IcePatch2Client.Proxy";
     string clientProxy = communicator->getProperties()->getProperty(clientProxyProperty);
@@ -228,8 +226,7 @@ PatcherI::PatcherI(const FileServerPrxPtr& server,
     _dataDir(dataDir),
     _thorough(thorough),
     _chunkSize(chunkSize),
-    _remove(remove),
-    _useSmallFileAPI(false)
+    _remove(remove)
 {
     init(server);
 }
@@ -247,58 +244,32 @@ class GetFileInfoSeqAsyncCB
 {
 public:
 
-    GetFileInfoSeqAsyncCB(bool useSmallFileAPI) :
-        _useSmallFileAPI(useSmallFileAPI)
+    GetFileInfoSeqAsyncCB()
 
     {
         _largeFileInfoSeqFuture = _largeFileInfoSeqPromise.get_future();
-        _fileInfoSeqFuture = _fileInfoSeqPromise.get_future();
-    }
-
-    void complete(FileInfoSeq fileInfoSeq)
-    {
-        assert(_useSmallFileAPI);
-        _fileInfoSeqPromise.set_value(fileInfoSeq);
     }
 
     void complete(LargeFileInfoSeq largeFileInfoSeq)
     {
-        assert(!_useSmallFileAPI);
         _largeFileInfoSeqPromise.set_value(largeFileInfoSeq);
     }
 
     void exception(std::exception_ptr exception)
     {
-        if (_useSmallFileAPI)
-        {
-            _fileInfoSeqPromise.set_exception(exception);
-        }
-        else
-        {
-            _largeFileInfoSeqPromise.set_exception(exception);
-        }
-    }
-
-    FileInfoSeq getFileInfoSeq()
-    {
-        assert(_useSmallFileAPI);
-        return _fileInfoSeqFuture.get();
+        _largeFileInfoSeqPromise.set_exception(exception);
     }
 
     LargeFileInfoSeq getLargeFileInfoSeq()
     {
-        assert(!_useSmallFileAPI);
         return _largeFileInfoSeqFuture.get();
     }
 
 private:
 
     std::promise<LargeFileInfoSeq> _largeFileInfoSeqPromise;
-    std::promise<FileInfoSeq> _fileInfoSeqPromise;
-
     std::future<LargeFileInfoSeq> _largeFileInfoSeqFuture;
-    std::future<FileInfoSeq> _fileInfoSeqFuture;
-    bool _useSmallFileAPI;
+
 };
 
 class PatcherGetFileInfoSeqCB : public GetFileInfoSeqCB
@@ -391,145 +362,98 @@ PatcherI::prepare()
             throw runtime_error("server returned illegal value");
         }
 
-        while(true)
+        std::shared_ptr<GetFileInfoSeqAsyncCB> curCB;
+        std::shared_ptr<GetFileInfoSeqAsyncCB> nxtCB;
+        for(size_t node0 = 0; node0 < 256; ++node0)
         {
-            std::shared_ptr<GetFileInfoSeqAsyncCB> curCB;
-            std::shared_ptr<GetFileInfoSeqAsyncCB> nxtCB;
-            try
+            if(tree0.nodes[node0].checksum != checksumSeq[node0])
             {
-                for(size_t node0 = 0; node0 < 256; ++node0)
+                if (!curCB)
                 {
-                    if(tree0.nodes[node0].checksum != checksumSeq[node0])
-                    {
-                        if (!curCB)
-                        {
-                            curCB = std::make_shared<GetFileInfoSeqAsyncCB>(_useSmallFileAPI);
-                            if (_useSmallFileAPI)
-                            {
-                                _serverCompress->getFileInfoSeqAsync(
-                                    static_cast<int32_t>(node0),
-                                    [curCB](FileInfoSeq fileInfoSeq) { curCB->complete(fileInfoSeq); },
-                                    [curCB](exception_ptr exception) { curCB->exception(exception); });
-                            }
-                            else
-                            {
-                                _serverCompress->getLargeFileInfoSeqAsync(
-                                    static_cast<int32_t>(node0),
-                                    [curCB](LargeFileInfoSeq fileInfoSeq) { curCB->complete(fileInfoSeq); },
-                                    [curCB](exception_ptr exception) { curCB->exception(exception); });
-                            }
-                        }
-                        else
-                        {
-                            assert(nxtCB);
-                            swap(nxtCB, curCB);
-                        }
-
-                        size_t node0Nxt = node0;
-                        do
-                        {
-                            ++node0Nxt;
-                        }
-                        while(node0Nxt < 256 && tree0.nodes[node0Nxt].checksum == checksumSeq[node0Nxt]);
-
-                        if(node0Nxt < 256)
-                        {
-                            nxtCB = std::make_shared<GetFileInfoSeqAsyncCB>(_useSmallFileAPI);
-                            if (_useSmallFileAPI)
-                            {
-                                _serverCompress->getFileInfoSeqAsync(
-                                    static_cast<int32_t>(node0Nxt),
-                                    [nxtCB](FileInfoSeq fileInfoSeq) { nxtCB->complete(fileInfoSeq); },
-                                    [nxtCB](exception_ptr exception) { nxtCB->exception(exception); });
-                            }
-                            else
-                            {
-                                _serverCompress->getLargeFileInfoSeqAsync(
-                                    static_cast<int32_t>(node0Nxt),
-                                    [nxtCB](LargeFileInfoSeq fileInfoSeq) { nxtCB->complete(fileInfoSeq); },
-                                    [nxtCB](exception_ptr exception) { nxtCB->exception(exception); });
-                            }
-                        }
-
-                        LargeFileInfoSeq files;
-                        if (_useSmallFileAPI)
-                        {
-                            FileInfoSeq smallFiles = curCB->getFileInfoSeq();
-                            files.resize(smallFiles.size());
-                            transform(smallFiles.begin(), smallFiles.end(), files.begin(), toLargeFileInfo);
-                        }
-                        else
-                        {
-                            files = curCB->getLargeFileInfoSeq();
-                        }
-
-                        sort(files.begin(), files.end(), FileInfoLess());
-                        files.erase(unique(files.begin(), files.end(), FileInfoEqual()), files.end());
-
-                        //
-                        // Compute the set of files which were removed.
-                        //
-                        set_difference(tree0.nodes[node0].files.begin(),
-                                       tree0.nodes[node0].files.end(),
-                                       files.begin(),
-                                       files.end(),
-                                       back_inserter(_removeFiles),
-                                       FileInfoWithoutFlagsLess()); // NOTE: We ignore the flags here.
-
-                        //
-                        // Compute the set of files which were updated (either the file contents, flags or both).
-                        //
-                        LargeFileInfoSeq updatedFiles;
-                        updatedFiles.reserve(files.size());
-
-                        set_difference(files.begin(),
-                                       files.end(),
-                                       tree0.nodes[node0].files.begin(),
-                                       tree0.nodes[node0].files.end(),
-                                       back_inserter(updatedFiles),
-                                       FileInfoLess());
-
-                        //
-                        // Compute the set of files whose contents was updated.
-                        //
-                        LargeFileInfoSeq contentsUpdatedFiles;
-                        contentsUpdatedFiles.reserve(files.size());
-
-                        set_difference(files.begin(),
-                                       files.end(),
-                                       tree0.nodes[node0].files.begin(),
-                                       tree0.nodes[node0].files.end(),
-                                       back_inserter(contentsUpdatedFiles),
-                                       FileInfoWithoutFlagsLess()); // NOTE: We ignore the flags here.
-                        copy(contentsUpdatedFiles.begin(), contentsUpdatedFiles.end(), back_inserter(_updateFiles));
-
-                        //
-                        // Compute the set of files whose flags were updated.
-                        //
-                        set_difference(updatedFiles.begin(),
-                                       updatedFiles.end(),
-                                       contentsUpdatedFiles.begin(),
-                                       contentsUpdatedFiles.end(),
-                                       back_inserter(_updateFlags),
-                                       FileInfoLess());
-                    }
-
-                    if(!_feedback->fileListProgress(static_cast<int32_t>(node0 + 1) * 100 / 256))
-                    {
-                        return false;
-                    }
+                    curCB = std::make_shared<GetFileInfoSeqAsyncCB>();
+                    _serverCompress->getLargeFileInfoSeqAsync(
+                        static_cast<int32_t>(node0),
+                        [curCB](LargeFileInfoSeq fileInfoSeq) { curCB->complete(fileInfoSeq); },
+                        [curCB](exception_ptr exception) { curCB->exception(exception); });
                 }
+                else
+                {
+                    assert(nxtCB);
+                    swap(nxtCB, curCB);
+                }
+
+                size_t node0Nxt = node0;
+                do
+                {
+                    ++node0Nxt;
+                }
+                while(node0Nxt < 256 && tree0.nodes[node0Nxt].checksum == checksumSeq[node0Nxt]);
+
+                if(node0Nxt < 256)
+                {
+                    nxtCB = std::make_shared<GetFileInfoSeqAsyncCB>();
+                    _serverCompress->getLargeFileInfoSeqAsync(
+                        static_cast<int32_t>(node0Nxt),
+                        [nxtCB](LargeFileInfoSeq fileInfoSeq) { nxtCB->complete(fileInfoSeq); },
+                        [nxtCB](exception_ptr exception) { nxtCB->exception(exception); });
+                }
+
+                LargeFileInfoSeq files = curCB->getLargeFileInfoSeq();
+                sort(files.begin(), files.end(), FileInfoLess());
+                files.erase(unique(files.begin(), files.end(), FileInfoEqual()), files.end());
+
+                //
+                // Compute the set of files which were removed.
+                //
+                set_difference(tree0.nodes[node0].files.begin(),
+                                tree0.nodes[node0].files.end(),
+                                files.begin(),
+                                files.end(),
+                                back_inserter(_removeFiles),
+                                FileInfoWithoutFlagsLess()); // NOTE: We ignore the flags here.
+
+                //
+                // Compute the set of files which were updated (either the file contents, flags or both).
+                //
+                LargeFileInfoSeq updatedFiles;
+                updatedFiles.reserve(files.size());
+
+                set_difference(files.begin(),
+                                files.end(),
+                                tree0.nodes[node0].files.begin(),
+                                tree0.nodes[node0].files.end(),
+                                back_inserter(updatedFiles),
+                                FileInfoLess());
+
+                //
+                // Compute the set of files whose contents was updated.
+                //
+                LargeFileInfoSeq contentsUpdatedFiles;
+                contentsUpdatedFiles.reserve(files.size());
+
+                set_difference(files.begin(),
+                                files.end(),
+                                tree0.nodes[node0].files.begin(),
+                                tree0.nodes[node0].files.end(),
+                                back_inserter(contentsUpdatedFiles),
+                                FileInfoWithoutFlagsLess()); // NOTE: We ignore the flags here.
+                copy(contentsUpdatedFiles.begin(), contentsUpdatedFiles.end(), back_inserter(_updateFiles));
+
+                //
+                // Compute the set of files whose flags were updated.
+                //
+                set_difference(updatedFiles.begin(),
+                                updatedFiles.end(),
+                                contentsUpdatedFiles.begin(),
+                                contentsUpdatedFiles.end(),
+                                back_inserter(_updateFlags),
+                                FileInfoLess());
             }
-            catch(const Ice::OperationNotExistException&)
+
+            if(!_feedback->fileListProgress(static_cast<int32_t>(node0 + 1) * 100 / 256))
             {
-                if(!_useSmallFileAPI)
-                {
-                    _useSmallFileAPI = true;
-                    continue;
-                }
-                throw;
+                return false;
             }
-            break;
         }
 
         if(!_feedback->fileListEnd())
@@ -839,27 +763,14 @@ void getFileCompressed(
     std::string path,
     int64_t pos,
     int chunkSize,
-    std::shared_ptr<GetFileCompressedCB> cb,
-    bool useSmallFileAPI)
+    std::shared_ptr<GetFileCompressedCB> cb)
 {
-    if (useSmallFileAPI)
-    {
-        serverNoCompress->getFileCompressedAsync(
-            path,
-            static_cast<int32_t>(pos),
-            chunkSize,
-            [cb](std::pair<const uint8_t*, const uint8_t*> result) { cb->complete(ByteSeq(result.first, result.second)); },
-            [cb](exception_ptr exception) { cb->exception(exception); });
-    }
-    else
-    {
-        serverNoCompress->getLargeFileCompressedAsync(
-            path,
-            pos,
-            chunkSize,
-            [cb](std::pair<const uint8_t*, const uint8_t*> result) { cb->complete(ByteSeq(result.first, result.second)); },
-            [cb](exception_ptr exception) { cb->exception(exception); });
-    }
+    serverNoCompress->getLargeFileCompressedAsync(
+        path,
+        pos,
+        chunkSize,
+        [cb](std::pair<const uint8_t*, const uint8_t*> result) { cb->complete(ByteSeq(result.first, result.second)); },
+        [cb](exception_ptr exception) { cb->exception(exception); });
 }
 
 bool
@@ -940,13 +851,7 @@ PatcherI::updateFilesInternal(const LargeFileInfoSeq& files, const DecompressorP
                         {
                             assert(!nxtCB);
                             curCB = std::make_shared<GetFileCompressedCB>();
-                            getFileCompressed(
-                                _serverNoCompress,
-                                p->path,
-                                pos,
-                                _chunkSize,
-                                curCB,
-                                _useSmallFileAPI);
+                            getFileCompressed(_serverNoCompress, p->path, pos, _chunkSize, curCB);
                         }
                         else
                         {
@@ -957,13 +862,7 @@ PatcherI::updateFilesInternal(const LargeFileInfoSeq& files, const DecompressorP
                         if(pos + _chunkSize < p->size)
                         {
                             nxtCB = std::make_shared<GetFileCompressedCB>();
-                            getFileCompressed(
-                                _serverNoCompress,
-                                p->path,
-                                pos + _chunkSize,
-                                _chunkSize,
-                                nxtCB,
-                                _useSmallFileAPI);
+                            getFileCompressed(_serverNoCompress, p->path, pos + _chunkSize, _chunkSize, nxtCB);
                         }
                         else
                         {
@@ -977,13 +876,7 @@ PatcherI::updateFilesInternal(const LargeFileInfoSeq& files, const DecompressorP
                             if(q != files.end())
                             {
                                 nxtCB = std::make_shared<GetFileCompressedCB>();
-                                getFileCompressed(
-                                    _serverNoCompress,
-                                    q->path,
-                                    0,
-                                    _chunkSize,
-                                    nxtCB,
-                                    _useSmallFileAPI);
+                                getFileCompressed(_serverNoCompress, q->path, 0, _chunkSize, nxtCB);
                             }
                         }
 

--- a/slice/IcePatch2/FileServer.ice
+++ b/slice/IcePatch2/FileServer.ice
@@ -50,16 +50,6 @@ exception FileSizeRangeException extends FileAccessException
 /// The interface that provides access to files.
 interface FileServer
 {
-    /// Return file information for the specified partition. <p class="Deprecated"> This operation is deprecated and
-    /// only present for compatibility with old Ice clients (older than version 3.6).
-    /// @param partition The partition number in the range 0-255.
-    /// @return A sequence containing information about the files in the specified partition.
-    /// @throws PartitionOutOfRangeException If the partition number is out of range.
-    /// @throws FileSizeRangeException If a file is larger than 2.1GB.
-    ["deprecate:getFileInfoSeq() is deprecated, use getLargeFileInfoSeq() instead.",
-     "nonmutating", "cpp:const"] idempotent FileInfoSeq getFileInfoSeq(int partition)
-        throws PartitionOutOfRangeException, FileSizeRangeException;
-
     /// Returns file information for the specified partition.
     /// @param partition The partition number in the range 0-255.
     /// @return A sequence containing information about the files in the specified partition.
@@ -77,20 +67,6 @@ interface FileServer
     /// file set is up-to-date.
     /// @return The master checksum for the file set.
     ["nonmutating", "cpp:const"] idempotent Ice::ByteSeq getChecksum();
-
-    /// Read the specified file. This operation may only return fewer bytes than requested in case there was an end-of-file
-    /// condition. <p class="Deprecated"> This operation is deprecated and only present for compatibility with old Ice
-    /// clients (older than version 3.6).
-    /// @param path The pathname (relative to the data directory) for the file to be read.
-    /// @param pos The file offset at which to begin reading.
-    /// @param num The number of bytes to be read.
-    /// @return A sequence containing the compressed file contents.
-    /// @throws FileAccessException If an error occurred while trying to read the file.
-    /// @throws FileSizeRangeException If a file is larger than 2.1GB.
-    ["deprecate:getFileCompressed() is deprecated, use getLargeFileCompressed() instead.",
-     "amd", "nonmutating", "cpp:const", "cpp:array"]
-    idempotent Ice::ByteSeq getFileCompressed(string path, int pos, int num)
-        throws FileAccessException, FileSizeRangeException;
 
     /// Read the specified file. This operation may only return fewer bytes than requested in case there was an
     /// end-of-file condition.


### PR DESCRIPTION
This PR removes the deprecated IcePatch2 APIs and simplifies the implementation.