### PR TITLE
Dispatch/upcall renaming and sendResponse refactoring

### DIFF
--- a/cpp/src/Ice/CollocatedRequestHandler.h
+++ b/cpp/src/Ice/CollocatedRequestHandler.h
@@ -43,15 +43,13 @@ namespace IceInternal
 
         bool sentAsync(OutgoingAsyncBase*);
 
-        void invokeAll(Ice::OutputStream*, std::int32_t, std::int32_t);
+        void dispatchAll(Ice::InputStream&, std::int32_t, std::int32_t);
 
     private:
         void handleException(std::int32_t, std::exception_ptr);
 
         void sendResponse(Ice::OutgoingResponse);
-        void sendResponse(std::int32_t, Ice::OutputStream*);
-        void sendNoResponse();
-        void invokeException(std::int32_t, std::exception_ptr);
+        void dispatchException(std::int32_t, std::exception_ptr);
 
         const std::shared_ptr<Ice::ObjectAdapterI> _adapter;
         const bool _hasExecutor;

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -98,10 +98,10 @@ namespace
     };
 
 #if TARGET_OS_IPHONE != 0
-    class FinishCall final : public ExecutorWorkItem
+    class ExecuteFinish final : public ExecutorWorkItem
     {
     public:
-        FinishCall(const IncomingConnectionFactoryPtr& factory) : _factory(factory) {}
+        ExecuteFinish(const IncomingConnectionFactoryPtr& factory) : _factory(factory) {}
 
         void run() final { _factory->finish(); }
 
@@ -1843,7 +1843,7 @@ IceInternal::IncomingConnectionFactory::setState(State state)
             else
             {
 #if TARGET_OS_IPHONE != 0
-                _adapter->getThreadPool()->execute(make_shared<FinishCall>(shared_from_this()));
+                _adapter->getThreadPool()->execute(make_shared<ExecuteFinish>(shared_from_this()));
 #endif
                 state = StateFinished;
             }

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1658,7 +1658,7 @@ ConnectionI::upcall(
     const HeartbeatCallback& heartbeatCallback,
     InputStream& stream)
 {
-    int completedUpCallCount = 0;
+    int completedUpcallCount = 0;
 
     //
     // Notify the factory that the connection establishment and
@@ -1667,7 +1667,7 @@ ConnectionI::upcall(
     if (connectionStartCompleted)
     {
         connectionStartCompleted(shared_from_this());
-        ++completedUpCallCount;
+        ++completedUpcallCount;
     }
 
     //
@@ -1694,7 +1694,7 @@ ConnectionI::upcall(
             p->outAsync->invokeSent();
 #endif
         }
-        ++completedUpCallCount;
+        ++completedUpcallCount;
     }
 
     //
@@ -1704,7 +1704,7 @@ ConnectionI::upcall(
     if (outAsync)
     {
         outAsync->invokeResponse();
-        ++completedUpCallCount;
+        ++completedUpcallCount;
     }
 
     if (heartbeatCallback)
@@ -1723,7 +1723,7 @@ ConnectionI::upcall(
             Error out(_instance->initializationData().logger);
             out << "connection callback exception:\nunknown c++ exception" << '\n' << _desc;
         }
-        ++completedUpCallCount;
+        ++completedUpcallCount;
     }
 
     // Dispatch must be done outside the thread synchronization, so that nested calls are possible.
@@ -1738,10 +1738,10 @@ ConnectionI::upcall(
     //
     // Decrease the upcall count.
     //
-    if (completedUpCallCount > 0)
+    if (completedUpcallCount > 0)
     {
         std::lock_guard lock(_mutex);
-        _upcallCount -= completedUpCallCount;
+        _upcallCount -= completedUpcallCount;
         if (_upcallCount == 0)
         {
             // Only initiate shutdown if not already initiated. It might have already been initiated if the sent

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -204,7 +204,7 @@ namespace Ice
 
         void exception(std::exception_ptr);
 
-        void dispatch(
+        void upCall(
             std::function<void(ConnectionIPtr)>,
             const std::vector<OutgoingMessage>&,
             std::uint8_t,
@@ -274,9 +274,7 @@ namespace Ice
         void sendHeartbeatNow();
 
         void sendResponse(OutgoingResponse, std::uint8_t compress);
-        void sendResponse(std::int32_t, Ice::OutputStream*, std::uint8_t);
-        void sendNoResponse();
-        void invokeException(std::int32_t, std::exception_ptr, int);
+        void dispatchException(std::exception_ptr, int);
 
         bool initialize(IceInternal::SocketOperation = IceInternal::SocketOperationNone);
         bool validate(IceInternal::SocketOperation = IceInternal::SocketOperationNone);
@@ -298,7 +296,7 @@ namespace Ice
             HeartbeatCallback&,
             int&);
 
-        void invokeAll(Ice::InputStream&, std::int32_t, std::int32_t, std::uint8_t, const ObjectAdapterIPtr&);
+        void dispatchAll(Ice::InputStream&, std::int32_t, std::int32_t, std::uint8_t, const ObjectAdapterIPtr&);
 
         void scheduleTimeout(IceInternal::SocketOperation status);
         void unscheduleTimeout(IceInternal::SocketOperation status);
@@ -367,7 +365,7 @@ namespace Ice
 
         Observer _observer;
 
-        int _upcallCount;
+        int _upCallCount;
 
         State _state; // The current state.
         bool _shutdownInitiated;

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -204,16 +204,20 @@ namespace Ice
 
         void exception(std::exception_ptr);
 
-        void upCall(
-            std::function<void(ConnectionIPtr)>,
-            const std::vector<OutgoingMessage>&,
-            std::uint8_t,
-            std::int32_t,
-            std::int32_t,
-            const ObjectAdapterIPtr&,
-            const IceInternal::OutgoingAsyncBasePtr&,
-            const HeartbeatCallback&,
-            Ice::InputStream&);
+        // This method is called to execute user code (connection start completion callback, invocation sent callbacks,
+        // servant dispatch, invocation response, heartbeat callback). Only the invocation sent callbacks and one of the
+        // other callbacks can be set at the same time. TODO: improve this to use separate functions encapsulated with
+        // an std::function
+        void upcall(
+            std::function<void(ConnectionIPtr)> connectionStartCompleted,
+            const std::vector<OutgoingMessage>& sentMessages, // for calling invocation sent callbacks
+            std::uint8_t compress,
+            std::int32_t requestId,
+            std::int32_t dispatchCount,
+            const ObjectAdapterIPtr& adapter,
+            const IceInternal::OutgoingAsyncBasePtr& outAsync, // for callback the invocation response
+            const HeartbeatCallback& heartbeatCallback,
+            Ice::InputStream& stream); //
         void finish(bool);
 
         void closeCallback(const CloseCallback&);
@@ -278,7 +282,7 @@ namespace Ice
 
         bool initialize(IceInternal::SocketOperation = IceInternal::SocketOperationNone);
         bool validate(IceInternal::SocketOperation = IceInternal::SocketOperationNone);
-        IceInternal::SocketOperation sendNextMessage(std::vector<OutgoingMessage>&);
+        IceInternal::SocketOperation sendNextMessages(std::vector<OutgoingMessage>&);
         IceInternal::AsyncStatus sendMessage(OutgoingMessage&);
 
 #ifdef ICE_HAS_BZIP2
@@ -365,7 +369,8 @@ namespace Ice
 
         Observer _observer;
 
-        int _upCallCount;
+        // The number of user calls currently executed by the thread-pool (servant dispatch, invocation response, ...)
+        int _upcallCount;
 
         State _state; // The current state.
         bool _shutdownInitiated;

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -207,7 +207,7 @@ namespace Ice
         // This method is called to execute user code (connection start completion callback, invocation sent callbacks,
         // servant dispatch, invocation response, heartbeat callback). Only the invocation sent callbacks and one of the
         // other callbacks can be set at the same time. TODO: improve this to use separate functions encapsulated with
-        // an std::function
+        // a std::function
         void upcall(
             std::function<void(ConnectionIPtr)> connectionStartCompleted,
             const std::vector<OutgoingMessage>& sentMessages, // for calling invocation sent callbacks
@@ -217,7 +217,7 @@ namespace Ice
             const ObjectAdapterIPtr& adapter,
             const IceInternal::OutgoingAsyncBasePtr& outAsync, // for callback the invocation response
             const HeartbeatCallback& heartbeatCallback,
-            Ice::InputStream& stream); //
+            Ice::InputStream& stream); // the incoming request stream
         void finish(bool);
 
         void closeCallback(const CloseCallback&);


### PR DESCRIPTION
This PR contains a number of variable and data member renaming to better distinguish up calls from dispatches. "Num" suffixed variables are also now suffixed by "Count".  It also merges the sendResponse/sendNoResponse methods into a single method.

The same renaming is done in the collocated request handler class. There's also a small refactoring to make `dispatchAll` more consistent with the connection's `dispatchAll` method.