### PR TITLE
Add type parameter to propertyToProxy

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -7,7 +7,7 @@ including RPC, pub/sub, server deployment, and more.
 
 Ice for C++ is the C++ implementation of Ice.
 
-## Sample Code with the Ice C++11 Mapping
+## Sample Code
 
 ```slice
 // Slice definitions (Hello.ice)
@@ -38,10 +38,10 @@ main(int argc, char* argv[])
     try
     {
         const Ice::CommunicatorHolder ich(argc, argv);
-        auto hello = Ice::checkedCast<HelloPrx>(ich->stringToProxy("hello:default -h localhost -p 10000"));
+        HelloPrx hello{ich.communicator(), "hello:default -h localhost -p 10000"};
         hello->sayHello();
     }
-    catch(const std::exception& ex)
+    catch (const std::exception& ex)
     {
         cerr << ex.what() << endl;
         return 1;
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
         adapter->activate();
         communicator->waitForShutdown();
     }
-    catch(const std::exception& ex)
+    catch (const std::exception& ex)
     {
         cerr << ex.what() << endl;
         return 1;
@@ -97,115 +97,22 @@ int main(int argc, char* argv[])
 #include <Ice/Ice.h>
 #include <Hello.h>
 
-class Printer : public Demo::Hello
+class Printer final : public Demo::Hello
 {
 public:
     /**
      * Prints a message to the standard output.
      **/
-    virtual void sayHello(const Ice::Current&) override
+    void sayHello(const Ice::Current&) final
     {
         std::cout << "Hello World!" << std::endl;
     }
 }
 ```
 
-## Sample Code with the Ice C++98 Mapping
-
-```slice
-// Slice definitions (Hello.ice)
-
-#pragma once
-
-module Demo
-{
-    interface Hello
-    {
-        void sayHello();
-    }
-}
-```
-
-```cpp
-// Client application (Client.cpp)
-
-#include <Ice/Ice.h>
-#include <Hello.h>
-
-using namespace std;
-using namespace Demo;
-
-int main(int argc, char* argv[])
-{
-    try
-    {
-        Ice::CommunicatorHolder ich(argc, argv);
-        HelloPrx hello = HelloPrx::checkedCast(
-            ich->stringToProxy("hello:default -h localhost -p 10000"));
-        hello->sayHello();
-    }
-    catch(const std::exception& ex)
-    {
-        cerr << ex.what() << endl;
-        return 1;
-    }
-    return 0;
-}
-```
-
-```cpp
-// Server application (Server.cpp)
-
-#include <Ice/Ice.h>
-#include <HelloI.h>
-
-using namespace std;
-
-int main(int argc, char* argv[])
-{
-    try
-    {
-        Ice::CommunicatorHolder ich(argc, argv);
-        Ice::ObjectAdapterPtr adapter = ich->createObjectAdapterWithEndpoints(
-            "Hello",
-            "default -h localhost -p 10000");
-        adapter->add(new HelloI, Ice::stringToIdentity("hello"));
-        adapter->activate();
-        ich->waitForShutdown();
-    }
-    catch(const std::exception& ex)
-    {
-        cerr << ex.what() << endl;
-        return 1;
-    }
-    return 0;
-}
-```
-
-```cpp
-// Printer implementation (Printer.h)
-
-#include <Ice/Ice.h>
-#include <Hello.h>
-
-class Printer : public Demo::Hello
-{
-public:
-    /**
-     * Prints a message to the standard output.
-     **/
-    virtual void sayHello(const Ice::Current&)
-    {
-        std::cout << "Hello World!" << std::endl;
-    }
-}
-```
-
-[Getting started C++11]: https://doc.zeroc.com/ice/3.7/hello-world-application/writing-an-ice-application-with-c++-c++11
-[Examples C++11]: https://github.com/zeroc-ice/ice-demos/tree/3.7/cpp11
-[Getting started C++98]: https://doc.zeroc.com/ice/3.7/hello-world-application/writing-an-ice-application-with-c++-c++98
-[Examples C++98]: https://github.com/zeroc-ice/ice-demos/tree/3.7/cpp98
+[Getting started with Ice C++]: https://doc.zeroc.com/ice/3.8/hello-world-application/writing-an-ice-application-with-c++
+[C++ Examples]: https://github.com/zeroc-ice/ice-demos/tree/3.8/cpp
 [NuGet packages]: https://www.nuget.org/packages?q=zeroc.ice.v
-[Documentation]: https://doc.zeroc.com/ice/3.7
-[Building from source]: https://github.com/zeroc-ice/ice/blob/3.7/cpp/BUILDING.md
+[Documentation]: https://doc.zeroc.com/ice/3.8
+[Building from source]: https://github.com/zeroc-ice/ice/blob/3.8/cpp/BUILDING.md
 [Ice framework]: https://github.com/zeroc-ice/ice

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -90,8 +90,7 @@ public:
     /**
      * Convert a proxy into a string.
      * @param obj The proxy to convert into a stringified proxy.
-     * @return The stringified proxy, or an empty string if
-     * <code>obj</code> is nil.
+     * @return The stringified proxy, or an empty string if <code>obj</code> is nullopt.
      * @see #stringToProxy
      */
     std::string proxyToString(const std::optional<ObjectPrx>& obj) const;
@@ -101,10 +100,15 @@ public:
      * refers to a property containing a stringified proxy, such as <code>MyProxy=id:tcp -h localhost -p 10000</code>.
      * Additional properties configure local settings for the proxy, such as <code>MyProxy.PreferSecure=1</code>. The
      * "Properties" appendix in the Ice manual describes each of the supported proxy properties.
+     * @tparam Prx The type of the proxy to return.
      * @param property The base property name.
-     * @return The proxy.
+     * @return The proxy, or nullopt if the property is not set.
      */
-    std::optional<ObjectPrx> propertyToProxy(const std::string& property) const;
+    template<typename Prx = ObjectPrx, std::enable_if_t<std::is_base_of<ObjectPrx, Prx>::value, bool> = true>
+    std::optional<Prx> propertyToProxy(const std::string& property) const
+    {
+        return std::optional<Prx>{_propertyToProxy(property)};
+    }
 
     /**
      * Convert a proxy to a set of proxy properties.
@@ -359,6 +363,8 @@ private:
     // constructor.
     //
     void finishSetup(int&, const char*[]);
+
+    std::optional<ObjectPrx> _propertyToProxy(const std::string& property) const;
 
     friend ICE_API CommunicatorPtr initialize(int&, const char*[], const InitializationData&, std::int32_t);
     friend ICE_API CommunicatorPtr initialize(StringSeq&, const InitializationData&, std::int32_t);

--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -212,7 +212,7 @@ RouterService::start(int argc, char* argv[], int& status)
     optional<PermissionsVerifierPrx> verifier;
     try
     {
-        verifier = optional<PermissionsVerifierPrx>(communicator()->propertyToProxy(verifierProperty));
+        verifier = communicator()->propertyToProxy<PermissionsVerifierPrx>(verifierProperty);
         if (verifier)
         {
             verifier->ice_ping();
@@ -241,7 +241,7 @@ RouterService::start(int argc, char* argv[], int& status)
     optional<SessionManagerPrx> sessionManager;
     try
     {
-        sessionManager = optional<SessionManagerPrx>(communicator()->propertyToProxy(sessionManagerProperty));
+        sessionManager = communicator()->propertyToProxy<SessionManagerPrx>(sessionManagerProperty);
         if (sessionManager)
         {
             sessionManager->ice_ping();
@@ -272,7 +272,7 @@ RouterService::start(int argc, char* argv[], int& status)
     optional<SSLPermissionsVerifierPrx> sslVerifier;
     try
     {
-        sslVerifier = optional<SSLPermissionsVerifierPrx>(communicator()->propertyToProxy(sslVerifierProperty));
+        sslVerifier = communicator()->propertyToProxy<SSLPermissionsVerifierPrx>(sslVerifierProperty);
         if (sslVerifier)
         {
             sslVerifier->ice_ping();
@@ -308,7 +308,7 @@ RouterService::start(int argc, char* argv[], int& status)
     optional<SSLSessionManagerPrx> sslSessionManager;
     try
     {
-        sslSessionManager = optional<SSLSessionManagerPrx>(communicator()->propertyToProxy(sslSessionManagerProperty));
+        sslSessionManager = communicator()->propertyToProxy<SSLSessionManagerPrx>(sslSessionManagerProperty);
         if (sslSessionManager)
         {
             sslSessionManager->ice_ping();

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -98,7 +98,7 @@ Ice::Communicator::proxyToString(const std::optional<ObjectPrx>& proxy) const
 }
 
 std::optional<ObjectPrx>
-Ice::Communicator::propertyToProxy(const string& p) const
+Ice::Communicator::_propertyToProxy(const string& p) const
 {
     return _instance->proxyFactory()->propertyToProxy(p);
 }

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -681,7 +681,7 @@ IceInternal::Instance::setServerProcessProxy(const ObjectAdapterPtr& adminAdapte
     const string serverId = _initData.properties->getProperty("Ice.Admin.ServerId");
     if(locator && serverId != "")
     {
-        ProcessPrx process = Ice::uncheckedCast<ProcessPrx>(admin, "Process");
+        ProcessPrx process{admin->ice_facet("Process")};
         try
         {
             //
@@ -1496,7 +1496,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
     //
     if(!_referenceFactory->getDefaultRouter())
     {
-        optional<RouterPrx> router = Ice::uncheckedCast<RouterPrx>(_proxyFactory->propertyToProxy("Ice.Default.Router"));
+        optional<RouterPrx> router{_proxyFactory->propertyToProxy("Ice.Default.Router")};
         if(router)
         {
             _referenceFactory = _referenceFactory->setDefaultRouter(router);
@@ -1505,7 +1505,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
 
     if(!_referenceFactory->getDefaultLocator())
     {
-        optional<LocatorPrx> locator = Ice::uncheckedCast<LocatorPrx>(_proxyFactory->propertyToProxy("Ice.Default.Locator"));
+        optional<LocatorPrx> locator{_proxyFactory->propertyToProxy("Ice.Default.Locator")};
         if(locator)
         {
             _referenceFactory = _referenceFactory->setDefaultLocator(locator);

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -222,8 +222,7 @@ filterLogMessages(LogMessageSeq& logMessages, const set<LogMessageType>& message
 RemoteLoggerPrx
 changeCommunicator(const RemoteLoggerPrx& prx, const CommunicatorPtr& communicator)
 {
-    optional<RemoteLoggerPrx> result = Ice::uncheckedCast<RemoteLoggerPrx>(communicator->stringToProxy(prx->ice_toString()));
-    assert(result);
+    RemoteLoggerPrx result{communicator, prx->ice_toString()};
     return result->ice_invocationTimeout(prx->ice_getInvocationTimeout());
 }
 

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -966,8 +966,7 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
 
         if (!router)
         {
-            router = Ice::uncheckedCast<RouterPrx>(
-                _instance->proxyFactory()->propertyToProxy(_name + ".Router"));
+            router = _communicator->propertyToProxy<RouterPrx>(_name + ".Router");
         }
         if(router)
         {
@@ -1034,7 +1033,7 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
 
         if(!properties->getProperty(_name + ".Locator").empty())
         {
-            setLocator(Ice::uncheckedCast<LocatorPrx>(_instance->proxyFactory()->propertyToProxy(_name + ".Locator")));
+            setLocator(_communicator->propertyToProxy<LocatorPrx>(_name + ".Locator"));
         }
         else
         {

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -735,7 +735,7 @@ IceInternal::ReferenceFactory::create(const Identity& ident,
         string property;
 
         property = propertyPrefix + ".Locator";
-        auto locator = Ice::uncheckedCast<LocatorPrx>(_communicator->propertyToProxy(property));
+        auto locator = _communicator->propertyToProxy<LocatorPrx>(property);
         if(locator)
         {
             if(locator->ice_getEncodingVersion() != encoding)
@@ -749,7 +749,7 @@ IceInternal::ReferenceFactory::create(const Identity& ident,
         }
 
         property = propertyPrefix + ".Router";
-        auto router = Ice::uncheckedCast<RouterPrx>(_communicator->propertyToProxy(property));
+        auto router = _communicator->propertyToProxy<RouterPrx>(property);
         if (router)
         {
             if(propertyPrefix.size() > 7 && propertyPrefix.substr(propertyPrefix.size() - 7, 7) == ".Router")

--- a/cpp/src/Ice/ReferenceFactory.h
+++ b/cpp/src/Ice/ReferenceFactory.h
@@ -38,7 +38,7 @@ public:
     //
     // Create a reference from a string.
     //
-    ReferencePtr create(const ::std::string&, const std::string&);
+    ReferencePtr create(const ::std::string& proxyString, const std::string& prefix);
 
     //
     // Create a reference by unmarshaling it from a stream.

--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -321,7 +321,7 @@ run(const Ice::StringSeq& args)
                 os << "Ice/LocatorFinder" << (ssl ? " -s" : "");
                 os << ":tcp -h \"" << host << "\" -p " << (port == 0 ? 4061 : port) << " -t " << timeout;
                 os << ":ssl -h \"" << host << "\" -p " << (port == 0 ? 4062 : port) << " -t " << timeout;
-                auto finder = Ice::uncheckedCast<Ice::LocatorFinderPrx>(communicator->stringToProxy(os.str()));
+                Ice::LocatorFinderPrx finder{communicator, os.str()};
                 try
                 {
                     communicator->setDefaultLocator(finder->getLocator());
@@ -570,8 +570,8 @@ run(const Ice::StringSeq& args)
             if(registry->ice_getIdentity() == localRegistry->ice_getIdentity())
             {
                 auto colloc = communicator->createObjectAdapter(""); // colloc-only adapter
-                communicator->setDefaultRouter(Ice::uncheckedCast<Ice::RouterPrx>(
-                    colloc->addWithUUID(make_shared<ReuseConnectionRouter>(locator))));
+                communicator->setDefaultRouter(
+                    Ice::RouterPrx{colloc->addWithUUID(make_shared<ReuseConnectionRouter>(locator))});
                 registry = registry->ice_router(communicator->getDefaultRouter());
             }
 

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -394,7 +394,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
     {
         try
         {
-            mapper = uncheckedCast<UserAccountMapperPrx>(communicator()->propertyToProxy(mapperProperty));
+            mapper = communicator()->propertyToProxy<UserAccountMapperPrx>(mapperProperty);
         }
         catch(const std::exception& ex)
         {
@@ -410,8 +410,8 @@ NodeService::startImpl(int argc, char* argv[], int& status)
         {
             try
             {
-                auto object = _adapter->addWithUUID(make_shared<FileUserAccountMapperI>(userAccountFileProperty));
-                mapper = uncheckedCast<UserAccountMapperPrx>(object);
+                mapper = UserAccountMapperPrx{
+                    _adapter->addWithUUID(make_shared<FileUserAccountMapperI>(userAccountFileProperty))};
             }
             catch(const exception& ex)
             {
@@ -451,7 +451,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
     // evictors and object factories necessary to store these objects.
     //
     Identity id = stringToIdentity(instanceName + "/Node-" + name);
-    auto nodeProxy = uncheckedCast<NodePrx>(_adapter->createProxy(id));
+    NodePrx nodeProxy{_adapter->createProxy(id)};
     _node = make_shared<NodeI>(_adapter, *_sessions, _activator, _timer, traceLevels, nodeProxy, name, mapper,
                                instanceName);
     _adapter->add(_node, nodeProxy->ice_getIdentity());

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -332,7 +332,7 @@ NodeEntry::loadServer(const shared_ptr<ServerEntry>& entry, const ServerInfo& se
             if(timeout > 0s)
             {
                 auto timeoutInMilliseconds = secondsToInt(timeout) * 1000;
-                node = Ice::uncheckedCast<NodePrx>(node->ice_invocationTimeout(std::move(timeoutInMilliseconds)));
+                node = node->ice_invocationTimeout(std::move(timeoutInMilliseconds));
             }
 
             ServerInfo info = server;
@@ -447,7 +447,7 @@ NodeEntry::destroyServer(const shared_ptr<ServerEntry>& entry, const ServerInfo&
             if(timeout > 0s)
             {
                 int timeoutInMilliseconds = secondsToInt(timeout) * 1000;
-                node = Ice::uncheckedCast<NodePrx>(node->ice_invocationTimeout(std::move(timeoutInMilliseconds)));
+                node = node->ice_invocationTimeout(std::move(timeoutInMilliseconds));
             }
         }
 

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -148,8 +148,7 @@ NodeSessionI::create(const shared_ptr<Database>& database,
         ObjectInfo objInfo = { node, string{Node::ice_staticId()} };
         database->addInternalObject(objInfo, true); // Add or update previous node proxy.
 
-        nodeSession->_proxy = Ice::uncheckedCast<NodeSessionPrx>(
-            database->getInternalAdapter()->addWithUUID(nodeSession));
+        nodeSession->_proxy = NodeSessionPrx{database->getInternalAdapter()->addWithUUID(nodeSession)};
     }
     catch(const NodeActiveException&)
     {

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -1472,7 +1472,7 @@ Parser::writeMessage(const list<string>& args, int fd)
         string server = *p++;
 
         auto serverAdmin = _admin->getServerAdmin(server);
-        auto process = Ice::uncheckedCast<Ice::ProcessPrx>(serverAdmin, "Process");
+        ProcessPrx process{serverAdmin->ice_facet("Process")};
 
         process->writeMessage(*p,  fd);
     }
@@ -1628,7 +1628,7 @@ Parser::propertiesServer(const list<string>& args, bool single)
     try
     {
         auto serverAdmin = _admin->getServerAdmin(args.front());
-        auto propAdmin = Ice::uncheckedCast<Ice::PropertiesAdminPrx>(serverAdmin, "Properties");
+        Ice::PropertiesAdminPrx propAdmin{serverAdmin->ice_facet("Properties")};
 
         if(single)
         {
@@ -1719,7 +1719,7 @@ Parser::startService(const list<string>& args)
     try
     {
         auto admin = _admin->getServerAdmin(server);
-        auto manager = Ice::uncheckedCast<IceBox::ServiceManagerPrx>(admin, "IceBox.ServiceManager");
+        IceBox::ServiceManagerPrx manager{admin->ice_facet("IceBox.ServiceManager")};
         manager->startService(service);
     }
     catch(const IceBox::AlreadyStartedException&)
@@ -1758,7 +1758,7 @@ Parser::stopService(const list<string>& args)
     try
     {
         auto admin = _admin->getServerAdmin(server);
-        auto manager = Ice::uncheckedCast<IceBox::ServiceManagerPrx>(admin, "IceBox.ServiceManager");
+        IceBox::ServiceManagerPrx manager{admin->ice_facet("IceBox.ServiceManager")};
         manager->stopService(service);
     }
     catch(const IceBox::AlreadyStoppedException&)
@@ -1883,11 +1883,11 @@ Parser::propertiesService(const list<string>& args, bool single)
         Ice::PropertiesAdminPrxPtr propAdmin;
         if(getPropertyAsInt(info.descriptor->propertySet.properties, "IceBox.UseSharedCommunicator." + service) > 0)
         {
-            propAdmin = Ice::uncheckedCast<Ice::PropertiesAdminPrx>(admin, "IceBox.SharedCommunicator.Properties");
+            propAdmin = Ice::PropertiesAdminPrx{admin->ice_facet("IceBox.SharedCommunicator.Properties")};
         }
         else
         {
-            propAdmin = Ice::uncheckedCast<Ice::PropertiesAdminPrx>(admin, "IceBox.Service." + service + ".Properties");
+            propAdmin = Ice::PropertiesAdminPrx{admin->ice_facet("IceBox.Service." + service + ".Properties")};
         }
 
         if(single)
@@ -2512,7 +2512,7 @@ Parser::showLog(const string& id, const string& reader, bool tail, bool follow, 
                                 adminCallbackTemplate->ice_getIdentity().category };
 
         auto servant = make_shared<RemoteLoggerI>();
-        auto prx = Ice::uncheckedCast<Ice::RemoteLoggerPrx>(adapter->add(servant, ident));
+        Ice::RemoteLoggerPrx prx{adapter->add(servant, ident)};
         adapter->activate();
 
         loggerAdmin->attachRemoteLogger(prx, Ice::LogMessageTypeSeq(), Ice::StringSeq(), tail ? lineCount : -1);

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -133,8 +133,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
             {
                 try
                 {
-                    auto manager = Ice::uncheckedCast<IceStorm::TopicManagerPrx>(
-                        communicator->propertyToProxy(p.first));
+                    auto manager = communicator->propertyToProxy<IceStorm::TopicManagerPrx>(p.first);
                     managers.insert({manager->ice_getIdentity(), manager});
                 }
                 catch(const Ice::ProxyParseException&)
@@ -166,7 +165,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
         os << "IceStorm/Finder";
         os << ":tcp" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
         os << ":ssl" << (host.empty() ? "" : (" -h \"" + host + "\"")) << " -p " << port << " -t " << timeout;
-        auto finder = Ice::uncheckedCast<IceStorm::FinderPrx>(communicator->stringToProxy(os.str()));
+        IceStorm::FinderPrx finder{communicator, os.str()};
         try
         {
             defaultManager = finder->getTopicManager();

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -140,7 +140,7 @@ ServiceI::start(const string& name, const shared_ptr<Communicator>& communicator
         try
         {
             auto manager = make_shared<TransientTopicManagerImpl>(_instance);
-            _managerProxy = Ice::uncheckedCast<TopicManagerPrx>(topicAdapter->add(manager, topicManagerId));
+            _managerProxy = TopicManagerPrx{topicAdapter->add(manager, topicManagerId)};
         }
         catch(const Ice::Exception& ex)
         {
@@ -163,7 +163,7 @@ ServiceI::start(const string& name, const shared_ptr<Communicator>& communicator
             auto instance = make_shared<PersistentInstance>(instanceName, name, communicator, publishAdapter, topicAdapter);
             _manager = TopicManagerImpl::create(instance);
             _instance = std::move(instance);
-            _managerProxy = uncheckedCast<TopicManagerPrx>(topicAdapter->add(_manager->getServant(), topicManagerId));
+            _managerProxy = TopicManagerPrx{topicAdapter->add(_manager->getServant(), topicManagerId)};
         }
         catch(const IceUtil::Exception& ex)
         {
@@ -196,7 +196,7 @@ ServiceI::start(const string& name, const shared_ptr<Communicator>& communicator
                 try
                 {
                     int nodeid = stoi(prop.first.substr(prefix.size()));
-                    nodes[nodeid] = uncheckedCast<NodePrx>(communicator->propertyToProxy(prop.first));
+                    nodes[nodeid] = communicator->propertyToProxy<NodePrx>(prop.first);
                 }
                 catch(const std::invalid_argument&)
                 {
@@ -286,7 +286,7 @@ ServiceI::start(const string& name, const shared_ptr<Communicator>& communicator
                 ident.category = instanceName;
                 ident.name = os.str();
 
-                nodes[nodeid] = uncheckedCast<NodePrx>((*p)->ice_adapterId(adapterid)->ice_identity(ident));
+                nodes[nodeid] = NodePrx{(*p)->ice_adapterId(adapterid)->ice_identity(ident)};
             }
         }
 
@@ -338,13 +338,13 @@ ServiceI::start(const string& name, const shared_ptr<Communicator>& communicator
                 // We're not using an IceGrid deployment. Here we need
                 // a proxy which is used to create proxies to the
                 // replicas later.
-                _managerProxy = uncheckedCast<TopicManagerPrx>(topicAdapter->createProxy(topicManagerId));
+                _managerProxy = TopicManagerPrx{topicAdapter->createProxy(topicManagerId)};
             }
             else
             {
                 // If we're using IceGrid deployment we need to create
                 // indirect proxies.
-                _managerProxy = uncheckedCast<TopicManagerPrx>(topicAdapter->createIndirectProxy(topicManagerId));
+                _managerProxy = TopicManagerPrx{topicAdapter->createIndirectProxy(topicManagerId)};
             }
 
             _manager = TopicManagerImpl::create(instance);

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -368,7 +368,7 @@ TopicImpl::create(shared_ptr<PersistentInstance> instance,
     auto publisher = make_shared<PublisherI>(topicImpl, instance);
     topicImpl->_publisherPrxPtr = instance->publishAdapter()->add(publisher, pubid);
     auto topicLink = make_shared<TopicLinkI>(topicImpl, instance);
-    topicImpl->_linkPrxPtr = Ice::uncheckedCast<TopicLinkPrx>(instance->publishAdapter()->add(topicLink, linkid));
+    topicImpl->_linkPrxPtr = TopicLinkPrx{instance->publishAdapter()->add(topicLink, linkid)};
 
     return topicImpl;
 }


### PR DESCRIPTION
This PR add s a type parameter to propertyToProxy - to let you get back a std::optional<Prx>.

It also removes a number of uncheckedCast. Many more to go though.