### PR TITLE
.editorconfig: move general indentation setting to csharp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,11 +9,6 @@ guidelines = 120
 
 #### Core EditorConfig Options ####
 
-# Indentation and spacing
-indent_size = 4
-indent_style = space
-tab_width = 4
-
 # New line preferences
 insert_final_newline = true
 

--- a/csharp/.editorconfig
+++ b/csharp/.editorconfig
@@ -1,6 +1,13 @@
 # C# files
 [*.cs]
 
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
 #### .NET Coding Conventions ####
 
 # Organize usings


### PR DESCRIPTION
When indent_size and friend are set at the root it overrides vscode's  auto detect functionality. So for languages like YAML, Java, etc. that use 2 spaces everything gets rewritten to 4 on save. 

So instead of having a global default I think it makes sense to move theses specific things to the language in question and let the editor's auto detect feature figure it out otherwise. 

We can also add more language sections whenever we want in the future.

 