### PR TITLE
Allow mapping a Slice module to multiple Java packages.

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Util.java
@@ -642,15 +642,6 @@ public final class Util
         }
 
         StringBuilder buf = new StringBuilder(id.length());
-        for(int i = 0; i < _iceTypeIdPrefixes.length; ++i)
-        {
-            if(id.startsWith(_iceTypeIdPrefixes[i]))
-            {
-                buf.append("com.zeroc");
-                break;
-            }
-        }
-
         int start = 2;
         boolean done = false;
         while(!done)
@@ -770,17 +761,4 @@ public final class Util
 
     private static java.lang.Object _processLoggerMutex = new java.lang.Object();
     private static Logger _processLogger = null;
-
-    static private String[] _iceTypeIdPrefixes =
-    {
-        "::Glacier2::",
-        "::Ice::",
-        "::IceBox::",
-        "::IceDiscovery::",
-        "::IceGrid::",
-        "::IceLocatorDiscovery::",
-        "::IceMX::",
-        "::IcePatch2::",
-        "::IceStorm::"
-    };
 }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Instance.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Instance.java
@@ -5,6 +5,8 @@
 package com.zeroc.IceInternal;
 
 import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.zeroc.Ice.Instrumentation.ThreadState;
 
@@ -761,10 +763,22 @@ public final class Instance implements java.util.function.Function<String, Class
             if(pos != -1)
             {
                 String topLevelModule = typeId.substring(2, pos);
-                String pkg = _initData.properties.getProperty("Ice.Package." + topLevelModule);
-                if(pkg.length() > 0)
+                String[] packages = _builtInModulePackages.get(topLevelModule);
+                if (packages == null)
                 {
-                    c = getConcreteClass(pkg + "." + className);
+                    packages = _initData.properties.getPropertyAsListWithDefault("Ice.Package." + topLevelModule, null);
+                }
+
+                if(packages != null)
+                {
+                    for(String pkg : packages)
+                    {
+                        c = getConcreteClass(pkg + "." + className);
+                        if(c != null)
+                        {
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -1880,4 +1894,16 @@ public final class Instance implements java.util.function.Function<String, Class
     private static boolean _oneOffDone = false;
     private QueueExecutorService _queueExecutorService;
     private QueueExecutor _queueExecutor;
+
+    private Map<String,String[]> _builtInModulePackages = java.util.Collections.unmodifiableMap(new HashMap<String, String[]>() {{ 
+        put("Glacier2", new String[] { "com.zeroc" });
+        put("Ice", new String[] { "com.zeroc" });
+        put("IceBox", new String[] { "com.zeroc" });
+        put("IceDiscovery", new String[] { "com.zeroc" });
+        put("IceGrid", new String[] { "com.zeroc" });
+        put("IceLocatorDiscovery", new String[] { "com.zeroc" });
+        put("IceMX", new String[] { "com.zeroc.Ice", "com.zeroc.Glacier2", "com.zeroc.IceStorm" });
+        put("IcePatch2", new String[] { "com.zeroc" });
+        put("IceStorm", new String[] { "com.zeroc" });
+    }});
 }


### PR DESCRIPTION
This PR updates the way that classes are resolves from typeIDs, to allow a toplevel Slice module to check several JavaPackages.

Which is required by IceMX module fix in #1963