### PR TITLE
Make Connection.EnableIdleCheck true by default

### DIFF
--- a/cpp/src/Ice/ConnectionOptions.h
+++ b/cpp/src/Ice/ConnectionOptions.h
@@ -15,7 +15,7 @@ namespace Ice
         std::chrono::seconds connectTimeout = std::chrono::seconds(10);
         std::chrono::seconds closeTimeout = std::chrono::seconds(10);
         std::chrono::seconds idleTimeout = std::chrono::seconds(60);
-        bool enableIdleCheck = false; // TODO: switch to true
+        bool enableIdleCheck = true;
         std::chrono::seconds inactivityTimeout = std::chrono::seconds(300);
     };
 }

--- a/cpp/test/Ice/hold/Client.cpp
+++ b/cpp/test/Ice/hold/Client.cpp
@@ -21,7 +21,6 @@ Client::run(int argc, char** argv)
     Ice::InitializationData initData;
     initData.properties = createTestProperties(argc, argv);
     initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
-    initData.properties->setProperty("Ice.Connection.EnableIdleCheck", "1");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
     void allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/hold/Server.cpp
+++ b/cpp/test/Ice/hold/Server.cpp
@@ -30,7 +30,6 @@ Server::run(int argc, char** argv)
     properties->setProperty("TestAdapter1.ThreadPool.SizeMax", "5");
     properties->setProperty("TestAdapter1.ThreadPool.SizeWarn", "0");
     properties->setProperty("TestAdapter1.ThreadPool.Serialize", "0");
-    properties->setProperty("TestAdapter1.Connection.EnableIdleCheck", "1");
 
     Ice::ObjectAdapterPtr adapter1 = communicator->createObjectAdapter("TestAdapter1");
     adapter1->add(make_shared<HoldI>(timer, adapter1), Ice::stringToIdentity("hold"));
@@ -40,7 +39,6 @@ Server::run(int argc, char** argv)
     properties->setProperty("TestAdapter2.ThreadPool.SizeMax", "5");
     properties->setProperty("TestAdapter2.ThreadPool.SizeWarn", "0");
     properties->setProperty("TestAdapter2.ThreadPool.Serialize", "1");
-    properties->setProperty("TestAdapter2.Connection.EnableIdleCheck", "1");
     Ice::ObjectAdapterPtr adapter2 = communicator->createObjectAdapter("TestAdapter2");
     adapter2->add(make_shared<HoldI>(timer, adapter2), Ice::stringToIdentity("hold"));
 

--- a/cpp/test/Ice/idleTimeout/AllTests.cpp
+++ b/cpp/test/Ice/idleTimeout/AllTests.cpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace Ice;
 using namespace Test;
 
-// The client and server have the same idle timeout (1s) and the server has EnableIdleCheck = 1.
+// The client and server have the same idle timeout (1s) and the server enables connection idle checks (the default).
 // We verify that the server's idle check does not abort the connection as long as this connection receives heartbeats,
 // even when the heartbeats are not read off the connection in a timely manner.
 // To verify this situation, we use an OA with a 1-thread thread pool and use this unique thread for a long synchronous
@@ -26,7 +26,7 @@ testIdleCheckDoesNotAbortConnectionWhenThreadPoolIsExhausted(const TestIntfPrx& 
 }
 
 // We verify that the idle check aborts the connection when the connection (here server connection) remains idle for
-// longer than idle timeout. Here, the server has an idle timeout of 1s and EnableIdleCheck = 1. We intentionally
+// longer than idle timeout. Here, the server has an idle timeout of 1s and idle checks enable. We intentionally
 // misconfigure the client with an idle timeout of 3s to send heartbeats every 1.5s, which is too long to prevent the
 // server from aborting the connection.
 void
@@ -58,6 +58,37 @@ testConnectionAbortedByIdleCheck(const string& proxyString, const PropertiesPtr&
     cout << "ok" << endl;
 }
 
+// Verifies the behavior with the idle check enabled or disabled when the client and the server have mismatched idle
+// timeouts (here: 3s on the server side and 1s on the client side).
+void
+testEnableDisableIdleCheck(bool enabled, const string& proxyString, const PropertiesPtr& properties)
+{
+    cout << "testing connection with idle check " << (enabled ? "enabled" : "disabled") << "... " << flush;
+
+    // Create a new communicator with the desired properties.
+    Ice::InitializationData initData;
+    initData.properties = properties->clone();
+    initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
+    initData.properties->setProperty("Ice.Connection.EnableIdleCheck", enabled ? "1" : "0");
+    initData.properties->setProperty("Ice.Warn.Connections", "0");
+    Ice::CommunicatorHolder holder = initialize(initData);
+    TestIntfPrx p(holder.communicator(), proxyString);
+
+    ConnectionPtr connection = p->ice_getConnection();
+    test(connection);
+    try
+    {
+        p->sleep(2000); // the implementation in the server sleeps for 2,000ms
+        test(!enabled);
+    }
+    catch (const TimeoutException&)
+    {
+        test(enabled);
+    }
+
+    cout << "ok" << endl;
+}
+
 void
 allTests(TestHelper* helper)
 {
@@ -65,8 +96,12 @@ allTests(TestHelper* helper)
     string proxyString = "test: " + helper->getTestEndpoint();
     TestIntfPrx p(communicator, proxyString);
 
+    string proxyString3s = "test: " + helper->getTestEndpoint(1);
+
     testIdleCheckDoesNotAbortConnectionWhenThreadPoolIsExhausted(p);
     testConnectionAbortedByIdleCheck(proxyString, communicator->getProperties());
+    testEnableDisableIdleCheck(true, proxyString3s, communicator->getProperties());
+    testEnableDisableIdleCheck(false, proxyString3s, communicator->getProperties());
 
     p->shutdown();
 }

--- a/cpp/test/Ice/idleTimeout/AllTests.cpp
+++ b/cpp/test/Ice/idleTimeout/AllTests.cpp
@@ -26,7 +26,7 @@ testIdleCheckDoesNotAbortConnectionWhenThreadPoolIsExhausted(const TestIntfPrx& 
 }
 
 // We verify that the idle check aborts the connection when the connection (here server connection) remains idle for
-// longer than idle timeout. Here, the server has an idle timeout of 1s and idle checks enable. We intentionally
+// longer than idle timeout. Here, the server has an idle timeout of 1s and idle checks enabled. We intentionally
 // misconfigure the client with an idle timeout of 3s to send heartbeats every 1.5s, which is too long to prevent the
 // server from aborting the connection.
 void

--- a/cpp/test/Ice/idleTimeout/Server.cpp
+++ b/cpp/test/Ice/idleTimeout/Server.cpp
@@ -20,7 +20,6 @@ Server::run(int argc, char** argv)
     initData.properties = createTestProperties(argc, argv);
     initData.properties->setProperty("Ice.Warn.Connections", "0");
     initData.properties->setProperty("TestAdapter.Connection.IdleTimeout", "1"); // 1 second
-    initData.properties->setProperty("TestAdapter.Connection.EnableIdleCheck", "1");
     initData.properties->setProperty("TestAdapter.ThreadPool.Size", "1"); // dedicated thread pool with a single thread
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
@@ -28,6 +27,13 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     adapter->activate();
+
+    communicator->getProperties()->setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
+    communicator->getProperties()->setProperty("TestAdapter3s.Connection.IdleTimeout", "3");
+    Ice::ObjectAdapterPtr adapter3s = communicator->createObjectAdapter("TestAdapter3s");
+    adapter3s->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter3s->activate();
+
     serverReady();
     communicator->waitForShutdown();
 }


### PR DESCRIPTION
This PR makes EnableIdleCheck true by default. It also adds a test to verify disabling the IdleCheck actually works.