### PR TITLE
Remove Optional Classes from 'cpp/Ice/optional' Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           # Cross tests
           - os: ubuntu-22.04
             config: "cross"
-            test_flags: "--all-cross"
+            test_flags: "--all-cross --rfilter Ice/optional"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -630,7 +630,7 @@ allTests(Test::TestHelper* helper, bool)
     //
     // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
     //
-    optional<FixedStruct> ofs{ in_place, 53 };
+    optional<FixedStruct> ofs{{53}};
 
     initial->sendOptionalStruct(true, ofs);
     initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalStruct(true, ofs);
@@ -753,7 +753,7 @@ allTests(Test::TestHelper* helper, bool)
     {
         FPtr f = make_shared<F>();
 
-        f->fsf = FixedStruct(56);
+        f->fsf = FixedStruct{56};
         f->fse = *f->fsf;
 
         FPtr rf = dynamic_pointer_cast<F>(initial->pingPong(f));

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -204,11 +204,11 @@ public:
         _f = make_shared<F>();
         in->startValue();
         in->startSlice();
-        // Don't read af on purpose
-        // in.read(1, _f->af);
+        // Don't read fsf on purpose
+        // in.read(1, _f->fsf);
         in->endSlice();
         in->startSlice();
-        in->read(_f->ae);
+        in->read(_f->fse);
         in->endSlice();
         in->endValue();
     }
@@ -311,7 +311,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->h = string("test");
     mo1->i = MyEnum::MyEnumMember;
     mo1->j = MyInterfacePrx(communicator, "test");
-    mo1->k = mo1;
     mo1->bs = ByteSeq();
     (*mo1->bs).push_back(byte{5});
     mo1->ss = StringSeq();
@@ -337,8 +336,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->fss->push_back(fs);
     mo1->vss = VarStructSeq();
     mo1->vss->push_back(vs);
-    mo1->oos = OneOptionalSeq();
-    mo1->oos->push_back(oo1);
     mo1->mips = MyInterfacePrxSeq();
     mo1->mips->push_back(MyInterfacePrx(communicator, "test"));
 
@@ -348,9 +345,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->ifsd.value()[4] = fs;
     mo1->ivsd = IntVarStructDict();
     mo1->ivsd.value()[5] = vs;
-    mo1->iood = IntOneOptionalDict();
-    mo1->iood.value()[5] = make_shared<OneOptional>();
-    mo1->iood.value()[5]->a = 15;
     mo1->imipd = IntMyInterfacePrxDict();
     mo1->imipd.value()[5] = MyInterfacePrx(communicator, "test");
 
@@ -374,7 +368,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->h == string("test"));
     test(mo3->i = MyEnum::MyEnumMember);
     test(mo3->j = MyInterfacePrx(communicator, "test"));
-    test(mo3->k == mo1);
     test(mo3->bs == mo1->bs);
     test(mo3->ss == mo1->ss);
     test(mo3->iid == mo1->iid);
@@ -386,13 +379,11 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->es == mo1->es);
     test(mo3->fss == mo1->fss);
     test(mo3->vss == mo1->vss);
-    test(mo3->oos == mo1->oos);
     test(mo3->mips == mo1->mips);
 
     test(mo3->ied == mo1->ied);
     test(mo3->ifsd == mo1->ifsd);
     test(mo3->ivsd == mo1->ivsd);
-    test(mo3->iood == mo1->iood);
     test(mo3->imipd == mo1->imipd);
 
     test(mo3->bos == mo1->bos);
@@ -437,7 +428,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo4->h);
     test(!mo4->i);
     test(!mo4->j);
-    test(!mo4->k);
     test(!mo4->bs);
     test(!mo4->ss);
     test(!mo4->iid);
@@ -449,18 +439,15 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo4->es);
     test(!mo4->fss);
     test(!mo4->vss);
-    test(!mo4->oos);
     test(!mo4->mips);
 
     test(!mo4->ied);
     test(!mo4->ifsd);
     test(!mo4->ivsd);
-    test(!mo4->iood);
     test(!mo4->imipd);
 
     test(!mo4->bos);
 
-    mo1->k = mo1;
     MultiOptionalPtr mo5 = dynamic_pointer_cast<MultiOptional>(initial->pingPong(mo1));
 
     test(mo5->a == mo1->a);
@@ -473,7 +460,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->h == mo1->h);
     test(mo5->i == mo1->i);
     test(mo5->j == mo1->j);
-    test(mo5->k == mo5->k);
     test(mo5->bs == mo1->bs);
     test(mo5->ss == mo1->ss);
     test(mo5->iid == mo1->iid);
@@ -485,7 +471,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->es == mo1->es);
     test(mo5->fss == mo1->fss);
     test(mo5->vss == mo1->vss);
-    test(!mo5->oos->empty() && (*mo5->oos)[0]->a == oo1->a);
 
     test(mo5->mips.value().size() == mo1->mips.value().size());
     for (size_t i = 0; i < mo5->mips.value().size(); ++i)
@@ -496,7 +481,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->ied == mo1->ied);
     test(mo5->ifsd == mo1->ifsd);
     test(mo5->ivsd == mo1->ivsd);
-    test(!mo5->iood->empty() && (*mo5->iood)[5]->a == 15);
 
     test(mo5->imipd.value().size() == mo1->imipd.value().size());
     for (auto& v : mo5->imipd.value())
@@ -513,7 +497,6 @@ allTests(Test::TestHelper* helper, bool)
     mo6->e = nullopt;
     mo6->g = nullopt;
     mo6->i = nullopt;
-    mo6->k = nullopt;
     mo6->ss = nullopt;
     mo6->sid = nullopt;
     mo6->vs = nullopt;
@@ -537,7 +520,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo7->h == mo1->h);
     test(!mo7->i);
     test(mo7->j == mo1->j);
-    test(!mo7->k);
     test(mo7->bs == mo1->bs);
     test(!mo7->ss);
     test(mo7->iid == mo1->iid);
@@ -549,13 +531,11 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->es);
     test(mo7->fss == mo1->fss);
     test(!mo7->vss);
-    test(!mo7->oos->empty() && (*mo7->oos)[0]->a == oo1->a);
     test(!mo7->mips);
 
     test(!mo7->ied);
     test(mo7->ifsd == mo1->ifsd);
     test(!mo7->ivsd);
-    test(!mo7->iood->empty() && (*mo7->iood)[5]->a == 15);
     test(!mo7->imipd);
 
     // Clear the second half of the optional parameters
@@ -571,12 +551,9 @@ allTests(Test::TestHelper* helper, bool)
 
     mo8->shs = nullopt;
     mo8->fss = nullopt;
-    mo8->oos = nullopt;
 
     mo8->ifsd = nullopt;
-    mo8->iood = nullopt;
 
-    mo8->k = mo8;
     MultiOptionalPtr mo9 = dynamic_pointer_cast<MultiOptional>(initial->pingPong(mo8));
     test(mo9->a == mo1->a);
     test(!mo9->b);
@@ -588,7 +565,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo9->h);
     test(mo9->i == mo1->i);
     test(!mo9->j);
-    test(mo9->k == mo9);
     test(!mo9->bs);
     test(mo9->ss == mo1->ss);
     test(!mo9->iid);
@@ -600,7 +576,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo8->es == mo1->es);
     test(!mo8->fss);
     test(mo8->vss == mo1->vss);
-    test(!mo8->oos);
 
     test(mo8->mips.value().size() == mo1->mips.value().size());
     for (size_t i = 0; i < mo8->mips.value().size(); ++i)
@@ -611,7 +586,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo8->ied == mo1->ied);
     test(!mo8->ifsd);
     test(mo8->ivsd == mo1->ivsd);
-    test(!mo8->iood);
 
     Ice::ByteSeq inEncaps;
     Ice::ByteSeq outEncaps;
@@ -653,38 +627,29 @@ allTests(Test::TestHelper* helper, bool)
         factory->setEnabled(false);
     }
 
-    mo1->k = nullptr;
-    mo2->k = nullptr;
-    mo3->k = nullptr;
-    mo4->k = nullptr;
-    mo5->k = nullptr;
-    mo6->k = nullptr;
-    mo7->k = nullptr;
-    mo8->k = nullptr;
-    mo9->k = nullptr;
-
     //
-    // Use the 1.0 encoding with operations whose only class parameters are optional.
+    // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
     //
-    optional<OneOptionalPtr> oo(make_shared<OneOptional>(53));
-    initial->sendOptionalClass(true, oo);
-    initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalClass(true, oo);
+    optional<FixedStruct> ofs{ in_place, 53 };
 
-    initial->returnOptionalClass(true, oo);
-    test(oo);
-    initial->ice_encodingVersion(Ice::Encoding_1_0)->returnOptionalClass(true, oo);
-    test(!oo);
+    initial->sendOptionalStruct(true, ofs);
+    initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalStruct(true, ofs);
+
+    initial->returnOptionalStruct(true, ofs);
+    test(ofs);
+    initial->ice_encodingVersion(Ice::Encoding_1_0)->returnOptionalStruct(true, ofs);
+    test(!ofs);
 
     GPtr g = make_shared<G>();
-    g->gg1Opt = make_shared<G1>("gg1Opt");
-    g->gg2 = make_shared<G2>(10);
-    g->gg2Opt = make_shared<G2>(20);
-    g->gg1 = make_shared<G1>("gg1");
+    g->gg1Opt = G1{ "gg1Opt" };
+    g->gg2 = G2{ 10 };
+    g->gg2Opt = G2{ 20 };
+    g->gg1 = G1{ "gg1" };
     GPtr r = initial->opG(g);
-    test("gg1Opt" == r->gg1Opt.value()->a);
-    test(10 == r->gg2->a);
-    test(20 == r->gg2Opt.value()->a);
-    test("gg1" == r->gg1->a);
+    test("gg1Opt" == r->gg1Opt.value().a);
+    test(10 == r->gg2.a);
+    test(20 == r->gg2Opt.value().a);
+    test("gg1" == r->gg1.a);
 
     initial->opVoid();
 
@@ -784,15 +749,15 @@ allTests(Test::TestHelper* helper, bool)
 
     cout << "ok" << endl;
 
-    cout << "testing marshaling of objects with optional objects..." << flush;
+    cout << "testing marshaling of objects with optional members..." << flush;
     {
         FPtr f = make_shared<F>();
 
-        f->af = make_shared<A>();
-        f->ae = *f->af;
+        f->fsf = FixedStruct(56);
+        f->fse = *f->fsf;
 
         FPtr rf = dynamic_pointer_cast<F>(initial->pingPong(f));
-        test(rf->ae == *rf->af);
+        test(rf->fse == *rf->fsf);
 
         factory->setEnabled(true);
         Ice::OutputStream out(communicator);
@@ -808,7 +773,7 @@ allTests(Test::TestHelper* helper, bool)
         factory->setEnabled(false);
 
         rf = dynamic_cast<FObjectReader*>(obj.get())->getF();
-        test(rf->ae && !rf->af);
+        test(rf->fse.m == 56 && !rf->fsf);
     }
     cout << "ok" << endl;
 
@@ -1247,38 +1212,27 @@ allTests(Test::TestHelper* helper, bool)
     }
 
     {
-        // TODO: remove this testing for tagged classes alongside the tagged class support.
-        optional<OneOptionalPtr> p1;
-        optional<OneOptionalPtr> p3;
-        optional<OneOptionalPtr> p2 = initial->opOneOptional(p1, p3);
-        test(!p2 && !p3);
-
-        if (initial->supportsNullOptional())
-        {
-            p2 = initial->opOneOptional(OneOptionalPtr(), p3);
-            test(*p2 == nullptr && *p3 == nullptr);
-        }
+        OneOptionalPtr p1 = make_shared<OneOptional>(nullopt);
+        OneOptionalPtr p3 = p1;
+        OneOptionalPtr p2 = initial->opOneOptional(p1, p3);
+        test(p2->a == nullopt && p3->a == nullopt);
 
         p1 = make_shared<OneOptional>(58);
         p2 = initial->opOneOptional(p1, p3);
-        test((*p2)->a == 58 && (*p3)->a == 58);
+        test(p2->a == 58 && p3->a == 58);
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
-        out.write(2, p1);
+        out.write(p1);
         out.endEncapsulation();
         out.finished(inEncaps);
         initial->ice_invoke("opOneOptional", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
-        in.read(1, p2);
-        in.read(3, p3);
+        in.read(p2);
+        in.read(p3);
         in.endEncapsulation();
-        test((*p2)->a == 58 && (*p3)->a == 58);
-
-        Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
-        in2.startEncapsulation();
-        in2.endEncapsulation();
+        test(p2->a == 58 && p3->a == 58);
     }
 
     {
@@ -1313,23 +1267,22 @@ allTests(Test::TestHelper* helper, bool)
 
     {
         FPtr f = make_shared<F>();
-        f->af = make_shared<A>();
-        (*f->af)->requiredA = 56;
-        f->ae = *f->af;
+        f->fsf = FixedStruct();
+        (*f->fsf).m = 56;
+        f->fse = *f->fsf;
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
         out.write(1, make_optional(f));
-        out.write(2, make_optional(f->ae));
+        out.write(2, make_optional(f->fse));
         out.endEncapsulation();
         out.finished(inEncaps);
 
         Ice::InputStream in(communicator, out.getEncoding(), inEncaps);
         in.startEncapsulation();
-        optional<APtr> a;
-        in.read(2, a);
+        in.read(2, ofs);
         in.endEncapsulation();
-        test(a && *a && (*a)->requiredA == 56);
+        test(ofs && (*ofs).m == 56);
     }
     cout << "ok" << endl;
 
@@ -1663,34 +1616,30 @@ allTests(Test::TestHelper* helper, bool)
     }
 
     {
-        optional<IntOneOptionalDict> p1;
-        optional<IntOneOptionalDict> p3;
-        optional<IntOneOptionalDict> p2 = initial->opIntOneOptionalDict(p1, p3);
-        test(!p2 && !p3);
+        IntOneOptionalDict p1;
+        p1.insert(make_pair<int, OneOptionalPtr>(0, make_shared<OneOptional>(nullopt)));
+        IntOneOptionalDict p3 = p1;
+        IntOneOptionalDict p2 = initial->opIntOneOptionalDict(p1, p3);
+        test(p2[0]->a == nullopt && p3[0]->a == nullopt);
 
         IntOneOptionalDict ss;
         ss.insert(make_pair<int, OneOptionalPtr>(1, make_shared<OneOptional>(58)));
         p1 = ss;
         p2 = initial->opIntOneOptionalDict(p1, p3);
-        test(p2 && p3);
-        test((*p2)[1]->a == 58 && (*p3)[1]->a == 58);
+        test(p2[1]->a == 58 && p3[1]->a == 58);
 
         Ice::OutputStream out(communicator);
         out.startEncapsulation();
-        out.write(2, p1);
+        out.write(p1);
         out.endEncapsulation();
         out.finished(inEncaps);
         initial->ice_invoke("opIntOneOptionalDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
         Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
         in.startEncapsulation();
-        in.read(1, p2);
-        in.read(3, p3);
+        in.read(p2);
+        in.read(p3);
         in.endEncapsulation();
-        test((*p2)[1]->a == 58 && (*p3)[1]->a == 58);
-
-        Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
-        in2.startEncapsulation();
-        in2.endEncapsulation();
+        test(p2[1]->a == 58 && p3[1]->a == 58);
     }
 
     cout << "ok" << endl;
@@ -1699,14 +1648,14 @@ allTests(Test::TestHelper* helper, bool)
     {
         try
         {
-            initial->opOptionalException(nullopt, nullopt, nullopt);
+            initial->opOptionalException(nullopt, nullopt, make_shared<OneOptional>(53));
             test(false);
         }
         catch (const OptionalException& ex)
         {
             test(!ex.a);
             test(!ex.b);
-            test(!ex.o);
+            test(ex.o->a == 53);
         }
 
         try
@@ -1718,30 +1667,14 @@ allTests(Test::TestHelper* helper, bool)
         {
             test(ex.a == 30);
             test(ex.b == string("test"));
-            test((*ex.o)->a = 53);
-        }
-
-        try
-        {
-            //
-            // Use the 1.0 encoding with an exception whose only class members are optional.
-            //
-            initial->ice_encodingVersion(Ice::Encoding_1_0)
-                ->opOptionalException(30, string("test"), make_shared<OneOptional>(53));
-            test(false);
-        }
-        catch (const OptionalException& ex)
-        {
-            test(!ex.a);
-            test(!ex.b);
-            test(!ex.o);
+            test(ex.o->a == 53);
         }
 
         try
         {
             optional<int32_t> a;
             optional<string> b;
-            optional<OneOptionalPtr> o;
+            OneOptionalPtr o = make_shared<OneOptional>(53);
             initial->opDerivedException(a, b, o);
             test(false);
         }
@@ -1749,9 +1682,9 @@ allTests(Test::TestHelper* helper, bool)
         {
             test(!ex.a);
             test(!ex.b);
-            test(!ex.o);
+            test(ex.o->a == 53);
             test(!ex.ss);
-            test(!ex.o2);
+            test(ex.o2->a == 53);
             test(ex.d1 == "d1");
             test(ex.d2 == "d2");
         }
@@ -1764,7 +1697,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             optional<int32_t> a = 30;
             optional<string> b = string("test2");
-            optional<OneOptionalPtr> o = make_shared<OneOptional>(53);
+            OneOptionalPtr o = make_shared<OneOptional>(53);
             initial->opDerivedException(a, b, o);
             test(false);
         }
@@ -1772,9 +1705,9 @@ allTests(Test::TestHelper* helper, bool)
         {
             test(ex.a == 30);
             test(ex.b == string("test2"));
-            test((*ex.o)->a == 53);
+            test(ex.o->a == 53);
             test(ex.ss == string("test2"));
-            test((*ex.o2)->a == 53);
+            test(ex.o2->a == 53);
             test(ex.d1 == "d1");
             test(ex.d2 == "d2");
         }
@@ -1787,7 +1720,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             optional<int32_t> a;
             optional<string> b;
-            optional<OneOptionalPtr> o;
+            OneOptionalPtr o = make_shared<OneOptional>(53);
             initial->opRequiredException(a, b, o);
             test(false);
         }
@@ -1795,9 +1728,9 @@ allTests(Test::TestHelper* helper, bool)
         {
             test(!ex.a);
             test(!ex.b);
-            test(!ex.o);
+            test(ex.o->a == 53);
             test(ex.ss == string("test"));
-            test(!ex.o2);
+            test(ex.o2->a == 53);
         }
         catch (const OptionalException&)
         {
@@ -1808,7 +1741,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             optional<int32_t> a = 30;
             optional<string> b = string("test2");
-            optional<OneOptionalPtr> o = make_shared<OneOptional>(53);
+            OneOptionalPtr o = make_shared<OneOptional>(53);
             initial->opRequiredException(a, b, o);
             test(false);
         }
@@ -1816,7 +1749,7 @@ allTests(Test::TestHelper* helper, bool)
         {
             test(ex.a == 30);
             test(ex.b == string("test2"));
-            test((*ex.o)->a == 53);
+            test(ex.o->a == 53);
             test(ex.ss == string("test2"));
             test(ex.o2->a == 53);
         }
@@ -1832,7 +1765,10 @@ allTests(Test::TestHelper* helper, bool)
         test(initial->opMStruct1());
         test(initial->opMDict1());
         test(initial->opMSeq1());
-        test(initial->opMG1());
+        {
+            Test::GPtr p1 = initial->opMG1();
+            test(!p1->gg1Opt && !p1->gg2Opt);
+        }
 
         {
             optional<Test::SmallStruct> p1, p2, p3;
@@ -1866,13 +1802,18 @@ allTests(Test::TestHelper* helper, bool)
             test(p2 == p1 && p3 == p1);
         }
         {
-            optional<Test::GPtr> p1, p2, p3;
-            p3 = initial->opMG2(nullopt, p2);
-            test(!p2 && !p3);
-
+            Test::GPtr p1, p2, p3;
             p1 = make_shared<Test::G>();
+            p1->gg1 = G1{ "gg1" };
+            p1->gg2 = G2{ 10 };
+            p1->gg2Opt = G2 { 20 };
+
             p3 = initial->opMG2(p1, p2);
-            test(p2 && p3 && *p3 == *p2);
+            test(*p3 == *p2);
+            test(p2->gg1.a == "gg1");
+            test(!p2->gg1Opt);
+            test(p2->gg2.a == 10);
+            test(p2->gg2Opt && p2->gg2Opt.value().a == 20);
         }
     }
     cout << "ok" << endl;

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -641,10 +641,10 @@ allTests(Test::TestHelper* helper, bool)
     test(!ofs);
 
     GPtr g = make_shared<G>();
-    g->gg1Opt = G1{ "gg1Opt" };
-    g->gg2 = G2{ 10 };
-    g->gg2Opt = G2{ 20 };
-    g->gg1 = G1{ "gg1" };
+    g->gg1Opt = G1{"gg1Opt"};
+    g->gg2 = G2{10};
+    g->gg2Opt = G2{20};
+    g->gg1 = G1{"gg1"};
     GPtr r = initial->opG(g);
     test("gg1Opt" == r->gg1Opt.value().a);
     test(10 == r->gg2.a);
@@ -1804,9 +1804,9 @@ allTests(Test::TestHelper* helper, bool)
         {
             Test::GPtr p1, p2, p3;
             p1 = make_shared<Test::G>();
-            p1->gg1 = G1{ "gg1" };
-            p1->gg2 = G2{ 10 };
-            p1->gg2Opt = G2 { 20 };
+            p1->gg1 = G1{"gg1"};
+            p1->gg2 = G2{10};
+            p1->gg2Opt = G2{20};
 
             p3 = initial->opMG2(p1, p2);
             test(*p3 == *p2);

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -80,7 +80,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;
@@ -92,13 +91,11 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
 
     optional(29) BoolSeq bos;
@@ -137,14 +134,14 @@ exception OptionalException
     bool req = false;
     optional(1) int a = 5;
     optional(2) string b;
-    optional(50) OneOptional o;
+    OneOptional o;
 }
 
 exception DerivedException extends OptionalException
 {
     string d1;
     optional(600) string ss = "test";
-    optional(601) OneOptional o2;
+    OneOptional o2;
     string d2;
 }
 
@@ -162,20 +159,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -194,13 +191,13 @@ interface Initial
 
     ["marshaled-result"] Object pingPong(Object o);
 
-    void opOptionalException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opOptionalException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
-    void opDerivedException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opDerivedException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
-    void opRequiredException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opRequiredException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
     optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
@@ -227,9 +224,9 @@ interface Initial
 
     optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
-    optional(1) OneOptional opOneOptional(optional(2) OneOptional p1, out optional(3) OneOptional p3);
-
     optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
+
+    OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
     // Custom mapping operations
     ["cpp:array"] optional(1) ByteSeq opByteSeq(["cpp:array"] optional(2) ByteSeq p1,
@@ -275,13 +272,13 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct fs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct fs);
 
     G opG(G g);
 
@@ -299,21 +296,14 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    ["marshaled-result"] optional(1) G opMG1();
-    ["marshaled-result"] optional(1) G opMG2(optional(2) G p1, out optional(3) G p2);
+    ["marshaled-result"] G opMG1();
+    ["marshaled-result"] G opMG2(G p1, out G p2);
 
     bool supportsRequiredParams();
 
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();
-
-    // TODO: remove.
-    // This test actually uses this flag only for tagged classes (to be removed), not tagged proxies.
-    // For tagged proxies: in IceRPC and from Ice 3.8 on, we don't distinguish between a not-set tagged
-    // proxy and a tagged proxy set to nullopt. We encode as not-set in both cases, and decode successfully both to
-    // nulltopt.
-    bool supportsNullOptional();
 }
 
 }

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -80,27 +80,27 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) ByteSeq bs;
-    optional(12) StringSeq ss;
-    optional(13) IntIntDict iid;
-    optional(14) StringIntDict sid;
-    optional(15) FixedStruct fs;
-    optional(16) VarStruct vs;
+    optional(12) ByteSeq bs;
+    optional(13) StringSeq ss;
+    optional(14) IntIntDict iid;
+    optional(15) StringIntDict sid;
+    optional(16) FixedStruct fs;
+    optional(17) VarStruct vs;
 
-    optional(17) ShortSeq shs;
-    optional(18) MyEnumSeq es;
-    optional(19) FixedStructSeq fss;
-    optional(20) VarStructSeq vss;
-    optional(21) MyInterfacePrxSeq mips;
+    optional(18) ShortSeq shs;
+    optional(19) MyEnumSeq es;
+    optional(20) FixedStructSeq fss;
+    optional(21) VarStructSeq vss;
+    optional(23) MyInterfacePrxSeq mips;
 
-    optional(22) IntEnumDict ied;
-    optional(23) IntFixedStructDict ifsd;
-    optional(24) IntVarStructDict ivsd;
-    optional(25) IntMyInterfacePrxDict imipd;
+    optional(24) IntEnumDict ied;
+    optional(25) IntFixedStructDict ifsd;
+    optional(26) IntVarStructDict ivsd;
+    optional(28) IntMyInterfacePrxDict imipd;
 
-    optional(26) BoolSeq bos;
+    optional(29) BoolSeq bos;
 
-    optional(27) Serializable ser;
+    optional(30) Serializable ser;
 }
 
 class A

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -80,27 +80,27 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(12) ByteSeq bs;
-    optional(13) StringSeq ss;
-    optional(14) IntIntDict iid;
-    optional(15) StringIntDict sid;
-    optional(16) FixedStruct fs;
-    optional(17) VarStruct vs;
+    optional(11) ByteSeq bs;
+    optional(12) StringSeq ss;
+    optional(13) IntIntDict iid;
+    optional(14) StringIntDict sid;
+    optional(15) FixedStruct fs;
+    optional(16) VarStruct vs;
 
-    optional(18) ShortSeq shs;
-    optional(19) MyEnumSeq es;
-    optional(20) FixedStructSeq fss;
-    optional(21) VarStructSeq vss;
-    optional(23) MyInterfacePrxSeq mips;
+    optional(17) ShortSeq shs;
+    optional(18) MyEnumSeq es;
+    optional(19) FixedStructSeq fss;
+    optional(20) VarStructSeq vss;
+    optional(21) MyInterfacePrxSeq mips;
 
-    optional(24) IntEnumDict ied;
-    optional(25) IntFixedStructDict ifsd;
-    optional(26) IntVarStructDict ivsd;
-    optional(28) IntMyInterfacePrxDict imipd;
+    optional(22) IntEnumDict ied;
+    optional(23) IntFixedStructDict ifsd;
+    optional(24) IntVarStructDict ivsd;
+    optional(25) IntMyInterfacePrxDict imipd;
 
-    optional(29) BoolSeq bos;
+    optional(26) BoolSeq bos;
 
-    optional(30) Serializable ser;
+    optional(27) Serializable ser;
 }
 
 class A

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -80,7 +80,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;
@@ -92,13 +91,11 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
 
     optional(29) BoolSeq bos;
@@ -137,14 +134,14 @@ exception OptionalException
     bool req = false;
     optional(1) int a = 5;
     optional(2) string b;
-    optional(50) OneOptional o;
+    OneOptional o;
 }
 
 exception DerivedException extends OptionalException
 {
     string d1;
     optional(600) string ss = "test";
-    optional(601) OneOptional o2;
+    OneOptional o2;
     string d2;
 }
 
@@ -162,20 +159,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -195,13 +192,13 @@ interface Initial
 
     Object pingPong(Object o);
 
-    void opOptionalException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opOptionalException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
-    void opDerivedException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opDerivedException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
-    void opRequiredException(optional(1) int a, optional(2) string b, optional(3) OneOptional o)
+    void opRequiredException(optional(1) int a, optional(2) string b, OneOptional o)
         throws OptionalException;
 
     optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
@@ -228,9 +225,9 @@ interface Initial
 
     optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
-    optional(1) OneOptional opOneOptional(optional(2) OneOptional p1, out optional(3) OneOptional p3);
-
     optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
+
+    OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
     // Custom mapping operations
     ["cpp:array"] optional(1) ByteSeq opByteSeq(["cpp:array"] optional(2) ByteSeq p1,
@@ -275,13 +272,13 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct fs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct fs);
 
     G opG(G g);
 
@@ -299,17 +296,14 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    ["marshaled-result"] optional(1) G opMG1();
-    ["marshaled-result"] optional(1) G opMG2(optional(2) G p1, out optional(3) G p2);
+    ["marshaled-result"] G opMG1();
+    ["marshaled-result"] G opMG2(G p1, out G p2);
 
     bool supportsRequiredParams();
 
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();
-
-    // TODO: remove. See Test.ice comment.
-    bool supportsNullOptional();
 }
 
 }

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -27,18 +27,13 @@ InitialI::pingPongAsync(
     const Ice::Current&)
 {
     response(obj);
-    if (dynamic_pointer_cast<MultiOptional>(obj))
-    {
-        // Break cyclic reference count
-        dynamic_pointer_cast<MultiOptional>(obj)->k = shared_ptr<MultiOptional>();
-    }
 }
 
 void
 InitialI::opOptionalExceptionAsync(
     optional<int> a,
     optional<string> b,
-    optional<shared_ptr<Test::OneOptional>> o,
+    shared_ptr<Test::OneOptional> o,
     function<void()>,
     function<void(exception_ptr)> ex,
     const Ice::Current&)
@@ -50,7 +45,7 @@ void
 InitialI::opDerivedExceptionAsync(
     optional<int> a,
     optional<string> b,
-    optional<shared_ptr<Test::OneOptional>> o,
+    shared_ptr<Test::OneOptional> o,
     function<void()>,
     function<void(exception_ptr)> ex,
     const Ice::Current&)
@@ -62,7 +57,7 @@ void
 InitialI::opRequiredExceptionAsync(
     optional<int> a,
     optional<string> b,
-    optional<shared_ptr<Test::OneOptional>> o,
+    shared_ptr<Test::OneOptional> o,
     function<void()>,
     function<void(exception_ptr)> ex,
     const Ice::Current&)
@@ -75,10 +70,7 @@ InitialI::opRequiredExceptionAsync(
     {
         e.ss = b.value();
     }
-    if (o)
-    {
-        e.o2 = o.value();
-    }
+    e.o2 = o;
 
     ex(make_exception_ptr(e));
 }
@@ -205,9 +197,8 @@ InitialI::opVarStructAsync(
 
 void
 InitialI::opOneOptionalAsync(
-    optional<shared_ptr<Test::OneOptional>> p1,
-    function<void(const optional<shared_ptr<Test::OneOptional>>&, const optional<shared_ptr<Test::OneOptional>>&)>
-        response,
+    shared_ptr<Test::OneOptional> p1,
+    function<void(const shared_ptr<Test::OneOptional>&, const shared_ptr<Test::OneOptional>&)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
@@ -395,8 +386,8 @@ InitialI::opStringIntDictAsync(
 
 void
 InitialI::opIntOneOptionalDictAsync(
-    optional<Test::IntOneOptionalDict> p1,
-    function<void(const optional<Test::IntOneOptionalDict>&, const optional<Test::IntOneOptionalDict>&)> response,
+    Test::IntOneOptionalDict p1,
+    function<void(const Test::IntOneOptionalDict&, const Test::IntOneOptionalDict&)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
@@ -414,9 +405,9 @@ InitialI::opClassAndUnknownOptionalAsync(
 }
 
 void
-InitialI::sendOptionalClassAsync(
+InitialI::sendOptionalStructAsync(
     bool,
-    optional<shared_ptr<Test::OneOptional>>,
+    optional<Test::FixedStruct>,
     function<void()> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
@@ -425,13 +416,13 @@ InitialI::sendOptionalClassAsync(
 }
 
 void
-InitialI::returnOptionalClassAsync(
+InitialI::returnOptionalStructAsync(
     bool,
-    function<void(const optional<shared_ptr<Test::OneOptional>>&)> response,
+    function<void(const optional<Test::FixedStruct>&)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
-    response(make_shared<OneOptional>(53));
+    response(Test::FixedStruct(53));
 }
 
 void
@@ -518,7 +509,7 @@ InitialI::opMG1Async(
 
 void
 InitialI::opMG2Async(
-    optional<GPtr> p1,
+    GPtr p1,
     function<void(OpMG2MarshaledResult)> response,
     function<void(exception_ptr)>,
     const Ice::Current& current)
@@ -548,10 +539,4 @@ InitialI::supportsCsharpSerializableAsync(
     const Ice::Current&)
 {
     response(true);
-}
-
-void
-InitialI::supportsNullOptionalAsync(function<void(bool)> response, function<void(exception_ptr)>, const Ice::Current&)
-{
-    response(false);
 }

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -422,7 +422,7 @@ InitialI::returnOptionalStructAsync(
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
-    response(Test::FixedStruct(53));
+    response(Test::FixedStruct{53});
 }
 
 void

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -23,7 +23,7 @@ public:
     void opOptionalExceptionAsync(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::shared_ptr<Test::OneOptional>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
@@ -31,7 +31,7 @@ public:
     void opDerivedExceptionAsync(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::shared_ptr<Test::OneOptional>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
@@ -39,7 +39,7 @@ public:
     void opRequiredExceptionAsync(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::shared_ptr<Test::OneOptional>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
@@ -117,10 +117,10 @@ public:
         const Ice::Current&) final;
 
     void opOneOptionalAsync(
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::shared_ptr<Test::OneOptional>,
         std::function<void(
-            const std::optional<std::shared_ptr<Test::OneOptional>>&,
-            const std::optional<std::shared_ptr<Test::OneOptional>>&)>,
+            const std::shared_ptr<Test::OneOptional>&,
+            const std::shared_ptr<Test::OneOptional>&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
@@ -249,9 +249,9 @@ public:
         const Ice::Current&) final;
 
     void opIntOneOptionalDictAsync(
-        std::optional<Test::IntOneOptionalDict>,
+        Test::IntOneOptionalDict,
         std::function<
-            void(const std::optional<Test::IntOneOptionalDict>&, const std::optional<Test::IntOneOptionalDict>&)>,
+            void(const Test::IntOneOptionalDict&, const Test::IntOneOptionalDict&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
@@ -261,16 +261,16 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void sendOptionalClassAsync(
+    void sendOptionalStructAsync(
         bool,
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::optional<Test::FixedStruct>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void returnOptionalClassAsync(
+    void returnOptionalStructAsync(
         bool,
-        std::function<void(const std::optional<std::shared_ptr<Test::OneOptional>>&)>,
+        std::function<void(const std::optional<Test::FixedStruct>&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
@@ -321,7 +321,7 @@ public:
         const Ice::Current&) final;
 
     void opMG2Async(
-        std::optional<Test::GPtr>,
+        Test::GPtr,
         std::function<void(OpMG2MarshaledResult)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
@@ -337,11 +337,6 @@ public:
         const Ice::Current&) final;
 
     void supportsCsharpSerializableAsync(
-        std::function<void(bool)>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
-
-    void supportsNullOptionalAsync(
         std::function<void(bool)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -118,9 +118,7 @@ public:
 
     void opOneOptionalAsync(
         std::shared_ptr<Test::OneOptional>,
-        std::function<void(
-            const std::shared_ptr<Test::OneOptional>&,
-            const std::shared_ptr<Test::OneOptional>&)>,
+        std::function<void(const std::shared_ptr<Test::OneOptional>&, const std::shared_ptr<Test::OneOptional>&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
@@ -250,8 +248,7 @@ public:
 
     void opIntOneOptionalDictAsync(
         Test::IntOneOptionalDict,
-        std::function<
-            void(const Test::IntOneOptionalDict&, const Test::IntOneOptionalDict&)>,
+        std::function<void(const Test::IntOneOptionalDict&, const Test::IntOneOptionalDict&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -344,7 +344,7 @@ InitialI::sendOptionalStruct(bool, optional<FixedStruct>, const Ice::Current&)
 void
 InitialI::returnOptionalStruct(bool, optional<FixedStruct>& fs, const Ice::Current&)
 {
-    fs = FixedStruct(53);
+    fs = FixedStruct{53};
 }
 
 GPtr

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -21,17 +21,11 @@ InitialI::shutdown(const Current& current)
 Test::Initial::PingPongMarshaledResult
 InitialI::pingPong(shared_ptr<Value> obj, const Current& current)
 {
-    auto result = PingPongMarshaledResult(obj, current);
-    if (dynamic_pointer_cast<MultiOptional>(obj))
-    {
-        // Break cyclic reference count
-        dynamic_pointer_cast<MultiOptional>(obj)->k = shared_ptr<MultiOptional>();
-    }
-    return result;
+    return PingPongMarshaledResult(obj, current);
 }
 
 void
-InitialI::opOptionalException(optional<int32_t> a, optional<string> b, optional<OneOptionalPtr> o, const Ice::Current&)
+InitialI::opOptionalException(optional<int32_t> a, optional<string> b, OneOptionalPtr o, const Ice::Current&)
 {
     OptionalException ex;
     ex.a = a;
@@ -41,7 +35,7 @@ InitialI::opOptionalException(optional<int32_t> a, optional<string> b, optional<
 }
 
 void
-InitialI::opDerivedException(optional<int32_t> a, optional<string> b, optional<OneOptionalPtr> o, const Ice::Current&)
+InitialI::opDerivedException(optional<int32_t> a, optional<string> b, OneOptionalPtr o, const Ice::Current&)
 {
     DerivedException ex;
     ex.a = a;
@@ -55,7 +49,7 @@ InitialI::opDerivedException(optional<int32_t> a, optional<string> b, optional<O
 }
 
 void
-InitialI::opRequiredException(optional<int32_t> a, optional<string> b, optional<OneOptionalPtr> o, const Ice::Current&)
+InitialI::opRequiredException(optional<int32_t> a, optional<string> b, OneOptionalPtr o, const Ice::Current&)
 {
     RequiredException ex;
     ex.a = a;
@@ -65,10 +59,7 @@ InitialI::opRequiredException(optional<int32_t> a, optional<string> b, optional<
     {
         ex.ss = b.value();
     }
-    if (o)
-    {
-        ex.o2 = o.value();
-    }
+    ex.o2 = o;
     throw ex;
 }
 
@@ -156,8 +147,8 @@ InitialI::opVarStruct(optional<VarStruct> p1, optional<VarStruct>& p3, const Cur
     return p1;
 }
 
-optional<OneOptionalPtr>
-InitialI::opOneOptional(optional<OneOptionalPtr> p1, optional<OneOptionalPtr>& p3, const Current&)
+OneOptionalPtr
+InitialI::opOneOptional(OneOptionalPtr p1, OneOptionalPtr& p3, const Current&)
 {
     p3 = p1;
     return p1;
@@ -333,8 +324,8 @@ InitialI::opStringIntDict(optional<StringIntDict> p1, optional<StringIntDict>& p
     return p3;
 }
 
-optional<IntOneOptionalDict>
-InitialI::opIntOneOptionalDict(optional<IntOneOptionalDict> p1, optional<IntOneOptionalDict>& p3, const Current&)
+IntOneOptionalDict
+InitialI::opIntOneOptionalDict(IntOneOptionalDict p1, IntOneOptionalDict& p3, const Current&)
 {
     p3 = p1;
     return p3;
@@ -346,14 +337,14 @@ InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 }
 
 void
-InitialI::sendOptionalClass(bool, optional<OneOptionalPtr>, const Ice::Current&)
+InitialI::sendOptionalStruct(bool, optional<FixedStruct>, const Ice::Current&)
 {
 }
 
 void
-InitialI::returnOptionalClass(bool, optional<OneOptionalPtr>& o, const Ice::Current&)
+InitialI::returnOptionalStruct(bool, optional<FixedStruct>& fs, const Ice::Current&)
 {
-    o = make_shared<OneOptional>(53);
+    fs = FixedStruct(53);
 }
 
 GPtr
@@ -410,7 +401,7 @@ InitialI::opMG1(const Ice::Current& current)
 }
 
 InitialI::OpMG2MarshaledResult
-InitialI::opMG2(optional<Test::GPtr> p1, const Ice::Current& current)
+InitialI::opMG2(Test::GPtr p1, const Ice::Current& current)
 {
     return OpMG2MarshaledResult(p1, p1, current);
 }
@@ -431,10 +422,4 @@ bool
 InitialI::supportsCsharpSerializable(const Ice::Current&)
 {
     return true;
-}
-
-bool
-InitialI::supportsNullOptional(const Ice::Current&)
-{
-    return false;
 }

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -66,8 +66,7 @@ public:
     virtual std::optional<Test::VarStruct>
     opVarStruct(std::optional<Test::VarStruct>, std::optional<Test::VarStruct>&, const Ice::Current&);
 
-    virtual Test::OneOptionalPtr
-    opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&);
+    virtual Test::OneOptionalPtr opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&);
 
     virtual std::optional<Test::MyInterfacePrx>
     opMyInterfaceProxy(std::optional<Test::MyInterfacePrx>, std::optional<Test::MyInterfacePrx>&, const Ice::Current&);
@@ -140,10 +139,8 @@ public:
     virtual std::optional<::Test::StringIntDict>
     opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&);
 
-    virtual ::Test::IntOneOptionalDict opIntOneOptionalDict(
-        ::Test::IntOneOptionalDict,
-        ::Test::IntOneOptionalDict&,
-        const Ice::Current&);
+    virtual ::Test::IntOneOptionalDict
+    opIntOneOptionalDict(::Test::IntOneOptionalDict, ::Test::IntOneOptionalDict&, const Ice::Current&);
 
     virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -18,19 +18,19 @@ public:
     virtual void opOptionalException(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<Test::OneOptionalPtr>,
+        Test::OneOptionalPtr,
         const Ice::Current&);
 
     virtual void opDerivedException(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<Test::OneOptionalPtr>,
+        Test::OneOptionalPtr,
         const Ice::Current&);
 
     virtual void opRequiredException(
         std::optional<std::int32_t>,
         std::optional<std::string>,
-        std::optional<Test::OneOptionalPtr>,
+        Test::OneOptionalPtr,
         const Ice::Current&);
 
     virtual std::optional<std::uint8_t>
@@ -66,8 +66,8 @@ public:
     virtual std::optional<Test::VarStruct>
     opVarStruct(std::optional<Test::VarStruct>, std::optional<Test::VarStruct>&, const Ice::Current&);
 
-    virtual std::optional<Test::OneOptionalPtr>
-    opOneOptional(std::optional<Test::OneOptionalPtr>, std::optional<Test::OneOptionalPtr>&, const Ice::Current&);
+    virtual Test::OneOptionalPtr
+    opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&);
 
     virtual std::optional<Test::MyInterfacePrx>
     opMyInterfaceProxy(std::optional<Test::MyInterfacePrx>, std::optional<Test::MyInterfacePrx>&, const Ice::Current&);
@@ -140,16 +140,16 @@ public:
     virtual std::optional<::Test::StringIntDict>
     opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&);
 
-    virtual std::optional<::Test::IntOneOptionalDict> opIntOneOptionalDict(
-        std::optional<::Test::IntOneOptionalDict>,
-        std::optional<::Test::IntOneOptionalDict>&,
+    virtual ::Test::IntOneOptionalDict opIntOneOptionalDict(
+        ::Test::IntOneOptionalDict,
+        ::Test::IntOneOptionalDict&,
         const Ice::Current&);
 
     virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
-    virtual void sendOptionalClass(bool, std::optional<Test::OneOptionalPtr>, const Ice::Current&);
+    virtual void sendOptionalStruct(bool, std::optional<Test::FixedStruct>, const Ice::Current&);
 
-    virtual void returnOptionalClass(bool, std::optional<Test::OneOptionalPtr>&, const Ice::Current&);
+    virtual void returnOptionalStruct(bool, std::optional<Test::FixedStruct>&, const Ice::Current&);
 
     virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
 
@@ -169,15 +169,13 @@ public:
 
     virtual OpMG1MarshaledResult opMG1(const Ice::Current&);
 
-    virtual OpMG2MarshaledResult opMG2(std::optional<Test::GPtr>, const Ice::Current&);
+    virtual OpMG2MarshaledResult opMG2(Test::GPtr, const Ice::Current&);
 
     virtual bool supportsRequiredParams(const Ice::Current&);
 
     virtual bool supportsJavaSerializable(const Ice::Current&);
 
     virtual bool supportsCsharpSerializable(const Ice::Current&);
-
-    virtual bool supportsNullOptional(const Ice::Current&);
 };
 
 #endif


### PR DESCRIPTION
This PR removes our testing of optional classes from the `cpp/Ice/optional` test.
To my knowledge, this is the only test using optional classes in C++.

In some places, I just removed the testing, but where possible I tried to keep the testing logic, but:
- either replace the optional class with an optional struct
- or keep the class, but simple send it as a required param

That second statement maybe sound out-of-place in the `optional` test. But, the class in question (`OneOptional`) has an optional parameter, and I think it's still worth testing classes with optional members, even if the class itself is not being used as an optional.