### PR TITLE
Remove IceUtil::Exception::ice_throw

### DIFF
--- a/cpp/include/Ice/Exception.h
+++ b/cpp/include/Ice/Exception.h
@@ -31,6 +31,11 @@ namespace Ice
          */
         static std::string_view ice_staticId() noexcept;
 
+        /**
+         * Throws this exception.
+         */
+        virtual void ice_throw() const = 0;
+
         /// \cond STREAM
         virtual void _write(::Ice::OutputStream*) const;
         virtual void _read(::Ice::InputStream*);

--- a/cpp/include/Ice/ExceptionHelpers.h
+++ b/cpp/include/Ice/ExceptionHelpers.h
@@ -10,30 +10,18 @@
 
 namespace Ice
 {
-    class LocalException;
-
     /**
-     * Helper template for the implementation of Ice::LocalException. It implements ice_id.
+     * Helper template for the implementation of Ice::UserException. It implements ice_id and ice_throw.
      * \headerfile Ice/Ice.h
      */
-    template<typename T, typename B> class LocalExceptionHelper : public IceUtil::ExceptionHelper<T, B>
+    template<typename T, typename B> class UserExceptionHelper : public B
     {
     public:
-        using IceUtil::ExceptionHelper<T, B>::ExceptionHelper;
+        using B::B;
 
         std::string ice_id() const override { return std::string{T::ice_staticId()}; }
-    };
 
-    /**
-     * Helper template for the implementation of Ice::UserException. It implements ice_id.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T, typename B> class UserExceptionHelper : public IceUtil::ExceptionHelper<T, B>
-    {
-    public:
-        using IceUtil::ExceptionHelper<T, B>::ExceptionHelper;
-
-        std::string ice_id() const override { return std::string{T::ice_staticId()}; }
+        void ice_throw() const override { throw static_cast<const T&>(*this); }
 
     protected:
         /// \cond STREAM

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -35,34 +35,36 @@ namespace Ice
      * Indicates that Iconv does not support the code.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API IconvInitializationException : public IceUtil::ExceptionHelper<IconvInitializationException>
+    class ICE_API IconvInitializationException : public IceUtil::Exception
     {
     public:
+        using IceUtil::Exception::Exception;
+
         /**
          * Constructs the exception with a reason. The file and line number are required.
          * @param file The file name in which the exception was raised, typically __FILE__.
          * @param line The line number at which the exception was raised, typically __LINE__.
          * @param reason More detail about the failure.
          */
-        IconvInitializationException(const char* file, int line, const std::string& reason);
+        IconvInitializationException(const char* file, int line, std::string reason) noexcept;
 
         /**
          * Obtains the Slice type ID of this exception.
          * @return The fully-scoped type ID.
          */
-        virtual std::string ice_id() const;
+        std::string ice_id() const override;
 
         /**
          * Prints a description of this exception to the given stream.
          * @param str The output stream.
          */
-        virtual void ice_print(std::ostream& str) const;
+        void ice_print(std::ostream& str) const override;
 
         /**
          * Obtains the reason for the failure.
          * @return The reason.
          */
-        std::string reason() const;
+        std::string reason() const noexcept;
 
     private:
         std::string _reason;

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -35,7 +35,7 @@ namespace Ice
      * Indicates that Iconv does not support the code.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API IconvInitializationException : public IceUtil::Exception
+    class ICE_API IconvInitializationException final : public IceUtil::Exception
     {
     public:
         using IceUtil::Exception::Exception;
@@ -52,19 +52,13 @@ namespace Ice
          * Obtains the Slice type ID of this exception.
          * @return The fully-scoped type ID.
          */
-        std::string ice_id() const override;
+        std::string ice_id() const final;
 
         /**
          * Prints a description of this exception to the given stream.
          * @param str The output stream.
          */
-        void ice_print(std::ostream& str) const override;
-
-        /**
-         * Obtains the reason for the failure.
-         * @return The reason.
-         */
-        std::string reason() const noexcept;
+        void ice_print(std::ostream& str) const final;
 
     private:
         std::string _reason;

--- a/cpp/include/Ice/LocalException.h
+++ b/cpp/include/Ice/LocalException.h
@@ -32,6 +32,9 @@ namespace Ice
     public:
         using Exception::Exception;
 
+        // temporary
+        void ice_throw() const final { assert(false); }
+
         /**
          * Obtains the Slice type ID of this exception.
          * @return The fully-scoped type ID.
@@ -77,8 +80,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The reason for the failure.
          */
@@ -122,8 +123,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The reason for the failure.
@@ -177,8 +176,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The kind of object that could not be removed: "servant", "facet", "object", "default servant",
@@ -240,8 +237,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The kind of object that could not be removed: "servant", "facet", "object", "default servant",
          * "servant locator", "value factory", "plugin", "object adapter", "object adapter with router", "replica
@@ -294,8 +289,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The name of the operation that was invoked.
          */
@@ -323,8 +316,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -367,8 +358,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * This field is set to the textual representation of the unknown exception if available.
          */
@@ -397,8 +386,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -423,8 +410,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -445,8 +430,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -468,8 +451,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -511,8 +492,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * Name of the adapter.
@@ -559,8 +538,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * Adapter ID.
          */
@@ -604,8 +581,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The stringified proxy for which no suitable endpoint is available.
@@ -651,8 +626,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * Describes the failure and includes the string that could not be parsed.
          */
@@ -696,8 +669,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * Describes the failure and includes the string that could not be parsed.
@@ -743,8 +714,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * Describes the failure and includes the string that could not be parsed.
          */
@@ -788,8 +757,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * Describes the failure and includes the string that could not be parsed.
@@ -835,8 +802,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * Describes the failure and includes the string that could not be parsed.
          */
@@ -861,8 +826,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -902,8 +865,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * Describes why this servant is illegal.
@@ -963,8 +924,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The identity of the Ice Object to which the request was sent.
          */
@@ -998,8 +957,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1021,8 +978,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1043,8 +998,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1091,8 +1044,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The error number describing the system exception. For C++ and Unix, this is equivalent to <code>errno</code>.
          * For C++ and Windows, this is the value returned by <code>GetLastError()</code> or
@@ -1119,8 +1070,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1161,8 +1110,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The domain of the error.
@@ -1208,8 +1155,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The path of the file responsible for the error.
          */
@@ -1234,8 +1179,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1256,8 +1199,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1278,8 +1219,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1322,8 +1261,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The error number describing the DNS problem. For C++ and Unix, this is equivalent to <code>h_errno</code>.
          * For C++ and Windows, this is the value returned by <code>WSAGetLastError()</code>.
@@ -1353,8 +1290,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1375,8 +1310,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1397,8 +1330,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1419,8 +1350,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1441,8 +1370,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1463,8 +1390,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1485,8 +1410,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1526,8 +1449,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The reason for the failure.
@@ -1573,8 +1494,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * A sequence containing the first four bytes of the incorrect message.
@@ -1630,8 +1549,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The version of the unsupported protocol.
@@ -1692,8 +1609,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The version of the unsupported encoding.
          */
@@ -1722,8 +1637,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1744,8 +1657,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1766,8 +1677,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1788,8 +1697,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1813,8 +1720,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1857,8 +1762,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * True if the connection was closed gracefully, false otherwise.
          */
@@ -1883,8 +1786,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1905,8 +1806,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1928,8 +1827,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1950,8 +1847,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1972,8 +1867,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -1994,8 +1887,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -2040,8 +1931,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The Slice type ID of the class instance for which no factory could be found.
@@ -2101,8 +1990,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The Slice type ID of the class instance that was unmarshaled.
          */
@@ -2131,8 +2018,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -2153,8 +2038,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -2175,8 +2058,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 
     /**
@@ -2216,8 +2097,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
 
         /**
          * The name of the unsupported feature.
@@ -2263,8 +2142,6 @@ namespace Ice
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The reason for the failure.
          */
@@ -2289,8 +2166,6 @@ namespace Ice
         std::string ice_id() const override;
 
         void ice_print(std::ostream& stream) const override;
-
-        void ice_throw() const override;
     };
 }
 

--- a/cpp/include/Ice/LocalException.h
+++ b/cpp/include/Ice/LocalException.h
@@ -32,9 +32,6 @@ namespace Ice
     public:
         using Exception::Exception;
 
-        // temporary
-        void ice_throw() const final { assert(false); }
-
         /**
          * Obtains the Slice type ID of this exception.
          * @return The fully-scoped type ID.

--- a/cpp/include/IceBT/Types.h
+++ b/cpp/include/IceBT/Types.h
@@ -65,8 +65,6 @@ namespace IceBT
 
         std::string ice_id() const override;
 
-        void ice_throw() const override;
-
         /**
          * Provides more information about the failure.
          */

--- a/cpp/include/IceBox/Service.h
+++ b/cpp/include/IceBox/Service.h
@@ -79,8 +79,6 @@ namespace IceBox
 
         void ice_print(std::ostream& stream) const override;
 
-        void ice_throw() const override;
-
         /**
          * The reason for the failure.
          */

--- a/cpp/include/IceSSL/Plugin.h
+++ b/cpp/include/IceSSL/Plugin.h
@@ -149,12 +149,14 @@ namespace IceSSL
      * Thrown if the certificate cannot be read.
      * \headerfile IceSSL/IceSSL.h
      */
-    class ICESSL_API CertificateReadException : public IceUtil::ExceptionHelper<CertificateReadException>
+    class ICESSL_API CertificateReadException : public Ice::Exception
     {
     public:
-        CertificateReadException(const char*, int, const std::string&);
+        using Ice::Exception::Exception;
 
-        virtual std::string ice_id() const;
+        CertificateReadException(const char*, int, std::string) noexcept;
+
+        std::string ice_id() const override;
 
         /** The reason for the exception. */
         std::string reason;
@@ -167,12 +169,14 @@ namespace IceSSL
      * Thrown if the certificate cannot be encoded.
      * \headerfile IceSSL/IceSSL.h
      */
-    class ICESSL_API CertificateEncodingException : public IceUtil::ExceptionHelper<CertificateEncodingException>
+    class ICESSL_API CertificateEncodingException : public Ice::Exception
     {
     public:
-        CertificateEncodingException(const char*, int, const std::string&);
+        using Ice::Exception::Exception;
 
-        virtual std::string ice_id() const;
+        CertificateEncodingException(const char*, int, std::string) noexcept;
+
+        std::string ice_id() const override;
 
         /** The reason for the exception. */
         std::string reason;
@@ -185,12 +189,14 @@ namespace IceSSL
      * This exception is thrown if a distinguished name cannot be parsed.
      * \headerfile IceSSL/IceSSL.h
      */
-    class ICESSL_API ParseException : public IceUtil::ExceptionHelper<ParseException>
+    class ICESSL_API ParseException : public Ice::Exception
     {
     public:
-        ParseException(const char*, int, const std::string&);
+        using Ice::Exception::Exception;
 
-        virtual std::string ice_id() const;
+        ParseException(const char*, int, std::string) noexcept;
+
+        std::string ice_id() const override;
 
         /** The reason for the exception. */
         std::string reason;

--- a/cpp/include/IceUtil/CtrlCHandler.h
+++ b/cpp/include/IceUtil/CtrlCHandler.h
@@ -69,11 +69,12 @@ namespace IceUtil
      *
      * \headerfile Ice/Ice.h
      */
-    class ICE_API CtrlCHandlerException : public ExceptionHelper<CtrlCHandlerException>
+    class ICE_API CtrlCHandlerException final : public Exception
     {
     public:
-        CtrlCHandlerException(const char*, int);
-        virtual std::string ice_id() const;
+        using Exception::Exception;
+
+        std::string ice_id() const final;
     };
 }
 

--- a/cpp/include/IceUtil/Exception.h
+++ b/cpp/include/IceUtil/Exception.h
@@ -53,11 +53,6 @@ namespace IceUtil
         virtual const char* what() const noexcept;
 
         /**
-         * Throws this exception.
-         */
-        virtual void ice_throw() const = 0;
-
-        /**
          * Returns the name of the file where this exception was constructed.
          * @return The file name.
          */
@@ -85,40 +80,25 @@ namespace IceUtil
     ICE_API std::ostream& operator<<(std::ostream&, const Exception&);
 
     /**
-     * Helper template for the implementation of Ice::Exception.
-     * It implements ice_throw.
-     * \headerfile Ice/Ice.h
-     */
-    // We generate a text graph, because the inheritance graph for this type has too many nodes.
-    /// \inheritancegraph{TEXT}
-    template<typename E, typename B = Exception> class ExceptionHelper : public B
-    {
-    public:
-        using B::B;
-
-        virtual void ice_throw() const override { throw static_cast<const E&>(*this); }
-    };
-
-    /**
      * This exception indicates that a function was called with an illegal parameter
      * value. It is used only by the Slice to C++98 mapping; std::invalid_argument is
      * used by the Slice to C++11 mapping.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API IllegalArgumentException : public ExceptionHelper<IllegalArgumentException>
+    class ICE_API IllegalArgumentException : public Exception
     {
     public:
-        IllegalArgumentException(const char*, int);
-        IllegalArgumentException(const char*, int, const std::string&);
+        using Exception::Exception;
+        IllegalArgumentException(const char*, int, std::string) noexcept;
 
-        virtual std::string ice_id() const;
-        virtual void ice_print(std::ostream&) const;
+        std::string ice_id() const override;
+        void ice_print(std::ostream&) const override;
 
         /**
          * Provides the reason this exception was thrown.
          * @return The reason.
          */
-        std::string reason() const;
+        std::string reason() const noexcept;
 
     private:
         const std::string _reason;
@@ -128,20 +108,20 @@ namespace IceUtil
      * This exception indicates the failure of a string conversion.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API IllegalConversionException : public ExceptionHelper<IllegalConversionException>
+    class ICE_API IllegalConversionException : public Exception
     {
     public:
-        IllegalConversionException(const char*, int);
-        IllegalConversionException(const char*, int, const std::string&);
+        using Exception::Exception;
+        IllegalConversionException(const char*, int, std::string) noexcept;
 
-        virtual std::string ice_id() const;
-        virtual void ice_print(std::ostream&) const;
+        std::string ice_id() const override;
+        void ice_print(std::ostream&) const override;
 
         /**
          * Provides the reason this exception was thrown.
          * @return The reason.
          */
-        std::string reason() const;
+        std::string reason() const noexcept;
 
     private:
         const std::string _reason;
@@ -151,25 +131,27 @@ namespace IceUtil
      * This exception indicates the failure to lock a file.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API FileLockException : public ExceptionHelper<FileLockException>
+    class ICE_API FileLockException : public Exception
     {
     public:
-        FileLockException(const char*, int, int, const std::string&);
+        using Exception::Exception;
 
-        virtual std::string ice_id() const;
-        virtual void ice_print(std::ostream&) const;
+        FileLockException(const char*, int, int, std::string) noexcept;
+
+        std::string ice_id() const override;
+        void ice_print(std::ostream&) const override;
 
         /**
          * Returns the path to the file.
          * @return The file path.
          */
-        std::string path() const;
+        const std::string& path() const noexcept;
 
         /**
          * Returns the error number for the failed locking attempt.
          * @return The error number.
          */
-        int error() const;
+        int error() const noexcept;
 
     private:
         const int _error;

--- a/cpp/include/IceUtil/Exception.h
+++ b/cpp/include/IceUtil/Exception.h
@@ -134,8 +134,6 @@ namespace IceUtil
     class ICE_API FileLockException : public Exception
     {
     public:
-        using Exception::Exception;
-
         FileLockException(const char*, int, int, std::string) noexcept;
 
         std::string ice_id() const override;

--- a/cpp/include/IceUtil/Options.h
+++ b/cpp/include/IceUtil/Options.h
@@ -13,25 +13,27 @@
 
 namespace IceUtilInternal
 {
-    class ICE_API APIException : public IceUtil::ExceptionHelper<APIException>
+    class ICE_API APIException : public IceUtil::Exception
     {
     public:
-        APIException(const char*, int, const ::std::string&);
-        virtual ::std::string ice_id() const;
-        virtual void ice_print(std::ostream&) const;
-        ::std::string reason;
+        using IceUtil::Exception::Exception;
+        APIException(const char*, int, std::string) noexcept;
+        std::string ice_id() const override;
+        void ice_print(std::ostream&) const override;
+        std::string reason;
     };
 
     ICE_API ::std::ostream& operator<<(::std::ostream&, const APIException&);
 
-    class ICE_API BadOptException : public IceUtil::ExceptionHelper<BadOptException>
+    class ICE_API BadOptException : public IceUtil::Exception
     {
     public:
-        BadOptException(const char*, int, const ::std::string&);
-        virtual ::std::string ice_id() const;
-        virtual void ice_print(std::ostream&) const;
+        using IceUtil::Exception::Exception;
+        BadOptException(const char*, int, std::string) noexcept;
+        std::string ice_id() const override;
+        void ice_print(std::ostream&) const override;
 
-        ::std::string reason;
+        std::string reason;
     };
 
     ICE_API ::std::ostream& operator<<(::std::ostream&, const BadOptException&);

--- a/cpp/src/Ice/IconvStringConverter.cpp
+++ b/cpp/src/Ice/IconvStringConverter.cpp
@@ -29,9 +29,4 @@ IconvInitializationException::ice_id() const
     return "::Ice::IconvInitializationException";
 }
 
-string
-IconvInitializationException::reason() const noexcept
-{
-    return _reason;
-}
 #endif

--- a/cpp/src/Ice/IconvStringConverter.cpp
+++ b/cpp/src/Ice/IconvStringConverter.cpp
@@ -10,9 +10,9 @@ using namespace std;
 using namespace Ice;
 using namespace IceUtil;
 
-IconvInitializationException::IconvInitializationException(const char* file, int line, const string& reason)
-    : ExceptionHelper<IconvInitializationException>(file, line),
-      _reason(reason)
+IconvInitializationException::IconvInitializationException(const char* file, int line, string reason) noexcept
+    : Exception(file, line),
+      _reason(std::move(reason))
 {
 }
 
@@ -30,7 +30,7 @@ IconvInitializationException::ice_id() const
 }
 
 string
-IconvInitializationException::reason() const
+IconvInitializationException::reason() const noexcept
 {
     return _reason;
 }

--- a/cpp/src/Ice/LocalException.cpp
+++ b/cpp/src/Ice/LocalException.cpp
@@ -37,12 +37,6 @@ Ice::InitializationException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::InitializationException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::InitializationException::ice_staticId() noexcept
 {
@@ -54,12 +48,6 @@ string
 Ice::PluginInitializationException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::PluginInitializationException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -75,12 +63,6 @@ Ice::AlreadyRegisteredException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::AlreadyRegisteredException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::AlreadyRegisteredException::ice_staticId() noexcept
 {
@@ -92,12 +74,6 @@ string
 Ice::NotRegisteredException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::NotRegisteredException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -113,12 +89,6 @@ Ice::TwowayOnlyException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::TwowayOnlyException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::TwowayOnlyException::ice_staticId() noexcept
 {
@@ -130,12 +100,6 @@ string
 Ice::CloneNotImplementedException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::CloneNotImplementedException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -151,12 +115,6 @@ Ice::UnknownException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnknownException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnknownException::ice_staticId() noexcept
 {
@@ -168,12 +126,6 @@ string
 Ice::UnknownLocalException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::UnknownLocalException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -189,12 +141,6 @@ Ice::UnknownUserException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnknownUserException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnknownUserException::ice_staticId() noexcept
 {
@@ -206,12 +152,6 @@ string
 Ice::VersionMismatchException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::VersionMismatchException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -227,12 +167,6 @@ Ice::CommunicatorDestroyedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::CommunicatorDestroyedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::CommunicatorDestroyedException::ice_staticId() noexcept
 {
@@ -244,12 +178,6 @@ string
 Ice::ObjectAdapterDeactivatedException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::ObjectAdapterDeactivatedException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -265,12 +193,6 @@ Ice::ObjectAdapterIdInUseException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ObjectAdapterIdInUseException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ObjectAdapterIdInUseException::ice_staticId() noexcept
 {
@@ -282,12 +204,6 @@ string
 Ice::NoEndpointException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::NoEndpointException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -303,12 +219,6 @@ Ice::EndpointParseException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::EndpointParseException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::EndpointParseException::ice_staticId() noexcept
 {
@@ -320,12 +230,6 @@ string
 Ice::EndpointSelectionTypeParseException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::EndpointSelectionTypeParseException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -341,12 +245,6 @@ Ice::VersionParseException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::VersionParseException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::VersionParseException::ice_staticId() noexcept
 {
@@ -358,12 +256,6 @@ string
 Ice::IdentityParseException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::IdentityParseException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -379,12 +271,6 @@ Ice::ProxyParseException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ProxyParseException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ProxyParseException::ice_staticId() noexcept
 {
@@ -396,12 +282,6 @@ string
 Ice::IllegalIdentityException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::IllegalIdentityException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -417,12 +297,6 @@ Ice::IllegalServantException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::IllegalServantException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::IllegalServantException::ice_staticId() noexcept
 {
@@ -434,12 +308,6 @@ string
 Ice::RequestFailedException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::RequestFailedException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -455,12 +323,6 @@ Ice::ObjectNotExistException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ObjectNotExistException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ObjectNotExistException::ice_staticId() noexcept
 {
@@ -474,12 +336,6 @@ Ice::FacetNotExistException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::FacetNotExistException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::FacetNotExistException::ice_staticId() noexcept
 {
@@ -491,12 +347,6 @@ string
 Ice::OperationNotExistException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::OperationNotExistException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -522,12 +372,6 @@ Ice::SyscallException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::SyscallException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::SyscallException::ice_staticId() noexcept
 {
@@ -539,12 +383,6 @@ string
 Ice::SocketException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::SocketException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -560,12 +398,6 @@ Ice::CFNetworkException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::CFNetworkException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::CFNetworkException::ice_staticId() noexcept
 {
@@ -577,12 +409,6 @@ string
 Ice::FileException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::FileException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -598,12 +424,6 @@ Ice::ConnectFailedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectFailedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectFailedException::ice_staticId() noexcept
 {
@@ -615,12 +435,6 @@ string
 Ice::ConnectionRefusedException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::ConnectionRefusedException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -636,12 +450,6 @@ Ice::ConnectionLostException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectionLostException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectionLostException::ice_staticId() noexcept
 {
@@ -653,12 +461,6 @@ string
 Ice::DNSException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::DNSException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -674,12 +476,6 @@ Ice::OperationInterruptedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::OperationInterruptedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::OperationInterruptedException::ice_staticId() noexcept
 {
@@ -691,12 +487,6 @@ string
 Ice::TimeoutException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::TimeoutException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -712,12 +502,6 @@ Ice::ConnectTimeoutException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectTimeoutException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectTimeoutException::ice_staticId() noexcept
 {
@@ -729,12 +513,6 @@ string
 Ice::CloseTimeoutException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::CloseTimeoutException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -750,12 +528,6 @@ Ice::ConnectionTimeoutException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectionTimeoutException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectionTimeoutException::ice_staticId() noexcept
 {
@@ -767,12 +539,6 @@ string
 Ice::InvocationTimeoutException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::InvocationTimeoutException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -788,12 +554,6 @@ Ice::InvocationCanceledException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::InvocationCanceledException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::InvocationCanceledException::ice_staticId() noexcept
 {
@@ -805,12 +565,6 @@ string
 Ice::ProtocolException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::ProtocolException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -826,12 +580,6 @@ Ice::BadMagicException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::BadMagicException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::BadMagicException::ice_staticId() noexcept
 {
@@ -843,12 +591,6 @@ string
 Ice::UnsupportedProtocolException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::UnsupportedProtocolException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -864,12 +606,6 @@ Ice::UnsupportedEncodingException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnsupportedEncodingException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnsupportedEncodingException::ice_staticId() noexcept
 {
@@ -881,12 +617,6 @@ string
 Ice::UnknownMessageException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::UnknownMessageException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -902,12 +632,6 @@ Ice::ConnectionNotValidatedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectionNotValidatedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectionNotValidatedException::ice_staticId() noexcept
 {
@@ -919,12 +643,6 @@ string
 Ice::UnknownRequestIdException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::UnknownRequestIdException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -940,12 +658,6 @@ Ice::UnknownReplyStatusException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnknownReplyStatusException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnknownReplyStatusException::ice_staticId() noexcept
 {
@@ -957,12 +669,6 @@ string
 Ice::CloseConnectionException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::CloseConnectionException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -978,12 +684,6 @@ Ice::ConnectionManuallyClosedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::ConnectionManuallyClosedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::ConnectionManuallyClosedException::ice_staticId() noexcept
 {
@@ -995,12 +695,6 @@ string
 Ice::IllegalMessageSizeException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::IllegalMessageSizeException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1016,12 +710,6 @@ Ice::CompressionException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::CompressionException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::CompressionException::ice_staticId() noexcept
 {
@@ -1033,12 +721,6 @@ string
 Ice::DatagramLimitException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::DatagramLimitException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1054,12 +736,6 @@ Ice::MarshalException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::MarshalException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::MarshalException::ice_staticId() noexcept
 {
@@ -1071,12 +747,6 @@ string
 Ice::ProxyUnmarshalException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::ProxyUnmarshalException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1092,12 +762,6 @@ Ice::UnmarshalOutOfBoundsException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnmarshalOutOfBoundsException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnmarshalOutOfBoundsException::ice_staticId() noexcept
 {
@@ -1109,12 +773,6 @@ string
 Ice::NoValueFactoryException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::NoValueFactoryException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1130,12 +788,6 @@ Ice::UnexpectedObjectException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::UnexpectedObjectException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::UnexpectedObjectException::ice_staticId() noexcept
 {
@@ -1147,12 +799,6 @@ string
 Ice::MemoryLimitException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::MemoryLimitException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1168,12 +814,6 @@ Ice::StringConversionException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::StringConversionException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::StringConversionException::ice_staticId() noexcept
 {
@@ -1185,12 +825,6 @@ string
 Ice::EncapsulationException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::EncapsulationException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view
@@ -1206,12 +840,6 @@ Ice::FeatureNotSupportedException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::FeatureNotSupportedException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::FeatureNotSupportedException::ice_staticId() noexcept
 {
@@ -1225,12 +853,6 @@ Ice::SecurityException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-Ice::SecurityException::ice_throw() const
-{
-    throw *this;
-}
-
 string_view
 Ice::SecurityException::ice_staticId() noexcept
 {
@@ -1242,12 +864,6 @@ string
 Ice::FixedProxyException::ice_id() const
 {
     return string{ice_staticId()};
-}
-
-void
-Ice::FixedProxyException::ice_throw() const
-{
-    throw *this;
 }
 
 string_view

--- a/cpp/src/IceBT/Types.cpp
+++ b/cpp/src/IceBT/Types.cpp
@@ -12,12 +12,6 @@ IceBT::BluetoothException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-IceBT::BluetoothException::ice_throw() const
-{
-    throw *this;
-}
-
 std::string_view
 IceBT::BluetoothException::ice_staticId() noexcept
 {

--- a/cpp/src/IceBox/Service.cpp
+++ b/cpp/src/IceBox/Service.cpp
@@ -12,12 +12,6 @@ IceBox::FailureException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-IceBox::FailureException::ice_throw() const
-{
-    throw *this;
-}
-
 std::string_view
 IceBox::FailureException::ice_staticId() noexcept
 {

--- a/cpp/src/IceDB/IceDB.cpp
+++ b/cpp/src/IceDB/IceDB.cpp
@@ -25,12 +25,6 @@ LMDBException::ice_print(ostream& out) const
     out << ": " << mdb_strerror(_error);
 }
 
-void
-LMDBException::ice_throw() const
-{
-    throw *this;
-}
-
 int
 LMDBException::error() const
 {
@@ -61,12 +55,6 @@ KeyTooLongException::ice_print(ostream& out) const
     out << "Max size = " << maxKeySize;
 }
 
-void
-KeyTooLongException::ice_throw() const
-{
-    throw *this;
-}
-
 BadEnvException::BadEnvException(const char* file, int line, size_t size) : IceUtil::Exception(file, line), _size(size)
 {
 }
@@ -83,12 +71,6 @@ BadEnvException::ice_print(ostream& out) const
     IceUtil::Exception::ice_print(out);
     out << ": LMDB env max key size = " << _size;
     out << ", IceDB max key size = " << maxKeySize;
-}
-
-void
-BadEnvException::ice_throw() const
-{
-    throw *this;
 }
 
 Env::Env(const string& path, MDB_dbi maxDbs, size_t mapSize, unsigned int maxReaders)

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -49,7 +49,6 @@ namespace IceDB
 
         virtual std::string ice_id() const;
         virtual void ice_print(std::ostream&) const;
-        virtual void ice_throw() const;
 
         int error() const;
 
@@ -69,7 +68,6 @@ namespace IceDB
 
         virtual std::string ice_id() const;
         virtual void ice_print(std::ostream&) const;
-        virtual void ice_throw() const;
 
     private:
         const size_t _size;
@@ -87,7 +85,6 @@ namespace IceDB
 
         virtual std::string ice_id() const;
         virtual void ice_print(std::ostream&) const;
-        virtual void ice_throw() const;
 
     private:
         const size_t _size;

--- a/cpp/src/IceGrid/SynchronizationException.cpp
+++ b/cpp/src/IceGrid/SynchronizationException.cpp
@@ -14,12 +14,6 @@ IceGrid::SynchronizationException::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-IceGrid::SynchronizationException::ice_throw() const
-{
-    throw *this;
-}
-
 std::string_view
 IceGrid::SynchronizationException::ice_staticId() noexcept
 {

--- a/cpp/src/IceGrid/SynchronizationException.h
+++ b/cpp/src/IceGrid/SynchronizationException.h
@@ -22,7 +22,5 @@ namespace IceGrid
         static ::std::string_view ice_staticId() noexcept;
 
         std::string ice_id() const override;
-
-        void ice_throw() const override;
     };
 }

--- a/cpp/src/IceSSL/CertificateI.cpp
+++ b/cpp/src/IceSSL/CertificateI.cpp
@@ -40,9 +40,9 @@ const CertificateOID IceSSL::certificateOIDS[] = {
     {"0.9.2342.19200300.100.1.25", "DC"}};
 const int IceSSL::certificateOIDSSize = sizeof(IceSSL::certificateOIDS) / sizeof(CertificateOID);
 
-CertificateReadException::CertificateReadException(const char* file, int line, const string& r)
-    : IceUtil::ExceptionHelper<CertificateReadException>(file, line),
-      reason(r)
+CertificateReadException::CertificateReadException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      reason(std::move(r))
 {
 }
 
@@ -52,9 +52,9 @@ CertificateReadException::ice_id() const
     return "::IceSSL::CertificateReadException";
 }
 
-CertificateEncodingException::CertificateEncodingException(const char* file, int line, const string& r)
-    : IceUtil::ExceptionHelper<CertificateEncodingException>(file, line),
-      reason(r)
+CertificateEncodingException::CertificateEncodingException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      reason(std::move(r))
 {
 }
 
@@ -64,9 +64,9 @@ CertificateEncodingException::ice_id() const
     return "::IceSSL::CertificateEncodingException";
 }
 
-ParseException::ParseException(const char* file, int line, const string& r)
-    : IceUtil::ExceptionHelper<ParseException>(file, line),
-      reason(r)
+ParseException::ParseException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      reason(std::move(r))
 {
 }
 

--- a/cpp/src/IceStorm/SendQueueSizeMaxReached.cpp
+++ b/cpp/src/IceStorm/SendQueueSizeMaxReached.cpp
@@ -14,12 +14,6 @@ IceStorm::SendQueueSizeMaxReached::ice_id() const
     return string{ice_staticId()};
 }
 
-void
-IceStorm::SendQueueSizeMaxReached::ice_throw() const
-{
-    throw *this;
-}
-
 std::string_view
 IceStorm::SendQueueSizeMaxReached::ice_staticId() noexcept
 {

--- a/cpp/src/IceStorm/SendQueueSizeMaxReached.h
+++ b/cpp/src/IceStorm/SendQueueSizeMaxReached.h
@@ -22,7 +22,5 @@ namespace IceStorm
         static ::std::string_view ice_staticId() noexcept;
 
         std::string ice_id() const override;
-
-        void ice_throw() const override;
     };
 }

--- a/cpp/src/IceUtil/CtrlCHandler.cpp
+++ b/cpp/src/IceUtil/CtrlCHandler.cpp
@@ -26,11 +26,6 @@ namespace
     mutex globalMutex;
 }
 
-CtrlCHandlerException::CtrlCHandlerException(const char* file, int line)
-    : ExceptionHelper<CtrlCHandlerException>(file, line)
-{
-}
-
 string
 CtrlCHandlerException::ice_id() const
 {

--- a/cpp/src/IceUtil/Options.cpp
+++ b/cpp/src/IceUtil/Options.cpp
@@ -10,9 +10,9 @@
 using namespace std;
 using namespace IceUtil;
 
-IceUtilInternal::APIException::APIException(const char* file, int line, const string& r)
-    : IceUtil::ExceptionHelper<APIException>(file, line),
-      reason(r)
+IceUtilInternal::APIException::APIException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      reason(std::move(r))
 {
 }
 
@@ -39,9 +39,9 @@ IceUtilInternal::operator<<(ostream& out, const IceUtilInternal::APIException& e
     return out;
 }
 
-IceUtilInternal::BadOptException::BadOptException(const char* file, int line, const string& r)
-    : IceUtil::ExceptionHelper<BadOptException>(file, line),
-      reason(r)
+IceUtilInternal::BadOptException::BadOptException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      reason(std::move(r))
 {
 }
 

--- a/cpp/src/IceUtil/UtilException.cpp
+++ b/cpp/src/IceUtil/UtilException.cpp
@@ -562,14 +562,9 @@ IceUtil::operator<<(ostream& out, const IceUtil::Exception& ex)
     return out;
 }
 
-IceUtil::IllegalArgumentException::IllegalArgumentException(const char* file, int line)
-    : ExceptionHelper<IllegalArgumentException>(file, line)
-{
-}
-
-IceUtil::IllegalArgumentException::IllegalArgumentException(const char* file, int line, const string& r)
-    : ExceptionHelper<IllegalArgumentException>(file, line),
-      _reason(r)
+IceUtil::IllegalArgumentException::IllegalArgumentException(const char* file, int line, string r) noexcept
+    : Exception(file, line),
+      _reason(std::move(r))
 {
 }
 
@@ -587,7 +582,7 @@ IceUtil::IllegalArgumentException::ice_id() const
 }
 
 string
-IceUtil::IllegalArgumentException::reason() const
+IceUtil::IllegalArgumentException::reason() const noexcept
 {
     return _reason;
 }
@@ -595,14 +590,10 @@ IceUtil::IllegalArgumentException::reason() const
 //
 // IllegalConversionException
 //
-IceUtil::IllegalConversionException::IllegalConversionException(const char* file, int line)
-    : ExceptionHelper<IllegalConversionException>(file, line)
-{
-}
 
-IceUtil::IllegalConversionException::IllegalConversionException(const char* file, int line, const string& reason)
-    : ExceptionHelper<IllegalConversionException>(file, line),
-      _reason(reason)
+IceUtil::IllegalConversionException::IllegalConversionException(const char* file, int line, string reason) noexcept
+    : Exception(file, line),
+      _reason(std::move(reason))
 {
 }
 
@@ -620,15 +611,15 @@ IceUtil::IllegalConversionException::ice_id() const
 }
 
 string
-IceUtil::IllegalConversionException::reason() const
+IceUtil::IllegalConversionException::reason() const noexcept
 {
     return _reason;
 }
 
-IceUtil::FileLockException::FileLockException(const char* file, int line, int err, const string& path)
-    : ExceptionHelper<FileLockException>(file, line),
+IceUtil::FileLockException::FileLockException(const char* file, int line, int err, string path) noexcept
+    : Exception(file, line),
       _error(err),
-      _path(path)
+      _path(std::move(path))
 {
 }
 
@@ -650,7 +641,7 @@ IceUtil::FileLockException::ice_id() const
 }
 
 int
-IceUtil::FileLockException::error() const
+IceUtil::FileLockException::error() const noexcept
 {
     return _error;
 }

--- a/cpp/src/IceXML/Parser.cpp
+++ b/cpp/src/IceXML/Parser.cpp
@@ -16,11 +16,11 @@ using namespace IceXML;
 //
 // ParserException
 //
-IceXML::ParserException::ParserException(const string& reason) : _reason(reason) {}
+IceXML::ParserException::ParserException(string reason) noexcept : _reason(std::move(reason)) {}
 
-IceXML::ParserException::ParserException(const char* file, int line, const string& reason)
-    : IceUtil::ExceptionHelper<ParserException>(file, line),
-      _reason(reason)
+IceXML::ParserException::ParserException(const char* file, int line, string reason) noexcept
+    : Exception(file, line),
+      _reason(std::move(reason))
 {
 }
 
@@ -45,7 +45,7 @@ IceXML::ParserException::ice_print(std::ostream& out) const
 }
 
 string
-IceXML::ParserException::reason() const
+IceXML::ParserException::reason() const noexcept
 {
     return _reason;
 }

--- a/cpp/src/IceXML/Parser.h
+++ b/cpp/src/IceXML/Parser.h
@@ -5,7 +5,7 @@
 #ifndef ICE_XML_PARSER_H
 #define ICE_XML_PARSER_H
 
-#include <IceUtil/Exception.h>
+#include <Ice/Exception.h>
 
 #include <vector>
 #include <map>
@@ -34,16 +34,16 @@
 
 namespace IceXML
 {
-    class ICE_XML_API ParserException final : public IceUtil::ExceptionHelper<ParserException>
+    class ICE_XML_API ParserException final : public Ice::Exception
     {
     public:
-        ParserException(const std::string&);
-        ParserException(const char*, int, const std::string&);
+        ParserException(std::string) noexcept;
+        ParserException(const char*, int, std::string) noexcept;
 
         std::string ice_id() const override;
         void ice_print(std::ostream&) const override;
 
-        std::string reason() const;
+        std::string reason() const noexcept;
 
     private:
         std::string _reason;

--- a/cpp/test/Ice/background/TestI.cpp
+++ b/cpp/test/Ice/background/TestI.cpp
@@ -71,8 +71,7 @@ BackgroundControllerI::initializeSocketOperation(int status, const Current&)
 void
 BackgroundControllerI::initializeException(bool enable, const Current&)
 {
-    _configuration->initializeException(
-        enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) :nullptr);
+    _configuration->initializeException(enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) : nullptr);
 }
 
 void
@@ -84,7 +83,7 @@ BackgroundControllerI::readReady(bool enable, const Current&)
 void
 BackgroundControllerI::readException(bool enable, const Current&)
 {
-    _configuration->readException(enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) :nullptr);
+    _configuration->readException(enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) : nullptr);
 }
 
 void
@@ -96,7 +95,7 @@ BackgroundControllerI::writeReady(bool enable, const Current&)
 void
 BackgroundControllerI::writeException(bool enable, const Current&)
 {
-    _configuration->writeException(enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) :nullptr);
+    _configuration->writeException(enable ? make_exception_ptr(SocketException(__FILE__, __LINE__)) : nullptr);
 }
 
 void

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -966,17 +966,22 @@ namespace
 
         void opDerived() { called(); }
 
-        void exCB(const Exception& ex)
+        void exCB(std::exception_ptr ex)
         {
             try
             {
-                ex.ice_throw();
+                rethrow_exception(ex);
             }
             catch (const OperationNotExistException&)
             {
                 called();
             }
-            catch (const Exception&)
+            catch (const std::exception& ex)
+            {
+                cerr << ex.what() << endl;
+                test(false);
+            }
+            catch (...)
             {
                 test(false);
             }
@@ -991,17 +996,7 @@ namespace
 function<void(exception_ptr)>
 makeExceptionClosure(CallbackPtr& cb)
 {
-    return [&](exception_ptr e)
-    {
-        try
-        {
-            rethrow_exception(e);
-        }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
-    };
+    return [&](exception_ptr e) { cb->exCB(e); };
 }
 
 void
@@ -2146,14 +2141,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->ping();
         }
-        catch (const Exception& ex)
+        catch (...)
         {
-            cb->exCB(ex);
-        }
-        catch (const exception& ex)
-        {
-            cerr << ex.what() << endl;
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2165,13 +2155,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
         {
             cb->isA(f.get());
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2183,13 +2169,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
         {
             cb->id(f.get());
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2201,13 +2183,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
         {
             cb->ids(f.get());
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2220,13 +2198,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->opVoid();
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2239,13 +2213,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByte(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2258,13 +2228,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opBool(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2277,13 +2243,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opShortIntLong(get<0>(r), get<1>(r), get<2>(r), get<3>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2296,13 +2258,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opFloatDouble(get<0>(r), get<1>(r), get<2>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2315,13 +2273,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opString(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2334,13 +2288,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyEnum(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2353,13 +2303,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyClass(*get<0>(r), *get<1>(r), *get<2>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2381,13 +2327,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStruct(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2413,13 +2355,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByteS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2441,13 +2379,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opBoolS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2477,13 +2411,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opShortIntLongS(get<0>(r), get<1>(r), get<2>(r), get<3>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2506,13 +2436,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opFloatDoubleS(get<0>(r), get<1>(r), get<2>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2534,13 +2460,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2567,13 +2489,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByteSS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2598,13 +2516,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opFloatDoubleSS(get<0>(r), get<1>(r), get<2>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2628,13 +2542,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringSS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2655,13 +2565,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByteBoolD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2682,13 +2588,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opShortIntD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2709,13 +2611,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opLongFloatD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2736,13 +2634,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringStringD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2763,13 +2657,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringMyEnumD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2795,13 +2685,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyStructMyEnumD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2834,13 +2720,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByteBoolDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2872,13 +2754,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opShortIntDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2910,13 +2788,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opLongFloatDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2948,13 +2822,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringStringDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -2986,13 +2856,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringMyEnumDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3022,13 +2888,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyEnumStringDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3066,13 +2928,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyStructMyEnumDS(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3102,13 +2960,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opByteByteSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3137,13 +2991,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opBoolBoolSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3175,13 +3025,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opShortShortSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3213,13 +3059,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opIntIntSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3251,13 +3093,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opLongLongSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3289,13 +3127,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringFloatSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3327,13 +3161,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringDoubleSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3367,13 +3197,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opStringStringSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3405,13 +3231,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             auto r = f.get();
             cb->opMyEnumMyEnumSD(get<0>(r), get<1>(r));
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3432,13 +3254,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             {
                 cb->opIntS(f.get());
             }
-            catch (const Exception& ex)
-            {
-                cb->exCB(ex);
-            }
             catch (...)
             {
-                test(false);
+                cb->exCB(current_exception());
             }
             cb->check();
         }
@@ -3454,13 +3272,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->opDoubleMarshaling();
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3473,13 +3287,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->opIdempotent();
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3492,13 +3302,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->opNonmutating();
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }
@@ -3512,13 +3318,9 @@ twowaysAMI(const CommunicatorPtr& communicator, const MyClassPrx& p)
             f.get();
             cb->opDerived();
         }
-        catch (const Exception& ex)
-        {
-            cb->exCB(ex);
-        }
         catch (...)
         {
-            test(false);
+            cb->exCB(current_exception());
         }
         cb->check();
     }

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -976,9 +976,9 @@ namespace
             {
                 called();
             }
-            catch (const std::exception& ex)
+            catch (const std::exception& e)
             {
-                cerr << ex.what() << endl;
+                cerr << e.what() << endl;
                 test(false);
             }
             catch (...)

--- a/matlab/src/Communicator.cpp
+++ b/matlab/src/Communicator.cpp
@@ -57,9 +57,9 @@ extern "C"
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->stringToProxy(s));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -72,9 +72,9 @@ extern "C"
             auto p = restoreProxy(proxy);
             return createResultValue(createStringFromUTF8(deref<Ice::Communicator>(self)->proxyToString(p)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -84,9 +84,9 @@ extern "C"
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->propertyToProxy(prop));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -100,9 +100,9 @@ extern "C"
             auto d = deref<Ice::Communicator>(self)->proxyToProperty(p, prop);
             return createResultValue(createStringMap(d));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -114,9 +114,9 @@ extern "C"
             getIdentity(id, ident);
             return createResultValue(createStringFromUTF8(deref<Ice::Communicator>(self)->identityToString(ident)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -127,9 +127,9 @@ extern "C"
             auto p = deref<Ice::Communicator>(self)->getImplicitContext();
             *ctx = createShared<Ice::ImplicitContext>(p);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -141,9 +141,9 @@ extern "C"
             auto p = deref<Ice::Communicator>(self)->getProperties();
             *props = new shared_ptr<Ice::Properties>(move(p));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -155,9 +155,9 @@ extern "C"
             auto l = deref<Ice::Communicator>(self)->getLogger();
             *logger = createShared<Ice::Logger>(l);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -168,9 +168,9 @@ extern "C"
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->getDefaultRouter());
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -182,9 +182,9 @@ extern "C"
             optional<Ice::RouterPrx> p = Ice::uncheckedCast<Ice::RouterPrx>(restoreNullableProxy(proxy));
             deref<Ice::Communicator>(self)->setDefaultRouter(p);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -195,9 +195,9 @@ extern "C"
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->getDefaultLocator());
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -209,9 +209,9 @@ extern "C"
             optional<Ice::LocatorPrx> p = Ice::uncheckedCast<Ice::LocatorPrx>(restoreNullableProxy(proxy));
             deref<Ice::Communicator>(self)->setDefaultLocator(p);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -223,9 +223,9 @@ extern "C"
             auto m = static_cast<Ice::CompressBatch>(getEnumerator(mode, "Ice.CompressBatch"));
             deref<Ice::Communicator>(self)->flushBatchRequests(m);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -245,9 +245,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }

--- a/matlab/src/Connection.cpp
+++ b/matlab/src/Connection.cpp
@@ -140,9 +140,9 @@ extern "C"
         {
             return createResultValue(createBool(deref<Ice::Connection>(self) == deref<Ice::Connection>(other)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -153,9 +153,9 @@ extern "C"
             auto mode = static_cast<Ice::ConnectionClose>(getEnumerator(m, "Ice.ConnectionClose"));
             deref<Ice::Connection>(self)->close(mode);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -194,9 +194,9 @@ extern "C"
             Ice::ObjectPrx proxy = deref<Ice::Connection>(self)->createProxy(ident);
             *r = createProxy(std::move(proxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -208,9 +208,9 @@ extern "C"
             auto mode = static_cast<Ice::CompressBatch>(getEnumerator(c, "Ice.CompressBatch"));
             deref<Ice::Connection>(self)->flushBatchRequests(mode);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -230,9 +230,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -243,9 +243,9 @@ extern "C"
         {
             *endpoint = createShared<Ice::Endpoint>(deref<Ice::Connection>(self)->getEndpoint());
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -256,9 +256,9 @@ extern "C"
         {
             deref<Ice::Connection>(self)->heartbeat();
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -276,9 +276,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -313,9 +313,9 @@ extern "C"
             }
             deref<Ice::Connection>(self)->setACM(timeout, close, heartbeat);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -333,9 +333,9 @@ extern "C"
             mexCallMATLAB(1, &r, 3, params, "Ice.ACM");
             return createResultValue(r);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -345,9 +345,9 @@ extern "C"
         {
             return createResultValue(createStringFromUTF8(deref<Ice::Connection>(self)->type()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -357,9 +357,9 @@ extern "C"
         {
             return createResultValue(createInt(deref<Ice::Connection>(self)->timeout()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -369,9 +369,9 @@ extern "C"
         {
             return createResultValue(createStringFromUTF8(deref<Ice::Connection>(self)->toString()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -382,9 +382,9 @@ extern "C"
             shared_ptr<Ice::ConnectionInfo> info = deref<Ice::Connection>(self)->getInfo();
             return createResultValue(createInfo(info));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -394,9 +394,9 @@ extern "C"
         {
             deref<Ice::Connection>(self)->setBufferSize(rcvSize, sndSize);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -407,9 +407,9 @@ extern "C"
         {
             deref<Ice::Connection>(self)->throwException();
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }

--- a/matlab/src/Endpoint.cpp
+++ b/matlab/src/Endpoint.cpp
@@ -137,9 +137,9 @@ extern "C"
             return createResultValue(
                 createBool(Ice::targetEqualTo(deref<Ice::Endpoint>(self), deref<Ice::Endpoint>(other))));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -149,9 +149,9 @@ extern "C"
         {
             return createResultValue(createStringFromUTF8(deref<Ice::Endpoint>(self)->toString()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -162,9 +162,9 @@ extern "C"
             shared_ptr<Ice::EndpointInfo> info = deref<Ice::Endpoint>(self)->getInfo();
             return createResultValue(createInfo(info));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 }

--- a/matlab/src/Future.cpp
+++ b/matlab/src/Future.cpp
@@ -160,9 +160,9 @@ extern "C"
             bool b = deref<SimpleFuture>(self)->waitForState(s, timeout);
             return createResultValue(createBool(b));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -183,18 +183,11 @@ extern "C"
         if (!f->waitForState(Future::State::Finished, -1))
         {
             assert(f->getException());
-            try
-            {
-                rethrow_exception(f->getException());
-            }
-            catch (const std::exception& ex)
-            {
-                //
-                // The C++ object won't be used after this.
-                //
-                delete reinterpret_cast<shared_ptr<SimpleFuture>*>(self);
-                return convertException(ex);
-            }
+            //
+            // The C++ object won't be used after this.
+            //
+            delete reinterpret_cast<shared_ptr<SimpleFuture>*>(self);
+            return convertException(f->getException());
         }
 
         //

--- a/matlab/src/ImplicitContext.cpp
+++ b/matlab/src/ImplicitContext.cpp
@@ -23,9 +23,9 @@ extern "C"
         {
             return createResultValue(createStringMap(deref<Ice::ImplicitContext>(self)->getContext()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -37,9 +37,9 @@ extern "C"
             getStringMap(newContext, ctx);
             deref<Ice::ImplicitContext>(self)->setContext(ctx);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -51,9 +51,9 @@ extern "C"
             return createResultValue(
                 createBool(deref<Ice::ImplicitContext>(self)->containsKey(getStringFromUTF16(key))));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -64,9 +64,9 @@ extern "C"
             return createResultValue(
                 createStringFromUTF8(deref<Ice::ImplicitContext>(self)->get(getStringFromUTF16(key))));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -78,9 +78,9 @@ extern "C"
             string v = getStringFromUTF16(value);
             return createResultValue(createStringFromUTF8(deref<Ice::ImplicitContext>(self)->put(k, v)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -91,9 +91,9 @@ extern "C"
             string k = getStringFromUTF16(key);
             return createResultValue(createStringFromUTF8(deref<Ice::ImplicitContext>(self)->remove(k)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 }

--- a/matlab/src/Init.cpp
+++ b/matlab/src/Init.cpp
@@ -59,9 +59,9 @@ extern "C"
             *r = new shared_ptr<Ice::Communicator>(Ice::initialize(a, id));
             return createResultValue(createStringList(a));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -71,9 +71,9 @@ extern "C"
         {
             return createResultValue(createIdentity(Ice::stringToIdentity(getStringFromUTF16(s))));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -86,9 +86,9 @@ extern "C"
             getIdentity(id, ident);
             return createResultValue(createStringFromUTF8(Ice::identityToString(ident, m)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 

--- a/matlab/src/Logger.cpp
+++ b/matlab/src/Logger.cpp
@@ -23,9 +23,9 @@ extern "C"
         {
             deref<Ice::Logger>(self)->print(getStringFromUTF16(message));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -36,9 +36,9 @@ extern "C"
         {
             deref<Ice::Logger>(self)->trace(getStringFromUTF16(category), getStringFromUTF16(message));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -49,9 +49,9 @@ extern "C"
         {
             deref<Ice::Logger>(self)->warning(getStringFromUTF16(message));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -62,9 +62,9 @@ extern "C"
         {
             deref<Ice::Logger>(self)->error(getStringFromUTF16(message));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -75,9 +75,9 @@ extern "C"
         {
             return createResultValue(createStringFromUTF8(deref<Ice::Logger>(self)->getPrefix()));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -89,9 +89,9 @@ extern "C"
             auto newLogger = logger->cloneWithPrefix(getStringFromUTF16(prefix));
             *r = newLogger == logger ? 0 : new shared_ptr<Ice::Logger>(move(newLogger));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -164,9 +164,9 @@ extern "C"
         {
             return createResultValue(createBool(restoreProxy(self) == restoreProxy(other)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -188,9 +188,9 @@ extern "C"
             in.read(proxy);
             *r = createProxy(std::move(proxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -217,9 +217,9 @@ extern "C"
             assert(p.second > p.first);
             return createResultValue(createByteArray(p.first, p.second));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -247,9 +247,9 @@ extern "C"
             }
             return createResultValue(createInvokeResultValue(createBool(ok), results));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
         return 0;
     }
@@ -275,9 +275,9 @@ extern "C"
             }
             return createResultValue(createInvokeResultValue(createBool(ok), results));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
         return 0;
     }
@@ -321,9 +321,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<InvocationFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -363,9 +363,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<InvocationFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -390,9 +390,9 @@ extern "C"
             auto newProxy = proxy->ice_identity(ident);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -412,9 +412,9 @@ extern "C"
             auto newProxy = proxy->ice_context(ctx);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -432,9 +432,9 @@ extern "C"
             auto newProxy = proxy->ice_facet(f);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -452,9 +452,9 @@ extern "C"
             auto newProxy = proxy->ice_adapterId(id);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -465,9 +465,9 @@ extern "C"
         {
             return createResultValue(createInt(static_cast<int>(restoreProxy(self)->ice_getEndpoints().size())));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -482,9 +482,9 @@ extern "C"
             }
             *r = createShared<Ice::Endpoint>(endpoints[idx]);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -510,9 +510,9 @@ extern "C"
             }
             (*v)[idx] = deref<Ice::Endpoint>(e);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -532,9 +532,9 @@ extern "C"
             auto newProxy = proxy->ice_endpoints(tmp);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -552,9 +552,9 @@ extern "C"
             auto newProxy = proxy->ice_locatorCacheTimeout(t);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -572,9 +572,9 @@ extern "C"
             auto newProxy = proxy->ice_invocationTimeout(t);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -593,9 +593,9 @@ extern "C"
             auto newProxy = proxy->ice_connectionId(id);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -613,9 +613,9 @@ extern "C"
             auto newProxy = proxy->ice_connectionCached(v == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -626,9 +626,9 @@ extern "C"
         {
             return createResultValue(createInt(static_cast<int>(restoreProxy(self)->ice_getEndpointSelection())));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
     }
 
@@ -641,9 +641,9 @@ extern "C"
                 static_cast<Ice::EndpointSelectionType>(getEnumerator(type, "Ice.EndpointSelectionType")));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -663,9 +663,9 @@ extern "C"
             auto newProxy = proxy->ice_encodingVersion(ev);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -686,9 +686,9 @@ extern "C"
             auto newProxy = proxy->ice_router(Ice::uncheckedCast<Ice::RouterPrx>(router));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -709,9 +709,9 @@ extern "C"
             auto newProxy = proxy->ice_locator(Ice::uncheckedCast<Ice::LocatorPrx>(locator));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -729,9 +729,9 @@ extern "C"
             auto newProxy = proxy->ice_secure(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -749,9 +749,9 @@ extern "C"
             auto newProxy = proxy->ice_preferSecure(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -769,9 +769,9 @@ extern "C"
             auto newProxy = proxy->ice_twoway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -789,9 +789,9 @@ extern "C"
             auto newProxy = proxy->ice_oneway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -809,9 +809,9 @@ extern "C"
             auto newProxy = proxy->ice_batchOneway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -829,9 +829,9 @@ extern "C"
             auto newProxy = proxy->ice_datagram();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -849,9 +849,9 @@ extern "C"
             auto newProxy = proxy->ice_batchDatagram();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -864,9 +864,9 @@ extern "C"
             auto newProxy = proxy->ice_compress(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -892,9 +892,9 @@ extern "C"
             auto newProxy = proxy->ice_timeout(t);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -921,9 +921,9 @@ extern "C"
             auto newProxy = proxy->ice_fixed(deref<Ice::Connection>(connection));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -944,9 +944,9 @@ extern "C"
                 *r = new shared_ptr<Ice::Connection>(move(conn));
             }
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -965,9 +965,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<GetConnectionFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -983,9 +983,9 @@ extern "C"
                 *r = new shared_ptr<Ice::Connection>(move(conn));
             }
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -996,9 +996,9 @@ extern "C"
         {
             restoreProxy(self)->ice_flushBatchRequests();
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -1016,9 +1016,9 @@ extern "C"
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -1055,9 +1055,9 @@ extern "C"
             bool b = deref<InvocationFuture>(self)->waitForState(state, timeout);
             return createResultValue(createBool(b));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -1067,18 +1067,8 @@ extern "C"
         if (!f->waitForState(Future::State::Finished, -1))
         {
             assert(f->getException());
-            try
-            {
-                rethrow_exception(f->getException());
-            }
-            catch (const std::exception& ex)
-            {
-                //
-                // The C++ object won't be used after this.
-                //
-                delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
-                return createResultException(convertException(ex));
-            }
+            delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
+            return createResultException(f->getException());
         }
 
         bool ok;
@@ -1115,18 +1105,11 @@ extern "C"
         if (!f->waitForState(Future::State::Finished, -1))
         {
             assert(f->getException());
-            try
-            {
-                rethrow_exception(f->getException());
-            }
-            catch (const std::exception& ex)
-            {
-                //
-                // The C++ object won't be used after this.
-                //
-                delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
-                return convertException(ex);
-            }
+            //
+            // The C++ object won't be used after this.
+            //
+            delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
+            return convertException(f->getException());
         }
 
         //
@@ -1163,9 +1146,9 @@ extern "C"
             bool b = deref<GetConnectionFuture>(self)->waitForState(state, timeout);
             return createResultValue(createBool(b));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -1175,18 +1158,9 @@ extern "C"
         if (!f->waitForState(Future::State::Finished, -1))
         {
             assert(f->getException());
-            try
-            {
-                rethrow_exception(f->getException());
-            }
-            catch (const std::exception& ex)
-            {
-                //
-                // The C++ object won't be used after this.
-                //
-                delete reinterpret_cast<shared_ptr<GetConnectionFuture>*>(self);
-                return convertException(ex);
-            }
+            // The C++ object won't be used after this.
+            delete reinterpret_cast<shared_ptr<GetConnectionFuture>*>(self);
+            return convertException(f->getException());
         }
 
         auto c = f->getConnection();

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -1068,7 +1068,7 @@ extern "C"
         {
             assert(f->getException());
             delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
-            return createResultException(f->getException());
+            return createResultException(convertException(f->getException()));
         }
 
         bool ok;

--- a/matlab/src/Properties.cpp
+++ b/matlab/src/Properties.cpp
@@ -31,9 +31,9 @@ extern "C"
             *r = new shared_ptr<Ice::Properties>(move(props));
             return createResultValue(createStringList(a));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -49,9 +49,9 @@ extern "C"
         {
             return createResultValue(createStringFromUTF8(deref<Ice::Properties>(self)->getProperty(key)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -62,9 +62,9 @@ extern "C"
             return createResultValue(
                 createStringFromUTF8(deref<Ice::Properties>(self)->getPropertyWithDefault(key, dflt)));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -74,9 +74,9 @@ extern "C"
         {
             *r = deref<Ice::Properties>(self)->getPropertyAsInt(key);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -87,9 +87,9 @@ extern "C"
         {
             *r = deref<Ice::Properties>(self)->getPropertyAsIntWithDefault(key, dflt);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -101,9 +101,9 @@ extern "C"
             auto l = deref<Ice::Properties>(self)->getPropertyAsList(key);
             return createResultValue(createStringList(l));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -116,9 +116,9 @@ extern "C"
             Ice::StringSeq l = deref<Ice::Properties>(self)->getPropertyAsListWithDefault(key, d);
             return createResultValue(createStringList(l));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -129,9 +129,9 @@ extern "C"
             auto d = deref<Ice::Properties>(self)->getPropertiesForPrefix(prefix);
             return createResultValue(createStringMap(d));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -141,9 +141,9 @@ extern "C"
         {
             deref<Ice::Properties>(self)->setProperty(key, value);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -155,9 +155,9 @@ extern "C"
             auto opts = deref<Ice::Properties>(self)->getCommandLineOptions();
             return createResultValue(createStringList(opts));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -170,9 +170,9 @@ extern "C"
             Ice::StringSeq rem = deref<Ice::Properties>(self)->parseCommandLineOptions(prefix, opts);
             return createResultValue(createStringList(rem));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -185,9 +185,9 @@ extern "C"
             Ice::StringSeq rem = deref<Ice::Properties>(self)->parseIceCommandLineOptions(opts);
             return createResultValue(createStringList(rem));
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return createResultException(convertException(ex));
+            return createResultException(convertException(std::current_exception()));
         }
     }
 
@@ -197,9 +197,9 @@ extern "C"
         {
             deref<Ice::Properties>(self)->load(file);
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }
@@ -210,9 +210,9 @@ extern "C"
         {
             *r = new shared_ptr<Ice::Properties>(deref<Ice::Properties>(self)->clone());
         }
-        catch (const std::exception& ex)
+        catch (...)
         {
-            return convertException(ex);
+            return convertException(std::current_exception());
         }
         return 0;
     }

--- a/matlab/src/Util.h
+++ b/matlab/src/Util.h
@@ -34,7 +34,7 @@ namespace IceMatlab
     void getProtocolVersion(mxArray*, Ice::ProtocolVersion&);
     mxArray* createEncodingVersion(const Ice::EncodingVersion&);
     void getEncodingVersion(mxArray*, Ice::EncodingVersion&);
-    mxArray* convertException(const std::exception&);
+    mxArray* convertException(std::exception_ptr);
     mxArray* createResultValue(mxArray*);
     mxArray* createResultException(mxArray*);
     mxArray* createOptionalValue(bool, mxArray*);

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -2017,7 +2017,8 @@ IcePHP::CommunicatorInfoI::addFactory(zval* factory, string_view id)
     {
         if (_defaultFactory->getDelegate())
         {
-            throwException(make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
+            throwException(
+                make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
             return false;
         }
 
@@ -2028,7 +2029,8 @@ IcePHP::CommunicatorInfoI::addFactory(zval* factory, string_view id)
         FactoryMap::iterator p = _factories.find(id);
         if (p != _factories.end())
         {
-            throwException(make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
+            throwException(
+                make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
             return false;
         }
         _factories.insert(FactoryMap::value_type(id, make_shared<FactoryWrapper>(factory, shared_from_this())));

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -242,9 +242,9 @@ ZEND_METHOD(Ice_Communicator, shutdown)
     {
         _this->getCommunicator()->shutdown();
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
     }
 }
 
@@ -257,9 +257,9 @@ ZEND_METHOD(Ice_Communicator, isShutdown)
     {
         RETURN_BOOL(_this->getCommunicator()->isShutdown() ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -273,9 +273,9 @@ ZEND_METHOD(Ice_Communicator, waitForShutdown)
     {
         _this->getCommunicator()->waitForShutdown();
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
     }
 }
 
@@ -345,9 +345,9 @@ ZEND_METHOD(Ice_Communicator, stringToProxy)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -383,9 +383,9 @@ ZEND_METHOD(Ice_Communicator, proxyToString)
         }
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -422,9 +422,9 @@ ZEND_METHOD(Ice_Communicator, propertyToProxy)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -473,9 +473,9 @@ ZEND_METHOD(Ice_Communicator, proxyToProperty)
             array_init(return_value);
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -508,9 +508,9 @@ ZEND_METHOD(Ice_Communicator, identityToString)
         string str = _this->getCommunicator()->identityToString(id);
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -539,9 +539,9 @@ ZEND_METHOD(Ice_Communicator, getValueFactoryManager)
         assert(!obj->ptr);
         obj->ptr = new ValueFactoryManagerPtr(vfm);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -566,9 +566,9 @@ ZEND_METHOD(Ice_Communicator, getProperties)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -591,9 +591,9 @@ ZEND_METHOD(Ice_Communicator, getLogger)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -629,9 +629,9 @@ ZEND_METHOD(Ice_Communicator, getDefaultRouter)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -672,9 +672,9 @@ ZEND_METHOD(Ice_Communicator, setDefaultRouter)
         }
         _this->getCommunicator()->setDefaultRouter(router);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -710,9 +710,9 @@ ZEND_METHOD(Ice_Communicator, getDefaultLocator)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -753,9 +753,9 @@ ZEND_METHOD(Ice_Communicator, setDefaultLocator)
         }
         _this->getCommunicator()->setDefaultLocator(locator);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -786,9 +786,9 @@ ZEND_METHOD(Ice_Communicator, flushBatchRequests)
     {
         _this->getCommunicator()->flushBatchRequests(cb);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -966,9 +966,9 @@ createCommunicator(zval* zv, const ActiveCommunicatorPtr& ac)
 
         return info;
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         return 0;
     }
 }
@@ -1009,9 +1009,9 @@ initializeCommunicator(zval* zv, Ice::StringSeq& args, bool hasArgs, const Ice::
 
         return info;
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         return 0;
     }
 }
@@ -1405,9 +1405,9 @@ ZEND_FUNCTION(Ice_identityToString)
         string str = Ice::identityToString(id, static_cast<Ice::ToStringMode>(mode));
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1430,9 +1430,9 @@ ZEND_FUNCTION(Ice_stringToIdentity)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -2017,10 +2017,7 @@ IcePHP::CommunicatorInfoI::addFactory(zval* factory, string_view id)
     {
         if (_defaultFactory->getDelegate())
         {
-            Ice::AlreadyRegisteredException ex(__FILE__, __LINE__);
-            ex.kindOfObject = "value factory";
-            ex.id = id;
-            throwException(ex);
+            throwException(make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
             return false;
         }
 
@@ -2031,10 +2028,7 @@ IcePHP::CommunicatorInfoI::addFactory(zval* factory, string_view id)
         FactoryMap::iterator p = _factories.find(id);
         if (p != _factories.end())
         {
-            Ice::AlreadyRegisteredException ex(__FILE__, __LINE__);
-            ex.kindOfObject = "value factory";
-            ex.id = id;
-            throwException(ex);
+            throwException(make_exception_ptr(Ice::AlreadyRegisteredException{__FILE__, __LINE__, "value factory", string{id}}));
             return false;
         }
         _factories.insert(FactoryMap::value_type(id, make_shared<FactoryWrapper>(factory, shared_from_this())));

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -58,9 +58,9 @@ ZEND_METHOD(Ice_Connection, __toString)
         string str = _this->toString();
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -91,9 +91,9 @@ ZEND_METHOD(Ice_Connection, close)
     {
         _this->close(cc);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -115,9 +115,9 @@ ZEND_METHOD(Ice_Connection, getEndpoint)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -148,9 +148,9 @@ ZEND_METHOD(Ice_Connection, flushBatchRequests)
     {
         _this->flushBatchRequests(cb);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -169,9 +169,9 @@ ZEND_METHOD(Ice_Connection, heartbeat)
     {
         _this->heartbeat();
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -233,9 +233,9 @@ ZEND_METHOD(Ice_Connection, setACM)
     {
         _this->setACM(timeout, close, heartbeat);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -266,9 +266,9 @@ ZEND_METHOD(Ice_Connection, getACM)
         add_property_long(return_value, "close", static_cast<long>(acm.close));
         add_property_long(return_value, "heartbeat", static_cast<long>(acm.heartbeat));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -287,9 +287,9 @@ ZEND_METHOD(Ice_Connection, type)
         string str = _this->type();
         RETURN_STRINGL(str.c_str(), str.length());
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -308,9 +308,9 @@ ZEND_METHOD(Ice_Connection, timeout)
         int32_t timeout = _this->timeout();
         ZVAL_LONG(return_value, static_cast<long>(timeout));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -334,9 +334,9 @@ ZEND_METHOD(Ice_Connection, getInfo)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -365,9 +365,9 @@ ZEND_METHOD(Ice_Connection, setBufferSize)
     {
         _this->setBufferSize(rcvSize, sndSize);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -385,9 +385,9 @@ ZEND_METHOD(Ice_Connection, throwException)
     {
         _this->throwException();
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }

--- a/php/src/Endpoint.cpp
+++ b/php/src/Endpoint.cpp
@@ -53,9 +53,9 @@ ZEND_METHOD(Ice_Endpoint, __toString)
         string str = _this->toString();
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -114,9 +114,9 @@ ZEND_METHOD(Ice_EndpointInfo, type)
         short type = static_cast<short>(_this->type());
         RETURN_LONG(type);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -135,9 +135,9 @@ ZEND_METHOD(Ice_EndpointInfo, datagram)
     {
         RETURN_BOOL(_this->datagram() ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -156,9 +156,9 @@ ZEND_METHOD(Ice_EndpointInfo, secure)
     {
         RETURN_BOOL(_this->secure() ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }

--- a/php/src/Logger.cpp
+++ b/php/src/Logger.cpp
@@ -60,9 +60,9 @@ ZEND_METHOD(Ice_Logger, print)
     {
         _this->print(msg);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -93,9 +93,9 @@ ZEND_METHOD(Ice_Logger, trace)
     {
         _this->trace(category, msg);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -122,9 +122,9 @@ ZEND_METHOD(Ice_Logger, warning)
     {
         _this->warning(msg);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -151,9 +151,9 @@ ZEND_METHOD(Ice_Logger, error)
     {
         _this->error(msg);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -182,9 +182,9 @@ ZEND_METHOD(Ice_Logger, cloneWithPrefix)
     {
         clone = _this->cloneWithPrefix(prefix);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -434,9 +434,9 @@ IcePHP::TypedInvocation::prepareRequest(
         {
             return false;
         }
-        catch (const Ice::Exception& ex)
+        catch (...)
         {
-            throwException(ex);
+            throwException(current_exception());
             return false;
         }
     }
@@ -569,8 +569,7 @@ IcePHP::TypedInvocation::unmarshalException(zval* zex, const pair<const byte*, c
         {
             ostringstream os;
             os << "operation raised undeclared exception `" << info->id << "'";
-            Ice::UnknownUserException uue(__FILE__, __LINE__, os.str());
-            convertException(zex, uue);
+            convertException(zex, make_exception_ptr(Ice::UnknownUserException{__FILE__, __LINE__, os.str()}));
             return;
         }
     }
@@ -578,8 +577,7 @@ IcePHP::TypedInvocation::unmarshalException(zval* zex, const pair<const byte*, c
     // Getting here should be impossible: we can get here only if the sender has marshaled a sequence of type IDs, none
     // of which we have a factory for. This means that sender and receiver disagree about the Slice definitions they
     // use.
-    Ice::UnknownUserException uue(__FILE__, __LINE__, "unknown exception");
-    convertException(zex, uue);
+    convertException(zex, make_exception_ptr(Ice::UnknownUserException{__FILE__, __LINE__, "unknown exception"}));
 }
 
 bool
@@ -695,9 +693,9 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
     catch (const AbortMarshaling&)
     {
     }
-    catch (const Ice::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
     }
 }
 

--- a/php/src/Properties.cpp
+++ b/php/src/Properties.cpp
@@ -55,9 +55,9 @@ ZEND_METHOD(Ice_Properties, __toString)
         }
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -85,9 +85,9 @@ ZEND_METHOD(Ice_Properties, getProperty)
         string val = _this->getProperty(propName);
         RETURN_STRINGL(val.c_str(), static_cast<int>(val.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -124,9 +124,9 @@ ZEND_METHOD(Ice_Properties, getPropertyWithDefault)
         string val = _this->getPropertyWithDefault(propName, defaultValue);
         RETURN_STRINGL(val.c_str(), static_cast<int>(val.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -154,9 +154,9 @@ ZEND_METHOD(Ice_Properties, getPropertyAsInt)
         int32_t val = _this->getPropertyAsInt(propName);
         RETURN_LONG(static_cast<long>(val));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -191,9 +191,9 @@ ZEND_METHOD(Ice_Properties, getPropertyAsIntWithDefault)
         int32_t val = _this->getPropertyAsIntWithDefault(propName, static_cast<int32_t>(def));
         RETURN_LONG(val);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -224,9 +224,9 @@ ZEND_METHOD(Ice_Properties, getPropertyAsList)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -269,9 +269,9 @@ ZEND_METHOD(Ice_Properties, getPropertyAsListWithDefault)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -307,9 +307,9 @@ ZEND_METHOD(Ice_Properties, getPropertiesForPrefix)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -345,9 +345,9 @@ ZEND_METHOD(Ice_Properties, setProperty)
     {
         _this->setProperty(propName, propValue);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -370,9 +370,9 @@ ZEND_METHOD(Ice_Properties, getCommandLineOptions)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -415,9 +415,9 @@ ZEND_METHOD(Ice_Properties, parseCommandLineOptions)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -456,9 +456,9 @@ ZEND_METHOD(Ice_Properties, parseIceCommandLineOptions)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -486,9 +486,9 @@ ZEND_METHOD(Ice_Properties, load)
     {
         _this->load(file);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -512,9 +512,9 @@ ZEND_METHOD(Ice_Properties, clone)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -613,9 +613,9 @@ ZEND_FUNCTION(Ice_createProperties)
             }
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -92,9 +92,9 @@ ZEND_METHOD(Ice_ObjectPrx, __toString)
         string str = _this->proxy->ice_toString();
         RETURN_STRINGL(str.c_str(), static_cast<int>(str.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -156,9 +156,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_identity)
                 RETURN_NULL();
             }
         }
-        catch (const IceUtil::Exception& ex)
-        {
-            throwException(ex);
+        catch (...)
+    {
+        throwException(current_exception());
             RETURN_NULL();
         }
     }
@@ -209,9 +209,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_context)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -231,9 +231,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getFacet)
         string facet = _this->proxy->ice_getFacet();
         ZVAL_STRINGL(return_value, facet.c_str(), static_cast<int>(facet.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -262,9 +262,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_facet)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -284,9 +284,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getAdapterId)
         string id = _this->proxy->ice_getAdapterId();
         ZVAL_STRINGL(return_value, id.c_str(), static_cast<int>(id.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -315,9 +315,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_adapterId)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -349,9 +349,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEndpoints)
             add_index_zval(return_value, idx++, &elem);
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -401,9 +401,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_endpoints)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -423,9 +423,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getLocatorCacheTimeout)
         int32_t timeout = _this->proxy->ice_getLocatorCacheTimeout();
         ZVAL_LONG(return_value, static_cast<long>(timeout));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -445,9 +445,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getConnectionId)
         string connectionId = _this->proxy->ice_getConnectionId();
         ZVAL_STRINGL(return_value, connectionId.c_str(), static_cast<int>(connectionId.length()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -474,9 +474,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_locatorCacheTimeout)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -496,9 +496,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isConnectionCached)
         bool b = _this->proxy->ice_isConnectionCached();
         ZVAL_BOOL(return_value, b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -525,9 +525,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_connectionCached)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -547,9 +547,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEndpointSelection)
         Ice::EndpointSelectionType type = _this->proxy->ice_getEndpointSelection();
         ZVAL_LONG(return_value, type == Ice::EndpointSelectionType::Random ? 0 : 1);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -583,9 +583,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_endpointSelection)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -605,9 +605,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isSecure)
         bool b = _this->proxy->ice_isSecure();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -634,9 +634,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_secure)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -658,9 +658,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getEncodingVersion)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -693,9 +693,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_encodingVersion)
                 RETURN_NULL();
             }
         }
-        catch (const IceUtil::Exception& ex)
-        {
-            throwException(ex);
+        catch (...)
+    {
+        throwException(current_exception());
             RETURN_NULL();
         }
     }
@@ -716,9 +716,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isPreferSecure)
         bool b = _this->proxy->ice_isPreferSecure();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -745,9 +745,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_preferSecure)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -785,9 +785,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getRouter)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -832,9 +832,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_router)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -870,9 +870,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getLocator)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -917,9 +917,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_locator)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -941,9 +941,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_twoway)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -963,9 +963,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isTwoway)
         bool b = _this->proxy->ice_isTwoway();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -987,9 +987,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_oneway)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1009,9 +1009,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isOneway)
         bool b = _this->proxy->ice_isOneway();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -1033,9 +1033,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_batchOneway)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1055,9 +1055,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isBatchOneway)
         bool b = _this->proxy->ice_isBatchOneway();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -1079,9 +1079,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_datagram)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1101,9 +1101,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isDatagram)
         bool b = _this->proxy->ice_isDatagram();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -1125,9 +1125,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_batchDatagram)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1147,9 +1147,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isBatchDatagram)
         bool b = _this->proxy->ice_isBatchDatagram();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -1176,9 +1176,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_compress)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1205,9 +1205,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getCompress)
             assignUnset(return_value);
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1234,9 +1234,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_timeout)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1263,9 +1263,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getTimeout)
             assignUnset(return_value);
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1292,9 +1292,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_invocationTimeout)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1313,9 +1313,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getInvocationTimeout)
     {
         ZVAL_LONG(return_value, static_cast<long>(_this->proxy->ice_getInvocationTimeout()));
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1342,9 +1342,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_connectionId)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1377,9 +1377,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_fixed)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1399,9 +1399,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_isFixed)
         bool b = _this->proxy->ice_isFixed();
         RETURN_BOOL(b ? 1 : 0);
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_FALSE;
     }
 }
@@ -1424,9 +1424,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getConnection)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1449,9 +1449,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getCachedConnection)
             RETURN_NULL();
         }
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1470,9 +1470,9 @@ ZEND_METHOD(Ice_ObjectPrx, ice_flushBatchRequests)
     {
         _this->proxy->ice_flushBatchRequests();
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETURN_NULL();
     }
 }
@@ -1573,9 +1573,9 @@ do_cast(INTERNAL_FUNCTION_PARAMETERS, bool check)
     {
         // Ignore.
     }
-    catch (const IceUtil::Exception& ex)
+    catch (...)
     {
-        throwException(ex);
+        throwException(current_exception());
         RETVAL_FALSE;
     }
 }

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -157,8 +157,8 @@ ZEND_METHOD(Ice_ObjectPrx, ice_identity)
             }
         }
         catch (...)
-    {
-        throwException(current_exception());
+        {
+            throwException(current_exception());
             RETURN_NULL();
         }
     }
@@ -694,8 +694,8 @@ ZEND_METHOD(Ice_ObjectPrx, ice_encodingVersion)
             }
         }
         catch (...)
-    {
-        throwException(current_exception());
+        {
+            throwException(current_exception());
             RETURN_NULL();
         }
     }

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -550,6 +550,10 @@ convertLocalException(std::exception_ptr ex, zval* zex)
     catch (const Ice::LocalException&)
     {
     }
+    catch (...)
+    {
+        assert(false);
+    }
 
     return true;
 }
@@ -557,14 +561,13 @@ convertLocalException(std::exception_ptr ex, zval* zex)
 void
 IcePHP::convertException(zval* zex, std::exception_ptr ex)
 {
-    ostringstream ostr;
-
     try
     {
         rethrow_exception(ex);
     }
     catch (const Ice::LocalException& e)
     {
+        ostringstream ostr;
         ostr << e;
         string str = ostr.str();
 
@@ -595,6 +598,7 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
     }
     catch (const Ice::UserException& e)
     {
+        ostringstream ostr;
         ostr << e;
         string str = ostr.str();
 
@@ -609,6 +613,7 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
     }
     catch (const Ice::Exception& e)
     {
+        ostringstream ostr;
         ostr << e;
         string str = ostr.str();
 
@@ -623,8 +628,7 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
     }
     catch (const std::exception& e)
     {
-        ostr << e.what();
-        string str = ostr.str();
+        string str = e.what();
 
         zend_class_entry* cls = idToClass("Ice::UnknownException");
         assert(cls);
@@ -637,8 +641,7 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
     }
     catch (...)
     {
-        ostr << "unknown c++ exception";
-        string str = ostr.str();
+        string str = "unknown c++ exception";
 
         zend_class_entry* cls = idToClass("Ice::UnknownException");
         assert(cls);

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -89,10 +89,10 @@ namespace IcePHP
     bool extractEncodingVersion(zval*, Ice::EncodingVersion&);
 
     // Convert the given exception into its PHP equivalent.
-    void convertException(zval*, const Ice::Exception&);
+    void convertException(zval*, std::exception_ptr);
 
     // Convert the exception and "throw" it.
-    void throwException(const Ice::Exception&);
+    void throwException(std::exception_ptr);
 
     // Convert a Zend type (e.g., IS_BOOL, etc.) to a string for use in error messages.
     std::string zendTypeToString(int);

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -904,6 +904,10 @@ convertLocalException(std::exception_ptr ex, PyObject* p)
         // Nothing to do.
         //
     }
+    catch (...)
+    {
+        assert(false);
+    }
 }
 
 PyObject*
@@ -988,7 +992,7 @@ IcePy::convertException(std::exception_ptr ex)
     }
     catch (...)
     {
-        string_view str = "unknown c++ exception";
+        static constexpr string_view str = "unknown c++ exception";
 
         type = lookupType("Ice.UnknownException");
         assert(type);

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -720,14 +720,14 @@ IcePy::createExceptionInstance(PyObject* type)
 }
 
 static void
-convertLocalException(const Ice::LocalException& ex, PyObject* p)
+convertLocalException(std::exception_ptr ex, PyObject* p)
 {
     //
     // Transfer data members from Ice exception to Python exception.
     //
     try
     {
-        ex.ice_throw();
+        rethrow_exception(ex);
     }
     catch (const Ice::InitializationException& e)
     {
@@ -928,7 +928,7 @@ IcePy::convertException(std::exception_ptr ex)
             p = createExceptionInstance(type);
             if (p.get())
             {
-                convertLocalException(e, p.get());
+                convertLocalException(ex, p.get());
             }
         }
         else

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -469,7 +469,7 @@ namespace IceRuby
     //
     // Create the Ruby equivalent of an Ice local exception.
     //
-    VALUE convertLocalException(const Ice::LocalException&);
+    VALUE convertLocalException(std::exception_ptr);
 }
 
 //
@@ -494,7 +494,7 @@ ice_start:                                                                      
 
 #define ICE_RUBY_CATCH                                                                                                 \
     catch (const ::IceRuby::RubyException& ex) { ICE_RUBY_RETHROW(ex.ex); }                                            \
-    catch (const ::Ice::LocalException& ex) { ICE_RUBY_RETHROW(convertLocalException(ex)); }                           \
+    catch (const ::Ice::LocalException&) { ICE_RUBY_RETHROW(convertLocalException(current_exception())); }             \
     catch (const ::Ice::Exception& ex)                                                                                 \
     {                                                                                                                  \
         string msg_ = "unknown Ice exception: " + ex.ice_id();                                                         \

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -77,8 +77,8 @@
         return [NSNull null];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -98,8 +98,8 @@
         return [ICEObjectAdapter getHandle:oa];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -114,8 +114,8 @@
         return [ICEObjectAdapter getHandle:oa];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -133,8 +133,8 @@
         return [ICEObjectAdapter getHandle:oa];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -185,8 +185,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -217,8 +217,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -231,8 +231,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -282,8 +282,8 @@
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -296,8 +296,8 @@
         return adminPrx ? [[ICEObjectPrx alloc] initWithCppObjectPrx:adminPrx.value()] : [NSNull null];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -311,8 +311,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -325,8 +325,8 @@
         return [self facetToFacade:self.communicator->removeAdminFacet(fromNSString(facet))];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -346,8 +346,8 @@
         return [self facetToFacade:servant];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -366,8 +366,8 @@
         return facets;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -385,8 +385,8 @@
         return self.communicator->getClientDispatchQueue();
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -398,8 +398,8 @@
         return self.communicator->getServerDispatchQueue();
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -474,8 +474,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -58,9 +58,9 @@
         }
         return [NSNull null];
     }
-    catch (const std::exception& e)
+    catch (...)
     {
-        *error = convertException(e);
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -76,9 +76,9 @@
         }
         return [NSNull null];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -97,9 +97,9 @@
         auto oa = self.communicator->createObjectAdapter(fromNSString(name));
         return [ICEObjectAdapter getHandle:oa];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -113,9 +113,9 @@
         auto oa = self.communicator->createObjectAdapterWithEndpoints(fromNSString(name), fromNSString(endpoints));
         return [ICEObjectAdapter getHandle:oa];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -132,9 +132,9 @@
             Ice::uncheckedCast<Ice::RouterPrx>([router prx]).value());
         return [ICEObjectAdapter getHandle:oa];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -184,9 +184,9 @@
         self.communicator->setDefaultRouter(Ice::uncheckedCast<Ice::RouterPrx>(r));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -216,9 +216,9 @@
         self.communicator->setDefaultLocator((Ice::uncheckedCast<Ice::LocatorPrx>(l)));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -230,9 +230,9 @@
         self.communicator->flushBatchRequests(Ice::CompressBatch(compress));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -260,12 +260,12 @@
                 }
             });
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 
@@ -281,9 +281,9 @@
         auto prx = self.communicator->createAdmin(adapter, ident);
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -295,9 +295,9 @@
         auto adminPrx = self.communicator->getAdmin();
         return adminPrx ? [[ICEObjectPrx alloc] initWithCppObjectPrx:adminPrx.value()] : [NSNull null];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -310,9 +310,9 @@
         self.communicator->addAdminFacet(servant, fromNSString(facet));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -324,9 +324,9 @@
         // servant can either be a Swift wrapped facet or a builtin admin facet
         return [self facetToFacade:self.communicator->removeAdminFacet(fromNSString(facet))];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -345,9 +345,9 @@
 
         return [self facetToFacade:servant];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -365,9 +365,9 @@
 
         return facets;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -384,9 +384,9 @@
     {
         return self.communicator->getClientDispatchQueue();
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -397,9 +397,9 @@
     {
         return self.communicator->getServerDispatchQueue();
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -473,9 +473,9 @@
         self.communicator->getPluginManager()->initializePlugins();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -28,9 +28,9 @@
         auto prx = self.connection->createProxy(Ice::Identity{fromNSString(name), fromNSString(category)});
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -42,9 +42,9 @@
         self.connection->setAdapter(oa == nil ? nullptr : [oa objectAdapter]);
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -69,9 +69,9 @@
         self.connection->flushBatchRequests(Ice::CompressBatch(compress));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -99,12 +99,12 @@
                 }
             });
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 
@@ -131,9 +131,9 @@
         }
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -166,9 +166,9 @@
         self.connection->heartbeat();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -193,12 +193,12 @@
                 }
             });
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 
@@ -256,9 +256,9 @@
         auto info = self.connection->getInfo();
         return createConnectionInfo(info);
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -270,9 +270,9 @@
         self.connection->setBufferSize(rcvSize, sndSize);
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -284,9 +284,9 @@
         self.connection->throwException();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -29,8 +29,8 @@
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -43,8 +43,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -70,8 +70,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -132,8 +132,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -167,8 +167,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -257,8 +257,8 @@
         return createConnectionInfo(info);
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -271,8 +271,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -285,8 +285,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/Convert.h
+++ b/swift/src/IceImpl/Convert.h
@@ -17,7 +17,6 @@ namespace IceSSL
 }
 
 NSError* convertException(std::exception_ptr);
-NSError* convertException(const std::exception&);
 std::exception_ptr convertException(ICERuntimeException*);
 
 inline NSString*

--- a/swift/src/IceImpl/Convert.mm
+++ b/swift/src/IceImpl/Convert.mm
@@ -10,374 +10,342 @@
 NSError*
 convertException(std::exception_ptr exc)
 {
-        assert(exc);
-        Class<ICEExceptionFactory> factory = [ICEUtil exceptionFactory];
+    assert(exc);
+    Class<ICEExceptionFactory> factory = [ICEUtil exceptionFactory];
 
-        try
-        {
-            rethrow_exception(exc);
-        }
-        catch (const Ice::InitializationException& e)
-        {
-            return [factory initializationException:toNSString(e.reason)
-                                               file:toNSString(e.ice_file())
-                                               line:e.ice_line()];
-        }
-        catch (const Ice::PluginInitializationException& e)
-        {
-            return [factory pluginInitializationException:toNSString(e.reason)
-                                                     file:toNSString(e.ice_file())
-                                                     line:e.ice_line()];
-        }
-        catch (const Ice::AlreadyRegisteredException& e)
-        {
-            return [factory alreadyRegisteredException:toNSString(e.kindOfObject)
-                                                    id:toNSString(e.id)
-                                                  file:toNSString(e.ice_file())
-                                                  line:e.ice_line()];
-        }
-        catch (const Ice::NotRegisteredException& e)
-        {
-            return [factory notRegisteredException:toNSString(e.kindOfObject)
+    try
+    {
+        rethrow_exception(exc);
+    }
+    catch (const Ice::InitializationException& e)
+    {
+        return [factory initializationException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::PluginInitializationException& e)
+    {
+        return [factory pluginInitializationException:toNSString(e.reason)
+                                                 file:toNSString(e.ice_file())
+                                                 line:e.ice_line()];
+    }
+    catch (const Ice::AlreadyRegisteredException& e)
+    {
+        return [factory alreadyRegisteredException:toNSString(e.kindOfObject)
                                                 id:toNSString(e.id)
                                               file:toNSString(e.ice_file())
                                               line:e.ice_line()];
-        }
-        catch (const Ice::TwowayOnlyException& e)
-        {
-            return [factory twowayOnlyException:toNSString(e.operation)
-                                           file:toNSString(e.ice_file())
-                                           line:e.ice_line()];
-        }
-        catch (const Ice::CloneNotImplementedException& e)
-        {
-            return [factory cloneNotImplementedException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::VersionMismatchException& e)
-        {
-            return [factory versionMismatchException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::CommunicatorDestroyedException& e)
-        {
-            return [factory communicatorDestroyedException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ObjectAdapterDeactivatedException& e)
-        {
-            return [factory objectAdapterDeactivatedException:toNSString(e.name)
-                                                         file:toNSString(e.ice_file())
-                                                         line:e.ice_line()];
-        }
-        catch (const Ice::ObjectAdapterIdInUseException& e)
-        {
-            return [factory objectAdapterIdInUseException:toNSString(e.id)
+    }
+    catch (const Ice::NotRegisteredException& e)
+    {
+        return [factory notRegisteredException:toNSString(e.kindOfObject)
+                                            id:toNSString(e.id)
+                                          file:toNSString(e.ice_file())
+                                          line:e.ice_line()];
+    }
+    catch (const Ice::TwowayOnlyException& e)
+    {
+        return [factory twowayOnlyException:toNSString(e.operation) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::CloneNotImplementedException& e)
+    {
+        return [factory cloneNotImplementedException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::VersionMismatchException& e)
+    {
+        return [factory versionMismatchException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::CommunicatorDestroyedException& e)
+    {
+        return [factory communicatorDestroyedException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ObjectAdapterDeactivatedException& e)
+    {
+        return [factory objectAdapterDeactivatedException:toNSString(e.name)
                                                      file:toNSString(e.ice_file())
                                                      line:e.ice_line()];
-        }
-        catch (const Ice::NoEndpointException& e)
-        {
-            return [factory noEndpointException:toNSString(e.proxy) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::EndpointParseException& e)
-        {
-            return [factory endpointParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::EndpointSelectionTypeParseException& e)
-        {
-            return [factory endpointSelectionTypeParseException:toNSString(e.str)
-                                                           file:toNSString(e.ice_file())
-                                                           line:e.ice_line()];
-        }
-        catch (const Ice::VersionParseException& e)
-        {
-            return [factory versionParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::IdentityParseException& e)
-        {
-            return [factory identityParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ProxyParseException& e)
-        {
-            return [factory proxyParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::IllegalIdentityException& e)
-        {
-            return [factory illegalIdentityException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::IllegalServantException& e)
-        {
-            return [factory illegalServantException:toNSString(e.reason)
-                                               file:toNSString(e.ice_file())
-                                               line:e.ice_line()];
-        }
-        catch (const Ice::DNSException& e)
-        {
-            return [factory dNSException:e.error
-                                    host:toNSString(e.host)
-                                    file:toNSString(e.ice_file())
-                                    line:e.ice_line()];
-        }
-        catch (const Ice::OperationInterruptedException& e)
-        {
-            return [factory operationInterruptedException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::InvocationCanceledException& e)
-        {
-            return [factory invocationCanceledException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::FeatureNotSupportedException& e)
-        {
-            return [factory featureNotSupportedException:toNSString(e.unsupportedFeature)
-                                                    file:toNSString(e.ice_file())
-                                                    line:e.ice_line()];
-        }
-        catch (const Ice::FixedProxyException& e)
-        {
-            return [factory fixedProxyException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::SecurityException& e)
-        {
-            return [factory securityException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::UnknownLocalException& e)
-        {
-            return [factory unknownLocalException:toNSString(e.unknown)
-                                             file:toNSString(e.ice_file())
-                                             line:e.ice_line()];
-        }
-        catch (const Ice::UnknownUserException& e)
-        {
-            return [factory unknownUserException:toNSString(e.unknown) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::UnknownException& e)
-        {
-            return [factory unknownException:toNSString(e.unknown) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ObjectNotExistException& e)
-        {
-            return [factory objectNotExistException:toNSString(e.id.name)
-                                           category:toNSString(e.id.category)
-                                              facet:toNSString(e.facet)
-                                          operation:toNSString(e.operation)
-                                               file:toNSString(e.ice_file())
-                                               line:e.ice_line()];
-        }
-        catch (const Ice::FacetNotExistException& e)
-        {
-            return [factory facetNotExistException:toNSString(e.id.name)
-                                          category:toNSString(e.id.category)
-                                             facet:toNSString(e.facet)
-                                         operation:toNSString(e.operation)
-                                              file:toNSString(e.ice_file())
-                                              line:e.ice_line()];
-        }
-        catch (const Ice::OperationNotExistException& e)
-        {
-            return [factory operationNotExistException:toNSString(e.id.name)
-                                              category:toNSString(e.id.category)
-                                                 facet:toNSString(e.facet)
-                                             operation:toNSString(e.operation)
-                                                  file:toNSString(e.ice_file())
-                                                  line:e.ice_line()];
-        }
-        catch (const Ice::RequestFailedException& e)
-        {
-            return [factory requestFailedException:toNSString(e.id.name)
-                                          category:toNSString(e.id.category)
-                                             facet:toNSString(e.facet)
-                                         operation:toNSString(e.operation)
-                                              file:toNSString(e.ice_file())
-                                              line:e.ice_line()];
-        }
-        catch (const Ice::ConnectionRefusedException& e)
-        {
-            return [factory connectionRefusedException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::FileException& e)
-        {
-            return [factory fileException:e.error
-                                     path:toNSString(e.path)
-                                     file:toNSString(e.ice_file())
-                                     line:e.ice_line()];
-        }
-        catch (const Ice::ConnectFailedException& e)
-        {
-            return [factory connectFailedException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ConnectionLostException& e)
-        {
-            return [factory connectionLostException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::SocketException& e)
-        {
-            return [factory socketException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::SyscallException& e)
-        {
-            return [factory syscallException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ConnectTimeoutException& e)
-        {
-            return [factory connectTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::CloseTimeoutException& e)
-        {
-            return [factory closeTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ConnectionTimeoutException& e)
-        {
-            return [factory connectionTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::InvocationTimeoutException& e)
-        {
-            return [factory invocationTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::TimeoutException& e)
-        {
-            return [factory timeoutException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::BadMagicException& e)
-        {
-            NSData* badMagic = [[NSData alloc] initWithBytes:e.badMagic.data() length:e.badMagic.size()];
-            return [factory badMagicException:toNSString(e.reason)
-                                     badMagic:badMagic
-                                         file:toNSString(e.ice_file())
-                                         line:e.ice_line()];
-        }
-        catch (const Ice::UnsupportedProtocolException& e)
-        {
-            return [factory unsupportedProtocolException:toNSString(e.reason)
-                                                badMajor:e.bad.major
-                                                badMinor:e.bad.minor
-                                          supportedMajor:e.supported.major
-                                          supportedMinor:e.supported.minor
-                                                    file:toNSString(e.ice_file())
-                                                    line:e.ice_line()];
-        }
-        catch (const Ice::UnsupportedEncodingException& e)
-        {
-            return [factory unsupportedEncodingException:toNSString(e.reason)
-                                                badMajor:e.bad.major
-                                                badMinor:e.bad.minor
-                                          supportedMajor:e.supported.major
-                                          supportedMinor:e.supported.minor
-                                                    file:toNSString(e.ice_file())
-                                                    line:e.ice_line()];
-        }
-        catch (const Ice::UnknownMessageException& e)
-        {
-            return [factory unknownMessageException:toNSString(e.reason)
-                                               file:toNSString(e.ice_file())
-                                               line:e.ice_line()];
-        }
-        catch (const Ice::ConnectionNotValidatedException& e)
-        {
-            return [factory connectionNotValidatedException:toNSString(e.reason)
+    }
+    catch (const Ice::ObjectAdapterIdInUseException& e)
+    {
+        return [factory objectAdapterIdInUseException:toNSString(e.id) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::NoEndpointException& e)
+    {
+        return [factory noEndpointException:toNSString(e.proxy) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::EndpointParseException& e)
+    {
+        return [factory endpointParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::EndpointSelectionTypeParseException& e)
+    {
+        return [factory endpointSelectionTypeParseException:toNSString(e.str)
                                                        file:toNSString(e.ice_file())
                                                        line:e.ice_line()];
-        }
-        catch (const Ice::UnknownRequestIdException& e)
-        {
-            return [factory unknownRequestIdException:toNSString(e.reason)
-                                                 file:toNSString(e.ice_file())
-                                                 line:e.ice_line()];
-        }
-        catch (const Ice::UnknownReplyStatusException& e)
-        {
-            return [factory unknownReplyStatusException:toNSString(e.reason)
-                                                   file:toNSString(e.ice_file())
-                                                   line:e.ice_line()];
-        }
-        catch (const Ice::CloseConnectionException& e)
-        {
-            return [factory closeConnectionException:toNSString(e.reason)
+    }
+    catch (const Ice::VersionParseException& e)
+    {
+        return [factory versionParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::IdentityParseException& e)
+    {
+        return [factory identityParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ProxyParseException& e)
+    {
+        return [factory proxyParseException:toNSString(e.str) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::IllegalIdentityException& e)
+    {
+        return [factory illegalIdentityException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::IllegalServantException& e)
+    {
+        return [factory illegalServantException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::DNSException& e)
+    {
+        return [factory dNSException:e.error host:toNSString(e.host) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::OperationInterruptedException& e)
+    {
+        return [factory operationInterruptedException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::InvocationCanceledException& e)
+    {
+        return [factory invocationCanceledException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::FeatureNotSupportedException& e)
+    {
+        return [factory featureNotSupportedException:toNSString(e.unsupportedFeature)
                                                 file:toNSString(e.ice_file())
                                                 line:e.ice_line()];
-        }
-        catch (const Ice::ConnectionManuallyClosedException& e)
-        {
-            return [factory connectionManuallyClosedException:e.graceful
-                                                         file:toNSString(e.ice_file())
-                                                         line:e.ice_line()];
-        }
-        catch (const Ice::IllegalMessageSizeException& e)
-        {
-            return [factory illegalMessageSizeException:toNSString(e.reason)
+    }
+    catch (const Ice::FixedProxyException& e)
+    {
+        return [factory fixedProxyException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::SecurityException& e)
+    {
+        return [factory securityException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::UnknownLocalException& e)
+    {
+        return [factory unknownLocalException:toNSString(e.unknown) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::UnknownUserException& e)
+    {
+        return [factory unknownUserException:toNSString(e.unknown) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::UnknownException& e)
+    {
+        return [factory unknownException:toNSString(e.unknown) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ObjectNotExistException& e)
+    {
+        return [factory objectNotExistException:toNSString(e.id.name)
+                                       category:toNSString(e.id.category)
+                                          facet:toNSString(e.facet)
+                                      operation:toNSString(e.operation)
+                                           file:toNSString(e.ice_file())
+                                           line:e.ice_line()];
+    }
+    catch (const Ice::FacetNotExistException& e)
+    {
+        return [factory facetNotExistException:toNSString(e.id.name)
+                                      category:toNSString(e.id.category)
+                                         facet:toNSString(e.facet)
+                                     operation:toNSString(e.operation)
+                                          file:toNSString(e.ice_file())
+                                          line:e.ice_line()];
+    }
+    catch (const Ice::OperationNotExistException& e)
+    {
+        return [factory operationNotExistException:toNSString(e.id.name)
+                                          category:toNSString(e.id.category)
+                                             facet:toNSString(e.facet)
+                                         operation:toNSString(e.operation)
+                                              file:toNSString(e.ice_file())
+                                              line:e.ice_line()];
+    }
+    catch (const Ice::RequestFailedException& e)
+    {
+        return [factory requestFailedException:toNSString(e.id.name)
+                                      category:toNSString(e.id.category)
+                                         facet:toNSString(e.facet)
+                                     operation:toNSString(e.operation)
+                                          file:toNSString(e.ice_file())
+                                          line:e.ice_line()];
+    }
+    catch (const Ice::ConnectionRefusedException& e)
+    {
+        return [factory connectionRefusedException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::FileException& e)
+    {
+        return [factory fileException:e.error path:toNSString(e.path) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectFailedException& e)
+    {
+        return [factory connectFailedException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectionLostException& e)
+    {
+        return [factory connectionLostException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::SocketException& e)
+    {
+        return [factory socketException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::SyscallException& e)
+    {
+        return [factory syscallException:e.error file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectTimeoutException& e)
+    {
+        return [factory connectTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::CloseTimeoutException& e)
+    {
+        return [factory closeTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectionTimeoutException& e)
+    {
+        return [factory connectionTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::InvocationTimeoutException& e)
+    {
+        return [factory invocationTimeoutException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::TimeoutException& e)
+    {
+        return [factory timeoutException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::BadMagicException& e)
+    {
+        NSData* badMagic = [[NSData alloc] initWithBytes:e.badMagic.data() length:e.badMagic.size()];
+        return [factory badMagicException:toNSString(e.reason)
+                                 badMagic:badMagic
+                                     file:toNSString(e.ice_file())
+                                     line:e.ice_line()];
+    }
+    catch (const Ice::UnsupportedProtocolException& e)
+    {
+        return [factory unsupportedProtocolException:toNSString(e.reason)
+                                            badMajor:e.bad.major
+                                            badMinor:e.bad.minor
+                                      supportedMajor:e.supported.major
+                                      supportedMinor:e.supported.minor
+                                                file:toNSString(e.ice_file())
+                                                line:e.ice_line()];
+    }
+    catch (const Ice::UnsupportedEncodingException& e)
+    {
+        return [factory unsupportedEncodingException:toNSString(e.reason)
+                                            badMajor:e.bad.major
+                                            badMinor:e.bad.minor
+                                      supportedMajor:e.supported.major
+                                      supportedMinor:e.supported.minor
+                                                file:toNSString(e.ice_file())
+                                                line:e.ice_line()];
+    }
+    catch (const Ice::UnknownMessageException& e)
+    {
+        return [factory unknownMessageException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectionNotValidatedException& e)
+    {
+        return [factory connectionNotValidatedException:toNSString(e.reason)
                                                    file:toNSString(e.ice_file())
                                                    line:e.ice_line()];
-        }
-        catch (const Ice::CompressionException& e)
-        {
-            return [factory compressionException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::DatagramLimitException& e)
-        {
-            return [factory datagramLimitException:toNSString(e.reason)
-                                              file:toNSString(e.ice_file())
-                                              line:e.ice_line()];
-        }
-        catch (const Ice::ProxyUnmarshalException& e)
-        {
-            return [factory proxyUnmarshalException:toNSString(e.reason)
+    }
+    catch (const Ice::UnknownRequestIdException& e)
+    {
+        return [factory unknownRequestIdException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::UnknownReplyStatusException& e)
+    {
+        return [factory unknownReplyStatusException:toNSString(e.reason)
                                                file:toNSString(e.ice_file())
                                                line:e.ice_line()];
-        }
-        catch (const Ice::UnmarshalOutOfBoundsException& e)
-        {
-            return [factory unmarshalOutOfBoundsException:toNSString(e.reason)
-                                                     file:toNSString(e.ice_file())
-                                                     line:e.ice_line()];
-        }
-        catch (const Ice::NoValueFactoryException& e)
-        {
-            return [factory noValueFactoryException:toNSString(e.reason)
-                                               type:toNSString(e.type)
+    }
+    catch (const Ice::CloseConnectionException& e)
+    {
+        return [factory closeConnectionException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ConnectionManuallyClosedException& e)
+    {
+        return [factory connectionManuallyClosedException:e.graceful file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::IllegalMessageSizeException& e)
+    {
+        return [factory illegalMessageSizeException:toNSString(e.reason)
                                                file:toNSString(e.ice_file())
                                                line:e.ice_line()];
-        }
-        catch (const Ice::UnexpectedObjectException& e)
-        {
-            return [factory unexpectedObjectException:toNSString(e.reason)
-                                                 type:toNSString(e.type)
-                                         expectedType:toNSString(e.expectedType)
+    }
+    catch (const Ice::CompressionException& e)
+    {
+        return [factory compressionException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::DatagramLimitException& e)
+    {
+        return [factory datagramLimitException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ProxyUnmarshalException& e)
+    {
+        return [factory proxyUnmarshalException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::UnmarshalOutOfBoundsException& e)
+    {
+        return [factory unmarshalOutOfBoundsException:toNSString(e.reason)
                                                  file:toNSString(e.ice_file())
                                                  line:e.ice_line()];
-        }
-        catch (const Ice::MemoryLimitException& e)
-        {
-            return [factory memoryLimitException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::StringConversionException& e)
-        {
-            return [factory stringConversionException:toNSString(e.reason)
-                                                 file:toNSString(e.ice_file())
-                                                 line:e.ice_line()];
-        }
-        catch (const Ice::EncapsulationException& e)
-        {
-            return [factory encapsulationException:toNSString(e.reason)
-                                              file:toNSString(e.ice_file())
-                                              line:e.ice_line()];
-        }
-        catch (const Ice::MarshalException& e)
-        {
-            return [factory marshalException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::ProtocolException& e)
-        {
-            return [factory protocolException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const Ice::LocalException& e)
-        {
-            return [factory localException:toNSString(e.ice_file()) line:e.ice_line()];
-        }
-        catch (const std::exception& e)
-        {
-            return [factory runtimeError:toNSString(e.what())];
-        }
-        catch (...)
-        {
-            return [factory runtimeError:toNSString("unknown c++ exception")];
-        }
+    }
+    catch (const Ice::NoValueFactoryException& e)
+    {
+        return [factory noValueFactoryException:toNSString(e.reason)
+                                           type:toNSString(e.type)
+                                           file:toNSString(e.ice_file())
+                                           line:e.ice_line()];
+    }
+    catch (const Ice::UnexpectedObjectException& e)
+    {
+        return [factory unexpectedObjectException:toNSString(e.reason)
+                                             type:toNSString(e.type)
+                                     expectedType:toNSString(e.expectedType)
+                                             file:toNSString(e.ice_file())
+                                             line:e.ice_line()];
+    }
+    catch (const Ice::MemoryLimitException& e)
+    {
+        return [factory memoryLimitException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::StringConversionException& e)
+    {
+        return [factory stringConversionException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::EncapsulationException& e)
+    {
+        return [factory encapsulationException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::MarshalException& e)
+    {
+        return [factory marshalException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::ProtocolException& e)
+    {
+        return [factory protocolException:toNSString(e.reason) file:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const Ice::LocalException& e)
+    {
+        return [factory localException:toNSString(e.ice_file()) line:e.ice_line()];
+    }
+    catch (const std::exception& e)
+    {
+        return [factory runtimeError:toNSString(e.what())];
+    }
+    catch (...)
+    {
+        return [factory runtimeError:toNSString("unknown c++ exception")];
+    }
 }
 
 std::exception_ptr

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -166,8 +166,8 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -196,8 +196,8 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
             IceInternal::escapeString(fromNSString(string), fromNSString(special), instance->toStringMode()));
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -110,9 +110,9 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
         }
         return [ICECommunicator getHandle:communicator];
     }
-    catch (const std::exception& err)
+    catch (...)
     {
-        *error = convertException(err);
+        *error = convertException(std::current_exception());
     }
     return nil;
 }
@@ -145,9 +145,9 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
         }
         return [ICEProperties getHandle:props];
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
-        *error = convertException(ex);
+        *error = convertException(std::current_exception());
     }
 
     return nil;
@@ -165,9 +165,9 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
         *category = toNSString(ident.category);
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -195,9 +195,9 @@ static Class<ICEAdminFacetFactory> _adminFacetFactory;
         return toNSString(
             IceInternal::escapeString(fromNSString(string), fromNSString(special), instance->toStringMode()));
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }

--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -35,9 +35,9 @@
         self.objectAdapter->activate();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -103,9 +103,9 @@
         auto prx = self.objectAdapter->createProxy(Ice::Identity{fromNSString(name), fromNSString(category)});
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -119,9 +119,9 @@
         auto prx = self.objectAdapter->createDirectProxy(Ice::Identity{fromNSString(name), fromNSString(category)});
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -135,9 +135,9 @@
         auto prx = self.objectAdapter->createIndirectProxy(Ice::Identity{fromNSString(name), fromNSString(category)});
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -192,9 +192,9 @@
         self.objectAdapter->refreshPublishedEndpoints();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -214,9 +214,9 @@
         self.objectAdapter->setPublishedEndpoints(endpts);
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -227,9 +227,9 @@
     {
         return self.objectAdapter->getDispatchQueue();
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }

--- a/swift/src/IceImpl/ObjectAdapter.mm
+++ b/swift/src/IceImpl/ObjectAdapter.mm
@@ -36,8 +36,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -104,8 +104,8 @@
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -120,8 +120,8 @@
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -136,8 +136,8 @@
         return [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -193,8 +193,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -215,8 +215,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -228,8 +228,8 @@
         return self.objectAdapter->getDispatchQueue();
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -54,8 +54,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -98,8 +98,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -120,8 +120,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -139,8 +139,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -158,8 +158,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -177,8 +177,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -196,8 +196,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -215,8 +215,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -262,8 +262,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -295,8 +295,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -325,8 +325,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -420,8 +420,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -434,8 +434,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -455,8 +455,8 @@
         return connection ? connection : [NSNull null];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -504,8 +504,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -552,8 +552,8 @@
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -589,8 +589,8 @@
         }
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -660,8 +660,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -694,8 +694,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -53,9 +53,9 @@
         auto prx = _prx->ice_identity(Ice::Identity{fromNSString(name), fromNSString(category)});
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -97,9 +97,9 @@
         auto prx = _prx->ice_adapterId(fromNSString(id));
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -119,9 +119,9 @@
         auto prx = _prx->ice_endpoints(endpts);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -138,9 +138,9 @@
         auto prx = _prx->ice_locatorCacheTimeout(timeout);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -157,9 +157,9 @@
         auto prx = _prx->ice_invocationTimeout(timeout);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -176,9 +176,9 @@
         auto prx = _prx->ice_connectionId(fromNSString(connectionId));
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -195,9 +195,9 @@
         auto prx = _prx->ice_connectionCached(cached);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -214,9 +214,9 @@
         auto prx = _prx->ice_endpointSelection(Ice::EndpointSelectionType(type));
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -261,9 +261,9 @@
         auto prx = _prx->ice_router(Ice::uncheckedCast<Ice::RouterPrx>(r));
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -294,9 +294,9 @@
         auto prx = _prx->ice_locator(Ice::uncheckedCast<Ice::LocatorPrx>(l));
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -324,9 +324,9 @@
         auto prx = _prx->ice_preferSecure(b);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -419,9 +419,9 @@
         auto prx = _prx->ice_timeout(timeout);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -433,9 +433,9 @@
         auto prx = _prx->ice_fixed([connection connection]);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -454,9 +454,9 @@
 
         return connection ? connection : [NSNull null];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -481,12 +481,12 @@
                 }
             });
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 
@@ -503,9 +503,9 @@
         _prx->ice_flushBatchRequests();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -530,12 +530,12 @@
                 }
             });
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 
@@ -551,9 +551,9 @@
         auto prx = _prx->ice_collocationOptimized(collocated);
         return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -588,9 +588,9 @@
             return [NSNull null];
         }
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -659,9 +659,9 @@
         p.get_future().get();
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -693,9 +693,9 @@
             context ? ctx : Ice::noExplicitContext);
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -754,12 +754,12 @@
             },
             context ? ctx : Ice::noExplicitContext);
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
         // Typically CommunicatorDestroyedException. Note that the callback is called on the
         // thread making the invocation, which is fine since we only use it to fulfill the
         // PromiseKit promise.
-        exception(convertException(ex));
+        exception(convertException(std::current_exception()));
     }
 }
 

--- a/swift/src/IceImpl/Properties.mm
+++ b/swift/src/IceImpl/Properties.mm
@@ -57,9 +57,9 @@
         self.properties->setProperty(fromNSString(key), fromNSString(value));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -79,9 +79,9 @@
         fromNSArray(options, s);
         return toNSArray(self.properties->parseCommandLineOptions(fromNSString(prefix), s));
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -94,9 +94,9 @@
         fromNSArray(options, s);
         return toNSArray(self.properties->parseIceCommandLineOptions(s));
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -108,9 +108,9 @@
         self.properties->load(fromNSString(file));
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/Properties.mm
+++ b/swift/src/IceImpl/Properties.mm
@@ -58,8 +58,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }
@@ -80,8 +80,8 @@
         return toNSArray(self.properties->parseCommandLineOptions(fromNSString(prefix), s));
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -95,8 +95,8 @@
         return toNSArray(self.properties->parseIceCommandLineOptions(s));
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -109,8 +109,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/PropertiesAdmin.mm
+++ b/swift/src/IceImpl/PropertiesAdmin.mm
@@ -19,9 +19,9 @@
         // This function does not use current so we do not pass it from Swift
         return toNSString(self.propertiesAdmin->getProperty(fromNSString(key), Ice::Current{}));
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -33,9 +33,9 @@
         // This function does not use current so we do not pass it from Swift
         return toNSDictionary(self.propertiesAdmin->getPropertiesForPrefix(fromNSString(prefix), Ice::Current{}));
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -50,9 +50,9 @@
         self.propertiesAdmin->setProperties(props, Ice::Current{});
         return YES;
     }
-    catch (const std::exception& ex)
-    {
-        *error = convertException(ex);
+    catch (...)
+{
+     *error = convertException(std::current_exception());
         return NO;
     }
 }

--- a/swift/src/IceImpl/PropertiesAdmin.mm
+++ b/swift/src/IceImpl/PropertiesAdmin.mm
@@ -20,8 +20,8 @@
         return toNSString(self.propertiesAdmin->getProperty(fromNSString(key), Ice::Current{}));
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -34,8 +34,8 @@
         return toNSDictionary(self.propertiesAdmin->getPropertiesForPrefix(fromNSString(prefix), Ice::Current{}));
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return nil;
     }
 }
@@ -51,8 +51,8 @@
         return YES;
     }
     catch (...)
-{
-     *error = convertException(std::current_exception());
+    {
+        *error = convertException(std::current_exception());
         return NO;
     }
 }


### PR DESCRIPTION
This PR removes ice_throw from IceUtil::Exception, and the base IceUtil::ExceptionHelper.

ice_throw is still used for user exceptions. I am not sure we can remove it - probably not.