### PR TITLE
Remove Testing of Recursively Optional Classes

### DIFF
--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -675,15 +675,6 @@ allTests(Test::TestHelper* helper, bool)
     initial->ice_encodingVersion(Ice::Encoding_1_0)->returnOptionalClass(true, oo);
     test(!oo);
 
-    RecursiveSeq recursive1;
-    recursive1.push_back(make_shared<Recursive>());
-    RecursiveSeq recursive2;
-    recursive2.push_back(make_shared<Recursive>());
-    recursive1[0]->value = recursive2;
-    RecursivePtr outer = make_shared<Recursive>();
-    outer->value = recursive1;
-    initial->pingPong(outer);
-
     GPtr g = make_shared<G>();
     g->gg1Opt = make_shared<G1>("gg1Opt");
     g->gg2 = make_shared<G2>(10);

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -188,14 +188,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -188,14 +188,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 ["amd"]
 interface Initial
 {

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -365,15 +365,6 @@ namespace Ice
                 initial2.returnOptionalClass(true, out oo);
                 test(!oo.HasValue);
 
-                Test.Recursive[] recursive1 = new Test.Recursive[1];
-                recursive1[0] = new Test.Recursive();
-                Test.Recursive[] recursive2 = new Test.Recursive[1];
-                recursive2[0] = new Test.Recursive();
-                recursive1[0].value = recursive2;
-                Test.Recursive outer = new Test.Recursive();
-                outer.value = recursive1;
-                initial.pingPong(outer);
-
                 Test.G g = new Test.G();
                 g.gg1Opt = new Ice.Optional<Test.G1>(new Test.G1("gg1Opt"));
                 g.gg2 = new Test.G2(10);

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -190,14 +190,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -190,13 +190,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive {
-    optional(0) RecursiveSeq value;
-}
-
 ["amd"]
 interface Initial
 {

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -399,15 +399,6 @@ public class AllTests {
     oo = initial2.returnOptionalClass(true);
     test(!oo.isPresent());
 
-    Recursive[] recursive1 = new Recursive[1];
-    recursive1[0] = new Recursive();
-    Recursive[] recursive2 = new Recursive[1];
-    recursive2[0] = new Recursive();
-    recursive1[0].setValue(recursive2);
-    Recursive outer = new Recursive();
-    outer.setValue(recursive1);
-    initial.pingPong(outer);
-
     G g = new G();
     g.setGg1Opt(new G1("gg1Opt"));
     g.gg2 = new G2(10);

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -191,13 +191,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive {
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -191,13 +191,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive {
-    optional(0) RecursiveSeq value;
-}
-
 ["amd"]
 interface Initial
 {

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -272,13 +272,6 @@
             oo1 = await initial2.returnOptionalClass(true);
             test(oo1 === undefined);
 
-            const recursive1 = [new Test.Recursive()];
-            const recursive2 = [new Test.Recursive()];
-            recursive1[0].value = recursive2;
-            const outer = new Test.Recursive();
-            outer.value = recursive1;
-            await initial.pingPong(outer);
-
             let g = new Test.G();
             g.gg1Opt = new Test.G1("gg1Opt");
             g.gg2 = new Test.G2(new Ice.Long(0, 10));

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -190,14 +190,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -269,13 +269,6 @@ export class Client extends TestHelper
         oo1 = await initial2.returnOptionalClass(true);
         test(oo1 === undefined);
 
-        const recursive1 = [new Test.Recursive()];
-        const recursive2 = [new Test.Recursive()];
-        recursive1[0].value = recursive2;
-        const outer = new Test.Recursive();
-        outer.value = recursive1;
-        await initial.pingPong(outer);
-
         let g = new Test.G();
         g.gg1Opt = new Test.G1("gg1Opt");
         g.gg2 = new Test.G2(new Ice.Long(0, 10));

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -192,14 +192,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -318,18 +318,6 @@ classdef AllTests
             r = initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).returnOptionalClass(true);
             assert(r == Ice.Unset);
 
-            recursive1 = {};
-            recursive2 = {};
-            r1 = Recursive();
-            r2 = Recursive();
-            r1.value = recursive2;
-            recursive1{1} = r1;
-            recursive2{1} = r2;
-
-            outer = Recursive();
-            outer.value = recursive1;
-            initial.pingPong(outer);
-
             g = G();
             g.gg1Opt = G1('gg1Opt');
             g.gg2 = G2(10);

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -191,14 +191,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -353,14 +353,6 @@ def allTests(helper, communicator):
     r = initial.ice_encodingVersion(Ice.Encoding_1_0).returnOptionalClass(True)
     test(r is Ice.Unset)
 
-    recursive1 = [Test.Recursive()]
-    recursive2 = [Test.Recursive()]
-    recursive1[0].value = recursive2
-
-    outer = Test.Recursive()
-    outer.value = recursive1
-    initial.pingPong(outer)
-
     g = Test.G()
     g.gg1Opt = Test.G1("gg1Opt")
     g.gg2 = Test.G2(10)

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -190,13 +190,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive {
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -313,14 +313,6 @@ def allTests(helper, communicator)
     r = initial.ice_encodingVersion(Ice::Encoding_1_0).returnOptionalClass(true)
     test(r == Ice::Unset)
 
-    recursive1 = [ Test::Recursive.new ]
-    recursive2 = [ Test::Recursive.new ]
-    recursive1[0].value = recursive2;
-
-    outer = Test::Recursive.new
-    outer.value = recursive1
-    initial.pingPong(outer)
-
     g = Test::G.new
     g.gg1Opt = Test::G1.new("gg1Opt")
     g.gg2 = Test::G2.new(10)

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -190,14 +190,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -570,13 +570,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
         oo = try initial2.returnOptionalClass(true)
         try test(oo == nil)
 
-        let recursive1 = [Recursive()]
-        let recursive2 = [Recursive()]
-        recursive1[0].value = recursive2
-        let outer = Recursive()
-        outer.value = recursive1
-        _ = try initial.pingPong(outer)
-
         var g: G! = G()
         g.gg1Opt = G1(a: "gg1Opt")
         g.gg2 = G2(a: 10)

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -194,14 +194,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive
-{
-    optional(0) RecursiveSeq value;
-}
-
 interface Initial
 {
     void shutdown();

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -195,13 +195,6 @@ class G
     G1 gg1;
 }
 
-class Recursive;
-sequence<Recursive> RecursiveSeq;
-
-class Recursive {
-    optional(0) RecursiveSeq value;
-}
-
 ["amd"]
 interface Initial
 {


### PR DESCRIPTION
As part of disallowing optional (tagged) classes, first I need to remove all our testing of them.
To try and avoid any further merge conflicts, I'm going to be doing this very piece-meal now.

This PR removes our testing of classes that contain optional sequences of itself.
Without optional classes, recursive optional types are impossible, so it's a straight deletion.