### PR TITLE
Add Test to Ensure we Only Validate Metadata for the Current Language.

### DIFF
--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.err
@@ -16,5 +16,6 @@ WarningInvalidMetaData.ice:42: warning: ignoring invalid metadata `cpp:view-type
 WarningInvalidMetaData.ice:47: warning: ignoring invalid metadata `cpp:const'
 WarningInvalidMetaData.ice:47: warning: ignoring invalid metadata `cpp:ice_print'
 WarningInvalidMetaData.ice:53: warning: ignoring invalid metadata `cpp:virtual'
-WarningInvalidMetaData.ice:58: warning: ignoring invalid metadata `cpp98:foo'
-WarningInvalidMetaData.ice:58: warning: ignoring invalid metadata `cpp11:bar'
+WarningInvalidMetaData.ice:58: warning: ignoring invalid metadata `cpp:bad'
+WarningInvalidMetaData.ice:63: warning: ignoring invalid metadata `cpp98:foo'
+WarningInvalidMetaData.ice:63: warning: ignoring invalid metadata `cpp11:bar'

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
@@ -53,7 +53,7 @@ exception E
 {
 }
 
-["bad", "cpp:bad", "java:bad"] // We only validate metadata when it has an applicable language prefix
+["bad", "cpp:bad", "java:bad"] // We only validate metadata when it has an applicable language prefix.
 class C
 {
 }

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetaData.ice
@@ -53,6 +53,11 @@ exception E
 {
 }
 
+["bad", "cpp:bad", "java:bad"] // We only validate metadata when it has an applicable language prefix
+class C
+{
+}
+
 ["cpp98:foo", "cpp11:bar"] // The cpp98 and cpp11 attributes were removed in 3.8. We issue a friendly warning.
 class P
 {


### PR DESCRIPTION
This PR adds an explicit test that ensures we don't attempt to validate metadata for a language other than the one we're compiling for.

ie. `slice2cpp` will not report an invalidmetadata warning for `java:bad` (whereas `slice2java` would).

----

This test was inspired by https://github.com/zeroc-ice/ice/pull/2019#pullrequestreview-1977682580