### PR TITLE
Remove noncopyable class

### DIFF
--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -127,7 +127,6 @@ namespace IceInternal
 #    endif
             }
 
-            // Non-copyable
             DescriptorHolder(const DescriptorHolder&) = delete;
             DescriptorHolder& operator=(const DescriptorHolder&) = delete;
         };

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -1089,9 +1089,10 @@ namespace Ice
 
         using ValueList = std::vector<std::shared_ptr<Value>>;
 
-        class ICE_API EncapsDecoder : private ::IceUtil::noncopyable
+        class ICE_API EncapsDecoder
         {
         public:
+            EncapsDecoder(const EncapsDecoder&) = delete;
             virtual ~EncapsDecoder();
 
             virtual void read(PatchFunc, void*) = 0;
@@ -1293,13 +1294,14 @@ namespace Ice
             std::int32_t _valueIdIndex; // The ID of the next value to unmarshal.
         };
 
-        class Encaps : private ::IceUtil::noncopyable
+        class Encaps
         {
         public:
             Encaps() : start(0), decoder(0), previous(0)
             {
                 // Inlined for performance reasons.
             }
+            Encaps(const Encaps&) = delete;
             ~Encaps()
             {
                 // Inlined for performance reasons.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -1095,6 +1095,8 @@ namespace Ice
             EncapsDecoder(const EncapsDecoder&) = delete;
             virtual ~EncapsDecoder();
 
+            EncapsDecoder& operator=(const EncapsDecoder&) = delete;
+
             virtual void read(PatchFunc, void*) = 0;
             virtual void throwException(UserExceptionFactory) = 0;
 
@@ -1307,6 +1309,9 @@ namespace Ice
                 // Inlined for performance reasons.
                 delete decoder;
             }
+
+            Encaps& operator=(const Encaps&) = delete;
+
             void reset()
             {
                 // Inlined for performance reasons.

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -17,9 +17,12 @@ namespace Ice
      * Base class for logger output utility classes.
      * \headerfile Ice/Ice.h
      */
-    class ICE_API LoggerOutputBase : private IceUtil::noncopyable
+    class ICE_API LoggerOutputBase
     {
     public:
+        LoggerOutputBase() = default;
+        LoggerOutputBase(const LoggerOutputBase&) = delete;
+
         /** Obtains the collected output. */
         std::string str() const;
 

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -23,6 +23,8 @@ namespace Ice
         LoggerOutputBase() = default;
         LoggerOutputBase(const LoggerOutputBase&) = delete;
 
+        LoggerOutputBase& operator=(const LoggerOutputBase&) = delete;
+
         /** Obtains the collected output. */
         std::string str() const;
 

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -894,6 +894,8 @@ namespace Ice
             EncapsEncoder(const EncapsEncoder&) = delete;
             virtual ~EncapsEncoder();
 
+            EncapsEncoder& operator=(const EncapsEncoder&) = delete;
+
             virtual void write(const std::shared_ptr<Value>&) = 0;
             virtual void write(const UserException&) = 0;
 
@@ -1036,6 +1038,9 @@ namespace Ice
                 // Inlined for performance reasons.
                 delete encoder;
             }
+
+            Encaps& operator=(const Encaps&) = delete;
+
             void reset()
             {
                 // Inlined for performance reasons.

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -888,9 +888,10 @@ namespace Ice
 
         typedef std::vector<std::shared_ptr<Value>> ValueList;
 
-        class ICE_API EncapsEncoder : private ::IceUtil::noncopyable
+        class ICE_API EncapsEncoder
         {
         public:
+            EncapsEncoder(const EncapsEncoder&) = delete;
             virtual ~EncapsEncoder();
 
             virtual void write(const std::shared_ptr<Value>&) = 0;
@@ -1019,16 +1020,17 @@ namespace Ice
             InstanceData _preAllocatedInstanceData;
             InstanceData* _current;
 
-            std::int32_t _valueIdIndex; // The ID of the next value to marhsal
+            std::int32_t _valueIdIndex; // The ID of the next value to marshal
         };
 
-        class Encaps : private ::IceUtil::noncopyable
+        class Encaps
         {
         public:
             Encaps() : format(FormatType::DefaultFormat), encoder(0), previous(0)
             {
                 // Inlined for performance reasons.
             }
+            Encaps(const Encaps&) = delete;
             ~Encaps()
             {
                 // Inlined for performance reasons.

--- a/cpp/include/Ice/SHA1.h
+++ b/cpp/include/Ice/SHA1.h
@@ -20,17 +20,16 @@ namespace IceInternal
     {
     public:
         SHA1();
+        SHA1(const SHA1&) = delete;
         ~SHA1();
+
+        SHA1 operator=(const SHA1&) = delete;
 
         void update(const unsigned char*, std::size_t);
         void finalize(std::vector<unsigned char>&);
         void finalize(std::vector<std::byte>&);
 
     private:
-        // noncopyable
-        SHA1(const SHA1&);
-        SHA1 operator=(const SHA1&);
-
         class Hasher;
         std::unique_ptr<Hasher> _hasher;
     };

--- a/cpp/include/IceUtil/Config.h
+++ b/cpp/include/IceUtil/Config.h
@@ -65,22 +65,4 @@
 #    endif
 #endif
 
-namespace IceUtil
-{
-    //
-    // By deriving from this class, other classes are made non-copyable.
-    //
-    class ICE_API noncopyable
-    {
-    protected:
-        noncopyable() {}
-        ~noncopyable() {} // May not be virtual! Classes without virtual
-                          // operations also derive from noncopyable.
-
-    private:
-        noncopyable(const noncopyable&);
-        const noncopyable& operator=(const noncopyable&);
-    };
-}
-
 #endif

--- a/cpp/include/IceUtil/FileUtil.h
+++ b/cpp/include/IceUtil/FileUtil.h
@@ -94,7 +94,7 @@ namespace IceUtilInternal
     // This class is used to implement process file locking. This class
     // is not intended to do file locking within the same process.
     //
-    class ICE_API FileLock : public IceUtil::noncopyable
+    class ICE_API FileLock
     {
     public:
         //
@@ -106,6 +106,8 @@ namespace IceUtilInternal
         // file.
         //
         FileLock(const std::string&);
+
+        FileLock(const FileLock&) = delete;
 
         //
         // The destructor releases the lock and removes the file.

--- a/cpp/include/IceUtil/FileUtil.h
+++ b/cpp/include/IceUtil/FileUtil.h
@@ -114,6 +114,8 @@ namespace IceUtilInternal
         //
         virtual ~FileLock();
 
+        FileLock& operator=(const FileLock&) = delete;
+
     private:
 #ifdef _WIN32
         HANDLE _fd;

--- a/cpp/include/IceUtil/OutputUtil.h
+++ b/cpp/include/IceUtil/OutputUtil.h
@@ -20,17 +20,18 @@ namespace IceUtilInternal
 
     //
     // Technically it's not necessary to have print() & newline() as virtual
-    // since the opeator<< functions are specific to each OutputBase
+    // since the operator<< functions are specific to each OutputBase
     // derivative. However, since it's possible to call print() & newline()
     // manually I've decided to leave them as virtual.
     //
 
-    class ICE_API OutputBase : private ::IceUtil::noncopyable
+    class ICE_API OutputBase
     {
     public:
         OutputBase();
         OutputBase(std::ostream&);
         OutputBase(const std::string&);
+        OutputBase(const OutputBase&) = delete;
         virtual ~OutputBase();
 
         void setIndent(int);  // What is the indent level?
@@ -46,7 +47,7 @@ namespace IceUtilInternal
         void dec(); // Decrement indentation level.
 
         void useCurrentPosAsIndent(); // Save the current position as indentation.
-        void zeroIndent();            // Use zero identation.
+        void zeroIndent();            // Use zero indentation.
         void restoreIndent();         // Restore indentation.
         int currIndent();             // Return current indent value.
 

--- a/cpp/include/IceUtil/OutputUtil.h
+++ b/cpp/include/IceUtil/OutputUtil.h
@@ -34,6 +34,8 @@ namespace IceUtilInternal
         OutputBase(const OutputBase&) = delete;
         virtual ~OutputBase();
 
+        OutputBase& operator=(const OutputBase&) = delete;
+
         void setIndent(int);  // What is the indent level?
         void setUseTab(bool); // Should we output tabs?
 

--- a/cpp/src/Ice/SHA1.cpp
+++ b/cpp/src/Ice/SHA1.cpp
@@ -24,19 +24,17 @@ namespace IceInternal
     {
     public:
         Hasher();
+        Hasher(const Hasher&) = delete;
 #ifdef _WIN32
         ~Hasher();
 #endif
+        Hasher operator=(const Hasher&) = delete;
 
         void update(const unsigned char*, std::size_t);
         void finalize(std::vector<unsigned char>&);
         void finalize(vector<byte>&);
 
     private:
-        // noncopyable
-        Hasher(const Hasher&);
-        Hasher operator=(const Hasher&);
-
 #if defined(_WIN32)
         HCRYPTPROV _ctx;
         HCRYPTHASH _hash;

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -117,23 +117,25 @@ namespace IceDB
     {
     public:
         explicit Env(const std::string&, MDB_dbi = 0, size_t = 0, unsigned int = 0);
+        Env(const Env&) = delete;
         ~Env();
+
+        Env& operator=(const Env&) = delete;
 
         void close();
 
         MDB_env* menv() const;
 
     private:
-        // Not implemented: class is not copyable
-        Env(const Env&);
-        void operator=(const Env&);
-
         MDB_env* _menv;
     };
 
     class ICE_DB_API Txn
     {
     public:
+        Txn(const Txn&) = delete;
+        Txn& operator=(const Txn&) = delete;
+
         void commit();
         void rollback();
 
@@ -147,11 +149,6 @@ namespace IceDB
 
         MDB_txn* _mtxn;
         const bool _readOnly;
-
-    private:
-        // Not implemented: class is not copyable
-        Txn(const Txn&);
-        void operator=(const Txn&);
     };
 
     class ICE_DB_API ReadOnlyTxn : public Txn
@@ -299,6 +296,9 @@ namespace IceDB
         CursorBase(MDB_dbi dbi, const Txn& txn);
         ~CursorBase();
 
+        CursorBase(const CursorBase&) = delete;
+        CursorBase& operator=(const CursorBase&) = delete;
+
         bool get(MDB_val*, MDB_val*, MDB_cursor_op);
         void put(MDB_val*, MDB_val*, unsigned int);
         bool find(MDB_val*);
@@ -307,10 +307,6 @@ namespace IceDB
         void renew(const ReadOnlyTxn&);
 
     private:
-        // Not implemented: class is not copyable
-        CursorBase(const CursorBase&);
-        void operator=(const CursorBase&);
-
         MDB_cursor* _mcursor;
         const bool _readOnly;
     };

--- a/cpp/src/IceUtil/OutputUtil.cpp
+++ b/cpp/src/IceUtil/OutputUtil.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 
 using namespace std;
-using namespace IceUtil;
 using namespace IceUtilInternal;
 
 namespace IceUtilInternal

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -25,6 +25,7 @@ namespace Slice
         ~Gen();
 
         Gen(const Gen&) = delete;
+        Gen& operator=(const Gen&) = delete;
 
         void generate(const UnitPtr&);
 

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -15,7 +15,9 @@ namespace Slice
     public:
         CsGenerator() = default;
         CsGenerator(const CsGenerator&) = delete;
-        virtual ~CsGenerator(){};
+        virtual ~CsGenerator() = default;
+
+        CsGenerator& operator=(const CsGenerator&) = delete;
 
         //
         // Convert a dimension-less array declaration to one with a dimension.

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -10,9 +10,11 @@
 
 namespace Slice
 {
-    class CsGenerator : private ::IceUtil::noncopyable
+    class CsGenerator
     {
     public:
+        CsGenerator() = default;
+        CsGenerator(const CsGenerator&) = delete;
         virtual ~CsGenerator(){};
 
         //

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -95,10 +95,11 @@ namespace Slice
         ::IceUtilInternal::Output& _out;
     };
 
-    class Gen : private ::IceUtil::noncopyable
+    class Gen
     {
     public:
         Gen(const std::string&, const std::vector<std::string>&, const std::string&, bool);
+        Gen(const Gen&) = delete;
         ~Gen();
 
         void generate(const UnitPtr&);

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -137,6 +137,8 @@ namespace Slice
         Gen(const Gen&) = delete;
         ~Gen();
 
+        Gen& operator=(const Gen&) = delete;
+
         void generate(const UnitPtr&);
 
     private:

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -130,10 +130,11 @@ namespace Slice
         void writeSeeAlso(::IceUtilInternal::Output&, const UnitPtr&, const std::string&);
     };
 
-    class Gen : private ::IceUtil::noncopyable
+    class Gen
     {
     public:
         Gen(const std::string&, const std::string&, const std::vector<std::string>&, const std::string&);
+        Gen(const Gen&) = delete;
         ~Gen();
 
         void generate(const UnitPtr&);

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -63,6 +63,8 @@ namespace Slice
         JavaGenerator(const JavaGenerator&) = delete;
         virtual ~JavaGenerator();
 
+        JavaGenerator& operator=(const JavaGenerator&) = delete;
+
         //
         // Validate all metadata in the unit with a "java:" prefix.
         //

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -57,9 +57,10 @@ namespace Slice
         virtual void printHeader();
     };
 
-    class JavaGenerator : private ::IceUtil::noncopyable
+    class JavaGenerator
     {
     public:
+        JavaGenerator(const JavaGenerator&) = delete;
         virtual ~JavaGenerator();
 
         //

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -12,9 +12,11 @@ namespace Slice
 {
     std::string relativePath(const std::string&, const std::string&);
 
-    class JsGenerator : private ::IceUtil::noncopyable
+    class JsGenerator
     {
     public:
+        JsGenerator() = default;
+        JsGenerator(const JsGenerator&) = delete;
         virtual ~JsGenerator(){};
 
         static bool isClassType(const TypePtr&);

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -19,6 +19,8 @@ namespace Slice
         JsGenerator(const JsGenerator&) = delete;
         virtual ~JsGenerator(){};
 
+        JsGenerator& operator=(const JsGenerator&) = delete;
+
         static bool isClassType(const TypePtr&);
         static std::string getDefinedIn(const ContainedPtr&);
         static std::string getModuleMetadata(const TypePtr&);

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -16,7 +16,10 @@ namespace Slice
     {
     public:
         Gen(const std::string&, const std::vector<std::string>&, const std::string&);
+        Gen(const Gen&) = delete;
         ~Gen();
+
+        Gen& operator=(const Gen&) = delete;
 
         void generate(const UnitPtr&);
         void printHeader();

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -47,9 +47,11 @@ namespace Slice
         std::map<std::string, StringList> exceptions;
     };
 
-    class SwiftGenerator : private IceUtil::noncopyable
+    class SwiftGenerator
     {
     public:
+        SwiftGenerator() = default;
+        SwiftGenerator(const SwiftGenerator&) = delete;
         virtual ~SwiftGenerator(){};
 
         static void validateMetaData(const UnitPtr&);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -52,7 +52,9 @@ namespace Slice
     public:
         SwiftGenerator() = default;
         SwiftGenerator(const SwiftGenerator&) = delete;
-        virtual ~SwiftGenerator(){};
+        virtual ~SwiftGenerator() = default;
+
+        SwiftGenerator& operator=(const SwiftGenerator&) = delete;
 
         static void validateMetaData(const UnitPtr&);
 


### PR DESCRIPTION
This PR removes the noncopyable helper class. With modern C++, we can simply delete the copy constructor and copy-assignment operator.