### PR TITLE
Add move ctor and assignment operator to InputStream

### DIFF
--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -178,13 +178,13 @@ namespace Ice
 
         /**
          * Move constructor.
-         * @param other The output stream to move into this output stream.
+         * @param other The input stream to move into this input stream.
          */
         InputStream(InputStream&& other) noexcept;
 
         /**
          * Move assignment operator.
-         * @param other The output stream to move into this output stream.
+         * @param other The input stream to move into this input stream.
          */
         InputStream& operator=(InputStream&& other) noexcept;
 

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -176,6 +176,18 @@ namespace Ice
         InputStream(const CommunicatorPtr&, const EncodingVersion&, IceInternal::Buffer&, bool = false);
         /// \endcond
 
+        /**
+         * Move constructor.
+         * @param other The output stream to move into this output stream.
+         */
+        InputStream(InputStream&& other) noexcept;
+
+        /**
+         * Move assignment operator.
+         * @param other The output stream to move into this output stream.
+         */
+        InputStream& operator=(InputStream&& other) noexcept;
+
         ~InputStream()
         {
             // Inlined for performance reasons.

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -28,12 +28,11 @@ namespace
             int32_t requestId,
             int32_t dispatchCount)
             : _outAsync(outAsync),
-              _stream(stream.instance(), currentProtocolEncoding),
+              _stream(std::move(stream)),
               _handler(handler),
               _requestId(requestId),
               _dispatchCount(dispatchCount)
         {
-            _stream.swap(stream);
         }
 
         void run() final

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -86,9 +86,8 @@ namespace
               _connectionStartCompleted(std::move(connectionStartCompleted)),
               _sentCBs(sentCBs),
               _messageUpcall(std::move(messageUpcall)),
-              _messageStream(messageStream.instance(), currentProtocolEncoding)
+              _messageStream(std::move(messageStream))
         {
-            _messageStream.swap(messageStream);
         }
 
         void run() final { _connection->upcall(_connectionStartCompleted, _sentCBs, _messageUpcall, _messageStream); }
@@ -3190,7 +3189,7 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
                     }
 
                     // The message stream is adopted by the outgoing.
-                    stream.swap(*outAsync->getIs());
+                    *outAsync->getIs() = std::move(stream);
 
 #if defined(ICE_USE_IOCP)
                     //

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -142,7 +142,9 @@ Ice::InputStream::InputStream(InputStream&& other) noexcept :
     _compactIdResolver(std::move(other._compactIdResolver))
 {
     // Reset other to its default state. See initialize().
-    other._instance = nullptr;
+
+    // TODO: reset instance
+    // other._instance = nullptr;
     other._encoding = currentEncoding;
     other._traceSlicing = false;
     other._classGraphDepthMax = 0x7fffffff;
@@ -174,7 +176,9 @@ Ice::InputStream::operator=(InputStream&& other) noexcept
         _compactIdResolver = std::move(other._compactIdResolver);
 
         // Reset other to its default state. See initialize().
-        other._instance = nullptr;
+
+        // TODO: reset _instance.
+        // other._instance = nullptr;
         other._encoding = currentEncoding;
         other._traceSlicing = false;
         other._classGraphDepthMax = 0x7fffffff;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -141,19 +141,11 @@ Ice::InputStream::InputStream(InputStream&& other) noexcept
       _logger(std::move(other._logger)),
       _compactIdResolver(std::move(other._compactIdResolver))
 {
-    // Reset other to its default state. See initialize().
-
-    other._instance = nullptr;
-    other._encoding = currentEncoding;
-    other._traceSlicing = false;
-    other._classGraphDepthMax = 0x7fffffff;
-    other._closure = nullptr;
-    other._sliceValues = true;
-    other._startSeq = -1;
-    other._minSeqSize = 0;
-
     resetEncapsulation();
+
+    // Reset other to its default state
     other.resetEncapsulation();
+    other.initialize(currentEncoding);
 }
 
 InputStream&
@@ -174,19 +166,11 @@ Ice::InputStream::operator=(InputStream&& other) noexcept
         _logger = std::move(other._logger);
         _compactIdResolver = std::move(other._compactIdResolver);
 
-        // Reset other to its default state. See initialize().
-
-        other._instance = nullptr;
-        other._encoding = currentEncoding;
-        other._traceSlicing = false;
-        other._classGraphDepthMax = 0x7fffffff;
-        other._closure = nullptr;
-        other._sliceValues = true;
-        other._startSeq = -1;
-        other._minSeqSize = 0;
-
         resetEncapsulation();
+
+        // Reset other to its default state.
         other.resetEncapsulation();
+        other.initialize(currentEncoding);
     }
     return *this;
 }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -143,8 +143,7 @@ Ice::InputStream::InputStream(InputStream&& other) noexcept
 {
     // Reset other to its default state. See initialize().
 
-    // TODO: reset instance
-    // other._instance = nullptr;
+    other._instance = nullptr;
     other._encoding = currentEncoding;
     other._traceSlicing = false;
     other._classGraphDepthMax = 0x7fffffff;
@@ -177,8 +176,7 @@ Ice::InputStream::operator=(InputStream&& other) noexcept
 
         // Reset other to its default state. See initialize().
 
-        // TODO: reset _instance.
-        // other._instance = nullptr;
+        other._instance = nullptr;
         other._encoding = currentEncoding;
         other._traceSlicing = false;
         other._classGraphDepthMax = 0x7fffffff;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -127,6 +127,68 @@ Ice::InputStream::InputStream(Instance* instance, const EncodingVersion& encodin
     initialize(instance, encoding);
 }
 
+Ice::InputStream::InputStream(InputStream&& other) noexcept :
+    Buffer(std::move(other)),
+    _instance(other._instance),
+    _encoding(std::move(other._encoding)),
+    _traceSlicing(other._traceSlicing),
+    _classGraphDepthMax(other._classGraphDepthMax),
+    _closure(other._closure),
+    _sliceValues(other._sliceValues),
+    _startSeq(other._startSeq),
+    _minSeqSize(other._minSeqSize),
+    _valueFactoryManager(std::move(other._valueFactoryManager)),
+    _logger(std::move(other._logger)),
+    _compactIdResolver(std::move(other._compactIdResolver))
+{
+    // Reset other to its default state. See initialize().
+    other._instance = nullptr;
+    other._encoding = currentEncoding;
+    other._traceSlicing = false;
+    other._classGraphDepthMax = 0x7fffffff;
+    other._closure = nullptr;
+    other._sliceValues = true;
+    other._startSeq = -1;
+    other._minSeqSize = 0;
+
+    resetEncapsulation();
+    other.resetEncapsulation();
+}
+
+InputStream&
+Ice::InputStream::operator=(InputStream&& other) noexcept
+{
+    if (this != &other)
+    {
+        Buffer::operator=(std::move(other));
+        _instance = other._instance;
+        _encoding = std::move(other._encoding);
+        _traceSlicing = other._traceSlicing;
+        _classGraphDepthMax = other._classGraphDepthMax;
+        _closure = other._closure;
+        _sliceValues = other._sliceValues;
+        _startSeq = other._startSeq;
+        _minSeqSize = other._minSeqSize;
+        _valueFactoryManager = std::move(other._valueFactoryManager);
+        _logger = std::move(other._logger);
+        _compactIdResolver = std::move(other._compactIdResolver);
+
+        // Reset other to its default state. See initialize().
+        other._instance = nullptr;
+        other._encoding = currentEncoding;
+        other._traceSlicing = false;
+        other._classGraphDepthMax = 0x7fffffff;
+        other._closure = nullptr;
+        other._sliceValues = true;
+        other._startSeq = -1;
+        other._minSeqSize = 0;
+
+        resetEncapsulation();
+        other.resetEncapsulation();
+    }
+    return *this;
+}
+
 void
 Ice::InputStream::initialize(const CommunicatorPtr& communicator)
 {
@@ -153,12 +215,12 @@ Ice::InputStream::initialize(Instance* instance, const EncodingVersion& encoding
 void
 Ice::InputStream::initialize(const EncodingVersion& encoding)
 {
-    _instance = 0;
+    _instance = nullptr;
     _encoding = encoding;
-    _currentEncaps = 0;
+    _currentEncaps = nullptr;
     _traceSlicing = false;
     _classGraphDepthMax = 0x7fffffff;
-    _closure = 0;
+    _closure = nullptr;
     _sliceValues = true;
     _startSeq = -1;
     _minSeqSize = 0;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -127,19 +127,19 @@ Ice::InputStream::InputStream(Instance* instance, const EncodingVersion& encodin
     initialize(instance, encoding);
 }
 
-Ice::InputStream::InputStream(InputStream&& other) noexcept :
-    Buffer(std::move(other)),
-    _instance(other._instance),
-    _encoding(std::move(other._encoding)),
-    _traceSlicing(other._traceSlicing),
-    _classGraphDepthMax(other._classGraphDepthMax),
-    _closure(other._closure),
-    _sliceValues(other._sliceValues),
-    _startSeq(other._startSeq),
-    _minSeqSize(other._minSeqSize),
-    _valueFactoryManager(std::move(other._valueFactoryManager)),
-    _logger(std::move(other._logger)),
-    _compactIdResolver(std::move(other._compactIdResolver))
+Ice::InputStream::InputStream(InputStream&& other) noexcept
+    : Buffer(std::move(other)),
+      _instance(other._instance),
+      _encoding(std::move(other._encoding)),
+      _traceSlicing(other._traceSlicing),
+      _classGraphDepthMax(other._classGraphDepthMax),
+      _closure(other._closure),
+      _sliceValues(other._sliceValues),
+      _startSeq(other._startSeq),
+      _minSeqSize(other._minSeqSize),
+      _valueFactoryManager(std::move(other._valueFactoryManager)),
+      _logger(std::move(other._logger)),
+      _compactIdResolver(std::move(other._compactIdResolver))
 {
     // Reset other to its default state. See initialize().
 


### PR DESCRIPTION
This PR adds a move ctor and assignment operator to InputStream and uses them in a few spots.

Move ctor / move-assignment operator is more idiomatic than swap in modern C++. Unfortunately we rely on swap keeping "instance" as is which makes this PR not quite correct.