### PR TITLE
Remove workaround for old proguard version

### DIFF
--- a/java/src/IceGridGUI/build.gradle
+++ b/java/src/IceGridGUI/build.gradle
@@ -88,8 +88,7 @@ jar {
 
 project.ext.libJars = []
 
-project.ext.jarBuilder = icegridguiProguard.toBoolean() && JavaVersion.current() > JavaVersion.VERSION_1_8 ?
-    "proguard-jar.gradle" : "plain-jar.gradle"
+project.ext.jarBuilder = icegridguiProguard.toBoolean() ? "proguard-jar.gradle" : "plain-jar.gradle"
 
 apply from: jarBuilder
 

--- a/java/src/IceGridGUI/proguard-jar.gradle
+++ b/java/src/IceGridGUI/proguard-jar.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.guardsquare:proguard-gradle:7.4.0-beta02"
+        classpath "com.guardsquare:proguard-gradle:7.4.2"
     }
 }
 


### PR DESCRIPTION
This PR removes a workaround for an old ProGuard version that prevented the ProGuard JAR from being built with JDK 8. This is no longer an issue with ProGuard-Gradle version 7.4.2.

See https://github.com/zeroc-ice/ice/commit/96c5e9abfc2af1a200ef62990417b19418df4086






