### PR TITLE
IceSSL for C# simplifications

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -60,7 +60,7 @@ runs:
       with:
         distribution: "oracle"
         java-version: "17"
-      if: runner.os == 'Linux'
+      if: matrix.language == 'java'
 
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
         with:
           # See:
           # - https://github.com/zeroc-ice/ice/issues/1653 IceGrid/replication
-          # - https://github.com/zeroc-ice/ice/issues/1745 csharp/IceSSL/configuration
           # - https://github.com/zeroc-ice/ice/issues/1945 matlab/Ice/slicing
-          flags: "--rfilter IceGrid/replication --rfilter csharp/IceSSL/configuration --rfilter matlab/Ice/slicing ${{ matrix.test_flags }}"
+          flags: "--rfilter IceGrid/replication --rfilter matlab/Ice/slicing ${{ matrix.test_flags }}"
         # Don't test matlab on Windows
         if: matrix.language != 'matlab' || runner.os != 'Windows'

--- a/csharp/src/Ice/IceSSL/AcceptorI.cs
+++ b/csharp/src/Ice/IceSSL/AcceptorI.cs
@@ -55,9 +55,9 @@ internal class AcceptorI : IceInternal.Acceptor
         }
     }
 
-    private EndpointI _endpoint;
-    private readonly IceInternal.Acceptor _delegate;
-    private readonly Instance _instance;
     private readonly string _adapterName;
+    private readonly IceInternal.Acceptor _delegate;
+    private EndpointI _endpoint;
+    private readonly Instance _instance;
     private readonly SslServerAuthenticationOptions _serverAuthenticationOptions;
 }

--- a/csharp/src/Ice/IceSSL/ConnectorI.cs
+++ b/csharp/src/Ice/IceSSL/ConnectorI.cs
@@ -14,14 +14,6 @@ internal sealed class ConnectorI : IceInternal.Connector
 
     public short type() => _delegate.type();
 
-    // Only for use by EndpointI.
-    internal ConnectorI(Instance instance, IceInternal.Connector del, string host)
-    {
-        _instance = instance;
-        _delegate = del;
-        _host = host;
-    }
-
     public override bool Equals(object obj)
     {
         if (obj is not ConnectorI)
@@ -38,9 +30,17 @@ internal sealed class ConnectorI : IceInternal.Connector
         return _delegate.Equals(p._delegate);
     }
 
+    public override int GetHashCode() => _delegate.GetHashCode();
+
     public override string ToString() => _delegate.ToString();
 
-    public override int GetHashCode() => _delegate.GetHashCode();
+    // Only for use by EndpointI.
+    internal ConnectorI(Instance instance, IceInternal.Connector del, string host)
+    {
+        _instance = instance;
+        _delegate = del;
+        _host = host;
+    }
 
     private readonly IceInternal.Connector _delegate;
     private readonly string _host;

--- a/csharp/src/Ice/IceSSL/Instance.cs
+++ b/csharp/src/Ice/IceSSL/Instance.cs
@@ -16,11 +16,7 @@ internal class Instance : IceInternal.ProtocolInstance
 
     internal string securityTraceCategory() => _engine.securityTraceCategory();
 
-    internal bool initialized() => _engine.initialized();
-
     internal X509Certificate2Collection certs() => _engine.certs();
-
-    internal int checkCRL() => _engine.checkCRL();
 
     internal void traceStream(SslStream stream, string connInfo) => _engine.traceStream(stream, connInfo);
 

--- a/csharp/src/Ice/IceSSL/SSLEngine.cs
+++ b/csharp/src/Ice/IceSSL/SSLEngine.cs
@@ -228,7 +228,7 @@ internal class SSLEngine
         }
     }
 
-    internal SslClientAuthenticationOptions clientAuthenticationOptions(
+    internal SslClientAuthenticationOptions createClientAuthenticationOptions(
         RemoteCertificateValidationCallback remoteCertificateValidationCallback,
         string host)
     {
@@ -265,7 +265,7 @@ internal class SSLEngine
         };
     }
 
-    internal SslServerAuthenticationOptions serverAuthenticationOptions(
+    internal SslServerAuthenticationOptions createServerAuthenticationOptions(
         RemoteCertificateValidationCallback remoteCertificateValidationCallback)
     {
         // Get the certificate collection and select the first one.

--- a/csharp/src/Ice/IceSSL/SSLEngine.cs
+++ b/csharp/src/Ice/IceSSL/SSLEngine.cs
@@ -228,7 +228,6 @@ internal class SSLEngine
         };
 
         authenticationOptions.CertificateChainPolicy = new X509ChainPolicy();
-        authenticationOptions.CertificateChainPolicy = new X509ChainPolicy();
         if (_caCerts is null)
         {
             authenticationOptions.CertificateChainPolicy.TrustMode = X509ChainTrustMode.System;

--- a/csharp/src/Ice/IceSSL/SSLEngine.cs
+++ b/csharp/src/Ice/IceSSL/SSLEngine.cs
@@ -125,12 +125,20 @@ internal class SSLEngine
             }
             try
             {
-                if (Path.GetExtension(certAuthFile).Equals(".pem", StringComparison.OrdinalIgnoreCase))
+                try
                 {
+                    // First try to import as a PEM file, which supports importing multiple certificates from a PEM
+                    // encoded file
                     _caCerts.ImportFromPemFile(certAuthFile);
                 }
-                else
+                catch (CryptographicException)
                 {
+                    // Expected if the file is not in PEM format.
+                }
+
+                if (_caCerts.Count == 0)
+                {
+                    // Fallback to Import which handles DER/PFX.
                     _caCerts.Import(certAuthFile);
                 }
             }

--- a/csharp/src/Ice/IceSSL/TransceiverI.cs
+++ b/csharp/src/Ice/IceSSL/TransceiverI.cs
@@ -305,7 +305,7 @@ internal sealed class TransceiverI : IceInternal.Transceiver
         info.incoming = _incoming;
         info.adapterName = _adapterName;
         info.cipher = _cipher;
-        if (_sslStream.RemoteCertificate is X509Certificate2 remoteCertificate)
+        if (_sslStream is SslStream sslStream && sslStream.RemoteCertificate is X509Certificate2 remoteCertificate)
         {
             info.certs = [remoteCertificate];
         }
@@ -547,7 +547,7 @@ internal sealed class TransceiverI : IceInternal.Transceiver
             if (checkCertName && !string.IsNullOrEmpty(_host))
             {
                 if (traceLevel >= 1)
-                {     
+                {
                     logger.trace(traceCategory, "SSL certificate validation failed - Hostname mismatch");
                 }
             }

--- a/csharp/test/IceSSL/configuration/AllTests.cs
+++ b/csharp/test/IceSSL/configuration/AllTests.cs
@@ -186,7 +186,11 @@ public class AllTests
                 try
                 {
                     server.noCert();
-                    test(!((IceSSL.ConnectionInfo)server.ice_getConnection().getInfo()).verified);
+                    test(false);
+                }
+                catch (Ice.SecurityException)
+                {
+                    // Expected.
                 }
                 catch (Ice.LocalException ex)
                 {
@@ -267,13 +271,10 @@ public class AllTests
 
                 comm.destroy();
 
-                //
                 // Test IceSSL.VerifyPeer=1. Client has a certificate.
                 //
-                // Provide "cacert1" to the client to verify the server
-                // certificate (without this the client connection wouln't be
-                // able to provide the certificate chain).
-                //
+                // Provide "cacert1" to the client to verify the server certificate (without this the client connection
+                // wouldn't be able to provide the certificate chain).
                 initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                 comm = Ice.Util.initialize(ref args, initData);
                 fact = Test.ServerFactoryPrxHelper.checkedCast(comm.stringToProxy(factoryRef));

--- a/csharp/test/IceSSL/configuration/TestI.cs
+++ b/csharp/test/IceSSL/configuration/TestI.cs
@@ -16,7 +16,7 @@ internal sealed class ServerI : ServerDisp_
         try
         {
             IceSSL.ConnectionInfo info = (IceSSL.ConnectionInfo)current.con.getInfo();
-            test(info.certs == null);
+            test(info.certs.Length == 0);
         }
         catch (Ice.LocalException)
         {
@@ -31,7 +31,7 @@ internal sealed class ServerI : ServerDisp_
         {
             IceSSL.ConnectionInfo info = (IceSSL.ConnectionInfo)current.con.getInfo();
             test(info.verified);
-            test(info.certs.Length == 2 &&
+            test(info.certs.Length == 1 &&
                  info.certs[0].Subject.Equals(subjectDN) &&
                  info.certs[0].Issuer.Equals(issuerDN));
         }


### PR DESCRIPTION
This PR simplifies the IceSSL C# implementation. The main issue resolved by this PR is the two code paths mentioned by @externl in the [previous PR](https://github.com/zeroc-ice/ice/pull/1983#pullrequestreview-1960305774) for merging IceSSL into the core.

IceSSL.VerifyPeer 0 meaning was updated, to match the new behavior already present in Java IceSSL implementation. With this new behavior, it no longer allows ignore verification errors. 

IceSSL.CheckCRL is no longer used, CRL would be only available with the native platform APIs.

I also updated the connection info to only provide the peer certificate, as SslStream only provides the peer certificate, not the chain. There is no way to retrieve the certificate chain when the user provides the authentication options. We only have the certificate chain when we use the built-in certificate validation.

I also remove IceSSL.VerifyDepthMax