### PR TITLE
Update brace style in C++ generated code

### DIFF
--- a/cpp/include/IceUtil/OutputUtil.h
+++ b/cpp/include/IceUtil/OutputUtil.h
@@ -96,9 +96,6 @@ namespace IceUtilInternal
         void spar(char = '('); // Start a paramater list.
         void epar(char = ')'); // End a paramater list.
 
-        void spar(std::string_view); // Start a paramater list.
-        void epar(std::string_view); // End a paramater list.
-
     private:
         std::string _blockStart;
         std::string _blockEnd;

--- a/cpp/src/IceUtil/OutputUtil.cpp
+++ b/cpp/src/IceUtil/OutputUtil.cpp
@@ -342,21 +342,6 @@ IceUtilInternal::Output::epar(char c)
     _out << c;
 }
 
-void
-IceUtilInternal::Output::spar(string_view s)
-{
-    _emptyBlock = false;
-    _out << s;
-    _par = 0;
-}
-
-void
-IceUtilInternal::Output::epar(string_view s)
-{
-    _par = -1;
-    _out << s;
-}
-
 Output&
 IceUtilInternal::operator<<(Output& out, ios_base& (*val)(ios_base&))
 {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2706,12 +2706,12 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // These type IDs are sorted alphabetically.
     C << nl << "static const ::std::vector<::std::string> allTypeIds = ";
-    C.spar("{ ");
+    C.spar('{');
     for (const auto& typeId : p->ids())
     {
         C << '"' + typeId + '"';
     }
-    C.epar(" }");
+    C.epar('}');
     C << ";";
 
     C << nl << "return allTypeIds;";
@@ -2768,12 +2768,12 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
         C << sp;
         C << nl << "static constexpr ::std::string_view allOperations[] = ";
-        C.spar("{ ");
+        C.spar('{');
         for (const auto& opName : allOpNames)
         {
             C << '"' + opName + '"';
         }
-        C.epar(" }");
+        C.epar('}');
         C << ";";
 
         C << sp;


### PR DESCRIPTION
It's a small update to the C++ generated code. string_view lists are now like:
```cpp
static constexpr ::std::string_view allOperations[] = {"findAdapterById", "findObjectById", "getRegistry", "ice_id", "ice_ids", "ice_isA", "ice_ping"};
```

without a space after the opening { or before the closing }, just like in our clang format.