### PR TITLE
Remove Glacier2 refresh session code

### DIFF
--- a/cpp/src/Glacier2/ClientBlobject.h
+++ b/cpp/src/Glacier2/ClientBlobject.h
@@ -26,7 +26,7 @@ namespace Glacier2
             std::pair<const std::byte*, const std::byte*> inEncaps,
             std::function<void(bool, std::pair<const std::byte*, const std::byte*>)> response,
             std::function<void(std::exception_ptr)> error,
-            const Ice::Current& current) override;
+            const Ice::Current& current) final;
 
         std::shared_ptr<StringSet> categories();
         std::shared_ptr<StringSet> adapterIds();

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -30,8 +30,7 @@ Glacier2::RouterI::RouterI(
       _userId(userId),
       _session(std::move(session)),
       _controlId(controlId),
-      _context(context),
-      _timestamp(chrono::steady_clock::now())
+      _context(context)
 {
     //
     // If Glacier2 will be used with pre 3.2 clients, then the client proxy must be set.
@@ -160,12 +159,6 @@ Glacier2::RouterI::createSessionFromSecureConnectionAsync(
 }
 
 void
-Glacier2::RouterI::refreshSessionAsync(function<void()>, function<void(exception_ptr)>, const Current&)
-{
-    assert(false); // Must not be called in this router implementation.
-}
-
-void
 Glacier2::RouterI::destroySession(const Current&)
 {
     assert(false); // Must not be called in this router implementation.
@@ -211,20 +204,6 @@ optional<SessionPrx>
 Glacier2::RouterI::getSession() const
 {
     return _session; // No mutex lock necessary, _session is immutable.
-}
-
-chrono::steady_clock::time_point
-Glacier2::RouterI::getTimestamp() const
-{
-    // Can only be called with the SessionRouterI mutex locked
-    return _timestamp;
-}
-
-void
-Glacier2::RouterI::updateTimestamp() const
-{
-    // Can only be called with the SessionRouterI mutex locked
-    _timestamp = chrono::steady_clock::now();
 }
 
 void

--- a/cpp/src/Glacier2/RouterI.h
+++ b/cpp/src/Glacier2/RouterI.h
@@ -30,33 +30,29 @@ namespace Glacier2
 
         void destroy(std::function<void(std::exception_ptr)>);
 
-        std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const override;
-        std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const override;
-        Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) override;
-        std::string getCategoryForClient(const Ice::Current&) const override;
+        std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const final;
+        std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const final;
+        Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) final;
+        std::string getCategoryForClient(const Ice::Current&) const final;
         void createSessionAsync(
             std::string,
             std::string,
             std::function<void(const std::optional<SessionPrx>& returnValue)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) override;
+            const Ice::Current&) final;
         void createSessionFromSecureConnectionAsync(
             std::function<void(const std::optional<SessionPrx>& returnValue)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) override;
-        void refreshSessionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
-            override;
-        void destroySession(const Ice::Current&) override;
-        std::int64_t getSessionTimeout(const Ice::Current&) const override;
-        int getACMTimeout(const Ice::Current&) const override;
+            const Ice::Current&) final;
+        void refreshSession(const Ice::Current&) final {}
+        void destroySession(const Ice::Current&) final;
+        std::int64_t getSessionTimeout(const Ice::Current&) const final;
+        int getACMTimeout(const Ice::Current&) const final;
 
         std::shared_ptr<ClientBlobject> getClientBlobject() const;
         std::shared_ptr<ServerBlobject> getServerBlobject() const;
 
         std::optional<SessionPrx> getSession() const;
-
-        std::chrono::steady_clock::time_point getTimestamp() const;
-        void updateTimestamp() const;
 
         void updateObserver(const std::shared_ptr<Glacier2::Instrumentation::RouterObserver>&);
 
@@ -76,8 +72,6 @@ namespace Glacier2
         const std::optional<SessionPrx> _session;
         const Ice::Identity _controlId;
         const Ice::Context _context;
-        const std::mutex _timestampMutex;
-        mutable std::chrono::steady_clock::time_point _timestamp;
 
         std::shared_ptr<Glacier2::Instrumentation::SessionObserver> _observer;
     };

--- a/cpp/src/Glacier2/ServerBlobject.h
+++ b/cpp/src/Glacier2/ServerBlobject.h
@@ -18,7 +18,7 @@ namespace Glacier2
             std::pair<const std::byte*, const std::byte*> inEncaps,
             std::function<void(bool, std::pair<const std::byte*, const std::byte*>)> response,
             std::function<void(std::exception_ptr)> error,
-            const Ice::Current& current) override;
+            const Ice::Current& current) final;
     };
 }
 

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -68,37 +68,35 @@ namespace Glacier2
             std::optional<SessionManagerPrx>,
             std::optional<SSLPermissionsVerifierPrx>,
             std::optional<SSLSessionManagerPrx>);
-        ~SessionRouterI() override;
+        ~SessionRouterI() final;
         void destroy();
 
-        std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const override;
-        std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const override;
-        Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) override;
-        std::string getCategoryForClient(const Ice::Current&) const override;
+        std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const final;
+        std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const final;
+        Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) final;
+        std::string getCategoryForClient(const Ice::Current&) const final;
         void createSessionAsync(
             std::string,
             std::string,
             std::function<void(const std::optional<SessionPrx>&)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) override;
+            const Ice::Current&) final;
         void createSessionFromSecureConnectionAsync(
             std::function<void(const std::optional<SessionPrx>&)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) override;
-        void refreshSessionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
-            override;
-        void destroySession(const Ice::Current&) override;
-        std::int64_t getSessionTimeout(const Ice::Current&) const override;
-        int getACMTimeout(const Ice::Current&) const override;
+            const Ice::Current&) final;
+        void refreshSession(const Ice::Current&) final {}
+        void destroySession(const Ice::Current&) final;
+        std::int64_t getSessionTimeout(const Ice::Current&) const final;
+        int getACMTimeout(const Ice::Current&) const final;
 
-        void updateSessionObservers() override;
+        void updateSessionObservers() final;
 
         std::shared_ptr<RouterI> getRouter(const Ice::ConnectionPtr&, const Ice::Identity&, bool = true) const;
 
         Ice::ObjectPtr getClientBlobject(const Ice::ConnectionPtr&, const Ice::Identity&) const;
         Ice::ObjectPtr getServerBlobject(const std::string&) const;
 
-        void refreshSession(const Ice::ConnectionPtr&);
         void destroySession(const Ice::ConnectionPtr&);
 
         int sessionTraceLevel() const { return _sessionTraceLevel; }

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -77,9 +77,11 @@ module Glacier2
         ["amd", "format:sliced"] Session* createSessionFromSecureConnection()
             throws PermissionDeniedException, CannotCreateSessionException;
 
-        /// Keep the calling client's session with this router alive.
-        /// @throws SessionNotExistException Raised if no session exists for the calling client.
-        ["amd"] void refreshSession()
+        /// Keep the session with this router alive.
+        /// @throws SessionNotExistException Raised if no session exists for the caller (client).
+        /// @remarks This operation is provided for backward compatibility with Ice 3.7 and earlier and does nothing in
+        /// newer version of Glacier2.
+        void refreshSession()
             throws SessionNotExistException;
 
         /// Destroy the calling client's session with this router.


### PR DESCRIPTION
This PR removes the "refresh session" logic from Glacier2 but keep the refreshSession operation as-is for backwards compatibility.

TODO: mark operation as deprecated once #2085 is fixed.

As of Ice 3.8, all application-level refresh session / keep alive / heartbeat logic is deprecated and not recommended.

The correct approach is to rely on the idle timeout and idle check.