### PR TITLE
Use INT64_C macro for Slice long literals in C++ generated code

### DIFF
--- a/cpp/src/IceSSL/SChannelCertificateI.cpp
+++ b/cpp/src/IceSSL/SChannelCertificateI.cpp
@@ -84,8 +84,8 @@ namespace
         mutable std::mutex _mutex;
     };
 
-    const int64_t TICKS_PER_MSECOND = 10000LL;
-    const int64_t MSECS_TO_EPOCH = 11644473600000LL;
+    const int64_t TICKS_PER_MSECOND = INT64_C(10000);
+    const int64_t MSECS_TO_EPOCH = INT64_C(11644473600000);
 
     void loadCertificate(PCERT_SIGNED_CONTENT_INFO* cert, const char* buffer, DWORD length)
     {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -121,7 +121,7 @@ namespace
             }
             else if (bp && bp->kind() == Builtin::KindLong)
             {
-                out << value << "LL";
+                out << "INT64_C(" << value << ")";
             }
             else if (bp && bp->kind() == Builtin::KindFloat)
             {


### PR DESCRIPTION
Fix #1872 