### PR TITLE
Close generate files

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -610,7 +610,6 @@ Slice::Gen::Gen(
     const string& dir)
     : _base(base),
       _headerExtension(headerExtension),
-      _implHeaderExtension(headerExtension),
       _sourceExtension(sourceExtension),
       _extraHeaders(extraHeaders),
       _include(include),
@@ -638,8 +637,6 @@ Slice::Gen::~Gen()
 
     H.close();
     C.close();
-    implH.close();
-    implC.close();
 }
 
 void

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -635,6 +635,11 @@ Slice::Gen::~Gen()
     H << "\n\n#include <IceUtil/PopDisableWarnings.h>";
     H << "\n#endif\n";
     C << '\n';
+
+    H.close();
+    C.close();
+    implH.close();
+    implC.close();
 }
 
 void
@@ -845,15 +850,6 @@ Slice::Gen::generate(const UnitPtr& p)
         StreamVisitor streamVisitor(H);
         p->visit(&streamVisitor, false);
     }
-}
-
-void
-Slice::Gen::closeOutput()
-{
-    H.close();
-    C.close();
-    implH.close();
-    implC.close();
 }
 
 void

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -49,12 +49,8 @@ namespace Slice
         ::IceUtilInternal::Output H;
         ::IceUtilInternal::Output C;
 
-        ::IceUtilInternal::Output implH;
-        ::IceUtilInternal::Output implC;
-
         std::string _base;
         std::string _headerExtension;
-        std::string _implHeaderExtension;
         std::string _sourceExtension;
         std::vector<std::string> _extraHeaders;
         std::string _include;

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -27,7 +27,6 @@ namespace Slice
         Gen(const Gen&) = delete;
 
         void generate(const UnitPtr&);
-        void closeOutput();
 
         static TypeContext setUseWstring(ContainedPtr, std::list<TypeContext>&, TypeContext);
         static TypeContext resetUseWstring(std::list<TypeContext>&);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1885,6 +1885,7 @@ Slice::Gen::~Gen()
     if (_out.isOpen())
     {
         _out << '\n';
+        _out.close();
     }
 }
 
@@ -1926,12 +1927,6 @@ Slice::Gen::generate(const UnitPtr& p)
 
     DispatcherVisitor dispatcherVisitor(_out, _tie);
     p->visit(&dispatcherVisitor, false);
-}
-
-void
-Slice::Gen::closeOutput()
-{
-    _out.close();
 }
 
 void

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -102,7 +102,6 @@ namespace Slice
         ~Gen();
 
         void generate(const UnitPtr&);
-        void closeOutput();
 
     private:
         IceUtilInternal::Output _out;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -673,11 +673,13 @@ Slice::Gen::~Gen()
     if (_jsout.isOpen() || _useStdout)
     {
         _jsout << '\n';
+        _jsout.close();
     }
 
     if (_tsout.isOpen() || _useStdout)
     {
         _tsout << '\n';
+        _tsout.close();
     }
 }
 
@@ -823,20 +825,6 @@ Slice::Gen::generate(const UnitPtr& p)
             _tsout << "/** slice2js: generated end **/";
             _tsout << "\n";
         }
-    }
-}
-
-void
-Slice::Gen::closeOutput()
-{
-    if (_jsout.isOpen())
-    {
-        _jsout.close();
-    }
-
-    if (_tsout.isOpen())
-    {
-        _tsout.close();
     }
 }
 

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -48,7 +48,6 @@ namespace Slice
         ~Gen();
 
         void generate(const UnitPtr&);
-        void closeOutput();
 
     private:
         IceUtilInternal::Output _jsout;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -73,6 +73,7 @@ Gen::~Gen()
     if (_out.isOpen())
     {
         _out << nl;
+        _out.close();
     }
 }
 
@@ -99,12 +100,6 @@ Gen::generate(const UnitPtr& p)
 
     ObjectExtVisitor objectExtVisitor(_out);
     p->visit(&objectExtVisitor, false);
-}
-
-void
-Gen::closeOutput()
-{
-    _out.close();
 }
 
 void

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -19,7 +19,6 @@ namespace Slice
         ~Gen();
 
         void generate(const UnitPtr&);
-        void closeOutput();
         void printHeader();
 
     private:


### PR DESCRIPTION
Previously, several of our slice compilers had `closeOutput` functions which were unused. I've removed this function and moved the logic to the destructors.