### PR TITLE
Resynchronize Slice Compiler

### DIFF
--- a/cpp/include/IceUtil/ScannerConfig.h
+++ b/cpp/include/IceUtil/ScannerConfig.h
@@ -20,12 +20,9 @@
 #    include <stdint.h>
 #endif
 
-//
-// VC++ using C++17 standard deprecate 'register' storage
-// class specifier used by lex generated Scanners.
-//
 #if defined(_MSC_VER)
-#    pragma warning(disable : 5033)
+// warning C4267: conversion from 'size_t' to 'int', possible loss of data
+#    pragma warning(disable : 4267)
 #endif
 
 #if defined(__clang__)

--- a/cpp/include/IceUtil/ScannerConfig.h
+++ b/cpp/include/IceUtil/ScannerConfig.h
@@ -21,20 +21,16 @@
 #endif
 
 //
-// Clang++ >= 5.1 and VC++ using C++17 standard deprecate 'register' storage
+// VC++ using C++17 standard deprecate 'register' storage
 // class specifier used by lex generated Scanners.
 //
-#if defined(__clang__)
-#    pragma clang diagnostic ignored "-Wdeprecated-register"
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 #    pragma warning(disable : 5033)
 #endif
 
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
-#    pragma clang diagnostic ignored "-Wsign-conversion"
-#    pragma clang diagnostic ignored "-Wdocumentation"
-#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#    pragma clang diagnostic ignored "-Wsign-compare"
 #endif
 
 #ifdef __GNUC__

--- a/cpp/include/IceUtil/ScannerConfig.h
+++ b/cpp/include/IceUtil/ScannerConfig.h
@@ -33,6 +33,7 @@
 #ifdef __GNUC__
 #    pragma GCC diagnostic ignored "-Wunused-function"
 #    pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#    pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 
 #endif

--- a/cpp/include/IceUtil/ScannerConfig.h
+++ b/cpp/include/IceUtil/ScannerConfig.h
@@ -28,6 +28,7 @@
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-compare"
+#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #ifdef __GNUC__

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -137,6 +137,7 @@
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-conversion"
+#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 using namespace std;
@@ -158,7 +159,7 @@ slice_error(const char* s)
     }
 }
 
-#line 167 "src/Slice/Grammar.cpp"
+#line 168 "src/Slice/Grammar.cpp"
 
 #ifndef YY_CAST
 #    ifdef __cplusplus
@@ -330,7 +331,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 // This must match the definition of 'yylex' (or 'slice_lex') in the generated scanner.
 int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 
-#line 343 "src/Slice/Grammar.cpp"
+#line 344 "src/Slice/Grammar.cpp"
 
 #ifdef short
 #    undef short
@@ -678,17 +679,17 @@ static const yytype_int8 yytranslate[] = {
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
-    0,    178,  178,  186,  189,  197,  201,  211,  215,  224,  232,  241,  250,  249,  255,  254,  259,  264,  263,
-    269,  268,  273,  278,  277,  283,  282,  287,  292,  291,  297,  296,  301,  306,  305,  311,  310,  315,  320,
-    319,  324,  329,  328,  334,  333,  338,  342,  352,  351,  384,  388,  399,  410,  409,  435,  443,  452,  465,
-    483,  562,  568,  579,  597,  675,  681,  692,  701,  710,  723,  727,  738,  749,  748,  787,  791,  802,  827,
-    917,  929,  942,  941,  975,  1009, 1018, 1021, 1029, 1038, 1041, 1045, 1053, 1083, 1117, 1139, 1165, 1171, 1177,
-    1183, 1193, 1217, 1247, 1271, 1306, 1305, 1328, 1327, 1350, 1354, 1365, 1379, 1378, 1412, 1447, 1482, 1487, 1497,
-    1501, 1510, 1519, 1522, 1526, 1534, 1541, 1553, 1565, 1576, 1584, 1598, 1608, 1624, 1628, 1640, 1639, 1671, 1670,
-    1688, 1694, 1702, 1714, 1734, 1741, 1751, 1755, 1796, 1802, 1813, 1816, 1832, 1848, 1860, 1872, 1883, 1899, 1903,
-    1912, 1915, 1923, 1924, 1925, 1926, 1927, 1928, 1929, 1930, 1931, 1932, 1937, 1941, 1946, 1977, 2013, 2019, 2027,
-    2034, 2046, 2055, 2064, 2099, 2106, 2113, 2125, 2134, 2148, 2149, 2150, 2151, 2152, 2153, 2154, 2155, 2156, 2157,
-    2158, 2159, 2160, 2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175};
+    0,    179,  179,  187,  190,  198,  202,  212,  216,  225,  233,  242,  251,  250,  256,  255,  260,  265,  264,
+    270,  269,  274,  279,  278,  284,  283,  288,  293,  292,  298,  297,  302,  307,  306,  312,  311,  316,  321,
+    320,  325,  330,  329,  335,  334,  339,  343,  353,  352,  385,  389,  400,  411,  410,  436,  444,  453,  466,
+    484,  563,  569,  580,  598,  676,  682,  693,  702,  711,  724,  728,  739,  750,  749,  788,  792,  803,  828,
+    918,  930,  943,  942,  976,  1010, 1019, 1022, 1030, 1039, 1042, 1046, 1054, 1084, 1118, 1140, 1166, 1172, 1178,
+    1184, 1194, 1218, 1248, 1272, 1307, 1306, 1329, 1328, 1351, 1355, 1366, 1380, 1379, 1413, 1448, 1483, 1488, 1498,
+    1502, 1511, 1520, 1523, 1527, 1535, 1542, 1554, 1566, 1577, 1585, 1599, 1609, 1625, 1629, 1641, 1640, 1672, 1671,
+    1689, 1695, 1703, 1715, 1735, 1742, 1752, 1756, 1797, 1803, 1814, 1817, 1833, 1849, 1861, 1873, 1884, 1900, 1904,
+    1913, 1916, 1924, 1925, 1926, 1927, 1928, 1929, 1930, 1931, 1932, 1933, 1938, 1942, 1947, 1978, 2014, 2020, 2028,
+    2035, 2047, 2056, 2065, 2100, 2107, 2114, 2126, 2135, 2149, 2150, 2151, 2152, 2153, 2154, 2155, 2156, 2157, 2158,
+    2159, 2160, 2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175, 2176};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -1577,61 +1578,61 @@ yyreduce:
     switch (yyn)
     {
         case 2: /* start: definitions  */
-#line 179 "src/Slice/Grammar.y"
+#line 180 "src/Slice/Grammar.y"
         {
         }
-#line 1734 "src/Slice/Grammar.cpp"
+#line 1735 "src/Slice/Grammar.cpp"
         break;
 
         case 3: /* opt_semicolon: ';'  */
-#line 187 "src/Slice/Grammar.y"
+#line 188 "src/Slice/Grammar.y"
         {
         }
-#line 1741 "src/Slice/Grammar.cpp"
+#line 1742 "src/Slice/Grammar.cpp"
         break;
 
         case 4: /* opt_semicolon: %empty  */
-#line 190 "src/Slice/Grammar.y"
+#line 191 "src/Slice/Grammar.y"
         {
         }
-#line 1748 "src/Slice/Grammar.cpp"
+#line 1749 "src/Slice/Grammar.cpp"
         break;
 
         case 5: /* global_meta_data: ICE_GLOBAL_METADATA_OPEN string_list ICE_GLOBAL_METADATA_CLOSE  */
-#line 198 "src/Slice/Grammar.y"
+#line 199 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[-1];
         }
-#line 1756 "src/Slice/Grammar.cpp"
+#line 1757 "src/Slice/Grammar.cpp"
         break;
 
         case 6: /* global_meta_data: ICE_GLOBAL_METADATA_IGNORE string_list ICE_GLOBAL_METADATA_CLOSE  */
-#line 202 "src/Slice/Grammar.y"
+#line 203 "src/Slice/Grammar.y"
         {
             currentUnit->error("global metadata must appear before any definitions");
             yyval = yyvsp[-1]; // Dummy
         }
-#line 1765 "src/Slice/Grammar.cpp"
+#line 1766 "src/Slice/Grammar.cpp"
         break;
 
         case 7: /* meta_data: ICE_METADATA_OPEN string_list ICE_METADATA_CLOSE  */
-#line 212 "src/Slice/Grammar.y"
+#line 213 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[-1];
         }
-#line 1773 "src/Slice/Grammar.cpp"
+#line 1774 "src/Slice/Grammar.cpp"
         break;
 
         case 8: /* meta_data: %empty  */
-#line 216 "src/Slice/Grammar.y"
+#line 217 "src/Slice/Grammar.y"
         {
             yyval = make_shared<StringListTok>();
         }
-#line 1781 "src/Slice/Grammar.cpp"
+#line 1782 "src/Slice/Grammar.cpp"
         break;
 
         case 9: /* definitions: definitions global_meta_data  */
-#line 225 "src/Slice/Grammar.y"
+#line 226 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[0]);
             if (!metaData->v.empty())
@@ -1639,11 +1640,11 @@ yyreduce:
                 currentUnit->addGlobalMetaData(metaData->v);
             }
         }
-#line 1793 "src/Slice/Grammar.cpp"
+#line 1794 "src/Slice/Grammar.cpp"
         break;
 
         case 10: /* definitions: definitions meta_data definition  */
-#line 233 "src/Slice/Grammar.y"
+#line 234 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
@@ -1652,186 +1653,186 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 1806 "src/Slice/Grammar.cpp"
+#line 1807 "src/Slice/Grammar.cpp"
         break;
 
         case 11: /* definitions: %empty  */
-#line 242 "src/Slice/Grammar.y"
+#line 243 "src/Slice/Grammar.y"
         {
         }
-#line 1813 "src/Slice/Grammar.cpp"
+#line 1814 "src/Slice/Grammar.cpp"
         break;
 
         case 12: /* $@1: %empty  */
-#line 250 "src/Slice/Grammar.y"
+#line 251 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Module>(yyvsp[0]));
         }
-#line 1821 "src/Slice/Grammar.cpp"
+#line 1822 "src/Slice/Grammar.cpp"
         break;
 
         case 14: /* $@2: %empty  */
-#line 255 "src/Slice/Grammar.y"
+#line 256 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<ClassDecl>(yyvsp[0]));
         }
-#line 1829 "src/Slice/Grammar.cpp"
+#line 1830 "src/Slice/Grammar.cpp"
         break;
 
         case 16: /* definition: class_decl  */
-#line 260 "src/Slice/Grammar.y"
+#line 261 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after class forward declaration");
         }
-#line 1837 "src/Slice/Grammar.cpp"
+#line 1838 "src/Slice/Grammar.cpp"
         break;
 
         case 17: /* $@3: %empty  */
-#line 264 "src/Slice/Grammar.y"
+#line 265 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<ClassDef>(yyvsp[0]));
         }
-#line 1845 "src/Slice/Grammar.cpp"
+#line 1846 "src/Slice/Grammar.cpp"
         break;
 
         case 19: /* $@4: %empty  */
-#line 269 "src/Slice/Grammar.y"
+#line 270 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<InterfaceDecl>(yyvsp[0]));
         }
-#line 1853 "src/Slice/Grammar.cpp"
+#line 1854 "src/Slice/Grammar.cpp"
         break;
 
         case 21: /* definition: interface_decl  */
-#line 274 "src/Slice/Grammar.y"
+#line 275 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after interface forward declaration");
         }
-#line 1861 "src/Slice/Grammar.cpp"
+#line 1862 "src/Slice/Grammar.cpp"
         break;
 
         case 22: /* $@5: %empty  */
-#line 278 "src/Slice/Grammar.y"
+#line 279 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<InterfaceDef>(yyvsp[0]));
         }
-#line 1869 "src/Slice/Grammar.cpp"
+#line 1870 "src/Slice/Grammar.cpp"
         break;
 
         case 24: /* $@6: %empty  */
-#line 283 "src/Slice/Grammar.y"
+#line 284 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr);
         }
-#line 1877 "src/Slice/Grammar.cpp"
+#line 1878 "src/Slice/Grammar.cpp"
         break;
 
         case 26: /* definition: exception_decl  */
-#line 288 "src/Slice/Grammar.y"
+#line 289 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after exception forward declaration");
         }
-#line 1885 "src/Slice/Grammar.cpp"
+#line 1886 "src/Slice/Grammar.cpp"
         break;
 
         case 27: /* $@7: %empty  */
-#line 292 "src/Slice/Grammar.y"
+#line 293 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Exception>(yyvsp[0]));
         }
-#line 1893 "src/Slice/Grammar.cpp"
+#line 1894 "src/Slice/Grammar.cpp"
         break;
 
         case 29: /* $@8: %empty  */
-#line 297 "src/Slice/Grammar.y"
+#line 298 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr);
         }
-#line 1901 "src/Slice/Grammar.cpp"
+#line 1902 "src/Slice/Grammar.cpp"
         break;
 
         case 31: /* definition: struct_decl  */
-#line 302 "src/Slice/Grammar.y"
+#line 303 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after struct forward declaration");
         }
-#line 1909 "src/Slice/Grammar.cpp"
+#line 1910 "src/Slice/Grammar.cpp"
         break;
 
         case 32: /* $@9: %empty  */
-#line 306 "src/Slice/Grammar.y"
+#line 307 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Struct>(yyvsp[0]));
         }
-#line 1917 "src/Slice/Grammar.cpp"
+#line 1918 "src/Slice/Grammar.cpp"
         break;
 
         case 34: /* $@10: %empty  */
-#line 311 "src/Slice/Grammar.y"
+#line 312 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Sequence>(yyvsp[0]));
         }
-#line 1925 "src/Slice/Grammar.cpp"
+#line 1926 "src/Slice/Grammar.cpp"
         break;
 
         case 36: /* definition: sequence_def  */
-#line 316 "src/Slice/Grammar.y"
+#line 317 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after sequence definition");
         }
-#line 1933 "src/Slice/Grammar.cpp"
+#line 1934 "src/Slice/Grammar.cpp"
         break;
 
         case 37: /* $@11: %empty  */
-#line 320 "src/Slice/Grammar.y"
+#line 321 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Dictionary>(yyvsp[0]));
         }
-#line 1941 "src/Slice/Grammar.cpp"
+#line 1942 "src/Slice/Grammar.cpp"
         break;
 
         case 39: /* definition: dictionary_def  */
-#line 325 "src/Slice/Grammar.y"
+#line 326 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after dictionary definition");
         }
-#line 1949 "src/Slice/Grammar.cpp"
+#line 1950 "src/Slice/Grammar.cpp"
         break;
 
         case 40: /* $@12: %empty  */
-#line 329 "src/Slice/Grammar.y"
+#line 330 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Enum>(yyvsp[0]));
         }
-#line 1957 "src/Slice/Grammar.cpp"
+#line 1958 "src/Slice/Grammar.cpp"
         break;
 
         case 42: /* $@13: %empty  */
-#line 334 "src/Slice/Grammar.y"
+#line 335 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Const>(yyvsp[0]));
         }
-#line 1965 "src/Slice/Grammar.cpp"
+#line 1966 "src/Slice/Grammar.cpp"
         break;
 
         case 44: /* definition: const_def  */
-#line 339 "src/Slice/Grammar.y"
+#line 340 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after const definition");
         }
-#line 1973 "src/Slice/Grammar.cpp"
+#line 1974 "src/Slice/Grammar.cpp"
         break;
 
         case 45: /* definition: error ';'  */
-#line 343 "src/Slice/Grammar.y"
+#line 344 "src/Slice/Grammar.y"
         {
             yyerrok;
         }
-#line 1981 "src/Slice/Grammar.cpp"
+#line 1982 "src/Slice/Grammar.cpp"
         break;
 
         case 46: /* @14: %empty  */
-#line 352 "src/Slice/Grammar.y"
+#line 353 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -1847,11 +1848,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2001 "src/Slice/Grammar.cpp"
+#line 2002 "src/Slice/Grammar.cpp"
         break;
 
         case 47: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
-#line 368 "src/Slice/Grammar.y"
+#line 369 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -1863,38 +1864,38 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2017 "src/Slice/Grammar.cpp"
+#line 2018 "src/Slice/Grammar.cpp"
         break;
 
         case 48: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
-#line 385 "src/Slice/Grammar.y"
+#line 386 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2025 "src/Slice/Grammar.cpp"
+#line 2026 "src/Slice/Grammar.cpp"
         break;
 
         case 49: /* exception_id: ICE_EXCEPTION keyword  */
-#line 389 "src/Slice/Grammar.y"
+#line 390 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as exception name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2035 "src/Slice/Grammar.cpp"
+#line 2036 "src/Slice/Grammar.cpp"
         break;
 
         case 50: /* exception_decl: exception_id  */
-#line 400 "src/Slice/Grammar.y"
+#line 401 "src/Slice/Grammar.y"
         {
             currentUnit->error("exceptions cannot be forward declared");
             yyval = nullptr;
         }
-#line 2044 "src/Slice/Grammar.cpp"
+#line 2045 "src/Slice/Grammar.cpp"
         break;
 
         case 51: /* @15: %empty  */
-#line 410 "src/Slice/Grammar.y"
+#line 411 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             auto base = dynamic_pointer_cast<Exception>(yyvsp[0]);
@@ -1907,11 +1908,11 @@ yyreduce:
             }
             yyval = ex;
         }
-#line 2061 "src/Slice/Grammar.cpp"
+#line 2062 "src/Slice/Grammar.cpp"
         break;
 
         case 52: /* exception_def: exception_id exception_extends @15 '{' data_members '}'  */
-#line 423 "src/Slice/Grammar.y"
+#line 424 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -1919,11 +1920,11 @@ yyreduce:
             }
             yyval = yyvsp[-3];
         }
-#line 2073 "src/Slice/Grammar.cpp"
+#line 2074 "src/Slice/Grammar.cpp"
         break;
 
         case 53: /* exception_extends: extends scoped_name  */
-#line 436 "src/Slice/Grammar.y"
+#line 437 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -1931,19 +1932,19 @@ yyreduce:
             cont->checkIntroduced(scoped->v);
             yyval = contained;
         }
-#line 2085 "src/Slice/Grammar.cpp"
+#line 2086 "src/Slice/Grammar.cpp"
         break;
 
         case 54: /* exception_extends: %empty  */
-#line 444 "src/Slice/Grammar.y"
+#line 445 "src/Slice/Grammar.y"
         {
             yyval = nullptr;
         }
-#line 2093 "src/Slice/Grammar.cpp"
+#line 2094 "src/Slice/Grammar.cpp"
         break;
 
         case 55: /* type_id: type ICE_IDENTIFIER  */
-#line 453 "src/Slice/Grammar.y"
+#line 454 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
@@ -1951,11 +1952,11 @@ yyreduce:
             typestring->v = make_pair(type, ident->v);
             yyval = typestring;
         }
-#line 2105 "src/Slice/Grammar.cpp"
+#line 2106 "src/Slice/Grammar.cpp"
         break;
 
         case 56: /* tag: ICE_TAG_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 466 "src/Slice/Grammar.y"
+#line 467 "src/Slice/Grammar.y"
         {
             auto i = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
 
@@ -1973,11 +1974,11 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2127 "src/Slice/Grammar.cpp"
+#line 2128 "src/Slice/Grammar.cpp"
         break;
 
         case 57: /* tag: ICE_TAG_OPEN scoped_name ')'  */
-#line 484 "src/Slice/Grammar.y"
+#line 485 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
 
@@ -2058,31 +2059,31 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2210 "src/Slice/Grammar.cpp"
+#line 2211 "src/Slice/Grammar.cpp"
         break;
 
         case 58: /* tag: ICE_TAG_OPEN ')'  */
-#line 563 "src/Slice/Grammar.y"
+#line 564 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2220 "src/Slice/Grammar.cpp"
+#line 2221 "src/Slice/Grammar.cpp"
         break;
 
         case 59: /* tag: ICE_TAG  */
-#line 569 "src/Slice/Grammar.y"
+#line 570 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2230 "src/Slice/Grammar.cpp"
+#line 2231 "src/Slice/Grammar.cpp"
         break;
 
         case 60: /* optional: ICE_OPTIONAL_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 580 "src/Slice/Grammar.y"
+#line 581 "src/Slice/Grammar.y"
         {
             auto i = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
 
@@ -2100,11 +2101,11 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2252 "src/Slice/Grammar.cpp"
+#line 2253 "src/Slice/Grammar.cpp"
         break;
 
         case 61: /* optional: ICE_OPTIONAL_OPEN scoped_name ')'  */
-#line 598 "src/Slice/Grammar.y"
+#line 599 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2184,31 +2185,31 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2334 "src/Slice/Grammar.cpp"
+#line 2335 "src/Slice/Grammar.cpp"
         break;
 
         case 62: /* optional: ICE_OPTIONAL_OPEN ')'  */
-#line 676 "src/Slice/Grammar.y"
+#line 677 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2344 "src/Slice/Grammar.cpp"
+#line 2345 "src/Slice/Grammar.cpp"
         break;
 
         case 63: /* optional: ICE_OPTIONAL  */
-#line 682 "src/Slice/Grammar.y"
+#line 683 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2354 "src/Slice/Grammar.cpp"
+#line 2355 "src/Slice/Grammar.cpp"
         break;
 
         case 64: /* tagged_type_id: tag type_id  */
-#line 693 "src/Slice/Grammar.y"
+#line 694 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
@@ -2217,11 +2218,11 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2367 "src/Slice/Grammar.cpp"
+#line 2368 "src/Slice/Grammar.cpp"
         break;
 
         case 65: /* tagged_type_id: optional type_id  */
-#line 702 "src/Slice/Grammar.y"
+#line 703 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
@@ -2230,11 +2231,11 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2380 "src/Slice/Grammar.cpp"
+#line 2381 "src/Slice/Grammar.cpp"
         break;
 
         case 66: /* tagged_type_id: type_id  */
-#line 711 "src/Slice/Grammar.y"
+#line 712 "src/Slice/Grammar.y"
         {
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
             auto m = make_shared<TaggedDefTok>(-1);
@@ -2242,38 +2243,38 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2392 "src/Slice/Grammar.cpp"
+#line 2393 "src/Slice/Grammar.cpp"
         break;
 
         case 67: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
-#line 724 "src/Slice/Grammar.y"
+#line 725 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2400 "src/Slice/Grammar.cpp"
+#line 2401 "src/Slice/Grammar.cpp"
         break;
 
         case 68: /* struct_id: ICE_STRUCT keyword  */
-#line 728 "src/Slice/Grammar.y"
+#line 729 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as struct name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2410 "src/Slice/Grammar.cpp"
+#line 2411 "src/Slice/Grammar.cpp"
         break;
 
         case 69: /* struct_decl: struct_id  */
-#line 739 "src/Slice/Grammar.y"
+#line 740 "src/Slice/Grammar.y"
         {
             currentUnit->error("structs cannot be forward declared");
             yyval = nullptr; // Dummy
         }
-#line 2419 "src/Slice/Grammar.cpp"
+#line 2420 "src/Slice/Grammar.cpp"
         break;
 
         case 70: /* @16: %empty  */
-#line 749 "src/Slice/Grammar.y"
+#line 750 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2291,11 +2292,11 @@ yyreduce:
             }
             yyval = st;
         }
-#line 2441 "src/Slice/Grammar.cpp"
+#line 2442 "src/Slice/Grammar.cpp"
         break;
 
         case 71: /* struct_def: struct_id @16 '{' data_members '}'  */
-#line 767 "src/Slice/Grammar.y"
+#line 768 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -2311,29 +2312,29 @@ yyreduce:
                 currentUnit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
             }
         }
-#line 2461 "src/Slice/Grammar.cpp"
+#line 2462 "src/Slice/Grammar.cpp"
         break;
 
         case 72: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
-#line 788 "src/Slice/Grammar.y"
+#line 789 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2469 "src/Slice/Grammar.cpp"
+#line 2470 "src/Slice/Grammar.cpp"
         break;
 
         case 73: /* class_name: ICE_CLASS keyword  */
-#line 792 "src/Slice/Grammar.y"
+#line 793 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as class name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2479 "src/Slice/Grammar.cpp"
+#line 2480 "src/Slice/Grammar.cpp"
         break;
 
         case 74: /* class_id: ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 803 "src/Slice/Grammar.y"
+#line 804 "src/Slice/Grammar.y"
         {
             int64_t id = dynamic_pointer_cast<IntegerTok>(yyvsp[-1])->v;
             if (id < 0)
@@ -2358,11 +2359,11 @@ yyreduce:
             classId->t = static_cast<int>(id);
             yyval = classId;
         }
-#line 2508 "src/Slice/Grammar.cpp"
+#line 2509 "src/Slice/Grammar.cpp"
         break;
 
         case 75: /* class_id: ICE_CLASS ICE_IDENT_OPEN scoped_name ')'  */
-#line 828 "src/Slice/Grammar.y"
+#line 829 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
 
@@ -2453,33 +2454,33 @@ yyreduce:
             classId->t = id;
             yyval = classId;
         }
-#line 2602 "src/Slice/Grammar.cpp"
+#line 2603 "src/Slice/Grammar.cpp"
         break;
 
         case 76: /* class_id: class_name  */
-#line 918 "src/Slice/Grammar.y"
+#line 919 "src/Slice/Grammar.y"
         {
             auto classId = make_shared<ClassIdTok>();
             classId->v = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
             classId->t = -1;
             yyval = classId;
         }
-#line 2613 "src/Slice/Grammar.cpp"
+#line 2614 "src/Slice/Grammar.cpp"
         break;
 
         case 77: /* class_decl: class_name  */
-#line 930 "src/Slice/Grammar.y"
+#line 931 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
             ClassDeclPtr cl = cont->createClassDecl(ident->v);
             yyval = cl;
         }
-#line 2624 "src/Slice/Grammar.cpp"
+#line 2625 "src/Slice/Grammar.cpp"
         break;
 
         case 78: /* @17: %empty  */
-#line 942 "src/Slice/Grammar.y"
+#line 943 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<ClassIdTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2496,11 +2497,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2645 "src/Slice/Grammar.cpp"
+#line 2646 "src/Slice/Grammar.cpp"
         break;
 
         case 79: /* class_def: class_id class_extends @17 '{' data_members '}'  */
-#line 959 "src/Slice/Grammar.y"
+#line 960 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -2512,11 +2513,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2661 "src/Slice/Grammar.cpp"
+#line 2662 "src/Slice/Grammar.cpp"
         break;
 
         case 80: /* class_extends: extends scoped_name  */
-#line 976 "src/Slice/Grammar.y"
+#line 977 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2550,33 +2551,33 @@ yyreduce:
                 }
             }
         }
-#line 2699 "src/Slice/Grammar.cpp"
+#line 2700 "src/Slice/Grammar.cpp"
         break;
 
         case 81: /* class_extends: %empty  */
-#line 1010 "src/Slice/Grammar.y"
+#line 1011 "src/Slice/Grammar.y"
         {
             yyval = nullptr;
         }
-#line 2707 "src/Slice/Grammar.cpp"
+#line 2708 "src/Slice/Grammar.cpp"
         break;
 
         case 82: /* extends: ICE_EXTENDS  */
-#line 1019 "src/Slice/Grammar.y"
+#line 1020 "src/Slice/Grammar.y"
         {
         }
-#line 2714 "src/Slice/Grammar.cpp"
+#line 2715 "src/Slice/Grammar.cpp"
         break;
 
         case 83: /* extends: ':'  */
-#line 1022 "src/Slice/Grammar.y"
+#line 1023 "src/Slice/Grammar.y"
         {
         }
-#line 2721 "src/Slice/Grammar.cpp"
+#line 2722 "src/Slice/Grammar.cpp"
         break;
 
         case 84: /* data_members: meta_data data_member ';' data_members  */
-#line 1030 "src/Slice/Grammar.y"
+#line 1031 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
@@ -2585,33 +2586,33 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 2734 "src/Slice/Grammar.cpp"
+#line 2735 "src/Slice/Grammar.cpp"
         break;
 
         case 85: /* data_members: error ';' data_members  */
-#line 1039 "src/Slice/Grammar.y"
+#line 1040 "src/Slice/Grammar.y"
         {
         }
-#line 2741 "src/Slice/Grammar.cpp"
+#line 2742 "src/Slice/Grammar.cpp"
         break;
 
         case 86: /* data_members: meta_data data_member  */
-#line 1042 "src/Slice/Grammar.y"
+#line 1043 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after definition");
         }
-#line 2749 "src/Slice/Grammar.cpp"
+#line 2750 "src/Slice/Grammar.cpp"
         break;
 
         case 87: /* data_members: %empty  */
-#line 1046 "src/Slice/Grammar.y"
+#line 1047 "src/Slice/Grammar.y"
         {
         }
-#line 2756 "src/Slice/Grammar.cpp"
+#line 2757 "src/Slice/Grammar.cpp"
         break;
 
         case 88: /* data_member: tagged_type_id  */
-#line 1054 "src/Slice/Grammar.y"
+#line 1055 "src/Slice/Grammar.y"
         {
             auto def = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
@@ -2641,11 +2642,11 @@ yyreduce:
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
         }
-#line 2790 "src/Slice/Grammar.cpp"
+#line 2791 "src/Slice/Grammar.cpp"
         break;
 
         case 89: /* data_member: tagged_type_id '=' const_initializer  */
-#line 1084 "src/Slice/Grammar.y"
+#line 1085 "src/Slice/Grammar.y"
         {
             auto def = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-2]);
             auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
@@ -2697,11 +2698,11 @@ yyreduce:
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
         }
-#line 2828 "src/Slice/Grammar.cpp"
+#line 2829 "src/Slice/Grammar.cpp"
         break;
 
         case 90: /* data_member: type keyword  */
-#line 1118 "src/Slice/Grammar.y"
+#line 1119 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2723,11 +2724,11 @@ yyreduce:
             assert(yyval);
             currentUnit->error("keyword `" + name + "' cannot be used as data member name");
         }
-#line 2854 "src/Slice/Grammar.cpp"
+#line 2855 "src/Slice/Grammar.cpp"
         break;
 
         case 91: /* data_member: type  */
-#line 1140 "src/Slice/Grammar.y"
+#line 1141 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
@@ -2748,50 +2749,50 @@ yyreduce:
             assert(yyval);
             currentUnit->error("missing data member name");
         }
-#line 2879 "src/Slice/Grammar.cpp"
+#line 2880 "src/Slice/Grammar.cpp"
         break;
 
         case 92: /* return_type: tag type  */
-#line 1166 "src/Slice/Grammar.y"
+#line 1167 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
             yyval = m;
         }
-#line 2889 "src/Slice/Grammar.cpp"
+#line 2890 "src/Slice/Grammar.cpp"
         break;
 
         case 93: /* return_type: optional type  */
-#line 1172 "src/Slice/Grammar.y"
+#line 1173 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
             yyval = m;
         }
-#line 2899 "src/Slice/Grammar.cpp"
+#line 2900 "src/Slice/Grammar.cpp"
         break;
 
         case 94: /* return_type: type  */
-#line 1178 "src/Slice/Grammar.y"
+#line 1179 "src/Slice/Grammar.y"
         {
             auto m = make_shared<TaggedDefTok>(-1);
             m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
             yyval = m;
         }
-#line 2909 "src/Slice/Grammar.cpp"
+#line 2910 "src/Slice/Grammar.cpp"
         break;
 
         case 95: /* return_type: ICE_VOID  */
-#line 1184 "src/Slice/Grammar.y"
+#line 1185 "src/Slice/Grammar.y"
         {
             auto m = make_shared<TaggedDefTok>(-1);
             yyval = m;
         }
-#line 2918 "src/Slice/Grammar.cpp"
+#line 2919 "src/Slice/Grammar.cpp"
         break;
 
         case 96: /* operation_preamble: return_type ICE_IDENT_OPEN  */
-#line 1194 "src/Slice/Grammar.y"
+#line 1195 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2816,11 +2817,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2946 "src/Slice/Grammar.cpp"
+#line 2947 "src/Slice/Grammar.cpp"
         break;
 
         case 97: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_IDENT_OPEN  */
-#line 1218 "src/Slice/Grammar.y"
+#line 1219 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2850,11 +2851,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2980 "src/Slice/Grammar.cpp"
+#line 2981 "src/Slice/Grammar.cpp"
         break;
 
         case 98: /* operation_preamble: return_type ICE_KEYWORD_OPEN  */
-#line 1248 "src/Slice/Grammar.y"
+#line 1249 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2879,11 +2880,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3008 "src/Slice/Grammar.cpp"
+#line 3009 "src/Slice/Grammar.cpp"
         break;
 
         case 99: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_KEYWORD_OPEN  */
-#line 1272 "src/Slice/Grammar.y"
+#line 1273 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2912,11 +2913,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3041 "src/Slice/Grammar.cpp"
+#line 3042 "src/Slice/Grammar.cpp"
         break;
 
         case 100: /* @18: %empty  */
-#line 1306 "src/Slice/Grammar.y"
+#line 1307 "src/Slice/Grammar.y"
         {
             if (yyvsp[-2])
             {
@@ -2928,11 +2929,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3057 "src/Slice/Grammar.cpp"
+#line 3058 "src/Slice/Grammar.cpp"
         break;
 
         case 101: /* operation: operation_preamble parameters ')' @18 throws  */
-#line 1318 "src/Slice/Grammar.y"
+#line 1319 "src/Slice/Grammar.y"
         {
             auto op = dynamic_pointer_cast<Operation>(yyvsp[-1]);
             auto el = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
@@ -2942,11 +2943,11 @@ yyreduce:
                 op->setExceptionList(el->v);
             }
         }
-#line 3071 "src/Slice/Grammar.cpp"
+#line 3072 "src/Slice/Grammar.cpp"
         break;
 
         case 102: /* @19: %empty  */
-#line 1328 "src/Slice/Grammar.y"
+#line 1329 "src/Slice/Grammar.y"
         {
             if (yyvsp[-2])
             {
@@ -2954,11 +2955,11 @@ yyreduce:
             }
             yyerrok;
         }
-#line 3083 "src/Slice/Grammar.cpp"
+#line 3084 "src/Slice/Grammar.cpp"
         break;
 
         case 103: /* operation: operation_preamble error ')' @19 throws  */
-#line 1336 "src/Slice/Grammar.y"
+#line 1337 "src/Slice/Grammar.y"
         {
             auto op = dynamic_pointer_cast<Operation>(yyvsp[-1]);
             auto el = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
@@ -2968,29 +2969,29 @@ yyreduce:
                 op->setExceptionList(el->v); // Dummy
             }
         }
-#line 3097 "src/Slice/Grammar.cpp"
+#line 3098 "src/Slice/Grammar.cpp"
         break;
 
         case 104: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
-#line 1351 "src/Slice/Grammar.y"
+#line 1352 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3105 "src/Slice/Grammar.cpp"
+#line 3106 "src/Slice/Grammar.cpp"
         break;
 
         case 105: /* interface_id: ICE_INTERFACE keyword  */
-#line 1355 "src/Slice/Grammar.y"
+#line 1356 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as interface name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 3115 "src/Slice/Grammar.cpp"
+#line 3116 "src/Slice/Grammar.cpp"
         break;
 
         case 106: /* interface_decl: interface_id  */
-#line 1366 "src/Slice/Grammar.y"
+#line 1367 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto cont = currentUnit->currentContainer();
@@ -2998,11 +2999,11 @@ yyreduce:
             cont->checkIntroduced(ident->v, cl);
             yyval = cl;
         }
-#line 3127 "src/Slice/Grammar.cpp"
+#line 3128 "src/Slice/Grammar.cpp"
         break;
 
         case 107: /* @20: %empty  */
-#line 1379 "src/Slice/Grammar.y"
+#line 1380 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3019,11 +3020,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3148 "src/Slice/Grammar.cpp"
+#line 3149 "src/Slice/Grammar.cpp"
         break;
 
         case 108: /* interface_def: interface_id interface_extends @20 '{' operations '}'  */
-#line 1396 "src/Slice/Grammar.y"
+#line 1397 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -3035,11 +3036,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3164 "src/Slice/Grammar.cpp"
+#line 3165 "src/Slice/Grammar.cpp"
         break;
 
         case 109: /* interface_list: scoped_name ',' interface_list  */
-#line 1413 "src/Slice/Grammar.y"
+#line 1414 "src/Slice/Grammar.y"
         {
             auto intfs = dynamic_pointer_cast<InterfaceListTok>(yyvsp[0]);
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
@@ -3074,11 +3075,11 @@ yyreduce:
             }
             yyval = intfs;
         }
-#line 3203 "src/Slice/Grammar.cpp"
+#line 3204 "src/Slice/Grammar.cpp"
         break;
 
         case 110: /* interface_list: scoped_name  */
-#line 1448 "src/Slice/Grammar.y"
+#line 1449 "src/Slice/Grammar.y"
         {
             auto intfs = make_shared<InterfaceListTok>();
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
@@ -3113,45 +3114,45 @@ yyreduce:
             }
             yyval = intfs;
         }
-#line 3242 "src/Slice/Grammar.cpp"
+#line 3243 "src/Slice/Grammar.cpp"
         break;
 
         case 111: /* interface_list: ICE_OBJECT  */
-#line 1483 "src/Slice/Grammar.y"
+#line 1484 "src/Slice/Grammar.y"
         {
             currentUnit->error("illegal inheritance from type Object");
             yyval = make_shared<InterfaceListTok>(); // Dummy
         }
-#line 3251 "src/Slice/Grammar.cpp"
+#line 3252 "src/Slice/Grammar.cpp"
         break;
 
         case 112: /* interface_list: ICE_VALUE  */
-#line 1488 "src/Slice/Grammar.y"
+#line 1489 "src/Slice/Grammar.y"
         {
             currentUnit->error("illegal inheritance from type Value");
             yyval = make_shared<ClassListTok>(); // Dummy
         }
-#line 3260 "src/Slice/Grammar.cpp"
+#line 3261 "src/Slice/Grammar.cpp"
         break;
 
         case 113: /* interface_extends: extends interface_list  */
-#line 1498 "src/Slice/Grammar.y"
+#line 1499 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3268 "src/Slice/Grammar.cpp"
+#line 3269 "src/Slice/Grammar.cpp"
         break;
 
         case 114: /* interface_extends: %empty  */
-#line 1502 "src/Slice/Grammar.y"
+#line 1503 "src/Slice/Grammar.y"
         {
             yyval = make_shared<InterfaceListTok>();
         }
-#line 3276 "src/Slice/Grammar.cpp"
+#line 3277 "src/Slice/Grammar.cpp"
         break;
 
         case 115: /* operations: meta_data operation ';' operations  */
-#line 1511 "src/Slice/Grammar.y"
+#line 1512 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
@@ -3160,55 +3161,55 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 3289 "src/Slice/Grammar.cpp"
+#line 3290 "src/Slice/Grammar.cpp"
         break;
 
         case 116: /* operations: error ';' operations  */
-#line 1520 "src/Slice/Grammar.y"
+#line 1521 "src/Slice/Grammar.y"
         {
         }
-#line 3296 "src/Slice/Grammar.cpp"
+#line 3297 "src/Slice/Grammar.cpp"
         break;
 
         case 117: /* operations: meta_data operation  */
-#line 1523 "src/Slice/Grammar.y"
+#line 1524 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after definition");
         }
-#line 3304 "src/Slice/Grammar.cpp"
+#line 3305 "src/Slice/Grammar.cpp"
         break;
 
         case 118: /* operations: %empty  */
-#line 1527 "src/Slice/Grammar.y"
+#line 1528 "src/Slice/Grammar.y"
         {
         }
-#line 3311 "src/Slice/Grammar.cpp"
+#line 3312 "src/Slice/Grammar.cpp"
         break;
 
         case 119: /* exception_list: exception ',' exception_list  */
-#line 1535 "src/Slice/Grammar.y"
+#line 1536 "src/Slice/Grammar.y"
         {
             auto exception = dynamic_pointer_cast<Exception>(yyvsp[-2]);
             auto exceptionList = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
             exceptionList->v.push_front(exception);
             yyval = exceptionList;
         }
-#line 3322 "src/Slice/Grammar.cpp"
+#line 3323 "src/Slice/Grammar.cpp"
         break;
 
         case 120: /* exception_list: exception  */
-#line 1542 "src/Slice/Grammar.y"
+#line 1543 "src/Slice/Grammar.y"
         {
             auto exception = dynamic_pointer_cast<Exception>(yyvsp[0]);
             auto exceptionList = make_shared<ExceptionListTok>();
             exceptionList->v.push_front(exception);
             yyval = exceptionList;
         }
-#line 3333 "src/Slice/Grammar.cpp"
+#line 3334 "src/Slice/Grammar.cpp"
         break;
 
         case 121: /* exception: scoped_name  */
-#line 1554 "src/Slice/Grammar.y"
+#line 1555 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3220,21 +3221,21 @@ yyreduce:
             cont->checkIntroduced(scoped->v, exception);
             yyval = exception;
         }
-#line 3349 "src/Slice/Grammar.cpp"
+#line 3350 "src/Slice/Grammar.cpp"
         break;
 
         case 122: /* exception: keyword  */
-#line 1566 "src/Slice/Grammar.y"
+#line 1567 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as exception name");
             yyval = currentUnit->currentContainer()->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
         }
-#line 3359 "src/Slice/Grammar.cpp"
+#line 3360 "src/Slice/Grammar.cpp"
         break;
 
         case 123: /* sequence_def: ICE_SEQUENCE '<' meta_data type '>' ICE_IDENTIFIER  */
-#line 1577 "src/Slice/Grammar.y"
+#line 1578 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
@@ -3242,11 +3243,11 @@ yyreduce:
             ContainerPtr cont = currentUnit->currentContainer();
             yyval = cont->createSequence(ident->v, type, metaData->v);
         }
-#line 3371 "src/Slice/Grammar.cpp"
+#line 3372 "src/Slice/Grammar.cpp"
         break;
 
         case 124: /* sequence_def: ICE_SEQUENCE '<' meta_data type '>' keyword  */
-#line 1585 "src/Slice/Grammar.y"
+#line 1586 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
@@ -3255,11 +3256,11 @@ yyreduce:
             yyval = cont->createSequence(ident->v, type, metaData->v); // Dummy
             currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
         }
-#line 3384 "src/Slice/Grammar.cpp"
+#line 3385 "src/Slice/Grammar.cpp"
         break;
 
         case 125: /* dictionary_def: ICE_DICTIONARY '<' meta_data type ',' meta_data type '>' ICE_IDENTIFIER  */
-#line 1599 "src/Slice/Grammar.y"
+#line 1600 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto keyMetaData = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
@@ -3269,11 +3270,11 @@ yyreduce:
             ContainerPtr cont = currentUnit->currentContainer();
             yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v);
         }
-#line 3398 "src/Slice/Grammar.cpp"
+#line 3399 "src/Slice/Grammar.cpp"
         break;
 
         case 126: /* dictionary_def: ICE_DICTIONARY '<' meta_data type ',' meta_data type '>' keyword  */
-#line 1609 "src/Slice/Grammar.y"
+#line 1610 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto keyMetaData = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
@@ -3284,29 +3285,29 @@ yyreduce:
             yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v); // Dummy
             currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
         }
-#line 3413 "src/Slice/Grammar.cpp"
+#line 3414 "src/Slice/Grammar.cpp"
         break;
 
         case 127: /* enum_id: ICE_ENUM ICE_IDENTIFIER  */
-#line 1625 "src/Slice/Grammar.y"
+#line 1626 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3421 "src/Slice/Grammar.cpp"
+#line 3422 "src/Slice/Grammar.cpp"
         break;
 
         case 128: /* enum_id: ICE_ENUM keyword  */
-#line 1629 "src/Slice/Grammar.y"
+#line 1630 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as enumeration name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 3431 "src/Slice/Grammar.cpp"
+#line 3432 "src/Slice/Grammar.cpp"
         break;
 
         case 129: /* @21: %empty  */
-#line 1640 "src/Slice/Grammar.y"
+#line 1641 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3322,11 +3323,11 @@ yyreduce:
             currentUnit->pushContainer(en);
             yyval = en;
         }
-#line 3451 "src/Slice/Grammar.cpp"
+#line 3452 "src/Slice/Grammar.cpp"
         break;
 
         case 130: /* enum_def: enum_id @21 '{' enumerator_list '}'  */
-#line 1656 "src/Slice/Grammar.y"
+#line 1657 "src/Slice/Grammar.y"
         {
             auto en = dynamic_pointer_cast<Enum>(yyvsp[-3]);
             if (en)
@@ -3340,11 +3341,11 @@ yyreduce:
             }
             yyval = yyvsp[-3];
         }
-#line 3469 "src/Slice/Grammar.cpp"
+#line 3470 "src/Slice/Grammar.cpp"
         break;
 
         case 131: /* @22: %empty  */
-#line 1671 "src/Slice/Grammar.y"
+#line 1672 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing enumeration name");
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3352,37 +3353,37 @@ yyreduce:
             currentUnit->pushContainer(en);
             yyval = en;
         }
-#line 3481 "src/Slice/Grammar.cpp"
+#line 3482 "src/Slice/Grammar.cpp"
         break;
 
         case 132: /* enum_def: ICE_ENUM @22 '{' enumerator_list '}'  */
-#line 1679 "src/Slice/Grammar.y"
+#line 1680 "src/Slice/Grammar.y"
         {
             currentUnit->popContainer();
             yyval = yyvsp[-4];
         }
-#line 3490 "src/Slice/Grammar.cpp"
+#line 3491 "src/Slice/Grammar.cpp"
         break;
 
         case 133: /* enumerator_list: enumerator ',' enumerator_list  */
-#line 1689 "src/Slice/Grammar.y"
+#line 1690 "src/Slice/Grammar.y"
         {
             auto ens = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[-2]);
             ens->v.splice(ens->v.end(), dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0])->v);
             yyval = ens;
         }
-#line 3500 "src/Slice/Grammar.cpp"
+#line 3501 "src/Slice/Grammar.cpp"
         break;
 
         case 134: /* enumerator_list: enumerator  */
-#line 1695 "src/Slice/Grammar.y"
+#line 1696 "src/Slice/Grammar.y"
         {
         }
-#line 3507 "src/Slice/Grammar.cpp"
+#line 3508 "src/Slice/Grammar.cpp"
         break;
 
         case 135: /* enumerator: ICE_IDENTIFIER  */
-#line 1703 "src/Slice/Grammar.y"
+#line 1704 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto ens = make_shared<EnumeratorListTok>();
@@ -3394,11 +3395,11 @@ yyreduce:
             }
             yyval = ens;
         }
-#line 3523 "src/Slice/Grammar.cpp"
+#line 3524 "src/Slice/Grammar.cpp"
         break;
 
         case 136: /* enumerator: ICE_IDENTIFIER '=' enumerator_initializer  */
-#line 1715 "src/Slice/Grammar.y"
+#line 1716 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
             auto ens = make_shared<EnumeratorListTok>();
@@ -3418,39 +3419,39 @@ yyreduce:
             }
             yyval = ens;
         }
-#line 3547 "src/Slice/Grammar.cpp"
+#line 3548 "src/Slice/Grammar.cpp"
         break;
 
         case 137: /* enumerator: keyword  */
-#line 1735 "src/Slice/Grammar.y"
+#line 1736 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as enumerator");
             auto ens = make_shared<EnumeratorListTok>(); // Dummy
             yyval = ens;
         }
-#line 3558 "src/Slice/Grammar.cpp"
+#line 3559 "src/Slice/Grammar.cpp"
         break;
 
         case 138: /* enumerator: %empty  */
-#line 1742 "src/Slice/Grammar.y"
+#line 1743 "src/Slice/Grammar.y"
         {
             auto ens = make_shared<EnumeratorListTok>();
             yyval = ens; // Dummy
         }
-#line 3567 "src/Slice/Grammar.cpp"
+#line 3568 "src/Slice/Grammar.cpp"
         break;
 
         case 139: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
-#line 1752 "src/Slice/Grammar.y"
+#line 1753 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3575 "src/Slice/Grammar.cpp"
+#line 3576 "src/Slice/Grammar.cpp"
         break;
 
         case 140: /* enumerator_initializer: scoped_name  */
-#line 1756 "src/Slice/Grammar.y"
+#line 1757 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v);
@@ -3486,38 +3487,38 @@ yyreduce:
 
             yyval = tok;
         }
-#line 3615 "src/Slice/Grammar.cpp"
+#line 3616 "src/Slice/Grammar.cpp"
         break;
 
         case 141: /* out_qualifier: ICE_OUT  */
-#line 1797 "src/Slice/Grammar.y"
+#line 1798 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = true;
             yyval = out;
         }
-#line 3625 "src/Slice/Grammar.cpp"
+#line 3626 "src/Slice/Grammar.cpp"
         break;
 
         case 142: /* out_qualifier: %empty  */
-#line 1803 "src/Slice/Grammar.y"
+#line 1804 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = false;
             yyval = out;
         }
-#line 3635 "src/Slice/Grammar.cpp"
+#line 3636 "src/Slice/Grammar.cpp"
         break;
 
         case 143: /* parameters: %empty  */
-#line 1814 "src/Slice/Grammar.y"
+#line 1815 "src/Slice/Grammar.y"
         {
         }
-#line 3642 "src/Slice/Grammar.cpp"
+#line 3643 "src/Slice/Grammar.cpp"
         break;
 
         case 144: /* parameters: out_qualifier meta_data tagged_type_id  */
-#line 1817 "src/Slice/Grammar.y"
+#line 1818 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3533,11 +3534,11 @@ yyreduce:
                 }
             }
         }
-#line 3662 "src/Slice/Grammar.cpp"
+#line 3663 "src/Slice/Grammar.cpp"
         break;
 
         case 145: /* parameters: parameters ',' out_qualifier meta_data tagged_type_id  */
-#line 1833 "src/Slice/Grammar.y"
+#line 1834 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3553,11 +3554,11 @@ yyreduce:
                 }
             }
         }
-#line 3682 "src/Slice/Grammar.cpp"
+#line 3683 "src/Slice/Grammar.cpp"
         break;
 
         case 146: /* parameters: out_qualifier meta_data type keyword  */
-#line 1849 "src/Slice/Grammar.y"
+#line 1850 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3569,11 +3570,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3698 "src/Slice/Grammar.cpp"
+#line 3699 "src/Slice/Grammar.cpp"
         break;
 
         case 147: /* parameters: parameters ',' out_qualifier meta_data type keyword  */
-#line 1861 "src/Slice/Grammar.y"
+#line 1862 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3585,11 +3586,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3714 "src/Slice/Grammar.cpp"
+#line 3715 "src/Slice/Grammar.cpp"
         break;
 
         case 148: /* parameters: out_qualifier meta_data type  */
-#line 1873 "src/Slice/Grammar.y"
+#line 1874 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3600,11 +3601,11 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3729 "src/Slice/Grammar.cpp"
+#line 3730 "src/Slice/Grammar.cpp"
         break;
 
         case 149: /* parameters: parameters ',' out_qualifier meta_data type  */
-#line 1884 "src/Slice/Grammar.y"
+#line 1885 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3615,128 +3616,128 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3744 "src/Slice/Grammar.cpp"
+#line 3745 "src/Slice/Grammar.cpp"
         break;
 
         case 150: /* throws: ICE_THROWS exception_list  */
-#line 1900 "src/Slice/Grammar.y"
+#line 1901 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3752 "src/Slice/Grammar.cpp"
+#line 3753 "src/Slice/Grammar.cpp"
         break;
 
         case 151: /* throws: %empty  */
-#line 1904 "src/Slice/Grammar.y"
+#line 1905 "src/Slice/Grammar.y"
         {
             yyval = make_shared<ExceptionListTok>();
         }
-#line 3760 "src/Slice/Grammar.cpp"
+#line 3761 "src/Slice/Grammar.cpp"
         break;
 
         case 152: /* scoped_name: ICE_IDENTIFIER  */
-#line 1913 "src/Slice/Grammar.y"
+#line 1914 "src/Slice/Grammar.y"
         {
         }
-#line 3767 "src/Slice/Grammar.cpp"
+#line 3768 "src/Slice/Grammar.cpp"
         break;
 
         case 153: /* scoped_name: ICE_SCOPED_IDENTIFIER  */
-#line 1916 "src/Slice/Grammar.y"
+#line 1917 "src/Slice/Grammar.y"
         {
         }
-#line 3774 "src/Slice/Grammar.cpp"
+#line 3775 "src/Slice/Grammar.cpp"
         break;
 
         case 154: /* builtin: ICE_BOOL  */
-#line 1923 "src/Slice/Grammar.y"
-        {
-        }
-#line 3780 "src/Slice/Grammar.cpp"
-        break;
-
-        case 155: /* builtin: ICE_BYTE  */
 #line 1924 "src/Slice/Grammar.y"
         {
         }
-#line 3786 "src/Slice/Grammar.cpp"
+#line 3781 "src/Slice/Grammar.cpp"
         break;
 
-        case 156: /* builtin: ICE_SHORT  */
+        case 155: /* builtin: ICE_BYTE  */
 #line 1925 "src/Slice/Grammar.y"
         {
         }
-#line 3792 "src/Slice/Grammar.cpp"
+#line 3787 "src/Slice/Grammar.cpp"
         break;
 
-        case 157: /* builtin: ICE_INT  */
+        case 156: /* builtin: ICE_SHORT  */
 #line 1926 "src/Slice/Grammar.y"
         {
         }
-#line 3798 "src/Slice/Grammar.cpp"
+#line 3793 "src/Slice/Grammar.cpp"
         break;
 
-        case 158: /* builtin: ICE_LONG  */
+        case 157: /* builtin: ICE_INT  */
 #line 1927 "src/Slice/Grammar.y"
         {
         }
-#line 3804 "src/Slice/Grammar.cpp"
+#line 3799 "src/Slice/Grammar.cpp"
         break;
 
-        case 159: /* builtin: ICE_FLOAT  */
+        case 158: /* builtin: ICE_LONG  */
 #line 1928 "src/Slice/Grammar.y"
         {
         }
-#line 3810 "src/Slice/Grammar.cpp"
+#line 3805 "src/Slice/Grammar.cpp"
         break;
 
-        case 160: /* builtin: ICE_DOUBLE  */
+        case 159: /* builtin: ICE_FLOAT  */
 #line 1929 "src/Slice/Grammar.y"
         {
         }
-#line 3816 "src/Slice/Grammar.cpp"
+#line 3811 "src/Slice/Grammar.cpp"
         break;
 
-        case 161: /* builtin: ICE_STRING  */
+        case 160: /* builtin: ICE_DOUBLE  */
 #line 1930 "src/Slice/Grammar.y"
         {
         }
-#line 3822 "src/Slice/Grammar.cpp"
+#line 3817 "src/Slice/Grammar.cpp"
         break;
 
-        case 162: /* builtin: ICE_OBJECT  */
+        case 161: /* builtin: ICE_STRING  */
 #line 1931 "src/Slice/Grammar.y"
         {
         }
-#line 3828 "src/Slice/Grammar.cpp"
+#line 3823 "src/Slice/Grammar.cpp"
         break;
 
-        case 163: /* builtin: ICE_VALUE  */
+        case 162: /* builtin: ICE_OBJECT  */
 #line 1932 "src/Slice/Grammar.y"
         {
         }
-#line 3834 "src/Slice/Grammar.cpp"
+#line 3829 "src/Slice/Grammar.cpp"
+        break;
+
+        case 163: /* builtin: ICE_VALUE  */
+#line 1933 "src/Slice/Grammar.y"
+        {
+        }
+#line 3835 "src/Slice/Grammar.cpp"
         break;
 
         case 164: /* type: ICE_OBJECT '*'  */
-#line 1938 "src/Slice/Grammar.y"
+#line 1939 "src/Slice/Grammar.y"
         {
             yyval = currentUnit->builtin(Builtin::KindObjectProxy);
         }
-#line 3842 "src/Slice/Grammar.cpp"
+#line 3843 "src/Slice/Grammar.cpp"
         break;
 
         case 165: /* type: builtin  */
-#line 1942 "src/Slice/Grammar.y"
+#line 1943 "src/Slice/Grammar.y"
         {
             auto typeName = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             yyval = currentUnit->builtin(Builtin::kindFromString(typeName->v).value());
         }
-#line 3851 "src/Slice/Grammar.cpp"
+#line 3852 "src/Slice/Grammar.cpp"
         break;
 
         case 166: /* type: scoped_name  */
-#line 1947 "src/Slice/Grammar.y"
+#line 1948 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3767,11 +3768,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3886 "src/Slice/Grammar.cpp"
+#line 3887 "src/Slice/Grammar.cpp"
         break;
 
         case 167: /* type: scoped_name '*'  */
-#line 1978 "src/Slice/Grammar.y"
+#line 1979 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3802,50 +3803,50 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3921 "src/Slice/Grammar.cpp"
+#line 3922 "src/Slice/Grammar.cpp"
         break;
 
         case 168: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2014 "src/Slice/Grammar.y"
+#line 2015 "src/Slice/Grammar.y"
         {
             auto str1 = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             auto str2 = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             str1->v += str2->v;
         }
-#line 3931 "src/Slice/Grammar.cpp"
+#line 3932 "src/Slice/Grammar.cpp"
         break;
 
         case 169: /* string_literal: ICE_STRING_LITERAL  */
-#line 2020 "src/Slice/Grammar.y"
+#line 2021 "src/Slice/Grammar.y"
         {
         }
-#line 3938 "src/Slice/Grammar.cpp"
+#line 3939 "src/Slice/Grammar.cpp"
         break;
 
         case 170: /* string_list: string_list ',' string_literal  */
-#line 2028 "src/Slice/Grammar.y"
+#line 2029 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = dynamic_pointer_cast<StringListTok>(yyvsp[-2]);
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3949 "src/Slice/Grammar.cpp"
+#line 3950 "src/Slice/Grammar.cpp"
         break;
 
         case 171: /* string_list: string_literal  */
-#line 2035 "src/Slice/Grammar.y"
+#line 2036 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = make_shared<StringListTok>();
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3960 "src/Slice/Grammar.cpp"
+#line 3961 "src/Slice/Grammar.cpp"
         break;
 
         case 172: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2047 "src/Slice/Grammar.y"
+#line 2048 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindLong);
             auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
@@ -3854,11 +3855,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), intVal->literal);
             yyval = def;
         }
-#line 3973 "src/Slice/Grammar.cpp"
+#line 3974 "src/Slice/Grammar.cpp"
         break;
 
         case 173: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2056 "src/Slice/Grammar.y"
+#line 2057 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindDouble);
             auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
@@ -3867,11 +3868,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), floatVal->literal);
             yyval = def;
         }
-#line 3986 "src/Slice/Grammar.cpp"
+#line 3987 "src/Slice/Grammar.cpp"
         break;
 
         case 174: /* const_initializer: scoped_name  */
-#line 2065 "src/Slice/Grammar.y"
+#line 2066 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ConstDefTokPtr def;
@@ -3906,44 +3907,44 @@ yyreduce:
             }
             yyval = def;
         }
-#line 4025 "src/Slice/Grammar.cpp"
+#line 4026 "src/Slice/Grammar.cpp"
         break;
 
         case 175: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2100 "src/Slice/Grammar.y"
+#line 2101 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindString);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
             yyval = def;
         }
-#line 4036 "src/Slice/Grammar.cpp"
+#line 4037 "src/Slice/Grammar.cpp"
         break;
 
         case 176: /* const_initializer: ICE_FALSE  */
-#line 2107 "src/Slice/Grammar.y"
+#line 2108 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "false", "false");
             yyval = def;
         }
-#line 4047 "src/Slice/Grammar.cpp"
+#line 4048 "src/Slice/Grammar.cpp"
         break;
 
         case 177: /* const_initializer: ICE_TRUE  */
-#line 2114 "src/Slice/Grammar.y"
+#line 2115 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "true", "true");
             yyval = def;
         }
-#line 4058 "src/Slice/Grammar.cpp"
+#line 4059 "src/Slice/Grammar.cpp"
         break;
 
         case 178: /* const_def: ICE_CONST meta_data type ICE_IDENTIFIER '=' const_initializer  */
-#line 2126 "src/Slice/Grammar.y"
+#line 2127 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-4]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
@@ -3957,11 +3958,11 @@ yyreduce:
                 value->valueAsString,
                 value->valueAsLiteral);
         }
-#line 4071 "src/Slice/Grammar.cpp"
+#line 4072 "src/Slice/Grammar.cpp"
         break;
 
         case 179: /* const_def: ICE_CONST meta_data type '=' const_initializer  */
-#line 2135 "src/Slice/Grammar.y"
+#line 2136 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
@@ -3976,206 +3977,206 @@ yyreduce:
                 value->valueAsLiteral,
                 Dummy); // Dummy
         }
-#line 4084 "src/Slice/Grammar.cpp"
+#line 4085 "src/Slice/Grammar.cpp"
         break;
 
         case 180: /* keyword: ICE_MODULE  */
-#line 2148 "src/Slice/Grammar.y"
-        {
-        }
-#line 4090 "src/Slice/Grammar.cpp"
-        break;
-
-        case 181: /* keyword: ICE_CLASS  */
 #line 2149 "src/Slice/Grammar.y"
         {
         }
-#line 4096 "src/Slice/Grammar.cpp"
+#line 4091 "src/Slice/Grammar.cpp"
         break;
 
-        case 182: /* keyword: ICE_INTERFACE  */
+        case 181: /* keyword: ICE_CLASS  */
 #line 2150 "src/Slice/Grammar.y"
         {
         }
-#line 4102 "src/Slice/Grammar.cpp"
+#line 4097 "src/Slice/Grammar.cpp"
         break;
 
-        case 183: /* keyword: ICE_EXCEPTION  */
+        case 182: /* keyword: ICE_INTERFACE  */
 #line 2151 "src/Slice/Grammar.y"
         {
         }
-#line 4108 "src/Slice/Grammar.cpp"
+#line 4103 "src/Slice/Grammar.cpp"
         break;
 
-        case 184: /* keyword: ICE_STRUCT  */
+        case 183: /* keyword: ICE_EXCEPTION  */
 #line 2152 "src/Slice/Grammar.y"
         {
         }
-#line 4114 "src/Slice/Grammar.cpp"
+#line 4109 "src/Slice/Grammar.cpp"
         break;
 
-        case 185: /* keyword: ICE_SEQUENCE  */
+        case 184: /* keyword: ICE_STRUCT  */
 #line 2153 "src/Slice/Grammar.y"
         {
         }
-#line 4120 "src/Slice/Grammar.cpp"
+#line 4115 "src/Slice/Grammar.cpp"
         break;
 
-        case 186: /* keyword: ICE_DICTIONARY  */
+        case 185: /* keyword: ICE_SEQUENCE  */
 #line 2154 "src/Slice/Grammar.y"
         {
         }
-#line 4126 "src/Slice/Grammar.cpp"
+#line 4121 "src/Slice/Grammar.cpp"
         break;
 
-        case 187: /* keyword: ICE_ENUM  */
+        case 186: /* keyword: ICE_DICTIONARY  */
 #line 2155 "src/Slice/Grammar.y"
         {
         }
-#line 4132 "src/Slice/Grammar.cpp"
+#line 4127 "src/Slice/Grammar.cpp"
         break;
 
-        case 188: /* keyword: ICE_OUT  */
+        case 187: /* keyword: ICE_ENUM  */
 #line 2156 "src/Slice/Grammar.y"
         {
         }
-#line 4138 "src/Slice/Grammar.cpp"
+#line 4133 "src/Slice/Grammar.cpp"
         break;
 
-        case 189: /* keyword: ICE_EXTENDS  */
+        case 188: /* keyword: ICE_OUT  */
 #line 2157 "src/Slice/Grammar.y"
         {
         }
-#line 4144 "src/Slice/Grammar.cpp"
+#line 4139 "src/Slice/Grammar.cpp"
         break;
 
-        case 190: /* keyword: ICE_THROWS  */
+        case 189: /* keyword: ICE_EXTENDS  */
 #line 2158 "src/Slice/Grammar.y"
         {
         }
-#line 4150 "src/Slice/Grammar.cpp"
+#line 4145 "src/Slice/Grammar.cpp"
         break;
 
-        case 191: /* keyword: ICE_VOID  */
+        case 190: /* keyword: ICE_THROWS  */
 #line 2159 "src/Slice/Grammar.y"
         {
         }
-#line 4156 "src/Slice/Grammar.cpp"
+#line 4151 "src/Slice/Grammar.cpp"
         break;
 
-        case 192: /* keyword: ICE_BOOL  */
+        case 191: /* keyword: ICE_VOID  */
 #line 2160 "src/Slice/Grammar.y"
         {
         }
-#line 4162 "src/Slice/Grammar.cpp"
+#line 4157 "src/Slice/Grammar.cpp"
         break;
 
-        case 193: /* keyword: ICE_BYTE  */
+        case 192: /* keyword: ICE_BOOL  */
 #line 2161 "src/Slice/Grammar.y"
         {
         }
-#line 4168 "src/Slice/Grammar.cpp"
+#line 4163 "src/Slice/Grammar.cpp"
         break;
 
-        case 194: /* keyword: ICE_SHORT  */
+        case 193: /* keyword: ICE_BYTE  */
 #line 2162 "src/Slice/Grammar.y"
         {
         }
-#line 4174 "src/Slice/Grammar.cpp"
+#line 4169 "src/Slice/Grammar.cpp"
         break;
 
-        case 195: /* keyword: ICE_INT  */
+        case 194: /* keyword: ICE_SHORT  */
 #line 2163 "src/Slice/Grammar.y"
         {
         }
-#line 4180 "src/Slice/Grammar.cpp"
+#line 4175 "src/Slice/Grammar.cpp"
         break;
 
-        case 196: /* keyword: ICE_LONG  */
+        case 195: /* keyword: ICE_INT  */
 #line 2164 "src/Slice/Grammar.y"
         {
         }
-#line 4186 "src/Slice/Grammar.cpp"
+#line 4181 "src/Slice/Grammar.cpp"
         break;
 
-        case 197: /* keyword: ICE_FLOAT  */
+        case 196: /* keyword: ICE_LONG  */
 #line 2165 "src/Slice/Grammar.y"
         {
         }
-#line 4192 "src/Slice/Grammar.cpp"
+#line 4187 "src/Slice/Grammar.cpp"
         break;
 
-        case 198: /* keyword: ICE_DOUBLE  */
+        case 197: /* keyword: ICE_FLOAT  */
 #line 2166 "src/Slice/Grammar.y"
         {
         }
-#line 4198 "src/Slice/Grammar.cpp"
+#line 4193 "src/Slice/Grammar.cpp"
         break;
 
-        case 199: /* keyword: ICE_STRING  */
+        case 198: /* keyword: ICE_DOUBLE  */
 #line 2167 "src/Slice/Grammar.y"
         {
         }
-#line 4204 "src/Slice/Grammar.cpp"
+#line 4199 "src/Slice/Grammar.cpp"
         break;
 
-        case 200: /* keyword: ICE_OBJECT  */
+        case 199: /* keyword: ICE_STRING  */
 #line 2168 "src/Slice/Grammar.y"
         {
         }
-#line 4210 "src/Slice/Grammar.cpp"
+#line 4205 "src/Slice/Grammar.cpp"
         break;
 
-        case 201: /* keyword: ICE_CONST  */
+        case 200: /* keyword: ICE_OBJECT  */
 #line 2169 "src/Slice/Grammar.y"
         {
         }
-#line 4216 "src/Slice/Grammar.cpp"
+#line 4211 "src/Slice/Grammar.cpp"
         break;
 
-        case 202: /* keyword: ICE_FALSE  */
+        case 201: /* keyword: ICE_CONST  */
 #line 2170 "src/Slice/Grammar.y"
         {
         }
-#line 4222 "src/Slice/Grammar.cpp"
+#line 4217 "src/Slice/Grammar.cpp"
         break;
 
-        case 203: /* keyword: ICE_TRUE  */
+        case 202: /* keyword: ICE_FALSE  */
 #line 2171 "src/Slice/Grammar.y"
         {
         }
-#line 4228 "src/Slice/Grammar.cpp"
+#line 4223 "src/Slice/Grammar.cpp"
         break;
 
-        case 204: /* keyword: ICE_IDEMPOTENT  */
+        case 203: /* keyword: ICE_TRUE  */
 #line 2172 "src/Slice/Grammar.y"
         {
         }
-#line 4234 "src/Slice/Grammar.cpp"
+#line 4229 "src/Slice/Grammar.cpp"
         break;
 
-        case 205: /* keyword: ICE_TAG  */
+        case 204: /* keyword: ICE_IDEMPOTENT  */
 #line 2173 "src/Slice/Grammar.y"
         {
         }
-#line 4240 "src/Slice/Grammar.cpp"
+#line 4235 "src/Slice/Grammar.cpp"
         break;
 
-        case 206: /* keyword: ICE_OPTIONAL  */
+        case 205: /* keyword: ICE_TAG  */
 #line 2174 "src/Slice/Grammar.y"
         {
         }
-#line 4246 "src/Slice/Grammar.cpp"
+#line 4241 "src/Slice/Grammar.cpp"
         break;
 
-        case 207: /* keyword: ICE_VALUE  */
+        case 206: /* keyword: ICE_OPTIONAL  */
 #line 2175 "src/Slice/Grammar.y"
         {
         }
-#line 4252 "src/Slice/Grammar.cpp"
+#line 4247 "src/Slice/Grammar.cpp"
         break;
 
-#line 4256 "src/Slice/Grammar.cpp"
+        case 207: /* keyword: ICE_VALUE  */
+#line 2176 "src/Slice/Grammar.y"
+        {
+        }
+#line 4253 "src/Slice/Grammar.cpp"
+        break;
+
+#line 4257 "src/Slice/Grammar.cpp"
 
         default:
             break;
@@ -4361,4 +4362,4 @@ yyreturnlab:
     return yyresult;
 }
 
-#line 2178 "src/Slice/Grammar.y"
+#line 2179 "src/Slice/Grammar.y"

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -120,12 +120,6 @@
 #include <limits>
 
 #ifdef _MSC_VER
-// warning C4102: 'yyoverflowlab' : unreferenced label
-#    pragma warning(disable : 4102)
-// warning C4065: switch statement contains 'default' but no 'case' labels
-#    pragma warning(disable : 4065)
-// warning C4244: '=': conversion from 'int' to 'yytype_int16', possible loss of data
-#    pragma warning(disable : 4244)
 // warning C4127: conditional expression is constant
 #    pragma warning(disable : 4127)
 #endif
@@ -164,7 +158,7 @@ slice_error(const char* s)
     }
 }
 
-#line 173 "src/Slice/Grammar.cpp"
+#line 167 "src/Slice/Grammar.cpp"
 
 #ifndef YY_CAST
 #    ifdef __cplusplus
@@ -336,7 +330,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 // This must match the definition of 'yylex' (or 'slice_lex') in the generated scanner.
 int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 
-#line 349 "src/Slice/Grammar.cpp"
+#line 343 "src/Slice/Grammar.cpp"
 
 #ifdef short
 #    undef short
@@ -684,17 +678,17 @@ static const yytype_int8 yytranslate[] = {
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
-    0,    184,  184,  192,  195,  203,  207,  217,  221,  230,  238,  247,  256,  255,  261,  260,  265,  270,  269,
-    275,  274,  279,  284,  283,  289,  288,  293,  298,  297,  303,  302,  307,  312,  311,  317,  316,  321,  326,
-    325,  330,  335,  334,  340,  339,  344,  348,  358,  357,  390,  394,  405,  416,  415,  441,  449,  458,  471,
-    489,  568,  574,  585,  603,  681,  687,  698,  707,  716,  729,  733,  744,  755,  754,  793,  797,  808,  833,
-    923,  935,  948,  947,  981,  1015, 1024, 1027, 1035, 1044, 1047, 1051, 1059, 1089, 1123, 1145, 1171, 1177, 1183,
-    1189, 1199, 1223, 1253, 1277, 1312, 1311, 1334, 1333, 1356, 1360, 1371, 1385, 1384, 1418, 1453, 1488, 1493, 1503,
-    1507, 1516, 1525, 1528, 1532, 1540, 1547, 1559, 1571, 1582, 1590, 1604, 1614, 1630, 1634, 1646, 1645, 1677, 1676,
-    1694, 1700, 1708, 1720, 1740, 1747, 1757, 1761, 1802, 1808, 1819, 1822, 1838, 1854, 1866, 1878, 1889, 1905, 1909,
-    1918, 1921, 1929, 1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1943, 1947, 1952, 1983, 2019, 2025, 2033,
-    2040, 2052, 2061, 2070, 2105, 2112, 2119, 2131, 2140, 2154, 2155, 2156, 2157, 2158, 2159, 2160, 2161, 2162, 2163,
-    2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175, 2176, 2177, 2178, 2179, 2180, 2181};
+    0,    178,  178,  186,  189,  197,  201,  211,  215,  224,  232,  241,  250,  249,  255,  254,  259,  264,  263,
+    269,  268,  273,  278,  277,  283,  282,  287,  292,  291,  297,  296,  301,  306,  305,  311,  310,  315,  320,
+    319,  324,  329,  328,  334,  333,  338,  342,  352,  351,  384,  388,  399,  410,  409,  435,  443,  452,  465,
+    483,  562,  568,  579,  597,  675,  681,  692,  701,  710,  723,  727,  738,  749,  748,  787,  791,  802,  827,
+    917,  929,  942,  941,  975,  1009, 1018, 1021, 1029, 1038, 1041, 1045, 1053, 1083, 1117, 1139, 1165, 1171, 1177,
+    1183, 1193, 1217, 1247, 1271, 1306, 1305, 1328, 1327, 1350, 1354, 1365, 1379, 1378, 1412, 1447, 1482, 1487, 1497,
+    1501, 1510, 1519, 1522, 1526, 1534, 1541, 1553, 1565, 1576, 1584, 1598, 1608, 1624, 1628, 1640, 1639, 1671, 1670,
+    1688, 1694, 1702, 1714, 1734, 1741, 1751, 1755, 1796, 1802, 1813, 1816, 1832, 1848, 1860, 1872, 1883, 1899, 1903,
+    1912, 1915, 1923, 1924, 1925, 1926, 1927, 1928, 1929, 1930, 1931, 1932, 1937, 1941, 1946, 1977, 2013, 2019, 2027,
+    2034, 2046, 2055, 2064, 2099, 2106, 2113, 2125, 2134, 2148, 2149, 2150, 2151, 2152, 2153, 2154, 2155, 2156, 2157,
+    2158, 2159, 2160, 2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -1583,61 +1577,61 @@ yyreduce:
     switch (yyn)
     {
         case 2: /* start: definitions  */
-#line 185 "src/Slice/Grammar.y"
+#line 179 "src/Slice/Grammar.y"
         {
         }
-#line 1740 "src/Slice/Grammar.cpp"
+#line 1734 "src/Slice/Grammar.cpp"
         break;
 
         case 3: /* opt_semicolon: ';'  */
-#line 193 "src/Slice/Grammar.y"
+#line 187 "src/Slice/Grammar.y"
         {
         }
-#line 1747 "src/Slice/Grammar.cpp"
+#line 1741 "src/Slice/Grammar.cpp"
         break;
 
         case 4: /* opt_semicolon: %empty  */
-#line 196 "src/Slice/Grammar.y"
+#line 190 "src/Slice/Grammar.y"
         {
         }
-#line 1754 "src/Slice/Grammar.cpp"
+#line 1748 "src/Slice/Grammar.cpp"
         break;
 
         case 5: /* global_meta_data: ICE_GLOBAL_METADATA_OPEN string_list ICE_GLOBAL_METADATA_CLOSE  */
-#line 204 "src/Slice/Grammar.y"
+#line 198 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[-1];
         }
-#line 1762 "src/Slice/Grammar.cpp"
+#line 1756 "src/Slice/Grammar.cpp"
         break;
 
         case 6: /* global_meta_data: ICE_GLOBAL_METADATA_IGNORE string_list ICE_GLOBAL_METADATA_CLOSE  */
-#line 208 "src/Slice/Grammar.y"
+#line 202 "src/Slice/Grammar.y"
         {
             currentUnit->error("global metadata must appear before any definitions");
             yyval = yyvsp[-1]; // Dummy
         }
-#line 1771 "src/Slice/Grammar.cpp"
+#line 1765 "src/Slice/Grammar.cpp"
         break;
 
         case 7: /* meta_data: ICE_METADATA_OPEN string_list ICE_METADATA_CLOSE  */
-#line 218 "src/Slice/Grammar.y"
+#line 212 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[-1];
         }
-#line 1779 "src/Slice/Grammar.cpp"
+#line 1773 "src/Slice/Grammar.cpp"
         break;
 
         case 8: /* meta_data: %empty  */
-#line 222 "src/Slice/Grammar.y"
+#line 216 "src/Slice/Grammar.y"
         {
             yyval = make_shared<StringListTok>();
         }
-#line 1787 "src/Slice/Grammar.cpp"
+#line 1781 "src/Slice/Grammar.cpp"
         break;
 
         case 9: /* definitions: definitions global_meta_data  */
-#line 231 "src/Slice/Grammar.y"
+#line 225 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[0]);
             if (!metaData->v.empty())
@@ -1645,11 +1639,11 @@ yyreduce:
                 currentUnit->addGlobalMetaData(metaData->v);
             }
         }
-#line 1799 "src/Slice/Grammar.cpp"
+#line 1793 "src/Slice/Grammar.cpp"
         break;
 
         case 10: /* definitions: definitions meta_data definition  */
-#line 239 "src/Slice/Grammar.y"
+#line 233 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
@@ -1658,186 +1652,186 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 1812 "src/Slice/Grammar.cpp"
+#line 1806 "src/Slice/Grammar.cpp"
         break;
 
         case 11: /* definitions: %empty  */
-#line 248 "src/Slice/Grammar.y"
+#line 242 "src/Slice/Grammar.y"
         {
         }
-#line 1819 "src/Slice/Grammar.cpp"
+#line 1813 "src/Slice/Grammar.cpp"
         break;
 
         case 12: /* $@1: %empty  */
-#line 256 "src/Slice/Grammar.y"
+#line 250 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Module>(yyvsp[0]));
         }
-#line 1827 "src/Slice/Grammar.cpp"
+#line 1821 "src/Slice/Grammar.cpp"
         break;
 
         case 14: /* $@2: %empty  */
-#line 261 "src/Slice/Grammar.y"
+#line 255 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<ClassDecl>(yyvsp[0]));
         }
-#line 1835 "src/Slice/Grammar.cpp"
+#line 1829 "src/Slice/Grammar.cpp"
         break;
 
         case 16: /* definition: class_decl  */
-#line 266 "src/Slice/Grammar.y"
+#line 260 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after class forward declaration");
         }
-#line 1843 "src/Slice/Grammar.cpp"
+#line 1837 "src/Slice/Grammar.cpp"
         break;
 
         case 17: /* $@3: %empty  */
-#line 270 "src/Slice/Grammar.y"
+#line 264 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<ClassDef>(yyvsp[0]));
         }
-#line 1851 "src/Slice/Grammar.cpp"
+#line 1845 "src/Slice/Grammar.cpp"
         break;
 
         case 19: /* $@4: %empty  */
-#line 275 "src/Slice/Grammar.y"
+#line 269 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<InterfaceDecl>(yyvsp[0]));
         }
-#line 1859 "src/Slice/Grammar.cpp"
+#line 1853 "src/Slice/Grammar.cpp"
         break;
 
         case 21: /* definition: interface_decl  */
-#line 280 "src/Slice/Grammar.y"
+#line 274 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after interface forward declaration");
         }
-#line 1867 "src/Slice/Grammar.cpp"
+#line 1861 "src/Slice/Grammar.cpp"
         break;
 
         case 22: /* $@5: %empty  */
-#line 284 "src/Slice/Grammar.y"
+#line 278 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<InterfaceDef>(yyvsp[0]));
         }
-#line 1875 "src/Slice/Grammar.cpp"
+#line 1869 "src/Slice/Grammar.cpp"
         break;
 
         case 24: /* $@6: %empty  */
-#line 289 "src/Slice/Grammar.y"
+#line 283 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr);
         }
-#line 1883 "src/Slice/Grammar.cpp"
+#line 1877 "src/Slice/Grammar.cpp"
         break;
 
         case 26: /* definition: exception_decl  */
-#line 294 "src/Slice/Grammar.y"
+#line 288 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after exception forward declaration");
         }
-#line 1891 "src/Slice/Grammar.cpp"
+#line 1885 "src/Slice/Grammar.cpp"
         break;
 
         case 27: /* $@7: %empty  */
-#line 298 "src/Slice/Grammar.y"
+#line 292 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Exception>(yyvsp[0]));
         }
-#line 1899 "src/Slice/Grammar.cpp"
+#line 1893 "src/Slice/Grammar.cpp"
         break;
 
         case 29: /* $@8: %empty  */
-#line 303 "src/Slice/Grammar.y"
+#line 297 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr);
         }
-#line 1907 "src/Slice/Grammar.cpp"
+#line 1901 "src/Slice/Grammar.cpp"
         break;
 
         case 31: /* definition: struct_decl  */
-#line 308 "src/Slice/Grammar.y"
+#line 302 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after struct forward declaration");
         }
-#line 1915 "src/Slice/Grammar.cpp"
+#line 1909 "src/Slice/Grammar.cpp"
         break;
 
         case 32: /* $@9: %empty  */
-#line 312 "src/Slice/Grammar.y"
+#line 306 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Struct>(yyvsp[0]));
         }
-#line 1923 "src/Slice/Grammar.cpp"
+#line 1917 "src/Slice/Grammar.cpp"
         break;
 
         case 34: /* $@10: %empty  */
-#line 317 "src/Slice/Grammar.y"
+#line 311 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Sequence>(yyvsp[0]));
         }
-#line 1931 "src/Slice/Grammar.cpp"
+#line 1925 "src/Slice/Grammar.cpp"
         break;
 
         case 36: /* definition: sequence_def  */
-#line 322 "src/Slice/Grammar.y"
+#line 316 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after sequence definition");
         }
-#line 1939 "src/Slice/Grammar.cpp"
+#line 1933 "src/Slice/Grammar.cpp"
         break;
 
         case 37: /* $@11: %empty  */
-#line 326 "src/Slice/Grammar.y"
+#line 320 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Dictionary>(yyvsp[0]));
         }
-#line 1947 "src/Slice/Grammar.cpp"
+#line 1941 "src/Slice/Grammar.cpp"
         break;
 
         case 39: /* definition: dictionary_def  */
-#line 331 "src/Slice/Grammar.y"
+#line 325 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after dictionary definition");
         }
-#line 1955 "src/Slice/Grammar.cpp"
+#line 1949 "src/Slice/Grammar.cpp"
         break;
 
         case 40: /* $@12: %empty  */
-#line 335 "src/Slice/Grammar.y"
+#line 329 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Enum>(yyvsp[0]));
         }
-#line 1963 "src/Slice/Grammar.cpp"
+#line 1957 "src/Slice/Grammar.cpp"
         break;
 
         case 42: /* $@13: %empty  */
-#line 340 "src/Slice/Grammar.y"
+#line 334 "src/Slice/Grammar.y"
         {
             assert(yyvsp[0] == nullptr || dynamic_pointer_cast<Const>(yyvsp[0]));
         }
-#line 1971 "src/Slice/Grammar.cpp"
+#line 1965 "src/Slice/Grammar.cpp"
         break;
 
         case 44: /* definition: const_def  */
-#line 345 "src/Slice/Grammar.y"
+#line 339 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after const definition");
         }
-#line 1979 "src/Slice/Grammar.cpp"
+#line 1973 "src/Slice/Grammar.cpp"
         break;
 
         case 45: /* definition: error ';'  */
-#line 349 "src/Slice/Grammar.y"
+#line 343 "src/Slice/Grammar.y"
         {
             yyerrok;
         }
-#line 1987 "src/Slice/Grammar.cpp"
+#line 1981 "src/Slice/Grammar.cpp"
         break;
 
         case 46: /* @14: %empty  */
-#line 358 "src/Slice/Grammar.y"
+#line 352 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -1853,11 +1847,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2007 "src/Slice/Grammar.cpp"
+#line 2001 "src/Slice/Grammar.cpp"
         break;
 
         case 47: /* module_def: ICE_MODULE ICE_IDENTIFIER @14 '{' definitions '}'  */
-#line 374 "src/Slice/Grammar.y"
+#line 368 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -1869,38 +1863,38 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2023 "src/Slice/Grammar.cpp"
+#line 2017 "src/Slice/Grammar.cpp"
         break;
 
         case 48: /* exception_id: ICE_EXCEPTION ICE_IDENTIFIER  */
-#line 391 "src/Slice/Grammar.y"
+#line 385 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2031 "src/Slice/Grammar.cpp"
+#line 2025 "src/Slice/Grammar.cpp"
         break;
 
         case 49: /* exception_id: ICE_EXCEPTION keyword  */
-#line 395 "src/Slice/Grammar.y"
+#line 389 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as exception name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2041 "src/Slice/Grammar.cpp"
+#line 2035 "src/Slice/Grammar.cpp"
         break;
 
         case 50: /* exception_decl: exception_id  */
-#line 406 "src/Slice/Grammar.y"
+#line 400 "src/Slice/Grammar.y"
         {
             currentUnit->error("exceptions cannot be forward declared");
             yyval = nullptr;
         }
-#line 2050 "src/Slice/Grammar.cpp"
+#line 2044 "src/Slice/Grammar.cpp"
         break;
 
         case 51: /* @15: %empty  */
-#line 416 "src/Slice/Grammar.y"
+#line 410 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             auto base = dynamic_pointer_cast<Exception>(yyvsp[0]);
@@ -1913,11 +1907,11 @@ yyreduce:
             }
             yyval = ex;
         }
-#line 2067 "src/Slice/Grammar.cpp"
+#line 2061 "src/Slice/Grammar.cpp"
         break;
 
         case 52: /* exception_def: exception_id exception_extends @15 '{' data_members '}'  */
-#line 429 "src/Slice/Grammar.y"
+#line 423 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -1925,11 +1919,11 @@ yyreduce:
             }
             yyval = yyvsp[-3];
         }
-#line 2079 "src/Slice/Grammar.cpp"
+#line 2073 "src/Slice/Grammar.cpp"
         break;
 
         case 53: /* exception_extends: extends scoped_name  */
-#line 442 "src/Slice/Grammar.y"
+#line 436 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -1937,19 +1931,19 @@ yyreduce:
             cont->checkIntroduced(scoped->v);
             yyval = contained;
         }
-#line 2091 "src/Slice/Grammar.cpp"
+#line 2085 "src/Slice/Grammar.cpp"
         break;
 
         case 54: /* exception_extends: %empty  */
-#line 450 "src/Slice/Grammar.y"
+#line 444 "src/Slice/Grammar.y"
         {
             yyval = nullptr;
         }
-#line 2099 "src/Slice/Grammar.cpp"
+#line 2093 "src/Slice/Grammar.cpp"
         break;
 
         case 55: /* type_id: type ICE_IDENTIFIER  */
-#line 459 "src/Slice/Grammar.y"
+#line 453 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
@@ -1957,11 +1951,11 @@ yyreduce:
             typestring->v = make_pair(type, ident->v);
             yyval = typestring;
         }
-#line 2111 "src/Slice/Grammar.cpp"
+#line 2105 "src/Slice/Grammar.cpp"
         break;
 
         case 56: /* tag: ICE_TAG_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 472 "src/Slice/Grammar.y"
+#line 466 "src/Slice/Grammar.y"
         {
             auto i = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
 
@@ -1979,11 +1973,11 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2133 "src/Slice/Grammar.cpp"
+#line 2127 "src/Slice/Grammar.cpp"
         break;
 
         case 57: /* tag: ICE_TAG_OPEN scoped_name ')'  */
-#line 490 "src/Slice/Grammar.y"
+#line 484 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
 
@@ -2064,31 +2058,31 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2216 "src/Slice/Grammar.cpp"
+#line 2210 "src/Slice/Grammar.cpp"
         break;
 
         case 58: /* tag: ICE_TAG_OPEN ')'  */
+#line 563 "src/Slice/Grammar.y"
+        {
+            currentUnit->error("missing tag");
+            auto m = make_shared<TaggedDefTok>(-1); // Dummy
+            yyval = m;
+        }
+#line 2220 "src/Slice/Grammar.cpp"
+        break;
+
+        case 59: /* tag: ICE_TAG  */
 #line 569 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2226 "src/Slice/Grammar.cpp"
-        break;
-
-        case 59: /* tag: ICE_TAG  */
-#line 575 "src/Slice/Grammar.y"
-        {
-            currentUnit->error("missing tag");
-            auto m = make_shared<TaggedDefTok>(-1); // Dummy
-            yyval = m;
-        }
-#line 2236 "src/Slice/Grammar.cpp"
+#line 2230 "src/Slice/Grammar.cpp"
         break;
 
         case 60: /* optional: ICE_OPTIONAL_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 586 "src/Slice/Grammar.y"
+#line 580 "src/Slice/Grammar.y"
         {
             auto i = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
 
@@ -2106,11 +2100,11 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2258 "src/Slice/Grammar.cpp"
+#line 2252 "src/Slice/Grammar.cpp"
         break;
 
         case 61: /* optional: ICE_OPTIONAL_OPEN scoped_name ')'  */
-#line 604 "src/Slice/Grammar.y"
+#line 598 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2190,31 +2184,31 @@ yyreduce:
             auto m = make_shared<TaggedDefTok>(tag);
             yyval = m;
         }
-#line 2340 "src/Slice/Grammar.cpp"
+#line 2334 "src/Slice/Grammar.cpp"
         break;
 
         case 62: /* optional: ICE_OPTIONAL_OPEN ')'  */
+#line 676 "src/Slice/Grammar.y"
+        {
+            currentUnit->error("missing tag");
+            auto m = make_shared<TaggedDefTok>(-1); // Dummy
+            yyval = m;
+        }
+#line 2344 "src/Slice/Grammar.cpp"
+        break;
+
+        case 63: /* optional: ICE_OPTIONAL  */
 #line 682 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing tag");
             auto m = make_shared<TaggedDefTok>(-1); // Dummy
             yyval = m;
         }
-#line 2350 "src/Slice/Grammar.cpp"
-        break;
-
-        case 63: /* optional: ICE_OPTIONAL  */
-#line 688 "src/Slice/Grammar.y"
-        {
-            currentUnit->error("missing tag");
-            auto m = make_shared<TaggedDefTok>(-1); // Dummy
-            yyval = m;
-        }
-#line 2360 "src/Slice/Grammar.cpp"
+#line 2354 "src/Slice/Grammar.cpp"
         break;
 
         case 64: /* tagged_type_id: tag type_id  */
-#line 699 "src/Slice/Grammar.y"
+#line 693 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
@@ -2223,11 +2217,11 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2373 "src/Slice/Grammar.cpp"
+#line 2367 "src/Slice/Grammar.cpp"
         break;
 
         case 65: /* tagged_type_id: optional type_id  */
-#line 708 "src/Slice/Grammar.y"
+#line 702 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
@@ -2236,11 +2230,11 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2386 "src/Slice/Grammar.cpp"
+#line 2380 "src/Slice/Grammar.cpp"
         break;
 
         case 66: /* tagged_type_id: type_id  */
-#line 717 "src/Slice/Grammar.y"
+#line 711 "src/Slice/Grammar.y"
         {
             auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
             auto m = make_shared<TaggedDefTok>(-1);
@@ -2248,38 +2242,38 @@ yyreduce:
             m->name = ts->v.second;
             yyval = m;
         }
-#line 2398 "src/Slice/Grammar.cpp"
+#line 2392 "src/Slice/Grammar.cpp"
         break;
 
         case 67: /* struct_id: ICE_STRUCT ICE_IDENTIFIER  */
-#line 730 "src/Slice/Grammar.y"
+#line 724 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2406 "src/Slice/Grammar.cpp"
+#line 2400 "src/Slice/Grammar.cpp"
         break;
 
         case 68: /* struct_id: ICE_STRUCT keyword  */
-#line 734 "src/Slice/Grammar.y"
+#line 728 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as struct name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2416 "src/Slice/Grammar.cpp"
+#line 2410 "src/Slice/Grammar.cpp"
         break;
 
         case 69: /* struct_decl: struct_id  */
-#line 745 "src/Slice/Grammar.y"
+#line 739 "src/Slice/Grammar.y"
         {
             currentUnit->error("structs cannot be forward declared");
             yyval = nullptr; // Dummy
         }
-#line 2425 "src/Slice/Grammar.cpp"
+#line 2419 "src/Slice/Grammar.cpp"
         break;
 
         case 70: /* @16: %empty  */
-#line 755 "src/Slice/Grammar.y"
+#line 749 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2297,11 +2291,11 @@ yyreduce:
             }
             yyval = st;
         }
-#line 2447 "src/Slice/Grammar.cpp"
+#line 2441 "src/Slice/Grammar.cpp"
         break;
 
         case 71: /* struct_def: struct_id @16 '{' data_members '}'  */
-#line 773 "src/Slice/Grammar.y"
+#line 767 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -2317,29 +2311,29 @@ yyreduce:
                 currentUnit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
             }
         }
-#line 2467 "src/Slice/Grammar.cpp"
+#line 2461 "src/Slice/Grammar.cpp"
         break;
 
         case 72: /* class_name: ICE_CLASS ICE_IDENTIFIER  */
-#line 794 "src/Slice/Grammar.y"
+#line 788 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 2475 "src/Slice/Grammar.cpp"
+#line 2469 "src/Slice/Grammar.cpp"
         break;
 
         case 73: /* class_name: ICE_CLASS keyword  */
-#line 798 "src/Slice/Grammar.y"
+#line 792 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as class name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 2485 "src/Slice/Grammar.cpp"
+#line 2479 "src/Slice/Grammar.cpp"
         break;
 
         case 74: /* class_id: ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'  */
-#line 809 "src/Slice/Grammar.y"
+#line 803 "src/Slice/Grammar.y"
         {
             int64_t id = dynamic_pointer_cast<IntegerTok>(yyvsp[-1])->v;
             if (id < 0)
@@ -2364,11 +2358,11 @@ yyreduce:
             classId->t = static_cast<int>(id);
             yyval = classId;
         }
-#line 2514 "src/Slice/Grammar.cpp"
+#line 2508 "src/Slice/Grammar.cpp"
         break;
 
         case 75: /* class_id: ICE_CLASS ICE_IDENT_OPEN scoped_name ')'  */
-#line 834 "src/Slice/Grammar.y"
+#line 828 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
 
@@ -2459,33 +2453,33 @@ yyreduce:
             classId->t = id;
             yyval = classId;
         }
-#line 2608 "src/Slice/Grammar.cpp"
+#line 2602 "src/Slice/Grammar.cpp"
         break;
 
         case 76: /* class_id: class_name  */
-#line 924 "src/Slice/Grammar.y"
+#line 918 "src/Slice/Grammar.y"
         {
             auto classId = make_shared<ClassIdTok>();
             classId->v = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
             classId->t = -1;
             yyval = classId;
         }
-#line 2619 "src/Slice/Grammar.cpp"
+#line 2613 "src/Slice/Grammar.cpp"
         break;
 
         case 77: /* class_decl: class_name  */
-#line 936 "src/Slice/Grammar.y"
+#line 930 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
             ClassDeclPtr cl = cont->createClassDecl(ident->v);
             yyval = cl;
         }
-#line 2630 "src/Slice/Grammar.cpp"
+#line 2624 "src/Slice/Grammar.cpp"
         break;
 
         case 78: /* @17: %empty  */
-#line 948 "src/Slice/Grammar.y"
+#line 942 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<ClassIdTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2502,11 +2496,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2651 "src/Slice/Grammar.cpp"
+#line 2645 "src/Slice/Grammar.cpp"
         break;
 
         case 79: /* class_def: class_id class_extends @17 '{' data_members '}'  */
-#line 965 "src/Slice/Grammar.y"
+#line 959 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -2518,11 +2512,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2667 "src/Slice/Grammar.cpp"
+#line 2661 "src/Slice/Grammar.cpp"
         break;
 
         case 80: /* class_extends: extends scoped_name  */
-#line 982 "src/Slice/Grammar.y"
+#line 976 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -2556,33 +2550,33 @@ yyreduce:
                 }
             }
         }
-#line 2705 "src/Slice/Grammar.cpp"
+#line 2699 "src/Slice/Grammar.cpp"
         break;
 
         case 81: /* class_extends: %empty  */
-#line 1016 "src/Slice/Grammar.y"
+#line 1010 "src/Slice/Grammar.y"
         {
             yyval = nullptr;
         }
-#line 2713 "src/Slice/Grammar.cpp"
+#line 2707 "src/Slice/Grammar.cpp"
         break;
 
         case 82: /* extends: ICE_EXTENDS  */
-#line 1025 "src/Slice/Grammar.y"
+#line 1019 "src/Slice/Grammar.y"
         {
         }
-#line 2720 "src/Slice/Grammar.cpp"
+#line 2714 "src/Slice/Grammar.cpp"
         break;
 
         case 83: /* extends: ':'  */
-#line 1028 "src/Slice/Grammar.y"
+#line 1022 "src/Slice/Grammar.y"
         {
         }
-#line 2727 "src/Slice/Grammar.cpp"
+#line 2721 "src/Slice/Grammar.cpp"
         break;
 
         case 84: /* data_members: meta_data data_member ';' data_members  */
-#line 1036 "src/Slice/Grammar.y"
+#line 1030 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
@@ -2591,33 +2585,33 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 2740 "src/Slice/Grammar.cpp"
+#line 2734 "src/Slice/Grammar.cpp"
         break;
 
         case 85: /* data_members: error ';' data_members  */
-#line 1045 "src/Slice/Grammar.y"
+#line 1039 "src/Slice/Grammar.y"
         {
         }
-#line 2747 "src/Slice/Grammar.cpp"
+#line 2741 "src/Slice/Grammar.cpp"
         break;
 
         case 86: /* data_members: meta_data data_member  */
-#line 1048 "src/Slice/Grammar.y"
+#line 1042 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after definition");
         }
-#line 2755 "src/Slice/Grammar.cpp"
+#line 2749 "src/Slice/Grammar.cpp"
         break;
 
         case 87: /* data_members: %empty  */
-#line 1052 "src/Slice/Grammar.y"
+#line 1046 "src/Slice/Grammar.y"
         {
         }
-#line 2762 "src/Slice/Grammar.cpp"
+#line 2756 "src/Slice/Grammar.cpp"
         break;
 
         case 88: /* data_member: tagged_type_id  */
-#line 1060 "src/Slice/Grammar.y"
+#line 1054 "src/Slice/Grammar.y"
         {
             auto def = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
@@ -2647,11 +2641,11 @@ yyreduce:
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
         }
-#line 2796 "src/Slice/Grammar.cpp"
+#line 2790 "src/Slice/Grammar.cpp"
         break;
 
         case 89: /* data_member: tagged_type_id '=' const_initializer  */
-#line 1090 "src/Slice/Grammar.y"
+#line 1084 "src/Slice/Grammar.y"
         {
             auto def = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-2]);
             auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
@@ -2703,11 +2697,11 @@ yyreduce:
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
         }
-#line 2834 "src/Slice/Grammar.cpp"
+#line 2828 "src/Slice/Grammar.cpp"
         break;
 
         case 90: /* data_member: type keyword  */
-#line 1124 "src/Slice/Grammar.y"
+#line 1118 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2729,11 +2723,11 @@ yyreduce:
             assert(yyval);
             currentUnit->error("keyword `" + name + "' cannot be used as data member name");
         }
-#line 2860 "src/Slice/Grammar.cpp"
+#line 2854 "src/Slice/Grammar.cpp"
         break;
 
         case 91: /* data_member: type  */
-#line 1146 "src/Slice/Grammar.y"
+#line 1140 "src/Slice/Grammar.y"
         {
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
@@ -2754,50 +2748,50 @@ yyreduce:
             assert(yyval);
             currentUnit->error("missing data member name");
         }
-#line 2885 "src/Slice/Grammar.cpp"
+#line 2879 "src/Slice/Grammar.cpp"
         break;
 
         case 92: /* return_type: tag type  */
+#line 1166 "src/Slice/Grammar.y"
+        {
+            auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
+            m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
+            yyval = m;
+        }
+#line 2889 "src/Slice/Grammar.cpp"
+        break;
+
+        case 93: /* return_type: optional type  */
 #line 1172 "src/Slice/Grammar.y"
         {
             auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
             yyval = m;
         }
-#line 2895 "src/Slice/Grammar.cpp"
-        break;
-
-        case 93: /* return_type: optional type  */
-#line 1178 "src/Slice/Grammar.y"
-        {
-            auto m = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
-            m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
-            yyval = m;
-        }
-#line 2905 "src/Slice/Grammar.cpp"
+#line 2899 "src/Slice/Grammar.cpp"
         break;
 
         case 94: /* return_type: type  */
-#line 1184 "src/Slice/Grammar.y"
+#line 1178 "src/Slice/Grammar.y"
         {
             auto m = make_shared<TaggedDefTok>(-1);
             m->type = dynamic_pointer_cast<Type>(yyvsp[0]);
             yyval = m;
         }
-#line 2915 "src/Slice/Grammar.cpp"
+#line 2909 "src/Slice/Grammar.cpp"
         break;
 
         case 95: /* return_type: ICE_VOID  */
-#line 1190 "src/Slice/Grammar.y"
+#line 1184 "src/Slice/Grammar.y"
         {
             auto m = make_shared<TaggedDefTok>(-1);
             yyval = m;
         }
-#line 2924 "src/Slice/Grammar.cpp"
+#line 2918 "src/Slice/Grammar.cpp"
         break;
 
         case 96: /* operation_preamble: return_type ICE_IDENT_OPEN  */
-#line 1200 "src/Slice/Grammar.y"
+#line 1194 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2822,11 +2816,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2952 "src/Slice/Grammar.cpp"
+#line 2946 "src/Slice/Grammar.cpp"
         break;
 
         case 97: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_IDENT_OPEN  */
-#line 1224 "src/Slice/Grammar.y"
+#line 1218 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2856,11 +2850,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 2986 "src/Slice/Grammar.cpp"
+#line 2980 "src/Slice/Grammar.cpp"
         break;
 
         case 98: /* operation_preamble: return_type ICE_KEYWORD_OPEN  */
-#line 1254 "src/Slice/Grammar.y"
+#line 1248 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2885,11 +2879,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3014 "src/Slice/Grammar.cpp"
+#line 3008 "src/Slice/Grammar.cpp"
         break;
 
         case 99: /* operation_preamble: ICE_IDEMPOTENT return_type ICE_KEYWORD_OPEN  */
-#line 1278 "src/Slice/Grammar.y"
+#line 1272 "src/Slice/Grammar.y"
         {
             auto returnType = dynamic_pointer_cast<TaggedDefTok>(yyvsp[-1]);
             string name = dynamic_pointer_cast<StringTok>(yyvsp[0])->v;
@@ -2918,11 +2912,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3047 "src/Slice/Grammar.cpp"
+#line 3041 "src/Slice/Grammar.cpp"
         break;
 
         case 100: /* @18: %empty  */
-#line 1312 "src/Slice/Grammar.y"
+#line 1306 "src/Slice/Grammar.y"
         {
             if (yyvsp[-2])
             {
@@ -2934,11 +2928,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3063 "src/Slice/Grammar.cpp"
+#line 3057 "src/Slice/Grammar.cpp"
         break;
 
         case 101: /* operation: operation_preamble parameters ')' @18 throws  */
-#line 1324 "src/Slice/Grammar.y"
+#line 1318 "src/Slice/Grammar.y"
         {
             auto op = dynamic_pointer_cast<Operation>(yyvsp[-1]);
             auto el = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
@@ -2948,11 +2942,11 @@ yyreduce:
                 op->setExceptionList(el->v);
             }
         }
-#line 3077 "src/Slice/Grammar.cpp"
+#line 3071 "src/Slice/Grammar.cpp"
         break;
 
         case 102: /* @19: %empty  */
-#line 1334 "src/Slice/Grammar.y"
+#line 1328 "src/Slice/Grammar.y"
         {
             if (yyvsp[-2])
             {
@@ -2960,11 +2954,11 @@ yyreduce:
             }
             yyerrok;
         }
-#line 3089 "src/Slice/Grammar.cpp"
+#line 3083 "src/Slice/Grammar.cpp"
         break;
 
         case 103: /* operation: operation_preamble error ')' @19 throws  */
-#line 1342 "src/Slice/Grammar.y"
+#line 1336 "src/Slice/Grammar.y"
         {
             auto op = dynamic_pointer_cast<Operation>(yyvsp[-1]);
             auto el = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
@@ -2974,29 +2968,29 @@ yyreduce:
                 op->setExceptionList(el->v); // Dummy
             }
         }
-#line 3103 "src/Slice/Grammar.cpp"
+#line 3097 "src/Slice/Grammar.cpp"
         break;
 
         case 104: /* interface_id: ICE_INTERFACE ICE_IDENTIFIER  */
-#line 1357 "src/Slice/Grammar.y"
+#line 1351 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3111 "src/Slice/Grammar.cpp"
+#line 3105 "src/Slice/Grammar.cpp"
         break;
 
         case 105: /* interface_id: ICE_INTERFACE keyword  */
-#line 1361 "src/Slice/Grammar.y"
+#line 1355 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as interface name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 3121 "src/Slice/Grammar.cpp"
+#line 3115 "src/Slice/Grammar.cpp"
         break;
 
         case 106: /* interface_decl: interface_id  */
-#line 1372 "src/Slice/Grammar.y"
+#line 1366 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto cont = currentUnit->currentContainer();
@@ -3004,11 +2998,11 @@ yyreduce:
             cont->checkIntroduced(ident->v, cl);
             yyval = cl;
         }
-#line 3133 "src/Slice/Grammar.cpp"
+#line 3127 "src/Slice/Grammar.cpp"
         break;
 
         case 107: /* @20: %empty  */
-#line 1385 "src/Slice/Grammar.y"
+#line 1379 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3025,11 +3019,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3154 "src/Slice/Grammar.cpp"
+#line 3148 "src/Slice/Grammar.cpp"
         break;
 
         case 108: /* interface_def: interface_id interface_extends @20 '{' operations '}'  */
-#line 1402 "src/Slice/Grammar.y"
+#line 1396 "src/Slice/Grammar.y"
         {
             if (yyvsp[-3])
             {
@@ -3041,11 +3035,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3170 "src/Slice/Grammar.cpp"
+#line 3164 "src/Slice/Grammar.cpp"
         break;
 
         case 109: /* interface_list: scoped_name ',' interface_list  */
-#line 1419 "src/Slice/Grammar.y"
+#line 1413 "src/Slice/Grammar.y"
         {
             auto intfs = dynamic_pointer_cast<InterfaceListTok>(yyvsp[0]);
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
@@ -3080,11 +3074,11 @@ yyreduce:
             }
             yyval = intfs;
         }
-#line 3209 "src/Slice/Grammar.cpp"
+#line 3203 "src/Slice/Grammar.cpp"
         break;
 
         case 110: /* interface_list: scoped_name  */
-#line 1454 "src/Slice/Grammar.y"
+#line 1448 "src/Slice/Grammar.y"
         {
             auto intfs = make_shared<InterfaceListTok>();
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
@@ -3119,45 +3113,45 @@ yyreduce:
             }
             yyval = intfs;
         }
-#line 3248 "src/Slice/Grammar.cpp"
+#line 3242 "src/Slice/Grammar.cpp"
         break;
 
         case 111: /* interface_list: ICE_OBJECT  */
-#line 1489 "src/Slice/Grammar.y"
+#line 1483 "src/Slice/Grammar.y"
         {
             currentUnit->error("illegal inheritance from type Object");
             yyval = make_shared<InterfaceListTok>(); // Dummy
         }
-#line 3257 "src/Slice/Grammar.cpp"
+#line 3251 "src/Slice/Grammar.cpp"
         break;
 
         case 112: /* interface_list: ICE_VALUE  */
-#line 1494 "src/Slice/Grammar.y"
+#line 1488 "src/Slice/Grammar.y"
         {
             currentUnit->error("illegal inheritance from type Value");
             yyval = make_shared<ClassListTok>(); // Dummy
         }
-#line 3266 "src/Slice/Grammar.cpp"
+#line 3260 "src/Slice/Grammar.cpp"
         break;
 
         case 113: /* interface_extends: extends interface_list  */
-#line 1504 "src/Slice/Grammar.y"
+#line 1498 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3274 "src/Slice/Grammar.cpp"
+#line 3268 "src/Slice/Grammar.cpp"
         break;
 
         case 114: /* interface_extends: %empty  */
-#line 1508 "src/Slice/Grammar.y"
+#line 1502 "src/Slice/Grammar.y"
         {
             yyval = make_shared<InterfaceListTok>();
         }
-#line 3282 "src/Slice/Grammar.cpp"
+#line 3276 "src/Slice/Grammar.cpp"
         break;
 
         case 115: /* operations: meta_data operation ';' operations  */
-#line 1517 "src/Slice/Grammar.y"
+#line 1511 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
@@ -3166,55 +3160,55 @@ yyreduce:
                 contained->setMetaData(metaData->v);
             }
         }
-#line 3295 "src/Slice/Grammar.cpp"
+#line 3289 "src/Slice/Grammar.cpp"
         break;
 
         case 116: /* operations: error ';' operations  */
-#line 1526 "src/Slice/Grammar.y"
+#line 1520 "src/Slice/Grammar.y"
         {
         }
-#line 3302 "src/Slice/Grammar.cpp"
+#line 3296 "src/Slice/Grammar.cpp"
         break;
 
         case 117: /* operations: meta_data operation  */
-#line 1529 "src/Slice/Grammar.y"
+#line 1523 "src/Slice/Grammar.y"
         {
             currentUnit->error("`;' missing after definition");
         }
-#line 3310 "src/Slice/Grammar.cpp"
+#line 3304 "src/Slice/Grammar.cpp"
         break;
 
         case 118: /* operations: %empty  */
-#line 1533 "src/Slice/Grammar.y"
+#line 1527 "src/Slice/Grammar.y"
         {
         }
-#line 3317 "src/Slice/Grammar.cpp"
+#line 3311 "src/Slice/Grammar.cpp"
         break;
 
         case 119: /* exception_list: exception ',' exception_list  */
-#line 1541 "src/Slice/Grammar.y"
+#line 1535 "src/Slice/Grammar.y"
         {
             auto exception = dynamic_pointer_cast<Exception>(yyvsp[-2]);
             auto exceptionList = dynamic_pointer_cast<ExceptionListTok>(yyvsp[0]);
             exceptionList->v.push_front(exception);
             yyval = exceptionList;
         }
-#line 3328 "src/Slice/Grammar.cpp"
+#line 3322 "src/Slice/Grammar.cpp"
         break;
 
         case 120: /* exception_list: exception  */
-#line 1548 "src/Slice/Grammar.y"
+#line 1542 "src/Slice/Grammar.y"
         {
             auto exception = dynamic_pointer_cast<Exception>(yyvsp[0]);
             auto exceptionList = make_shared<ExceptionListTok>();
             exceptionList->v.push_front(exception);
             yyval = exceptionList;
         }
-#line 3339 "src/Slice/Grammar.cpp"
+#line 3333 "src/Slice/Grammar.cpp"
         break;
 
         case 121: /* exception: scoped_name  */
-#line 1560 "src/Slice/Grammar.y"
+#line 1554 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3226,21 +3220,21 @@ yyreduce:
             cont->checkIntroduced(scoped->v, exception);
             yyval = exception;
         }
-#line 3355 "src/Slice/Grammar.cpp"
+#line 3349 "src/Slice/Grammar.cpp"
         break;
 
         case 122: /* exception: keyword  */
-#line 1572 "src/Slice/Grammar.y"
+#line 1566 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as exception name");
             yyval = currentUnit->currentContainer()->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
         }
-#line 3365 "src/Slice/Grammar.cpp"
+#line 3359 "src/Slice/Grammar.cpp"
         break;
 
         case 123: /* sequence_def: ICE_SEQUENCE '<' meta_data type '>' ICE_IDENTIFIER  */
-#line 1583 "src/Slice/Grammar.y"
+#line 1577 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
@@ -3248,11 +3242,11 @@ yyreduce:
             ContainerPtr cont = currentUnit->currentContainer();
             yyval = cont->createSequence(ident->v, type, metaData->v);
         }
-#line 3377 "src/Slice/Grammar.cpp"
+#line 3371 "src/Slice/Grammar.cpp"
         break;
 
         case 124: /* sequence_def: ICE_SEQUENCE '<' meta_data type '>' keyword  */
-#line 1591 "src/Slice/Grammar.y"
+#line 1585 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
@@ -3261,11 +3255,11 @@ yyreduce:
             yyval = cont->createSequence(ident->v, type, metaData->v); // Dummy
             currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
         }
-#line 3390 "src/Slice/Grammar.cpp"
+#line 3384 "src/Slice/Grammar.cpp"
         break;
 
         case 125: /* dictionary_def: ICE_DICTIONARY '<' meta_data type ',' meta_data type '>' ICE_IDENTIFIER  */
-#line 1605 "src/Slice/Grammar.y"
+#line 1599 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto keyMetaData = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
@@ -3275,11 +3269,11 @@ yyreduce:
             ContainerPtr cont = currentUnit->currentContainer();
             yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v);
         }
-#line 3404 "src/Slice/Grammar.cpp"
+#line 3398 "src/Slice/Grammar.cpp"
         break;
 
         case 126: /* dictionary_def: ICE_DICTIONARY '<' meta_data type ',' meta_data type '>' keyword  */
-#line 1615 "src/Slice/Grammar.y"
+#line 1609 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto keyMetaData = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
@@ -3290,29 +3284,29 @@ yyreduce:
             yyval = cont->createDictionary(ident->v, keyType, keyMetaData->v, valueType, valueMetaData->v); // Dummy
             currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
         }
-#line 3419 "src/Slice/Grammar.cpp"
+#line 3413 "src/Slice/Grammar.cpp"
         break;
 
         case 127: /* enum_id: ICE_ENUM ICE_IDENTIFIER  */
-#line 1631 "src/Slice/Grammar.y"
+#line 1625 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3427 "src/Slice/Grammar.cpp"
+#line 3421 "src/Slice/Grammar.cpp"
         break;
 
         case 128: /* enum_id: ICE_ENUM keyword  */
-#line 1635 "src/Slice/Grammar.y"
+#line 1629 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as enumeration name");
             yyval = yyvsp[0]; // Dummy
         }
-#line 3437 "src/Slice/Grammar.cpp"
+#line 3431 "src/Slice/Grammar.cpp"
         break;
 
         case 129: /* @21: %empty  */
-#line 1646 "src/Slice/Grammar.y"
+#line 1640 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3328,11 +3322,11 @@ yyreduce:
             currentUnit->pushContainer(en);
             yyval = en;
         }
-#line 3457 "src/Slice/Grammar.cpp"
+#line 3451 "src/Slice/Grammar.cpp"
         break;
 
         case 130: /* enum_def: enum_id @21 '{' enumerator_list '}'  */
-#line 1662 "src/Slice/Grammar.y"
+#line 1656 "src/Slice/Grammar.y"
         {
             auto en = dynamic_pointer_cast<Enum>(yyvsp[-3]);
             if (en)
@@ -3346,11 +3340,11 @@ yyreduce:
             }
             yyval = yyvsp[-3];
         }
-#line 3475 "src/Slice/Grammar.cpp"
+#line 3469 "src/Slice/Grammar.cpp"
         break;
 
         case 131: /* @22: %empty  */
-#line 1677 "src/Slice/Grammar.y"
+#line 1671 "src/Slice/Grammar.y"
         {
             currentUnit->error("missing enumeration name");
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3358,37 +3352,37 @@ yyreduce:
             currentUnit->pushContainer(en);
             yyval = en;
         }
-#line 3487 "src/Slice/Grammar.cpp"
+#line 3481 "src/Slice/Grammar.cpp"
         break;
 
         case 132: /* enum_def: ICE_ENUM @22 '{' enumerator_list '}'  */
-#line 1685 "src/Slice/Grammar.y"
+#line 1679 "src/Slice/Grammar.y"
         {
             currentUnit->popContainer();
             yyval = yyvsp[-4];
         }
-#line 3496 "src/Slice/Grammar.cpp"
+#line 3490 "src/Slice/Grammar.cpp"
         break;
 
         case 133: /* enumerator_list: enumerator ',' enumerator_list  */
-#line 1695 "src/Slice/Grammar.y"
+#line 1689 "src/Slice/Grammar.y"
         {
             auto ens = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[-2]);
             ens->v.splice(ens->v.end(), dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0])->v);
             yyval = ens;
         }
-#line 3506 "src/Slice/Grammar.cpp"
+#line 3500 "src/Slice/Grammar.cpp"
         break;
 
         case 134: /* enumerator_list: enumerator  */
-#line 1701 "src/Slice/Grammar.y"
+#line 1695 "src/Slice/Grammar.y"
         {
         }
-#line 3513 "src/Slice/Grammar.cpp"
+#line 3507 "src/Slice/Grammar.cpp"
         break;
 
         case 135: /* enumerator: ICE_IDENTIFIER  */
-#line 1709 "src/Slice/Grammar.y"
+#line 1703 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto ens = make_shared<EnumeratorListTok>();
@@ -3400,11 +3394,11 @@ yyreduce:
             }
             yyval = ens;
         }
-#line 3529 "src/Slice/Grammar.cpp"
+#line 3523 "src/Slice/Grammar.cpp"
         break;
 
         case 136: /* enumerator: ICE_IDENTIFIER '=' enumerator_initializer  */
-#line 1721 "src/Slice/Grammar.y"
+#line 1715 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
             auto ens = make_shared<EnumeratorListTok>();
@@ -3424,39 +3418,39 @@ yyreduce:
             }
             yyval = ens;
         }
-#line 3553 "src/Slice/Grammar.cpp"
+#line 3547 "src/Slice/Grammar.cpp"
         break;
 
         case 137: /* enumerator: keyword  */
-#line 1741 "src/Slice/Grammar.y"
+#line 1735 "src/Slice/Grammar.y"
         {
             auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             currentUnit->error("keyword `" + ident->v + "' cannot be used as enumerator");
             auto ens = make_shared<EnumeratorListTok>(); // Dummy
             yyval = ens;
         }
-#line 3564 "src/Slice/Grammar.cpp"
+#line 3558 "src/Slice/Grammar.cpp"
         break;
 
         case 138: /* enumerator: %empty  */
-#line 1748 "src/Slice/Grammar.y"
+#line 1742 "src/Slice/Grammar.y"
         {
             auto ens = make_shared<EnumeratorListTok>();
             yyval = ens; // Dummy
         }
-#line 3573 "src/Slice/Grammar.cpp"
+#line 3567 "src/Slice/Grammar.cpp"
         break;
 
         case 139: /* enumerator_initializer: ICE_INTEGER_LITERAL  */
-#line 1758 "src/Slice/Grammar.y"
+#line 1752 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3581 "src/Slice/Grammar.cpp"
+#line 3575 "src/Slice/Grammar.cpp"
         break;
 
         case 140: /* enumerator_initializer: scoped_name  */
-#line 1762 "src/Slice/Grammar.y"
+#line 1756 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v);
@@ -3492,38 +3486,38 @@ yyreduce:
 
             yyval = tok;
         }
-#line 3621 "src/Slice/Grammar.cpp"
+#line 3615 "src/Slice/Grammar.cpp"
         break;
 
         case 141: /* out_qualifier: ICE_OUT  */
-#line 1803 "src/Slice/Grammar.y"
+#line 1797 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = true;
             yyval = out;
         }
-#line 3631 "src/Slice/Grammar.cpp"
+#line 3625 "src/Slice/Grammar.cpp"
         break;
 
         case 142: /* out_qualifier: %empty  */
-#line 1809 "src/Slice/Grammar.y"
+#line 1803 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = false;
             yyval = out;
         }
-#line 3641 "src/Slice/Grammar.cpp"
+#line 3635 "src/Slice/Grammar.cpp"
         break;
 
         case 143: /* parameters: %empty  */
-#line 1820 "src/Slice/Grammar.y"
+#line 1814 "src/Slice/Grammar.y"
         {
         }
-#line 3648 "src/Slice/Grammar.cpp"
+#line 3642 "src/Slice/Grammar.cpp"
         break;
 
         case 144: /* parameters: out_qualifier meta_data tagged_type_id  */
-#line 1823 "src/Slice/Grammar.y"
+#line 1817 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3539,11 +3533,11 @@ yyreduce:
                 }
             }
         }
-#line 3668 "src/Slice/Grammar.cpp"
+#line 3662 "src/Slice/Grammar.cpp"
         break;
 
         case 145: /* parameters: parameters ',' out_qualifier meta_data tagged_type_id  */
-#line 1839 "src/Slice/Grammar.y"
+#line 1833 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3559,11 +3553,11 @@ yyreduce:
                 }
             }
         }
-#line 3688 "src/Slice/Grammar.cpp"
+#line 3682 "src/Slice/Grammar.cpp"
         break;
 
         case 146: /* parameters: out_qualifier meta_data type keyword  */
-#line 1855 "src/Slice/Grammar.y"
+#line 1849 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3575,11 +3569,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3704 "src/Slice/Grammar.cpp"
+#line 3698 "src/Slice/Grammar.cpp"
         break;
 
         case 147: /* parameters: parameters ',' out_qualifier meta_data type keyword  */
-#line 1867 "src/Slice/Grammar.y"
+#line 1861 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3591,11 +3585,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3720 "src/Slice/Grammar.cpp"
+#line 3714 "src/Slice/Grammar.cpp"
         break;
 
         case 148: /* parameters: out_qualifier meta_data type  */
-#line 1879 "src/Slice/Grammar.y"
+#line 1873 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3606,11 +3600,11 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3735 "src/Slice/Grammar.cpp"
+#line 3729 "src/Slice/Grammar.cpp"
         break;
 
         case 149: /* parameters: parameters ',' out_qualifier meta_data type  */
-#line 1890 "src/Slice/Grammar.y"
+#line 1884 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3621,128 +3615,128 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3750 "src/Slice/Grammar.cpp"
+#line 3744 "src/Slice/Grammar.cpp"
         break;
 
         case 150: /* throws: ICE_THROWS exception_list  */
-#line 1906 "src/Slice/Grammar.y"
+#line 1900 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3758 "src/Slice/Grammar.cpp"
+#line 3752 "src/Slice/Grammar.cpp"
         break;
 
         case 151: /* throws: %empty  */
-#line 1910 "src/Slice/Grammar.y"
+#line 1904 "src/Slice/Grammar.y"
         {
             yyval = make_shared<ExceptionListTok>();
         }
-#line 3766 "src/Slice/Grammar.cpp"
+#line 3760 "src/Slice/Grammar.cpp"
         break;
 
         case 152: /* scoped_name: ICE_IDENTIFIER  */
-#line 1919 "src/Slice/Grammar.y"
+#line 1913 "src/Slice/Grammar.y"
         {
         }
-#line 3773 "src/Slice/Grammar.cpp"
+#line 3767 "src/Slice/Grammar.cpp"
         break;
 
         case 153: /* scoped_name: ICE_SCOPED_IDENTIFIER  */
-#line 1922 "src/Slice/Grammar.y"
+#line 1916 "src/Slice/Grammar.y"
+        {
+        }
+#line 3774 "src/Slice/Grammar.cpp"
+        break;
+
+        case 154: /* builtin: ICE_BOOL  */
+#line 1923 "src/Slice/Grammar.y"
         {
         }
 #line 3780 "src/Slice/Grammar.cpp"
         break;
 
-        case 154: /* builtin: ICE_BOOL  */
-#line 1929 "src/Slice/Grammar.y"
+        case 155: /* builtin: ICE_BYTE  */
+#line 1924 "src/Slice/Grammar.y"
         {
         }
 #line 3786 "src/Slice/Grammar.cpp"
         break;
 
-        case 155: /* builtin: ICE_BYTE  */
-#line 1930 "src/Slice/Grammar.y"
+        case 156: /* builtin: ICE_SHORT  */
+#line 1925 "src/Slice/Grammar.y"
         {
         }
 #line 3792 "src/Slice/Grammar.cpp"
         break;
 
-        case 156: /* builtin: ICE_SHORT  */
-#line 1931 "src/Slice/Grammar.y"
+        case 157: /* builtin: ICE_INT  */
+#line 1926 "src/Slice/Grammar.y"
         {
         }
 #line 3798 "src/Slice/Grammar.cpp"
         break;
 
-        case 157: /* builtin: ICE_INT  */
-#line 1932 "src/Slice/Grammar.y"
+        case 158: /* builtin: ICE_LONG  */
+#line 1927 "src/Slice/Grammar.y"
         {
         }
 #line 3804 "src/Slice/Grammar.cpp"
         break;
 
-        case 158: /* builtin: ICE_LONG  */
-#line 1933 "src/Slice/Grammar.y"
+        case 159: /* builtin: ICE_FLOAT  */
+#line 1928 "src/Slice/Grammar.y"
         {
         }
 #line 3810 "src/Slice/Grammar.cpp"
         break;
 
-        case 159: /* builtin: ICE_FLOAT  */
-#line 1934 "src/Slice/Grammar.y"
+        case 160: /* builtin: ICE_DOUBLE  */
+#line 1929 "src/Slice/Grammar.y"
         {
         }
 #line 3816 "src/Slice/Grammar.cpp"
         break;
 
-        case 160: /* builtin: ICE_DOUBLE  */
-#line 1935 "src/Slice/Grammar.y"
+        case 161: /* builtin: ICE_STRING  */
+#line 1930 "src/Slice/Grammar.y"
         {
         }
 #line 3822 "src/Slice/Grammar.cpp"
         break;
 
-        case 161: /* builtin: ICE_STRING  */
-#line 1936 "src/Slice/Grammar.y"
+        case 162: /* builtin: ICE_OBJECT  */
+#line 1931 "src/Slice/Grammar.y"
         {
         }
 #line 3828 "src/Slice/Grammar.cpp"
         break;
 
-        case 162: /* builtin: ICE_OBJECT  */
-#line 1937 "src/Slice/Grammar.y"
+        case 163: /* builtin: ICE_VALUE  */
+#line 1932 "src/Slice/Grammar.y"
         {
         }
 #line 3834 "src/Slice/Grammar.cpp"
         break;
 
-        case 163: /* builtin: ICE_VALUE  */
-#line 1938 "src/Slice/Grammar.y"
-        {
-        }
-#line 3840 "src/Slice/Grammar.cpp"
-        break;
-
         case 164: /* type: ICE_OBJECT '*'  */
-#line 1944 "src/Slice/Grammar.y"
+#line 1938 "src/Slice/Grammar.y"
         {
             yyval = currentUnit->builtin(Builtin::KindObjectProxy);
         }
-#line 3848 "src/Slice/Grammar.cpp"
+#line 3842 "src/Slice/Grammar.cpp"
         break;
 
         case 165: /* type: builtin  */
-#line 1948 "src/Slice/Grammar.y"
+#line 1942 "src/Slice/Grammar.y"
         {
             auto typeName = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             yyval = currentUnit->builtin(Builtin::kindFromString(typeName->v).value());
         }
-#line 3857 "src/Slice/Grammar.cpp"
+#line 3851 "src/Slice/Grammar.cpp"
         break;
 
         case 166: /* type: scoped_name  */
-#line 1953 "src/Slice/Grammar.y"
+#line 1947 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3773,11 +3767,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3892 "src/Slice/Grammar.cpp"
+#line 3886 "src/Slice/Grammar.cpp"
         break;
 
         case 167: /* type: scoped_name '*'  */
-#line 1984 "src/Slice/Grammar.y"
+#line 1978 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3808,50 +3802,50 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3927 "src/Slice/Grammar.cpp"
+#line 3921 "src/Slice/Grammar.cpp"
         break;
 
         case 168: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2020 "src/Slice/Grammar.y"
+#line 2014 "src/Slice/Grammar.y"
         {
             auto str1 = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             auto str2 = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             str1->v += str2->v;
         }
-#line 3937 "src/Slice/Grammar.cpp"
+#line 3931 "src/Slice/Grammar.cpp"
         break;
 
         case 169: /* string_literal: ICE_STRING_LITERAL  */
-#line 2026 "src/Slice/Grammar.y"
+#line 2020 "src/Slice/Grammar.y"
         {
         }
-#line 3944 "src/Slice/Grammar.cpp"
+#line 3938 "src/Slice/Grammar.cpp"
         break;
 
         case 170: /* string_list: string_list ',' string_literal  */
-#line 2034 "src/Slice/Grammar.y"
+#line 2028 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = dynamic_pointer_cast<StringListTok>(yyvsp[-2]);
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3955 "src/Slice/Grammar.cpp"
+#line 3949 "src/Slice/Grammar.cpp"
         break;
 
         case 171: /* string_list: string_literal  */
-#line 2041 "src/Slice/Grammar.y"
+#line 2035 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = make_shared<StringListTok>();
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3966 "src/Slice/Grammar.cpp"
+#line 3960 "src/Slice/Grammar.cpp"
         break;
 
         case 172: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2053 "src/Slice/Grammar.y"
+#line 2047 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindLong);
             auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
@@ -3860,11 +3854,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), intVal->literal);
             yyval = def;
         }
-#line 3979 "src/Slice/Grammar.cpp"
+#line 3973 "src/Slice/Grammar.cpp"
         break;
 
         case 173: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2062 "src/Slice/Grammar.y"
+#line 2056 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindDouble);
             auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
@@ -3873,11 +3867,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), floatVal->literal);
             yyval = def;
         }
-#line 3992 "src/Slice/Grammar.cpp"
+#line 3986 "src/Slice/Grammar.cpp"
         break;
 
         case 174: /* const_initializer: scoped_name  */
-#line 2071 "src/Slice/Grammar.y"
+#line 2065 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ConstDefTokPtr def;
@@ -3912,44 +3906,44 @@ yyreduce:
             }
             yyval = def;
         }
-#line 4031 "src/Slice/Grammar.cpp"
+#line 4025 "src/Slice/Grammar.cpp"
         break;
 
         case 175: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2106 "src/Slice/Grammar.y"
+#line 2100 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindString);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
             yyval = def;
         }
-#line 4042 "src/Slice/Grammar.cpp"
+#line 4036 "src/Slice/Grammar.cpp"
         break;
 
         case 176: /* const_initializer: ICE_FALSE  */
-#line 2113 "src/Slice/Grammar.y"
+#line 2107 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "false", "false");
             yyval = def;
         }
-#line 4053 "src/Slice/Grammar.cpp"
+#line 4047 "src/Slice/Grammar.cpp"
         break;
 
         case 177: /* const_initializer: ICE_TRUE  */
-#line 2120 "src/Slice/Grammar.y"
+#line 2114 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "true", "true");
             yyval = def;
         }
-#line 4064 "src/Slice/Grammar.cpp"
+#line 4058 "src/Slice/Grammar.cpp"
         break;
 
         case 178: /* const_def: ICE_CONST meta_data type ICE_IDENTIFIER '=' const_initializer  */
-#line 2132 "src/Slice/Grammar.y"
+#line 2126 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-4]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
@@ -3963,11 +3957,11 @@ yyreduce:
                 value->valueAsString,
                 value->valueAsLiteral);
         }
-#line 4077 "src/Slice/Grammar.cpp"
+#line 4071 "src/Slice/Grammar.cpp"
         break;
 
         case 179: /* const_def: ICE_CONST meta_data type '=' const_initializer  */
-#line 2141 "src/Slice/Grammar.y"
+#line 2135 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
@@ -3982,206 +3976,206 @@ yyreduce:
                 value->valueAsLiteral,
                 Dummy); // Dummy
         }
-#line 4090 "src/Slice/Grammar.cpp"
+#line 4084 "src/Slice/Grammar.cpp"
         break;
 
         case 180: /* keyword: ICE_MODULE  */
-#line 2154 "src/Slice/Grammar.y"
+#line 2148 "src/Slice/Grammar.y"
+        {
+        }
+#line 4090 "src/Slice/Grammar.cpp"
+        break;
+
+        case 181: /* keyword: ICE_CLASS  */
+#line 2149 "src/Slice/Grammar.y"
         {
         }
 #line 4096 "src/Slice/Grammar.cpp"
         break;
 
-        case 181: /* keyword: ICE_CLASS  */
-#line 2155 "src/Slice/Grammar.y"
+        case 182: /* keyword: ICE_INTERFACE  */
+#line 2150 "src/Slice/Grammar.y"
         {
         }
 #line 4102 "src/Slice/Grammar.cpp"
         break;
 
-        case 182: /* keyword: ICE_INTERFACE  */
-#line 2156 "src/Slice/Grammar.y"
+        case 183: /* keyword: ICE_EXCEPTION  */
+#line 2151 "src/Slice/Grammar.y"
         {
         }
 #line 4108 "src/Slice/Grammar.cpp"
         break;
 
-        case 183: /* keyword: ICE_EXCEPTION  */
-#line 2157 "src/Slice/Grammar.y"
+        case 184: /* keyword: ICE_STRUCT  */
+#line 2152 "src/Slice/Grammar.y"
         {
         }
 #line 4114 "src/Slice/Grammar.cpp"
         break;
 
-        case 184: /* keyword: ICE_STRUCT  */
-#line 2158 "src/Slice/Grammar.y"
+        case 185: /* keyword: ICE_SEQUENCE  */
+#line 2153 "src/Slice/Grammar.y"
         {
         }
 #line 4120 "src/Slice/Grammar.cpp"
         break;
 
-        case 185: /* keyword: ICE_SEQUENCE  */
-#line 2159 "src/Slice/Grammar.y"
+        case 186: /* keyword: ICE_DICTIONARY  */
+#line 2154 "src/Slice/Grammar.y"
         {
         }
 #line 4126 "src/Slice/Grammar.cpp"
         break;
 
-        case 186: /* keyword: ICE_DICTIONARY  */
-#line 2160 "src/Slice/Grammar.y"
+        case 187: /* keyword: ICE_ENUM  */
+#line 2155 "src/Slice/Grammar.y"
         {
         }
 #line 4132 "src/Slice/Grammar.cpp"
         break;
 
-        case 187: /* keyword: ICE_ENUM  */
-#line 2161 "src/Slice/Grammar.y"
+        case 188: /* keyword: ICE_OUT  */
+#line 2156 "src/Slice/Grammar.y"
         {
         }
 #line 4138 "src/Slice/Grammar.cpp"
         break;
 
-        case 188: /* keyword: ICE_OUT  */
-#line 2162 "src/Slice/Grammar.y"
+        case 189: /* keyword: ICE_EXTENDS  */
+#line 2157 "src/Slice/Grammar.y"
         {
         }
 #line 4144 "src/Slice/Grammar.cpp"
         break;
 
-        case 189: /* keyword: ICE_EXTENDS  */
-#line 2163 "src/Slice/Grammar.y"
+        case 190: /* keyword: ICE_THROWS  */
+#line 2158 "src/Slice/Grammar.y"
         {
         }
 #line 4150 "src/Slice/Grammar.cpp"
         break;
 
-        case 190: /* keyword: ICE_THROWS  */
-#line 2164 "src/Slice/Grammar.y"
+        case 191: /* keyword: ICE_VOID  */
+#line 2159 "src/Slice/Grammar.y"
         {
         }
 #line 4156 "src/Slice/Grammar.cpp"
         break;
 
-        case 191: /* keyword: ICE_VOID  */
-#line 2165 "src/Slice/Grammar.y"
+        case 192: /* keyword: ICE_BOOL  */
+#line 2160 "src/Slice/Grammar.y"
         {
         }
 #line 4162 "src/Slice/Grammar.cpp"
         break;
 
-        case 192: /* keyword: ICE_BOOL  */
-#line 2166 "src/Slice/Grammar.y"
+        case 193: /* keyword: ICE_BYTE  */
+#line 2161 "src/Slice/Grammar.y"
         {
         }
 #line 4168 "src/Slice/Grammar.cpp"
         break;
 
-        case 193: /* keyword: ICE_BYTE  */
-#line 2167 "src/Slice/Grammar.y"
+        case 194: /* keyword: ICE_SHORT  */
+#line 2162 "src/Slice/Grammar.y"
         {
         }
 #line 4174 "src/Slice/Grammar.cpp"
         break;
 
-        case 194: /* keyword: ICE_SHORT  */
-#line 2168 "src/Slice/Grammar.y"
+        case 195: /* keyword: ICE_INT  */
+#line 2163 "src/Slice/Grammar.y"
         {
         }
 #line 4180 "src/Slice/Grammar.cpp"
         break;
 
-        case 195: /* keyword: ICE_INT  */
-#line 2169 "src/Slice/Grammar.y"
+        case 196: /* keyword: ICE_LONG  */
+#line 2164 "src/Slice/Grammar.y"
         {
         }
 #line 4186 "src/Slice/Grammar.cpp"
         break;
 
-        case 196: /* keyword: ICE_LONG  */
-#line 2170 "src/Slice/Grammar.y"
+        case 197: /* keyword: ICE_FLOAT  */
+#line 2165 "src/Slice/Grammar.y"
         {
         }
 #line 4192 "src/Slice/Grammar.cpp"
         break;
 
-        case 197: /* keyword: ICE_FLOAT  */
-#line 2171 "src/Slice/Grammar.y"
+        case 198: /* keyword: ICE_DOUBLE  */
+#line 2166 "src/Slice/Grammar.y"
         {
         }
 #line 4198 "src/Slice/Grammar.cpp"
         break;
 
-        case 198: /* keyword: ICE_DOUBLE  */
-#line 2172 "src/Slice/Grammar.y"
+        case 199: /* keyword: ICE_STRING  */
+#line 2167 "src/Slice/Grammar.y"
         {
         }
 #line 4204 "src/Slice/Grammar.cpp"
         break;
 
-        case 199: /* keyword: ICE_STRING  */
-#line 2173 "src/Slice/Grammar.y"
+        case 200: /* keyword: ICE_OBJECT  */
+#line 2168 "src/Slice/Grammar.y"
         {
         }
 #line 4210 "src/Slice/Grammar.cpp"
         break;
 
-        case 200: /* keyword: ICE_OBJECT  */
-#line 2174 "src/Slice/Grammar.y"
+        case 201: /* keyword: ICE_CONST  */
+#line 2169 "src/Slice/Grammar.y"
         {
         }
 #line 4216 "src/Slice/Grammar.cpp"
         break;
 
-        case 201: /* keyword: ICE_CONST  */
-#line 2175 "src/Slice/Grammar.y"
+        case 202: /* keyword: ICE_FALSE  */
+#line 2170 "src/Slice/Grammar.y"
         {
         }
 #line 4222 "src/Slice/Grammar.cpp"
         break;
 
-        case 202: /* keyword: ICE_FALSE  */
-#line 2176 "src/Slice/Grammar.y"
+        case 203: /* keyword: ICE_TRUE  */
+#line 2171 "src/Slice/Grammar.y"
         {
         }
 #line 4228 "src/Slice/Grammar.cpp"
         break;
 
-        case 203: /* keyword: ICE_TRUE  */
-#line 2177 "src/Slice/Grammar.y"
+        case 204: /* keyword: ICE_IDEMPOTENT  */
+#line 2172 "src/Slice/Grammar.y"
         {
         }
 #line 4234 "src/Slice/Grammar.cpp"
         break;
 
-        case 204: /* keyword: ICE_IDEMPOTENT  */
-#line 2178 "src/Slice/Grammar.y"
+        case 205: /* keyword: ICE_TAG  */
+#line 2173 "src/Slice/Grammar.y"
         {
         }
 #line 4240 "src/Slice/Grammar.cpp"
         break;
 
-        case 205: /* keyword: ICE_TAG  */
-#line 2179 "src/Slice/Grammar.y"
+        case 206: /* keyword: ICE_OPTIONAL  */
+#line 2174 "src/Slice/Grammar.y"
         {
         }
 #line 4246 "src/Slice/Grammar.cpp"
         break;
 
-        case 206: /* keyword: ICE_OPTIONAL  */
-#line 2180 "src/Slice/Grammar.y"
+        case 207: /* keyword: ICE_VALUE  */
+#line 2175 "src/Slice/Grammar.y"
         {
         }
 #line 4252 "src/Slice/Grammar.cpp"
         break;
 
-        case 207: /* keyword: ICE_VALUE  */
-#line 2181 "src/Slice/Grammar.y"
-        {
-        }
-#line 4258 "src/Slice/Grammar.cpp"
-        break;
-
-#line 4262 "src/Slice/Grammar.cpp"
+#line 4256 "src/Slice/Grammar.cpp"
 
         default:
             break;
@@ -4367,4 +4361,4 @@ yyreturnlab:
     return yyresult;
 }
 
-#line 2184 "src/Slice/Grammar.y"
+#line 2178 "src/Slice/Grammar.y"

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -143,7 +143,6 @@
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-conversion"
-#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 using namespace std;
@@ -692,10 +691,10 @@ static const yytype_int16 yyrline[] = {
     923,  935,  948,  947,  981,  1015, 1024, 1027, 1035, 1044, 1047, 1051, 1059, 1089, 1123, 1145, 1171, 1177, 1183,
     1189, 1199, 1223, 1253, 1277, 1312, 1311, 1334, 1333, 1356, 1360, 1371, 1385, 1384, 1418, 1453, 1488, 1493, 1503,
     1507, 1516, 1525, 1528, 1532, 1540, 1547, 1559, 1571, 1582, 1590, 1604, 1614, 1630, 1634, 1646, 1645, 1677, 1676,
-    1694, 1700, 1708, 1720, 1740, 1747, 1757, 1761, 1799, 1805, 1816, 1819, 1835, 1851, 1863, 1875, 1886, 1902, 1906,
-    1915, 1918, 1926, 1927, 1928, 1929, 1930, 1931, 1932, 1933, 1934, 1935, 1940, 1944, 1949, 1980, 2016, 2022, 2030,
-    2037, 2049, 2058, 2067, 2102, 2109, 2116, 2128, 2137, 2151, 2152, 2153, 2154, 2155, 2156, 2157, 2158, 2159, 2160,
-    2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175, 2176, 2177, 2178};
+    1694, 1700, 1708, 1720, 1740, 1747, 1757, 1761, 1802, 1808, 1819, 1822, 1838, 1854, 1866, 1878, 1889, 1905, 1909,
+    1918, 1921, 1929, 1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1943, 1947, 1952, 1983, 2019, 2025, 2033,
+    2040, 2052, 2061, 2070, 2105, 2112, 2119, 2131, 2140, 2154, 2155, 2156, 2157, 2158, 2159, 2160, 2161, 2162, 2163,
+    2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172, 2173, 2174, 2175, 2176, 2177, 2178, 2179, 2180, 2181};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -2009,7 +2008,7 @@ yyreduce:
                     ostringstream os;
                     os << "enumerator `" << scoped->v << "' could designate";
                     bool first = true;
-                    for (EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+                    for (const auto& p : enumerators)
                     {
                         if (first)
                         {
@@ -2020,7 +2019,7 @@ yyreduce:
                             os << " or";
                         }
 
-                        os << " `" << (*p)->scoped() << "'";
+                        os << " `" << p->scoped() << "'";
                     }
                     currentUnit->error(os.str());
                 }
@@ -2135,7 +2134,7 @@ yyreduce:
                     ostringstream os;
                     os << "enumerator `" << scoped->v << "' could designate";
                     bool first = true;
-                    for (EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+                    for (const auto& p : enumerators)
                     {
                         if (first)
                         {
@@ -2146,7 +2145,7 @@ yyreduce:
                             os << " or";
                         }
 
-                        os << " `" << (*p)->scoped() << "'";
+                        os << " `" << p->scoped() << "'";
                     }
                     currentUnit->error(os.str());
                 }
@@ -2342,7 +2341,7 @@ yyreduce:
         case 74: /* class_id: ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'  */
 #line 809 "src/Slice/Grammar.y"
         {
-            std::int64_t id = dynamic_pointer_cast<IntegerTok>(yyvsp[-1])->v;
+            int64_t id = dynamic_pointer_cast<IntegerTok>(yyvsp[-1])->v;
             if (id < 0)
             {
                 currentUnit->error("invalid compact id for class: id must be a positive integer");
@@ -2394,7 +2393,7 @@ yyreduce:
                     ostringstream os;
                     os << "enumerator `" << scoped->v << "' could designate";
                     bool first = true;
-                    for (EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+                    for (const auto& p : enumerators)
                     {
                         if (first)
                         {
@@ -2405,7 +2404,7 @@ yyreduce:
                             os << " or";
                         }
 
-                        os << " `" << (*p)->scoped() << "'";
+                        os << " `" << p->scoped() << "'";
                     }
                     currentUnit->error(os.str());
                 }
@@ -3473,7 +3472,7 @@ yyreduce:
                     {
                         try
                         {
-                            std::int64_t v = std::stoll(constant->value(), nullptr, 0);
+                            int64_t v = std::stoll(constant->value(), nullptr, 0);
                             tok = make_shared<IntegerTok>();
                             tok->v = v;
                             tok->literal = constant->value();
@@ -3493,38 +3492,38 @@ yyreduce:
 
             yyval = tok;
         }
-#line 3618 "src/Slice/Grammar.cpp"
+#line 3621 "src/Slice/Grammar.cpp"
         break;
 
         case 141: /* out_qualifier: ICE_OUT  */
-#line 1800 "src/Slice/Grammar.y"
+#line 1803 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = true;
             yyval = out;
         }
-#line 3628 "src/Slice/Grammar.cpp"
+#line 3631 "src/Slice/Grammar.cpp"
         break;
 
         case 142: /* out_qualifier: %empty  */
-#line 1806 "src/Slice/Grammar.y"
+#line 1809 "src/Slice/Grammar.y"
         {
             auto out = make_shared<BoolTok>();
             out->v = false;
             yyval = out;
         }
-#line 3638 "src/Slice/Grammar.cpp"
+#line 3641 "src/Slice/Grammar.cpp"
         break;
 
         case 143: /* parameters: %empty  */
-#line 1817 "src/Slice/Grammar.y"
+#line 1820 "src/Slice/Grammar.y"
         {
         }
-#line 3645 "src/Slice/Grammar.cpp"
+#line 3648 "src/Slice/Grammar.cpp"
         break;
 
         case 144: /* parameters: out_qualifier meta_data tagged_type_id  */
-#line 1820 "src/Slice/Grammar.y"
+#line 1823 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3540,11 +3539,11 @@ yyreduce:
                 }
             }
         }
-#line 3665 "src/Slice/Grammar.cpp"
+#line 3668 "src/Slice/Grammar.cpp"
         break;
 
         case 145: /* parameters: parameters ',' out_qualifier meta_data tagged_type_id  */
-#line 1836 "src/Slice/Grammar.y"
+#line 1839 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto tsp = dynamic_pointer_cast<TaggedDefTok>(yyvsp[0]);
@@ -3560,11 +3559,11 @@ yyreduce:
                 }
             }
         }
-#line 3685 "src/Slice/Grammar.cpp"
+#line 3688 "src/Slice/Grammar.cpp"
         break;
 
         case 146: /* parameters: out_qualifier meta_data type keyword  */
-#line 1852 "src/Slice/Grammar.y"
+#line 1855 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3576,11 +3575,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3701 "src/Slice/Grammar.cpp"
+#line 3704 "src/Slice/Grammar.cpp"
         break;
 
         case 147: /* parameters: parameters ',' out_qualifier meta_data type keyword  */
-#line 1864 "src/Slice/Grammar.y"
+#line 1867 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-3]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
@@ -3592,11 +3591,11 @@ yyreduce:
                 currentUnit->error("keyword `" + ident->v + "' cannot be used as parameter name");
             }
         }
-#line 3717 "src/Slice/Grammar.cpp"
+#line 3720 "src/Slice/Grammar.cpp"
         break;
 
         case 148: /* parameters: out_qualifier meta_data type  */
-#line 1876 "src/Slice/Grammar.y"
+#line 1879 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3607,11 +3606,11 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3732 "src/Slice/Grammar.cpp"
+#line 3735 "src/Slice/Grammar.cpp"
         break;
 
         case 149: /* parameters: parameters ',' out_qualifier meta_data type  */
-#line 1887 "src/Slice/Grammar.y"
+#line 1890 "src/Slice/Grammar.y"
         {
             auto isOutParam = dynamic_pointer_cast<BoolTok>(yyvsp[-2]);
             auto type = dynamic_pointer_cast<Type>(yyvsp[0]);
@@ -3622,128 +3621,128 @@ yyreduce:
                 currentUnit->error("missing parameter name");
             }
         }
-#line 3747 "src/Slice/Grammar.cpp"
+#line 3750 "src/Slice/Grammar.cpp"
         break;
 
         case 150: /* throws: ICE_THROWS exception_list  */
-#line 1903 "src/Slice/Grammar.y"
+#line 1906 "src/Slice/Grammar.y"
         {
             yyval = yyvsp[0];
         }
-#line 3755 "src/Slice/Grammar.cpp"
+#line 3758 "src/Slice/Grammar.cpp"
         break;
 
         case 151: /* throws: %empty  */
-#line 1907 "src/Slice/Grammar.y"
+#line 1910 "src/Slice/Grammar.y"
         {
             yyval = make_shared<ExceptionListTok>();
         }
-#line 3763 "src/Slice/Grammar.cpp"
+#line 3766 "src/Slice/Grammar.cpp"
         break;
 
         case 152: /* scoped_name: ICE_IDENTIFIER  */
-#line 1916 "src/Slice/Grammar.y"
-        {
-        }
-#line 3770 "src/Slice/Grammar.cpp"
-        break;
-
-        case 153: /* scoped_name: ICE_SCOPED_IDENTIFIER  */
 #line 1919 "src/Slice/Grammar.y"
         {
         }
-#line 3777 "src/Slice/Grammar.cpp"
+#line 3773 "src/Slice/Grammar.cpp"
+        break;
+
+        case 153: /* scoped_name: ICE_SCOPED_IDENTIFIER  */
+#line 1922 "src/Slice/Grammar.y"
+        {
+        }
+#line 3780 "src/Slice/Grammar.cpp"
         break;
 
         case 154: /* builtin: ICE_BOOL  */
-#line 1926 "src/Slice/Grammar.y"
-        {
-        }
-#line 3783 "src/Slice/Grammar.cpp"
-        break;
-
-        case 155: /* builtin: ICE_BYTE  */
-#line 1927 "src/Slice/Grammar.y"
-        {
-        }
-#line 3789 "src/Slice/Grammar.cpp"
-        break;
-
-        case 156: /* builtin: ICE_SHORT  */
-#line 1928 "src/Slice/Grammar.y"
-        {
-        }
-#line 3795 "src/Slice/Grammar.cpp"
-        break;
-
-        case 157: /* builtin: ICE_INT  */
 #line 1929 "src/Slice/Grammar.y"
         {
         }
-#line 3801 "src/Slice/Grammar.cpp"
+#line 3786 "src/Slice/Grammar.cpp"
         break;
 
-        case 158: /* builtin: ICE_LONG  */
+        case 155: /* builtin: ICE_BYTE  */
 #line 1930 "src/Slice/Grammar.y"
         {
         }
-#line 3807 "src/Slice/Grammar.cpp"
+#line 3792 "src/Slice/Grammar.cpp"
         break;
 
-        case 159: /* builtin: ICE_FLOAT  */
+        case 156: /* builtin: ICE_SHORT  */
 #line 1931 "src/Slice/Grammar.y"
         {
         }
-#line 3813 "src/Slice/Grammar.cpp"
+#line 3798 "src/Slice/Grammar.cpp"
         break;
 
-        case 160: /* builtin: ICE_DOUBLE  */
+        case 157: /* builtin: ICE_INT  */
 #line 1932 "src/Slice/Grammar.y"
         {
         }
-#line 3819 "src/Slice/Grammar.cpp"
+#line 3804 "src/Slice/Grammar.cpp"
         break;
 
-        case 161: /* builtin: ICE_STRING  */
+        case 158: /* builtin: ICE_LONG  */
 #line 1933 "src/Slice/Grammar.y"
         {
         }
-#line 3825 "src/Slice/Grammar.cpp"
+#line 3810 "src/Slice/Grammar.cpp"
         break;
 
-        case 162: /* builtin: ICE_OBJECT  */
+        case 159: /* builtin: ICE_FLOAT  */
 #line 1934 "src/Slice/Grammar.y"
         {
         }
-#line 3831 "src/Slice/Grammar.cpp"
+#line 3816 "src/Slice/Grammar.cpp"
         break;
 
-        case 163: /* builtin: ICE_VALUE  */
+        case 160: /* builtin: ICE_DOUBLE  */
 #line 1935 "src/Slice/Grammar.y"
         {
         }
-#line 3837 "src/Slice/Grammar.cpp"
+#line 3822 "src/Slice/Grammar.cpp"
+        break;
+
+        case 161: /* builtin: ICE_STRING  */
+#line 1936 "src/Slice/Grammar.y"
+        {
+        }
+#line 3828 "src/Slice/Grammar.cpp"
+        break;
+
+        case 162: /* builtin: ICE_OBJECT  */
+#line 1937 "src/Slice/Grammar.y"
+        {
+        }
+#line 3834 "src/Slice/Grammar.cpp"
+        break;
+
+        case 163: /* builtin: ICE_VALUE  */
+#line 1938 "src/Slice/Grammar.y"
+        {
+        }
+#line 3840 "src/Slice/Grammar.cpp"
         break;
 
         case 164: /* type: ICE_OBJECT '*'  */
-#line 1941 "src/Slice/Grammar.y"
+#line 1944 "src/Slice/Grammar.y"
         {
             yyval = currentUnit->builtin(Builtin::KindObjectProxy);
         }
-#line 3845 "src/Slice/Grammar.cpp"
+#line 3848 "src/Slice/Grammar.cpp"
         break;
 
         case 165: /* type: builtin  */
-#line 1945 "src/Slice/Grammar.y"
+#line 1948 "src/Slice/Grammar.y"
         {
             auto typeName = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             yyval = currentUnit->builtin(Builtin::kindFromString(typeName->v).value());
         }
-#line 3854 "src/Slice/Grammar.cpp"
+#line 3857 "src/Slice/Grammar.cpp"
         break;
 
         case 166: /* type: scoped_name  */
-#line 1950 "src/Slice/Grammar.y"
+#line 1953 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3774,11 +3773,11 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3889 "src/Slice/Grammar.cpp"
+#line 3892 "src/Slice/Grammar.cpp"
         break;
 
         case 167: /* type: scoped_name '*'  */
-#line 1981 "src/Slice/Grammar.y"
+#line 1984 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             ContainerPtr cont = currentUnit->currentContainer();
@@ -3809,50 +3808,50 @@ yyreduce:
                 yyval = nullptr;
             }
         }
-#line 3924 "src/Slice/Grammar.cpp"
+#line 3927 "src/Slice/Grammar.cpp"
         break;
 
         case 168: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 2017 "src/Slice/Grammar.y"
+#line 2020 "src/Slice/Grammar.y"
         {
             auto str1 = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
             auto str2 = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             str1->v += str2->v;
         }
-#line 3934 "src/Slice/Grammar.cpp"
+#line 3937 "src/Slice/Grammar.cpp"
         break;
 
         case 169: /* string_literal: ICE_STRING_LITERAL  */
-#line 2023 "src/Slice/Grammar.y"
+#line 2026 "src/Slice/Grammar.y"
         {
         }
-#line 3941 "src/Slice/Grammar.cpp"
+#line 3944 "src/Slice/Grammar.cpp"
         break;
 
         case 170: /* string_list: string_list ',' string_literal  */
-#line 2031 "src/Slice/Grammar.y"
+#line 2034 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = dynamic_pointer_cast<StringListTok>(yyvsp[-2]);
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3952 "src/Slice/Grammar.cpp"
+#line 3955 "src/Slice/Grammar.cpp"
         break;
 
         case 171: /* string_list: string_literal  */
-#line 2038 "src/Slice/Grammar.y"
+#line 2041 "src/Slice/Grammar.y"
         {
             auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto stringList = make_shared<StringListTok>();
             stringList->v.push_back(str->v);
             yyval = stringList;
         }
-#line 3963 "src/Slice/Grammar.cpp"
+#line 3966 "src/Slice/Grammar.cpp"
         break;
 
         case 172: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2050 "src/Slice/Grammar.y"
+#line 2053 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindLong);
             auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
@@ -3861,11 +3860,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), intVal->literal);
             yyval = def;
         }
-#line 3976 "src/Slice/Grammar.cpp"
+#line 3979 "src/Slice/Grammar.cpp"
         break;
 
         case 173: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2059 "src/Slice/Grammar.y"
+#line 2062 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindDouble);
             auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
@@ -3874,11 +3873,11 @@ yyreduce:
             auto def = make_shared<ConstDefTok>(type, sstr.str(), floatVal->literal);
             yyval = def;
         }
-#line 3989 "src/Slice/Grammar.cpp"
+#line 3992 "src/Slice/Grammar.cpp"
         break;
 
         case 174: /* const_initializer: scoped_name  */
-#line 2068 "src/Slice/Grammar.y"
+#line 2071 "src/Slice/Grammar.y"
         {
             auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             ConstDefTokPtr def;
@@ -3913,44 +3912,44 @@ yyreduce:
             }
             yyval = def;
         }
-#line 4028 "src/Slice/Grammar.cpp"
+#line 4031 "src/Slice/Grammar.cpp"
         break;
 
         case 175: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2103 "src/Slice/Grammar.y"
+#line 2106 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindString);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
             yyval = def;
         }
-#line 4039 "src/Slice/Grammar.cpp"
+#line 4042 "src/Slice/Grammar.cpp"
         break;
 
         case 176: /* const_initializer: ICE_FALSE  */
-#line 2110 "src/Slice/Grammar.y"
+#line 2113 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "false", "false");
             yyval = def;
         }
-#line 4050 "src/Slice/Grammar.cpp"
+#line 4053 "src/Slice/Grammar.cpp"
         break;
 
         case 177: /* const_initializer: ICE_TRUE  */
-#line 2117 "src/Slice/Grammar.y"
+#line 2120 "src/Slice/Grammar.y"
         {
             BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "true", "true");
             yyval = def;
         }
-#line 4061 "src/Slice/Grammar.cpp"
+#line 4064 "src/Slice/Grammar.cpp"
         break;
 
         case 178: /* const_def: ICE_CONST meta_data type ICE_IDENTIFIER '=' const_initializer  */
-#line 2129 "src/Slice/Grammar.y"
+#line 2132 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-4]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
@@ -3964,11 +3963,11 @@ yyreduce:
                 value->valueAsString,
                 value->valueAsLiteral);
         }
-#line 4074 "src/Slice/Grammar.cpp"
+#line 4077 "src/Slice/Grammar.cpp"
         break;
 
         case 179: /* const_def: ICE_CONST meta_data type '=' const_initializer  */
-#line 2138 "src/Slice/Grammar.y"
+#line 2141 "src/Slice/Grammar.y"
         {
             auto metaData = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
             auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
@@ -3983,206 +3982,206 @@ yyreduce:
                 value->valueAsLiteral,
                 Dummy); // Dummy
         }
-#line 4087 "src/Slice/Grammar.cpp"
+#line 4090 "src/Slice/Grammar.cpp"
         break;
 
         case 180: /* keyword: ICE_MODULE  */
-#line 2151 "src/Slice/Grammar.y"
-        {
-        }
-#line 4093 "src/Slice/Grammar.cpp"
-        break;
-
-        case 181: /* keyword: ICE_CLASS  */
-#line 2152 "src/Slice/Grammar.y"
-        {
-        }
-#line 4099 "src/Slice/Grammar.cpp"
-        break;
-
-        case 182: /* keyword: ICE_INTERFACE  */
-#line 2153 "src/Slice/Grammar.y"
-        {
-        }
-#line 4105 "src/Slice/Grammar.cpp"
-        break;
-
-        case 183: /* keyword: ICE_EXCEPTION  */
 #line 2154 "src/Slice/Grammar.y"
         {
         }
-#line 4111 "src/Slice/Grammar.cpp"
+#line 4096 "src/Slice/Grammar.cpp"
         break;
 
-        case 184: /* keyword: ICE_STRUCT  */
+        case 181: /* keyword: ICE_CLASS  */
 #line 2155 "src/Slice/Grammar.y"
         {
         }
-#line 4117 "src/Slice/Grammar.cpp"
+#line 4102 "src/Slice/Grammar.cpp"
         break;
 
-        case 185: /* keyword: ICE_SEQUENCE  */
+        case 182: /* keyword: ICE_INTERFACE  */
 #line 2156 "src/Slice/Grammar.y"
         {
         }
-#line 4123 "src/Slice/Grammar.cpp"
+#line 4108 "src/Slice/Grammar.cpp"
         break;
 
-        case 186: /* keyword: ICE_DICTIONARY  */
+        case 183: /* keyword: ICE_EXCEPTION  */
 #line 2157 "src/Slice/Grammar.y"
         {
         }
-#line 4129 "src/Slice/Grammar.cpp"
+#line 4114 "src/Slice/Grammar.cpp"
         break;
 
-        case 187: /* keyword: ICE_ENUM  */
+        case 184: /* keyword: ICE_STRUCT  */
 #line 2158 "src/Slice/Grammar.y"
         {
         }
-#line 4135 "src/Slice/Grammar.cpp"
+#line 4120 "src/Slice/Grammar.cpp"
         break;
 
-        case 188: /* keyword: ICE_OUT  */
+        case 185: /* keyword: ICE_SEQUENCE  */
 #line 2159 "src/Slice/Grammar.y"
         {
         }
-#line 4141 "src/Slice/Grammar.cpp"
+#line 4126 "src/Slice/Grammar.cpp"
         break;
 
-        case 189: /* keyword: ICE_EXTENDS  */
+        case 186: /* keyword: ICE_DICTIONARY  */
 #line 2160 "src/Slice/Grammar.y"
         {
         }
-#line 4147 "src/Slice/Grammar.cpp"
+#line 4132 "src/Slice/Grammar.cpp"
         break;
 
-        case 190: /* keyword: ICE_THROWS  */
+        case 187: /* keyword: ICE_ENUM  */
 #line 2161 "src/Slice/Grammar.y"
         {
         }
-#line 4153 "src/Slice/Grammar.cpp"
+#line 4138 "src/Slice/Grammar.cpp"
         break;
 
-        case 191: /* keyword: ICE_VOID  */
+        case 188: /* keyword: ICE_OUT  */
 #line 2162 "src/Slice/Grammar.y"
         {
         }
-#line 4159 "src/Slice/Grammar.cpp"
+#line 4144 "src/Slice/Grammar.cpp"
         break;
 
-        case 192: /* keyword: ICE_BOOL  */
+        case 189: /* keyword: ICE_EXTENDS  */
 #line 2163 "src/Slice/Grammar.y"
         {
         }
-#line 4165 "src/Slice/Grammar.cpp"
+#line 4150 "src/Slice/Grammar.cpp"
         break;
 
-        case 193: /* keyword: ICE_BYTE  */
+        case 190: /* keyword: ICE_THROWS  */
 #line 2164 "src/Slice/Grammar.y"
         {
         }
-#line 4171 "src/Slice/Grammar.cpp"
+#line 4156 "src/Slice/Grammar.cpp"
         break;
 
-        case 194: /* keyword: ICE_SHORT  */
+        case 191: /* keyword: ICE_VOID  */
 #line 2165 "src/Slice/Grammar.y"
         {
         }
-#line 4177 "src/Slice/Grammar.cpp"
+#line 4162 "src/Slice/Grammar.cpp"
         break;
 
-        case 195: /* keyword: ICE_INT  */
+        case 192: /* keyword: ICE_BOOL  */
 #line 2166 "src/Slice/Grammar.y"
         {
         }
-#line 4183 "src/Slice/Grammar.cpp"
+#line 4168 "src/Slice/Grammar.cpp"
         break;
 
-        case 196: /* keyword: ICE_LONG  */
+        case 193: /* keyword: ICE_BYTE  */
 #line 2167 "src/Slice/Grammar.y"
         {
         }
-#line 4189 "src/Slice/Grammar.cpp"
+#line 4174 "src/Slice/Grammar.cpp"
         break;
 
-        case 197: /* keyword: ICE_FLOAT  */
+        case 194: /* keyword: ICE_SHORT  */
 #line 2168 "src/Slice/Grammar.y"
         {
         }
-#line 4195 "src/Slice/Grammar.cpp"
+#line 4180 "src/Slice/Grammar.cpp"
         break;
 
-        case 198: /* keyword: ICE_DOUBLE  */
+        case 195: /* keyword: ICE_INT  */
 #line 2169 "src/Slice/Grammar.y"
         {
         }
-#line 4201 "src/Slice/Grammar.cpp"
+#line 4186 "src/Slice/Grammar.cpp"
         break;
 
-        case 199: /* keyword: ICE_STRING  */
+        case 196: /* keyword: ICE_LONG  */
 #line 2170 "src/Slice/Grammar.y"
         {
         }
-#line 4207 "src/Slice/Grammar.cpp"
+#line 4192 "src/Slice/Grammar.cpp"
         break;
 
-        case 200: /* keyword: ICE_OBJECT  */
+        case 197: /* keyword: ICE_FLOAT  */
 #line 2171 "src/Slice/Grammar.y"
         {
         }
-#line 4213 "src/Slice/Grammar.cpp"
+#line 4198 "src/Slice/Grammar.cpp"
         break;
 
-        case 201: /* keyword: ICE_CONST  */
+        case 198: /* keyword: ICE_DOUBLE  */
 #line 2172 "src/Slice/Grammar.y"
         {
         }
-#line 4219 "src/Slice/Grammar.cpp"
+#line 4204 "src/Slice/Grammar.cpp"
         break;
 
-        case 202: /* keyword: ICE_FALSE  */
+        case 199: /* keyword: ICE_STRING  */
 #line 2173 "src/Slice/Grammar.y"
         {
         }
-#line 4225 "src/Slice/Grammar.cpp"
+#line 4210 "src/Slice/Grammar.cpp"
         break;
 
-        case 203: /* keyword: ICE_TRUE  */
+        case 200: /* keyword: ICE_OBJECT  */
 #line 2174 "src/Slice/Grammar.y"
         {
         }
-#line 4231 "src/Slice/Grammar.cpp"
+#line 4216 "src/Slice/Grammar.cpp"
         break;
 
-        case 204: /* keyword: ICE_IDEMPOTENT  */
+        case 201: /* keyword: ICE_CONST  */
 #line 2175 "src/Slice/Grammar.y"
         {
         }
-#line 4237 "src/Slice/Grammar.cpp"
+#line 4222 "src/Slice/Grammar.cpp"
         break;
 
-        case 205: /* keyword: ICE_TAG  */
+        case 202: /* keyword: ICE_FALSE  */
 #line 2176 "src/Slice/Grammar.y"
         {
         }
-#line 4243 "src/Slice/Grammar.cpp"
+#line 4228 "src/Slice/Grammar.cpp"
         break;
 
-        case 206: /* keyword: ICE_OPTIONAL  */
+        case 203: /* keyword: ICE_TRUE  */
 #line 2177 "src/Slice/Grammar.y"
         {
         }
-#line 4249 "src/Slice/Grammar.cpp"
+#line 4234 "src/Slice/Grammar.cpp"
         break;
 
-        case 207: /* keyword: ICE_VALUE  */
+        case 204: /* keyword: ICE_IDEMPOTENT  */
 #line 2178 "src/Slice/Grammar.y"
         {
         }
-#line 4255 "src/Slice/Grammar.cpp"
+#line 4240 "src/Slice/Grammar.cpp"
         break;
 
-#line 4259 "src/Slice/Grammar.cpp"
+        case 205: /* keyword: ICE_TAG  */
+#line 2179 "src/Slice/Grammar.y"
+        {
+        }
+#line 4246 "src/Slice/Grammar.cpp"
+        break;
+
+        case 206: /* keyword: ICE_OPTIONAL  */
+#line 2180 "src/Slice/Grammar.y"
+        {
+        }
+#line 4252 "src/Slice/Grammar.cpp"
+        break;
+
+        case 207: /* keyword: ICE_VALUE  */
+#line 2181 "src/Slice/Grammar.y"
+        {
+        }
+#line 4258 "src/Slice/Grammar.cpp"
+        break;
+
+#line 4262 "src/Slice/Grammar.cpp"
 
         default:
             break;
@@ -4368,4 +4367,4 @@ yyreturnlab:
     return yyresult;
 }
 
-#line 2181 "src/Slice/Grammar.y"
+#line 2184 "src/Slice/Grammar.y"

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -71,12 +71,6 @@ int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 #include <limits>
 
 #ifdef _MSC_VER
-// warning C4102: 'yyoverflowlab' : unreferenced label
-#    pragma warning(disable:4102)
-// warning C4065: switch statement contains 'default' but no 'case' labels
-#    pragma warning(disable:4065)
-// warning C4244: '=': conversion from 'int' to 'yytype_int16', possible loss of data
-#    pragma warning(disable:4244)
 // warning C4127: conditional expression is constant
 #    pragma warning(disable:4127)
 #endif

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -94,7 +94,6 @@ int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-conversion"
-#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 using namespace std;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -545,7 +545,7 @@ tag
         auto b = dynamic_pointer_cast<Builtin>(constant->type());
         if(b && b->isIntegralType())
         {
-            std::int64_t l = std::stoll(constant->value(), nullptr, 0);
+            int64_t l = std::stoll(constant->value(), nullptr, 0);
             if (l < 0 || l > std::numeric_limits<int32_t>::max())
             {
                 currentUnit->error("tag is out of range");
@@ -658,7 +658,7 @@ optional
         auto b = dynamic_pointer_cast<Builtin>(constant->type());
         if(b && b->isIntegralType())
         {
-            std::int64_t l = std::stoll(constant->value(), nullptr, 0);
+            int64_t l = std::stoll(constant->value(), nullptr, 0);
             if (l < 0 || l > std::numeric_limits<int32_t>::max())
             {
                 currentUnit->error("tag is out of range");
@@ -808,7 +808,7 @@ class_id
 // ----------------------------------------------------------------------
 : ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'
 {
-    std::int64_t id = dynamic_pointer_cast<IntegerTok>($3)->v;
+    int64_t id = dynamic_pointer_cast<IntegerTok>($3)->v;
     if(id < 0)
     {
         currentUnit->error("invalid compact id for class: id must be a positive integer");
@@ -1775,7 +1775,7 @@ enumerator_initializer
             {
                 try
                 {
-                    std::int64_t v = std::stoll(constant->value(), nullptr, 0);
+                    int64_t v = std::stoll(constant->value(), nullptr, 0);
                     tok = make_shared<IntegerTok>();
                     tok->v = v;
                     tok->literal = constant->value();

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -88,6 +88,7 @@ int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 #if defined(__clang__)
 #    pragma clang diagnostic ignored "-Wconversion"
 #    pragma clang diagnostic ignored "-Wsign-conversion"
+#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 using namespace std;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -31,13 +31,13 @@
 // `N` is the number of tokens that are being combined, and (Cur) is their combined location.
 #define YYLLOC_DEFAULT(Cur, Rhs, N)                               \
 do                                                                \
-    if(N == 1)                                                    \
+    if (N == 1)                                                   \
     {                                                             \
         (Cur) = (YYRHSLOC((Rhs), 1));                             \
     }                                                             \
     else                                                          \
     {                                                             \
-        if(N)                                                     \
+        if (N)                                                    \
         {                                                         \
             (Cur).firstLine = (YYRHSLOC((Rhs), 1)).firstLine;     \
             (Cur).firstColumn = (YYRHSLOC((Rhs), 1)).firstColumn; \
@@ -72,29 +72,29 @@ int slice_lex(YYSTYPE* lvalp, YYLTYPE* llocp);
 
 #ifdef _MSC_VER
 // warning C4102: 'yyoverflowlab' : unreferenced label
-#   pragma warning(disable:4102)
+#    pragma warning(disable:4102)
 // warning C4065: switch statement contains 'default' but no 'case' labels
-#   pragma warning(disable:4065)
+#    pragma warning(disable:4065)
 // warning C4244: '=': conversion from 'int' to 'yytype_int16', possible loss of data
-#   pragma warning(disable:4244)
+#    pragma warning(disable:4244)
 // warning C4127: conditional expression is constant
-#   pragma warning(disable:4127)
+#    pragma warning(disable:4127)
 #endif
 
 // Avoid old style cast warnings in generated grammar
 #ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wold-style-cast"
-#  pragma GCC diagnostic ignored "-Wunused-label"
+#    pragma GCC diagnostic ignored "-Wold-style-cast"
+#    pragma GCC diagnostic ignored "-Wunused-label"
 
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753
-#  pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+#    pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
 
 // Avoid clang warnings in generate grammar
 #if defined(__clang__)
-#   pragma clang diagnostic ignored "-Wconversion"
-#   pragma clang diagnostic ignored "-Wsign-conversion"
-#   pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#    pragma clang diagnostic ignored "-Wconversion"
+#    pragma clang diagnostic ignored "-Wsign-conversion"
+#    pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 using namespace std;
@@ -231,7 +231,7 @@ definitions
 : definitions global_meta_data
 {
     auto metaData = dynamic_pointer_cast<StringListTok>($2);
-    if(!metaData->v.empty())
+    if (!metaData->v.empty())
     {
         currentUnit->addGlobalMetaData(metaData->v);
     }
@@ -240,7 +240,7 @@ definitions
 {
     auto metaData = dynamic_pointer_cast<StringListTok>($2);
     auto contained = dynamic_pointer_cast<Contained>($3);
-    if(contained && !metaData->v.empty())
+    if (contained && !metaData->v.empty())
     {
         contained->setMetaData(metaData->v);
     }
@@ -360,7 +360,7 @@ module_def
     auto ident = dynamic_pointer_cast<StringTok>($2);
     ContainerPtr cont = currentUnit->currentContainer();
     ModulePtr module = cont->createModule(ident->v);
-    if(module)
+    if (module)
     {
         cont->checkIntroduced(ident->v, module);
         currentUnit->pushContainer(module);
@@ -373,7 +373,7 @@ module_def
 }
 '{' definitions '}'
 {
-    if($3)
+    if ($3)
     {
         currentUnit->popContainer();
         $$ = $3;
@@ -419,7 +419,7 @@ exception_def
     auto base = dynamic_pointer_cast<Exception>($2);
     ContainerPtr cont = currentUnit->currentContainer();
     ExceptionPtr ex = cont->createException(ident->v, base);
-    if(ex)
+    if (ex)
     {
         cont->checkIntroduced(ident->v, ex);
         currentUnit->pushContainer(ex);
@@ -428,7 +428,7 @@ exception_def
 }
 '{' data_members '}'
 {
-    if($3)
+    if ($3)
     {
         currentUnit->popContainer();
     }
@@ -494,10 +494,10 @@ tag
     ContainerPtr cont = currentUnit->currentContainer();
     assert(cont);
     ContainedList cl = cont->lookupContained(scoped->v, false);
-    if(cl.empty())
+    if (cl.empty())
     {
         EnumeratorList enumerators = cont->enumerators(scoped->v);
-        if(enumerators.size() == 1)
+        if (enumerators.size() == 1)
         {
             // Found
             cl.push_back(enumerators.front());
@@ -505,14 +505,14 @@ tag
             currentUnit->warning(Deprecated, string("referencing enumerator `") + scoped->v
                           + "' without its enumeration's scope is deprecated");
         }
-        else if(enumerators.size() > 1)
+        else if (enumerators.size() > 1)
         {
             ostringstream os;
             os << "enumerator `" << scoped->v << "' could designate";
             bool first = true;
-            for(EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+            for (const auto& p : enumerators)
             {
-                if(first)
+                if (first)
                 {
                     first = false;
                 }
@@ -521,7 +521,7 @@ tag
                     os << " or";
                 }
 
-                os << " `" << (*p)->scoped() << "'";
+                os << " `" << p->scoped() << "'";
             }
             currentUnit->error(os.str());
         }
@@ -531,7 +531,7 @@ tag
         }
     }
 
-    if(cl.empty())
+    if (cl.empty())
     {
         YYERROR; // Can't continue, jump to next yyerrok
     }
@@ -540,10 +540,10 @@ tag
     int tag = -1;
     auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front());
     auto constant = dynamic_pointer_cast<Const>(cl.front());
-    if(constant)
+    if (constant)
     {
         auto b = dynamic_pointer_cast<Builtin>(constant->type());
-        if(b && b->isIntegralType())
+        if (b && b->isIntegralType())
         {
             int64_t l = std::stoll(constant->value(), nullptr, 0);
             if (l < 0 || l > std::numeric_limits<int32_t>::max())
@@ -553,12 +553,12 @@ tag
             tag = static_cast<int>(l);
         }
     }
-    else if(enumerator)
+    else if (enumerator)
     {
         tag = enumerator->value();
     }
 
-    if(tag < 0)
+    if (tag < 0)
     {
         currentUnit->error("invalid tag `" + scoped->v + "'");
     }
@@ -607,10 +607,10 @@ optional
     ContainerPtr cont = currentUnit->currentContainer();
     assert(cont);
     ContainedList cl = cont->lookupContained(scoped->v, false);
-    if(cl.empty())
+    if (cl.empty())
     {
         EnumeratorList enumerators = cont->enumerators(scoped->v);
-        if(enumerators.size() == 1)
+        if (enumerators.size() == 1)
         {
             // Found
             cl.push_back(enumerators.front());
@@ -618,14 +618,14 @@ optional
             currentUnit->warning(Deprecated, string("referencing enumerator `") + scoped->v
                           + "' without its enumeration's scope is deprecated");
         }
-        else if(enumerators.size() > 1)
+        else if (enumerators.size() > 1)
         {
             ostringstream os;
             os << "enumerator `" << scoped->v << "' could designate";
             bool first = true;
-            for(EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+            for (const auto& p : enumerators)
             {
-                if(first)
+                if (first)
                 {
                     first = false;
                 }
@@ -634,7 +634,7 @@ optional
                     os << " or";
                 }
 
-                os << " `" << (*p)->scoped() << "'";
+                os << " `" << p->scoped() << "'";
             }
             currentUnit->error(os.str());
         }
@@ -644,7 +644,7 @@ optional
         }
     }
 
-    if(cl.empty())
+    if (cl.empty())
     {
         YYERROR; // Can't continue, jump to next yyerrok
     }
@@ -653,10 +653,10 @@ optional
     int tag = -1;
     auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front());
     auto constant = dynamic_pointer_cast<Const>(cl.front());
-    if(constant)
+    if (constant)
     {
         auto b = dynamic_pointer_cast<Builtin>(constant->type());
-        if(b && b->isIntegralType())
+        if (b && b->isIntegralType())
         {
             int64_t l = std::stoll(constant->value(), nullptr, 0);
             if (l < 0 || l > std::numeric_limits<int32_t>::max())
@@ -666,12 +666,12 @@ optional
             tag = static_cast<int>(l);
         }
     }
-    else if(enumerator)
+    else if (enumerator)
     {
         tag = enumerator->value();
     }
 
-    if(tag < 0)
+    if (tag < 0)
     {
         currentUnit->error("invalid tag `" + scoped->v + "'");
     }
@@ -757,7 +757,7 @@ struct_def
     auto ident = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
     StructPtr st = cont->createStruct(ident->v);
-    if(st)
+    if (st)
     {
         cont->checkIntroduced(ident->v, st);
         currentUnit->pushContainer(st);
@@ -772,7 +772,7 @@ struct_def
 }
 '{' data_members '}'
 {
-    if($2)
+    if ($2)
     {
         currentUnit->popContainer();
     }
@@ -781,7 +781,7 @@ struct_def
     // Empty structures are not allowed
     auto st = dynamic_pointer_cast<Struct>($$);
     assert(st);
-    if(st->dataMembers().empty())
+    if (st->dataMembers().empty())
     {
         currentUnit->error("struct `" + st->name() + "' must have at least one member"); // $$ is a dummy
     }
@@ -809,7 +809,7 @@ class_id
 : ICE_CLASS ICE_IDENT_OPEN ICE_INTEGER_LITERAL ')'
 {
     int64_t id = dynamic_pointer_cast<IntegerTok>($3)->v;
-    if(id < 0)
+    if (id < 0)
     {
         currentUnit->error("invalid compact id for class: id must be a positive integer");
     }
@@ -820,7 +820,7 @@ class_id
     else
     {
         string typeId = currentUnit->getTypeId(static_cast<int>(id));
-        if(!typeId.empty())
+        if (!typeId.empty())
         {
             currentUnit->error("invalid compact id for class: already assigned to class `" + typeId + "'");
         }
@@ -838,10 +838,10 @@ class_id
     ContainerPtr cont = currentUnit->currentContainer();
     assert(cont);
     ContainedList cl = cont->lookupContained(scoped->v, false);
-    if(cl.empty())
+    if (cl.empty())
     {
         EnumeratorList enumerators = cont->enumerators(scoped->v);
-        if(enumerators.size() == 1)
+        if (enumerators.size() == 1)
         {
             // Found
             cl.push_back(enumerators.front());
@@ -849,14 +849,14 @@ class_id
             currentUnit->warning(Deprecated, string("referencing enumerator `") + scoped->v
                           + "' without its enumeration's scope is deprecated");
         }
-        else if(enumerators.size() > 1)
+        else if (enumerators.size() > 1)
         {
             ostringstream os;
             os << "enumerator `" << scoped->v << "' could designate";
             bool first = true;
-            for(EnumeratorList::iterator p = enumerators.begin(); p != enumerators.end(); ++p)
+            for (const auto& p : enumerators)
             {
-                if(first)
+                if (first)
                 {
                     first = false;
                 }
@@ -865,7 +865,7 @@ class_id
                     os << " or";
                 }
 
-                os << " `" << (*p)->scoped() << "'";
+                os << " `" << p->scoped() << "'";
             }
             currentUnit->error(os.str());
         }
@@ -875,7 +875,7 @@ class_id
         }
     }
 
-    if(cl.empty())
+    if (cl.empty())
     {
         YYERROR; // Can't continue, jump to next yyerrok
     }
@@ -884,10 +884,10 @@ class_id
     int id = -1;
     auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front());
     auto constant = dynamic_pointer_cast<Const>(cl.front());
-    if(constant)
+    if (constant)
     {
         auto b = dynamic_pointer_cast<Builtin>(constant->type());
-        if(b && b->isIntegralType())
+        if (b && b->isIntegralType())
         {
             int64_t l = std::stoll(constant->value(), nullptr, 0);
             if (l < 0 || l > std::numeric_limits<int32_t>::max())
@@ -897,19 +897,19 @@ class_id
             id = static_cast<int>(l);
         }
     }
-    else if(enumerator)
+    else if (enumerator)
     {
         id = enumerator->value();
     }
 
-    if(id < 0)
+    if (id < 0)
     {
         currentUnit->error("invalid compact id for class: id must be a positive integer");
     }
     else
     {
         string typeId = currentUnit->getTypeId(id);
-        if(!typeId.empty())
+        if (!typeId.empty())
         {
             currentUnit->error("invalid compact id for class: already assigned to class `" + typeId + "'");
         }
@@ -951,7 +951,7 @@ class_def
     ContainerPtr cont = currentUnit->currentContainer();
     auto base = dynamic_pointer_cast<ClassDef>($2);
     ClassDefPtr cl = cont->createClassDef(ident->v, ident->t, base);
-    if(cl)
+    if (cl)
     {
         cont->checkIntroduced(ident->v, cl);
         currentUnit->pushContainer(cl);
@@ -964,7 +964,7 @@ class_def
 }
 '{' data_members '}'
 {
-    if($3)
+    if ($3)
     {
         currentUnit->popContainer();
         $$ = $3;
@@ -985,10 +985,10 @@ class_extends
     ContainerPtr cont = currentUnit->currentContainer();
     TypeList types = cont->lookupType(scoped->v);
     $$ = nullptr;
-    if(!types.empty())
+    if (!types.empty())
     {
         auto cl = dynamic_pointer_cast<ClassDecl>(types.front());
-        if(!cl)
+        if (!cl)
         {
             string msg = "`";
             msg += scoped->v;
@@ -998,7 +998,7 @@ class_extends
         else
         {
             ClassDefPtr def = cl->definition();
-            if(!def)
+            if (!def)
             {
                 string msg = "`";
                 msg += scoped->v;
@@ -1062,12 +1062,12 @@ data_member
     auto def = dynamic_pointer_cast<TaggedDefTok>($1);
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
     DataMemberPtr dm;
-    if(cl)
+    if (cl)
     {
         dm = cl->createDataMember(def->name, def->type, def->isTagged, def->tag, 0, "", "");
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
-    if(st)
+    if (st)
     {
         if (def->isTagged)
         {
@@ -1080,7 +1080,7 @@ data_member
         }
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
-    if(ex)
+    if (ex)
     {
         dm = ex->createDataMember(def->name, def->type, def->isTagged, def->tag, 0, "", "");
     }
@@ -1093,13 +1093,13 @@ data_member
     auto value = dynamic_pointer_cast<ConstDefTok>($3);
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
     DataMemberPtr dm;
-    if(cl)
+    if (cl)
     {
         dm = cl->createDataMember(def->name, def->type, def->isTagged, def->tag, value->v,
                                   value->valueAsString, value->valueAsLiteral);
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
-    if(st)
+    if (st)
     {
         if (def->isTagged)
         {
@@ -1113,7 +1113,7 @@ data_member
         }
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
-    if(ex)
+    if (ex)
     {
         dm = ex->createDataMember(def->name, def->type, def->isTagged, def->tag, value->v,
                                   value->valueAsString, value->valueAsLiteral);
@@ -1126,17 +1126,17 @@ data_member
     auto type = dynamic_pointer_cast<Type>($1);
     string name = dynamic_pointer_cast<StringTok>($2)->v;
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
-    if(cl)
+    if (cl)
     {
         $$ = cl->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
-    if(st)
+    if (st)
     {
         $$ = st->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
-    if(ex)
+    if (ex)
     {
         $$ = ex->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
     }
@@ -1147,17 +1147,17 @@ data_member
 {
     auto type = dynamic_pointer_cast<Type>($1);
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
-    if(cl)
+    if (cl)
     {
         $$ = cl->createDataMember(IceUtil::generateUUID(), type, false, 0, 0, "", ""); // Dummy
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
-    if(st)
+    if (st)
     {
         $$ = st->createDataMember(IceUtil::generateUUID(), type, false, 0, 0, "", ""); // Dummy
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
-    if(ex)
+    if (ex)
     {
         $$ = ex->createDataMember(IceUtil::generateUUID(), type, false, 0, 0, "", ""); // Dummy
     }
@@ -1202,10 +1202,10 @@ operation_preamble
     auto returnType = dynamic_pointer_cast<TaggedDefTok>($1);
     string name = dynamic_pointer_cast<StringTok>($2)->v;
     auto interface = dynamic_pointer_cast<InterfaceDef>(currentUnit->currentContainer());
-    if(interface)
+    if (interface)
     {
         OperationPtr op = interface->createOperation(name, returnType->type, returnType->isTagged, returnType->tag);
-        if(op)
+        if (op)
         {
             interface->checkIntroduced(name, op);
             currentUnit->pushContainer(op);
@@ -1235,7 +1235,7 @@ operation_preamble
             returnType->tag,
             Operation::Idempotent);
 
-        if(op)
+        if (op)
         {
             interface->checkIntroduced(name, op);
             currentUnit->pushContainer(op);
@@ -1256,10 +1256,10 @@ operation_preamble
     auto returnType = dynamic_pointer_cast<TaggedDefTok>($1);
     string name = dynamic_pointer_cast<StringTok>($2)->v;
     auto interface = dynamic_pointer_cast<InterfaceDef>(currentUnit->currentContainer());
-    if(interface)
+    if (interface)
     {
         OperationPtr op = interface->createOperation(name, returnType->type, returnType->isTagged, returnType->tag);
-        if(op)
+        if (op)
         {
             currentUnit->pushContainer(op);
             currentUnit->error("keyword `" + name + "' cannot be used as operation name");
@@ -1280,7 +1280,7 @@ operation_preamble
     auto returnType = dynamic_pointer_cast<TaggedDefTok>($2);
     string name = dynamic_pointer_cast<StringTok>($3)->v;
     auto interface = dynamic_pointer_cast<InterfaceDef>(currentUnit->currentContainer());
-    if(interface)
+    if (interface)
     {
         OperationPtr op = interface->createOperation(
             name,
@@ -1311,7 +1311,7 @@ operation
 // ----------------------------------------------------------------------
 : operation_preamble parameters ')'
 {
-    if($1)
+    if ($1)
     {
         currentUnit->popContainer();
         $$ = $1;
@@ -1326,14 +1326,14 @@ throws
     auto op = dynamic_pointer_cast<Operation>($4);
     auto el = dynamic_pointer_cast<ExceptionListTok>($5);
     assert(el);
-    if(op)
+    if (op)
     {
         op->setExceptionList(el->v);
     }
 }
 | operation_preamble error ')'
 {
-    if($1)
+    if ($1)
     {
         currentUnit->popContainer();
     }
@@ -1344,7 +1344,7 @@ throws
     auto op = dynamic_pointer_cast<Operation>($4);
     auto el = dynamic_pointer_cast<ExceptionListTok>($5);
     assert(el);
-    if(op)
+    if (op)
     {
         op->setExceptionList(el->v); // Dummy
     }
@@ -1388,7 +1388,7 @@ interface_def
     ContainerPtr cont = currentUnit->currentContainer();
     auto bases = dynamic_pointer_cast<InterfaceListTok>($2);
     InterfaceDefPtr interface = cont->createInterfaceDef(ident->v, bases->v);
-    if(interface)
+    if (interface)
     {
         cont->checkIntroduced(ident->v, interface);
         currentUnit->pushContainer(interface);
@@ -1401,7 +1401,7 @@ interface_def
 }
 '{' operations '}'
 {
-    if($3)
+    if ($3)
     {
         currentUnit->popContainer();
         $$ = $3;
@@ -1422,10 +1422,10 @@ interface_list
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
     TypeList types = cont->lookupType(scoped->v);
-    if(!types.empty())
+    if (!types.empty())
     {
         auto interface = dynamic_pointer_cast<InterfaceDecl>(types.front());
-        if(!interface)
+        if (!interface)
         {
             string msg = "`";
             msg += scoped->v;
@@ -1435,7 +1435,7 @@ interface_list
         else
         {
             InterfaceDefPtr def = interface->definition();
-            if(!def)
+            if (!def)
             {
                 string msg = "`";
                 msg += scoped->v;
@@ -1457,10 +1457,10 @@ interface_list
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
     TypeList types = cont->lookupType(scoped->v);
-    if(!types.empty())
+    if (!types.empty())
     {
         auto interface = dynamic_pointer_cast<InterfaceDecl>(types.front());
-        if(!interface)
+        if (!interface)
         {
             string msg = "`";
             msg += scoped->v;
@@ -1470,7 +1470,7 @@ interface_list
         else
         {
             InterfaceDefPtr def = interface->definition();
-            if(!def)
+            if (!def)
             {
                 string msg = "`";
                 msg += scoped->v;
@@ -1518,7 +1518,7 @@ operations
 {
     auto metaData = dynamic_pointer_cast<StringListTok>($1);
     auto contained = dynamic_pointer_cast<Contained>($2);
-    if(contained && !metaData->v.empty())
+    if (contained && !metaData->v.empty())
     {
         contained->setMetaData(metaData->v);
     }
@@ -1562,7 +1562,7 @@ exception
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
     ExceptionPtr exception = cont->lookupException(scoped->v);
-    if(!exception)
+    if (!exception)
     {
         exception = cont->createException(IceUtil::generateUUID(), 0, Dummy); // Dummy
     }
@@ -1648,7 +1648,7 @@ enum_def
     auto ident = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
     EnumPtr en = cont->createEnum(ident->v);
-    if(en)
+    if (en)
     {
         cont->checkIntroduced(ident->v, en);
     }
@@ -1662,10 +1662,10 @@ enum_def
 '{' enumerator_list '}'
 {
     auto en = dynamic_pointer_cast<Enum>($2);
-    if(en)
+    if (en)
     {
         auto enumerators = dynamic_pointer_cast<EnumeratorListTok>($4);
-        if(enumerators->v.empty())
+        if (enumerators->v.empty())
         {
             currentUnit->error("enum `" + en->name() + "' must have at least one enumerator");
         }
@@ -1712,7 +1712,7 @@ enumerator
     auto ens = make_shared<EnumeratorListTok>();
     ContainerPtr cont = currentUnit->currentContainer();
     EnumeratorPtr en = cont->createEnumerator(ident->v);
-    if(en)
+    if (en)
     {
         ens->v.push_front(en);
     }
@@ -1724,7 +1724,7 @@ enumerator
     auto ens = make_shared<EnumeratorListTok>();
     ContainerPtr cont = currentUnit->currentContainer();
     auto intVal = dynamic_pointer_cast<IntegerTok>($3);
-    if(intVal)
+    if (intVal)
     {
         if (intVal->v < 0 || intVal->v > std::numeric_limits<int32_t>::max())
         {
@@ -1764,14 +1764,14 @@ enumerator_initializer
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v);
     IntegerTokPtr tok;
-    if(!cl.empty())
+    if (!cl.empty())
     {
         auto constant = dynamic_pointer_cast<Const>(cl.front());
-        if(constant)
+        if (constant)
         {
             currentUnit->currentContainer()->checkIntroduced(scoped->v, constant);
             auto b = dynamic_pointer_cast<Builtin>(constant->type());
-            if(b && b->isIntegralType())
+            if (b && b->isIntegralType())
             {
                 try
                 {
@@ -1787,7 +1787,7 @@ enumerator_initializer
         }
     }
 
-    if(!tok)
+    if (!tok)
     {
         string msg = "illegal initializer: `" + scoped->v + "' is not an integer constant";
         currentUnit->error(msg); // $$ is dummy
@@ -1830,7 +1830,7 @@ parameters
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isTagged, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
         auto metaData = dynamic_pointer_cast<StringListTok>($2);
-        if(!metaData->v.empty())
+        if (!metaData->v.empty())
         {
             pd->setMetaData(metaData->v);
         }
@@ -1841,12 +1841,12 @@ parameters
     auto isOutParam = dynamic_pointer_cast<BoolTok>($3);
     auto tsp = dynamic_pointer_cast<TaggedDefTok>($5);
     auto op = dynamic_pointer_cast<Operation>(currentUnit->currentContainer());
-    if(op)
+    if (op)
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isTagged, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
         auto metaData = dynamic_pointer_cast<StringListTok>($4);
-        if(!metaData->v.empty())
+        if (!metaData->v.empty())
         {
             pd->setMetaData(metaData->v);
         }
@@ -1954,17 +1954,17 @@ type
 {
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
-    if(cont)
+    if (cont)
     {
         TypeList types = cont->lookupType(scoped->v);
-        if(types.empty())
+        if (types.empty())
         {
             YYERROR; // Can't continue, jump to next yyerrok
         }
         TypePtr firstType = types.front();
 
         auto interface = dynamic_pointer_cast<InterfaceDecl>(firstType);
-        if(interface)
+        if (interface)
         {
             string msg = "add a '*' after the interface name to specify its proxy type: '";
             msg += scoped->v;
@@ -1985,17 +1985,17 @@ type
 {
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
-    if(cont)
+    if (cont)
     {
         TypeList types = cont->lookupType(scoped->v);
-        if(types.empty())
+        if (types.empty())
         {
             YYERROR; // Can't continue, jump to next yyerrok
         }
         TypePtr firstType = types.front();
 
         auto interface = dynamic_pointer_cast<InterfaceDecl>(firstType);
-        if(!interface)
+        if (!interface)
         {
             string msg = "`";
             msg += scoped->v;
@@ -2073,7 +2073,7 @@ const_initializer
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ConstDefTokPtr def;
     ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v, false);
-    if(cl.empty())
+    if (cl.empty())
     {
         // Could be an enumerator
         def = make_shared<ConstDefTok>(nullptr, scoped->v, scoped->v);
@@ -2082,12 +2082,12 @@ const_initializer
     {
         auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front());
         auto constant = dynamic_pointer_cast<Const>(cl.front());
-        if(enumerator)
+        if (enumerator)
         {
             currentUnit->currentContainer()->checkIntroduced(scoped->v, enumerator);
             def = make_shared<ConstDefTok>(enumerator, scoped->v, scoped->v);
         }
-        else if(constant)
+        else if (constant)
         {
             currentUnit->currentContainer()->checkIntroduced(scoped->v, constant);
             def = make_shared<ConstDefTok>(constant, constant->value(), constant->value());

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -930,10 +930,10 @@ static char* yy_last_accepting_cpos;
 extern int yy_flex_debug;
 int yy_flex_debug = 1;
 
-static const flex_int32_t yy_rule_linenum[49] = {0,   129, 143, 144, 151, 152, 153, 160, 179, 192, 202, 209, 210,
-                                                 222, 223, 231, 242, 252, 260, 278, 301, 329, 334, 337, 343, 344,
-                                                 349, 355, 374, 379, 385, 386, 401, 406, 414, 419, 434, 444, 449,
-                                                 453, 458, 464, 470, 507, 517, 520, 527, 531, 545};
+static const flex_int32_t yy_rule_linenum[49] = {0,   127, 141, 142, 149, 150, 151, 158, 177, 190, 200, 207, 208,
+                                                 220, 221, 229, 240, 250, 258, 276, 299, 327, 332, 335, 341, 342,
+                                                 347, 353, 372, 377, 383, 384, 399, 404, 412, 417, 432, 442, 447,
+                                                 451, 456, 462, 468, 505, 515, 518, 525, 529, 543};
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -957,8 +957,6 @@ char* yytext;
 #include <math.h>
 
 #ifdef _MSC_VER
-// 'initializing' : conversion from '__int64' to 'int', possible loss of data
-#    pragma warning(disable : 4244)
 #    ifdef slice_wrap
 #        undef slice_wrap
 #        define slice_wrap() 1
@@ -1001,8 +999,8 @@ namespace
 #define YY_USER_INIT initScanner();
 #define YY_USER_ACTION preAction();
 
-#line 1188 "src/Slice/Scanner.cpp"
-#line 67 "src/Slice/Scanner.l"
+#line 1186 "src/Slice/Scanner.cpp"
+#line 65 "src/Slice/Scanner.l"
 /* Changes the default prefix of 'yy' to 'slice_' for functions and variables in the generated code. */
 /* Instructs flex to not suppress any warnings when generating the scanner. */
 /* Instructs flex to generate a scanner that supports verbose outputting (debug mode). */
@@ -1023,7 +1021,7 @@ namespace
 
 /* The scanner also has a built in 'INITIAL' start-condition state, which is the state the scanner is initialized in.
  * We use it solely to check for and consume any BOMs at the start of files. See Bug 3140. */
-#line 1215 "src/Slice/Scanner.cpp"
+#line 1213 "src/Slice/Scanner.cpp"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -1311,11 +1309,11 @@ YY_DECL
 
     {
 /* %% [7.0] user's declarations go here */
-#line 125 "src/Slice/Scanner.l"
+#line 123 "src/Slice/Scanner.l"
 
         /* ========== Literals ========== */
         /* Matches the start of a double-quoted string literal. */
-#line 1506 "src/Slice/Scanner.cpp"
+#line 1504 "src/Slice/Scanner.cpp"
 
         while (/*CONSTCOND*/ 1) /* loops until end-of-file is reached */
         {
@@ -1397,7 +1395,7 @@ YY_DECL
 
                 case 1:
                     YY_RULE_SETUP
-#line 129 "src/Slice/Scanner.l"
+#line 127 "src/Slice/Scanner.l"
                     {
                         yy_push_state(STRING_LITERAL);
                         startLocation(yylloc);
@@ -1412,10 +1410,10 @@ YY_DECL
                 /* Matches Escaped backslashes and any other valid string characters. Invalid characters are
                  * new-lines, non-printable ASCII characters, and double-quotes. */
                 case 2:
-#line 144 "src/Slice/Scanner.l"
+#line 142 "src/Slice/Scanner.l"
                 case 3:
                     YY_RULE_SETUP
-#line 144 "src/Slice/Scanner.l"
+#line 142 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         str->literal += yytext;
@@ -1424,12 +1422,12 @@ YY_DECL
                     YY_BREAK
                 /* Matches an escaped double-quote, single-quote, or question mark. */
                 case 4:
-#line 152 "src/Slice/Scanner.l"
+#line 150 "src/Slice/Scanner.l"
                 case 5:
-#line 153 "src/Slice/Scanner.l"
+#line 151 "src/Slice/Scanner.l"
                 case 6:
                     YY_RULE_SETUP
-#line 153 "src/Slice/Scanner.l"
+#line 151 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         str->literal += yytext;
@@ -1439,7 +1437,7 @@ YY_DECL
                 /* Matches an ANSI-C escape code pattern. */
                 case 7:
                     YY_RULE_SETUP
-#line 160 "src/Slice/Scanner.l"
+#line 158 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         char ansiCode;
@@ -1477,7 +1475,7 @@ YY_DECL
                 /* Matches an escaped octal value. Octal literals are limited to a max of 3 digits. */
                 case 8:
                     YY_RULE_SETUP
-#line 179 "src/Slice/Scanner.l"
+#line 177 "src/Slice/Scanner.l"
                     {
                         int64_t value = std::stoll((yytext + 1), nullptr, 8);
                         if (value > 255)
@@ -1493,7 +1491,7 @@ YY_DECL
                 /* Matches an escaped hexadecimal value. Hexadecimal literals are limited to a max of 2 digits. */
                 case 9:
                     YY_RULE_SETUP
-#line 192 "src/Slice/Scanner.l"
+#line 190 "src/Slice/Scanner.l"
                     {
                         int64_t value = std::stoll((yytext + 2), nullptr, 16);
                         assert(value <= 255);
@@ -1506,7 +1504,7 @@ YY_DECL
                 /* Matches an empty hexadecimal escape value. */
                 case 10:
                     YY_RULE_SETUP
-#line 202 "src/Slice/Scanner.l"
+#line 200 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("no hex digit in hex escape sequence");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1515,10 +1513,10 @@ YY_DECL
                     YY_BREAK
                 /* Matches a 4-char or 8-char size universal character code. */
                 case 11:
-#line 210 "src/Slice/Scanner.l"
+#line 208 "src/Slice/Scanner.l"
                 case 12:
                     YY_RULE_SETUP
-#line 210 "src/Slice/Scanner.l"
+#line 208 "src/Slice/Scanner.l"
                     {
                         int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
                         if (codePoint <= 0xdfff && codePoint >= 0xd800)
@@ -1533,10 +1531,10 @@ YY_DECL
                     YY_BREAK
                 /* Matches a universal character code that isn't the correct size, or uses incorrect characters. */
                 case 13:
-#line 223 "src/Slice/Scanner.l"
+#line 221 "src/Slice/Scanner.l"
                 case 14:
                     YY_RULE_SETUP
-#line 223 "src/Slice/Scanner.l"
+#line 221 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("unknown escape sequence in string literal: `" + string(yytext) + "'");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1548,7 +1546,7 @@ YY_DECL
                 case 15:
                     /* rule 15 can match eol */
                     YY_RULE_SETUP
-#line 231 "src/Slice/Scanner.l"
+#line 229 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         endLocation(yylloc);
@@ -1562,7 +1560,7 @@ YY_DECL
                  * because it only matches 2 characters (the lowest any match), and it's beneath the others. */
                 case 16:
                     YY_RULE_SETUP
-#line 242 "src/Slice/Scanner.l"
+#line 240 "src/Slice/Scanner.l"
                     {
                         currentUnit->warning(
                             All,
@@ -1578,7 +1576,7 @@ YY_DECL
                  * completeness. */
                 case 17:
                     YY_RULE_SETUP
-#line 252 "src/Slice/Scanner.l"
+#line 250 "src/Slice/Scanner.l"
                     {
                         currentUnit->warning(All, "dangling backslash in string literal");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1590,7 +1588,7 @@ YY_DECL
                  * the rules above this one. */
                 case 18:
                     YY_RULE_SETUP
-#line 260 "src/Slice/Scanner.l"
+#line 258 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         endLocation(yylloc);
@@ -1602,7 +1600,7 @@ YY_DECL
                     YY_BREAK
                 /* Matches EOF, but only while scanning a string literal. */
                 case YY_STATE_EOF(STRING_LITERAL):
-#line 270 "src/Slice/Scanner.l"
+#line 268 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
                     endLocation(yylloc);
@@ -1613,7 +1611,7 @@ YY_DECL
                     YY_BREAK
                 case 19:
                     YY_RULE_SETUP
-#line 278 "src/Slice/Scanner.l"
+#line 276 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
 
@@ -1639,7 +1637,7 @@ YY_DECL
                     YY_BREAK
                 case 20:
                     YY_RULE_SETUP
-#line 301 "src/Slice/Scanner.l"
+#line 299 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
 
@@ -1670,7 +1668,7 @@ YY_DECL
                 /* Matches and records a triple-slash style doc comment. */
                 case 21:
                     YY_RULE_SETUP
-#line 329 "src/Slice/Scanner.l"
+#line 327 "src/Slice/Scanner.l"
                     {
                         currentUnit->addToComment(yytext + 3);
                     }
@@ -1678,14 +1676,14 @@ YY_DECL
                 /* Matches and consumes a C++ style comment. */
                 case 22:
                     YY_RULE_SETUP
-#line 334 "src/Slice/Scanner.l"
+#line 332 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
                 /* Matches the start of a C style comment, and switches the scanner to the C_COMMENT state. */
                 case 23:
                     YY_RULE_SETUP
-#line 337 "src/Slice/Scanner.l"
+#line 335 "src/Slice/Scanner.l"
                     {
                         yy_push_state(C_COMMENT);
                     }
@@ -1694,10 +1692,10 @@ YY_DECL
                  * time to ensure Flex scans '* /' correctly. Flex prioritizes longer matches over shorter ones, so '*
                  * /' will match before '*'. */
                 case 24:
-#line 344 "src/Slice/Scanner.l"
+#line 342 "src/Slice/Scanner.l"
                 case 25:
                     YY_RULE_SETUP
-#line 344 "src/Slice/Scanner.l"
+#line 342 "src/Slice/Scanner.l"
                     {
                         yymore();
                     }
@@ -1707,7 +1705,7 @@ YY_DECL
                 case 26:
                     /* rule 26 can match eol */
                     YY_RULE_SETUP
-#line 349 "src/Slice/Scanner.l"
+#line 347 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                         yymore();
@@ -1716,7 +1714,7 @@ YY_DECL
                 /* Matches the end of a C style comment, and reverts the scanner state to what it previously was. */
                 case 27:
                     YY_RULE_SETUP
-#line 355 "src/Slice/Scanner.l"
+#line 353 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
 
@@ -1728,7 +1726,7 @@ YY_DECL
                 /* Handles reaching EOF while scanning a C style comment by issuing a warning but continuing normally.
                  */
                 case YY_STATE_EOF(C_COMMENT):
-#line 364 "src/Slice/Scanner.l"
+#line 362 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
 
@@ -1740,7 +1738,7 @@ YY_DECL
                 /* Matches the empty preprocessor directive. */
                 case 28:
                     YY_RULE_SETUP
-#line 374 "src/Slice/Scanner.l"
+#line 372 "src/Slice/Scanner.l"
                     {
                         yy_push_state(PREPROCESS);
                     }
@@ -1748,7 +1746,7 @@ YY_DECL
                 /* Matches a line preprocessor directive, but missing a line number. */
                 case 29:
                     YY_RULE_SETUP
-#line 379 "src/Slice/Scanner.l"
+#line 377 "src/Slice/Scanner.l"
                     {
                         yy_push_state(PREPROCESS);
                         currentUnit->error("missing line number in line preprocessor directive");
@@ -1756,10 +1754,10 @@ YY_DECL
                     YY_BREAK
                 /* Matches a line preprocessor directive (optionally with a file specified afterwards). */
                 case 30:
-#line 386 "src/Slice/Scanner.l"
+#line 384 "src/Slice/Scanner.l"
                 case 31:
                     YY_RULE_SETUP
-#line 386 "src/Slice/Scanner.l"
+#line 384 "src/Slice/Scanner.l"
                     {
                         int includeAction = scanPosition(yytext);
                         if (yylineno == 0 ||
@@ -1778,7 +1776,7 @@ YY_DECL
                  * found while scanning a preprocessor directive. */
                 case 32:
                     YY_RULE_SETUP
-#line 401 "src/Slice/Scanner.l"
+#line 399 "src/Slice/Scanner.l"
                     {
                         currentUnit->error(
                             "encountered unexpected token while scanning preprocessor directive: `" + string(yytext) +
@@ -1788,10 +1786,10 @@ YY_DECL
                 /* Matches a new-line character or EOF. This signals the end of the preprocessor statement. */
                 case 33:
 /* rule 33 can match eol */
-#line 407 "src/Slice/Scanner.l"
+#line 405 "src/Slice/Scanner.l"
                     YY_RULE_SETUP
                 case YY_STATE_EOF(PREPROCESS):
-#line 407 "src/Slice/Scanner.l"
+#line 405 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
                     nextLine();
@@ -1800,7 +1798,7 @@ YY_DECL
                 /* ========== Metadata ========== */
                 case 34:
                     YY_RULE_SETUP
-#line 414 "src/Slice/Scanner.l"
+#line 412 "src/Slice/Scanner.l"
                     {
                         yy_push_state(METADATA);
                         return ICE_METADATA_OPEN;
@@ -1808,7 +1806,7 @@ YY_DECL
                     YY_BREAK
                 case 35:
                     YY_RULE_SETUP
-#line 419 "src/Slice/Scanner.l"
+#line 417 "src/Slice/Scanner.l"
                     {
                         yy_push_state(METADATA);
 
@@ -1827,7 +1825,7 @@ YY_DECL
                 /* Matches the start of a metadata string, then switches the scanner into STRING_LITERAL mode. */
                 case 36:
                     YY_RULE_SETUP
-#line 434 "src/Slice/Scanner.l"
+#line 432 "src/Slice/Scanner.l"
                     {
                         yy_push_state(STRING_LITERAL);
                         startLocation(yylloc);
@@ -1840,7 +1838,7 @@ YY_DECL
                 /* Matches commas between string literals in quoted metadata and forwards them to the parser. */
                 case 37:
                     YY_RULE_SETUP
-#line 444 "src/Slice/Scanner.l"
+#line 442 "src/Slice/Scanner.l"
                     {
                         return yytext[0];
                     }
@@ -1849,14 +1847,14 @@ YY_DECL
                 case 38:
                     /* rule 38 can match eol */
                     YY_RULE_SETUP
-#line 449 "src/Slice/Scanner.l"
+#line 447 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                     }
                     YY_BREAK
                 case 39:
                     YY_RULE_SETUP
-#line 453 "src/Slice/Scanner.l"
+#line 451 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         return ICE_METADATA_CLOSE;
@@ -1864,7 +1862,7 @@ YY_DECL
                     YY_BREAK
                 case 40:
                     YY_RULE_SETUP
-#line 458 "src/Slice/Scanner.l"
+#line 456 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         return ICE_GLOBAL_METADATA_CLOSE;
@@ -1874,7 +1872,7 @@ YY_DECL
                  * error. */
                 case 41:
                     YY_RULE_SETUP
-#line 464 "src/Slice/Scanner.l"
+#line 462 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("invalid character between metadata");
                     }
@@ -1883,7 +1881,7 @@ YY_DECL
                 case 42:
                     /* rule 42 can match eol */
                     YY_RULE_SETUP
-#line 470 "src/Slice/Scanner.l"
+#line 468 "src/Slice/Scanner.l"
                     {
                         StringTokPtr ident = make_shared<StringTok>();
                         ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -1923,7 +1921,7 @@ YY_DECL
                     YY_BREAK
                 case 43:
                     YY_RULE_SETUP
-#line 507 "src/Slice/Scanner.l"
+#line 505 "src/Slice/Scanner.l"
                     {
                         StringTokPtr ident = make_shared<StringTok>();
                         ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -1935,7 +1933,7 @@ YY_DECL
                 /* Matches and consumes any whitespace, except for newlines. */
                 case 44:
                     YY_RULE_SETUP
-#line 517 "src/Slice/Scanner.l"
+#line 515 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
@@ -1943,7 +1941,7 @@ YY_DECL
                 case 45:
                     /* rule 45 can match eol */
                     YY_RULE_SETUP
-#line 520 "src/Slice/Scanner.l"
+#line 518 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                     }
@@ -1952,7 +1950,7 @@ YY_DECL
                 /* Matches and consumes a BOM, but only when the scanner has just started scanning a new file. */
                 case 46:
                     YY_RULE_SETUP
-#line 527 "src/Slice/Scanner.l"
+#line 525 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
@@ -1962,7 +1960,7 @@ YY_DECL
                 case 47:
                     /* rule 47 can match eol */
                     YY_RULE_SETUP
-#line 531 "src/Slice/Scanner.l"
+#line 529 "src/Slice/Scanner.l"
                     {
                         stringstream s;
                         s << "illegal input character: '\\";
@@ -1980,7 +1978,7 @@ YY_DECL
                  * sub-scanner. */
                 case 48:
                     YY_RULE_SETUP
-#line 545 "src/Slice/Scanner.l"
+#line 543 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
                         return yytext[0];
@@ -1988,10 +1986,10 @@ YY_DECL
                     YY_BREAK
                 case 49:
                     YY_RULE_SETUP
-#line 550 "src/Slice/Scanner.l"
+#line 548 "src/Slice/Scanner.l"
                     YY_FATAL_ERROR("flex scanner jammed");
                     YY_BREAK
-#line 2150 "src/Slice/Scanner.cpp"
+#line 2148 "src/Slice/Scanner.cpp"
                 case YY_STATE_EOF(INITIAL):
                 case YY_STATE_EOF(PRE_SLICE):
                 case YY_STATE_EOF(SLICE):
@@ -3002,7 +3000,7 @@ yyfree(void* ptr)
 
 /* %ok-for-header */
 
-#line 550 "src/Slice/Scanner.l"
+#line 548 "src/Slice/Scanner.l"
 
 namespace Slice
 {

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -1,11 +1,11 @@
-#line 2 "src/Slice/Scanner.cpp"
+#line 1 "src/Slice/Scanner.cpp"
 //
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
 #include "IceUtil/ScannerConfig.h"
 
-#line 9 "src/Slice/Scanner.cpp"
+#line 8 "src/Slice/Scanner.cpp"
 
 #define YY_INT_ALIGNED long int
 
@@ -357,6 +357,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #    else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -481,7 +482,7 @@ typedef size_t yy_size_t;
 #endif
 
 /* %if-not-reentrant */
-extern int yyleng;
+extern yy_size_t yyleng;
 /* %endif */
 
 /* %if-c-only */
@@ -532,7 +533,7 @@ struct yy_buffer_state
     /* Number of characters read into yy_ch_buf, not including EOB
      * characters.
      */
-    int yy_n_chars;
+    yy_size_t yy_n_chars;
 
     /* Whether we "own" the buffer - i.e., we know we created it,
      * and can realloc() it to grow it, and should free() it to
@@ -610,8 +611,8 @@ static YY_BUFFER_STATE* yy_buffer_stack = NULL; /**< Stack as an array. */
 /* %not-for-header */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static int yy_n_chars; /* number of characters read into yy_ch_buf */
-int yyleng;
+static yy_size_t yy_n_chars; /* number of characters read into yy_ch_buf */
+yy_size_t yyleng;
 
 /* Points to current character in buffer. */
 static char* yy_c_buf_p = NULL;
@@ -641,7 +642,7 @@ static void yy_init_buffer(YY_BUFFER_STATE b, FILE* file);
 
 YY_BUFFER_STATE yy_scan_buffer(char* base, yy_size_t size);
 YY_BUFFER_STATE yy_scan_string(const char* yy_str);
-YY_BUFFER_STATE yy_scan_bytes(const char* bytes, int len);
+YY_BUFFER_STATE yy_scan_bytes(const char* bytes, yy_size_t len);
 
 /* %endif */
 
@@ -710,7 +711,7 @@ static void yynoreturn yy_fatal_error(const char* msg);
     (yytext_ptr) = yy_bp;                                                                                              \
     /* %% [2.0] code to fiddle yytext and yyleng for yymore() goes here \ */                                           \
     (yytext_ptr) -= (yy_more_len);                                                                                     \
-    yyleng = (int)(yy_cp - (yytext_ptr));                                                                              \
+    yyleng = (yy_size_t)(yy_cp - (yytext_ptr));                                                                        \
     (yy_hold_char) = *yy_cp;                                                                                           \
     *yy_cp = '\0';                                                                                                     \
     /* %% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \ */                                          \
@@ -929,10 +930,10 @@ static char* yy_last_accepting_cpos;
 extern int yy_flex_debug;
 int yy_flex_debug = 1;
 
-static const flex_int32_t yy_rule_linenum[49] = {0,   135, 149, 150, 157, 158, 159, 166, 185, 198, 208, 215, 216,
-                                                 228, 229, 237, 248, 258, 266, 284, 298, 326, 331, 334, 340, 341,
-                                                 346, 352, 371, 376, 382, 383, 398, 403, 411, 416, 431, 441, 446,
-                                                 450, 455, 461, 467, 504, 514, 517, 524, 528, 542};
+static const flex_int32_t yy_rule_linenum[49] = {0,   129, 143, 144, 151, 152, 153, 160, 179, 192, 202, 209, 210,
+                                                 222, 223, 231, 242, 252, 260, 278, 301, 329, 334, 337, 343, 344,
+                                                 349, 355, 374, 379, 385, 386, 401, 406, 414, 419, 434, 444, 449,
+                                                 453, 458, 464, 470, 507, 517, 520, 527, 531, 545};
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -952,7 +953,6 @@ char* yytext;
 #include "Slice/Grammar.h"
 
 #include <iomanip>
-
 #include <stdlib.h>
 #include <math.h>
 
@@ -1001,8 +1001,8 @@ namespace
 #define YY_USER_INIT initScanner();
 #define YY_USER_ACTION preAction();
 
-#line 1194 "src/Slice/Scanner.cpp"
-#line 73 "src/Slice/Scanner.l"
+#line 1188 "src/Slice/Scanner.cpp"
+#line 67 "src/Slice/Scanner.l"
 /* Changes the default prefix of 'yy' to 'slice_' for functions and variables in the generated code. */
 /* Instructs flex to not suppress any warnings when generating the scanner. */
 /* Instructs flex to generate a scanner that supports verbose outputting (debug mode). */
@@ -1023,7 +1023,7 @@ namespace
 
 /* The scanner also has a built in 'INITIAL' start-condition state, which is the state the scanner is initialized in.
  * We use it solely to check for and consume any BOMs at the start of files. See Bug 3140. */
-#line 1221 "src/Slice/Scanner.cpp"
+#line 1215 "src/Slice/Scanner.cpp"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -1163,7 +1163,7 @@ static int yy_top_state(void);
         if (YY_CURRENT_BUFFER_LVALUE->yy_is_interactive)                                                               \
         {                                                                                                              \
             int c = '*';                                                                                               \
-            int n;                                                                                                     \
+            yy_size_t n;                                                                                               \
             for (n = 0; n < max_size && (c = getc(yyin)) != EOF && c != '\n'; ++n)                                     \
                 buf[n] = (char)c;                                                                                      \
             if (c == '\n')                                                                                             \
@@ -1311,11 +1311,11 @@ YY_DECL
 
     {
 /* %% [7.0] user's declarations go here */
-#line 131 "src/Slice/Scanner.l"
+#line 125 "src/Slice/Scanner.l"
 
         /* ========== Literals ========== */
         /* Matches the start of a double-quoted string literal. */
-#line 1512 "src/Slice/Scanner.cpp"
+#line 1506 "src/Slice/Scanner.cpp"
 
         while (/*CONSTCOND*/ 1) /* loops until end-of-file is reached */
         {
@@ -1397,7 +1397,7 @@ YY_DECL
 
                 case 1:
                     YY_RULE_SETUP
-#line 135 "src/Slice/Scanner.l"
+#line 129 "src/Slice/Scanner.l"
                     {
                         yy_push_state(STRING_LITERAL);
                         startLocation(yylloc);
@@ -1412,10 +1412,10 @@ YY_DECL
                 /* Matches Escaped backslashes and any other valid string characters. Invalid characters are
                  * new-lines, non-printable ASCII characters, and double-quotes. */
                 case 2:
-#line 150 "src/Slice/Scanner.l"
+#line 144 "src/Slice/Scanner.l"
                 case 3:
                     YY_RULE_SETUP
-#line 150 "src/Slice/Scanner.l"
+#line 144 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         str->literal += yytext;
@@ -1424,12 +1424,12 @@ YY_DECL
                     YY_BREAK
                 /* Matches an escaped double-quote, single-quote, or question mark. */
                 case 4:
-#line 158 "src/Slice/Scanner.l"
+#line 152 "src/Slice/Scanner.l"
                 case 5:
-#line 159 "src/Slice/Scanner.l"
+#line 153 "src/Slice/Scanner.l"
                 case 6:
                     YY_RULE_SETUP
-#line 159 "src/Slice/Scanner.l"
+#line 153 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         str->literal += yytext;
@@ -1439,7 +1439,7 @@ YY_DECL
                 /* Matches an ANSI-C escape code pattern. */
                 case 7:
                     YY_RULE_SETUP
-#line 166 "src/Slice/Scanner.l"
+#line 160 "src/Slice/Scanner.l"
                     {
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
                         char ansiCode;
@@ -1477,9 +1477,9 @@ YY_DECL
                 /* Matches an escaped octal value. Octal literals are limited to a max of 3 digits. */
                 case 8:
                     YY_RULE_SETUP
-#line 185 "src/Slice/Scanner.l"
+#line 179 "src/Slice/Scanner.l"
                     {
-                        std::int64_t value = std::stoll((yytext + 1), 0, 8);
+                        int64_t value = std::stoll((yytext + 1), nullptr, 8);
                         if (value > 255)
                         {
                             currentUnit->error("octal escape sequence out of range: `\\" + string(yytext + 1) + "'");
@@ -1493,9 +1493,9 @@ YY_DECL
                 /* Matches an escaped hexadecimal value. Hexadecimal literals are limited to a max of 2 digits. */
                 case 9:
                     YY_RULE_SETUP
-#line 198 "src/Slice/Scanner.l"
+#line 192 "src/Slice/Scanner.l"
                     {
-                        std::int64_t value = std::stoll((yytext + 2), 0, 16);
+                        int64_t value = std::stoll((yytext + 2), nullptr, 16);
                         assert(value <= 255);
 
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1506,7 +1506,7 @@ YY_DECL
                 /* Matches an empty hexadecimal escape value. */
                 case 10:
                     YY_RULE_SETUP
-#line 208 "src/Slice/Scanner.l"
+#line 202 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("no hex digit in hex escape sequence");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1515,12 +1515,12 @@ YY_DECL
                     YY_BREAK
                 /* Matches a 4-char or 8-char size universal character code. */
                 case 11:
-#line 216 "src/Slice/Scanner.l"
+#line 210 "src/Slice/Scanner.l"
                 case 12:
                     YY_RULE_SETUP
-#line 216 "src/Slice/Scanner.l"
+#line 210 "src/Slice/Scanner.l"
                     {
-                        std::int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
+                        int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
                         if (codePoint <= 0xdfff && codePoint >= 0xd800)
                         {
                             currentUnit->error(
@@ -1533,10 +1533,10 @@ YY_DECL
                     YY_BREAK
                 /* Matches a universal character code that isn't the correct size, or uses incorrect characters. */
                 case 13:
-#line 229 "src/Slice/Scanner.l"
+#line 223 "src/Slice/Scanner.l"
                 case 14:
                     YY_RULE_SETUP
-#line 229 "src/Slice/Scanner.l"
+#line 223 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("unknown escape sequence in string literal: `" + string(yytext) + "'");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1548,7 +1548,7 @@ YY_DECL
                 case 15:
                     /* rule 15 can match eol */
                     YY_RULE_SETUP
-#line 237 "src/Slice/Scanner.l"
+#line 231 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         endLocation(yylloc);
@@ -1562,7 +1562,7 @@ YY_DECL
                  * because it only matches 2 characters (the lowest any match), and it's beneath the others. */
                 case 16:
                     YY_RULE_SETUP
-#line 248 "src/Slice/Scanner.l"
+#line 242 "src/Slice/Scanner.l"
                     {
                         currentUnit->warning(
                             All,
@@ -1578,7 +1578,7 @@ YY_DECL
                  * completeness. */
                 case 17:
                     YY_RULE_SETUP
-#line 258 "src/Slice/Scanner.l"
+#line 252 "src/Slice/Scanner.l"
                     {
                         currentUnit->warning(All, "dangling backslash in string literal");
                         StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -1590,7 +1590,7 @@ YY_DECL
                  * the rules above this one. */
                 case 18:
                     YY_RULE_SETUP
-#line 266 "src/Slice/Scanner.l"
+#line 260 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         endLocation(yylloc);
@@ -1602,7 +1602,7 @@ YY_DECL
                     YY_BREAK
                 /* Matches EOF, but only while scanning a string literal. */
                 case YY_STATE_EOF(STRING_LITERAL):
-#line 276 "src/Slice/Scanner.l"
+#line 270 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
                     endLocation(yylloc);
@@ -1613,7 +1613,7 @@ YY_DECL
                     YY_BREAK
                 case 19:
                     YY_RULE_SETUP
-#line 284 "src/Slice/Scanner.l"
+#line 278 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
 
@@ -1639,7 +1639,7 @@ YY_DECL
                     YY_BREAK
                 case 20:
                     YY_RULE_SETUP
-#line 298 "src/Slice/Scanner.l"
+#line 301 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
 
@@ -1670,7 +1670,7 @@ YY_DECL
                 /* Matches and records a triple-slash style doc comment. */
                 case 21:
                     YY_RULE_SETUP
-#line 326 "src/Slice/Scanner.l"
+#line 329 "src/Slice/Scanner.l"
                     {
                         currentUnit->addToComment(yytext + 3);
                     }
@@ -1678,14 +1678,14 @@ YY_DECL
                 /* Matches and consumes a C++ style comment. */
                 case 22:
                     YY_RULE_SETUP
-#line 331 "src/Slice/Scanner.l"
+#line 334 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
                 /* Matches the start of a C style comment, and switches the scanner to the C_COMMENT state. */
                 case 23:
                     YY_RULE_SETUP
-#line 334 "src/Slice/Scanner.l"
+#line 337 "src/Slice/Scanner.l"
                     {
                         yy_push_state(C_COMMENT);
                     }
@@ -1694,10 +1694,10 @@ YY_DECL
                  * time to ensure Flex scans '* /' correctly. Flex prioritizes longer matches over shorter ones, so '*
                  * /' will match before '*'. */
                 case 24:
-#line 341 "src/Slice/Scanner.l"
+#line 344 "src/Slice/Scanner.l"
                 case 25:
                     YY_RULE_SETUP
-#line 341 "src/Slice/Scanner.l"
+#line 344 "src/Slice/Scanner.l"
                     {
                         yymore();
                     }
@@ -1707,7 +1707,7 @@ YY_DECL
                 case 26:
                     /* rule 26 can match eol */
                     YY_RULE_SETUP
-#line 346 "src/Slice/Scanner.l"
+#line 349 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                         yymore();
@@ -1716,7 +1716,7 @@ YY_DECL
                 /* Matches the end of a C style comment, and reverts the scanner state to what it previously was. */
                 case 27:
                     YY_RULE_SETUP
-#line 352 "src/Slice/Scanner.l"
+#line 355 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
 
@@ -1728,7 +1728,7 @@ YY_DECL
                 /* Handles reaching EOF while scanning a C style comment by issuing a warning but continuing normally.
                  */
                 case YY_STATE_EOF(C_COMMENT):
-#line 361 "src/Slice/Scanner.l"
+#line 364 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
 
@@ -1740,7 +1740,7 @@ YY_DECL
                 /* Matches the empty preprocessor directive. */
                 case 28:
                     YY_RULE_SETUP
-#line 371 "src/Slice/Scanner.l"
+#line 374 "src/Slice/Scanner.l"
                     {
                         yy_push_state(PREPROCESS);
                     }
@@ -1748,7 +1748,7 @@ YY_DECL
                 /* Matches a line preprocessor directive, but missing a line number. */
                 case 29:
                     YY_RULE_SETUP
-#line 376 "src/Slice/Scanner.l"
+#line 379 "src/Slice/Scanner.l"
                     {
                         yy_push_state(PREPROCESS);
                         currentUnit->error("missing line number in line preprocessor directive");
@@ -1756,10 +1756,10 @@ YY_DECL
                     YY_BREAK
                 /* Matches a line preprocessor directive (optionally with a file specified afterwards). */
                 case 30:
-#line 383 "src/Slice/Scanner.l"
+#line 386 "src/Slice/Scanner.l"
                 case 31:
                     YY_RULE_SETUP
-#line 383 "src/Slice/Scanner.l"
+#line 386 "src/Slice/Scanner.l"
                     {
                         int includeAction = scanPosition(yytext);
                         if (yylineno == 0 ||
@@ -1778,7 +1778,7 @@ YY_DECL
                  * found while scanning a preprocessor directive. */
                 case 32:
                     YY_RULE_SETUP
-#line 398 "src/Slice/Scanner.l"
+#line 401 "src/Slice/Scanner.l"
                     {
                         currentUnit->error(
                             "encountered unexpected token while scanning preprocessor directive: `" + string(yytext) +
@@ -1788,10 +1788,10 @@ YY_DECL
                 /* Matches a new-line character or EOF. This signals the end of the preprocessor statement. */
                 case 33:
 /* rule 33 can match eol */
-#line 404 "src/Slice/Scanner.l"
+#line 407 "src/Slice/Scanner.l"
                     YY_RULE_SETUP
                 case YY_STATE_EOF(PREPROCESS):
-#line 404 "src/Slice/Scanner.l"
+#line 407 "src/Slice/Scanner.l"
                 {
                     yy_pop_state();
                     nextLine();
@@ -1800,7 +1800,7 @@ YY_DECL
                 /* ========== Metadata ========== */
                 case 34:
                     YY_RULE_SETUP
-#line 411 "src/Slice/Scanner.l"
+#line 414 "src/Slice/Scanner.l"
                     {
                         yy_push_state(METADATA);
                         return ICE_METADATA_OPEN;
@@ -1808,7 +1808,7 @@ YY_DECL
                     YY_BREAK
                 case 35:
                     YY_RULE_SETUP
-#line 416 "src/Slice/Scanner.l"
+#line 419 "src/Slice/Scanner.l"
                     {
                         yy_push_state(METADATA);
 
@@ -1827,7 +1827,7 @@ YY_DECL
                 /* Matches the start of a metadata string, then switches the scanner into STRING_LITERAL mode. */
                 case 36:
                     YY_RULE_SETUP
-#line 431 "src/Slice/Scanner.l"
+#line 434 "src/Slice/Scanner.l"
                     {
                         yy_push_state(STRING_LITERAL);
                         startLocation(yylloc);
@@ -1840,7 +1840,7 @@ YY_DECL
                 /* Matches commas between string literals in quoted metadata and forwards them to the parser. */
                 case 37:
                     YY_RULE_SETUP
-#line 441 "src/Slice/Scanner.l"
+#line 444 "src/Slice/Scanner.l"
                     {
                         return yytext[0];
                     }
@@ -1849,14 +1849,14 @@ YY_DECL
                 case 38:
                     /* rule 38 can match eol */
                     YY_RULE_SETUP
-#line 446 "src/Slice/Scanner.l"
+#line 449 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                     }
                     YY_BREAK
                 case 39:
                     YY_RULE_SETUP
-#line 450 "src/Slice/Scanner.l"
+#line 453 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         return ICE_METADATA_CLOSE;
@@ -1864,7 +1864,7 @@ YY_DECL
                     YY_BREAK
                 case 40:
                     YY_RULE_SETUP
-#line 455 "src/Slice/Scanner.l"
+#line 458 "src/Slice/Scanner.l"
                     {
                         yy_pop_state();
                         return ICE_GLOBAL_METADATA_CLOSE;
@@ -1874,7 +1874,7 @@ YY_DECL
                  * error. */
                 case 41:
                     YY_RULE_SETUP
-#line 461 "src/Slice/Scanner.l"
+#line 464 "src/Slice/Scanner.l"
                     {
                         currentUnit->error("invalid character between metadata");
                     }
@@ -1883,7 +1883,7 @@ YY_DECL
                 case 42:
                     /* rule 42 can match eol */
                     YY_RULE_SETUP
-#line 467 "src/Slice/Scanner.l"
+#line 470 "src/Slice/Scanner.l"
                     {
                         StringTokPtr ident = make_shared<StringTok>();
                         ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -1923,7 +1923,7 @@ YY_DECL
                     YY_BREAK
                 case 43:
                     YY_RULE_SETUP
-#line 504 "src/Slice/Scanner.l"
+#line 507 "src/Slice/Scanner.l"
                     {
                         StringTokPtr ident = make_shared<StringTok>();
                         ident->v = *yytext == '\\' ? yytext + 1 : yytext;
@@ -1935,7 +1935,7 @@ YY_DECL
                 /* Matches and consumes any whitespace, except for newlines. */
                 case 44:
                     YY_RULE_SETUP
-#line 514 "src/Slice/Scanner.l"
+#line 517 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
@@ -1943,7 +1943,7 @@ YY_DECL
                 case 45:
                     /* rule 45 can match eol */
                     YY_RULE_SETUP
-#line 517 "src/Slice/Scanner.l"
+#line 520 "src/Slice/Scanner.l"
                     {
                         nextLine(yyleng);
                     }
@@ -1952,7 +1952,7 @@ YY_DECL
                 /* Matches and consumes a BOM, but only when the scanner has just started scanning a new file. */
                 case 46:
                     YY_RULE_SETUP
-#line 524 "src/Slice/Scanner.l"
+#line 527 "src/Slice/Scanner.l"
                     {
                     }
                     YY_BREAK
@@ -1962,7 +1962,7 @@ YY_DECL
                 case 47:
                     /* rule 47 can match eol */
                     YY_RULE_SETUP
-#line 528 "src/Slice/Scanner.l"
+#line 531 "src/Slice/Scanner.l"
                     {
                         stringstream s;
                         s << "illegal input character: '\\";
@@ -1980,7 +1980,7 @@ YY_DECL
                  * sub-scanner. */
                 case 48:
                     YY_RULE_SETUP
-#line 542 "src/Slice/Scanner.l"
+#line 545 "src/Slice/Scanner.l"
                     {
                         setLocation(yylloc);
                         return yytext[0];
@@ -1988,10 +1988,10 @@ YY_DECL
                     YY_BREAK
                 case 49:
                     YY_RULE_SETUP
-#line 547 "src/Slice/Scanner.l"
+#line 550 "src/Slice/Scanner.l"
                     YY_FATAL_ERROR("flex scanner jammed");
                     YY_BREAK
-#line 2147 "src/Slice/Scanner.cpp"
+#line 2150 "src/Slice/Scanner.cpp"
                 case YY_STATE_EOF(INITIAL):
                 case YY_STATE_EOF(PRE_SLICE):
                 case YY_STATE_EOF(SLICE):
@@ -2196,7 +2196,7 @@ yy_get_next_buffer(void)
 
     else
     {
-        int num_to_read = YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
+        yy_size_t num_to_read = YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
         while (num_to_read <= 0)
         { /* Not enough room in the buffer - grow it. */
@@ -2208,7 +2208,7 @@ yy_get_next_buffer(void)
 
             if (b->yy_is_our_buffer)
             {
-                int new_size = b->yy_buf_size * 2;
+                yy_size_t new_size = b->yy_buf_size * 2;
 
                 if (new_size <= 0)
                     b->yy_buf_size += b->yy_buf_size / 8;
@@ -2261,7 +2261,7 @@ yy_get_next_buffer(void)
     if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size)
     {
         /* Extend the array by 50%, plus the number we really need. */
-        int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+        yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
         YY_CURRENT_BUFFER_LVALUE->yy_ch_buf =
             (char*)yyrealloc((void*)YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t)new_size);
         if (!YY_CURRENT_BUFFER_LVALUE->yy_ch_buf)
@@ -2387,7 +2387,7 @@ input(void)
 
         else
         { /* need more input */
-            int offset = (int)((yy_c_buf_p) - (yytext_ptr));
+            yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
             ++(yy_c_buf_p);
 
             switch (yy_get_next_buffer())
@@ -2849,7 +2849,7 @@ yy_fatal_error(const char* msg)
     do                                                                                                                 \
     {                                                                                                                  \
         /* Undo effects of setting up yytext. */                                                                       \
-        int yyless_macro_arg = (n);                                                                                    \
+        yy_size_t yyless_macro_arg = (n);                                                                              \
         YY_LESS_LINENO(yyless_macro_arg);                                                                              \
         yytext[yyleng] = (yy_hold_char);                                                                               \
         (yy_c_buf_p) = yytext + yyless_macro_arg;                                                                      \
@@ -3002,7 +3002,7 @@ yyfree(void* ptr)
 
 /* %ok-for-header */
 
-#line 547 "src/Slice/Scanner.l"
+#line 550 "src/Slice/Scanner.l"
 
 namespace Slice
 {

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -3132,9 +3132,7 @@ namespace
         keywordMap["true"] = ICE_TRUE;
         keywordMap["idempotent"] = ICE_IDEMPOTENT;
         keywordMap["tag"] = ICE_TAG;
-        // 'optional' is kept as an alias for 'tag' for backwards compatability.
-        // We need a separate token type since we infer 'optional T' to mean 'tag T?'.
-        // But for 'tag' we require an optional (nullable) type. No inferencing is done.
+        // 'optional' is kept as an alias for 'tag' for backwards compatibility.
         keywordMap["optional"] = ICE_OPTIONAL;
         keywordMap["Value"] = ICE_VALUE;
     }

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -18,12 +18,12 @@
 
 #ifdef _MSC_VER
 // 'initializing' : conversion from '__int64' to 'int', possible loss of data
-#   pragma warning(disable:4244)
-#   ifdef slice_wrap
-#      undef slice_wrap
-#      define slice_wrap() 1
-#   endif
-#   define YY_NO_UNISTD_H
+#    pragma warning(disable:4244)
+#    ifdef slice_wrap
+#        undef slice_wrap
+#        define slice_wrap() 1
+#    endif
+#    define YY_NO_UNISTD_H
 #endif
 
 using namespace std;
@@ -31,14 +31,12 @@ using namespace Slice;
 
 namespace Slice
 {
+    // Definitions for the case-insensitive keyword-token map.
+    typedef map<string, int> StringTokenMap;
+    StringTokenMap keywordMap;
 
-// Definitions for the case-insensitive keyword-token map.
-typedef map<string, int> StringTokenMap;
-StringTokenMap keywordMap;
-
-int checkKeyword(string&);
-int checkIsScoped(const string&);
-
+    int checkKeyword(string&);
+    int checkIsScoped(const string&);
 }
 
 // Stores the scanner's current column position. Flex also automatically
@@ -49,16 +47,14 @@ string yyfilename;
 
 namespace
 {
+    void nextLine(int = 1);
+    int scanPosition(const char*);
+    void setLocation(TokenContext*);
+    void startLocation(TokenContext*);
+    void endLocation(TokenContext*);
 
-void nextLine(int = 1);
-int scanPosition(const char*);
-void setLocation(TokenContext*);
-void startLocation(TokenContext*);
-void endLocation(TokenContext*);
-
-void initScanner();
-void preAction();
-
+    void initScanner();
+    void preAction();
 }
 
 // Override some of the functions flex auto-generates with our own implementations.
@@ -181,7 +177,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
   /* Matches an escaped octal value. Octal literals are limited to a max of 3 digits. */
 <STRING_LITERAL>"\\"{oct}{1,3} {
     int64_t value = std::stoll((yytext + 1), nullptr, 8);
-    if(value > 255)
+    if (value > 255)
     {
         currentUnit->error("octal escape sequence out of range: `\\" + string(yytext + 1) + "'");
     }
@@ -212,7 +208,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 <STRING_LITERAL>"\\u"{hex}{4} |
 <STRING_LITERAL>"\\U"{hex}{8} {
     int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
-    if(codePoint <= 0xdfff && codePoint >= 0xd800)
+    if (codePoint <= 0xdfff && codePoint >= 0xd800)
     {
         currentUnit->error("a universal character name cannot designate a surrogate: `" + string(yytext) + "'");
     }
@@ -310,16 +306,16 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     string literal(yytext);
     ftp->literal = literal;
     char lastChar = literal[literal.size() - 1];
-    if(lastChar == 'f' || lastChar == 'F')
+    if (lastChar == 'f' || lastChar == 'F')
     {
         literal = literal.substr(0, literal.size() - 1);    // Clobber trailing 'f' or 'F' suffix
     }
     ftp->v = strtod(literal.c_str(), 0);
-    if((ftp->v == HUGE_VAL || ftp->v == -HUGE_VAL) && errno == ERANGE)
+    if ((ftp->v == HUGE_VAL || ftp->v == -HUGE_VAL) && errno == ERANGE)
     {
         currentUnit->error("floating-point constant `" + string(yytext) + "' too large (overflow)");
     }
-    else if(ftp->v == 0 && errno == ERANGE)
+    else if (ftp->v == 0 && errno == ERANGE)
     {
         currentUnit->error("floating-point constant `" + string(yytext) + "' too small (underflow)");
     }
@@ -388,11 +384,11 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 <*>^{preprocessor_lineno}                         |
 <*>^{preprocessor_lineno}[[:blank:]]+\"[^\"\n]*\" {
     int includeAction = scanPosition(yytext);
-    if(yylineno == 0 || includeAction == 1) // Push: Indicated the scanner has started scanning a new file.
+    if (yylineno == 0 || includeAction == 1) // Push: Indicated the scanner has started scanning a new file.
     {
         yy_push_state(INITIAL);
     }
-    else if(includeAction == 2) // Pop: Indicates the scanner has completed scanning a file.
+    else if (includeAction == 2) // Pop: Indicates the scanner has completed scanning a file.
     {
         yy_pop_state();
     }
@@ -423,7 +419,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     yy_push_state(METADATA);
 
     // We use a different token to indicate metadata that should be ignored (if it came after a slice definition).
-    if(yy_top_state() == PRE_SLICE)
+    if (yy_top_state() == PRE_SLICE)
     {
         return ICE_GLOBAL_METADATA_OPEN;
     }
@@ -475,29 +471,29 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     ident->v = *yytext == '\\' ? yytext + 1 : yytext;
     ident->v.erase(ident->v.find_first_of(" \t\v\n\r\f("));
     *yylval = ident;
-    if(*yytext == '\\')
+    if (*yytext == '\\')
     {
-        if(checkIsScoped(ident->v) == ICE_SCOPED_IDENTIFIER)
+        if (checkIsScoped(ident->v) == ICE_SCOPED_IDENTIFIER)
         {
             currentUnit->error("Operation identifiers cannot be scoped: `" + (ident->v) + "'");
         }
         return ICE_IDENT_OPEN;
     }
     int st = checkKeyword(ident->v);
-    if(st == ICE_IDENTIFIER)
+    if (st == ICE_IDENTIFIER)
     {
         return ICE_IDENT_OPEN;
     }
-    else if(st == ICE_SCOPED_IDENTIFIER)
+    else if (st == ICE_SCOPED_IDENTIFIER)
     {
         currentUnit->error("Operation identifiers cannot be scoped: `" + (ident->v) + "'");
         return ICE_IDENT_OPEN;
     }
-    else if(st == ICE_TAG)
+    else if (st == ICE_TAG)
     {
         return ICE_TAG_OPEN;
     }
-    else if(st == ICE_OPTIONAL)
+    else if (st == ICE_OPTIONAL)
     {
         return ICE_OPTIONAL_OPEN;
     }
@@ -554,154 +550,150 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 
 namespace Slice
 {
-
-// Check if an identifier looks like a keyword.
-// If the identifier is a keyword, return the
-// corresponding keyword token; otherwise, return
-// an identifier token.
-int checkKeyword(string& id)
-{
-    const StringTokenMap::const_iterator pos = keywordMap.find(id);
-    if(pos != keywordMap.end())
+    // Check if an identifier looks like a keyword.
+    // If the identifier is a keyword, return the
+    // corresponding keyword token; otherwise, return
+    // an identifier token.
+    int checkKeyword(string& id)
     {
-        if(pos->first != id)
+        const StringTokenMap::const_iterator pos = keywordMap.find(id);
+        if (pos != keywordMap.end())
         {
-            currentUnit->error("illegal identifier: `" + id + "' differs from keyword `" + pos->first +
-                        "' only in capitalization");
-            id = pos->first;
+            if (pos->first != id)
+            {
+                currentUnit->error("illegal identifier: `" + id + "' differs from keyword `" + pos->first +
+                            "' only in capitalization");
+                id = pos->first;
+            }
+            return pos->second;
         }
-        return pos->second;
+        return checkIsScoped(id);
     }
-    return checkIsScoped(id);
-}
 
-// Checks if an identifier is scoped or not, and returns the corresponding token.
-int checkIsScoped(const string& id)
-{
-    return id.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
-}
-
+    // Checks if an identifier is scoped or not, and returns the corresponding token.
+    int checkIsScoped(const string& id)
+    {
+        return id.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
+    }
 }
 
 namespace
 {
-
-void nextLine(int count)
-{
-    yylineno += count;
-    yycolno = 0;
-}
-
-int scanPosition(const char* s)
-{
-    string line(s);
-    // Skip the leading '#', optional 'line', and any whitespace before the line number.
-    string::size_type idx = line.find_first_not_of(" \t\r", (line.find('#') + 1));
-    if(line.find("line", idx) == idx)
+    void nextLine(int count)
     {
-        idx = line.find_first_not_of(" \t\r", (idx + 4));
+        yylineno += count;
+        yycolno = 0;
     }
-    line.erase(0, idx);
 
-    // Read the line number
-    yylineno = stoi(line.c_str(), &idx) - 1;
-
-    // Scan the remainder of the line for a filename.
-    idx = line.find_first_not_of(" \t\r", idx);
-    line.erase(0, idx);
-
-    int lineTypeCode = 0;
-    if(!line.empty())
+    int scanPosition(const char* s)
     {
-        if(line[0] == '"')
+        string line(s);
+        // Skip the leading '#', optional 'line', and any whitespace before the line number.
+        string::size_type idx = line.find_first_not_of(" \t\r", (line.find('#') + 1));
+        if (line.find("line", idx) == idx)
         {
-            string::size_type edx = line.rfind('"');
-            if(edx != string::npos)
-            {
-                line = line.substr(1, edx - 1);
-            }
-            else
-            {
-                currentUnit->error("mismatched quotations in line directive");
-                line = line.substr(1);
-            }
+            idx = line.find_first_not_of(" \t\r", (idx + 4));
         }
-        lineTypeCode = currentUnit->setCurrentFile(line, yylineno);
-        yyfilename = string(line);
+        line.erase(0, idx);
+
+        // Read the line number
+        yylineno = stoi(line.c_str(), &idx) - 1;
+
+        // Scan the remainder of the line for a filename.
+        idx = line.find_first_not_of(" \t\r", idx);
+        line.erase(0, idx);
+
+        int lineTypeCode = 0;
+        if (!line.empty())
+        {
+            if (line[0] == '"')
+            {
+                string::size_type edx = line.rfind('"');
+                if (edx != string::npos)
+                {
+                    line = line.substr(1, edx - 1);
+                }
+                else
+                {
+                    currentUnit->error("mismatched quotations in line directive");
+                    line = line.substr(1);
+                }
+            }
+            lineTypeCode = currentUnit->setCurrentFile(line, yylineno);
+            yyfilename = string(line);
+        }
+        return lineTypeCode;
     }
-    return lineTypeCode;
-}
 
-void setLocation(TokenContext* location)
-{
-    startLocation(location);
-    endLocation(location);
-}
-
-void startLocation(TokenContext* location)
-{
-    location->firstLine = yylineno;
-    // The string has already been scanned, so the scanner is positioned at the end of it.
-    location->firstColumn = yycolno - yyleng;
-    location->filename = yyfilename;
-}
-
-void endLocation(TokenContext* location)
-{
-    location->lastLine = yylineno;
-    location->lastColumn = yycolno;
-}
-
-// This function is always called once, right before scanning begins.
-void initScanner()
-{
-    // Ensure the scanner starts at line number 1, column position 0.
-    yylineno = 1;
-
-    keywordMap["module"] = ICE_MODULE;
-    keywordMap["class"] = ICE_CLASS;
-    keywordMap["interface"] = ICE_INTERFACE;
-    keywordMap["exception"] = ICE_EXCEPTION;
-    keywordMap["struct"] = ICE_STRUCT;
-    keywordMap["sequence"] = ICE_SEQUENCE;
-    keywordMap["dictionary"] = ICE_DICTIONARY;
-    keywordMap["enum"] = ICE_ENUM;
-    keywordMap["out"] = ICE_OUT;
-    keywordMap["extends"] = ICE_EXTENDS;
-    keywordMap["throws"] = ICE_THROWS;
-    keywordMap["void"] = ICE_VOID;
-    keywordMap["byte"] = ICE_BYTE;
-    keywordMap["bool"] = ICE_BOOL;
-    keywordMap["short"] = ICE_SHORT;
-    keywordMap["int"] = ICE_INT;
-    keywordMap["long"] = ICE_LONG;
-    keywordMap["float"] = ICE_FLOAT;
-    keywordMap["double"] = ICE_DOUBLE;
-    keywordMap["string"] = ICE_STRING;
-    keywordMap["Object"] = ICE_OBJECT;
-    keywordMap["const"] = ICE_CONST;
-    keywordMap["false"] = ICE_FALSE;
-    keywordMap["true"] = ICE_TRUE;
-    keywordMap["idempotent"] = ICE_IDEMPOTENT;
-    keywordMap["tag"] = ICE_TAG;
-    // 'optional' is kept as an alias for 'tag' for backwards compatability.
-    // We need a separate token type since we infer 'optional T' to mean 'tag T?'.
-    // But for 'tag' we require an optional (nullable) type. No inferencing is done.
-    keywordMap["optional"] = ICE_OPTIONAL;
-    keywordMap["Value"] = ICE_VALUE;
-}
-
-// This function is always called directly after a match has been made, but directly before it's action block is run.
-void preAction()
-{
-    yycolno += yyleng;
-
-    // We only use the 'INITIAL' state to consume BOMs, which can only validly be the first match in a file. This
-    // function being called means a match has already been made, so we switch states since BOMs are no longer valid.
-    if(YY_START == INITIAL)
+    void setLocation(TokenContext* location)
     {
-        BEGIN(PRE_SLICE);
+        startLocation(location);
+        endLocation(location);
     }
-}
 
+    void startLocation(TokenContext* location)
+    {
+        location->firstLine = yylineno;
+        // The string has already been scanned, so the scanner is positioned at the end of it.
+        location->firstColumn = yycolno - yyleng;
+        location->filename = yyfilename;
+    }
+
+    void endLocation(TokenContext* location)
+    {
+        location->lastLine = yylineno;
+        location->lastColumn = yycolno;
+    }
+
+    // This function is always called once, right before scanning begins.
+    void initScanner()
+    {
+        // Ensure the scanner starts at line number 1, column position 0.
+        yylineno = 1;
+
+        keywordMap["module"] = ICE_MODULE;
+        keywordMap["class"] = ICE_CLASS;
+        keywordMap["interface"] = ICE_INTERFACE;
+        keywordMap["exception"] = ICE_EXCEPTION;
+        keywordMap["struct"] = ICE_STRUCT;
+        keywordMap["sequence"] = ICE_SEQUENCE;
+        keywordMap["dictionary"] = ICE_DICTIONARY;
+        keywordMap["enum"] = ICE_ENUM;
+        keywordMap["out"] = ICE_OUT;
+        keywordMap["extends"] = ICE_EXTENDS;
+        keywordMap["throws"] = ICE_THROWS;
+        keywordMap["void"] = ICE_VOID;
+        keywordMap["byte"] = ICE_BYTE;
+        keywordMap["bool"] = ICE_BOOL;
+        keywordMap["short"] = ICE_SHORT;
+        keywordMap["int"] = ICE_INT;
+        keywordMap["long"] = ICE_LONG;
+        keywordMap["float"] = ICE_FLOAT;
+        keywordMap["double"] = ICE_DOUBLE;
+        keywordMap["string"] = ICE_STRING;
+        keywordMap["Object"] = ICE_OBJECT;
+        keywordMap["const"] = ICE_CONST;
+        keywordMap["false"] = ICE_FALSE;
+        keywordMap["true"] = ICE_TRUE;
+        keywordMap["idempotent"] = ICE_IDEMPOTENT;
+        keywordMap["tag"] = ICE_TAG;
+        // 'optional' is kept as an alias for 'tag' for backwards compatability.
+        // We need a separate token type since we infer 'optional T' to mean 'tag T?'.
+        // But for 'tag' we require an optional (nullable) type. No inferencing is done.
+        keywordMap["optional"] = ICE_OPTIONAL;
+        keywordMap["Value"] = ICE_VALUE;
+    }
+
+    // This function is always called directly after a match has been made, but directly before it's action block is run.
+    void preAction()
+    {
+        yycolno += yyleng;
+
+        // We only use the 'INITIAL' state to consume BOMs, which can only validly be the first match in a file. This
+        // function being called means a match has already been made, so we switch states since BOMs are no longer valid.
+        if (YY_START == INITIAL)
+        {
+            BEGIN(PRE_SLICE);
+        }
+    }
 }

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -180,7 +180,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 
   /* Matches an escaped octal value. Octal literals are limited to a max of 3 digits. */
 <STRING_LITERAL>"\\"{oct}{1,3} {
-    std::int64_t value = std::stoll((yytext + 1), nullptr, 8);
+    int64_t value = std::stoll((yytext + 1), nullptr, 8);
     if(value > 255)
     {
         currentUnit->error("octal escape sequence out of range: `\\" + string(yytext + 1) + "'");
@@ -193,7 +193,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
 
   /* Matches an escaped hexadecimal value. Hexadecimal literals are limited to a max of 2 digits. */
 <STRING_LITERAL>"\\x"{hex}{1,2} {
-    std::int64_t value = std::stoll((yytext + 2), nullptr, 16);
+    int64_t value = std::stoll((yytext + 2), nullptr, 16);
     assert(value <= 255);
 
     StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
@@ -211,7 +211,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
   /* Matches a 4-char or 8-char size universal character code. */
 <STRING_LITERAL>"\\u"{hex}{4} |
 <STRING_LITERAL>"\\U"{hex}{8} {
-    std::int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
+    int64_t codePoint = std::stoll((yytext + 2), nullptr, 16);
     if(codePoint <= 0xdfff && codePoint >= 0xd800)
     {
         currentUnit->error("a universal character name cannot designate a surrogate: `" + string(yytext) + "'");
@@ -291,10 +291,12 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     catch (const std::out_of_range&)
     {
         currentUnit->error("integer constant `" + string(yytext) + "' out of range");
+        itp->v = INT64_MAX;
     }
     catch (const std::invalid_argument&)
     {
         currentUnit->error("invalid integer constant `" + string(yytext) + "'");
+        itp->v = INT64_MAX;
     }
     return ICE_INTEGER_LITERAL;
 }

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -3,7 +3,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <IceUtil/ScannerConfig.h>
+#include "IceUtil/ScannerConfig.h"
 
 }
 

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -559,8 +559,9 @@ namespace Slice
         {
             if (pos->first != id)
             {
-                currentUnit->error("illegal identifier: `" + id + "' differs from keyword `" + pos->first +
-                            "' only in capitalization");
+                currentUnit->error(
+                    "illegal identifier: `" + id + "' differs from keyword `" + pos->first +
+                    "' only in capitalization");
                 id = pos->first;
             }
             return pos->second;
@@ -675,9 +676,7 @@ namespace
         keywordMap["true"] = ICE_TRUE;
         keywordMap["idempotent"] = ICE_IDEMPOTENT;
         keywordMap["tag"] = ICE_TAG;
-        // 'optional' is kept as an alias for 'tag' for backwards compatability.
-        // We need a separate token type since we infer 'optional T' to mean 'tag T?'.
-        // But for 'tag' we require an optional (nullable) type. No inferencing is done.
+        // 'optional' is kept as an alias for 'tag' for backwards compatibility.
         keywordMap["optional"] = ICE_OPTIONAL;
         keywordMap["Value"] = ICE_VALUE;
     }

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -17,8 +17,6 @@
 #include <math.h>
 
 #ifdef _MSC_VER
-// 'initializing' : conversion from '__int64' to 'int', possible loss of data
-#    pragma warning(disable:4244)
 #    ifdef slice_wrap
 #        undef slice_wrap
 #        define slice_wrap() 1


### PR DESCRIPTION
This PR resynchronizes the Bison+Flex files with their generated code.

It also fixes their formatting, since `clang-format` is incapable of formatting them.

Additionally, it updates the warnings we ignore. Some of them are now unnecssary, but for some reason,
there's some new warnings now that needed to be ignored for the builds to work.