### PR TITLE
Remove Outdated References from Windows Build Files

### DIFF
--- a/cpp/BUILDING.md
+++ b/cpp/BUILDING.md
@@ -290,7 +290,7 @@ environment variables:
 Open the Visual Studio solution that corresponds to the Visual Studio version
 you are using.
 
-- For Visual Studio 2022 use [msbuild/ice.v143.sln](./msbuild/ice.v143.sln)
+- For Visual Studio 2022 use [msbuild/ice.sln](./msbuild/ice.sln)
 
 Restore the solution NuGet packages using the NuGet package manager, if the
 automatic download of packages during build is not enabled.

--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -16,18 +16,9 @@
     </Target>
 
     <!-- Targets required to build Slice compilers -->
-    <Choose>
-        <When Condition="'$(OS)' != 'Windows_NT'">
-            <ItemGroup>
-                <SliceCompilers Include="slice2cs"/>
-            </ItemGroup>
-        </When>
-        <Otherwise>
-            <ItemGroup>
-                <SliceCompilers Include="c++98\slice2cs"/>
-            </ItemGroup>
-        </Otherwise>
-    </Choose>
+    <ItemGroup>
+        <SliceCompilers Include="slice2cs"/>
+    </ItemGroup>
 
     <Target Name="SliceCompilers" Condition="'$(ICE_BIN_DIST)' != 'all'">
         <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\ice.proj"
@@ -35,7 +26,7 @@
                  BuildInParallel="true"
                  Condition="'$(OS)' == 'Windows_NT'"/>
 
-        <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\ice.v143.sln"
+        <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\ice.sln"
                  Targets="@(SliceCompilers)"
                  BuildInParallel="true"
                  Properties="Platform=$(CppPlatform);Configuration=$(Configuration)"

--- a/java/msbuild/ice.proj
+++ b/java/msbuild/ice.proj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Gradle Condition="'$(Gradle)' == ''">gradlew</Gradle>
-    <slice2java>c++98\slice2java</slice2java>
+    <slice2java>slice2java</slice2java>
   </PropertyGroup>
 
   <Target Name="slice2java">
@@ -19,7 +19,7 @@
              Targets="NuGetRestore"
              BuildInParallel="true"/>
 
-    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\ice.$(DefaultPlatformToolset).sln"
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\msbuild\ice.sln"
              Targets="$(slice2java)"
              BuildInParallel="true"
              Properties="Platform=$(Platform);Configuration=$(Configuration)"/>


### PR DESCRIPTION
This PR fixes #1966 by updating the build files for C# and Java on Windows.

It also fixes the one other place we mention the old `ice.v143.sln` file: the C++ README.
I'm sure there's other parts of the README in need of fixing, but I just wanted to get the builds working again.