### PR TITLE
Remove Useless Language-Specific Metadata

### DIFF
--- a/cpp/test/Slice/errorDetection/StructMembers.ice
+++ b/cpp/test/Slice/errorDetection/StructMembers.ice
@@ -16,7 +16,7 @@ struct s2
 
 struct s4
 {
-    [ "Hi" ] long l;    // One member with metadata, OK
+    ["Hi"] long l;    // One member with metadata, OK
 }
 
 struct s5               // Two members, OK
@@ -27,24 +27,24 @@ struct s5               // Two members, OK
 
 struct s6
 {                       // Two members with metadata, OK
-    [ "Hi" ]    long l;
-                byte b;
+    ["Hi"]    long l;
+              byte b;
 }
 
 struct s7               // Two members with metadata, OK
 {
-    [ "Hi" ]    long l;
-    [ "there" ] byte b;
+    ["Hi"]    long l;
+    ["there"] byte b;
 }
 
 struct s8
 {
-    [ "hi" ] long ;     // Missing data member name
+    ["hi"] long ;     // Missing data member name
 }
 
 struct s9
 {
-    [ "there" ] long    // Missing data member name
+    ["there"] long    // Missing data member name
 }
 
 struct s10

--- a/csharp/test/Glacier2/sessionHelper/Callback.ice
+++ b/csharp/test/Glacier2/sessionHelper/Callback.ice
@@ -4,7 +4,6 @@
 
 #pragma once
 
-[["java:package:test.Glacier2.sessionHelper"]]
 module Test
 {
 

--- a/csharp/test/Ice/metrics/Test.ice
+++ b/csharp/test/Ice/metrics/Test.ice
@@ -4,7 +4,6 @@
 
 #pragma once
 
-[["java:package:test.Ice.metrics"]]
 module Test
 {
 

--- a/csharp/test/IceBox/admin/Test.ice
+++ b/csharp/test/IceBox/admin/Test.ice
@@ -7,7 +7,6 @@
 
 #include "Ice/PropertyDict.ice"
 
-[["java:package:test.IceBox.admin"]]
 module Test
 {
 

--- a/csharp/test/IceDiscovery/simple/Test.ice
+++ b/csharp/test/IceDiscovery/simple/Test.ice
@@ -4,7 +4,6 @@
 
 #pragma once
 
-[["java:package:test.IceDiscovery.simple"]]
 module Test
 {
 

--- a/js/test/Ice/operations/Test.ice
+++ b/js/test/Ice/operations/Test.ice
@@ -38,7 +38,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<["cpp:type:wstring"]string> WStringS;
+sequence<string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 

--- a/js/test/Ice/servantLocator/Test.ice
+++ b/js/test/Ice/servantLocator/Test.ice
@@ -4,7 +4,6 @@
 
 #pragma once
 
-[["java:package:test.Ice.servantLocator"]]
 module Test
 {
 

--- a/js/test/typescript/Ice/operations/Test.ice
+++ b/js/test/typescript/Ice/operations/Test.ice
@@ -40,7 +40,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<["cpp:type:wstring"]string> WStringS;
+sequence<string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 

--- a/matlab/test/Ice/exceptions/Test.ice
+++ b/matlab/test/Ice/exceptions/Test.ice
@@ -40,7 +40,6 @@ exception E
     string data;
 }
 
-["cpp:ice_print"]
 exception F
 {
     string data;

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -253,34 +253,33 @@ interface Initial
     optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1,
                                                                   out optional(3) SmallStructSeq p3);
 
-    ["java:optional"] optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1,
+    optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1,
                                                                     out optional(3) SmallStructList p3);
 
-    ["java:optional"] optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1,
+    optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1,
                                                                   out optional(3) FixedStructSeq p3);
 
-    ["java:optional"] optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
+    optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
                                                                     out optional(3) FixedStructList p3);
 
-    ["java:optional"] optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
+    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
                                                               out optional(3) VarStructSeq p3);
 
-    ["java:optional"] optional(1) Serializable opSerializable(optional(2) Serializable p1,
+    optional(1) Serializable opSerializable(optional(2) Serializable p1,
                                                               out optional(3) Serializable p3);
 
-    ["java:optional"] optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
+    optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
-    ["java:optional"] optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
+    optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
                                                                 out optional(3) StringIntDict p3);
 
-    ["java:optional"] optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
+    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
                                                                           out optional(3) IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 
     void sendOptionalClass(bool req, optional(1) OneOptional o);
 
-    ["java:optional"]
     void returnOptionalClass(bool req, out optional(1) OneOptional o);
 
     G opG(G g);

--- a/php/test/Slice/structure/Test.ice
+++ b/php/test/Slice/structure/Test.ice
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["cpp:include:list"]]
-
 module Test
 {
 

--- a/python/test/Ice/location/Test.ice
+++ b/python/test/Ice/location/Test.ice
@@ -22,7 +22,7 @@ interface TestLocator extends ::Ice::Locator
     //
     // Returns the number of request on the locator interface.
     //
-    ["cpp:const"] idempotent int getRequestCount();
+    idempotent int getRequestCount();
 }
 
 interface ServerManager

--- a/python/test/Slice/structure/Test.ice
+++ b/python/test/Slice/structure/Test.ice
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["cpp:include:list"]]
-
 module Test
 {
 

--- a/ruby/test/Slice/structure/Test.ice
+++ b/ruby/test/Slice/structure/Test.ice
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-[["cpp:include:list"]]
-
 module Test
 {
 

--- a/swift/test/Ice/exceptions/Test.ice
+++ b/swift/test/Ice/exceptions/Test.ice
@@ -42,7 +42,6 @@ exception E
     string data;
 }
 
-["cpp:ice_print"]
 exception F
 {
     string data;

--- a/swift/test/Ice/exceptions/TestAMD.ice
+++ b/swift/test/Ice/exceptions/TestAMD.ice
@@ -42,7 +42,6 @@ exception E
     string data;
 }
 
-["cpp:ice_print"]
 exception F
 {
     string data;

--- a/swift/test/Ice/inheritance/Test.ice
+++ b/swift/test/Ice/inheritance/Test.ice
@@ -71,7 +71,7 @@ class C extends B
     int cC;
 }
 
-["cpp:virtual"] class D extends C
+class D extends C
 {
     int dD;
 }
@@ -81,22 +81,22 @@ class C extends B
 module MD
 {
 
-["cpp:virtual"] class A
+class A
 {
     int aA;
 }
 
-["cpp:virtual"] class B extends A
+class B extends A
 {
     int bB;
 }
 
-["cpp:virtual"] class C extends B
+class C extends B
 {
     int cC;
 }
 
-["cpp:virtual"] class D extends C
+class D extends C
 {
     int dD;
 }
@@ -116,12 +116,12 @@ class B extends A
     int bB;
 }
 
-["cpp:virtual"] class C extends B
+class C extends B
 {
     int cC;
 }
 
-["cpp:virtual"] class D extends C
+class D extends C
 {
     int dD;
 }
@@ -136,7 +136,7 @@ class A
     int aA;
 }
 
-["cpp:virtual"] class B extends A
+class B extends A
 {
     int bB;
 }
@@ -146,7 +146,7 @@ class C extends B
     int cC;
 }
 
-["cpp:virtual"] class D extends C
+class D extends C
 {
     int dD;
 }
@@ -161,12 +161,12 @@ class A
     int aA;
 }
 
-["cpp:virtual"] class B extends A
+class B extends A
 {
     int bB;
 }
 
-["cpp:virtual"] class C extends B
+class C extends B
 {
     int cC;
 }

--- a/swift/test/Ice/location/Test.ice
+++ b/swift/test/Ice/location/Test.ice
@@ -22,7 +22,7 @@ interface TestLocator extends ::Ice::Locator
     //
     // Returns the number of request on the locator interface.
     //
-    ["cpp:const"] idempotent int getRequestCount();
+    idempotent int getRequestCount();
 }
 
 interface ServerManager

--- a/swift/test/Ice/operations/Test.ice
+++ b/swift/test/Ice/operations/Test.ice
@@ -40,7 +40,7 @@ sequence<long> LongS;
 sequence<float> FloatS;
 sequence<double> DoubleS;
 sequence<string> StringS;
-sequence<["cpp:type:wstring"]string> WStringS;
+sequence<string> WStringS;
 sequence<MyEnum> MyEnumS;
 sequence<MyClass*> MyClassS;
 
@@ -357,29 +357,29 @@ const string su2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194
 // Wide string literals
 //
 
-const ["cpp:type:wstring"]string ws0 = "\u005c";                           // backslash
-const ["cpp:type:wstring"]string ws1 = "\u0041";                           // A
-const ["cpp:type:wstring"]string ws2 = "\u0049\u0063\u0065";               // Ice
-const ["cpp:type:wstring"]string ws3 = "\u004121";                         // A21
-const ["cpp:type:wstring"]string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
-const ["cpp:type:wstring"]string ws5 = "\u00FF";                           // ÿ
-const ["cpp:type:wstring"]string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const ["cpp:type:wstring"]string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const ["cpp:type:wstring"]string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
-const ["cpp:type:wstring"]string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
-const ["cpp:type:wstring"]string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
+const string ws0 = "\u005c";                           // backslash
+const string ws1 = "\u0041";                           // A
+const string ws2 = "\u0049\u0063\u0065";               // Ice
+const string ws3 = "\u004121";                         // A21
+const string ws4 = "\\u0041 \\U00000041";              // \\u0041 \\U00000041
+const string ws5 = "\u00FF";                           // ÿ
+const string ws6 = "\u03FF";                           // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const string ws7 = "\u05F0";                           // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const string ws8 = "\U00010000";                       // LINEAR B SYLLABLE B008 A (U+10000)
+const string ws9 = "\U0001F34C";                       // BANANA (U+1F34C)
+const string ws10 = "\u0DA7";                          // Sinhala Letter Alpapraana Ttayanna
 
-const ["cpp:type:wstring"]string wsw0 = "\U0000005c";                      // backslash
-const ["cpp:type:wstring"]string wsw1 = "\U00000041";                      // A
-const ["cpp:type:wstring"]string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
-const ["cpp:type:wstring"]string wsw3 = "\U0000004121";                    // A21
-const ["cpp:type:wstring"]string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
-const ["cpp:type:wstring"]string wsw5 = "\U000000FF";                      // ÿ
-const ["cpp:type:wstring"]string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
-const ["cpp:type:wstring"]string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
-const ["cpp:type:wstring"]string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
-const ["cpp:type:wstring"]string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
-const ["cpp:type:wstring"]string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
+const string wsw0 = "\U0000005c";                      // backslash
+const string wsw1 = "\U00000041";                      // A
+const string wsw2 = "\U00000049\U00000063\U00000065";  // Ice
+const string wsw3 = "\U0000004121";                    // A21
+const string wsw4 = "\\u0041 \\U00000041";             // \\u0041 \\U00000041
+const string wsw5 = "\U000000FF";                      // ÿ
+const string wsw6 = "\U000003FF";                      // GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)
+const string wsw7 = "\U000005F0";                      // HEBREW LIGATURE YIDDISH DOUBLE VAV (U+05F0)
+const string wsw8 = "\U00010000";                      // LINEAR B SYLLABLE B008 A (U+10000)
+const string wsw9 = "\U0001F34C";                      // BANANA (U+1F34C)
+const string wsw10 = "\U00000DA7";                     // Sinhala Letter Alpapraana Ttayanna
 
 /**
 \'      single quote    byte 0x27 in ASCII encoding
@@ -394,13 +394,13 @@ const ["cpp:type:wstring"]string wsw10 = "\U00000DA7";                     // Si
 \t      horizontal tab  byte 0x09 in ASCII encoding
 \v      vertical tab    byte 0x0b in ASCII encoding
 **/
-const ["cpp:type:wstring"]string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
-const ["cpp:type:wstring"]string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
-const ["cpp:type:wstring"]string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
+const string wss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
+const string wss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
+const string wss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const ["cpp:type:wstring"]string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
-const ["cpp:type:wstring"]string wss4 = "\\\u0041\\"; /* \A\     */
-const ["cpp:type:wstring"]string wss5 = "\\u0041\\";  /* \u0041\ */
+const string wss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const string wss4 = "\\\u0041\\"; /* \A\     */
+const string wss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)
@@ -416,9 +416,9 @@ const ["cpp:type:wstring"]string wss5 = "\\u0041\\";  /* \u0041\ */
 // 🍂 - Unicode Character 'FALLEN LEAF' (U+1F342)
 // 🍃 - Unicode Character 'LEAF FLUTTERING IN WIND' (U+1F343)
 //
-const ["cpp:type:wstring"]string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
-const ["cpp:type:wstring"]string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
-const ["cpp:type:wstring"]string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const string wsu0 = "ĨŸÿĀἀ𐆔𐅪𐆘🍀🍁🍂🍃";
+const string wsu1 = "\u0128\u0178\u00FF\u0100\u1F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
+const string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 
 }
 

--- a/swift/test/Ice/operations/TestAMD.ice
+++ b/swift/test/Ice/operations/TestAMD.ice
@@ -273,7 +273,7 @@ class MyClass1
     string myClass1; // Same name as the enclosing class
 }
 
-["amd", "cs:tie"] interface MyDerivedClass extends MyClass
+["amd"] interface MyDerivedClass extends MyClass
 {
     void opDerived();
     MyClass1 opMyClass1(MyClass1 opMyClass1);

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -271,7 +271,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntStringDict ,opCustomIntStringDict(optional(2) IntStringDict p1, out optional(3) IntStringDict p3);
+    optional(1) IntStringDict opCustomIntStringDict(optional(2) IntStringDict p1, out optional(3) IntStringDict p3);
 
     optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -225,9 +225,7 @@ interface Initial
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
 
-    ["cpp:view-type:Util::string_view"] optional(1) string
-    opCustomString(["cpp:view-type:Util::string_view"] optional(2) string p1,
-                   out ["cpp:view-type:Util::string_view"] optional(3) string p3);
+    optional(1) string opCustomString(optional(2) string p1, out optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
@@ -241,41 +239,29 @@ interface Initial
 
     optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
 
-    // Custom mapping operations
-    ["cpp:array"] optional(1) ByteSeq opByteSeq(["cpp:array"] optional(2) ByteSeq p1,
-                                                out ["cpp:array"] optional(3) ByteSeq p3);
+    optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
 
-    ["cpp:array"] optional(1) BoolSeq opBoolSeq(["cpp:array"] optional(2) BoolSeq p1,
-                                                out ["cpp:array"] optional(3) BoolSeq p3);
+    optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
 
-    ["cpp:array"] optional(1) ShortSeq opShortSeq(["cpp:array"] optional(2) ShortSeq p1,
-                                                  out ["cpp:array"] optional(3) ShortSeq p3);
+    optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
 
-    ["cpp:array"] optional(1) IntSeq opIntSeq(["cpp:array"] optional(2) IntSeq p1,
-                                              out ["cpp:array"] optional(3) IntSeq p3);
+    optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
 
-    ["cpp:array"] optional(1) LongSeq opLongSeq(["cpp:array"] optional(2) LongSeq p1,
-                                                 out ["cpp:array"] optional(3) LongSeq p3);
+    optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
 
-    ["cpp:array"] optional(1) FloatSeq opFloatSeq(["cpp:array"] optional(2) FloatSeq p1,
-                                                   out ["cpp:array"] optional(3) FloatSeq p3);
+    optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
 
-    ["cpp:array"] optional(1) DoubleSeq opDoubleSeq(["cpp:array"] optional(2) DoubleSeq p1,
-                                                     out ["cpp:array"] optional(3) DoubleSeq p3);
+    optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
 
     optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
 
-    ["cpp:array"] optional(1) SmallStructSeq opSmallStructSeq(["cpp:array"] optional(2) SmallStructSeq p1,
-                                                              out ["cpp:array"] optional(3) SmallStructSeq p3);
+    optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
 
-    ["cpp:array"] optional(1) SmallStructList opSmallStructList(["cpp:array"] optional(2) SmallStructList p1,
-                                                                out ["cpp:array"] optional(3) SmallStructList p3);
+    optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
 
-    ["cpp:array"] optional(1) FixedStructSeq opFixedStructSeq(["cpp:array"] optional(2) FixedStructSeq p1,
-                                                              out ["cpp:array"] optional(3) FixedStructSeq p3);
+    optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
 
-    ["cpp:array"] optional(1) FixedStructList opFixedStructList(["cpp:array"] optional(2) FixedStructList p1,
-                                                                out ["cpp:array"] optional(3) FixedStructList p3);
+    optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
 
     optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
@@ -285,10 +271,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    ["cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>", "cpp:type:::Test::CustomMap< ::Ice::Int, std::string>"] optional(1) IntStringDict
-    opCustomIntStringDict(
-        ["cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>", "cpp:type:::Test::CustomMap< ::Ice::Int, std::string>"] optional(2) IntStringDict p1,
-        out ["cpp:view-type:::std::map< ::Ice::Int, ::Util::string_view>", "cpp:type:::Test::CustomMap< ::Ice::Int, std::string>"] optional(3) IntStringDict p3);
+    optional(1) IntStringDict ,opCustomIntStringDict(optional(2) IntStringDict p1, out optional(3) IntStringDict p3);
 
     optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 


### PR DESCRIPTION
It's clear that many of our test Slice files were copy/pasted from other languages.
This PR removes metadata that is useless, and probably just leftover from the copy/pastes.

Ex: Using `["cpp:const"]` in the Swift tests...

This is useless right? I guess CI will tell me.