### PR TITLE
Split StreamHelpers, remove S template functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,7 +77,8 @@
         "execution": "cpp",
         "type_traits": "cpp",
         "cassert": "cpp",
-        "span": "cpp"
+        "span": "cpp",
+        "functional": "cpp"
     },
     "C_Cpp.default.cppStandard": "c++20",
     "cSpell.words": [

--- a/cpp/include/Ice/EncodingVersion.h
+++ b/cpp/include/Ice/EncodingVersion.h
@@ -1,0 +1,41 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#ifndef ICE_ENCODING_VERSION_H
+#define ICE_ENCODING_VERSION_H
+
+#include "Config.h"
+#include "Comparable.h"
+#include <cstdint>
+
+namespace Ice
+{
+    /**
+     * Represents a version of the Slice encoding.
+     * \headerfile Ice/Ice.h
+     */
+    struct EncodingVersion
+    {
+        std::uint8_t major;
+        std::uint8_t minor;
+
+        /**
+         * Obtains a tuple containing all of the struct's data members.
+         * @return The data members in a tuple.
+         */
+        std::tuple<const std::uint8_t&, const std::uint8_t&> ice_tuple() const
+        {
+            return std::tie(major, minor);
+        }
+    };
+
+    using Ice::operator<;
+    using Ice::operator<=;
+    using Ice::operator>;
+    using Ice::operator>=;
+    using Ice::operator==;
+    using Ice::operator!=;
+}
+
+#endif

--- a/cpp/include/Ice/EncodingVersion.h
+++ b/cpp/include/Ice/EncodingVersion.h
@@ -24,10 +24,7 @@ namespace Ice
          * Obtains a tuple containing all of the struct's data members.
          * @return The data members in a tuple.
          */
-        std::tuple<const std::uint8_t&, const std::uint8_t&> ice_tuple() const
-        {
-            return std::tie(major, minor);
-        }
+        std::tuple<const std::uint8_t&, const std::uint8_t&> ice_tuple() const { return std::tie(major, minor); }
     };
 
     using Ice::operator<;

--- a/cpp/include/Ice/Ice.h
+++ b/cpp/include/Ice/Ice.h
@@ -33,6 +33,7 @@
 #    include "ObjectAdapter.h"
 #    include "Plugin.h"
 #    include "Properties.h"
+#    include "Protocol.h"
 #    include "ProxyFunctions.h"
 #    include "RegisterPlugins.h"
 #    include "ServantLocator.h"

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -12,7 +12,7 @@
 #include "LoggerF.h"
 #include "ValueFactory.h"
 #include "Buffer.h"
-#include "Ice/EncodingVersion.h"
+#include "EncodingVersion.h"
 #include "SlicedDataF.h"
 #include "UserExceptionFactory.h"
 #include "ValueFactory.h"

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -369,24 +369,7 @@ namespace Ice
          * @param sz The number of bytes in the encapsulation.
          * @return encoding The encapsulation's encoding version.
          */
-        EncodingVersion readEncapsulation(const std::byte*& v, std::int32_t& sz)
-        {
-            EncodingVersion encoding;
-            v = i;
-            read(sz);
-            if (sz < 6)
-            {
-                throwEncapsulationException(__FILE__, __LINE__);
-            }
-            if (i - sizeof(std::int32_t) + sz > b.end())
-            {
-                throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
-            }
-
-            read(encoding);
-            i += static_cast<size_t>(sz) - sizeof(std::int32_t) - 2;
-            return encoding;
-        }
+        EncodingVersion readEncapsulation(const std::byte*& v, std::int32_t& sz);
 
         /**
          * Determines the current encoding version.
@@ -515,12 +498,6 @@ namespace Ice
          * @param v Holds the extracted data.
          */
         template<typename T> void read(T& v) { StreamHelper<T, StreamableTraits<T>::helper>::read(this, v); }
-
-        void read(EncodingVersion& v)
-        {
-            read(v.major);
-            read(v.minor);
-        }
 
         /**
          * Reads an optional data value from the stream. For all types except proxies.

--- a/cpp/include/Ice/LocalException.h
+++ b/cpp/include/Ice/LocalException.h
@@ -5,10 +5,11 @@
 #ifndef ICE_LOCAL_EXCEPTION_H
 #define ICE_LOCAL_EXCEPTION_H
 
+#include "EncodingVersion.h"
 #include "Exception.h"
 #include "Ice/BuiltinSequences.h"
 #include "Ice/Identity.h"
-#include "Protocol.h"
+#include "Ice/Version.h"
 
 #include <string>
 #include <string_view>

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -11,6 +11,8 @@
 #include "Exception.h"
 #include "Proxy.h"
 
+#include <sstream>
+
 namespace Ice
 {
     /**

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -16,6 +16,7 @@
 #include "MetricsFunctional.h"
 
 #include <cassert>
+#include <sstream>
 #include <stdexcept>
 
 namespace IceMX

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -16,6 +16,7 @@
 #include "ObserverHelper.h"
 #include "LocalException.h"
 #include "Proxy.h"
+#include "Protocol.h"
 
 #include <cassert>
 #include <exception>

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -10,7 +10,7 @@
 #include "ValueF.h"
 #include "ProxyF.h"
 #include "Buffer.h"
-#include "Ice/EncodingVersion.h"
+#include "EncodingVersion.h"
 #include "SlicedDataF.h"
 #include "StreamableTraits.h"
 #include "Ice/Format.h"

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -357,12 +357,6 @@ namespace Ice
          */
         template<typename T> void write(const T& v) { StreamHelper<T, StreamableTraits<T>::helper>::write(this, v); }
 
-        void write(const EncodingVersion& v)
-        {
-            write(v.major);
-            write(v.minor);
-        }
-
         /**
          * Writes an optional data value to the stream. For all types except proxies.
          * @param tag The tag ID.

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -10,9 +10,9 @@
 #include "ValueF.h"
 #include "ProxyF.h"
 #include "Buffer.h"
-#include "Protocol.h"
+#include "Ice/EncodingVersion.h"
 #include "SlicedDataF.h"
-#include "StreamHelpers.h"
+#include "StreamableTraits.h"
 #include "Ice/Format.h"
 
 #include <cassert>
@@ -25,8 +25,6 @@
 
 namespace Ice
 {
-    class UserException;
-
     /**
      * Interface for output streams used to create a sequence of bytes from Slice types.
      * \headerfile Ice/Ice.h
@@ -207,61 +205,18 @@ namespace Ice
          * @param encoding The encoding version to use for the encapsulation.
          * @param format The class format to use for the encapsulation.
          */
-        void startEncapsulation(const EncodingVersion& encoding, FormatType format)
-        {
-            IceInternal::checkSupportedEncoding(encoding);
-
-            Encaps* oldEncaps = _currentEncaps;
-            if (!oldEncaps) // First allocated encaps?
-            {
-                _currentEncaps = &_preAllocatedEncaps;
-            }
-            else
-            {
-                _currentEncaps = new Encaps();
-                _currentEncaps->previous = oldEncaps;
-            }
-            _currentEncaps->format = format;
-            _currentEncaps->encoding = encoding;
-            _currentEncaps->start = b.size();
-
-            write(std::int32_t(0)); // Placeholder for the encapsulation length.
-            write(_currentEncaps->encoding);
-        }
+        void startEncapsulation(const EncodingVersion& encoding, FormatType format);
 
         /**
          * Ends the current encapsulation.
          */
-        void endEncapsulation()
-        {
-            assert(_currentEncaps);
-
-            // Size includes size and version.
-            const std::int32_t sz = static_cast<std::int32_t>(b.size() - _currentEncaps->start);
-            write(sz, &(*(b.begin() + _currentEncaps->start)));
-
-            Encaps* oldEncaps = _currentEncaps;
-            _currentEncaps = _currentEncaps->previous;
-            if (oldEncaps == &_preAllocatedEncaps)
-            {
-                oldEncaps->reset();
-            }
-            else
-            {
-                delete oldEncaps;
-            }
-        }
+        void endEncapsulation();
 
         /**
          * Writes an empty encapsulation using the given encoding version.
          * @param encoding The encoding version to use for the encapsulation.
          */
-        void writeEmptyEncapsulation(const EncodingVersion& encoding)
-        {
-            IceInternal::checkSupportedEncoding(encoding);
-            write(std::int32_t(6)); // Size
-            write(encoding);
-        }
+        void writeEmptyEncapsulation(const EncodingVersion& encoding);
 
         /**
          * Copies the marshaled form of an encapsulation to the buffer.
@@ -401,6 +356,12 @@ namespace Ice
          * @param v The data value to be written.
          */
         template<typename T> void write(const T& v) { StreamHelper<T, StreamableTraits<T>::helper>::write(this, v); }
+
+        void write(const EncodingVersion& v)
+        {
+            write(v.major);
+            write(v.minor);
+        }
 
         /**
          * Writes an optional data value to the stream. For all types except proxies.

--- a/cpp/include/Ice/Protocol.h
+++ b/cpp/include/Ice/Protocol.h
@@ -6,6 +6,7 @@
 #define ICE_PROTOCOL_H
 
 #include "Config.h"
+#include "EncodingVersion.h"
 #include "Ice/Version.h"
 
 #include <sstream>

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -5,13 +5,10 @@
 #ifndef ICE_STREAM_HELPERS_H
 #define ICE_STREAM_HELPERS_H
 
-#include "ValueF.h"
-#include "ProxyF.h"
-#include "UserException.h"
+#include "InputStream.h"
+#include "OutputStream.h"
 
 #include <iterator>
-#include <optional>
-#include <string_view>
 
 #if __has_include(<span>)
 #    include <span>
@@ -21,339 +18,7 @@ namespace Ice
 {
     /// \cond STREAM
 
-    /**
-     * The stream helper category allows streams to select the desired StreamHelper for a given streamable object.
-     */
-    typedef int StreamHelperCategory;
-
-    /** For types with no specialized trait. */
-    const StreamHelperCategory StreamHelperCategoryUnknown = 0;
-    /** For built-in types usually passed by value. */
-    const StreamHelperCategory StreamHelperCategoryBuiltinValue = 1;
-    /** For built-in types usually passed by reference. */
-    const StreamHelperCategory StreamHelperCategoryBuiltin = 2;
-    /** For struct types. */
-    const StreamHelperCategory StreamHelperCategoryStruct = 3;
-    /** For enum types. */
-    const StreamHelperCategory StreamHelperCategoryEnum = 4;
-    /** For sequence types. */
-    const StreamHelperCategory StreamHelperCategorySequence = 5;
-    /** For dictionary types. */
-    const StreamHelperCategory StreamHelperCategoryDictionary = 6;
-    /** For proxy types. */
-    const StreamHelperCategory StreamHelperCategoryProxy = 7;
-    /** For class types. */
-    const StreamHelperCategory StreamHelperCategoryClass = 8;
-    /** For exception types. */
-    const StreamHelperCategory StreamHelperCategoryUserException = 9;
-
-    /**
-     * The optional format.
-     *
-     * Optional data members and parameters are encoded with a specific
-     * optional format. This optional format describes how the data is encoded
-     * and how it can be skipped by the unmarshaling code if the optional ID
-     * isn't known to the receiver.
-     */
-    enum class OptionalFormat : unsigned char
-    {
-        /** Fixed 1-byte encoding. */
-        F1 = 0,
-        /** Fixed 2-byte encoding. */
-        F2 = 1,
-        /** Fixed 4-byte encoding. */
-        F4 = 2,
-        /** Fixed 8-byte encoding. */
-        F8 = 3,
-        /** "Size encoding" using 1 to 5 bytes, e.g., enum, class identifier. */
-        Size = 4,
-        /**
-         * "Size encoding" using 1 to 5 bytes followed by data, e.g., string, fixed size
-         * struct, or containers whose size can be computed prior to marshaling.
-         */
-        VSize = 5,
-        /** Fixed size using 4 bytes followed by data, e.g., variable-size struct, container. */
-        FSize = 6,
-        /** Class instance. */
-        Class = 7
-    };
-
-    /**
-     * Determines whether the provided type is a container. For now, the implementation only checks
-     * if there is a T::iterator typedef using SFINAE.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T> struct IsContainer
-    {
-        template<typename C> static char test(typename C::iterator*);
-
-        template<typename C> static long test(...);
-
-        static const bool value = sizeof(test<T>(0)) == sizeof(char);
-    };
-
-    /**
-     * Determines whether the provided type is a map. For now, the implementation only checks if there
-     * is a T::mapped_type typedef using SFINAE.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T> struct IsMap
-    {
-        template<typename C> static char test(typename C::mapped_type*);
-
-        template<typename C> static long test(...);
-
-        static const bool value = IsContainer<T>::value && sizeof(test<T>(0)) == sizeof(char);
-    };
-
-    /**
-     * Base traits template. Types with no specialized trait use this trait.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T, typename Enabler = void> struct StreamableTraits
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryUnknown;
-
-        //
-        // When extracting a sequence<T> from a stream, we can ensure the
-        // stream has at least StreamableTraits<T>::minWireSize * size bytes
-        // For containers, the minWireSize is 1 (just 1 byte for an empty container).
-        //
-        // static const int minWireSize = 1;
-
-        //
-        // Is this type encoded on a fixed number of bytes?
-        // Used only for marshaling/unmarshaling optional data members and parameters.
-        //
-        // static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for sequence and dictionary types.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T>
-    struct StreamableTraits<T, typename ::std::enable_if<IsMap<T>::value || IsContainer<T>::value>::type>
-    {
-        static const StreamHelperCategory helper =
-            IsMap<T>::value ? StreamHelperCategoryDictionary : StreamHelperCategorySequence;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for exceptions.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T>
-    struct StreamableTraits<T, typename ::std::enable_if<::std::is_base_of<::Ice::UserException, T>::value>::type>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryUserException;
-
-        //
-        // There is no sequence/dictionary of UserException (so no need for minWireSize)
-        // and no optional UserException (so no need for fixedLength)
-        //
-    };
-
-    /**
-     * Specialization for arrays (std::pair<const T*, const T*>).
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T> struct StreamableTraits<std::pair<T*, T*>>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategorySequence;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<bool>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 1;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::byte>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 1;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::uint8_t>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 1;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::int16_t>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 2;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::int32_t>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 4;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::int64_t>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 8;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<float>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 4;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<double>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 8;
-        static const bool fixedLength = true;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::string>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::string_view>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::wstring>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for built-in type (this is needed for sequence
-     * marshaling to figure out the minWireSize of each type).
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::wstring_view>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * vector<bool> is a special type in C++: the streams handle it like a built-in type.
-     * \headerfile Ice/Ice.h
-     */
-    template<> struct StreamableTraits<std::vector<bool>>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for proxy types.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T>
-    struct StreamableTraits<std::optional<T>, typename std::enable_if<std::is_base_of<ObjectPrx, T>::value>::type>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryProxy;
-        static const int minWireSize = 2;
-        static const bool fixedLength = false;
-    };
-
-    /**
-     * Specialization for class types.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T>
-    struct StreamableTraits<
-        ::std::shared_ptr<T>,
-        typename ::std::enable_if<::std::is_base_of<::Ice::Value, T>::value>::type>
-    {
-        static const StreamHelperCategory helper = StreamHelperCategoryClass;
-        static const int minWireSize = 1;
-        static const bool fixedLength = false;
-    };
-
-    //
     // StreamHelper templates used by streams to read and write data.
-    //
-
-    /** Base StreamHelper template; it must be specialized for each type. */
-    template<typename T, StreamHelperCategory st> struct StreamHelper;
 
     /**
      * Helper for smaller built-in type that are typically passed by value.
@@ -361,9 +26,9 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryBuiltinValue>
     {
-        template<class S> static inline void write(S* stream, T v) { stream->write(v); }
+        static void write(OutputStream* stream, T v) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     /**
@@ -372,7 +37,7 @@ namespace Ice
      */
     template<> struct StreamHelper<std::string_view, StreamHelperCategoryBuiltinValue>
     {
-        template<class S> static inline void write(S* stream, std::string_view v) { stream->write(v); }
+        static void write(OutputStream* stream, std::string_view v) { stream->write(v); }
 
         // No read: we marshal string views but unmarshal strings.
     };
@@ -383,7 +48,7 @@ namespace Ice
      */
     template<> struct StreamHelper<std::wstring_view, StreamHelperCategoryBuiltinValue>
     {
-        template<class S> static inline void write(S* stream, std::wstring_view v) { stream->write(v); }
+        static void write(OutputStream* stream, std::wstring_view v) { stream->write(v); }
 
         // No read: we marshal wstring views but unmarshal wstrings.
     };
@@ -394,9 +59,9 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryBuiltin>
     {
-        template<class S> static inline void write(S* stream, const T& v) { stream->write(v); }
+        static void write(OutputStream* stream, const T& v) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     //
@@ -405,24 +70,24 @@ namespace Ice
     //
 
     /**
-     * General writer. slice2cpp generates specializations as needed.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T, typename S> struct StreamWriter
-    {
-        static inline void write(S* stream, const T& v) { stream->writeAll(v.ice_tuple()); }
-    };
-
-    /**
      * General reader. slice2cpp generates specializations as needed.
      * \headerfile Ice/Ice.h
      */
-    template<typename T, typename S> struct StreamReader
+    template<typename T> struct StreamReader
     {
-        static inline void read(S*, T&)
+        static void read(InputStream*, T&)
         {
             // Default is to read nothing
         }
+    };
+
+    /**
+     * General writer. slice2cpp generates specializations as needed.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T> struct StreamWriter
+    {
+        static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple()); }
     };
 
     /**
@@ -431,9 +96,9 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryStruct>
     {
-        template<class S> static inline void write(S* stream, const T& v) { StreamWriter<T, S>::write(stream, v); }
+        static void write(OutputStream* stream, const T& v) { StreamWriter<T>::write(stream, v); }
 
-        template<class S> static inline void read(S* stream, T& v) { StreamReader<T, S>::read(stream, v); }
+        static void read(InputStream* stream, T& v) { StreamReader<T>::read(stream, v); }
     };
 
     /**
@@ -442,7 +107,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryEnum>
     {
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             if (static_cast<std::int32_t>(v) < StreamableTraits<T>::minValue ||
                 static_cast<std::int32_t>(v) > StreamableTraits<T>::maxValue)
@@ -452,7 +117,7 @@ namespace Ice
             stream->writeEnum(static_cast<std::int32_t>(v), StreamableTraits<T>::maxValue);
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             std::int32_t value = stream->readEnum(StreamableTraits<T>::maxValue);
             if (value < StreamableTraits<T>::minValue || value > StreamableTraits<T>::maxValue)
@@ -469,7 +134,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategorySequence>
     {
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             stream->writeSize(static_cast<std::int32_t>(v.size()));
             for (typename T::const_iterator p = v.begin(); p != v.end(); ++p)
@@ -478,7 +143,7 @@ namespace Ice
             }
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             std::int32_t sz = stream->readAndCheckSeqSize(StreamableTraits<typename T::value_type>::minWireSize);
             T(static_cast<size_t>(sz)).swap(v);
@@ -495,12 +160,12 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<std::pair<const T*, const T*>, StreamHelperCategorySequence>
     {
-        template<class S> static inline void write(S* stream, std::pair<const T*, const T*> v)
+        static void write(OutputStream* stream, std::pair<const T*, const T*> v)
         {
             stream->write(v.first, v.second);
         }
 
-        template<class S> static inline void read(S* stream, std::pair<const T*, const T*>& v) { stream->read(v); }
+        static void read(InputStream* stream, std::pair<const T*, const T*>& v) { stream->read(v); }
     };
 
 #ifdef __cpp_lib_span
@@ -510,7 +175,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<std::span<T>, StreamHelperCategorySequence>
     {
-        template<class S> inline static void write(S* stream, const std::span<T>& v)
+        static void write(OutputStream* stream, const std::span<T>& v)
         {
             stream->write(v.data(), v.data() + v.size());
         }
@@ -525,7 +190,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryDictionary>
     {
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             stream->writeSize(static_cast<std::int32_t>(v.size()));
             for (typename T::const_iterator p = v.begin(); p != v.end(); ++p)
@@ -535,7 +200,7 @@ namespace Ice
             }
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             std::int32_t sz = stream->readSize();
             v.clear();
@@ -555,7 +220,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryUserException>
     {
-        template<class S> static inline void write(S* stream, const T& v) { stream->writeException(v); }
+        static void write(OutputStream* stream, const T& v) { stream->writeException(v); }
 
         // no read: only used for marshaling
     };
@@ -566,9 +231,9 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryProxy>
     {
-        template<class S> static inline void write(S* stream, const T& v) { stream->write(v); }
+        static void write(OutputStream* stream, const T& v) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     /**
@@ -577,9 +242,9 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryClass>
     {
-        template<class S> static inline void write(S* stream, const T& v) { stream->write(v); }
+        static void write(OutputStream* stream, const T& v) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     //
@@ -685,9 +350,9 @@ namespace Ice
         //
         static const OptionalFormat optionalFormat = GetOptionalFormat<st, Traits::minWireSize, fixedLength>::value;
 
-        template<class S> static inline void write(S* stream, const T& v) { stream->write(v); }
+        static void write(OutputStream* stream, const T& v) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     /**
@@ -698,13 +363,13 @@ namespace Ice
     {
         static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             stream->writeSize(StreamableTraits<T>::minWireSize);
             stream->write(v);
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             stream->skipSize();
             stream->read(v);
@@ -719,14 +384,14 @@ namespace Ice
     {
         static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
-            typename S::size_type pos = stream->startSize();
+            OutputStream::size_type pos = stream->startSize();
             stream->write(v);
             stream->endSize(pos);
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             stream->skip(4);
             stream->read(v);
@@ -753,12 +418,12 @@ namespace Ice
     {
         static const OptionalFormat optionalFormat = OptionalFormat::FSize;
 
-        template<class S> static inline void write(S* stream, const T& v, std::int32_t)
+        static void write(OutputStream* stream, const T& v, std::int32_t)
         {
             StreamOptionalHelper<T, StreamHelperCategoryStruct, false>::write(stream, v);
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             StreamOptionalHelper<T, StreamHelperCategoryStruct, false>::read(stream, v);
         }
@@ -774,7 +439,7 @@ namespace Ice
     {
         static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
-        template<class S> static inline void write(S* stream, const T& v, std::int32_t n)
+        static void write(OutputStream* stream, const T& v, std::int32_t n)
         {
             //
             // The container size is the number of elements * the size of
@@ -785,7 +450,7 @@ namespace Ice
             stream->write(v);
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             stream->skipSize();
             stream->read(v);
@@ -803,9 +468,9 @@ namespace Ice
     {
         static const OptionalFormat optionalFormat = OptionalFormat::VSize;
 
-        template<class S> static inline void write(S* stream, const T& v, std::int32_t) { stream->write(v); }
+        static void write(OutputStream* stream, const T& v, std::int32_t) { stream->write(v); }
 
-        template<class S> static inline void read(S* stream, T& v) { stream->read(v); }
+        static void read(InputStream* stream, T& v) { stream->read(v); }
     };
 
     /**
@@ -824,12 +489,12 @@ namespace Ice
         static const OptionalFormat optionalFormat =
             StreamOptionalContainerHelper<T, fixedLength, size>::optionalFormat;
 
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             StreamOptionalContainerHelper<T, fixedLength, size>::write(stream, v, static_cast<std::int32_t>(v.size()));
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             StreamOptionalContainerHelper<T, fixedLength, size>::read(stream, v);
         }
@@ -851,13 +516,13 @@ namespace Ice
         static const OptionalFormat optionalFormat =
             StreamOptionalContainerHelper<P, fixedLength, size>::optionalFormat;
 
-        template<class S> static inline void write(S* stream, const P& v)
+        static void write(OutputStream* stream, const P& v)
         {
             std::int32_t n = static_cast<std::int32_t>(v.second - v.first);
             StreamOptionalContainerHelper<P, fixedLength, size>::write(stream, v, n);
         }
 
-        template<class S> static inline void read(S* stream, P& v)
+        static void read(InputStream* stream, P& v)
         {
             StreamOptionalContainerHelper<P, fixedLength, size>::read(stream, v);
         }
@@ -881,12 +546,12 @@ namespace Ice
         static const OptionalFormat optionalFormat =
             StreamOptionalContainerHelper<T, fixedLength, size>::optionalFormat;
 
-        template<class S> static inline void write(S* stream, const T& v)
+        static void write(OutputStream* stream, const T& v)
         {
             StreamOptionalContainerHelper<T, fixedLength, size>::write(stream, v, static_cast<std::int32_t>(v.size()));
         }
 
-        template<class S> static inline void read(S* stream, T& v)
+        static void read(InputStream* stream, T& v)
         {
             StreamOptionalContainerHelper<T, fixedLength, size>::read(stream, v);
         }

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -160,10 +160,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<std::pair<const T*, const T*>, StreamHelperCategorySequence>
     {
-        static void write(OutputStream* stream, std::pair<const T*, const T*> v)
-        {
-            stream->write(v.first, v.second);
-        }
+        static void write(OutputStream* stream, std::pair<const T*, const T*> v) { stream->write(v.first, v.second); }
 
         static void read(InputStream* stream, std::pair<const T*, const T*>& v) { stream->read(v); }
     };
@@ -175,10 +172,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<std::span<T>, StreamHelperCategorySequence>
     {
-        static void write(OutputStream* stream, const std::span<T>& v)
-        {
-            stream->write(v.data(), v.data() + v.size());
-        }
+        static void write(OutputStream* stream, const std::span<T>& v) { stream->write(v.data(), v.data() + v.size()); }
 
         // No read. span are only for view types.
     };

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -557,6 +557,20 @@ namespace Ice
         }
     };
 
+    // Specializations for EncodingVersion
+
+    template<> struct StreamableTraits<EncodingVersion>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryStruct;
+        static const int minWireSize = 2;
+        static const bool fixedLength = true;
+    };
+
+    template<> struct StreamReader<EncodingVersion>
+    {
+        static void read(InputStream* istr, EncodingVersion& v) { istr->readAll(v.major, v.minor); }
+    };
+
     /// \endcond
 }
 

--- a/cpp/include/Ice/StreamableTraits.h
+++ b/cpp/include/Ice/StreamableTraits.h
@@ -1,0 +1,354 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#ifndef ICE_STREAMABLE_TRAITS_H
+#define ICE_STREAMABLE_TRAITS_H
+
+#include "ValueF.h"
+#include "ProxyF.h"
+#include "UserException.h"
+
+#include <optional>
+#include <string_view>
+
+namespace Ice
+{
+    class InputStream;
+    class OutputStream;
+
+    /// \cond STREAM
+
+    /**
+     * The stream helper category allows streams to select the desired StreamHelper for a given streamable object.
+     */
+    using StreamHelperCategory = int;
+
+    /** For types with no specialized trait. */
+    const StreamHelperCategory StreamHelperCategoryUnknown = 0;
+    /** For built-in types usually passed by value. */
+    const StreamHelperCategory StreamHelperCategoryBuiltinValue = 1;
+    /** For built-in types usually passed by reference. */
+    const StreamHelperCategory StreamHelperCategoryBuiltin = 2;
+    /** For struct types. */
+    const StreamHelperCategory StreamHelperCategoryStruct = 3;
+    /** For enum types. */
+    const StreamHelperCategory StreamHelperCategoryEnum = 4;
+    /** For sequence types. */
+    const StreamHelperCategory StreamHelperCategorySequence = 5;
+    /** For dictionary types. */
+    const StreamHelperCategory StreamHelperCategoryDictionary = 6;
+    /** For proxy types. */
+    const StreamHelperCategory StreamHelperCategoryProxy = 7;
+    /** For class types. */
+    const StreamHelperCategory StreamHelperCategoryClass = 8;
+    /** For exception types. */
+    const StreamHelperCategory StreamHelperCategoryUserException = 9;
+
+    /**
+     * The optional format.
+     *
+     * Optional data members and parameters are encoded with a specific
+     * optional format. This optional format describes how the data is encoded
+     * and how it can be skipped by the unmarshaling code if the optional ID
+     * isn't known to the receiver.
+     */
+    enum class OptionalFormat : std::uint8_t
+    {
+        /** Fixed 1-byte encoding. */
+        F1 = 0,
+        /** Fixed 2-byte encoding. */
+        F2 = 1,
+        /** Fixed 4-byte encoding. */
+        F4 = 2,
+        /** Fixed 8-byte encoding. */
+        F8 = 3,
+        /** "Size encoding" using 1 to 5 bytes, e.g., enum, class identifier. */
+        Size = 4,
+        /**
+         * "Size encoding" using 1 to 5 bytes followed by data, e.g., string, fixed size
+         * struct, or containers whose size can be computed prior to marshaling.
+         */
+        VSize = 5,
+        /** Fixed size using 4 bytes followed by data, e.g., variable-size struct, container. */
+        FSize = 6,
+        /** Class instance. */
+        Class = 7
+    };
+
+    /**
+     * Determines whether the provided type is a container. For now, the implementation only checks
+     * if there is a T::iterator typedef using SFINAE.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T> struct IsContainer
+    {
+        template<typename C> static char test(typename C::iterator*);
+
+        template<typename C> static long test(...);
+
+        static const bool value = sizeof(test<T>(0)) == sizeof(char);
+    };
+
+    /**
+     * Determines whether the provided type is a map. For now, the implementation only checks if there
+     * is a T::mapped_type typedef using SFINAE.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T> struct IsMap
+    {
+        template<typename C> static char test(typename C::mapped_type*);
+
+        template<typename C> static long test(...);
+
+        static const bool value = IsContainer<T>::value && sizeof(test<T>(0)) == sizeof(char);
+    };
+
+    /**
+     * Base traits template. Types with no specialized trait use this trait.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T, typename Enabler = void> struct StreamableTraits
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryUnknown;
+
+        //
+        // When extracting a sequence<T> from a stream, we can ensure the
+        // stream has at least StreamableTraits<T>::minWireSize * size bytes
+        // For containers, the minWireSize is 1 (just 1 byte for an empty container).
+        //
+        // static const int minWireSize = 1;
+
+        //
+        // Is this type encoded on a fixed number of bytes?
+        // Used only for marshaling/unmarshaling optional data members and parameters.
+        //
+        // static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for sequence and dictionary types.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T>
+    struct StreamableTraits<T, typename ::std::enable_if<IsMap<T>::value || IsContainer<T>::value>::type>
+    {
+        static const StreamHelperCategory helper =
+            IsMap<T>::value ? StreamHelperCategoryDictionary : StreamHelperCategorySequence;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for exceptions.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T>
+    struct StreamableTraits<T, typename ::std::enable_if<::std::is_base_of<::Ice::UserException, T>::value>::type>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryUserException;
+
+        //
+        // There is no sequence/dictionary of UserException (so no need for minWireSize)
+        // and no optional UserException (so no need for fixedLength)
+        //
+    };
+
+    /**
+     * Specialization for arrays (std::pair<const T*, const T*>).
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T> struct StreamableTraits<std::pair<T*, T*>>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategorySequence;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<bool>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 1;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::byte>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 1;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::uint8_t>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 1;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::int16_t>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 2;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::int32_t>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 4;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::int64_t>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 8;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<float>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 4;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<double>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 8;
+        static const bool fixedLength = true;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::string>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::string_view>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::wstring>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for built-in type (this is needed for sequence
+     * marshaling to figure out the minWireSize of each type).
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::wstring_view>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * vector<bool> is a special type in C++: the streams handle it like a built-in type.
+     * \headerfile Ice/Ice.h
+     */
+    template<> struct StreamableTraits<std::vector<bool>>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for proxy types.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T>
+    struct StreamableTraits<std::optional<T>, typename std::enable_if<std::is_base_of<ObjectPrx, T>::value>::type>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryProxy;
+        static const int minWireSize = 2;
+        static const bool fixedLength = false;
+    };
+
+    /**
+     * Specialization for class types.
+     * \headerfile Ice/Ice.h
+     */
+    template<typename T>
+    struct StreamableTraits<
+        ::std::shared_ptr<T>,
+        typename ::std::enable_if<::std::is_base_of<::Ice::Value, T>::value>::type>
+    {
+        static const StreamHelperCategory helper = StreamHelperCategoryClass;
+        static const int minWireSize = 1;
+        static const bool fixedLength = false;
+    };
+
+    template<typename T, StreamHelperCategory st> struct StreamHelper;
+    template<typename T, StreamHelperCategory st, bool fixedLength> struct StreamOptionalHelper;
+    /// \endcond
+}
+
+#endif

--- a/cpp/include/Ice/StreamableTraits.h
+++ b/cpp/include/Ice/StreamableTraits.h
@@ -14,9 +14,6 @@
 
 namespace Ice
 {
-    class InputStream;
-    class OutputStream;
-
     /// \cond STREAM
 
     /**

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -5,6 +5,8 @@
 #include <Ice/EndpointI.h>
 #include <Ice/OutputStream.h>
 
+#include <sstream>
+
 using namespace std;
 
 void

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -6,6 +6,8 @@
 #include "Ice/LocalException.h"
 #include "Ice/SlicedData.h"
 
+#include <sstream>
+
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;

--- a/cpp/src/Ice/ImplicitContext.cpp
+++ b/cpp/src/Ice/ImplicitContext.cpp
@@ -2,7 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <Ice/ImplicitContext.h>
+#include "Ice/ImplicitContext.h"
+#include "Ice/StreamHelpers.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -20,6 +20,7 @@
 #include <Ice/StringConverter.h>
 
 #include "Ice/FactoryTable.h"
+#include "Ice/Protocol.h"
 #include "ReferenceFactory.h"
 #include "Endian.h"
 #include <iterator>
@@ -275,6 +276,120 @@ Ice::InputStream::resetEncapsulation()
     }
 
     _preAllocatedEncaps.reset();
+}
+
+const EncodingVersion&
+Ice::InputStream::startEncapsulation()
+{
+    Encaps* oldEncaps = _currentEncaps;
+    if (!oldEncaps) // First allocated encaps?
+    {
+        _currentEncaps = &_preAllocatedEncaps;
+    }
+    else
+    {
+        _currentEncaps = new Encaps();
+        _currentEncaps->previous = oldEncaps;
+    }
+    _currentEncaps->start = static_cast<size_t>(i - b.begin());
+
+    //
+    // I don't use readSize() and writeSize() for encapsulations,
+    // because when creating an encapsulation, I must know in advance
+    // how many bytes the size information will require in the data
+    // stream. If I use an Int, it is always 4 bytes. For
+    // readSize()/writeSize(), it could be 1 or 5 bytes.
+    //
+    std::int32_t sz;
+    read(sz);
+    if (sz < 6)
+    {
+        throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
+    }
+    if (i - sizeof(std::int32_t) + sz > b.end())
+    {
+        throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
+    }
+    _currentEncaps->sz = sz;
+
+    read(_currentEncaps->encoding);
+    IceInternal::checkSupportedEncoding(_currentEncaps->encoding); // Make sure the encoding is supported
+
+    return _currentEncaps->encoding;
+}
+
+void
+Ice::InputStream::endEncapsulation()
+{
+    assert(_currentEncaps);
+
+    if (_currentEncaps->encoding != Encoding_1_0)
+    {
+        skipOptionals();
+        if (i != b.begin() + _currentEncaps->start + _currentEncaps->sz)
+        {
+            throwEncapsulationException(__FILE__, __LINE__);
+        }
+    }
+    else if (i != b.begin() + _currentEncaps->start + _currentEncaps->sz)
+    {
+        if (i + 1 != b.begin() + _currentEncaps->start + _currentEncaps->sz)
+        {
+            throwEncapsulationException(__FILE__, __LINE__);
+        }
+
+        //
+        // Ice version < 3.3 had a bug where user exceptions with
+        // class members could be encoded with a trailing byte
+        // when dispatched with AMD. So we tolerate an extra byte
+        // in the encapsulation.
+        //
+        ++i;
+    }
+
+    Encaps* oldEncaps = _currentEncaps;
+    _currentEncaps = _currentEncaps->previous;
+    if (oldEncaps == &_preAllocatedEncaps)
+    {
+        oldEncaps->reset();
+    }
+    else
+    {
+        delete oldEncaps;
+    }
+}
+
+EncodingVersion
+Ice::InputStream::skipEmptyEncapsulation()
+{
+    std::int32_t sz;
+    read(sz);
+    if (sz < 6)
+    {
+        throwEncapsulationException(__FILE__, __LINE__);
+    }
+    if (i - sizeof(std::int32_t) + sz > b.end())
+    {
+        throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
+    }
+    Ice::EncodingVersion encoding;
+    read(encoding);
+    IceInternal::checkSupportedEncoding(encoding); // Make sure the encoding is supported
+
+    if (encoding == Ice::Encoding_1_0)
+    {
+        if (sz != static_cast<std::int32_t>(sizeof(std::int32_t)) + 2)
+        {
+            throwEncapsulationException(__FILE__, __LINE__);
+        }
+    }
+    else
+    {
+        // Skip the optional content of the encapsulation if we are expecting an
+        // empty encapsulation.
+        i += static_cast<size_t>(sz) - sizeof(std::int32_t) - 2;
+    }
+    return encoding;
 }
 
 int32_t

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -392,6 +392,26 @@ Ice::InputStream::skipEmptyEncapsulation()
     return encoding;
 }
 
+EncodingVersion
+Ice::InputStream::readEncapsulation(const std::byte*& v, std::int32_t& sz)
+{
+    EncodingVersion encoding;
+    v = i;
+    read(sz);
+    if (sz < 6)
+    {
+        throwEncapsulationException(__FILE__, __LINE__);
+    }
+    if (i - sizeof(std::int32_t) + sz > b.end())
+    {
+        throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
+    }
+
+    read(encoding);
+    i += static_cast<size_t>(sz) - sizeof(std::int32_t) - 2;
+    return encoding;
+}
+
 int32_t
 Ice::InputStream::getEncapsulationSize()
 {

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -30,6 +30,8 @@
 #include <Ice/ImplicitContext.h>
 #include <Ice/FacetMap.h>
 #include <Ice/Process.h>
+#include "Ice/Protocol.h"
+
 #include <list>
 
 namespace Ice

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -11,6 +11,8 @@
 #include <Ice/Communicator.h>
 #include <Ice/LoggerUtil.h>
 
+#include "Ice/Protocol.h"
+
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;

--- a/cpp/src/Ice/InstrumentationI.h
+++ b/cpp/src/Ice/InstrumentationI.h
@@ -8,6 +8,8 @@
 #include <Ice/MetricsObserverI.h>
 #include <Ice/Connection.h>
 
+#include <sstream>
+
 namespace IceInternal
 {
     template<typename T, typename O> class ObserverWithDelegateT : public IceMX::ObserverT<T>, public virtual O

--- a/cpp/src/Ice/MarshaledResult.cpp
+++ b/cpp/src/Ice/MarshaledResult.cpp
@@ -5,6 +5,7 @@
 #include "Ice/MarshaledResult.h"
 #include "Ice/ObjectAdapter.h"
 #include "Ice/ReplyStatus.h"
+#include "Ice/Protocol.h"
 
 using namespace Ice;
 using namespace IceInternal;

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -10,6 +10,7 @@
 #include "Ice/OutputStream.h"
 
 #include <algorithm>
+#include <sstream>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -4,6 +4,7 @@
 
 #include "Ice/ObjectAdapter.h"
 #include "Ice/OutgoingResponse.h"
+#include "Ice/Protocol.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -4,9 +4,7 @@
 
 #include <IceUtil/StringUtil.h>
 #include <IceUtil/Random.h>
-#include <Ice/LoggerUtil.h>
-#include <Ice/Communicator.h>
-#include <Ice/ObjectAdapter.h>
+#include <Ice/Ice.h>
 #include <IceGrid/Database.h>
 #include <IceGrid/TraceLevels.h>
 #include <IceGrid/Util.h>

--- a/cpp/src/IceSSL/SecureTransportCertificateI.cpp
+++ b/cpp/src/IceSSL/SecureTransportCertificateI.cpp
@@ -21,6 +21,7 @@
 #include <Security/Security.h>
 
 #include <mutex>
+#include <sstream>
 #include <stdexcept>
 
 using namespace Ice;

--- a/cpp/src/IceSSL/SecureTransportUtil.cpp
+++ b/cpp/src/IceSSL/SecureTransportUtil.cpp
@@ -13,6 +13,7 @@
 #include <IceUtil/StringUtil.h>
 
 #include <fstream>
+#include <sstream>
 
 #include <Security/Security.h>
 #include <CoreFoundation/CoreFoundation.h>

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -47,13 +47,16 @@ namespace
     };
 }
 
+/*
+TODO: how do we deal with this?
+
 //
 // This custom version of the StreamReader allows us to customize the
 // reading of ReplicaGroupDescriptor
 //
 namespace Ice
 {
-    template<> struct StreamReader<IceGrid::ReplicaGroupDescriptor, Ice::InputStream>
+    template<> struct StreamReader<IceGrid::ReplicaGroupDescriptor>
     {
         static void read(Ice::InputStream* is, IceGrid::ReplicaGroupDescriptor& v)
         {
@@ -69,6 +72,7 @@ namespace Ice
         }
     };
 }
+*/
 
 int run(const Ice::StringSeq&);
 

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -20,8 +20,6 @@ using namespace IceInternal;
 
 namespace
 {
-    bool skipReplicaGroupFilter = false;
-
     class ServerDescriptorI : public IceGrid::ServerDescriptor
     {
     public:
@@ -46,33 +44,6 @@ namespace
         string _serverVersion;
     };
 }
-
-/*
-TODO: how do we deal with this?
-
-//
-// This custom version of the StreamReader allows us to customize the
-// reading of ReplicaGroupDescriptor
-//
-namespace Ice
-{
-    template<> struct StreamReader<IceGrid::ReplicaGroupDescriptor>
-    {
-        static void read(Ice::InputStream* is, IceGrid::ReplicaGroupDescriptor& v)
-        {
-            is->read(v.id);
-            is->read(v.loadBalancing);
-            is->read(v.proxyOptions);
-            is->read(v.objects);
-            is->read(v.description);
-            if (!skipReplicaGroupFilter)
-            {
-                is->read(v.filter);
-            }
-        }
-    };
-}
-*/
 
 int run(const Ice::StringSeq&);
 
@@ -275,13 +246,10 @@ run(const Ice::StringSeq& args)
                 return 1;
             }
             stream.read(version);
-            if (version / 100 == 305)
+            if (version / 100 <= 305)
             {
-                if (debug)
-                {
-                    consoleOut << "Reading Ice 3.5.x data" << endl;
-                }
-                skipReplicaGroupFilter = true;
+                consoleErr << args[0] << ": cannot read file created by IceGrid 3.5 or earlier." << endl;
+                return 1;
             }
             stream.read(data);
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -824,16 +824,16 @@ Slice::writeStreamHelpers(Output& out, const ContainedPtr& c, DataMemberList dat
     //
     if (!optionalMembers.empty() || hasBaseDataMembers)
     {
-        out << nl << "template<typename S>";
-        out << nl << "struct StreamWriter<" << fullName << ", S>";
+        out << nl << "template<>";
+        out << nl << "struct StreamWriter<" << fullName << ">";
         out << sb;
         if (requiredMembers.empty() && optionalMembers.empty())
         {
-            out << nl << "static void write(S*, const " << fullName << "&)";
+            out << nl << "static void write(OutputStream*, const " << fullName << "&)";
         }
         else
         {
-            out << nl << "static void write(S* ostr, const " << fullName << "& v)";
+            out << nl << "static void write(OutputStream* ostr, const " << fullName << "& v)";
         }
 
         out << sb;
@@ -848,16 +848,16 @@ Slice::writeStreamHelpers(Output& out, const ContainedPtr& c, DataMemberList dat
     //
     // Generate StreamReader
     //
-    out << nl << "template<typename S>";
-    out << nl << "struct StreamReader<" << fullName << ", S>";
+    out << nl << "template<>";
+    out << nl << "struct StreamReader<" << fullName << ">";
     out << sb;
     if (requiredMembers.empty() && optionalMembers.empty())
     {
-        out << nl << "static void read(S*, " << fullName << "&)";
+        out << nl << "static void read(InputStream*, " << fullName << "&)";
     }
     else
     {
-        out << nl << "static void read(S* istr, " << fullName << "& v)";
+        out << nl << "static void read(InputStream* istr, " << fullName << "& v)";
     }
 
     out << sb;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2281,7 +2281,7 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     C << nl << "ostr->startSlice(ice_staticId(), -1, " << (base ? "false" : "true") << ");";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamWriter<" << name << ", ::Ice::OutputStream>::write(ostr, *this);";
+        C << nl << "::Ice::StreamWriter<" << name << ">::write(ostr, *this);";
     }
     C << nl << "ostr->endSlice();";
     if (base)
@@ -2296,7 +2296,7 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     C << nl << "istr->startSlice();";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamReader<" << name << ", ::Ice::InputStream>::read(istr, *this);";
+        C << nl << "::Ice::StreamReader<" << name << ">::read(istr, *this);";
     }
     C << nl << "istr->endSlice();";
     if (base)
@@ -2468,9 +2468,9 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     if (generateFriend)
     {
         H << sp;
-        H << nl << "template<typename T, typename S>";
+        H << nl << "template<typename T>";
         H << nl << "friend struct Ice::StreamWriter;";
-        H << nl << "template<typename T, typename S>";
+        H << nl << "template<typename T>";
         H << nl << "friend struct Ice::StreamReader;";
     }
 
@@ -2491,7 +2491,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << nl << "ostr->startSlice(ice_staticId(), -1, " << (base ? "false" : "true") << ");";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamWriter<" << name << ", ::Ice::OutputStream>::write(ostr, *this);";
+        C << nl << "::Ice::StreamWriter<" << name << ">::write(ostr, *this);";
     }
     C << nl << "ostr->endSlice();";
     if (base)
@@ -2506,7 +2506,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << nl << "istr->startSlice();";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamReader<" << name << ", ::Ice::InputStream>::read(istr, *this);";
+        C << nl << "::Ice::StreamReader<" << name << ">::read(istr, *this);";
     }
     C << nl << "istr->endSlice();";
     if (base)

--- a/slice/Ice/Version.ice
+++ b/slice/Ice/Version.ice
@@ -33,11 +33,15 @@ struct ProtocolVersion
     byte minor;
 }
 
+#ifndef __SLICE2CPP__
+// Ice for C++ provides an hand-written equivalent.
+
 /// A version structure for the encoding version.
 struct EncodingVersion
 {
     byte major;
     byte minor;
 }
+#endif
 
 }


### PR DESCRIPTION
This PR split the StreamHelpers header file in two:

- StreamableTraits.h, the "base" header
- StreamHelpers.h, the "details" header

It also removes all the "template S" from StreamHelpers, where S was always instantiated with the same class (InputStream for read and OutputStream for write).