### PR TITLE
Update CI to use a specific MATLAB release

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -94,8 +94,8 @@ runs:
       # ———— MATLAB ———— #
     - name: Setup MATLAB
       uses: matlab-actions/setup-matlab@v2
-        with:
-          release: 'R2023b'
+      with:
+        release: 'R2023b'
       if: matrix.language == 'matlab'
 
     - name: Set MATLAB_HOME

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -94,6 +94,8 @@ runs:
       # ———— MATLAB ———— #
     - name: Setup MATLAB
       uses: matlab-actions/setup-matlab@v2
+        with:
+          release: 'R2023b'
       if: matrix.language == 'matlab'
 
     - name: Set MATLAB_HOME


### PR DESCRIPTION
Updates CI to use R2023b

Related to https://github.com/zeroc-ice/ice/issues/2037