### PR TITLE
Added message upcall

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1489,10 +1489,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     // At this point, the protocol message is fully read and can therefore be decoded by parseMessage.
                     // parseMessage returns the operation to wait for readiness next.
                     newOp = static_cast<SocketOperation>(
-                        newOp | parseMessage(
-                                    upcallCount,
-                                    messageUpcall,
-                                    current.stream));
+                        newOp | parseMessage(upcallCount, messageUpcall, current.stream));
                 }
 
                 if (readyOp & SocketOperationWrite)

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -50,60 +50,36 @@ namespace
         Ice::ConnectionI* _connection;
     };
 
-    class ExecuteUpCall final : public ExecutorWorkItem
+    class ExecuteUpcall final : public ExecutorWorkItem
     {
     public:
-        ExecuteUpCall(
+        ExecuteUpcall(
             const ConnectionIPtr& connection,
             function<void(ConnectionIPtr)> connectionStartCompleted,
             const vector<ConnectionI::OutgoingMessage>& sentCBs,
-            uint8_t compress,
-            int32_t requestId,
-            int32_t requestCount,
-            const ObjectAdapterIPtr& adapter,
-            const OutgoingAsyncBasePtr& outAsync,
-            const HeartbeatCallback& heartbeatCallback,
-            InputStream& stream)
+            const function<bool(InputStream&)> messageUpcall,
+            InputStream& messageStream)
             : ExecutorWorkItem(connection),
               _connection(connection),
-              _connectionStartCompleted(std::move(connectionStartCompleted)),
+              _connectionStartCompleted(move(connectionStartCompleted)),
               _sentCBs(sentCBs),
-              _compress(compress),
-              _requestId(requestId),
-              _requestCount(requestCount),
-              _adapter(adapter),
-              _outAsync(outAsync),
-              _heartbeatCallback(heartbeatCallback),
-              _stream(stream.instance(), currentProtocolEncoding)
+              _messageUpcall(move(messageUpcall)),
+              _messageStream(messageStream.instance(), currentProtocolEncoding)
         {
-            _stream.swap(stream);
+            _messageStream.swap(messageStream);
         }
 
         void run() final
         {
-            _connection->upcall(
-                _connectionStartCompleted,
-                _sentCBs,
-                _compress,
-                _requestId,
-                _requestCount,
-                _adapter,
-                _outAsync,
-                _heartbeatCallback,
-                _stream);
+            _connection->upcall(_connectionStartCompleted, _sentCBs, _messageUpcall, _messageStream);
         }
 
     private:
         const ConnectionIPtr _connection;
         const function<void(Ice::ConnectionIPtr)> _connectionStartCompleted;
         const vector<ConnectionI::OutgoingMessage> _sentCBs;
-        const uint8_t _compress;
-        const int32_t _requestId;
-        const int32_t _requestCount;
-        const ObjectAdapterIPtr _adapter;
-        const OutgoingAsyncBasePtr _outAsync;
-        const HeartbeatCallback _heartbeatCallback;
-        InputStream _stream;
+        const function<bool(InputStream&)> _messageUpcall;
+        InputStream _messageStream;
     };
 
     class ExecuteFinish final : public ExecutorWorkItem
@@ -1299,15 +1275,11 @@ Ice::ConnectionI::finishAsync(SocketOperation operation)
 void
 Ice::ConnectionI::message(ThreadPoolCurrent& current)
 {
+    int upcallCount = 0;
+
     function<void(ConnectionIPtr)> connectionStartCompleted;
     vector<OutgoingMessage> sentCBs;
-    uint8_t compress = 0;
-    int32_t requestId = 0;
-    int32_t requestCount = 0;
-    ObjectAdapterIPtr adapter;
-    OutgoingAsyncBasePtr outAsync;
-    HeartbeatCallback heartbeatCallback;
-    int upcallCount = 0;
+    function<bool(InputStream&)> messageUpcall;
 
     ThreadPoolMessage<ConnectionI> msg(current, *this);
     {
@@ -1518,14 +1490,9 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                     // parseMessage returns the operation to wait for readiness next.
                     newOp = static_cast<SocketOperation>(
                         newOp | parseMessage(
-                                    current.stream,
-                                    requestCount,
-                                    requestId,
-                                    compress,
-                                    adapter,
-                                    outAsync,
-                                    heartbeatCallback,
-                                    upcallCount));
+                                    upcallCount,
+                                    messageUpcall,
+                                    current.stream));
                 }
 
                 if (readyOp & SocketOperationWrite)
@@ -1604,43 +1571,24 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
 
 // executeFromThisThread dispatches to the correct DispatchQueue
 #ifdef ICE_SWIFT
-    _threadPool->executeFromThisThread(make_shared<ExecuteUpCall>(
+    _threadPool->executeFromThisThread(make_shared<ExecuteUpcall>(
         shared_from_this(),
-        std::move(connectionStartCompleted),
+        move(connectionStartCompleted),
         sentCBs,
-        compress,
-        requestId,
-        requestCount,
-        adapter,
-        outAsync,
-        heartbeatCallback,
+        move(messageUpcall),
         current.stream));
 #else
     if (!_hasExecutor) // Optimization, call dispatch() directly if there's no executor.
     {
-        upcall(
-            connectionStartCompleted,
-            sentCBs,
-            compress,
-            requestId,
-            requestCount,
-            adapter,
-            outAsync,
-            heartbeatCallback,
-            current.stream);
+        upcall(connectionStartCompleted, sentCBs, move(messageUpcall), current.stream);
     }
     else
     {
-        _threadPool->executeFromThisThread(make_shared<ExecuteUpCall>(
+        _threadPool->executeFromThisThread(make_shared<ExecuteUpcall>(
             shared_from_this(),
-            std::move(connectionStartCompleted),
+            move(connectionStartCompleted),
             sentCBs,
-            compress,
-            requestId,
-            requestCount,
-            adapter,
-            outAsync,
-            heartbeatCallback,
+            move(messageUpcall),
             current.stream));
     }
 #endif
@@ -1650,13 +1598,8 @@ void
 ConnectionI::upcall(
     function<void(ConnectionIPtr)> connectionStartCompleted,
     const vector<OutgoingMessage>& sentCBs,
-    uint8_t compress,
-    int32_t requestId,
-    int32_t requestCount,
-    const ObjectAdapterIPtr& adapter,
-    const OutgoingAsyncBasePtr& outAsync,
-    const HeartbeatCallback& heartbeatCallback,
-    InputStream& stream)
+    function<bool(InputStream&)> messageUpcall,
+    InputStream& messageStream)
 {
     int completedUpcallCount = 0;
 
@@ -1697,42 +1640,9 @@ ConnectionI::upcall(
         ++completedUpcallCount;
     }
 
-    //
-    // Asynchronous replies must be handled outside the thread
-    // synchronization, so that nested calls are possible.
-    //
-    if (outAsync)
+    if (messageUpcall && messageUpcall(messageStream))
     {
-        outAsync->invokeResponse();
         ++completedUpcallCount;
-    }
-
-    if (heartbeatCallback)
-    {
-        try
-        {
-            heartbeatCallback(shared_from_this());
-        }
-        catch (const std::exception& ex)
-        {
-            Error out(_instance->initializationData().logger);
-            out << "connection callback exception:\n" << ex << '\n' << _desc;
-        }
-        catch (...)
-        {
-            Error out(_instance->initializationData().logger);
-            out << "connection callback exception:\nunknown c++ exception" << '\n' << _desc;
-        }
-        ++completedUpcallCount;
-    }
-
-    // Dispatch must be done outside the thread synchronization, so that nested calls are possible.
-    if (requestCount > 0)
-    {
-        dispatchAll(stream, requestCount, requestId, compress, adapter);
-
-        // Don't increase completedUpCallCount for dispatches. _upcallCount will be decreased when the outgoing reply is
-        // sent.
     }
 
     //
@@ -3224,14 +3134,9 @@ Ice::ConnectionI::doUncompress(InputStream& compressed, InputStream& uncompresse
 
 SocketOperation
 Ice::ConnectionI::parseMessage(
-    InputStream& stream,
-    int32_t& requestCount,
-    int32_t& requestId,
-    uint8_t& compress,
-    ObjectAdapterIPtr& adapter,
-    OutgoingAsyncBasePtr& outAsync,
-    HeartbeatCallback& heartbeatCallback,
-    int& upcallCount)
+    int32_t& upcallCount,
+    function<bool(InputStream&)>& upcall,
+    InputStream& stream)
 {
     assert(_state > StateNotValidated && _state < StateClosed);
 
@@ -3253,6 +3158,7 @@ Ice::ConnectionI::parseMessage(
         stream.i = stream.b.begin() + 8;
         uint8_t messageType;
         stream.read(messageType);
+        uint8_t compress;
         stream.read(compress);
 
         if (compress == 2)
@@ -3310,9 +3216,18 @@ Ice::ConnectionI::parseMessage(
                 else
                 {
                     traceRecv(stream, _logger, _traceLevels);
+
+                    auto adapter = _adapter;
+                    const int32_t requestCount = 1;
+                    int32_t requestId;
+
                     stream.read(requestId);
-                    requestCount = 1;
-                    adapter = _adapter;
+
+                    upcall = [this, requestCount, requestId, adapter, compress](InputStream& messageStream)
+                    {
+                        dispatchAll(messageStream, requestCount, requestId, compress, adapter);
+                        return false; // the upcall will be completed once the dispatch is done.
+                    };
                     ++upcallCount;
                 }
                 break;
@@ -3331,13 +3246,23 @@ Ice::ConnectionI::parseMessage(
                 else
                 {
                     traceRecv(stream, _logger, _traceLevels);
+
+                    auto adapter = _adapter;
+                    const int32_t requestId = 0;
+                    int32_t requestCount;
+
                     stream.read(requestCount);
                     if (requestCount < 0)
                     {
                         requestCount = 0;
                         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
                     }
-                    adapter = _adapter;
+
+                    upcall = [this, requestCount, requestId, adapter, compress](InputStream& messageStream)
+                    {
+                        dispatchAll(messageStream, requestCount, requestId, compress, adapter);
+                        return false; // the upcall will be completed once the servant dispatch is done.
+                    };
                     upcallCount += requestCount;
                 }
                 break;
@@ -3347,6 +3272,7 @@ Ice::ConnectionI::parseMessage(
             {
                 traceRecv(stream, _logger, _traceLevels);
 
+                int32_t requestId;
                 stream.read(requestId);
 
                 map<int32_t, OutgoingAsyncBasePtr>::iterator q = _asyncRequests.end();
@@ -3366,7 +3292,7 @@ Ice::ConnectionI::parseMessage(
 
                 if (q != _asyncRequests.end())
                 {
-                    outAsync = q->second;
+                    auto outAsync = q->second;
 
                     if (q == _asyncRequestsHint)
                     {
@@ -3378,6 +3304,7 @@ Ice::ConnectionI::parseMessage(
                         _asyncRequests.erase(q);
                     }
 
+                    // The message stream is adopted by the outgoing.
                     stream.swap(*outAsync->getIs());
 
 #if defined(ICE_USE_IOCP)
@@ -3392,24 +3319,17 @@ Ice::ConnectionI::parseMessage(
                         message->receivedReply = true;
                         outAsync = 0;
                     }
-                    else if (outAsync->response())
-                    {
-                        ++upcallCount;
-                    }
-                    else
-                    {
-                        outAsync = 0;
-                    }
-#else
-                    if (outAsync->response())
-                    {
-                        ++upcallCount;
-                    }
-                    else
-                    {
-                        outAsync = 0;
-                    }
 #endif
+                    if (outAsync && outAsync->response())
+                    {
+                        // The message stream is not used here because it has been adopted above.
+                        upcall = [outAsync](InputStream&)
+                        {
+                            outAsync->invokeResponse();
+                            return true; // upcall is done
+                        };
+                        ++upcallCount;
+                    }
                     _conditionVariable.notify_all(); // Notify threads blocked in close(false)
                 }
 
@@ -3421,7 +3341,25 @@ Ice::ConnectionI::parseMessage(
                 traceRecv(stream, _logger, _traceLevels);
                 if (_heartbeatCallback)
                 {
-                    heartbeatCallback = _heartbeatCallback;
+                    auto heartbeatCallback = _heartbeatCallback;
+                    upcall = [this, heartbeatCallback](InputStream&)
+                    {
+                        try
+                        {
+                            heartbeatCallback(shared_from_this());
+                        }
+                        catch (const std::exception& ex)
+                        {
+                            Error out(_instance->initializationData().logger);
+                            out << "connection callback exception:\n" << ex << '\n' << _desc;
+                        }
+                        catch (...)
+                        {
+                            Error out(_instance->initializationData().logger);
+                            out << "connection callback exception:\nunknown c++ exception" << '\n' << _desc;
+                        }
+                        return true; // upcall is done
+                    };
                     ++upcallCount;
                 }
                 break;

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -366,8 +366,8 @@ Ice::ConnectionI::startAsync(
         {
             if (connectionStartCompleted && connectionStartFailed)
             {
-                _connectionStartCompleted = std::std::move(connectionStartCompleted);
-                _connectionStartFailed = std::std::move(connectionStartFailed);
+                _connectionStartCompleted = std::move(connectionStartCompleted);
+                _connectionStartFailed = std::move(connectionStartFailed);
                 return;
             }
 
@@ -759,7 +759,7 @@ Ice::ConnectionI::flushBatchRequestsAsync(
             std::function<void(std::exception_ptr)> ex,
             std::function<void(bool)> sent)
             : ConnectionFlushBatchAsync(connection, instance),
-              LambdaInvoke(std::std::move(ex), std::std::move(sent))
+              LambdaInvoke(std::move(ex), std::move(sent))
         {
         }
     };
@@ -852,7 +852,7 @@ Ice::ConnectionI::heartbeatAsync(::std::function<void(::std::exception_ptr)> ex,
             std::function<void(std::exception_ptr)> ex,
             std::function<void(bool)> sent)
             : HeartbeatAsync(connection, communicator, instance),
-              LambdaInvoke(std::std::move(ex), std::std::move(sent))
+              LambdaInvoke(std::move(ex), std::move(sent))
         {
         }
     };
@@ -869,7 +869,7 @@ Ice::ConnectionI::setHeartbeatCallback(HeartbeatCallback callback)
     {
         return;
     }
-    _heartbeatCallback = std::std::move(callback);
+    _heartbeatCallback = std::move(callback);
 }
 
 void
@@ -881,12 +881,12 @@ Ice::ConnectionI::setCloseCallback(CloseCallback callback)
         if (callback)
         {
             auto self = shared_from_this();
-            _threadPool->execute([self, callback = std::std::move(callback)]() { self->closeCallback(callback); });
+            _threadPool->execute([self, callback = std::move(callback)]() { self->closeCallback(callback); });
         }
     }
     else
     {
-        _closeCallback = std::std::move(callback);
+        _closeCallback = std::move(callback);
     }
 }
 
@@ -927,7 +927,7 @@ Ice::ConnectionI::setACM(
 
     if (_state == StateActive)
     {
-        _monitor->restd::move(shared_from_this());
+        _monitor->remove(shared_from_this());
     }
     _monitor = _monitor->acm(timeout, close, heartbeat);
 
@@ -1467,7 +1467,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                 setState(StateHolding);
                 if (_connectionStartCompleted)
                 {
-                    connectionStartCompleted = std::std::move(_connectionStartCompleted);
+                    connectionStartCompleted = std::move(_connectionStartCompleted);
                     ++upcallCount;
                     _connectionStartCompleted = nullptr;
                     _connectionStartFailed = nullptr;
@@ -2281,7 +2281,7 @@ Ice::ConnectionI::setState(State state)
         }
         else if (_state == StateActive)
         {
-            _monitor->restd::move(shared_from_this());
+            _monitor->remove(shared_from_this());
         }
     }
 
@@ -3411,7 +3411,7 @@ Ice::ConnectionI::dispatchAll(
                     adapter->dispatchPipeline()->dispatch(
                         request,
                         [self = shared_from_this(), compress](OutgoingResponse response)
-                        { self->sendResponse(std::std::move(response), compress); });
+                        { self->sendResponse(std::move(response), compress); });
                 }
                 catch (...)
                 {

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1485,9 +1485,8 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
                 {
                     // At this point, the protocol message is fully read and can therefore be decoded by parseMessage.
                     // parseMessage returns the operation to wait for readiness next.
-                    newOp = static_cast<SocketOperation>(
-                        newOp |
-                        parseMessage(upcallCount, messageUpcall, current.stream));
+                    newOp =
+                        static_cast<SocketOperation>(newOp | parseMessage(upcallCount, messageUpcall, current.stream));
                 }
 
                 if (readyOp & SocketOperationWrite)

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -205,19 +205,13 @@ namespace Ice
         void exception(std::exception_ptr);
 
         // This method is called to execute user code (connection start completion callback, invocation sent callbacks,
-        // servant dispatch, invocation response, heartbeat callback). Only the invocation sent callbacks and one of the
-        // other callbacks can be set at the same time. TODO: improve this to use separate functions encapsulated with
-        // a std::function
+        // or an upcall issued from an incoming message). The invocation sent callbacks and the message upcall might
+        // both be set.
         void upcall(
             std::function<void(ConnectionIPtr)> connectionStartCompleted,
-            const std::vector<OutgoingMessage>& sentMessages, // for calling invocation sent callbacks
-            std::uint8_t compress,
-            std::int32_t requestId,
-            std::int32_t dispatchCount,
-            const ObjectAdapterIPtr& adapter,
-            const IceInternal::OutgoingAsyncBasePtr& outAsync, // for callback the invocation response
-            const HeartbeatCallback& heartbeatCallback,
-            Ice::InputStream& stream); // the incoming request stream
+            const std::vector<OutgoingMessage>& sentMessages,
+            std::function<bool(InputStream&)> messageUpcall,
+            InputStream& messageStream);
         void finish(bool);
 
         void closeCallback(const CloseCallback&);
@@ -291,14 +285,9 @@ namespace Ice
 #endif
 
         IceInternal::SocketOperation parseMessage(
-            Ice::InputStream&,
-            std::int32_t&,
-            std::int32_t&,
-            std::uint8_t&,
-            ObjectAdapterIPtr&,
-            IceInternal::OutgoingAsyncBasePtr&,
-            HeartbeatCallback&,
-            int&);
+            std::int32_t& upcallCount,
+            std::function<bool(InputStream&)>& messageUpcall,
+            Ice::InputStream& messageStream);
 
         void dispatchAll(Ice::InputStream&, std::int32_t, std::int32_t, std::uint8_t, const ObjectAdapterIPtr&);
 

--- a/cpp/src/Ice/ThreadPool.h
+++ b/cpp/src/Ice/ThreadPool.h
@@ -38,6 +38,7 @@ namespace IceInternal
     using ThreadPoolWorkItemPtr = std::shared_ptr<ThreadPoolWorkItem>;
 
     // A work item that is executed by the executor, if configured.
+    // TODO: look into replacing this class with a std::function.
     class ExecutorWorkItem : public ThreadPoolWorkItem, public std::enable_shared_from_this<ExecutorWorkItem>
     {
     public:


### PR DESCRIPTION
This PR adds a message upcall function to simplify the upcall code associated to an incoming message. This requires additional heap allocations for the upcall function.

Next step could be to also encapsulate the connection started callback and sent callbacks as upcall functions and use a vector to handle multiple upcalls. This would require an additional heap allocation for the vector.

Question: do we still care about minimizing such heap allocations?