### PR TITLE
Make OutputStream movable

### DIFF
--- a/cpp/include/Ice/AsyncResponseHandler.h
+++ b/cpp/include/Ice/AsyncResponseHandler.h
@@ -39,7 +39,7 @@ namespace IceInternal
         {
             if (!_responseSent.test_and_set())
             {
-                _sendResponse(Ice::OutgoingResponse{marshaledResult.outputStream(), _current});
+                _sendResponse(Ice::OutgoingResponse{std::move(marshaledResult).outputStream(), _current});
             }
             // else we ignore this call.
         }

--- a/cpp/include/Ice/MarshaledResult.h
+++ b/cpp/include/Ice/MarshaledResult.h
@@ -34,7 +34,7 @@ namespace Ice
 
         /// \cond INTERNAL
 
-        OutputStream& outputStream() noexcept { return _ostr; }
+        OutputStream&& outputStream() && noexcept { return std::move(_ostr); }
 
     protected:
         /**

--- a/cpp/include/Ice/OutgoingResponse.h
+++ b/cpp/include/Ice/OutgoingResponse.h
@@ -45,39 +45,37 @@ namespace Ice
          * @param replyStatus The status of the response.
          * @param exceptionId The ID of the exception, when the response carries an exception.
          * @param exceptionMessage The exception message, when the response carries an exception.
-         * @param outputStream The output stream that holds the response. Its underlying buffer is adopted by the new
-         * response.
+         * @param outputStream The output stream that holds the response.
          * @param current A reference to the current object of the request.
          */
         OutgoingResponse(
             ReplyStatus replyStatus,
             std::string exceptionId,
             std::string exceptionMessage,
-            OutputStream& outputStream,
+            OutputStream outputStream,
             const Current& current) noexcept;
 
         /**
          * Construct an OutgoingResponse object with the Ok reply status.
-         * @param outputStream The output stream that holds the response. Its underlying buffer is adopted by the new
-         * response.
+         * @param outputStream The output stream that holds the response.
          * @param current A reference to the current object of the request.
          */
-        OutgoingResponse(OutputStream& outputStream, const Current& current) noexcept
-            : OutgoingResponse(ReplyStatus::Ok, "", "", outputStream, current)
+        OutgoingResponse(OutputStream outputStream, const Current& current) noexcept
+            : OutgoingResponse(ReplyStatus::Ok, "", "", std::move(outputStream), current)
         {
         }
 
         /**
          * Move constructor.
-         * @param source The response to move into this new response.
+         * @param other The response to move into this new response.
          */
-        OutgoingResponse(OutgoingResponse&& source) noexcept;
+        OutgoingResponse(OutgoingResponse&& other) noexcept = default;
 
         /**
          * Move assignment operator.
-         * @param source The response to move into this response.
+         * @param other The response to move into this response.
          */
-        OutgoingResponse& operator=(OutgoingResponse&& source) noexcept;
+        OutgoingResponse& operator=(OutgoingResponse&& other) noexcept = default;
 
         OutgoingResponse(const OutgoingResponse&) = delete;
         OutgoingResponse& operator=(const OutgoingResponse&) = delete;

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -59,6 +59,18 @@ namespace Ice
             const EncodingVersion& version,
             const std::pair<const std::byte*, const std::byte*>& bytes);
 
+        /**
+         * Move constructor.
+         * @param other The output stream to move into this output stream.
+         */
+        OutputStream(OutputStream&& other) noexcept;
+
+        /**
+         * Move assignment operator.
+         * @param other The output stream to move into this output stream.
+         */
+        OutputStream& operator=(OutputStream&& other) noexcept;
+
         ~OutputStream()
         {
             // Inlined for performance reasons.

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -171,7 +171,12 @@ namespace
             ostr.write(exceptionMessage);
         }
 
-        return OutgoingResponse{replyStatus, std::move(exceptionId), std::move(exceptionMessage), ostr, current};
+        return OutgoingResponse{
+            replyStatus,
+            std::move(exceptionId),
+            std::move(exceptionMessage),
+            std::move(ostr),
+            current};
     }
 } // anonymous namespace
 
@@ -179,34 +184,14 @@ OutgoingResponse::OutgoingResponse(
     ReplyStatus replyStatus,
     string exceptionId,
     string exceptionMessage,
-    OutputStream& outputStream,
+    OutputStream outputStream,
     const Current& current) noexcept
     : _current(current),
       _exceptionId(std::move(exceptionId)),
       _exceptionMessage(std::move(exceptionMessage)),
+      _outputStream(std::move(outputStream)),
       _replyStatus(replyStatus)
 {
-    _outputStream.swap(outputStream);
-}
-
-OutgoingResponse::OutgoingResponse(OutgoingResponse&& other) noexcept
-    : _current(std::move(other._current)),
-      _exceptionId(std::move(other._exceptionId)),
-      _exceptionMessage(std::move(other._exceptionMessage)),
-      _replyStatus(other._replyStatus)
-{
-    _outputStream.swap(other._outputStream);
-}
-
-OutgoingResponse&
-OutgoingResponse::operator=(OutgoingResponse&& other) noexcept
-{
-    _current = std::move(other._current);
-    _replyStatus = other._replyStatus;
-    _exceptionId = std::move(other._exceptionId);
-    _exceptionMessage = std::move(other._exceptionMessage);
-    _outputStream.swap(other._outputStream);
-    return *this;
 }
 
 int32_t
@@ -233,7 +218,7 @@ Ice::makeOutgoingResponse(
             ostr.startEncapsulation(current.encoding, format);
             marshal(&ostr);
             ostr.endEncapsulation();
-            return OutgoingResponse{ostr, current};
+            return OutgoingResponse{std::move(ostr), current};
         }
         catch (...)
         {
@@ -244,7 +229,7 @@ Ice::makeOutgoingResponse(
     {
         // A oneway request cannot have a return or out params.
         assert(0);
-        return OutgoingResponse{ostr, current};
+        return OutgoingResponse{std::move(ostr), current};
     }
 }
 
@@ -266,7 +251,7 @@ Ice::makeEmptyOutgoingResponse(const Current& current) noexcept
             return makeOutgoingResponse(current_exception(), current);
         }
     }
-    return OutgoingResponse{ostr, current};
+    return OutgoingResponse{std::move(ostr), current};
 }
 
 OutgoingResponse
@@ -296,7 +281,7 @@ Ice::makeOutgoingResponse(bool ok, const pair<const byte*, const byte*>& encapsu
             return makeOutgoingResponse(current_exception(), current);
         }
     }
-    return OutgoingResponse{ostr, current};
+    return OutgoingResponse{std::move(ostr), current};
 }
 
 OutgoingResponse


### PR DESCRIPTION
This PR makes OutputStream movable in C++, and takes advantage of this new ability for OutgoingResponse.

It's likely we could use this feature (instead of swap) elsewhere.