### PR TITLE
Change Doc Links to just use Code Tags

### DIFF
--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -387,8 +387,8 @@ class InternalReplicaInfo
 
 interface InternalRegistry extends FileReader
 {
-    /// Register a node with the registry. If a node with the same name is already registered, [registerNode] will
-    /// overide the previous node only if it's not active.
+    /// Register a node with the registry. If a node with the same name is already registered,
+    /// <code>registerNode</code> will overide the previous node only if it's not active.
     /// @param info Some information on the node.
     /// @param prx The proxy of the node.
     /// @param loadInf The load information of the node.
@@ -397,8 +397,8 @@ interface InternalRegistry extends FileReader
     NodeSession* registerNode(InternalNodeInfo info, Node* prx, LoadInfo loadInf)
         throws NodeActiveException, PermissionDeniedException;
 
-    /// Register a replica with the registry. If a replica with the  same name is already registered, [registerReplica]
-    /// will overide the previous replica only if it's not active.
+    /// Register a replica with the registry. If a replica with the  same name is already registered,
+    /// <code>registerReplica</code> will overide the previous replica only if it's not active.
     /// @param info Some information on the replica.
     /// @param prx The proxy of the replica.
     /// @return The replica session proxy.

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -388,7 +388,8 @@ class InternalReplicaInfo
 interface InternalRegistry extends FileReader
 {
     /// Register a node with the registry. If a node with the same name is already registered,
-    /// <code>registerNode</code> will overide the previous node only if it's not active.
+    /// <code>registerNode</code> overrides the existing registration only when the previously
+    /// registered node is not active.
     /// @param info Some information on the node.
     /// @param prx The proxy of the node.
     /// @param loadInf The load information of the node.
@@ -397,8 +398,9 @@ interface InternalRegistry extends FileReader
     NodeSession* registerNode(InternalNodeInfo info, Node* prx, LoadInfo loadInf)
         throws NodeActiveException, PermissionDeniedException;
 
-    /// Register a replica with the registry. If a replica with the  same name is already registered,
-    /// <code>registerReplica</code> will overide the previous replica only if it's not active.
+    /// Register a replica with the registry. If a replica with the same name is already registered,
+    /// <code>registerReplica</code> overrides the existing registration only when the previously
+    /// registered node is not active.
     /// @param info Some information on the replica.
     /// @param prx The proxy of the replica.
     /// @return The replica session proxy.


### PR DESCRIPTION
This doc link seems suspicious. It links to the function that it's documenting... So there's no point to having it be a link.
This PR changes it to just use the `code` formatting, since that's what we do in similar situations.

For example:
https://github.com/zeroc-ice/ice/blob/82b83ddc8fd1786c420451f1f6040b0820136422/slice/IceGrid/Admin.ice#L647-L663

Or is there reason to keep these as links?