### PR TITLE
Restructure CI workflow 

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,60 +1,55 @@
 name: Build Ice
 
 inputs:
-  language:
-    description: "The programming language to build"
-    required: true
+  working_directory:
+    description: "The working directory to run the build in"
+    default: "."
     type: string
-  make_flags:
-    description: "Additional flags to pass to make"
-    required: false
+
+  build_flags:
+    description: "Additional flags to pass to the build"
     default: ""
     type: string
+
+  msbuild_project:
+    description: "The project file to build"
+    default: "ice.proj"
+    type: string
+
+  build_cpp_and_python:
+    description: "Build C++ and Python"
+    type: choice
+    default: "false"
+    options:
+      - true
+      - false
 
 runs:
   using: "composite"
   steps:
-    # Linux / macOS
-    - name: Build C++ Dependencies
-      working-directory: ./cpp
-      run: make -j3 V=1 srcs
-      shell: bash
-      if: (runner.os == 'macOS' || runner.os == 'Linux') && (inputs.language != 'cpp' || matrix.name == 'xcodesdk')
-
-    - name: Build C++ Tests for Scripting Languages
-      working-directory: ./cpp
-      run: make -j3 V=1 tests
-      shell: bash
-      if: (runner.os == 'macOS' || runner.os == 'Linux') && (inputs.language == 'php' || inputs.language == 'js' || inputs.language == 'ruby')
-
-    - name: Build Ice for Python
-      working-directory: ./python
-      run: make -j3 V=1
-      shell: bash
-      if: (runner.os == 'macOS' || runner.os == 'Linux') && (inputs.language == 'matlab' || matrix.name == 'xcodesdk')
-
-    - name: Build ${{ matrix.name || matrix.language }}
-      working-directory: ./${{ inputs.language }}
+    # macOS and Linux
+    - name: Build C++ and Python
       run: |
-        make ${{ inputs.make_flags }} -j3 V=1
+        make -C cpp srcs
+        make -C python
+      shell: bash
+      if: (runner.os == 'macOS' || runner.os == 'Linux') && inputs.build_cpp_and_python == 'true'
+    - name: Build
+      working-directory: ${{ inputs.working_directory }}
+      run: make ${{ inputs.build_flags }}
       shell: bash
       if: runner.os == 'macOS' || runner.os == 'Linux'
 
     # Windows
-    - name: Build C++ Dependencies
-      run: msbuild /m /p:Platform=x64 msbuild/ice.proj
-      working-directory: ./cpp
+    - name: Build C++ and Python
+      run: |
+        msbuild /m ${{ inputs.build_flags }} /t:BuildDist cpp/msbuild/ice.proj
+        msbuild /m ${{ inputs.build_flags }} python/msbuild/ice.proj
       shell: powershell
-      if: (runner.os == 'Windows') && (inputs.language != 'cpp')
+      if: runner.os == 'Windows' && inputs.build_cpp_and_python == 'true'
 
-    - name: Build Ice for Python
-      run: msbuild /m /p:Platform=x64 msbuild/ice.proj
-      working-directory: ./python
-      shell: powershell
-      if: runner.os == 'Windows' && inputs.language == 'matlab'
-
-    - name: Build ${{ matrix.name || matrix.language }}
-      run: msbuild /m /p:Platform=x64 msbuild/ice.proj
-      working-directory: ./${{ inputs.language }}
+    - name: Build
+      working-directory: ${{ inputs.working_directory }}
+      run: msbuild /m ${{ inputs.build_flags }} ${{ inputs.msbuild_project }}
       shell: powershell
       if: runner.os == 'Windows'

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -13,6 +13,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set Linux MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(nproc) V=1" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'Linux'
+
+    - name: Set macOS MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(sysctl -n hw.ncpu) V=1" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'macOS'
+
     # Python3 is already installed though Homebrew
     - name: Install brew dependencies
       run: brew install ruby node php lmdb mcpp || true
@@ -27,7 +37,7 @@ runs:
       if: runner.os == 'macOS'
 
     - name: Install testing dependencies from pip
-      run: python3 -m pip install --break-system-packages passlib cryptography numpy
+      run: python3 -m pip install --break-system-packages --user passlib cryptography numpy
       shell: bash
       if: runner.os == 'macOS'
 
@@ -41,7 +51,7 @@ runs:
         # We should consider removing the dependency on ice-xcode-builder
         brew install zeroc-ice/tap/ice-builder-xcode
       shell: bash
-      if: (runner.os == 'macOS') && (matrix.name == 'xcodesdk')
+      if: (runner.os == 'macOS') && (matrix.config == 'xcodesdk')
 
     - name: Install apt dependencies
       run: |
@@ -51,7 +61,6 @@ runs:
             ruby ruby-dev php-cli php-dev \
             libbluetooth-dev libdbus-1-dev \
             libsystemd-dev
-
       shell: bash
       if: runner.os == 'Linux'
 
@@ -60,7 +69,11 @@ runs:
       with:
         distribution: "oracle"
         java-version: "17"
-      if: matrix.language == 'java'
+
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.x
 
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy
@@ -86,29 +99,35 @@ runs:
       shell: powershell
       if: runner.os == 'Windows'
 
+    # # This choco install will overwrite the existing Python installation
+    # - name: Setup Debug Python
+    #   run: |
+    #     choco install python312 --installargs='/quiet Include_debug=1' -y --no-progress
+    #   shell: powershell
+    #   if: runner.os == 'Windows' && matrix.config == 'debug'
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy
       shell: powershell
       if: runner.os == 'Windows'
 
-      # ———— MATLAB ———— #
+    # ———— MATLAB ———— #
     - name: Setup MATLAB
       uses: matlab-actions/setup-matlab@v2
       with:
-        release: 'R2023b'
-      if: matrix.language == 'matlab'
+        release: "R2023b"
+      if: matrix.config == 'matlab'
 
     - name: Set MATLAB_HOME
       run: |
         echo "MATLAB_HOME=/opt/hostedtoolcache/MATLAB/2023.2.999/x64" >> $GITHUB_ENV
       shell: bash
-      if: matrix.language == 'matlab' && runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.config == 'matlab'
 
     - name: Set MATLAB_HOME
       run: |
         echo "MATLAB_HOME=C:\Program Files\MATLAB\R2023b\bin" >> $env:GITHUB_ENV
       shell: powershell
-      if: matrix.language == 'matlab' && runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.config == 'matlab'
 
     # https://github.com/matlab-actions/run-command/issues/53
     - name: Get run-matlab-command
@@ -121,17 +140,16 @@ runs:
         echo "LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
 
       shell: bash
-      if: matrix.language == 'matlab' && runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.config == 'matlab'
 
     # Windows is currently not working. We get an error: "'matlab' executable not found on the system path"
     # Is GITHUB_PATH set correctly?
     - name: Get run-matlab-command
       run: |
-        wget -O C:\Windows\System32\run-matlab-command.exe https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/win64/run-matlab-command.exe
+        Invoke-WebRequest https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/win64/run-matlab-command.exe -OutFile C:\Windows\System32\run-matlab-command.exe
         echo "MATLAB_COMMAND=C:\Windows\System32\run-matlab-command.exe" >> $env:GITHUB_ENV
-        echo "$env:MATLAB_HOME" >> $env:GITHUB_PATH
       shell: powershell
-      if: matrix.language == 'matlab' && runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.config == 'matlab'
 
       # ———— Cache ———— #
     - name: Setup ccache
@@ -139,9 +157,9 @@ runs:
       with:
         # create-symlink: true
         append-timestamp: false
-        key: ci-${{ runner.os }}-${{matrix.name || matrix.language }}-${{ github.sha }}
+        key: ci-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
         restore-keys: |
-          ci-${{ runner.os }}-${{matrix.name || matrix.language }}-
+          ci-${{ runner.os }}-${{ matrix.config }}-
           ci-${{ runner.os }}-
       if: inputs.use_ccache == 'true' && (runner.os == 'macOS' || runner.os == 'Linux')
 
@@ -162,8 +180,8 @@ runs:
     #       **/msbuild/**/x64
     #       **/include/generated
 
-    #     key: ci-${{ runner.os }}-${{matrix.name || matrix.language }}-${{ github.sha }}
+    #     key: ci-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
     #     restore-keys: |
-    #       ci-${{ runner.os }}-${{matrix.name || matrix.language }}-
+    #       ci-${{ runner.os }}-${{ matrix.config }}-
     #       ci-${{ runner.os }}-
     #   if: inputs.cache && runner.os == 'Windows'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Test
       working-directory: ${{ inputs.working_directory }}
-      run: python allTests.py --debug --all --continue --export-xml=test-report.xml --workers=4 ${{ inputs.flags }}
+      run: python allTests.py --debug --all --continue --workers=4 --export-xml=test-report.xml ${{ inputs.flags }}
       shell: powershell
       if: runner.os == 'Windows'
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,26 +1,32 @@
 name: Test Ice
 
 inputs:
+  working_directory:
+    description: "The working directory to run the tests in"
+    type: string
+
   flags:
     description: "Flags to pass to the test"
-    required: false
+    type: string
     default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Test ${{ matrix.name || matrix.language }}
-      run: python3 allTests.py --debug --all --continue --workers=4  --export-xml=test-report.xml --languages=${{ matrix.language }} ${{ inputs.flags }}
+    - name: Test
+      working-directory: ${{ inputs.working_directory }}
+      run: python3 allTests.py --debug --all --continue --workers=4 --export-xml=test-report.xml ${{ inputs.flags }}
       shell: bash
       if: runner.os == 'macOS' || runner.os == 'Linux'
 
     - name: Test
-      run: python allTests.py --debug --all --continue --export-xml=test-report.xml --platform=x64 --config=Release --workers=4 --languages=${{ matrix.language }} ${{ inputs.flags }}
+      working-directory: ${{ inputs.working_directory }}
+      run: python allTests.py --debug --all --continue --export-xml=test-report.xml --workers=4 ${{ inputs.flags }}
       shell: powershell
       if: runner.os == 'Windows'
 
     - name: Test Summary
       uses: test-summary/action@v2
       with:
-        paths: "test-report.xml"
+        paths: "${{ inputs.working_directory }}/test-report.xml"
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build and test
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "restructure-ci"]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
@@ -15,50 +15,78 @@ concurrency:
 
 jobs:
   ci:
-    name: ${{ matrix.name || matrix.language }} on ${{ matrix.os }}
+    name: ${{ matrix.config }} on ${{ matrix.os }}
     strategy:
-      matrix:
-        language: [cpp]
-        os: [macos-14, ubuntu-latest, windows-latest]
-        name: [""]
-        make_flags: [""]
-        test_flags: [""]
-        include:
-          - os: macos-14
-            language: swift
-          - os: macos-14
-            language: python
-          - os: macos-14
-            language: php
-          - os: macos-14
-            language: ruby
-          - os: macos-14
-            language: cpp
-            name: "xcodesdk"
-            make_flags: "CONFIGS=xcodesdk PLATFORMS=iphonesimulator"
-            test_flags: "--config=xcodesdk --platform=iphonesimulator --controller-app"
-
-          - os: ubuntu-latest
-            language: csharp
-          - os: ubuntu-latest
-            language: java
-          - os: ubuntu-latest
-            language: php
-          - os: ubuntu-latest
-            language: ruby
-          - os: ubuntu-latest
-            language: python
-          - os: ubuntu-latest
-            language: js
-          - os: ubuntu-latest
-            language: matlab
-
-          - os: windows-latest
-            language: python
-          - os: windows-latest
-            language: matlab
-
       fail-fast: false
+      matrix:
+        include:
+          # Release builds
+          - os: macos-14
+            config: "release"
+            build_flags: ""
+            # https://github.com/zeroc-ice/ice/issues/2061
+            test_flags: "--rfilter=csharp/Ice/adapterDeactivation"
+          - os: ubuntu-22.04
+            config: "release"
+            build_flags: ""
+            test_flags: ""
+          - os: windows-2022
+            config: "release"
+            build_flags: "/p:Platform=x64"
+            test_flags: "--platform=x64"
+          - os: windows-2022
+            config: "cpp-win32-release"
+            working_directory: "cpp"
+            build_flags: "/p:Platform=Win32"
+            msbuild_project: "msbuild/ice.proj"
+            test_flags: "--platform=Win32"
+
+          # Debug builds
+          - os: macos-14
+            config: "debug"
+            build_flags: "OPTIMIZE=no"
+            # https://github.com/zeroc-ice/ice/issues/2061
+            test_flags: "--swift-config=Debug --rfilter=csharp/Ice/adapterDeactivation"
+          - os: ubuntu-22.04
+            config: "debug"
+            build_flags: "OPTIMIZE=no"
+            test_flags: ""
+          # TODO - figure out how to properly install debug Python
+          # - os: windows-2022
+          #   config: "debug"
+          #   build_flags: "/p:Platform=x64 /p:Configuration=Debug"
+          #   test_flags: "--platform=x64 --config=Debug"
+
+          # Xcode SDK builds
+          # TODO - Should we also test the debug config here as well?
+          - os: macos-14
+            config: "xcodesdk"
+            working_directory: "cpp"
+            build_flags: "CONFIGS=xcodesdk PLATFORMS=iphonesimulator"
+            test_flags: "--config=xcodesdk --platform=iphonesimulator --controller-app"
+            build_cpp_and_python: true
+
+          # MATLAB
+          - os: ubuntu-22.04
+            config: "matlab"
+            working_directory: "matlab"
+            build_flags: ""
+            test_flags: ""
+            build_cpp_and_python: true
+          - os: windows-2022
+            config: "matlab"
+            working_directory: "matlab"
+            build_flags: "/p:Platform=x64"
+            msbuild_project: "msbuild/ice.proj"
+            test_flags: "--platform=x64"
+            build_cpp_and_python: true
+
+          # Cross tests
+          - os: ubuntu-22.04
+            config: "cross"
+            build_flags: ""
+            # These cross tests are currently failing
+            test_flags: "--all-cross --rfilter Ice/invoke --rfilter Ice/optional --rfilter Ice/slicing"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,20 +96,23 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
-      - name: Build ${{ matrix.name || matrix.language }} ${{matrix.make_flags}} on ${{ matrix.os }}
+      - name: Build ${{ matrix.config }} on ${{ matrix.os }}
         uses: ./.github/actions/build
         timeout-minutes: 90
         with:
-          language: ${{ matrix.language }}
-          make_flags: ${{ matrix.make_flags }}
+          working_directory: ${{ matrix.working_directory || '.' }}
+          build_cpp_and_python: ${{ matrix.build_cpp_and_python || false }}
+          build_flags: ${{ matrix.build_flags || '' }}
+          msbuild_project: ${{ matrix.msbuild_project || 'ice.proj' }}
 
-      - name: Test ${{ matrix.name || matrix.language }} on ${{ matrix.os }}
+      - name: Test ${{ matrix.config }} on ${{ matrix.os }}
         uses: ./.github/actions/test
         timeout-minutes: 90
         with:
+          working_directory: ${{ matrix.working_directory || '.' }}
           # See:
           # - https://github.com/zeroc-ice/ice/issues/1653 IceGrid/replication
           # - https://github.com/zeroc-ice/ice/issues/1945 matlab/Ice/slicing
-          flags: "--rfilter IceGrid/replication --rfilter matlab/Ice/slicing ${{ matrix.test_flags }}"
+          flags: "--rfilter=IceGrid/replication --rfilter=matlab/Ice/slicing ${{ matrix.test_flags }}"
         # Don't test matlab on Windows
-        if: matrix.language != 'matlab' || runner.os != 'Windows'
+        if: matrix.config != 'matlab' || runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build and test
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "restructure-ci"]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,10 @@ jobs:
           # Release builds
           - os: macos-14
             config: "release"
-            build_flags: ""
             # https://github.com/zeroc-ice/ice/issues/2061
             test_flags: "--rfilter=csharp/Ice/adapterDeactivation"
           - os: ubuntu-22.04
             config: "release"
-            build_flags: ""
-            test_flags: ""
           - os: windows-2022
             config: "release"
             build_flags: "/p:Platform=x64"
@@ -50,7 +47,6 @@ jobs:
           - os: ubuntu-22.04
             config: "debug"
             build_flags: "OPTIMIZE=no"
-            test_flags: ""
           # TODO - figure out how to properly install debug Python
           # - os: windows-2022
           #   config: "debug"
@@ -70,8 +66,6 @@ jobs:
           - os: ubuntu-22.04
             config: "matlab"
             working_directory: "matlab"
-            build_flags: ""
-            test_flags: ""
             build_cpp_and_python: true
           - os: windows-2022
             config: "matlab"
@@ -84,7 +78,6 @@ jobs:
           # Cross tests
           - os: ubuntu-22.04
             config: "cross"
-            build_flags: ""
             # These cross tests are currently failing
             test_flags: "--all-cross --rfilter Ice/invoke --rfilter Ice/optional --rfilter Ice/slicing"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build C++
         working-directory: ./cpp
-        run: make -j3 V=1 srcs
+        run: make V=1 srcs
 
       - name: Generate Doxygen Documentation for Slice
         working-directory: ./doxygen
@@ -46,7 +46,7 @@ jobs:
       - name: Generate Documentation for Swift
         working-directory: ./swift
         run: |
-          make -j3 V=1
+          make V=1
 
           xcodebuild docbuild \
             -project ice.xcodeproj \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   swift-format:
     name: Swift Format & Lint
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/cpp/src/IceSSL/SChannelEngine.cpp
+++ b/cpp/src/IceSSL/SChannelEngine.cpp
@@ -661,7 +661,7 @@ SChannel::SSLEngine::initialize()
             }
         }
 
-        for (int i = 0; i < certFiles.size(); ++i)
+        for (size_t i = 0; i < certFiles.size(); ++i)
         {
             string certFile = certFiles[i];
             string resolved;

--- a/matlab/msbuild/ice.matlab.targets
+++ b/matlab/msbuild/ice.matlab.targets
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0"
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="SliceCompile">
         <MakeDir Directories="@(SliceCompile->'%(OutputDir)')"/>
         <Exec Command="&quot;$(IceToolsPath)\slice2matlab.exe&quot; --output-dir %(SliceCompile.OutputDir) -I&quot;$(IceHome)\slice&quot; %(SliceCompile.AdditionalOptions) @(SliceCompile->'%(Identity)', ' ')" />
     </Target>
 
     <Target Name="SliceCompileClean">
-        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).php')" />
+        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).m')" />
     </Target>
 </Project>


### PR DESCRIPTION
This PR restructures the CI workflow 

- we now (generally) build and test all language mappings at the same time in the same job
- added debug jobs (currently disabled for Windows as I can't figure out how to install debug Python)
- add win32 cpp job (and fix a related bug)
- separate jobs for xcodesdk and matlab

Not sure why but we're now also seeing https://github.com/zeroc-ice/ice/issues/2061

Fixes #1967