### PR TITLE
Remove Recursive Optional Class Member 'k' from 'Ice/optional' Tests

### DIFF
--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -311,7 +311,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->h = string("test");
     mo1->i = MyEnum::MyEnumMember;
     mo1->j = MyInterfacePrx(communicator, "test");
-    mo1->k = mo1;
     mo1->bs = ByteSeq();
     (*mo1->bs).push_back(byte{5});
     mo1->ss = StringSeq();
@@ -374,7 +373,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->h == string("test"));
     test(mo3->i = MyEnum::MyEnumMember);
     test(mo3->j = MyInterfacePrx(communicator, "test"));
-    test(mo3->k == mo1);
     test(mo3->bs == mo1->bs);
     test(mo3->ss == mo1->ss);
     test(mo3->iid == mo1->iid);
@@ -437,7 +435,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo4->h);
     test(!mo4->i);
     test(!mo4->j);
-    test(!mo4->k);
     test(!mo4->bs);
     test(!mo4->ss);
     test(!mo4->iid);
@@ -460,7 +457,6 @@ allTests(Test::TestHelper* helper, bool)
 
     test(!mo4->bos);
 
-    mo1->k = mo1;
     MultiOptionalPtr mo5 = dynamic_pointer_cast<MultiOptional>(initial->pingPong(mo1));
 
     test(mo5->a == mo1->a);
@@ -473,7 +469,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->h == mo1->h);
     test(mo5->i == mo1->i);
     test(mo5->j == mo1->j);
-    test(mo5->k == mo5->k);
     test(mo5->bs == mo1->bs);
     test(mo5->ss == mo1->ss);
     test(mo5->iid == mo1->iid);
@@ -513,7 +508,6 @@ allTests(Test::TestHelper* helper, bool)
     mo6->e = nullopt;
     mo6->g = nullopt;
     mo6->i = nullopt;
-    mo6->k = nullopt;
     mo6->ss = nullopt;
     mo6->sid = nullopt;
     mo6->vs = nullopt;
@@ -537,7 +531,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo7->h == mo1->h);
     test(!mo7->i);
     test(mo7->j == mo1->j);
-    test(!mo7->k);
     test(mo7->bs == mo1->bs);
     test(!mo7->ss);
     test(mo7->iid == mo1->iid);
@@ -576,7 +569,6 @@ allTests(Test::TestHelper* helper, bool)
     mo8->ifsd = nullopt;
     mo8->iood = nullopt;
 
-    mo8->k = mo8;
     MultiOptionalPtr mo9 = dynamic_pointer_cast<MultiOptional>(initial->pingPong(mo8));
     test(mo9->a == mo1->a);
     test(!mo9->b);
@@ -588,7 +580,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo9->h);
     test(mo9->i == mo1->i);
     test(!mo9->j);
-    test(mo9->k == mo9);
     test(!mo9->bs);
     test(mo9->ss == mo1->ss);
     test(!mo9->iid);
@@ -652,16 +643,6 @@ allTests(Test::TestHelper* helper, bool)
         test(obj && dynamic_cast<TestObjectReader*>(obj.get()));
         factory->setEnabled(false);
     }
-
-    mo1->k = nullptr;
-    mo2->k = nullptr;
-    mo3->k = nullptr;
-    mo4->k = nullptr;
-    mo5->k = nullptr;
-    mo6->k = nullptr;
-    mo7->k = nullptr;
-    mo8->k = nullptr;
-    mo9->k = nullptr;
 
     //
     // Use the 1.0 encoding with operations whose only class parameters are optional.

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -80,7 +80,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -80,7 +80,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -27,11 +27,6 @@ InitialI::pingPongAsync(
     const Ice::Current&)
 {
     response(obj);
-    if (dynamic_pointer_cast<MultiOptional>(obj))
-    {
-        // Break cyclic reference count
-        dynamic_pointer_cast<MultiOptional>(obj)->k = shared_ptr<MultiOptional>();
-    }
 }
 
 void

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -21,13 +21,7 @@ InitialI::shutdown(const Current& current)
 Test::Initial::PingPongMarshaledResult
 InitialI::pingPong(shared_ptr<Value> obj, const Current& current)
 {
-    auto result = PingPongMarshaledResult(obj, current);
-    if (dynamic_pointer_cast<MultiOptional>(obj))
-    {
-        // Break cyclic reference count
-        dynamic_pointer_cast<MultiOptional>(obj)->k = shared_ptr<MultiOptional>();
-    }
-    return result;
+    return PingPongMarshaledResult(obj, current);
 }
 
 void

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -49,7 +49,6 @@ namespace Ice
                 mo1.h = "test";
                 mo1.i = Test.MyEnum.MyEnumMember;
                 mo1.j = new Ice.Optional<Test.MyInterfacePrx>(Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test")));
-                mo1.k = mo1;
                 mo1.bs = new byte[] { 5 };
                 mo1.ss = new string[] { "test", "test2" };
                 mo1.iid = new Dictionary<int, int>();
@@ -93,7 +92,6 @@ namespace Ice
                 test(mo1.h.Value == "test");
                 test(mo1.i.Value == Test.MyEnum.MyEnumMember);
                 test(mo1.j.Value.Equals(communicator.stringToProxy("test")));
-                test(mo1.k.Value == mo1);
                 test(ArraysEqual(mo1.bs.Value, new byte[] { (byte)5 }));
                 test(ArraysEqual(mo1.ss.Value, new String[] { "test", "test2" }));
                 test(mo1.iid.Value[4] == 3);
@@ -138,7 +136,6 @@ namespace Ice
                 test(!mo4.h.HasValue);
                 test(!mo4.i.HasValue);
                 test(!mo4.j.HasValue);
-                test(!mo4.k.HasValue);
                 test(!mo4.bs.HasValue);
                 test(!mo4.ss.HasValue);
                 test(!mo4.iid.HasValue);
@@ -172,7 +169,6 @@ namespace Ice
                 test(mo5.h.Value.Equals(mo1.h.Value));
                 test(mo5.i.Value == mo1.i.Value);
                 test(mo5.j.Value.Equals(mo1.j.Value));
-                test(mo5.k.Value == mo5);
                 test(ArraysEqual(mo5.bs.Value, mo1.bs.Value));
                 test(ArraysEqual(mo5.ss.Value, mo1.ss.Value));
                 test(mo5.iid.Value[4] == 3);
@@ -222,7 +218,6 @@ namespace Ice
                 test(mo7.h.Equals(mo1.h));
                 test(!mo7.i.HasValue);
                 test(mo7.j.Equals(mo1.j));
-                test(!mo7.k.HasValue);
                 test(ArraysEqual(mo7.bs.Value, mo1.bs.Value));
                 test(!mo7.ss.HasValue);
                 test(mo7.iid.Value[4] == 3);
@@ -252,7 +247,6 @@ namespace Ice
                 mo8.e = mo5.e;
                 mo8.g = mo5.g;
                 mo8.i = mo5.i;
-                mo8.k = mo8;
                 mo8.ss = mo5.ss;
                 mo8.sid = mo5.sid;
                 mo8.vs = mo5.vs;
@@ -276,7 +270,6 @@ namespace Ice
                 test(!mo9.h.HasValue);
                 test(mo9.i.Equals(mo1.i));
                 test(!mo9.j.HasValue);
-                test(mo9.k.Value == mo9);
                 test(!mo9.bs.HasValue);
                 test(ArraysEqual(mo9.ss.Value, mo1.ss.Value));
                 test(!mo9.iid.HasValue);

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -69,7 +69,6 @@ public class AllTests {
     mo1.setH("test");
     mo1.setI(MyEnum.MyEnumMember);
     mo1.setJ(MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
-    mo1.setK(mo1);
     mo1.setBs(new byte[] {(byte) 5});
     mo1.setSs(new String[] {"test", "test2"});
     mo1.setIid(new java.util.HashMap<>());
@@ -117,7 +116,6 @@ public class AllTests {
     test(mo1.getH().equals("test"));
     test(mo1.getI() == MyEnum.MyEnumMember);
     test(mo1.getJ().equals(communicator.stringToProxy("test")));
-    test(mo1.getK() == mo1);
     test(java.util.Arrays.equals(mo1.getBs(), new byte[] {(byte) 5}));
     test(java.util.Arrays.equals(mo1.getSs(), new String[] {"test", "test2"}));
     test(mo1.getIid().get(4) == 3);
@@ -164,7 +162,6 @@ public class AllTests {
     test(!mo4.hasH());
     test(!mo4.hasI());
     test(!mo4.hasJ());
-    test(!mo4.hasK());
     test(!mo4.hasBs());
     test(!mo4.hasSs());
     test(!mo4.hasIid());
@@ -205,7 +202,6 @@ public class AllTests {
     test(mo5.getH().equals(mo1.getH()));
     test(mo5.getI() == mo1.getI());
     test(mo5.getJ().equals(mo1.getJ()));
-    test(mo5.getK() == mo5);
     test(java.util.Arrays.equals(mo5.getBs(), mo1.getBs()));
     test(java.util.Arrays.equals(mo5.getSs(), mo1.getSs()));
     test(mo5.getIid().get(4) == 3);
@@ -259,7 +255,6 @@ public class AllTests {
     test(mo7.getH().equals(mo1.getH()));
     test(!mo7.hasI());
     test(mo7.getJ().equals(mo1.getJ()));
-    test(!mo7.hasK());
     test(java.util.Arrays.equals(mo7.getBs(), mo1.getBs()));
     test(!mo7.hasSs());
     test(mo7.getIid().get(4) == 3);
@@ -289,7 +284,6 @@ public class AllTests {
     mo8.setE(mo5.getE());
     mo8.setG(mo5.getG());
     mo8.setI(mo5.getI());
-    mo8.setK(mo8);
     mo8.setSs(mo5.getSs());
     mo8.setSid(mo5.getSid());
     mo8.setVs(mo5.getVs());
@@ -313,7 +307,6 @@ public class AllTests {
     test(!mo9.hasH());
     test(mo9.getI() == mo1.getI());
     test(!mo9.hasJ());
-    test(mo9.getK() == mo9);
     test(!mo9.hasBs());
     test(java.util.Arrays.equals(mo9.getSs(), mo1.getSs()));
     test(!mo9.hasIid());

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -77,7 +77,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -77,7 +77,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -52,7 +52,6 @@
             test(mo4.h === undefined);
             test(mo4.i === undefined);
             test(mo4.j === undefined);
-            test(mo4.k === undefined);
             test(mo4.bs === undefined);
             test(mo4.ss === undefined);
             test(mo4.iid === undefined);
@@ -88,7 +87,6 @@
             mo1.h = "test";
             mo1.i = Test.MyEnum.MyEnumMember;
             mo1.j = communicator.stringToProxy("test");
-            mo1.k = mo1;
             mo1.bs = new Uint8Array([5]);
             mo1.ss = ["test", "test2"];
             mo1.iid = new Map();
@@ -132,7 +130,6 @@
             test(mo1.h == mo5.h);
             test(mo1.i == mo5.i);
             test(mo1.j.equals(mo5.j));
-            test(mo5.k == mo5);
             test(ArrayUtil.equals(mo5.bs, mo1.bs));
             test(ArrayUtil.equals(mo5.ss, mo1.ss));
             test(mo5.iid.get(4) == 3);
@@ -182,7 +179,6 @@
             test(mo7.h == mo1.h);
             test(mo7.i === undefined);
             test(mo7.j.equals(mo1.j));
-            test(mo7.k === undefined);
             test(ArrayUtil.equals(mo7.bs, mo1.bs));
             test(mo7.ss === undefined);
             test(mo7.iid.get(4) == 3);
@@ -211,7 +207,6 @@
             mo8.e = mo1.e;
             mo8.g = mo1.g;
             mo8.i = mo1.i;
-            mo8.k = mo8;
             mo8.ss = mo1.ss;
             mo8.sid = mo1.sid;
             mo8.vs = mo1.vs;
@@ -236,7 +231,6 @@
             test(mo9.h === undefined);
             test(mo9.i == mo1.i);
             test(mo9.j === undefined);
-            test(mo9.k == mo9);
             test(mo9.bs === undefined);
             test(ArrayUtil.equals(mo9.ss, mo1.ss));
             test(mo9.iid === undefined);

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -49,7 +49,6 @@ export class Client extends TestHelper
         test(mo4.h === undefined);
         test(mo4.i === undefined);
         test(mo4.j === undefined);
-        test(mo4.k === undefined);
         test(mo4.bs === undefined);
         test(mo4.ss === undefined);
         test(mo4.iid === undefined);
@@ -85,7 +84,6 @@ export class Client extends TestHelper
         mo1.h = "test";
         mo1.i = Test.MyEnum.MyEnumMember;
         mo1.j = Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"));
-        mo1.k = mo1;
         mo1.bs = new Uint8Array([5]);
         mo1.ss = ["test", "test2"];
         mo1.iid = new Map();
@@ -129,7 +127,6 @@ export class Client extends TestHelper
         test(mo1.h == mo5.h);
         test(mo1.i == mo5.i);
         test(mo1.j.equals(mo5.j));
-        test(mo5.k == mo5);
         test(ArrayUtil.equals(mo5.bs, mo1.bs));
         test(ArrayUtil.equals(mo5.ss, mo1.ss));
         test(mo5.iid.get(4) == 3);
@@ -179,7 +176,6 @@ export class Client extends TestHelper
         test(mo7.h == mo1.h);
         test(mo7.i === undefined);
         test(mo7.j.equals(mo1.j));
-        test(mo7.k === undefined);
         test(ArrayUtil.equals(mo7.bs, mo1.bs));
         test(mo7.ss === undefined);
         test(mo7.iid.get(4) == 3);
@@ -208,7 +204,6 @@ export class Client extends TestHelper
         mo8.e = mo1.e;
         mo8.g = mo1.g;
         mo8.i = mo1.i;
-        mo8.k = mo8;
         mo8.ss = mo1.ss;
         mo8.sid = mo1.sid;
         mo8.vs = mo1.vs;
@@ -233,7 +228,6 @@ export class Client extends TestHelper
         test(mo9.h === undefined);
         test(mo9.i == mo1.i);
         test(mo9.j === undefined);
-        test(mo9.k == mo9);
         test(mo9.bs === undefined);
         test(ArrayUtil.equals(mo9.ss, mo1.ss));
         test(mo9.iid === undefined);

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -78,7 +78,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -33,7 +33,6 @@ classdef AllTests
             assert(mo1.h == Ice.Unset);
             assert(mo1.i == Ice.Unset);
             assert(mo1.j == Ice.Unset);
-            assert(mo1.k == Ice.Unset);
             assert(mo1.bs == Ice.Unset);
             assert(mo1.ss == Ice.Unset);
             assert(mo1.iid == Ice.Unset);
@@ -77,7 +76,7 @@ classdef AllTests
             imipd(5) = MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test'));
             mo1 = MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', MyEnum.MyEnumMember, ...
                                      MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')), ...
-                                     [], [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
+                                     [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
                                      [ fs ], [ vs ], oos, { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
                                      ied, ifsd, ivsd, iood, imipd, [false, true, false], []);
@@ -92,7 +91,6 @@ classdef AllTests
             assert(strcmp(mo1.h, 'test'));
             assert(mo1.i == MyEnum.MyEnumMember);
             assert(mo1.j == communicator.stringToProxy('test'));
-            assert(isempty(mo1.k));
             assert(mo1.bs == [5])
             assert(isequal(mo1.ss, {'test', 'test2'}));
             assert(mo1.iid(4) == 3);
@@ -144,7 +142,6 @@ classdef AllTests
             assert(mo4.h == Ice.Unset);
             assert(mo4.i == Ice.Unset);
             % assert(mo4.j == Ice.Unset);
-            assert(mo4.k == Ice.Unset);
             assert(mo4.bs == Ice.Unset);
             assert(mo4.ss == Ice.Unset);
             assert(mo4.iid == Ice.Unset);
@@ -178,9 +175,6 @@ classdef AllTests
             assert(strcmp(mo5.h, mo1.h));
             assert(mo5.i == mo1.i);
             assert(mo5.j == mo1.j);
-            % With the Swift mapping you cannot distinguish null from an
-            % unset optional, so we test for both to support cross-testing.
-            assert(isempty(mo5.k) || mo5.k == Ice.Unset);
             assert(mo5.bs(1) == 5);
             assert(isequal(mo5.ss, mo1.ss));
             assert(mo5.iid(4) == 3);
@@ -230,7 +224,6 @@ classdef AllTests
             assert(strcmp(mo7.h, mo1.h));
             assert(mo7.i == Ice.Unset);
             assert(mo7.j == mo1.j);
-            assert(mo7.k == Ice.Unset);
             assert(mo7.bs(1) == 5);
             assert(mo7.ss == Ice.Unset);
             assert(mo7.iid(4) == 3);
@@ -260,7 +253,6 @@ classdef AllTests
             mo8.e = mo5.e;
             mo8.g = mo5.g;
             mo8.i = mo5.i;
-            mo8.k = mo8;
             mo8.ss = mo5.ss;
             mo8.sid = mo5.sid;
             mo8.vs = mo5.vs;
@@ -284,7 +276,6 @@ classdef AllTests
             assert(mo9.h == Ice.Unset);
             assert(mo9.i == mo1.i);
             % assert(mo9.j == Ice.Unset);
-            assert(mo9.k == mo9);
             assert(mo9.bs == Ice.Unset);
             assert(isequal(mo9.ss, mo1.ss));
             assert(mo9.iid == Ice.Unset);

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -42,7 +42,6 @@ function allTests($helper)
     test($mo1->h == Ice\None);
     test($mo1->i == Ice\None);
     test($mo1->j == Ice\None);
-    test($mo1->k == Ice\None);
     test($mo1->bs == Ice\None);
     test($mo1->ss == Ice\None);
     test($mo1->iid == Ice\None);
@@ -71,7 +70,7 @@ function allTests($helper)
     $prx = $communicator->stringToProxy("test")->ice_uncheckedCast("::Test::MyInterface");
     $oo15 = new Test\OneOptional(15);
     $mo1 = new Test\MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', Test\MyEnum::MyEnumMember,
-                      $prx, null, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
+                      $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
                       $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs), array($oo1),
                       array($prx), array(4=>Test\MyEnum::MyEnumMember), array(4=>$fs), array(5=>$vs),
                       array(5=>$oo15), array(5=>$prx), array(false, true, false));
@@ -86,7 +85,6 @@ function allTests($helper)
     test($mo1->h == "test");
     test($mo1->i == Test\MyEnum::MyEnumMember);
     test($mo1->j == $prx);
-    test($mo1->k == null);
     test($mo1->bs == array(5));
     test($mo1->ss == array("test", "test2"));
     test($mo1->iid[4] == 3);
@@ -139,7 +137,6 @@ function allTests($helper)
     test($mo4->h == Ice\None);
     test($mo4->i == Ice\None);
     test($mo4->j == Ice\None);
-    test($mo4->k == Ice\None);
     test($mo4->bs == Ice\None);
     test($mo4->ss == Ice\None);
     test($mo4->iid == Ice\None);
@@ -173,11 +170,6 @@ function allTests($helper)
     test($mo5->h == $mo1->h);
     test($mo5->i == $mo1->i);
     test($mo5->j == $mo1->j);
-    //
-    // With Swift mapping you cannot distinguish null from unset
-    // so we test for both here to support cross testing.
-    //
-    test($mo5->k == null || $mo5->k == Ice\None);
     test($mo5->bs[0] == 5);
     test($mo5->ss == $mo1->ss);
     test($mo5->iid[4] == 3);
@@ -227,7 +219,6 @@ function allTests($helper)
     test($mo7->h == $mo1->h);
     test($mo7->i == Ice\None);
     test($mo7->j == $mo1->j);
-    test($mo7->k == Ice\None);
     test($mo7->bs[0] == 5);
     test($mo7->ss == Ice\None);
     test($mo7->iid[4] == 3);
@@ -257,7 +248,6 @@ function allTests($helper)
     $mo8->e = $mo5->e;
     $mo8->g = $mo5->g;
     $mo8->i = $mo5->i;
-    $mo8->k = $mo8;
     $mo8->ss = $mo5->ss;
     $mo8->sid = $mo5->sid;
     $mo8->vs = $mo5->vs;
@@ -281,7 +271,6 @@ function allTests($helper)
     test($mo9->h == Ice\None);
     test($mo9->i == $mo1->i);
     test($mo9->j == Ice\None);
-    test($mo9->k == $mo9);
     test($mo9->bs == Ice\None);
     test($mo9->ss == $mo1->ss);
     test($mo9->iid == Ice\None);

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -48,7 +48,6 @@ def allTests(helper, communicator):
     test(mo1.h is Ice.Unset)
     test(mo1.i is Ice.Unset)
     test(mo1.j is Ice.Unset)
-    test(mo1.k is Ice.Unset)
     test(mo1.bs is Ice.Unset)
     test(mo1.ss is Ice.Unset)
     test(mo1.iid is Ice.Unset)
@@ -85,7 +84,6 @@ def allTests(helper, communicator):
         "test",
         Test.MyEnum.MyEnumMember,
         Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")),
-        None,
         [5],
         ["test", "test2"],
         {4: 3},
@@ -116,7 +114,6 @@ def allTests(helper, communicator):
     test(mo1.h == "test")
     test(mo1.i == Test.MyEnum.MyEnumMember)
     test(mo1.j == communicator.stringToProxy("test"))
-    test(mo1.k is None)
     test(mo1.bs == [5])
     test(mo1.ss == ["test", "test2"])
     test(mo1.iid[4] == 3)
@@ -171,7 +168,6 @@ def allTests(helper, communicator):
     test(mo4.h is Ice.Unset)
     test(mo4.i is Ice.Unset)
     test(mo4.j is Ice.Unset)
-    test(mo4.k is Ice.Unset)
     test(mo4.bs is Ice.Unset)
     test(mo4.ss is Ice.Unset)
     test(mo4.iid is Ice.Unset)
@@ -205,11 +201,6 @@ def allTests(helper, communicator):
     test(mo5.h == mo1.h)
     test(mo5.i == mo1.i)
     test(mo5.j == mo1.j)
-    #
-    # With Swift mapping you cannot distinguish null from unset
-    # so we test for both here to support cross testing.
-    #
-    test(mo5.k is None or mo5.k is Ice.Unset)
     test(mo5.bs[0] == 5)
     test(mo5.ss == mo1.ss)
     test(mo5.iid[4] == 3)
@@ -261,7 +252,6 @@ def allTests(helper, communicator):
     test(mo7.h == mo1.h)
     test(mo7.i is Ice.Unset)
     test(mo7.j == mo1.j)
-    test(mo7.k is Ice.Unset)
     test(mo7.bs[0] == 5)
     test(mo7.ss is Ice.Unset)
     test(mo7.iid[4] == 3)
@@ -291,7 +281,6 @@ def allTests(helper, communicator):
     mo8.e = mo5.e
     mo8.g = mo5.g
     mo8.i = mo5.i
-    mo8.k = mo8
     mo8.ss = mo5.ss
     mo8.sid = mo5.sid
     mo8.vs = mo5.vs
@@ -315,7 +304,6 @@ def allTests(helper, communicator):
     test(mo9.h is Ice.Unset)
     test(mo9.i == mo1.i)
     test(mo9.j is Ice.Unset)
-    test(mo9.k == mo9)
     test(mo9.bs is Ice.Unset)
     test(mo9.ss == mo1.ss)
     test(mo9.iid is Ice.Unset)

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -38,7 +38,6 @@ def allTests(helper, communicator)
     test(mo1.h == Ice::Unset)
     test(mo1.i == Ice::Unset)
     test(mo1.j == Ice::Unset)
-    test(mo1.k == Ice::Unset)
     test(mo1.bs == Ice::Unset)
     test(mo1.ss == Ice::Unset)
     test(mo1.iid == Ice::Unset)
@@ -66,7 +65,7 @@ def allTests(helper, communicator)
     vs = Test::VarStruct.new("hello")
     mo1 = Test::MultiOptional.new(15, true, 19, 78, 99, 5.5, 1.0, "test", Test::MyEnum::MyEnumMember, \
                                   Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")), \
-                                  nil, [5], ["test", "test2"], {4=>3}, {"test"=>10}, fs, vs, [1], \
+                                  [5], ["test", "test2"], {4=>3}, {"test"=>10}, fs, vs, [1], \
                                   [Test::MyEnum::MyEnumMember, Test::MyEnum::MyEnumMember], \
                                   [ fs ], [ vs ], [ oo1 ], \
                                   [ Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")) ], \
@@ -84,7 +83,6 @@ def allTests(helper, communicator)
     test(mo1.h == "test")
     test(mo1.i == Test::MyEnum::MyEnumMember)
     test(mo1.j == communicator.stringToProxy("test"))
-    test(mo1.k == nil)
     test(mo1.bs == [5])
     test(mo1.ss == ["test", "test2"])
     test(mo1.iid[4] == 3)
@@ -137,7 +135,6 @@ def allTests(helper, communicator)
     test(mo4.h == Ice::Unset)
     test(mo4.i == Ice::Unset)
     test(mo4.j == Ice::Unset)
-    test(mo4.k == Ice::Unset)
     test(mo4.bs == Ice::Unset)
     test(mo4.ss == Ice::Unset)
     test(mo4.iid == Ice::Unset)
@@ -171,11 +168,6 @@ def allTests(helper, communicator)
     test(mo5.h == mo1.h)
     test(mo5.i == mo1.i)
     test(mo5.j == mo1.j)
-    #
-    # With Swift mapping you cannot distinguish null from unset
-    # so we test for both here to support cross testing.
-    #
-    test(mo5.k == nil || Ice::Unset)
     test(mo5.bs.unpack("C*") == [0x05])
     test(mo5.ss == mo1.ss)
     test(mo5.iid[4] == 3)
@@ -225,7 +217,6 @@ def allTests(helper, communicator)
     test(mo7.h == mo1.h)
     test(mo7.i == Ice::Unset)
     test(mo7.j == mo1.j)
-    test(mo7.k == Ice::Unset)
     test(mo7.bs.unpack("C*") == [0x05])
     test(mo7.ss == Ice::Unset)
     test(mo7.iid[4] == 3)
@@ -255,7 +246,6 @@ def allTests(helper, communicator)
     mo8.e = mo5.e
     mo8.g = mo5.g
     mo8.i = mo5.i
-    mo8.k = mo8
     mo8.ss = mo5.ss
     mo8.sid = mo5.sid
     mo8.vs = mo5.vs
@@ -279,7 +269,6 @@ def allTests(helper, communicator)
     test(mo9.h == Ice::Unset)
     test(mo9.i == mo1.i)
     test(mo9.j == Ice::Unset)
-    test(mo9.k == mo9)
     test(mo9.bs == Ice::Unset)
     test(mo9.ss == mo1.ss)
     test(mo9.iid == Ice::Unset)

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -76,7 +76,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -226,7 +226,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   mo1.h = "test"
   mo1.i = .MyEnumMember
   mo1.j = try uncheckedCast(prx: communicator.stringToProxy("test")!, type: MyInterfacePrx.self)
-  // mo1.k = mo1
   mo1.bs = ByteSeq([5])
   mo1.ss = ["test", "test2"]
   mo1.iid = [4: 3]
@@ -267,7 +266,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   try test(mo1.h! == "test")
   try test(mo1.i! == .MyEnumMember)
   try test(mo1.j! == communicator.stringToProxy("test"))
-  // try test(mo1.k! === mo1)
   try test(mo1.bs! == ByteSeq([5]))
   try test(mo1.ss! == ["test", "test2"])
   try test(mo1.iid![4]! == 3)
@@ -318,7 +316,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo4.h == nil)
     try test(mo4.i == nil)
     try test(mo4.j == nil)
-    try test(mo4.k == nil)
     try test(mo4.bs == nil)
     try test(mo4.ss == nil)
     try test(mo4.iid == nil)
@@ -360,7 +357,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo5.h == mo1.h)
     try test(mo5.i == mo1.i)
     try test(mo5.j == mo1.j)
-    // try test(mo5.k === mo5)
     try test(mo5.bs == mo1.bs)
     try test(mo5.ss == mo1.ss)
     try test(mo5.iid![4] == 3)
@@ -404,7 +400,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     mo8.e = mo5.e
     mo8.g = mo5.g
     mo8.i = mo5.i
-    // mo8.k = mo8
     mo8.ss = mo5.ss
     mo8.sid = mo5.sid
     mo8.vs = mo5.vs
@@ -431,7 +426,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo7.h == mo1.h)
     try test(mo7.i == nil)
     try test(mo7.j == mo1.j)
-    try test(mo7.k == nil)
     try test(mo7.bs == mo1.bs)
     try test(mo7.ss == nil)
     try test(mo7.iid![4] == 3)
@@ -469,7 +463,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo9.h == nil)
     try test(mo9.i == mo1.i)
     try test(mo9.j == nil)
-    // try test(mo9.k === mo9)
     try test(mo9.bs == nil)
     try test(mo9.ss == mo1.ss)
     try test(mo9.iid == nil)

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -80,7 +80,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -78,7 +78,6 @@ class MultiOptional
     optional(8) string h;
     optional(9) MyEnum i;
     optional(10) MyInterface* j;
-    optional(11) MultiOptional k;
     optional(12) ByteSeq bs;
     optional(13) StringSeq ss;
     optional(14) IntIntDict iid;


### PR DESCRIPTION
This is the first of 8 PRs, chopping off parts of the Ice/optional test, so we can eventually remove optional class support.
This one just removes the testing of nested `MultiOptional`s.