### PR TITLE
Update class mapping in C++

### DIFF
--- a/cpp/include/Ice/Ice.h
+++ b/cpp/include/Ice/Ice.h
@@ -16,6 +16,8 @@
 #include <optional>
 #include <Ice/Object.h>
 #include <Ice/SlicedData.h>
+#include <Ice/InputStream.h>
+#include <Ice/OutputStream.h>
 #include <Ice/MarshaledResult.h>
 #include <Ice/FactoryTable.h>
 #include <Ice/FactoryTableInit.h>

--- a/cpp/include/Ice/Value.h
+++ b/cpp/include/Ice/Value.h
@@ -5,21 +5,16 @@
 #ifndef ICE_VALUE_H
 #define ICE_VALUE_H
 
-#include <Ice/ValueF.h>
-#include <Ice/SlicedDataF.h>
-#include "InputStream.h"
-#include "OutputStream.h"
+#include "ValueF.h"
+#include "SlicedDataF.h"
 
 namespace Ice
 {
     class OutputStream;
     class InputStream;
-}
 
-namespace Ice
-{
     /**
-     * The base class for instances of Slice classes.
+     * The base class for instances of Slice-defined classes.
      * \headerfile Ice/Ice.h
      */
     class ICE_API Value
@@ -59,7 +54,7 @@ namespace Ice
         static std::string_view ice_staticId() noexcept;
 
         /**
-         * Returns a shallow copy of the object.
+         * Creates a shallow polymorphic copy of this instance.
          * @return The cloned value.
          */
         std::shared_ptr<Value> ice_clone() const { return _iceCloneImpl(); }
@@ -98,36 +93,6 @@ namespace Ice
     private:
         SlicedDataPtr _slicedData;
     };
-
-    /// \cond INTERNAL
-    template<typename T, typename Base> class ValueHelper : public Base
-    {
-    public:
-        using Base::Base;
-
-        ValueHelper() = default;
-
-        std::string ice_id() const override { return std::string{T::ice_staticId()}; }
-
-    protected:
-
-        virtual void _iceWriteImpl(Ice::OutputStream* os) const override
-        {
-            os->startSlice(T::ice_staticId(), -1, std::is_same<Base, Ice::Value>::value ? true : false);
-            Ice::StreamWriter<T, Ice::OutputStream>::write(os, static_cast<const T&>(*this));
-            os->endSlice();
-            Base::_iceWriteImpl(os);
-        }
-
-        virtual void _iceReadImpl(Ice::InputStream* is) override
-        {
-            is->startSlice();
-            Ice::StreamReader<T, Ice::InputStream>::read(is, static_cast<T&>(*this));
-            is->endSlice();
-            Base::_iceReadImpl(is);
-        }
-    };
-    /// \endcond
 }
 
 #endif

--- a/cpp/include/Ice/Value.h
+++ b/cpp/include/Ice/Value.h
@@ -25,16 +25,14 @@ namespace Ice
     class ICE_API Value
     {
     public:
-        // See "Rule of zero" at http://en.cppreference.com/w/cpp/language/rule_of_three
-        // The virtual dtor is actually not strictly necessary since Values are always stored
-        // in std::shared_ptr
-
+        // There is no copy constructor, move constructor, copy-assignment operator or move-assignment operator
+        // to prevent accidental slicing.
         Value() = default;
-        Value(const Value&) = default;
-        Value(Value&&) = default;
-        Value& operator=(const Value&) = default;
-        Value& operator=(Value&&) = default;
+        Value(Value&&) = delete;
         virtual ~Value() = default;
+
+        Value& operator=(const Value&) = delete;
+        Value& operator=(Value&&) = delete;
 
         /**
          * The Ice run time invokes this method prior to marshaling an object's data members. This allows a subclass
@@ -64,7 +62,7 @@ namespace Ice
          * Returns a shallow copy of the object.
          * @return The cloned value.
          */
-        inline std::shared_ptr<Value> ice_clone() const { return _iceCloneImpl(); }
+        std::shared_ptr<Value> ice_clone() const { return _iceCloneImpl(); }
 
         /**
          * Obtains the sliced data associated with this instance.
@@ -80,6 +78,15 @@ namespace Ice
 
     protected:
         /// \cond INTERNAL
+        Value(const Value&) = default; // for clone
+
+        // Helper class that allows derived classes to clone "this" even though the copy constructor is protected.
+        template<class T> struct CloneEnabler : public T
+        {
+            CloneEnabler(const T& other) : T(other) {}
+            static std::shared_ptr<T> clone(const T& other) { return std::make_shared<CloneEnabler>(other); }
+        };
+
         virtual std::shared_ptr<Value> _iceCloneImpl() const;
         /// \endcond
 
@@ -100,15 +107,9 @@ namespace Ice
 
         ValueHelper() = default;
 
-        std::shared_ptr<T> ice_clone() const { return std::static_pointer_cast<T>(_iceCloneImpl()); }
-
         std::string ice_id() const override { return std::string{T::ice_staticId()}; }
 
     protected:
-        virtual std::shared_ptr<Value> _iceCloneImpl() const override
-        {
-            return std::make_shared<T>(static_cast<const T&>(*this));
-        }
 
         virtual void _iceWriteImpl(Ice::OutputStream* os) const override
         {

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -10,6 +10,7 @@
 #include <Ice/LoggerUtil.h>
 #include <Ice/HashUtil.h>
 #include <Ice/NetworkProxy.h>
+#include "Ice/InputStream.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -6,6 +6,8 @@
 #include "Ice/AsyncResponseHandler.h"
 #include "Ice/LocalException.h"
 #include "Ice/SlicedData.h"
+#include "Ice/InputStream.h"
+#include "Ice/OutputStream.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/ServantManager.cpp
+++ b/cpp/src/Ice/ServantManager.cpp
@@ -8,6 +8,7 @@
 #include <Ice/LoggerUtil.h>
 #include <Ice/Instance.h>
 #include <Ice/StringUtil.h>
+#include "Ice/InputStream.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2386,8 +2386,8 @@ Slice::Gen::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
     H << nl << " * Creates a shallow polymorphic copy of this instance.";
     H << nl << " * @return The cloned value.";
     H << nl << " */";
-    H << nl << "::std::shared_ptr<" << name << "> ice_clone() const { return ::std::static_pointer_cast <"
-        << name << ">(_iceCloneImpl()); }";
+    H << nl << "::std::shared_ptr<" << name << "> ice_clone() const { return ::std::static_pointer_cast <" << name
+      << ">(_iceCloneImpl()); }";
 
     return true;
 }
@@ -2476,8 +2476,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << nl << "return CloneEnabler<" << name << ">::clone(*this);";
     C << eb;
 
-    string baseClass =
-        base ? getUnqualified(fixKwd(base->scoped()), scope) : getUnqualified("::Ice::Value", scope);
+    string baseClass = base ? getUnqualified(fixKwd(base->scoped()), scope) : getUnqualified("::Ice::Value", scope);
 
     H << nl << _dllMemberExport << "void _iceWriteImpl(::Ice::OutputStream*) const override;";
     C << sp << nl << "void" << nl << scoped.substr(2) << "::_iceWriteImpl(::Ice::OutputStream* ostr) const";

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -97,7 +97,7 @@ allTests(Test::TestHelper* helper)
     test(*ba2 > *ba1);
     test(*ba1 != *ba2);
 
-    *ba1 = *ba2;
+    ba1 = ba2->ice_clone();
     test(ba1->theS.str == "hello");
     test(ba1->str == "hi");
 
@@ -106,7 +106,7 @@ allTests(Test::TestHelper* helper)
     test(*ba1 <= *ba2);
 
     BasePtr bp1 = make_shared<Base>();
-    *bp1 = *ba2;
+    bp1 = ba2->ice_clone();
     test(bp1->theS.str == "hello");
     test(bp1->str == "hi");
 

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -291,10 +291,10 @@ allTests(Test::TestHelper* helper, bool)
     OneOptionalPtr oo2 = make_shared<OneOptional>(16);
     test(oo2->a && *oo2->a == 16);
 
-    OneOptionalPtr oo3 = make_shared<OneOptional>(*oo2);
+    OneOptionalPtr oo3 = oo2->ice_clone();
     test(oo3->a && *oo3->a == 16);
 
-    *oo3 = *oo1;
+    oo3 = oo1->ice_clone();
     test(oo3->a && *oo3->a == 15);
 
     OneOptionalPtr oon = make_shared<OneOptional>(nullopt);
@@ -359,10 +359,10 @@ allTests(Test::TestHelper* helper, bool)
     mo1->bos->push_back(true);
     mo1->bos->push_back(false);
 
-    MultiOptionalPtr mo2 = make_shared<MultiOptional>(*mo1);
+    MultiOptionalPtr mo2 = mo1->ice_clone();
 
     MultiOptionalPtr mo3 = make_shared<MultiOptional>();
-    *mo3 = *mo2;
+    mo3 = mo2->ice_clone();
 
     test(mo3->a == static_cast<uint8_t>(15));
     test(mo3->b == true);
@@ -507,7 +507,7 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->bos == mo1->bos);
 
     // Clear the first half of the optional parameters
-    MultiOptionalPtr mo6 = make_shared<MultiOptional>(*mo5);
+    MultiOptionalPtr mo6 = mo5->ice_clone();
     mo6->a = nullopt;
     mo6->c = nullopt;
     mo6->e = nullopt;
@@ -559,7 +559,7 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->imipd);
 
     // Clear the second half of the optional parameters
-    MultiOptionalPtr mo8 = make_shared<MultiOptional>(*mo5);
+    MultiOptionalPtr mo8 = mo5->ice_clone();
     mo8->b = nullopt;
     mo8->d = nullopt;
     mo8->f = nullopt;

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -15,7 +15,7 @@ using namespace Test;
 using namespace Test::Sub;
 using namespace Test2::Sub2;
 
-class TestObjectWriter : public Ice::ValueHelper<TestObjectWriter, Ice::Value>
+class TestObjectWriter : public Ice::Value
 {
 public:
     TestObjectWriter(const MyClassPtr& p)
@@ -36,7 +36,7 @@ public:
     bool called;
 };
 
-class TestObjectReader : public Ice::ValueHelper<TestObjectReader, Ice::Value>
+class TestObjectReader : public Ice::Value
 {
 public:
     TestObjectReader() { called = false; }
@@ -53,27 +53,6 @@ public:
     MyClassPtr obj;
     bool called;
 };
-
-// Required for ValueHelper<>'s _iceReadImpl and _iceWriteIpml
-namespace Ice
-{
-    template<class S> struct StreamWriter<TestObjectWriter, S>
-    {
-        static void write(S*, const TestObjectWriter&) { assert(false); }
-    };
-    template<class S> struct StreamReader<TestObjectWriter, S>
-    {
-        static void read(S*, TestObjectWriter&) { assert(false); }
-    };
-    template<class S> struct StreamWriter<TestObjectReader, S>
-    {
-        static void write(S*, const TestObjectReader&) { assert(false); }
-    };
-    template<class S> struct StreamReader<TestObjectReader, S>
-    {
-        static void read(S*, TestObjectReader&) { assert(false); }
-    };
-}
 
 void
 patchObject(void* addr, const shared_ptr<Ice::Value>& v)


### PR DESCRIPTION
This PR updates the Slice to C++ class mapping:
 - the generated class no longer uses a helper template (ValueHelper); this way, the virtual functions are generated out of line
 - the copy constructor is now protected; the move-constructor and assignment operators are deleted. This prevents slicing.

Fixes #1926 for mapped classes (still TODO: servants).
