### PR TITLE
Fix weak vtable/type_info for EndpointInfo and ConnectionInfo

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -79,15 +79,10 @@ namespace Ice
      * Base class providing access to the connection details.
      * \headerfile Ice/Ice.h
      */
-    class ConnectionInfo
+    class ICE_API ConnectionInfo
     {
     public:
         ConnectionInfo() = default;
-        virtual ~ConnectionInfo() = default;
-
-        // Deleted to prevent accidental slicing.
-        ConnectionInfo(const ConnectionInfo&) = delete;
-        ConnectionInfo& operator=(const ConnectionInfo&) = delete;
 
         /**
          * One-shot constructor to initialize all data members.
@@ -107,6 +102,12 @@ namespace Ice
               connectionId(connectionId)
         {
         }
+
+        virtual ~ConnectionInfo();
+
+        // Deleted to prevent accidental slicing.
+        ConnectionInfo(const ConnectionInfo&) = delete;
+        ConnectionInfo& operator=(const ConnectionInfo&) = delete;
 
         /**
          * The information of the underlying transport or null if there's no underlying transport.
@@ -301,7 +302,7 @@ namespace Ice
      * Provides access to the connection details of an IP connection
      * \headerfile Ice/Ice.h
      */
-    class IPConnectionInfo : public ConnectionInfo
+    class ICE_API IPConnectionInfo : public ConnectionInfo
     {
     public:
         IPConnectionInfo() : localAddress(""), localPort(-1), remoteAddress(""), remotePort(-1) {}
@@ -334,6 +335,12 @@ namespace Ice
         {
         }
 
+        ~IPConnectionInfo() override;
+
+        // Deleted to prevent accidental slicing.
+        IPConnectionInfo(const IPConnectionInfo&) = delete;
+        IPConnectionInfo& operator=(const IPConnectionInfo&) = delete;
+
         /**
          * The local address.
          */
@@ -356,7 +363,7 @@ namespace Ice
      * Provides access to the connection details of a TCP connection
      * \headerfile Ice/Ice.h
      */
-    class TCPConnectionInfo : public IPConnectionInfo
+    class ICE_API TCPConnectionInfo : public IPConnectionInfo
     {
     public:
         TCPConnectionInfo() : rcvSize(0), sndSize(0) {}
@@ -399,6 +406,8 @@ namespace Ice
         {
         }
 
+        ~TCPConnectionInfo() override;
+
         // Deleted to prevent accidental slicing.
         TCPConnectionInfo(const TCPConnectionInfo&) = delete;
         TCPConnectionInfo& operator=(const TCPConnectionInfo&) = delete;
@@ -417,7 +426,7 @@ namespace Ice
      * Provides access to the connection details of a UDP connection
      * \headerfile Ice/Ice.h
      */
-    class UDPConnectionInfo : public IPConnectionInfo
+    class ICE_API UDPConnectionInfo : public IPConnectionInfo
     {
     public:
         UDPConnectionInfo() : mcastPort(-1), rcvSize(0), sndSize(0) {}
@@ -466,6 +475,8 @@ namespace Ice
         {
         }
 
+        ~UDPConnectionInfo() override;
+
         // Deleted to prevent accidental slicing.
         UDPConnectionInfo(const UDPConnectionInfo&) = delete;
         UDPConnectionInfo& operator=(const UDPConnectionInfo&) = delete;
@@ -492,7 +503,7 @@ namespace Ice
      * Provides access to the connection details of a WebSocket connection
      * \headerfile Ice/Ice.h
      */
-    class WSConnectionInfo : public ConnectionInfo
+    class ICE_API WSConnectionInfo : public ConnectionInfo
     {
     public:
         WSConnectionInfo() = default;
@@ -515,6 +526,8 @@ namespace Ice
               headers(headers)
         {
         }
+
+        ~WSConnectionInfo() override;
 
         // Deleted to prevent accidental slicing.
         WSConnectionInfo(const WSConnectionInfo&) = delete;

--- a/cpp/include/Ice/Endpoint.h
+++ b/cpp/include/Ice/Endpoint.h
@@ -24,7 +24,7 @@ namespace Ice
      * Base class providing access to the endpoint details.
      * \headerfile Ice/Ice.h
      */
-    class EndpointInfo
+    class ICE_API EndpointInfo
     {
     public:
         EndpointInfo() = default;
@@ -42,7 +42,7 @@ namespace Ice
         {
         }
 
-        virtual ~EndpointInfo() = default;
+        virtual ~EndpointInfo();
 
         EndpointInfo(const EndpointInfo&) = delete;
         EndpointInfo& operator=(const EndpointInfo&) = delete;
@@ -82,11 +82,11 @@ namespace Ice
      * The user-level interface to an endpoint.
      * \headerfile Ice/Ice.h
      */
-    class Endpoint
+    class ICE_API Endpoint
     {
     public:
         Endpoint() = default;
-        virtual ~Endpoint() = default;
+        virtual ~Endpoint();
 
         Endpoint(const Endpoint&) = delete;
         Endpoint& operator=(const Endpoint&) = delete;
@@ -112,7 +112,7 @@ namespace Ice
      * @see Endpoint
      * \headerfile Ice/Ice.h
      */
-    class IPEndpointInfo : public EndpointInfo
+    class ICE_API IPEndpointInfo : public EndpointInfo
     {
     public:
         IPEndpointInfo() = default;
@@ -140,6 +140,8 @@ namespace Ice
         {
         }
 
+        ~IPEndpointInfo() override;
+
         IPEndpointInfo(const IPEndpointInfo&) = delete;
         IPEndpointInfo& operator=(const IPEndpointInfo&) = delete;
 
@@ -162,7 +164,7 @@ namespace Ice
      * @see Endpoint
      * \headerfile Ice/Ice.h
      */
-    class TCPEndpointInfo : public IPEndpointInfo
+    class ICE_API TCPEndpointInfo : public IPEndpointInfo
     {
     public:
         TCPEndpointInfo() = default;
@@ -187,6 +189,8 @@ namespace Ice
         {
         }
 
+        ~TCPEndpointInfo() override;
+
         TCPEndpointInfo(const TCPEndpointInfo&) = delete;
         TCPEndpointInfo& operator=(const TCPEndpointInfo&) = delete;
     };
@@ -196,7 +200,7 @@ namespace Ice
      * @see Endpoint
      * \headerfile Ice/Ice.h
      */
-    class UDPEndpointInfo : public IPEndpointInfo
+    class ICE_API UDPEndpointInfo : public IPEndpointInfo
     {
     public:
         UDPEndpointInfo() = default;
@@ -227,6 +231,8 @@ namespace Ice
         {
         }
 
+        ~UDPEndpointInfo() override;
+
         UDPEndpointInfo(const UDPEndpointInfo&) = delete;
         UDPEndpointInfo& operator=(const UDPEndpointInfo&) = delete;
 
@@ -244,7 +250,7 @@ namespace Ice
      * Provides access to a WebSocket endpoint information.
      * \headerfile Ice/Ice.h
      */
-    class WSEndpointInfo : public EndpointInfo
+    class ICE_API WSEndpointInfo : public EndpointInfo
     {
     public:
         WSEndpointInfo() = default;
@@ -262,6 +268,8 @@ namespace Ice
         {
         }
 
+        ~WSEndpointInfo() override;
+
         WSEndpointInfo(const WSEndpointInfo&) = delete;
         WSEndpointInfo& operator=(const WSEndpointInfo&) = delete;
 
@@ -276,7 +284,7 @@ namespace Ice
      * @see Endpoint
      * \headerfile Ice/Ice.h
      */
-    class OpaqueEndpointInfo : public EndpointInfo
+    class ICE_API OpaqueEndpointInfo : public EndpointInfo
     {
     public:
         OpaqueEndpointInfo() = default;
@@ -300,6 +308,8 @@ namespace Ice
               rawBytes(std::move(rawBytes))
         {
         }
+
+        ~OpaqueEndpointInfo() override;
 
         OpaqueEndpointInfo(const OpaqueEndpointInfo&) = delete;
         OpaqueEndpointInfo& operator=(const OpaqueEndpointInfo&) = delete;

--- a/cpp/include/Ice/SSLConnectionInfo.h
+++ b/cpp/include/Ice/SSLConnectionInfo.h
@@ -22,7 +22,7 @@ namespace IceSSL
     /**
      * Provides access to the connection details of an SSL connection.
      */
-    class ConnectionInfo : public Ice::ConnectionInfo
+    class ICE_API ConnectionInfo : public Ice::ConnectionInfo
     {
     public:
         ConnectionInfo() = default;
@@ -51,6 +51,8 @@ namespace IceSSL
               verified(verified)
         {
         }
+
+        ~ConnectionInfo() override;
 
         ConnectionInfo(const ConnectionInfo&) = delete;
         ConnectionInfo& operator=(const ConnectionInfo&) = delete;

--- a/cpp/include/Ice/SSLEndpointInfo.h
+++ b/cpp/include/Ice/SSLEndpointInfo.h
@@ -20,7 +20,7 @@ namespace IceSSL
     /**
      * Provides access to an SSL endpoint information.
      */
-    class EndpointInfo : public Ice::EndpointInfo
+    class ICE_API EndpointInfo : public Ice::EndpointInfo
     {
     public:
         EndpointInfo() = default;
@@ -35,6 +35,8 @@ namespace IceSSL
             : Ice::EndpointInfo(underlying, timeout, compress)
         {
         }
+
+        ~EndpointInfo() override;
 
         EndpointInfo(const EndpointInfo&) = delete;
         EndpointInfo& operator=(const EndpointInfo&) = delete;

--- a/cpp/include/IceBT/ConnectionInfo.h
+++ b/cpp/include/IceBT/ConnectionInfo.h
@@ -6,6 +6,7 @@
 #define ICE_BT_CONNECTION_INFO_H
 
 #include "Ice/Connection.h"
+#include "Types.h"
 
 #if defined(__clang__)
 #    pragma clang diagnostic push
@@ -21,7 +22,7 @@ namespace IceBT
      * Provides access to the details of a Bluetooth connection.
      * \headerfile IceBT/IceBT.h
      */
-    class ConnectionInfo : public Ice::ConnectionInfo
+    class ICEBT_API ConnectionInfo : public Ice::ConnectionInfo
     {
     public:
         ConnectionInfo()
@@ -34,6 +35,8 @@ namespace IceBT
               sndSize(0)
         {
         }
+
+        ~ConnectionInfo() override;
 
         ConnectionInfo(const ConnectionInfo&) = delete;
         ConnectionInfo& operator=(const ConnectionInfo&) = delete;

--- a/cpp/include/IceBT/EndpointInfo.h
+++ b/cpp/include/IceBT/EndpointInfo.h
@@ -6,6 +6,7 @@
 #define ICE_BT_ENDPOINT_INFO_H
 
 #include "Ice/Endpoint.h"
+#include "Types.h"
 
 #if defined(__clang__)
 #    pragma clang diagnostic push
@@ -21,7 +22,7 @@ namespace IceBT
      * Provides access to Bluetooth endpoint information.
      * \headerfile IceBT/IceBT.h
      */
-    class EndpointInfo : public Ice::EndpointInfo
+    class ICEBT_API EndpointInfo : public Ice::EndpointInfo
     {
     public:
         EndpointInfo() = default;
@@ -45,6 +46,8 @@ namespace IceBT
               uuid(uuid)
         {
         }
+
+        ~EndpointInfo() override;
 
         EndpointInfo(const EndpointInfo&) = delete;
         EndpointInfo& operator=(const EndpointInfo&) = delete;

--- a/cpp/include/IceIAP/ConnectionInfo.h
+++ b/cpp/include/IceIAP/ConnectionInfo.h
@@ -60,6 +60,8 @@ namespace IceIAP
         {
         }
 
+        ~ConnectionInfo() override;
+
         ConnectionInfo(const ConnectionInfo&) = delete;
         ConnectionInfo& operator=(const ConnectionInfo&) = delete;
 

--- a/cpp/include/IceIAP/EndpointInfo.h
+++ b/cpp/include/IceIAP/EndpointInfo.h
@@ -52,6 +52,8 @@ namespace IceIAP
         {
         }
 
+        ~EndpointInfo() override;
+
         EndpointInfo(const EndpointInfo&) = delete;
         EndpointInfo& operator=(const EndpointInfo&) = delete;
 

--- a/cpp/src/Ice/Connection.cpp
+++ b/cpp/src/Ice/Connection.cpp
@@ -7,6 +7,12 @@
 using namespace Ice;
 using namespace std;
 
+Ice::ConnectionInfo::~ConnectionInfo() {}
+Ice::IPConnectionInfo::~IPConnectionInfo() {}
+Ice::TCPConnectionInfo::~TCPConnectionInfo() {}
+Ice::UDPConnectionInfo::~UDPConnectionInfo() {}
+Ice::WSConnectionInfo::~WSConnectionInfo() {}
+
 Ice::Connection::~Connection() {}
 
 void

--- a/cpp/src/Ice/Connection.cpp
+++ b/cpp/src/Ice/Connection.cpp
@@ -7,6 +7,7 @@
 using namespace Ice;
 using namespace std;
 
+// Implement virtual destructors out of line to avoid weak vtables.
 Ice::ConnectionInfo::~ConnectionInfo() {}
 Ice::IPConnectionInfo::~IPConnectionInfo() {}
 Ice::TCPConnectionInfo::~TCPConnectionInfo() {}

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -99,27 +99,9 @@ IceInternal::EndpointI::checkOption(const string&, const string&, const string&)
     return false;
 }
 
-Ice::IPEndpointInfo::~IPEndpointInfo()
-{
-    // out of line to avoid weak vtable
-}
-
-Ice::TCPEndpointInfo::~TCPEndpointInfo()
-{
-    // out of line to avoid weak vtable
-}
-
-Ice::UDPEndpointInfo::~UDPEndpointInfo()
-{
-    // out of line to avoid weak vtable
-}
-
-Ice::WSEndpointInfo::~WSEndpointInfo()
-{
-    // out of line to avoid weak vtable
-}
-
-Ice::OpaqueEndpointInfo::~OpaqueEndpointInfo()
-{
-    // out of line to avoid weak vtable
-}
+// Implement virtual destructors out of line to avoid weak vtables.
+Ice::IPEndpointInfo::~IPEndpointInfo() {}
+Ice::TCPEndpointInfo::~TCPEndpointInfo() {}
+Ice::UDPEndpointInfo::~UDPEndpointInfo() {}
+Ice::WSEndpointInfo::~WSEndpointInfo() {}
+Ice::OpaqueEndpointInfo::~OpaqueEndpointInfo() {}

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -9,6 +9,16 @@
 
 using namespace std;
 
+Ice::EndpointInfo::~EndpointInfo()
+{
+    // out of line to avoid weak vtable
+}
+
+Ice::Endpoint::~Endpoint()
+{
+    // out of line to avoid weak vtable
+}
+
 void
 IceInternal::EndpointI::streamWrite(Ice::OutputStream* s) const
 {
@@ -87,4 +97,29 @@ IceInternal::EndpointI::checkOption(const string&, const string&, const string&)
 {
     // Must be overridden to check for options.
     return false;
+}
+
+Ice::IPEndpointInfo::~IPEndpointInfo()
+{
+    // out of line to avoid weak vtable
+}
+
+Ice::TCPEndpointInfo::~TCPEndpointInfo()
+{
+    // out of line to avoid weak vtable
+}
+
+Ice::UDPEndpointInfo::~UDPEndpointInfo()
+{
+    // out of line to avoid weak vtable
+}
+
+Ice::WSEndpointInfo::~WSEndpointInfo()
+{
+    // out of line to avoid weak vtable
+}
+
+Ice::OpaqueEndpointInfo::~OpaqueEndpointInfo()
+{
+    // out of line to avoid weak vtable
 }

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -12,6 +12,7 @@
 #include "Ice/Object.h"
 #include "Ice/Properties.h"
 #include "Ice/UUID.h"
+#include "IceBT/ConnectionInfo.h"
 #include "IceUtil/StringUtil.h"
 #include "Instance.h"
 #include "Util.h"

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -20,8 +20,9 @@ using namespace std;
 using namespace Ice;
 using namespace IceBT;
 
+// Implement virtual destructors out of line to avoid weak vtables.
 IceBT::ConnectionInfo::~ConnectionInfo() {}
-ICeBT::EndpointInfo::~EndpointInfo() {}
+IceBT::EndpointInfo::~EndpointInfo() {}
 
 IceBT::EndpointI::EndpointI(
     const InstancePtr& instance,

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -20,6 +20,9 @@ using namespace std;
 using namespace Ice;
 using namespace IceBT;
 
+IceBT::ConnectionInfo::~ConnectionInfo() {}
+ICeBT::EndpointInfo::~EndpointInfo() {}
+
 IceBT::EndpointI::EndpointI(
     const InstancePtr& instance,
     const string& addr,

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -20,6 +20,7 @@
 #    include "Ice/OutputStream.h"
 #    include "Ice/Properties.h"
 #    include "Ice/RegisterPlugins.h"
+#    include "IceIAP/ConnectionInfo.h"
 #    include "IceIAP/EndpointInfo.h"
 
 #    include <CoreFoundation/CoreFoundation.h>

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -77,6 +77,9 @@ namespace Ice
     }
 }
 
+IceIAP::ConnectionInfo::~ConnectionInfo() {}
+IceIAP::EndpointInfo::~EndpointInfo() {}
+
 IceObjC::iAPEndpointI::iAPEndpointI(
     const ProtocolInstancePtr& instance,
     const string& m,

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -77,6 +77,7 @@ namespace Ice
     }
 }
 
+// Implement virtual destructors out of line to avoid weak vtables.
 IceIAP::ConnectionInfo::~ConnectionInfo() {}
 IceIAP::EndpointInfo::~EndpointInfo() {}
 

--- a/cpp/src/IceSSL/SSLEndpointI.cpp
+++ b/cpp/src/IceSSL/SSLEndpointI.cpp
@@ -58,13 +58,9 @@ namespace
     }
 }
 
-IceSSL::ConnectionInfo::~ConnectionInfo()
-{
-}
+IceSSL::ConnectionInfo::~ConnectionInfo() {}
 
-IceSSL::EndpointInfo::~EndpointInfo()
-{
-}
+IceSSL::EndpointInfo::~EndpointInfo() {}
 
 IceSSL::EndpointI::EndpointI(const InstancePtr& instance, const IceInternal::EndpointIPtr& del)
     : _instance(instance),

--- a/cpp/src/IceSSL/SSLEndpointI.cpp
+++ b/cpp/src/IceSSL/SSLEndpointI.cpp
@@ -58,6 +58,14 @@ namespace
     }
 }
 
+IceSSL::ConnectionInfo::~ConnectionInfo()
+{
+}
+
+IceSSL::EndpointInfo::~EndpointInfo()
+{
+}
+
 IceSSL::EndpointI::EndpointI(const InstancePtr& instance, const IceInternal::EndpointIPtr& del)
     : _instance(instance),
       _delegate(del)

--- a/cpp/src/IceSSL/SSLEndpointI.cpp
+++ b/cpp/src/IceSSL/SSLEndpointI.cpp
@@ -57,9 +57,8 @@ namespace
         return nullptr;
     }
 }
-
+// Implement virtual destructors out of line to avoid weak vtables.
 IceSSL::ConnectionInfo::~ConnectionInfo() {}
-
 IceSSL::EndpointInfo::~EndpointInfo() {}
 
 IceSSL::EndpointI::EndpointI(const InstancePtr& instance, const IceInternal::EndpointIPtr& del)


### PR DESCRIPTION
This PR adds a public/exported out of line dtor to all EndpointInfo and ConnectionInfo.

Fixes #2071. 