### PR TITLE
Fix CI pip install

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -70,7 +70,7 @@ runs:
       if: runner.os == 'Windows'
 
     - name: Install testing dependencies from pip
-      run: python3 -m pip install passlib cryptography numpy
+      run: python3 -m pip install --break-system-packages passlib cryptography numpy
       shell: bash
       if: runner.os == 'macOS' || runner.os == 'Linux'
 

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -26,6 +26,11 @@ runs:
       shell: bash
       if: runner.os == 'macOS'
 
+    - name: Install testing dependencies from pip
+      run: python3 -m pip install --break-system-packages passlib cryptography numpy
+      shell: bash
+      if: runner.os == 'macOS'
+
     - name: Install xcodeproj gem
       run: gem install xcodeproj
       shell: bash
@@ -50,6 +55,11 @@ runs:
       shell: bash
       if: runner.os == 'Linux'
 
+    - name: Install testing dependencies from pip
+      run: python3 -m pip install passlib cryptography numpy
+      shell: bash
+      if: runner.os == 'Linux'
+
       # ———— Windows ———— #
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -68,11 +78,6 @@ runs:
         echo "PythonHome=$env:Python_ROOT_DIR"  >> $env:GITHUB_ENV
       shell: powershell
       if: runner.os == 'Windows'
-
-    - name: Install testing dependencies from pip
-      run: python3 -m pip install --break-system-packages passlib cryptography numpy
-      shell: bash
-      if: runner.os == 'macOS' || runner.os == 'Linux'
 
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy


### PR DESCRIPTION
CI is failing to setup pip packages on macOS

```
Done installing documentation for nanaimo, colored2, claide, CFPropertyList, atomos, xcodeproj after 0 seconds
6 gems installed
Run python3 -m pip install passlib cryptography numpy
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
```