### PR TITLE
IcePatch2 simplifications

### DIFF
--- a/cpp/include/IcePatch2/ClientUtil.h
+++ b/cpp/include/IcePatch2/ClientUtil.h
@@ -113,12 +113,12 @@ class ICEPATCH2_API PatcherFactory
 public:
 
     /// Create a patcher with the given parameters.
-    /// @server The proxy to the IcePath2 server.
-    /// @feedback The feedback object to use to report progress.
-    /// @dataDir The local data directory to patch.
-    /// @thorough If true, a thorough patch is performed and IcePatch2 client recomputes all checksums.
-    /// @chunkSize The size (in kilobytes) of the chunks to use when downloading files.
-    /// @remove Whether to delete files that exist locally, but not on the server. A negative or zero value prevents
+    /// @param server The proxy to the IcePath2 server.
+    /// @param feedback The feedback object to use to report progress.
+    /// @param dataDir The local data directory to patch.
+    /// @param thorough If true, a thorough patch is performed and IcePatch2 client recomputes all checksums.
+    /// @param chunkSize The size (in kilobytes) of the chunks to use when downloading files.
+    /// @param remove Whether to delete files that exist locally, but not on the server. A negative or zero value prevents
     /// removal of files. A value of 1 enables removal and causes the client to halt with an error if removal of a file
     /// fails. A value of 2 or greater also enables removal, but causes the client to silently ignore errors during
     /// removal.

--- a/cpp/include/IcePatch2/ClientUtil.h
+++ b/cpp/include/IcePatch2/ClientUtil.h
@@ -107,34 +107,28 @@ public:
 };
 typedef std::shared_ptr<Patcher> PatcherPtr;
 
-//
-// IcePatch2 clients instantiate the IcePatch2::Patcher class
-// using the patcher factory.
-//
+// IcePatch2 clients instantiate the IcePatch2::Patcher class using the patcher factory.
 class ICEPATCH2_API PatcherFactory
 {
 public:
 
-    //
-    // Create a patcher using configuration properties. The following
-    // properties are used to configure the patcher:
-    //
-    // - IcePatch2.InstanceName
-    // - IcePatch2.Endpoints
-    // - IcePatch2.Directory
-    // - IcePatch2.Thorough
-    // - IcePatch2.ChunkSize
-    // - IcePatch2.Remove
-    //
-    // See the Ice manual for more information on these properties.
-    //
-    static PatcherPtr create(const Ice::CommunicatorPtr&, const PatcherFeedbackPtr&);
-
-    //
-    // Create a patcher with the given parameters. These parameters
-    // are equivalent to the configuration properties described above.
-    //
-    static PatcherPtr create(const FileServerPrxPtr&, const PatcherFeedbackPtr&, const std::string&, bool, std::int32_t, std::int32_t);
+    /// Create a patcher with the given parameters.
+    /// @server The proxy to the IcePath2 server.
+    /// @feedback The feedback object to use to report progress.
+    /// @dataDir The local data directory to patch.
+    /// @thorough If true, a thorough patch is performed and IcePatch2 client recomputes all checksums.
+    /// @chunkSize The size (in kilobytes) of the chunks to use when downloading files.
+    /// @remove Whether to delete files that exist locally, but not on the server. A negative or zero value prevents
+    /// removal of files. A value of 1 enables removal and causes the client to halt with an error if removal of a file
+    /// fails. A value of 2 or greater also enables removal, but causes the client to silently ignore errors during
+    /// removal.
+    static PatcherPtr create(
+        const FileServerPrx& server,
+        const PatcherFeedbackPtr&feedback,
+        const std::string& dataDir,
+        bool thorough,
+        std::int32_t chunkSize,
+        std::int32_t remove);
 };
 
 }

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -438,15 +438,10 @@ NodeI::patchAsync(
             //
             // Patch the application.
             //
-            FileServerPrxPtr icepatch;
             if(patchApplication)
             {
                 assert(!appDistrib->icepatch.empty());
-                icepatch = Ice::checkedCast<FileServerPrx>(_communicator->stringToProxy(appDistrib->icepatch));
-                if(!icepatch)
-                {
-                    throw runtime_error("proxy `" + appDistrib->icepatch + "' is not a file server.");
-                }
+                FileServerPrx icepatch(_communicator, appDistrib->icepatch);
                 patch(icepatch, "distrib/" + application, appDistrib->directories);
             }
 
@@ -458,11 +453,7 @@ NodeI::patchAsync(
                 InternalDistributionDescriptorPtr dist = (*s)->getDistribution();
                 if(dist && (server.empty() || (*s)->getId() == server))
                 {
-                    icepatch = Ice::checkedCast<FileServerPrx>(_communicator->stringToProxy(dist->icepatch));
-                    if(!icepatch)
-                    {
-                        throw runtime_error("proxy `" + dist->icepatch + "' is not a file server.");
-                    }
+                    FileServerPrx icepatch(_communicator, dist->icepatch);
                     patch(icepatch, "servers/" + (*s)->getId() + "/distrib", dist->directories);
 
                     if(!server.empty())
@@ -1129,7 +1120,7 @@ NodeI::canRemoveServerDirectory(const string& name)
 }
 
 void
-NodeI::patch(const FileServerPrxPtr& icepatch, const string& dest, const vector<string>& directories)
+NodeI::patch(const FileServerPrx& icepatch, const string& dest, const vector<string>& directories)
 {
     IcePatch2::PatcherFeedbackPtr feedback = make_shared<LogPatcherFeedback>(_traceLevels, dest);
     IcePatch2Internal::createDirectory(_dataDir + "/" + dest);

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -134,7 +134,7 @@ public:
 private:
 
     std::vector<std::shared_ptr<ServerCommand>> checkConsistencyNoSync(const Ice::StringSeq&);
-    void patch(const IcePatch2::FileServerPrxPtr&, const std::string&, const std::vector<std::string>&);
+    void patch(const IcePatch2::FileServerPrx&, const std::string&, const std::vector<std::string>&);
 
     std::set<std::shared_ptr<ServerI>> getApplicationServers(const std::string&) const;
     std::string getFilePath(const std::string&) const;

--- a/cpp/src/IcePatch2/Calc.cpp
+++ b/cpp/src/IcePatch2/Calc.cpp
@@ -67,26 +67,23 @@ struct IFileInfoPathLess
     }
 };
 
-class CalcCB : public GetFileInfoSeqCB
+class CalcCB final : public GetFileInfoSeqCB
 {
 public:
 
-    virtual bool
-    remove(const string& path)
+    bool remove(const string& path) final
     {
         consoleOut << "removing: " << path << endl;
         return true;
     }
 
-    virtual bool
-    checksum(const string& path)
+    bool checksum(const string& path) final
     {
         consoleOut << "checksum: " << path << endl;
         return true;
     }
 
-    virtual bool
-    compress(const string& path)
+    bool compress(const string& path) final
     {
         consoleOut << "compress: " << path << endl;
         return true;

--- a/cpp/src/IcePatch2/FileServerI.h
+++ b/cpp/src/IcePatch2/FileServerI.h
@@ -11,7 +11,7 @@
 namespace IcePatch2
 {
 
-class FileServerI : public FileServer
+class FileServerI final : public FileServer
 {
 public:
 
@@ -20,11 +20,11 @@ public:
     FileInfoSeq getFileInfoSeq(std::int32_t, const Ice::Current&) const;
 
     LargeFileInfoSeq
-    getLargeFileInfoSeq(std::int32_t, const Ice::Current&) const;
+    getLargeFileInfoSeq(std::int32_t, const Ice::Current&) const final;
 
-    ByteSeqSeq getChecksumSeq(const Ice::Current&) const;
+    ByteSeqSeq getChecksumSeq(const Ice::Current&) const final;
 
-    Ice::ByteSeq getChecksum(const Ice::Current&) const;
+    Ice::ByteSeq getChecksum(const Ice::Current&) const final;
 
     void getFileCompressedAsync(
         std::string,
@@ -40,12 +40,11 @@ public:
         std::int32_t,
         std::function<void(const std::pair<const std::uint8_t*, const std::uint8_t*>& returnValue)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&) const;
+        const Ice::Current&) const final;
 
 private:
 
-    void
-    getFileCompressedInternal(
+    void getFileCompressedInternal(
         std::string,
         std::int64_t,
         std::int32_t,


### PR DESCRIPTION
This PR simplifies IcePatch2::Patcher by removing one of its constructors and using non-optional proxies. The logic from PatcherI::init was moved to the remaining constructor. Additionally, the reading of IcePatch2 properties has been moved to IcePatch2::Client, as that is the only place where it was required.