### PR TITLE
Remove Service.h from Ice/Ice.h

### DIFF
--- a/cpp/include/Ice/Ice.h
+++ b/cpp/include/Ice/Ice.h
@@ -51,7 +51,6 @@
 
 #    if !defined(__APPLE__) || TARGET_OS_IPHONE == 0
 #        include "CtrlCHandler.h"
-#        include "Service.h"
 #    endif
 #endif
 

--- a/cpp/include/Ice/Service.h
+++ b/cpp/include/Ice/Service.h
@@ -5,8 +5,7 @@
 #ifndef ICE_SERVICE_H
 #define ICE_SERVICE_H
 
-#include "Initialize.h"
-#include "LoggerUtil.h"
+#include "Ice.h"
 
 #ifdef _WIN32
 #    ifndef NOMINMAX
@@ -19,8 +18,7 @@
 namespace Ice
 {
     /**
-     * A singleton class comparable to Ice::Application but also provides the low-level, platform-specific
-     * initialization and shutdown procedures common to system services.
+     * A singleton class that helps you write Windows services and Unix daemons using Ice.
      * \headerfile Ice/Ice.h
      */
     class ICE_API Service

--- a/cpp/src/Ice/Makefile.mk
+++ b/cpp/src/Ice/Makefile.mk
@@ -23,7 +23,7 @@ Ice_cppflags                            += -DICE_USE_SYSTEMD $(shell pkg-config 
 endif
 endif
 
-Ice[iphoneos]_excludes                  := $(wildcard $(addprefix $(currentdir)/,Tcp*.cpp))
+Ice[iphoneos]_excludes                  := $(wildcard src/IceUtil/CtrlCHandler.cpp $(addprefix $(currentdir)/,Tcp*.cpp Service.cpp))
 Ice[iphoneos]_extra_sources             := $(wildcard $(addprefix $(currentdir)/ios/,*.cpp *.mm))
 Ice[iphonesimulator]_excludes           = $(Ice[iphoneos]_excludes)
 Ice[iphonesimulator]_extra_sources      = $(Ice[iphoneos]_extra_sources)

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -6,9 +6,10 @@
 #include "ArgVector.h"
 #include "ConsoleUtil.h"
 #include "LoggerI.h"
+#include "IceUtil/StringUtil.h"
 
 #ifdef _WIN32
-#    include "EventLoggerMsg.h"
+#    include "Ice/EventLoggerMsg.h"
 #    include <winsock2.h>
 #else
 #    include "Network.h"

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -2,30 +2,19 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <IceUtil/CtrlCHandler.h>
-#include <IceUtil/StringUtil.h>
-#include <Ice/ArgVector.h>
-#include <IceUtil/FileUtil.h>
-#include <Ice/ConsoleUtil.h>
-#include <Ice/StringConverter.h>
-#include <Ice/Service.h>
-#include <Ice/LoggerI.h>
-#include <Ice/Initialize.h>
-#include <Ice/Communicator.h>
-#include <Ice/LocalException.h>
-#include <Ice/Properties.h>
-#include <Ice/Instance.h>
-#include <Ice/LoggerUtil.h>
+#include "Ice/Service.h"
+#include "ArgVector.h"
+#include "ConsoleUtil.h"
+#include "LoggerI.h"
 
 #ifdef _WIN32
+#    include "EventLoggerMsg.h"
 #    include <winsock2.h>
-#    include <Ice/EventLoggerMsg.h>
 #else
-#    include <Ice/Logger.h>
-#    include <Ice/Network.h>
-#    include <sys/types.h>
-#    include <sys/stat.h>
+#    include "Network.h"
 #    include <csignal>
+#    include <sys/stat.h>
+#    include <sys/types.h>
 #    ifdef ICE_USE_SYSTEMD
 #        include <systemd/sd-daemon.h>
 #    endif
@@ -36,10 +25,10 @@ using namespace Ice;
 using namespace IceInternal;
 
 Ice::Service* Ice::Service::_instance = 0;
-static IceUtil::CtrlCHandler* _ctrlCHandler = 0;
+static CtrlCHandler* _ctrlCHandler = 0;
 
 //
-// Callback for IceUtil::CtrlCHandler.
+// Callback for CtrlCHandler.
 //
 static void
 ctrlCHandlerCallback(int sig)
@@ -745,7 +734,7 @@ Ice::Service::run(int argc, const char* const argv[], const InitializationData& 
         // communicator because we need to ensure that this is done before any
         // additional threads are created.
         //
-        _ctrlCHandler = new IceUtil::CtrlCHandler;
+        _ctrlCHandler = new CtrlCHandler;
 
         //
         // Initialize the communicator.
@@ -1182,7 +1171,7 @@ Ice::Service::showServiceStatus(const string& msg, SERVICE_STATUS& status)
 void
 Ice::Service::serviceMain(int argc, const wchar_t* const argv[])
 {
-    _ctrlCHandler = new IceUtil::CtrlCHandler;
+    _ctrlCHandler = new CtrlCHandler;
 
     //
     // Register the control handler function.
@@ -1623,7 +1612,7 @@ Ice::Service::runDaemon(int argc, char* argv[], const InitializationData& initDa
         // communicator thread pools currently use lazy initialization, but a thread can
         // be created to monitor connections.
         //
-        _ctrlCHandler = new IceUtil::CtrlCHandler;
+        _ctrlCHandler = new CtrlCHandler;
 
         //
         // Initialize the communicator.

--- a/cpp/src/IceGrid/Activator.h
+++ b/cpp/src/IceGrid/Activator.h
@@ -7,7 +7,9 @@
 
 #include <IceGrid/Internal.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#    include <windows.h>
+#else
 #    include <sys/types.h> // for uid_t, gid_t
 #endif
 

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -17,6 +17,8 @@
 #if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>
 #    include <unistd.h>
+#elif defined(_WIN32)
+#    include <windows.h>
 #endif
 
 #include <iterator>

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -12,6 +12,8 @@
 #if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>
 #    include <unistd.h>
+#elif defined(_WIN32)
+#    include <windows.h>
 #endif
 
 extern FILE* yyin;

--- a/cpp/test/Ice/logger/Client2.cpp
+++ b/cpp/test/Ice/logger/Client2.cpp
@@ -2,8 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <Ice/Ice.h>
-#include <TestHelper.h>
+#include "Ice/Ice.h"
+#include "TestHelper.h"
+
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 using namespace std;
 

--- a/cpp/test/Ice/logger/Client3.cpp
+++ b/cpp/test/Ice/logger/Client3.cpp
@@ -6,7 +6,7 @@
 #include "TestHelper.h"
 
 #ifdef _WIN32
-#include <windows.h>
+#    include <windows.h>
 #endif
 
 using namespace std;

--- a/cpp/test/Ice/logger/Client3.cpp
+++ b/cpp/test/Ice/logger/Client3.cpp
@@ -2,8 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <Ice/Ice.h>
-#include <TestHelper.h>
+#include "Ice/Ice.h"
+#include "TestHelper.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 using namespace std;
 

--- a/cpp/test/Ice/logger/Client4.cpp
+++ b/cpp/test/Ice/logger/Client4.cpp
@@ -2,8 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <Ice/Ice.h>
-#include <TestHelper.h>
+#include "Ice/Ice.h"
+#include "TestHelper.h"
+
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
This PR removes Service.h from Ice/Ice.h.

After this PR, you need to include Ice/Service.h in order to use the Ice::Service class (not a common occurrence).

The main benefit of this PR is on Windows, Ice/Ice.h no longer includes windows.h.