### PR TITLE
Fix Spelling of 'marshalling'

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -133,7 +133,7 @@ These are the changes since Ice 3.6.2.
 - Fixed a bug in the IceLocatorDiscovery plug-in that could occasionally
   trigger an infinite loop.
 
-- Fixed a bug in the unmarshalling code where passing optional input
+- Fixed a bug in the unmarshaling code where passing optional input
   parameters to an operation with no required input parameters would
   cause an Ice::EncapsulationException to be thrown if the receiver
   didn't expect the optional input parameters. The same applies for

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -1029,11 +1029,11 @@ namespace Ice
             size_t _classGraphDepth;
             Ice::ValueFactoryManagerPtr _valueFactoryManager;
 
-            // Encapsulation attributes for object un-marshalling
+            // Encapsulation attributes for object un-marshaling
             PatchMap _patchMap;
 
         private:
-            // Encapsulation attributes for object un-marshalling
+            // Encapsulation attributes for object un-marshaling
             IndexToPtrMap _unmarshaledMap;
             TypeIdMap _typeIdMap;
             std::int32_t _typeIdIndex;

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1934,7 +1934,7 @@ Ice::ConnectionI::finish(bool close)
         {
             //
             // Return the stream to the outgoing call. This is important for
-            // retriable AMI calls which are not marshalled again.
+            // retriable AMI calls which are not marshaled again.
             //
             OutgoingMessage* message = &_sendStreams.front();
             _writeStream.swap(*message->stream);

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -481,7 +481,7 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // _minSeqSize by the minimum size that this sequence will require on
     // the stream.
     //
-    // The goal of this check is to ensure that when we start un-marshalling
+    // The goal of this check is to ensure that when we start un-marshaling
     // a new sequence, we check the minimal size of this new sequence against
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's _minSeqSize.
@@ -498,7 +498,7 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
 
     //
     // If there isn't enough data to read on the stream for the sequence (and
-    // possibly enclosed sequences), something is wrong with the marshalled
+    // possibly enclosed sequences), something is wrong with the marshaled
     // data: it's claiming having more data that what is possible to read.
     //
     if (_startSeq + _minSeqSize > static_cast<int>(b.size()))
@@ -2312,7 +2312,7 @@ Ice::InputStream::EncapsDecoder11::throwException(UserExceptionFactory factory)
         skipSlice();
 
         //
-        // If this is the last slice, raise an exception and stop un-marshalling.
+        // If this is the last slice, raise an exception and stop un-marshaling.
         //
         if (_current->sliceFlags & FLAG_IS_LAST_SLICE)
         {
@@ -2487,7 +2487,7 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
     }
 
     //
-    // Preserve this slice if unmarshalling a value in Slice format. Exception slices are not preserved.
+    // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not preserved.
     //
     if (_current->sliceType == ValueSlice)
     {

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -213,7 +213,7 @@ Ice::OutputStream::swap(OutputStream& other)
 
     //
     // Swap is never called for streams that have encapsulations being written. However,
-    // encapsulations might still be set in case marshalling failed. We just
+    // encapsulations might still be set in case marshaling failed. We just
     // reset the encapsulations if there are still some set.
     //
     resetEncapsulation();
@@ -1158,9 +1158,9 @@ Ice::OutputStream::EncapsEncoder10::writePendingValues()
     while (!_toBeMarshaledMap.empty())
     {
         //
-        // Consider the to be marshalled instances as marshalled now,
+        // Consider the to be marshaled instances as marshaled now,
         // this is necessary to avoid adding again the "to be
-        // marshalled instances" into _toBeMarshaledMap while writing
+        // marshaled instances" into _toBeMarshaledMap while writing
         // instances.
         //
         _marshaledMap.insert(_toBeMarshaledMap.begin(), _toBeMarshaledMap.end());

--- a/cpp/src/IceGrid/Topics.cpp
+++ b/cpp/src/IceGrid/Topics.cpp
@@ -47,7 +47,7 @@ ObserverTopic::ObserverTopic(const IceStorm::TopicManagerPrx& topicManager, cons
         //
         // NOTE: collocation optimization needs to be turned on for the
         // topic because the subscribe() method is given a fixed proxy
-        // which can't be marshalled.
+        // which can't be marshaled.
         //
         _topics.insert({encodings[i], *topic});
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -767,7 +767,7 @@ Slice::CsVisitor::writeMarshaling(const ClassDefPtr& p)
     }
     _out << eb;
 
-    _out << sp << nl << "#endregion"; // Marshalling support
+    _out << sp << nl << "#endregion"; // marshaling support
 }
 
 string
@@ -2563,7 +2563,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         _out << eb;
     }
 
-    _out << sp << nl << "#endregion"; // Marshalling support
+    _out << sp << nl << "#endregion"; // marshaling support
 
     _out << eb;
 }
@@ -2810,7 +2810,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     {
         _out << sp << nl << "private static readonly " << name << " _nullMarshalValue = new " << name << "();";
     }
-    _out << sp << nl << "#endregion"; // Marshalling support
+    _out << sp << nl << "#endregion"; // marshaling support
 
     _out << eb;
 }

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -313,7 +313,7 @@ allTests(Test::TestHelper* helper)
 #if defined(NDEBUG) || !defined(__APPLE__)
         const int maxDepth = 2000;
 #else
-        // With debug, marshalling a graph of 2000 elements can cause a stack overflow on macOS
+        // With debug, marshaling a graph of 2000 elements can cause a stack overflow on macOS
         const int maxDepth = 1500;
 #endif
         for (; depth <= maxDepth; ++depth)

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -419,7 +419,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "ok" << endl;
 
-    cout << "testing marshalling... " << flush;
+    cout << "testing marshaling... " << flush;
     OneOptionalPtr oo4 = dynamic_pointer_cast<OneOptional>(initial->pingPong(make_shared<OneOptional>()));
     test(!oo4->a);
 
@@ -700,7 +700,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "ok" << endl;
 
-    cout << "testing marshalling of large containers with fixed size elements..." << flush;
+    cout << "testing marshaling of large containers with fixed size elements..." << flush;
     MultiOptionalPtr mc = make_shared<MultiOptional>();
 
     ByteSeq byteSeq;
@@ -747,7 +747,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "ok" << endl;
 
-    cout << "testing tag marshalling... " << flush;
+    cout << "testing tag marshaling... " << flush;
     {
         BPtr b = make_shared<B>();
         BPtr b2 = dynamic_pointer_cast<B>(initial->pingPong(b));
@@ -784,7 +784,7 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "ok" << endl;
 
-    cout << "testing marshalling of objects with optional objects..." << flush;
+    cout << "testing marshaling of objects with optional objects..." << flush;
     {
         FPtr f = make_shared<F>();
 
@@ -825,7 +825,7 @@ allTests(Test::TestHelper* helper, bool)
 
     if (communicator->getProperties()->getPropertyAsInt("Ice.Default.SlicedFormat") > 0)
     {
-        cout << "testing marshalling with unknown class slices... " << flush;
+        cout << "testing marshaling with unknown class slices... " << flush;
         {
             CPtr c = make_shared<C>();
             c->ss = "test";

--- a/csharp/src/Ice/BatchRequestInterceptor.cs
+++ b/csharp/src/Ice/BatchRequestInterceptor.cs
@@ -10,7 +10,7 @@ public interface BatchRequest
     void enqueue();
 
     /// <summary>
-    /// Get the marshalled size of the request.
+    /// Get the marshaled size of the request.
     /// </summary>
     /// <returns>The request size.</returns>
     int getSize();

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -802,7 +802,7 @@ public sealed class ConnectionI : IceInternal.EventHandler, ResponseHandler, Can
 
     public bool systemException(int requestId, SystemException ex, bool amd)
     {
-        return false; // System exceptions aren't marshalled.
+        return false; // System exceptions aren't marshaled.
     }
 
     public void invokeException(int requestId, LocalException ex, int invokeNum, bool amd)
@@ -1492,7 +1492,7 @@ public sealed class ConnectionI : IceInternal.EventHandler, ResponseHandler, Can
             {
                 //
                 // Return the stream to the outgoing call. This is important for
-                // retriable AMI calls which are not marshalled again.
+                // retriable AMI calls which are not marshaled again.
                 //
                 OutgoingMessage message = _sendStreams.First.Value;
                 _writeStream.swap(message.stream);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -424,7 +424,7 @@ public class InputStream
 
         //
         // Swap is never called for InputStreams that have encapsulations being read. However,
-        // encapsulations might still be set in case un-marshalling failed. We just
+        // encapsulations might still be set in case un-marshaling failed. We just
         // reset the encapsulations if there are still some set.
         //
         resetEncapsulation();
@@ -825,7 +825,7 @@ public class InputStream
         // _minSeqSize by the minimum size that this sequence will require on
         // the stream.
         //
-        // The goal of this check is to ensure that when we start un-marshalling
+        // The goal of this check is to ensure that when we start un-marshaling
         // a new sequence, we check the minimal size of this new sequence against
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's _minSeqSize.
@@ -842,7 +842,7 @@ public class InputStream
 
         //
         // If there isn't enough data to read on the stream for the sequence (and
-        // possibly enclosed sequences), something is wrong with the marshalled
+        // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
         if (_startSeq + _minSeqSize > _buf.size())
@@ -3657,7 +3657,7 @@ public class InputStream
             }
 
             //
-            // Preserve this slice if unmarshalling a value in Slice format. Exception slices are not preserved.
+            // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not preserved.
             //
             if (_current.sliceType == SliceType.ValueSlice)
             {

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -204,7 +204,7 @@ public class OutputStream
 
         //
         // Swap is never called for streams that have encapsulations being written. However,
-        // encapsulations might still be set in case marshalling failed. We just
+        // encapsulations might still be set in case marshaling failed. We just
         // reset the encapsulations if there are still some set.
         //
         resetEncapsulation();
@@ -2296,9 +2296,9 @@ public class OutputStream
             while (_toBeMarshaledMap.Count > 0)
             {
                 //
-                // Consider the to be marshalled instances as marshalled now,
+                // Consider the to be marshaled instances as marshaled now,
                 // this is necessary to avoid adding again the "to be
-                // marshalled instances" into _toBeMarshaledMap while writing
+                // marshaled instances" into _toBeMarshaledMap while writing
                 // instances.
                 //
                 foreach (var e in _toBeMarshaledMap)

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -282,7 +282,7 @@ namespace Ice
                     so.p.opVoid();
 
                     //
-                    // Test marshalling of null structs and structs with null members.
+                    // Test marshaling of null structs and structs with null members.
                     //
                     si1 = new Test.Structure();
                     si2 = null;

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -461,7 +461,7 @@ namespace Ice
                 }
                 output.WriteLine("ok");
 
-                output.Write("testing marshalling of objects with optional objects...");
+                output.Write("testing marshaling of objects with optional objects...");
                 output.Flush();
                 {
                     Test.F f = new Test.F();

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -682,7 +682,7 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
 
   @Override
   public boolean systemException(int requestId, SystemException ex, boolean amd) {
-    return false; // System exceptions aren't marshalled.
+    return false; // System exceptions aren't marshaled.
   }
 
   @Override
@@ -1268,7 +1268,7 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
       if (!_writeStream.isEmpty()) {
         //
         // Return the stream to the outgoing call. This is important for
-        // retriable AMI calls which are not marshalled again.
+        // retriable AMI calls which are not marshaled again.
         //
         OutgoingMessage message = _sendStreams.getFirst();
         _writeStream.swap(message.stream);

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -754,7 +754,7 @@ public class InputStream {
     // _minSeqSize by the minimum size that this sequence will require on
     // the stream.
     //
-    // The goal of this check is to ensure that when we start un-marshalling
+    // The goal of this check is to ensure that when we start un-marshaling
     // a new sequence, we check the minimal size of this new sequence against
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's _minSeqSize.
@@ -768,7 +768,7 @@ public class InputStream {
 
     //
     // If there isn't enough data to read on the stream for the sequence (and
-    // possibly enclosed sequences), something is wrong with the marshalled
+    // possibly enclosed sequences), something is wrong with the marshaled
     // data: it's claiming having more data that what is possible to read.
     //
     if (_startSeq + _minSeqSize > _buf.size()) {
@@ -1994,7 +1994,7 @@ public class InputStream {
       assert (index > 0);
 
       //
-      // Check if we have already unmarshalled the instance. If that's the case,
+      // Check if we have already unmarshaled the instance. If that's the case,
       // just invoke the callback and we're done.
       //
       Value obj = _unmarshaledMap.get(index);
@@ -2628,7 +2628,7 @@ public class InputStream {
       }
 
       //
-      // Preserve this slice if unmarshalling a value in Slice format. Exception slices are not
+      // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not
       // preserved.
       //
       if (_current.sliceType == SliceType.ValueSlice) {

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -249,7 +249,7 @@ public class OutputStream {
 
     //
     // Swap is never called for streams that have encapsulations being written. However,
-    // encapsulations might still be set in case marshalling failed. We just
+    // encapsulations might still be set in case marshaling failed. We just
     // reset the encapsulations if there are still some set.
     //
     resetEncapsulation();
@@ -1708,7 +1708,7 @@ public class OutputStream {
     void writePendingValues() {
       while (_toBeMarshaledMap.size() > 0) {
         //
-        // Consider the to be marshalled instances as marshaled now,
+        // Consider the to be marshaled instances as marshaled now,
         // this is necessary to avoid adding again the "to be
         // marshaled instances" into _toBeMarshaledMap while writing
         // instances.

--- a/java/src/IceGridGUI/src/main/resources/metrics.cfg
+++ b/java/src/IceGridGUI/src/main/resources/metrics.cfg
@@ -95,7 +95,7 @@ IceGridGUI.Metrics.Invocation.remotes.columnName = Remotes
     IceGridGUI.Metrics.Invocation.remotes.averageLifetime.fieldClass = IceGridGUI.LiveDeployment.MetricsViewEditor$AverageLifetimeMetricsField
     IceGridGUI.Metrics.Invocation.remotes.averageLifetime.scaleFactor = 1000.0d
     IceGridGUI.Metrics.Invocation.remotes.averageLifetime.columnName = Avg LfT
-    IceGridGUI.Metrics.Invocation.remotes.averageLifetime.columnToolTip = <html>Average remote invocation lifetime (ms)<br><br><p style="width: 300px;">The lifetime starts when the marshalled invocation is passed to the Ice connection for sending and ends when the Ice connection either sent the invocation (for oneway) or received the response (for twoway). This time doesn't include the marshalling of the invocation or un-marshalling of the response.</p></html>
+    IceGridGUI.Metrics.Invocation.remotes.averageLifetime.columnToolTip = <html>Average remote invocation lifetime (ms)<br><br><p style="width: 300px;">The lifetime starts when the marshaled invocation is passed to the Ice connection for sending and ends when the Ice connection either sent the invocation (for oneway) or received the response (for twoway). This time doesn't include the marshaling of the invocation or un-marshaling of the response.</p></html>
 
     IceGridGUI.Metrics.Invocation.remotes.size.fieldClass = IceGridGUI.LiveDeployment.MetricsViewEditor$DeltaAverageMetricsField
     IceGridGUI.Metrics.Invocation.remotes.size.dataField = size
@@ -131,7 +131,7 @@ IceGridGUI.Metrics.Invocation.collocated.columnName = Collocated
     IceGridGUI.Metrics.Invocation.collocated.averageLifetime.fieldClass = IceGridGUI.LiveDeployment.MetricsViewEditor$AverageLifetimeMetricsField
     IceGridGUI.Metrics.Invocation.collocated.averageLifetime.scaleFactor = 1000.0d
     IceGridGUI.Metrics.Invocation.collocated.averageLifetime.columnName = Avg LfT
-    IceGridGUI.Metrics.Invocation.collocated.averageLifetime.columnToolTip = <html>Average remote invocation lifetime (ms)<br><br><p style="width: 300px;">The lifetime starts when the marshalled invocation is passed to the Ice connection for sending and ends when the Ice connection either sent the invocation (for oneway) or received the response (for twoway). This time doesn't include the marshalling of the invocation or un-marshalling of the response.</p></html>
+    IceGridGUI.Metrics.Invocation.collocated.averageLifetime.columnToolTip = <html>Average remote invocation lifetime (ms)<br><br><p style="width: 300px;">The lifetime starts when the marshaled invocation is passed to the Ice connection for sending and ends when the Ice connection either sent the invocation (for oneway) or received the response (for twoway). This time doesn't include the marshaling of the invocation or un-marshaling of the response.</p></html>
 
     IceGridGUI.Metrics.Invocation.collocated.size.fieldClass = IceGridGUI.LiveDeployment.MetricsViewEditor$DeltaAverageMetricsField
     IceGridGUI.Metrics.Invocation.collocated.size.dataField = size

--- a/java/test/src/main/java/test/Ice/operations/Twoways.java
+++ b/java/test/src/main/java/test/Ice/operations/Twoways.java
@@ -213,8 +213,8 @@ class Twoways {
       test(r.returnValue == MyEnum.enum3);
 
       //
-      // Test marshalling of null enum (first enum value is
-      // marshalled in this case).
+      // Test marshaling of null enum (first enum value is
+      // marshaled in this case).
       //
       r = p.opMyEnum(null);
       test(r.p2 == MyEnum.enum1);
@@ -266,7 +266,7 @@ class Twoways {
       r.p3.p.opVoid();
 
       //
-      // Test marshalling of null structs and structs with default member values.
+      // Test marshaling of null structs and structs with default member values.
       //
       si1 = new Structure();
       si2 = null;

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -503,7 +503,7 @@ public class AllTests {
     }
     out.println("ok");
 
-    out.print("testing marshalling of objects with optional objects...");
+    out.print("testing marshaling of objects with optional objects...");
     out.flush();
     {
       F f = new F();

--- a/js/src/Ice/ConnectionI.js
+++ b/js/src/Ice/ConnectionI.js
@@ -1054,7 +1054,7 @@ class ConnectionI
             {
                 //
                 // Return the stream to the outgoing call. This is important for
-                // retriable AMI calls which are not marshalled again.
+                // retriable AMI calls which are not marshaled again.
                 //
                 this._writeStream.swap(this._sendStreams[0].stream);
             }

--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -2386,9 +2386,9 @@ class EncapsEncoder10 extends EncapsEncoder
         while(this._toBeMarshaledMap.size > 0)
         {
             //
-            // Consider the to be marshalled instances as marshalled now,
+            // Consider the to be marshaled instances as marshaled now,
             // this is necessary to avoid adding again the "to be
-            // marshalled instances" into _toBeMarshaledMap while writing
+            // marshaled instances" into _toBeMarshaledMap while writing
             // instances.
             //
             this._toBeMarshaledMap.forEach((value, key) => this._marshaledMap.set(key, value));

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -805,7 +805,7 @@ classdef InputStream < handle
             % _minSeqSize by the minimum size that this sequence will require on
             % the stream.
             %
-            % The goal of this check is to ensure that when we start un-marshalling
+            % The goal of this check is to ensure that when we start un-marshaling
             % a new sequence, we check the minimal size of this new sequence against
             % the estimated remaining buffer size. This estimation is based on
             % the minimum size of the enclosing sequences, it's _minSeqSize.
@@ -819,7 +819,7 @@ classdef InputStream < handle
 
             %
             % If there isn't enough data to read on the stream for the sequence (and
-            % possibly enclosed sequences), something is wrong with the marshalled
+            % possibly enclosed sequences), something is wrong with the marshaled
             % data: it's claiming to have more data than what is possible to read.
             %
             if obj.startSeq + obj.minSeqSize > obj.size + int32(1)

--- a/matlab/lib/+IceInternal/EncapsDecoder.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder.m
@@ -126,7 +126,7 @@ classdef (Abstract) EncapsDecoder < handle
         function addPatchEntry(obj, index, cb)
             %assert(index > 0);
             %
-            % Check if we have already unmarshalled the instance. If that's the case,
+            % Check if we have already unmarshaled the instance. If that's the case,
             % just invoke the callback and we're done.
             %
             if index <= length(obj.unmarshaledMap)

--- a/matlab/lib/+IceInternal/EncapsEncoder10.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder10.m
@@ -75,7 +75,7 @@ classdef EncapsEncoder10 < IceInternal.EncapsEncoder
         function writePendingValues(obj)
             while length(obj.toBeMarshaledMap) > 0
                 %
-                % Consider the to be marshalled instances as marshaled now,
+                % Consider the to be marshaled instances as marshaled now,
                 % this is necessary to avoid adding again the "to be
                 % marshaled instances" into toBeMarshaledMap while writing
                 % instances.

--- a/matlab/test/Ice/operations/Twoways.m
+++ b/matlab/test/Ice/operations/Twoways.m
@@ -168,8 +168,8 @@ classdef Twoways
             assert(r == MyEnum.enum3);
 
             %
-            % Test marshalling of null enum (first enum value is
-            % marshalled in this case).
+            % Test marshaling of null enum (first enum value is
+            % marshaled in this case).
             %
             [r, p2] = p.opMyEnum([]);
             assert(p2 == MyEnum.enum1);
@@ -218,7 +218,7 @@ classdef Twoways
             p3.p.opVoid();
 
             %
-            % Test marshalling of null structs and structs with default member values.
+            % Test marshaling of null structs and structs with default member values.
             %
             si1 = Structure();
             si2 = [];

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -380,7 +380,7 @@ classdef AllTests
 
             fprintf('ok\n');
 
-            fprintf('testing marshalling of objects with optional objects... ');
+            fprintf('testing marshaling of objects with optional objects... ');
 
             f = F();
 

--- a/php/test/Ice/operations/Client.php
+++ b/php/test/Ice/operations/Client.php
@@ -328,7 +328,7 @@ function twoways($communicator, $p, $bprx)
         test($so->s->s == "a new string");
         $so->p->opVoid();
 
-        // Test marshalling of null structs and structs with null members.
+        // Test marshaling of null structs and structs with null members.
         $si1 = new Test\Structure();
         $si2 = null;
 

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -387,7 +387,7 @@ function allTests($helper)
 
     echo "ok\n";
 
-    echo "testing marshalling of objects with optional objects...";
+    echo "testing marshaling of objects with optional objects...";
     flush();
 
     $f = new Test\F;

--- a/php/test/Ice/timeout/Client.php
+++ b/php/test/Ice/timeout/Client.php
@@ -220,7 +220,7 @@ function allTestsWithController($helper, $controller)
         $comm = Ice\initialize($initData);
         $to = $comm->stringToProxy($sref)->ice_uncheckedCast("::Test::Timeout");
         connect($to);
-        $controller->holdAdapter(-1); // Use larger value, marshalling of byte arrays is much slower in PHP
+        $controller->holdAdapter(-1); // Use larger value, marshaling of byte arrays is much slower in PHP
         try
         {
             $to->sendData($seq);
@@ -295,7 +295,7 @@ function allTestsWithController($helper, $controller)
         // $timeout->op(); // Ensure adapter is active.
         // $to = $to->ice_timeout(250)->ice_uncheckedCast("::Test::Timeout");
         // connect($to);
-        // $controller->holdAdapter(1000); // Use larger value, marshalling of byte arrays is much slower in PHP
+        // $controller->holdAdapter(1000); // Use larger value, marshaling of byte arrays is much slower in PHP
         // try
         // {
         //     $to->sendData($seq);

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -314,7 +314,7 @@ def twoways(helper, p):
     test(so.s.s == "a new string")
     so.p.opVoid()
 
-    # Test marshalling of null structs and structs with null members.
+    # Test marshaling of null structs and structs with null members.
     si1 = Test.Structure()
     si2 = None
 

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -421,7 +421,7 @@ def allTests(helper, communicator):
 
     print("ok")
 
-    sys.stdout.write("testing marshalling of objects with optional objects...")
+    sys.stdout.write("testing marshaling of objects with optional objects...")
     sys.stdout.flush()
 
     f = Test.F()

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -301,7 +301,7 @@ def twoways(helper, communicator, p)
     test(so.s.s == "a new string")
     so.p.opVoid()
 
-    # Test marshalling of null structs and structs with null members.
+    # Test marshaling of null structs and structs with null members.
     si1 = Test::Structure.new
     si2 = nil
 

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -383,7 +383,7 @@ def allTests(helper, communicator)
 
     puts "ok"
 
-    print "testing marshalling of objects with optional objects..."
+    print "testing marshaling of objects with optional objects..."
     STDOUT.flush
 
     f = Test::F.new

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -143,10 +143,10 @@ module IceMX
         /// The number of dispatch that failed with a user exception.
         int userException = 0;
 
-        /// The size of the dispatch. This corresponds to the size of the marshalled input parameters.
+        /// The size of the dispatch. This corresponds to the size of the marshaled input parameters.
         long size = 0;
 
-        /// The size of the dispatch reply. This corresponds to the size of the marshalled output and return parameters.
+        /// The size of the dispatch reply. This corresponds to the size of the marshaled output and return parameters.
         long replySize = 0;
     }
 
@@ -155,10 +155,10 @@ module IceMX
     /// embedded within {@link InvocationMetrics}.
     class ChildInvocationMetrics extends Metrics
     {
-        /// The size of the invocation. This corresponds to the size of the marshalled input parameters.
+        /// The size of the invocation. This corresponds to the size of the marshaled input parameters.
         long size = 0;
 
-        /// The size of the invocation reply. This corresponds to the size of the marshalled output and return
+        /// The size of the invocation reply. This corresponds to the size of the marshaled output and return
         /// parameters.
         long replySize = 0;
     }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -597,7 +597,7 @@ extension InputStream {
     // minSeqSize by the minimum size that this sequence will require on
     // the stream.
     //
-    // The goal of this check is to ensure that when we start un-marshalling
+    // The goal of this check is to ensure that when we start un-marshaling
     // a new sequence, we check the minimal size of this new sequence against
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's minSeqSize.
@@ -611,7 +611,7 @@ extension InputStream {
 
     //
     // If there isn't enough data to read on the stream for the sequence (and
-    // possibly enclosed sequences), something is wrong with the marshalled
+    // possibly enclosed sequences), something is wrong with the marshaled
     // data: it's claiming having more data that what is possible to read.
     //
     if startSeq + minSeqSize > data.count {
@@ -1618,7 +1618,7 @@ private class EncapsDecoder11: EncapsDecoder {
     }
 
     //
-    // Preserve this slice if unmarshalling a value in Slice format. Exception slices are not preserved.
+    // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not preserved.
     //
     if current.sliceType == .ValueSlice {
       let hasOptionalMembers = current.sliceFlags.contains(.FLAG_HAS_OPTIONAL_MEMBERS)

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -755,7 +755,7 @@ private final class EncapsEncoder10: EncapsEncoder {
   func writePendingValues() {
     while !toBeMarshaledMap.isEmpty {
       //
-      // Consider the to be marshalled instances as marshaled now,
+      // Consider the to be marshaled instances as marshaled now,
       // this is necessary to avoid adding again the "to be
       // marshaled instances" into _toBeMarshaledMap while writing
       // instances.
@@ -770,7 +770,7 @@ private final class EncapsEncoder10: EncapsEncoder {
 
       for (key, value) in savedMap {
         //
-        // Consider the to be marshalled instances as marshaled now,
+        // Consider the to be marshaled instances as marshaled now,
         // this is necessary to avoid adding again the "to be
         // marshaled instances" into _toBeMarshaledMap while writing
         // instances.

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -670,7 +670,7 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   }
   output.writeLine("ok")
 
-  output.write("testing marshalling of objects with optional objects...")
+  output.write("testing marshaling of objects with optional objects...")
   do {
     let f = F()
 


### PR DESCRIPTION
Both 'marshaling' and 'marshalling' are correct spellings of the word, the first is more common in America, the second in Britain. But we try to be careful and _only_ use the American spelling.

This PR fixes all the places where we were using the (double-'l') British spelling.