### PR TITLE
Update build system for internal Slice files in C++

### DIFF
--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -7,7 +7,7 @@
 #include <Ice/Ice.h>
 #include <IceGrid/Activator.h>
 #include <IceGrid/Admin.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/TraceLevels.h>
 #include <IceGrid/ServerI.h>
 #include "Util.h"

--- a/cpp/src/IceGrid/Activator.h
+++ b/cpp/src/IceGrid/Activator.h
@@ -5,7 +5,7 @@
 #ifndef ICE_GRID_ACTIVATOR_H
 #define ICE_GRID_ACTIVATOR_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 #ifdef _WIN32
 #    include <windows.h>

--- a/cpp/src/IceGrid/AdapterCache.h
+++ b/cpp/src/IceGrid/AdapterCache.h
@@ -7,7 +7,7 @@
 
 #include <IceGrid/Cache.h>
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 #include <optional>
 #include <set>

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -8,7 +8,7 @@
 #include <IceGrid/SessionI.h>
 #include <IceGrid/Topics.h>
 #include <IceGrid/ReapThread.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/Database.h
+++ b/cpp/src/IceGrid/Database.h
@@ -8,7 +8,7 @@
 #include <IceUtil/FileUtil.h>
 #include <Ice/CommunicatorF.h>
 #include <IceGrid/Admin.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/ServerCache.h>
 #include <IceGrid/NodeCache.h>
 #include <IceGrid/ReplicaCache.h>

--- a/cpp/src/IceGrid/DescriptorHelper.h
+++ b/cpp/src/IceGrid/DescriptorHelper.h
@@ -8,7 +8,7 @@
 #include <IceUtil/OutputUtil.h>
 #include <IceXML/Parser.h>
 #include <IceGrid/Admin.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <set>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/InternalRegistryI.h
+++ b/cpp/src/IceGrid/InternalRegistryI.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_INTERNALREGISTRYI_H
 
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/LocatorI.h
+++ b/cpp/src/IceGrid/LocatorI.h
@@ -5,7 +5,7 @@
 #ifndef ICE_GRID_LOCATOR_I_H
 #define ICE_GRID_LOCATOR_I_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/Registry.h>
 
 #include <set>

--- a/cpp/src/IceGrid/LocatorRegistryI.h
+++ b/cpp/src/IceGrid/LocatorRegistryI.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_LOCATOR_REGISTRY_I_H
 
 #include <Ice/Locator.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/Makefile.mk
+++ b/cpp/src/IceGrid/Makefile.mk
@@ -60,8 +60,6 @@ local_admin_srcs        = Internal.ice \
                           Util.cpp
 
 $(project)_programs             = icegridnode icegridregistry icegridadmin
-$(project)_sliceflags           := -Isrc --include-dir IceGrid
-$(project)_generated_includedir := $(project)/generated/IceGrid
 $(project)_dependencies         := IceGrid Glacier2 Ice
 $(project)_targetdir            := $(bindir)
 

--- a/cpp/src/IceGrid/NodeCache.h
+++ b/cpp/src/IceGrid/NodeCache.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_NODECACHE_H
 
 #include <IceGrid/Cache.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_NODE_I_H
 
 #include <IceUtil/Timer.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/PlatformInfo.h>
 #include <IceGrid/UserAccountMapper.h>
 #include <IceGrid/FileCache.h>

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -5,7 +5,7 @@
 #ifndef ICEGRID_NODE_SESSION_H
 #define ICEGRID_NODE_SESSION_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <set>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/NodeSessionManager.h
+++ b/cpp/src/IceGrid/NodeSessionManager.h
@@ -7,7 +7,7 @@
 
 #include <IceGrid/SessionManager.h>
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <set>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/ObjectCache.h
+++ b/cpp/src/IceGrid/ObjectCache.h
@@ -7,7 +7,7 @@
 
 #include <Ice/CommunicatorF.h>
 #include <IceGrid/Cache.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/PlatformInfo.h
+++ b/cpp/src/IceGrid/PlatformInfo.h
@@ -5,7 +5,7 @@
 #ifndef ICE_GRID_PLATFORM_INFO_H
 #define ICE_GRID_PLATFORM_INFO_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 #ifdef _WIN32
 #    include <pdh.h> // Performance data helper API

--- a/cpp/src/IceGrid/QueryI.cpp
+++ b/cpp/src/IceGrid/QueryI.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/QueryI.h>
 #include <IceGrid/Database.h>
 

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -29,7 +29,7 @@
 #include <IceGrid/FileUserAccountMapperI.h>
 #include <IceGrid/WellKnownObjectsManager.h>
 #include <IceGrid/FileCache.h>
-#include <IceGrid/IceLocatorDiscovery.h>
+#include "IceLocatorDiscovery.h"
 
 #include <IceGrid/RegistryAdminRouter.h>
 

--- a/cpp/src/IceGrid/RegistryI.h
+++ b/cpp/src/IceGrid/RegistryI.h
@@ -7,7 +7,7 @@
 
 #include <IceUtil/Timer.h>
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/PlatformInfo.h>
 #include <IceGrid/ReplicaSessionManager.h>
 #include <IceGrid/PluginFacade.h>

--- a/cpp/src/IceGrid/ReplicaCache.h
+++ b/cpp/src/IceGrid/ReplicaCache.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_REPLICACACHE_H
 
 #include <IceGrid/Cache.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceStorm/IceStorm.h>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/ReplicaSessionI.h
+++ b/cpp/src/IceGrid/ReplicaSessionI.h
@@ -6,7 +6,7 @@
 #define ICEGRID_REPLICA_SESSION_H
 
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/ReplicaSessionManager.h
+++ b/cpp/src/IceGrid/ReplicaSessionManager.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_REPLICA_SESSION_MANAGER_H
 
 #include <IceGrid/SessionManager.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -5,7 +5,7 @@
 #ifndef ICE_GRID_SERVER_ADAPTER_I_H
 #define ICE_GRID_SERVER_ADAPTER_I_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/ServerCache.h
+++ b/cpp/src/IceGrid/ServerCache.h
@@ -6,7 +6,7 @@
 #define ICE_GRID_SERVERCACHE_H
 
 #include <IceGrid/Descriptor.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/Registry.h>
 #include <IceGrid/Allocatable.h>
 #include <IceGrid/Cache.h>

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -7,7 +7,7 @@
 
 #include <IceUtil/Timer.h>
 #include <IceGrid/Activator.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 
 #include <optional>
 #include <set>

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -9,7 +9,7 @@
 #include <Ice/LoggerUtil.h>
 
 #include <IceGrid/Registry.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/Util.h>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/Topics.h
+++ b/cpp/src/IceGrid/Topics.h
@@ -6,7 +6,7 @@
 #define ICEGRID_TOPICS_H
 
 #include <IceStorm/IceStorm.h>
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/Registry.h>
 #include <set>
 

--- a/cpp/src/IceGrid/Util.cpp
+++ b/cpp/src/IceGrid/Util.cpp
@@ -5,7 +5,7 @@
 #include "Util.h"
 #include "Ice/Ice.h"
 #include "IceGrid/Admin.h"
-#include "IceGrid/Internal.h"
+#include "Internal.h"
 #include "IceUtil/IceUtil.h"
 #include "IceUtil/StringUtil.h"
 #include "IceUtil/FileUtil.h"

--- a/cpp/src/IceGrid/WellKnownObjectsManager.h
+++ b/cpp/src/IceGrid/WellKnownObjectsManager.h
@@ -5,7 +5,7 @@
 #ifndef ICE_GRID_WELL_KNOWN_OBJECTS_MANAGER_H
 #define ICE_GRID_WELL_KNOWN_OBJECTS_MANAGER_H
 
-#include <IceGrid/Internal.h>
+#include "Internal.h"
 #include <IceGrid/Registry.h>
 
 namespace IceGrid

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
@@ -88,14 +88,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
@@ -89,9 +89,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceGrid</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceGrid</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -133,36 +136,36 @@
     <SliceCompile Include="..\..\Internal.ice" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="..\..\IceGridAdmin.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Win32\Debug\Internal.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Internal.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Internal.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Internal.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
+    </ClInclude>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj.filters
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj.filters
@@ -96,20 +96,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
-      <Filter>Header Files\x64\Release</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="..\..\IceGridAdmin.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
@@ -121,5 +107,19 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Win32\Debug\Internal.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Internal.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Internal.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Internal.h">
+      <Filter>Header Files\x64\Release</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
@@ -100,14 +100,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceGridNode.rc" />

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
@@ -101,9 +101,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceGrid</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceGrid</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -208,49 +211,49 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Debug\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Release\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
+    <ClInclude Include="x64\Debug\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
+    <ClInclude Include="x64\Release\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj.filters
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj.filters
@@ -218,28 +218,28 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Debug\Internal.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Internal.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Internal.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Internal.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
@@ -100,14 +100,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceGridRegistry.rc" />

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
@@ -101,9 +101,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceGrid</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceGrid</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -202,49 +205,49 @@
     <SliceCompile Include="..\..\Internal.ice" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Debug\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Release\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
+    <ClInclude Include="x64\Debug\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Internal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\IceLocatorDiscovery.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
+    <ClInclude Include="x64\Release\Internal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj.filters
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj.filters
@@ -200,28 +200,28 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Internal.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Internal.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\IceLocatorDiscovery.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Internal.h">
+    <ClInclude Include="Win32\Debug\Internal.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\Internal.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\Internal.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\Internal.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/IceStorm/DBTypes.ice
+++ b/cpp/src/IceStorm/DBTypes.ice
@@ -6,8 +6,8 @@
 
 [["cpp:header-ext:h"]]
 
-#include <IceStorm/SubscriberRecord.ice>
-#include <IceStorm/LLURecord.ice>
+#include "SubscriberRecord.ice"
+#include "LLURecord.ice"
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -8,8 +8,8 @@
 
 #include <Ice/Identity.ice>
 #include <Ice/BuiltinSequences.ice>
-#include <IceStorm/SubscriberRecord.ice>
-#include <IceStorm/LLURecord.ice>
+#include "SubscriberRecord.ice"
+#include "LLURecord.ice"
 
 module IceStormElection
 {

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -5,7 +5,7 @@
 #include "Ice/ConsoleUtil.h"
 #include "Ice/Ice.h"
 #include "IceDB/IceDB.h"
-#include "IceStorm/DBTypes.h"
+#include "DBTypes.h"
 #include "IceUtil/FileUtil.h"
 #include "IceUtil/Options.h"
 #include "IceUtil/StringUtil.h"

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 
 #include <IceStorm/IceStorm.ice>
-#include <IceStorm/Election.ice>
+#include "Election.ice"
 #include <Ice/Context.ice>
 #include <Ice/OperationMode.ice>
 #include <Ice/BuiltinSequences.ice>

--- a/cpp/src/IceStorm/Instance.h
+++ b/cpp/src/IceStorm/Instance.h
@@ -8,7 +8,7 @@
 #include "Ice/CommunicatorF.h"
 #include "Ice/ObjectAdapterF.h"
 #include "Ice/PropertiesF.h"
-#include "IceStorm/Election.h"
+#include "Election.h"
 #include "Instrumentation.h"
 #include "Util.h"
 

--- a/cpp/src/IceStorm/LinkRecord.ice
+++ b/cpp/src/IceStorm/LinkRecord.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 
 #include <Ice/Identity.ice>
-#include <IceStorm/IceStormInternal.ice>
+#include "IceStormInternal.ice"
 
 module IceStorm
 {

--- a/cpp/src/IceStorm/Makefile.mk
+++ b/cpp/src/IceStorm/Makefile.mk
@@ -4,8 +4,6 @@
 
 $(project)_libraries            := IceStormService
 $(project)_programs             := icestormadmin icestormdb
-$(project)_sliceflags           := -Isrc --include-dir IceStorm
-$(project)_generated_includedir := $(project)/generated/IceStorm
 $(project)_dependencies         := IceStorm Ice Glacier2
 
 IceStormService_targetdir       := $(libdir)

--- a/cpp/src/IceStorm/NodeI.h
+++ b/cpp/src/IceStorm/NodeI.h
@@ -6,7 +6,7 @@
 #define ICESTORM_NODE_I_H
 
 #include "Ice/Ice.h"
-#include "IceStorm/Election.h"
+#include "Election.h"
 #include "IceUtil/IceUtil.h"
 #include "IceUtil/Timer.h"
 #include "Instance.h"

--- a/cpp/src/IceStorm/Observers.h
+++ b/cpp/src/IceStorm/Observers.h
@@ -6,7 +6,7 @@
 #define ICESTORM_OBSERVERS_H
 
 #include "Ice/Ice.h"
-#include "IceStorm/Election.h"
+#include "Election.h"
 #include "IceUtil/IceUtil.h"
 #include "Replica.h"
 

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -5,7 +5,7 @@
 #include "Parser.h"
 #include "Ice/ConsoleUtil.h"
 #include "Ice/Ice.h"
-#include "IceStorm/IceStormInternal.h"
+#include "IceStormInternal.h"
 #include "IceUtil/DisableWarnings.h"
 #include <algorithm>
 

--- a/cpp/src/IceStorm/Replica.h
+++ b/cpp/src/IceStorm/Replica.h
@@ -6,7 +6,7 @@
 #define ICESTORM_REPLICA_H
 
 #include "Ice/Ice.h"
-#include "IceStorm/Election.h"
+#include "Election.h"
 
 #include <set>
 

--- a/cpp/src/IceStorm/Subscriber.h
+++ b/cpp/src/IceStorm/Subscriber.h
@@ -6,8 +6,8 @@
 #define ICESTORM_SUBSCRIBER_H
 
 #include "Ice/ObserverHelper.h"
-#include "IceStorm/IceStormInternal.h"
-#include "IceStorm/SubscriberRecord.h"
+#include "IceStormInternal.h"
+#include "SubscriberRecord.h"
 #include "Instrumentation.h"
 
 #include <condition_variable>

--- a/cpp/src/IceStorm/TopicI.h
+++ b/cpp/src/IceStorm/TopicI.h
@@ -6,8 +6,8 @@
 #define ICESTORM_TOPIC_I_H
 
 #include "Ice/ObserverHelper.h"
-#include "IceStorm/Election.h"
-#include "IceStorm/IceStormInternal.h"
+#include "Election.h"
+#include "IceStormInternal.h"
 #include "Instrumentation.h"
 #include "Util.h"
 

--- a/cpp/src/IceStorm/TopicManagerI.h
+++ b/cpp/src/IceStorm/TopicManagerI.h
@@ -5,7 +5,7 @@
 #ifndef ICESTORM_TOPIC_MANAGER_I_H
 #define ICESTORM_TOPIC_MANAGER_I_H
 
-#include "IceStorm/Election.h"
+#include "Election.h"
 #include "IceStorm/IceStorm.h"
 #include "Instrumentation.h"
 #include "Replica.h"

--- a/cpp/src/IceStorm/TransientTopicI.h
+++ b/cpp/src/IceStorm/TransientTopicI.h
@@ -5,7 +5,7 @@
 #ifndef ICESTORM_TRANSIENT_TOPIC_I_H
 #define ICESTORM_TRANSIENT_TOPIC_I_H
 
-#include "IceStorm/IceStormInternal.h"
+#include "IceStormInternal.h"
 
 namespace IceStorm
 {

--- a/cpp/src/IceStorm/TransientTopicManagerI.h
+++ b/cpp/src/IceStorm/TransientTopicManagerI.h
@@ -5,7 +5,7 @@
 #ifndef ICESTORM_TRANSIENT_TOPIC_MANAGER_I_H
 #define ICESTORM_TRANSIENT_TOPIC_MANAGER_I_H
 
-#include "IceStorm/IceStormInternal.h"
+#include "IceStormInternal.h"
 
 namespace IceStorm
 {

--- a/cpp/src/IceStorm/Util.cpp
+++ b/cpp/src/IceStorm/Util.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "Util.h"
-#include "IceStorm/SubscriberRecord.h"
+#include "SubscriberRecord.h"
 #include "Instance.h"
 
 using namespace IceStorm;

--- a/cpp/src/IceStorm/Util.h
+++ b/cpp/src/IceStorm/Util.h
@@ -7,8 +7,8 @@
 
 #include "Ice/Ice.h"
 #include "IceDB/IceDB.h"
-#include "IceStorm/LLURecord.h"
-#include "IceStorm/SubscriberRecord.h"
+#include "LLURecord.h"
+#include "SubscriberRecord.h"
 
 namespace IceStorm
 {

--- a/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
@@ -83,14 +83,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Admin.cpp" />

--- a/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
@@ -84,9 +84,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceStorm</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceStorm</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -223,121 +226,121 @@
     <SliceCompile Include="..\..\SubscriberRecord.ice" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceStorm\Election.h">
+    <ClInclude Include="Win32\Debug\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Debug\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Debug\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\Election.h">
+    <ClInclude Include="Win32\Release\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Release\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Release\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\Election.h">
+    <ClInclude Include="x64\Debug\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\IceStormInternal.h">
+    <ClInclude Include="x64\Debug\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LinkRecord.h">
+    <ClInclude Include="x64\Debug\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\Election.h">
+    <ClInclude Include="x64\Release\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="x64\Release\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="x64\Release\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj.filters
+++ b/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj.filters
@@ -129,64 +129,64 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceStorm\Election.h">
+    <ClInclude Include="Win32\Debug\Election.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LinkRecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\Election.h">
+    <ClInclude Include="x64\Debug\Election.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LinkRecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\Election.h">
+    <ClInclude Include="Win32\Release\Election.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LinkRecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\Election.h">
+    <ClInclude Include="x64\Release\Election.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Debug\IceStormInternal.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\IceStormInternal.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\IceStormInternal.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\IceStormInternal.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Debug\LinkRecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\LinkRecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\LinkRecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\LinkRecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\LLURecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\LLURecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\LLURecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -84,9 +84,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceStorm</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceStorm</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -173,73 +176,73 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceStorm\DBTypes.h">
+    <ClInclude Include="Win32\Debug\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\DBTypes.h">
+    <ClInclude Include="Win32\Release\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\DBTypes.h">
+    <ClInclude Include="x64\Debug\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\DBTypes.h">
+    <ClInclude Include="x64\Release\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -83,14 +83,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceStormDB.rc" />

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj.filters
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj.filters
@@ -101,40 +101,40 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceStorm\DBTypes.h">
+    <ClInclude Include="Win32\Debug\DBTypes.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\DBTypes.h">
+    <ClInclude Include="x64\Debug\DBTypes.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\DBTypes.h">
+    <ClInclude Include="Win32\Release\DBTypes.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\DBTypes.h">
+    <ClInclude Include="x64\Release\DBTypes.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\LLURecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\LLURecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\LLURecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -90,9 +90,10 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceStorm\</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceStorm</BaseDirectoryForGeneratedInclude>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
     </SliceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -251,121 +252,121 @@
     <ClInclude Include="..\..\TransientTopicI.h" />
     <ClInclude Include="..\..\TransientTopicManagerI.h" />
     <ClInclude Include="..\..\Util.h" />
-    <ClInclude Include="Win32\Debug\IceStorm\Election.h">
+    <ClInclude Include="Win32\Debug\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Debug\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Debug\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\Election.h">
+    <ClInclude Include="Win32\Release\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Release\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Release\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\Election.h">
+    <ClInclude Include="x64\Debug\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\IceStormInternal.h">
+    <ClInclude Include="x64\Debug\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LinkRecord.h">
+    <ClInclude Include="x64\Debug\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Debug\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\SubscriberRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\Election.h">
+    <ClInclude Include="x64\Release\Election.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\Election.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="x64\Release\IceStormInternal.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\IceStormInternal.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="x64\Release\LinkRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LinkRecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="x64\Release\LLURecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\LLURecord.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -89,12 +89,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
-    </SliceCompile>
+    <SliceCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Election.ice" />

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj.filters
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj.filters
@@ -195,64 +195,64 @@
     <ClInclude Include="..\..\Util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\Election.h">
+    <ClInclude Include="Win32\Debug\Election.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LinkRecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\Election.h">
+    <ClInclude Include="x64\Debug\Election.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LinkRecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\LLURecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Debug\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\x64\Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\Election.h">
+    <ClInclude Include="Win32\Release\Election.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\IceStormInternal.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LinkRecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\LLURecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Release\IceStorm\SubscriberRecord.h">
-      <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\Election.h">
+    <ClInclude Include="x64\Release\Election.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\IceStormInternal.h">
+    <ClInclude Include="Win32\Debug\IceStormInternal.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\IceStormInternal.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\IceStormInternal.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\IceStormInternal.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LinkRecord.h">
+    <ClInclude Include="Win32\Debug\LinkRecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\LinkRecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\LinkRecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\LinkRecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\LLURecord.h">
+    <ClInclude Include="Win32\Debug\LLURecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\LLURecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\LLURecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\LLURecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceStorm\SubscriberRecord.h">
+    <ClInclude Include="Win32\Debug\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Debug\SubscriberRecord.h">
+      <Filter>Header Files\x64\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32\Release\SubscriberRecord.h">
+      <Filter>Header Files\Win32\Release</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\Release\SubscriberRecord.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -9,7 +9,7 @@
 #include <Ice/ConsoleUtil.h>
 #include <IceDB/IceDB.h>
 #include <IceGrid/Admin.h>
-#include <IceGrid/DBTypes.h>
+#include "DBTypes.h"
 #include <IceUtil/DisableWarnings.h>
 
 #include <iterator>

--- a/cpp/src/icegriddb/Makefile.mk
+++ b/cpp/src/icegriddb/Makefile.mk
@@ -3,8 +3,7 @@
 #
 
 $(project)_programs             :=  icegriddb
-$(project)_generated_includedir := $(project)/generated/IceGrid
-$(project)_sliceflags           := -Isrc --include-dir IceGrid -DICE_BUILDING_ICEGRIDDB
+$(project)_sliceflags           := -DICE_BUILDING_ICEGRIDDB
 
 $(project)/IceGridDB.cpp: $(includedir)/generated/IceGrid/Admin.h
 $(project)/generated/DBTypes.cpp: $(includedir)/generated/IceGrid/Admin.h

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -93,9 +93,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>$(IceSrcRootDir)\src\;%(IncludeDirectories)</IncludeDirectories>
-      <HeaderOutputDir>$(Platform)\$(Configuration)\IceGrid\</HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>IceGrid</BaseDirectoryForGeneratedInclude>
+      <IncludeDirectories>
+      </IncludeDirectories>
+      <HeaderOutputDir>
+      </HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>
+      </BaseDirectoryForGeneratedInclude>
       <AdditionalOptions>-DICE_BUILDING_ICEGRIDDB</AdditionalOptions>
     </SliceCompile>
   </ItemDefinitionGroup>
@@ -183,73 +186,73 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\DBTypes.h">
+    <ClInclude Include="Win32\Debug\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Descriptor.h">
+    <ClInclude Include="Win32\Debug\Descriptor.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Descriptor.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Exception.h">
+    <ClInclude Include="Win32\Debug\Exception.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Exception.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\DBTypes.h">
+    <ClInclude Include="Win32\Release\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Descriptor.h">
+    <ClInclude Include="Win32\Release\Descriptor.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Descriptor.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Exception.h">
+    <ClInclude Include="Win32\Release\Exception.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Exception.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\DBTypes.h">
+    <ClInclude Include="x64\Debug\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Descriptor.h">
+    <ClInclude Include="x64\Debug\Descriptor.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Descriptor.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Exception.h">
+    <ClInclude Include="x64\Debug\Exception.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Exception.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\DBTypes.h">
+    <ClInclude Include="x64\Release\DBTypes.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\DBTypes.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Descriptor.h">
+    <ClInclude Include="x64\Release\Descriptor.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\slice\IceGrid\Descriptor.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Exception.h">
+    <ClInclude Include="x64\Release\Exception.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -93,12 +93,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">
     <SliceCompile>
-      <IncludeDirectories>
-      </IncludeDirectories>
-      <HeaderOutputDir>
-      </HeaderOutputDir>
-      <BaseDirectoryForGeneratedInclude>
-      </BaseDirectoryForGeneratedInclude>
       <AdditionalOptions>-DICE_BUILDING_ICEGRIDDB</AdditionalOptions>
     </SliceCompile>
   </ItemDefinitionGroup>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj.filters
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj.filters
@@ -101,40 +101,40 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Debug\IceGrid\Descriptor.h">
+    <ClInclude Include="Win32\Debug\Descriptor.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Descriptor.h">
+    <ClInclude Include="x64\Debug\Descriptor.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Descriptor.h">
+    <ClInclude Include="Win32\Release\Descriptor.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Descriptor.h">
+    <ClInclude Include="x64\Release\Descriptor.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\Exception.h">
+    <ClInclude Include="Win32\Debug\Exception.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\Exception.h">
+    <ClInclude Include="x64\Debug\Exception.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\Exception.h">
+    <ClInclude Include="Win32\Release\Exception.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\Exception.h">
+    <ClInclude Include="x64\Release\Exception.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\IceGrid\DBTypes.h">
+    <ClInclude Include="Win32\Debug\DBTypes.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\IceGrid\DBTypes.h">
+    <ClInclude Include="x64\Debug\DBTypes.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\IceGrid\DBTypes.h">
+    <ClInclude Include="Win32\Release\DBTypes.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\IceGrid\DBTypes.h">
+    <ClInclude Include="x64\Release\DBTypes.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This PR simplifies the build system for internal Slice files used by IceGrid and IceStorm. 

The header files are now generated next to the .cpp files.