### PR TITLE
Switch 'Ice/optional' Tests to use Optional Structs Instead of Optional Classes

### DIFF
--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -1293,6 +1293,7 @@ allTests(Test::TestHelper* helper, bool)
         out.endEncapsulation();
         out.finished(inEncaps);
 
+        optional<FixedStruct> ofs;
         Ice::InputStream in(communicator, out.getEncoding(), inEncaps);
         in.startEncapsulation();
         in.read(2, ofs);

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -644,18 +644,6 @@ allTests(Test::TestHelper* helper, bool)
         factory->setEnabled(false);
     }
 
-    //
-    // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-    //
-    optional<FixedStruct> ofs{{53}};
-    initial->sendOptionalStruct(true, ofs);
-    initial->ice_encodingVersion(Ice::Encoding_1_0)->sendOptionalStruct(true, ofs);
-
-    initial->returnOptionalStruct(true, ofs);
-    test(ofs);
-    initial->ice_encodingVersion(Ice::Encoding_1_0)->returnOptionalStruct(true, ofs);
-    test(!ofs);
-
     GPtr g = make_shared<G>();
     g->gg1Opt = G1{"gg1Opt"};
     g->gg2 = G2{10};

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -278,10 +278,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -161,20 +161,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -278,9 +278,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -278,10 +278,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -161,20 +161,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -278,9 +278,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -409,27 +409,6 @@ InitialI::opClassAndUnknownOptionalAsync(
 }
 
 void
-InitialI::sendOptionalStructAsync(
-    bool,
-    optional<Test::FixedStruct>,
-    function<void()> response,
-    function<void(exception_ptr)>,
-    const Ice::Current&)
-{
-    response();
-}
-
-void
-InitialI::returnOptionalStructAsync(
-    bool,
-    function<void(const optional<Test::FixedStruct>&)> response,
-    function<void(exception_ptr)>,
-    const Ice::Current&)
-{
-    response(Test::FixedStruct{53});
-}
-
-void
 InitialI::opGAsync(
     shared_ptr<Test::G> g,
     function<void(const shared_ptr<Test::G>&)> response,

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -409,9 +409,9 @@ InitialI::opClassAndUnknownOptionalAsync(
 }
 
 void
-InitialI::sendOptionalClassAsync(
+InitialI::sendOptionalStructAsync(
     bool,
-    optional<shared_ptr<Test::OneOptional>>,
+    optional<Test::FixedStruct>,
     function<void()> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
@@ -420,13 +420,13 @@ InitialI::sendOptionalClassAsync(
 }
 
 void
-InitialI::returnOptionalClassAsync(
+InitialI::returnOptionalStructAsync(
     bool,
-    function<void(const optional<shared_ptr<Test::OneOptional>>&)> response,
+    function<void(const optional<Test::FixedStruct>&)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
-    response(make_shared<OneOptional>(53));
+    response(Test::FixedStruct{53});
 }
 
 void

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -261,16 +261,16 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void sendOptionalClassAsync(
+    void sendOptionalStructAsync(
         bool,
-        std::optional<std::shared_ptr<Test::OneOptional>>,
+        std::optional<Test::FixedStruct>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void returnOptionalClassAsync(
+    void returnOptionalStructAsync(
         bool,
-        std::function<void(const std::optional<std::shared_ptr<Test::OneOptional>>&)>,
+        std::function<void(const std::optional<Test::FixedStruct>&)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -261,19 +261,6 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void sendOptionalStructAsync(
-        bool,
-        std::optional<Test::FixedStruct>,
-        std::function<void()>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
-
-    void returnOptionalStructAsync(
-        bool,
-        std::function<void(const std::optional<Test::FixedStruct>&)>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
-
     void opGAsync(
         std::shared_ptr<Test::G>,
         std::function<void(const std::shared_ptr<Test::G>&)>,

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -340,14 +340,14 @@ InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 }
 
 void
-InitialI::sendOptionalClass(bool, optional<OneOptionalPtr>, const Ice::Current&)
+InitialI::sendOptionalStruct(bool, optional<FixedStruct>, const Ice::Current&)
 {
 }
 
 void
-InitialI::returnOptionalClass(bool, optional<OneOptionalPtr>& o, const Ice::Current&)
+InitialI::returnOptionalStruct(bool, optional<FixedStruct>& ofs, const Ice::Current&)
 {
-    o = make_shared<OneOptional>(53);
+    ofs = FixedStruct{53};
 }
 
 GPtr

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -339,17 +339,6 @@ InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 {
 }
 
-void
-InitialI::sendOptionalStruct(bool, optional<FixedStruct>, const Ice::Current&)
-{
-}
-
-void
-InitialI::returnOptionalStruct(bool, optional<FixedStruct>& ofs, const Ice::Current&)
-{
-    ofs = FixedStruct{53};
-}
-
 GPtr
 InitialI::opG(GPtr g, const Ice::Current&)
 {

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -147,9 +147,9 @@ public:
 
     virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
-    virtual void sendOptionalClass(bool, std::optional<Test::OneOptionalPtr>, const Ice::Current&);
+    virtual void sendOptionalStruct(bool, std::optional<Test::FixedStruct>, const Ice::Current&);
 
-    virtual void returnOptionalClass(bool, std::optional<Test::OneOptionalPtr>&, const Ice::Current&);
+    virtual void returnOptionalStruct(bool, std::optional<Test::FixedStruct>&, const Ice::Current&);
 
     virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
 

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -147,10 +147,6 @@ public:
 
     virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
-    virtual void sendOptionalStruct(bool, std::optional<Test::FixedStruct>, const Ice::Current&);
-
-    virtual void returnOptionalStruct(bool, std::optional<Test::FixedStruct>&, const Ice::Current&);
-
     virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
 
     virtual void opVoid(const Ice::Current&);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -336,19 +336,6 @@ namespace Ice
                 test(cb.obj != null && cb.obj is TestValueReader);
                 factory.setEnabled(false);
 
-                //
-                // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-                //
-                var ofs = new Ice.Optional<Test.FixedStruct>(new Test.FixedStruct(53));
-                initial.sendOptionalStruct(true, ofs);
-                Test.InitialPrx initial2 = (Test.InitialPrx)initial.ice_encodingVersion(Ice.Util.Encoding_1_0);
-                initial2.sendOptionalStruct(true, ofs);
-
-                initial.returnOptionalStruct(true, out ofs);
-                test(ofs.HasValue);
-                initial2.returnOptionalStruct(true, out ofs);
-                test(!ofs.HasValue);
-
                 Test.G g = new Test.G();
                 g.gg1Opt = new Ice.Optional<Test.G1>(new Test.G1("gg1Opt"));
                 g.gg2 = new Test.G2(10);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -1964,6 +1964,7 @@ namespace Ice
                         //
                         // Use the 1.0 encoding with an exception whose only class members are optional.
                         //
+                        Test.InitialPrx initial2 = (Test.InitialPrx)initial.ice_encodingVersion(Ice.Util.Encoding_1_0);
                         Ice.Optional<int> a = new Ice.Optional<int>(30);
                         Ice.Optional<string> b = new Ice.Optional<string>("test");
                         Ice.Optional<Test.OneOptional> o = new Ice.Optional<Test.OneOptional>(new Test.OneOptional(53));

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -337,17 +337,17 @@ namespace Ice
                 factory.setEnabled(false);
 
                 //
-                // Use the 1.0 encoding with operations whose only class parameters are optional.
+                // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
                 //
-                var oo = new Ice.Optional<Test.OneOptional>(new Test.OneOptional(53));
-                initial.sendOptionalClass(true, oo);
+                var ofs = new Ice.Optional<Test.FixedStruct>(new Test.FixedStruct(53));
+                initial.sendOptionalStruct(true, ofs);
                 Test.InitialPrx initial2 = (Test.InitialPrx)initial.ice_encodingVersion(Ice.Util.Encoding_1_0);
-                initial2.sendOptionalClass(true, oo);
+                initial2.sendOptionalStruct(true, ofs);
 
-                initial.returnOptionalClass(true, out oo);
-                test(oo.HasValue);
-                initial2.returnOptionalClass(true, out oo);
-                test(!oo.HasValue);
+                initial.returnOptionalStruct(true, out ofs);
+                test(ofs.HasValue);
+                initial2.returnOptionalStruct(true, out ofs);
+                test(!ofs.HasValue);
 
                 Test.G g = new Test.G();
                 g.gg1Opt = new Ice.Optional<Test.G1>(new Test.G1("gg1Opt"));
@@ -451,16 +451,16 @@ namespace Ice
                 }
                 output.WriteLine("ok");
 
-                output.Write("testing marshaling of objects with optional objects...");
+                output.Write("testing marshaling of objects with optional members...");
                 output.Flush();
                 {
                     Test.F f = new Test.F();
 
-                    f.af = new Test.A();
-                    f.ae = (Test.A)f.af;
+                    f.fsf = new Test.FixedStruct();
+                    f.fse = (Test.FixedStruct)f.fsf;
 
                     Test.F rf = (Test.F)initial.pingPong(f);
-                    test(rf.ae == rf.af.Value);
+                    test(rf.fse == rf.fsf.Value);
 
                     factory.setEnabled(true);
                     os = new Ice.OutputStream(communicator);
@@ -475,7 +475,7 @@ namespace Ice
                     @in.endEncapsulation();
                     factory.setEnabled(false);
                     rf = ((FValueReader)rocb.obj).getF();
-                    test(rf.ae != null && !rf.af.HasValue);
+                    test(rf.fse != null && !rf.fsf.HasValue);
                 }
                 output.WriteLine("ok");
 
@@ -1867,27 +1867,26 @@ namespace Ice
                     @in.endEncapsulation();
 
                     Test.F f = new Test.F();
-                    f.af = new Test.A();
-                    f.af.Value.requiredA = 56;
-                    f.ae = f.af.Value;
+                    f.fsf = new Test.FixedStruct(56);
+                    f.fse = f.fsf.Value;
 
                     os = new OutputStream(communicator);
                     os.startEncapsulation();
                     os.writeOptional(1, OptionalFormat.Class);
                     os.writeValue(f);
-                    os.writeOptional(2, OptionalFormat.Class);
-                    os.writeValue(f.ae);
+                    os.writeOptional(2, OptionalFormat.VSize);
+                    os.writeSize(4);
+                    Test.FixedStruct.ice_write(os, f.fse);
                     os.endEncapsulation();
                     inEncaps = os.finished();
 
                     @in = new InputStream(communicator, inEncaps);
                     @in.startEncapsulation();
-                    test(@in.readOptional(2, OptionalFormat.Class));
-                    ReadValueCallbackI rocb = new ReadValueCallbackI();
-                    @in.readValue(rocb.invoke);
+                    test(@in.readOptional(2, OptionalFormat.VSize));
+                    @in.skipSize();
+                    Test.FixedStruct fs1 = Test.FixedStruct.ice_read(@in);
                     @in.endEncapsulation();
-                    Test.A a = (Test.A)rocb.obj;
-                    test(a != null && a.requiredA == 56);
+                    test(fs1 != null && fs1.m == 56);
                 }
 
                 {
@@ -2333,15 +2332,13 @@ namespace Ice
                     _f = new Test.F();
                     @in.startValue();
                     @in.startSlice();
-                    // Don't read af on purpose
-                    //in.read(1, _f.af);
+                    // Don't read fsf on purpose
+                    //@in.read(1, _f.fsf);
                     @in.endSlice();
                     @in.startSlice();
-                    ReadValueCallbackI rocb = new ReadValueCallbackI();
-                    @in.readValue(rocb.invoke);
+                    _f.fse = Test.FixedStruct.ice_read(@in);
                     @in.endSlice();
                     @in.endValue();
-                    _f.ae = (Test.A)rocb.obj;
                 }
 
                 public Test.F getF()

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -260,10 +260,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -156,20 +156,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -260,9 +260,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -261,10 +261,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -156,20 +156,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -261,9 +261,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/csharp/test/Ice/optional/TestAMDI.cs
+++ b/csharp/test/Ice/optional/TestAMDI.cs
@@ -246,15 +246,15 @@ namespace Ice
                 }
 
                 public override Task
-                sendOptionalClassAsync(bool req, Ice.Optional<Test.OneOptional> o, Ice.Current current)
+                sendOptionalStructAsync(bool req, Ice.Optional<Test.FixedStruct> ofs, Ice.Current current)
                 {
                     return null;
                 }
 
-                public override Task<Ice.Optional<Test.OneOptional>>
-                returnOptionalClassAsync(bool req, Ice.Current current)
+                public override Task<Ice.Optional<Test.FixedStruct>>
+                returnOptionalStructAsync(bool req, Ice.Current current)
                 {
-                    return Task.FromResult(new Ice.Optional<Test.OneOptional>(new Test.OneOptional(53)));
+                    return Task.FromResult(new Ice.Optional<Test.FixedStruct>(new Test.FixedStruct(53)));
                 }
 
                 public override Task<Test.G>

--- a/csharp/test/Ice/optional/TestAMDI.cs
+++ b/csharp/test/Ice/optional/TestAMDI.cs
@@ -245,18 +245,6 @@ namespace Ice
                     return null;
                 }
 
-                public override Task
-                sendOptionalStructAsync(bool req, Ice.Optional<Test.FixedStruct> ofs, Ice.Current current)
-                {
-                    return null;
-                }
-
-                public override Task<Ice.Optional<Test.FixedStruct>>
-                returnOptionalStructAsync(bool req, Ice.Current current)
-                {
-                    return Task.FromResult(new Ice.Optional<Test.FixedStruct>(new Test.FixedStruct(53)));
-                }
-
                 public override Task<Test.G>
                 opGAsync(Test.G g, Ice.Current current)
                 {

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -305,19 +305,6 @@ namespace Ice
             {
             }
 
-            public override void sendOptionalStruct(bool req,
-                                                    Ice.Optional<Test.FixedStruct> ofs,
-                                                    Ice.Current current)
-            {
-            }
-
-            public override void returnOptionalStruct(bool req,
-                                                      out Ice.Optional<Test.FixedStruct> ofs,
-                                                      Ice.Current current)
-            {
-                ofs = new Test.FixedStruct(53);
-            }
-
             public override Test.G opG(Test.G g, Ice.Current current)
             {
                 return g;

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -305,17 +305,17 @@ namespace Ice
             {
             }
 
-            public override void sendOptionalClass(bool req,
-                                                   Ice.Optional<Test.OneOptional> o,
-                                                   Ice.Current current)
+            public override void sendOptionalStruct(bool req,
+                                                    Ice.Optional<Test.FixedStruct> ofs,
+                                                    Ice.Current current)
             {
             }
 
-            public override void returnOptionalClass(bool req,
-                                                     out Ice.Optional<Test.OneOptional> o,
-                                                     Ice.Current current)
+            public override void returnOptionalStruct(bool req,
+                                                      out Ice.Optional<Test.FixedStruct> ofs,
+                                                      Ice.Current current)
             {
-                o = new Test.OneOptional(53);
+                ofs = new Test.FixedStruct(53);
             }
 
             public override Test.G opG(Test.G g, Ice.Current current)

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -466,18 +466,6 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Void> sendOptionalStructAsync(
-      boolean req, Optional<FixedStruct> ofs, Current current) {
-    return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public CompletionStage<Optional<FixedStruct>> returnOptionalStructAsync(
-      boolean req, Current current) {
-    return CompletableFuture.completedFuture(Optional.of(new FixedStruct(53)));
-  }
-
-  @Override
   public CompletionStage<G> opGAsync(G g, Current current) {
     return CompletableFuture.completedFuture(g);
   }

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -466,15 +466,15 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Void> sendOptionalClassAsync(
-      boolean req, Optional<OneOptional> o, Current current) {
+  public CompletionStage<Void> sendOptionalStructAsync(
+      boolean req, Optional<FixedStruct> ofs, Current current) {
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public CompletionStage<Optional<OneOptional>> returnOptionalClassAsync(
+  public CompletionStage<Optional<FixedStruct>> returnOptionalStructAsync(
       boolean req, Current current) {
-    return CompletableFuture.completedFuture(Optional.of(new OneOptional(53)));
+    return CompletableFuture.completedFuture(Optional.of(new FixedStruct(53)));
   }
 
   @Override

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -376,19 +376,6 @@ public class AllTests {
     test(cb.value != null);
     factory.setEnabled(false);
 
-    //
-    // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-    //
-    Optional<FixedStruct> ofs = Optional.of(new FixedStruct(53));
-    initial.sendOptionalStruct(true, ofs);
-    InitialPrx initial2 = initial.ice_encodingVersion(com.zeroc.Ice.Util.Encoding_1_0);
-    initial2.sendOptionalStruct(true, ofs);
-
-    ofs = initial.returnOptionalStruct(true);
-    test(ofs.isPresent());
-    ofs = initial2.returnOptionalStruct(true);
-    test(!ofs.isPresent());
-
     G g = new G();
     g.setGg1Opt(new G1("gg1Opt"));
     g.gg2 = new G2(10);

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -2003,6 +2003,7 @@ public class AllTests {
         //
         // Use the 1.0 encoding with an exception whose only class members are optional.
         //
+        InitialPrx initial2 = initial.ice_encodingVersion(com.zeroc.Ice.Util.Encoding_1_0);
         OptionalInt a = OptionalInt.of(30);
         Optional<String> b = Optional.of("test");
         Optional<OneOptional> o = Optional.of(new OneOptional(53));

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -436,11 +436,11 @@ public final class InitialI implements Initial {
   public void opClassAndUnknownOptional(A p, Current current) {}
 
   @Override
-  public void sendOptionalClass(boolean req, Optional<OneOptional> o, Current current) {}
+  public void sendOptionalStruct(boolean req, Optional<FixedStruct> ofs, Current current) {}
 
   @Override
-  public Optional<OneOptional> returnOptionalClass(boolean req, Current current) {
-    return Optional.of(new OneOptional(53));
+  public Optional<FixedStruct> returnOptionalStruct(boolean req, Current current) {
+    return Optional.of(new FixedStruct(53));
   }
 
   @Override

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -436,14 +436,6 @@ public final class InitialI implements Initial {
   public void opClassAndUnknownOptional(A p, Current current) {}
 
   @Override
-  public void sendOptionalStruct(boolean req, Optional<FixedStruct> ofs, Current current) {}
-
-  @Override
-  public Optional<FixedStruct> returnOptionalStruct(boolean req, Current current) {
-    return Optional.of(new FixedStruct(53));
-  }
-
-  @Override
   public G opG(G g, Current current) {
     return g;
   }

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -307,11 +307,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    ["java:optional"]
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -158,20 +158,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -307,10 +307,10 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
     ["java:optional"]
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -309,11 +309,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    ["java:optional"]
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -158,20 +158,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -309,10 +309,10 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
     ["java:optional"]
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/js/test/Ice/optional/AMDInitialI.js
+++ b/js/test/Ice/optional/AMDInitialI.js
@@ -253,13 +253,13 @@
         {
         }
 
-        sendOptionalClass(req, current)
+        sendOptionalStruct(req, current)
         {
         }
 
-        returnOptionalClass(req, current)
+        returnOptionalStruct(req, current)
         {
-            return new Test.OneOptional(53);
+            return new Test.FixedStruct(53);
         }
 
         opG(g, current)

--- a/js/test/Ice/optional/AMDInitialI.js
+++ b/js/test/Ice/optional/AMDInitialI.js
@@ -253,15 +253,6 @@
         {
         }
 
-        sendOptionalStruct(req, current)
-        {
-        }
-
-        returnOptionalStruct(req, current)
-        {
-            return new Test.FixedStruct(53);
-        }
-
         opG(g, current)
         {
             return g;

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -254,17 +254,17 @@
             test(mo9.bos === undefined);
 
             //
-            // Use the 1.0 encoding with operations whose only class parameters are optional.
+            // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
             //
             const initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0);
-            const oo = new Test.OneOptional(53);
+            let ofs = new Test.FixedStruct(53);
 
-            await initial.sendOptionalClass(true, oo);
-            await initial2.sendOptionalClass(true, oo);
-            oo1 = await initial.returnOptionalClass(true);
-            test(oo1 !== undefined && oo1.a == 53);
-            oo1 = await initial2.returnOptionalClass(true);
-            test(oo1 === undefined);
+            await initial.sendOptionalStruct(true, ofs);
+            await initial2.sendOptionalStruct(true, ofs);
+            ofs = await initial.returnOptionalStruct(true);
+            test(ofs !== undefined && ofs.m == 53);
+            ofs = await initial2.returnOptionalStruct(true);
+            test(ofs === undefined);
 
             let g = new Test.G();
             g.gg1Opt = new Test.G1("gg1Opt");
@@ -329,12 +329,12 @@
             test(b.md == 13);
             out.writeLine("ok");
 
-            out.write("testing marshaling of objects with optional objects... ");
+            out.write("testing marshaling of objects with optional members... ");
             let f = new Test.F();
-            f.af = new Test.A();
-            f.ae = f.af;
+            f.fsf = new Test.FixedStruct();
+            f.fse = f.fsf;
             f = await initial.pingPong(f);
-            test(f.ae === f.af);
+            test(f.fse.equals(f.fsf));
             out.writeLine("ok");
 
             out.write("testing optional with default values... ");

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -253,19 +253,6 @@
 
             test(mo9.bos === undefined);
 
-            //
-            // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-            //
-            const initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0);
-            let ofs = new Test.FixedStruct(53);
-
-            await initial.sendOptionalStruct(true, ofs);
-            await initial2.sendOptionalStruct(true, ofs);
-            ofs = await initial.returnOptionalStruct(true);
-            test(ofs !== undefined && ofs.m == 53);
-            ofs = await initial2.returnOptionalStruct(true);
-            test(ofs === undefined);
-
             let g = new Test.G();
             g.gg1Opt = new Test.G1("gg1Opt");
             g.gg2 = new Test.G2(new Ice.Long(0, 10));

--- a/js/test/Ice/optional/InitialI.js
+++ b/js/test/Ice/optional/InitialI.js
@@ -253,7 +253,7 @@
         {
         }
 
-        sendOptionalClass(req, current)
+        sendOptionalStruct(req, current)
         {
         }
 
@@ -306,9 +306,9 @@
             return [p1, p1];
         }
 
-        returnOptionalClass(req, current)
+        returnOptionalStruct(req, current)
         {
-            return new Test.OneOptional(53);
+            return new Test.FixedStruct(53);
         }
 
         supportsRequiredParams(current)

--- a/js/test/Ice/optional/InitialI.js
+++ b/js/test/Ice/optional/InitialI.js
@@ -253,10 +253,6 @@
         {
         }
 
-        sendOptionalStruct(req, current)
-        {
-        }
-
         opG(g, current)
         {
             return g;
@@ -304,11 +300,6 @@
         opMG2(p1, current)
         {
             return [p1, p1];
-        }
-
-        returnOptionalStruct(req, current)
-        {
-            return new Test.FixedStruct(53);
         }
 
         supportsRequiredParams(current)

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -157,20 +157,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -263,9 +263,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -263,10 +263,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/js/test/typescript/Ice/optional/AMDInitialI.ts
+++ b/js/test/typescript/Ice/optional/AMDInitialI.ts
@@ -252,13 +252,13 @@ export class AMDInitialI extends Test.Initial
     {
     }
 
-    sendOptionalClass(req:boolean, one:Test.OneOptional, current:Ice.Current):void
+    sendOptionalStruct(req:boolean, one:Test.FixedStruct, current:Ice.Current):void
     {
     }
 
-    returnOptionalClass(req:boolean, current:Ice.Current):Test.OneOptional
+    returnOptionalStruct(req:boolean, current:Ice.Current):Test.FixedStruct
     {
-        return new Test.OneOptional(53);
+        return new Test.FixedStruct(53);
     }
 
     opG(g:Test.G, current:Ice.Current):Test.G

--- a/js/test/typescript/Ice/optional/AMDInitialI.ts
+++ b/js/test/typescript/Ice/optional/AMDInitialI.ts
@@ -252,15 +252,6 @@ export class AMDInitialI extends Test.Initial
     {
     }
 
-    sendOptionalStruct(req:boolean, one:Test.FixedStruct, current:Ice.Current):void
-    {
-    }
-
-    returnOptionalStruct(req:boolean, current:Ice.Current):Test.FixedStruct
-    {
-        return new Test.FixedStruct(53);
-    }
-
     opG(g:Test.G, current:Ice.Current):Test.G
     {
         return g;

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -251,17 +251,17 @@ export class Client extends TestHelper
         test(mo9.bos === undefined);
 
         //
-        // Use the 1.0 encoding with operations whose only class parameters are optional.
+        // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
         //
         const initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0);
-        const oo = new Test.OneOptional(53);
+        let ofs = new Test.FixedStruct(53);
 
-        await initial.sendOptionalClass(true, oo);
-        await initial2.sendOptionalClass(true, oo);
-        oo1 = await initial.returnOptionalClass(true);
-        test(oo1 !== undefined && oo1.a == 53);
-        oo1 = await initial2.returnOptionalClass(true);
-        test(oo1 === undefined);
+        await initial.sendOptionalStruct(true, ofs);
+        await initial2.sendOptionalStruct(true, ofs);
+        ofs = await initial.returnOptionalStruct(true);
+        test(ofs !== undefined && ofs.m == 53);
+        ofs = await initial2.returnOptionalStruct(true);
+        test(ofs === undefined);
 
         let g = new Test.G();
         g.gg1Opt = new Test.G1("gg1Opt");
@@ -326,12 +326,12 @@ export class Client extends TestHelper
         test(b.md == 13);
         out.writeLine("ok");
 
-        out.write("testing marshaling of objects with optional objects... ");
+        out.write("testing marshaling of objects with optional members... ");
         let f = new Test.F();
-        f.af = new Test.A();
-        f.ae = f.af;
+        f.fsf = new Test.FixedStruct();
+        f.fse = f.fsf;
         f = await initial.pingPong(f) as Test.F;
-        test(f.ae === f.af);
+        test(f.fse.equals(f.fsf));
         out.writeLine("ok");
 
         out.write("testing optional with default values... ");

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -250,19 +250,6 @@ export class Client extends TestHelper
 
         test(mo9.bos === undefined);
 
-        //
-        // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-        //
-        const initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0);
-        let ofs = new Test.FixedStruct(53);
-
-        await initial.sendOptionalStruct(true, ofs);
-        await initial2.sendOptionalStruct(true, ofs);
-        ofs = await initial.returnOptionalStruct(true);
-        test(ofs !== undefined && ofs.m == 53);
-        ofs = await initial2.returnOptionalStruct(true);
-        test(ofs === undefined);
-
         let g = new Test.G();
         g.gg1Opt = new Test.G1("gg1Opt");
         g.gg2 = new Test.G2(new Ice.Long(0, 10));

--- a/js/test/typescript/Ice/optional/InitialI.ts
+++ b/js/test/typescript/Ice/optional/InitialI.ts
@@ -252,13 +252,13 @@ export class InitialI extends Test.Initial
     {
     }
 
-    sendOptionalClass(req:boolean, one:Test.OneOptional, current:Ice.Current):void
+    sendOptionalStruct(req:boolean, one:Test.FixedStruct, current:Ice.Current):void
     {
     }
 
-    returnOptionalClass(req:boolean, current:Ice.Current):Test.OneOptional
+    returnOptionalStruct(req:boolean, current:Ice.Current):Test.FixedStruct
     {
-        return new Test.OneOptional(53);
+        return new Test.FixedStruct(53);
     }
 
     opG(g:Test.G, current:Ice.Current):Test.G

--- a/js/test/typescript/Ice/optional/InitialI.ts
+++ b/js/test/typescript/Ice/optional/InitialI.ts
@@ -252,15 +252,6 @@ export class InitialI extends Test.Initial
     {
     }
 
-    sendOptionalStruct(req:boolean, one:Test.FixedStruct, current:Ice.Current):void
-    {
-    }
-
-    returnOptionalStruct(req:boolean, current:Ice.Current):Test.FixedStruct
-    {
-        return new Test.FixedStruct(53);
-    }
-
     opG(g:Test.G, current:Ice.Current):Test.G
     {
         return g;

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -265,10 +265,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -159,20 +159,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -265,9 +265,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -299,14 +299,14 @@ classdef AllTests
             assert(mo9.bos == Ice.Unset);
 
             %
-            % Use the 1.0 encoding with operations whose only class parameters are optional.
+            % Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
             %
-            initial.sendOptionalClass(true, OneOptional(53));
-            initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).sendOptionalClass(true, OneOptional(53));
+            initial.sendOptionalStruct(true, FixedStruct(53));
+            initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).sendOptionalStruct(true, FixedStruct(53));
 
-            r = initial.returnOptionalClass(true);
+            r = initial.returnOptionalStruct(true);
             assert(r ~= Ice.Unset)
-            r = initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).returnOptionalClass(true);
+            r = initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).returnOptionalStruct(true);
             assert(r == Ice.Unset);
 
             g = G();
@@ -371,15 +371,15 @@ classdef AllTests
 
             fprintf('ok\n');
 
-            fprintf('testing marshaling of objects with optional objects... ');
+            fprintf('testing marshaling of objects with optional members... ');
 
             f = F();
 
-            f.af = A();
-            f.ae = f.af;
+            f.fsf = FixedStruct();
+            f.fse = f.fsf;
 
             rf = initial.pingPong(f);
-            assert(rf.ae == rf.af);
+            assert(rf.fse == rf.fsf);
 
             fprintf('ok\n');
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -298,17 +298,6 @@ classdef AllTests
 
             assert(mo9.bos == Ice.Unset);
 
-            %
-            % Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-            %
-            initial.sendOptionalStruct(true, FixedStruct(53));
-            initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).sendOptionalStruct(true, FixedStruct(53));
-
-            r = initial.returnOptionalStruct(true);
-            assert(r ~= Ice.Unset)
-            r = initial.ice_encodingVersion(Ice.EncodingVersion(1, 0)).returnOptionalStruct(true);
-            assert(r == Ice.Unset);
-
             g = G();
             g.gg1Opt = G1('gg1Opt');
             g.gg2 = G2(10);

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -158,20 +158,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -271,9 +271,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -271,10 +271,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -293,18 +293,6 @@ function allTests($helper)
 
     test($mo9->bos == Ice\None);
 
-    //
-    // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-    //
-    $ofs = new Test\FixedStruct(53);
-    $initial->sendOptionalStruct(true, $ofs);
-    $initial->ice_encodingVersion($Ice_Encoding_1_0)->sendOptionalStruct(true, $ofs);
-
-    $initial->returnOptionalStruct(true, $ofs);
-    test($ofs != Ice\None);
-    $initial->ice_encodingVersion($Ice_Encoding_1_0)->returnOptionalStruct(true, $ofs);
-    test($ofs == Ice\None);
-
     $g = new Test\G;
     $g->gg1Opt = new Test\G1("gg1Opt");
     $g->gg2 = new Test\G2(10);

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -294,16 +294,16 @@ function allTests($helper)
     test($mo9->bos == Ice\None);
 
     //
-    // Use the 1.0 encoding with operations whose only class parameters are optional.
+    // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
     //
-    $oo = new Test\OneOptional(53);
-    $initial->sendOptionalClass(true, $oo);
-    $initial->ice_encodingVersion($Ice_Encoding_1_0)->sendOptionalClass(true, $oo);
+    $ofs = new Test\FixedStruct(53);
+    $initial->sendOptionalStruct(true, $ofs);
+    $initial->ice_encodingVersion($Ice_Encoding_1_0)->sendOptionalStruct(true, $ofs);
 
-    $initial->returnOptionalClass(true, $oo);
-    test($oo != Ice\None);
-    $initial->ice_encodingVersion($Ice_Encoding_1_0)->returnOptionalClass(true, $oo);
-    test($oo == Ice\None);
+    $initial->returnOptionalStruct(true, $ofs);
+    test($ofs != Ice\None);
+    $initial->ice_encodingVersion($Ice_Encoding_1_0)->returnOptionalStruct(true, $ofs);
+    test($ofs == Ice\None);
 
     $g = new Test\G;
     $g->gg1Opt = new Test\G1("gg1Opt");
@@ -376,16 +376,16 @@ function allTests($helper)
 
     echo "ok\n";
 
-    echo "testing marshaling of objects with optional objects...";
+    echo "testing marshaling of objects with optional members...";
     flush();
 
     $f = new Test\F;
 
-    $f->af = new Test\A;
-    $f->ae = $f->af;
+    $f->fsf = new Test\FixedStruct;
+    $f->fse = $f->fsf;
 
     $rf = $initial->pingPong($f);
-    test($rf->ae == $rf->af);
+    test($rf->fse == $rf->fsf);
 
     echo "ok\n";
 

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -157,20 +157,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -263,9 +263,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -263,10 +263,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     ["marshaled-result"] optional(1) SmallStruct opMStruct1();

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -328,19 +328,6 @@ def allTests(helper, communicator):
 
     test(mo9.bos is Ice.Unset)
 
-    #
-    # Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-    #
-    initial.sendOptionalStruct(True, Test.FixedStruct(53))
-    initial.ice_encodingVersion(Ice.Encoding_1_0).sendOptionalStruct(
-        True, Test.FixedStruct(53)
-    )
-
-    r = initial.returnOptionalStruct(True)
-    test(r != Ice.Unset)
-    r = initial.ice_encodingVersion(Ice.Encoding_1_0).returnOptionalStruct(True)
-    test(r is Ice.Unset)
-
     g = Test.G()
     g.gg1Opt = Test.G1("gg1Opt")
     g.gg2 = Test.G2(10)

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -329,16 +329,16 @@ def allTests(helper, communicator):
     test(mo9.bos is Ice.Unset)
 
     #
-    # Use the 1.0 encoding with operations whose only class parameters are optional.
+    # Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
     #
-    initial.sendOptionalClass(True, Test.OneOptional(53))
-    initial.ice_encodingVersion(Ice.Encoding_1_0).sendOptionalClass(
-        True, Test.OneOptional(53)
+    initial.sendOptionalStruct(True, Test.FixedStruct(53))
+    initial.ice_encodingVersion(Ice.Encoding_1_0).sendOptionalStruct(
+        True, Test.FixedStruct(53)
     )
 
-    r = initial.returnOptionalClass(True)
+    r = initial.returnOptionalStruct(True)
     test(r != Ice.Unset)
-    r = initial.ice_encodingVersion(Ice.Encoding_1_0).returnOptionalClass(True)
+    r = initial.ice_encodingVersion(Ice.Encoding_1_0).returnOptionalStruct(True)
     test(r is Ice.Unset)
 
     g = Test.G()
@@ -409,16 +409,16 @@ def allTests(helper, communicator):
 
     print("ok")
 
-    sys.stdout.write("testing marshaling of objects with optional objects...")
+    sys.stdout.write("testing marshaling of objects with optional members...")
     sys.stdout.flush()
 
     f = Test.F()
 
-    f.af = Test.A()
-    f.ae = f.af
+    f.fsf = Test.FixedStruct()
+    f.fse = f.fsf
 
     rf = initial.pingPong(f)
-    test(rf.ae == rf.af)
+    test(rf.fse == rf.fsf)
 
     print("ok")
 

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -130,10 +130,10 @@ class InitialI(Test.Initial):
     def opClassAndUnknownOptional(self, p, current=None):
         pass
 
-    def sendOptionalFixedStruct(self, req, ofs, current=None):
+    def sendOptionalStruct(self, req, ofs, current=None):
         pass
 
-    def returnOptionalFixedStruct(self, req, current=None):
+    def returnOptionalStruct(self, req, current=None):
         return Test.FixedStruct(53)
 
     def opG(self, g, current=None):

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -130,11 +130,11 @@ class InitialI(Test.Initial):
     def opClassAndUnknownOptional(self, p, current=None):
         pass
 
-    def sendOptionalClass(self, req, o, current=None):
+    def sendOptionalFixedStruct(self, req, ofs, current=None):
         pass
 
-    def returnOptionalClass(self, req, current=None):
-        return Test.OneOptional(53)
+    def returnOptionalFixedStruct(self, req, current=None):
+        return Test.FixedStruct(53)
 
     def opG(self, g, current=None):
         return g

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -130,12 +130,6 @@ class InitialI(Test.Initial):
     def opClassAndUnknownOptional(self, p, current=None):
         pass
 
-    def sendOptionalStruct(self, req, ofs, current=None):
-        pass
-
-    def returnOptionalStruct(self, req, current=None):
-        return Test.FixedStruct(53)
-
     def opG(self, g, current=None):
         return g
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -136,11 +136,11 @@ class InitialI(Test.Initial):
     def opClassAndUnknownOptional(self, p, current=None):
         return Ice.Future.completed(None)
 
-    def sendOptionalClass(self, req, o, current=None):
+    def sendOptionalStruct(self, req, ofs, current=None):
         return Ice.Future.completed(None)
 
-    def returnOptionalClass(self, req, current=None):
-        return Ice.Future.completed(Test.OneOptional(53))
+    def returnOptionalStruct(self, req, current=None):
+        return Ice.Future.completed(Test.FixedStruct(53))
 
     def opG(self, g, current=None):
         return Ice.Future.completed(g)

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -136,12 +136,6 @@ class InitialI(Test.Initial):
     def opClassAndUnknownOptional(self, p, current=None):
         return Ice.Future.completed(None)
 
-    def sendOptionalStruct(self, req, ofs, current=None):
-        return Ice.Future.completed(None)
-
-    def returnOptionalStruct(self, req, current=None):
-        return Ice.Future.completed(Test.FixedStruct(53))
-
     def opG(self, g, current=None):
         return Ice.Future.completed(g)
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -157,20 +157,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -267,9 +267,9 @@ interface Initial
     void opOptionalAfterRequired(int p1, optional(1) int p2, optional(2) int p3, out int p4, out optional(3) int p5,
                                  out optional(4) int p6);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -267,10 +267,6 @@ interface Initial
     void opOptionalAfterRequired(int p1, optional(1) int p2, optional(2) int p3, out int p4, out optional(3) int p5,
                                  out optional(4) int p6);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -291,17 +291,6 @@ def allTests(helper, communicator)
 
     test(mo9.bos == Ice::Unset)
 
-    #
-    # Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-    #
-    initial.sendOptionalStruct(true, Test::FixedStruct.new(53))
-    initial.ice_encodingVersion(Ice::Encoding_1_0).sendOptionalStruct(true, Test::FixedStruct.new(53))
-
-    r = initial.returnOptionalStruct(true)
-    test(r != Ice::Unset)
-    r = initial.ice_encodingVersion(Ice::Encoding_1_0).returnOptionalStruct(true)
-    test(r == Ice::Unset)
-
     g = Test::G.new
     g.gg1Opt = Test::G1.new("gg1Opt")
     g.gg2 = Test::G2.new(10)

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -292,14 +292,14 @@ def allTests(helper, communicator)
     test(mo9.bos == Ice::Unset)
 
     #
-    # Use the 1.0 encoding with operations whose only class parameters are optional.
+    # Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
     #
-    initial.sendOptionalClass(true, Test::OneOptional.new(53))
-    initial.ice_encodingVersion(Ice::Encoding_1_0).sendOptionalClass(true, Test::OneOptional.new(53))
+    initial.sendOptionalStruct(true, Test::FixedStruct.new(53))
+    initial.ice_encodingVersion(Ice::Encoding_1_0).sendOptionalStruct(true, Test::FixedStruct.new(53))
 
-    r = initial.returnOptionalClass(true)
+    r = initial.returnOptionalStruct(true)
     test(r != Ice::Unset)
-    r = initial.ice_encodingVersion(Ice::Encoding_1_0).returnOptionalClass(true)
+    r = initial.ice_encodingVersion(Ice::Encoding_1_0).returnOptionalStruct(true)
     test(r == Ice::Unset)
 
     g = Test::G.new
@@ -372,16 +372,16 @@ def allTests(helper, communicator)
 
     puts "ok"
 
-    print "testing marshaling of objects with optional objects..."
+    print "testing marshaling of objects with optional members..."
     STDOUT.flush
 
     f = Test::F.new
 
-    f.af = Test::A.new
-    f.ae = f.af
+    f.fsf = Test::FixedStruct.new
+    f.fse = f.fsf
 
     rf = initial.pingPong(f)
-    test(rf.ae == rf.af)
+    test(rf.fse == rf.fsf)
 
     puts "ok"
 

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -157,20 +157,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -263,9 +263,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -263,10 +263,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -546,20 +546,7 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   }
   factory.setEnabled(enabled: false)
 
-  //
-  // Test that optional parameters are handled correctly (ignored) with the 1.0 encoding.
-  //
   do {
-    var ofs: FixedStruct? = FixedStruct(m: 53)
-    try initial.sendOptionalStruct(req: true, ofs: ofs)
-    let initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0)
-    try initial2.sendOptionalStruct(req: true, ofs: ofs)
-
-    ofs = try initial.returnOptionalStruct(true)
-    try test(ofs != nil && ofs!.m == 53)
-    ofs = try initial2.returnOptionalStruct(true)
-    try test(ofs == nil)
-
     var g: G! = G()
     g.gg1Opt = G1(a: "gg1Opt")
     g.gg2 = G2(a: 10)

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -133,7 +133,7 @@ class FValueReader: Ice.Value {
     // in.read(1, _f.fsf);
     try istr.endSlice()
     _ = try istr.startSlice()
-    self._f.fsa = try istr.read()
+    self._f.fse = try istr.read()
     try istr.endSlice()
     _ = try istr.endValue()
   }
@@ -551,9 +551,9 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   //
   do {
     var ofs: FixedStruct? = FixedStruct(m: 53)
-    try initial.sendOptionalStruct(req: true, o: ofs)
+    try initial.sendOptionalStruct(req: true, ofs)
     let initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0)
-    try initial2.sendOptionalStruct(req: true, o: ofs)
+    try initial2.sendOptionalStruct(req: true, ofs)
 
     ofs = try initial.returnOptionalStruct(true)
     try test(ofs != nil && ofs!.m == 53)
@@ -567,9 +567,9 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     g.gg1 = G1(a: "gg1")
     g = try initial.opG(g)
     try test(g.gg1Opt!.a == "gg1Opt")
-    try test(g.gg2!.a == 10)
+    try test(g.gg2.a == 10)
     try test(g.gg2Opt!.a == 20)
-    try test(g.gg1!.a == "gg1")
+    try test(g.gg1.a == "gg1")
 
     try initial.opVoid()
 
@@ -665,7 +665,7 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     let f = F()
 
     f.fsf = FixedStruct()
-    f.fse = f.fsf
+    f.fse = f.fsf!
 
     var rf = try initial.pingPong(f) as! F
     try test(rf.fse == rf.fsf)
@@ -683,7 +683,7 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try istr.endEncapsulation()
     factory.setEnabled(enabled: false)
     rf = (v as! FValueReader).getF()!
-    try test(rf.fse != nil && rf.fsf == nil)
+    try test(rf.fse.m == 0 && rf.fsf == nil)
   }
   output.writeLine("ok")
 
@@ -3082,7 +3082,7 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     let f = F()
     f.fsf = FixedStruct()
     f.fsf!.m = 56
-    f.fse = f.fsf
+    f.fse = f.fsf!
 
     ostr = Ice.OutputStream(communicator: communicator)
     ostr.startEncapsulation()
@@ -3093,9 +3093,9 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
 
     istr = Ice.InputStream(communicator: communicator, bytes: inEncaps)
     _ = try istr.startEncapsulation()
-    let fs1: FixedStruct? = try istr.ead(tag: 2);
+    let fs1: FixedStruct? = try istr.read(tag: 2)
     try istr.endEncapsulation()
-    try test(fs1 != nil && (fs1 as! FixedStruct).m == 56)
+    try test(fs1 != nil && fs1!.m == 56)
   }
 
   do {

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -551,9 +551,9 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   //
   do {
     var ofs: FixedStruct? = FixedStruct(m: 53)
-    try initial.sendOptionalStruct(req: true, ofs)
+    try initial.sendOptionalStruct(req: true, ofs: ofs)
     let initial2 = initial.ice_encodingVersion(Ice.Encoding_1_0)
-    try initial2.sendOptionalStruct(req: true, ofs)
+    try initial2.sendOptionalStruct(req: true, ofs: ofs)
 
     ofs = try initial.returnOptionalStruct(true)
     try test(ofs != nil && ofs!.m == 53)

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -270,10 +270,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -161,20 +161,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -270,9 +270,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -266,10 +266,6 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
-
-    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
-
     G opG(G g);
 
     void opVoid();

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -159,20 +159,20 @@ class OptionalWithCustom
 
 class E
 {
-    A ae;
+    FixedStruct fse;
 }
 
 class F extends E
 {
-    optional(1) A af;
+    optional(1) FixedStruct fsf;
 }
 
-class G1
+struct G1
 {
     string a;
 }
 
-class G2
+struct G2
 {
     long a;
 }
@@ -266,9 +266,9 @@ interface Initial
 
     void opClassAndUnknownOptional(A p);
 
-    void sendOptionalClass(bool req, optional(1) OneOptional o);
+    void sendOptionalStruct(bool req, optional(1) FixedStruct ofs);
 
-    void returnOptionalClass(bool req, out optional(1) OneOptional o);
+    void returnOptionalStruct(bool req, out optional(1) FixedStruct ofs);
 
     G opG(G g);
 

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -250,12 +250,12 @@ class InitialI: Initial {
     return Promise.value(())
   }
 
-  func sendOptionalClassAsync(req _: Bool, o _: OneOptional?, current _: Current) -> Promise<Void> {
+  func sendOptionalStructAsync(req _: Bool, ofs _: FixedStruct?, current _: Current) -> Promise<Void> {
     return Promise.value(())
   }
 
-  func returnOptionalClassAsync(req _: Bool, current _: Current) -> Promise<OneOptional?> {
-    return Promise.value(OneOptional(a: 53))
+  func returnOptionalStructAsync(req _: Bool, current _: Current) -> Promise<FixedStruct?> {
+    return Promise.value(FixedStruct(m: 53))
   }
 
   func opGAsync(g: G?, current _: Current) -> Promise<G?> {

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -250,18 +250,6 @@ class InitialI: Initial {
     return Promise.value(())
   }
 
-  func sendOptionalStructAsync(
-    req _: Bool,
-    ofs _: FixedStruct?,
-    current _: Current
-  ) -> Promise<Void> {
-    return Promise.value(())
-  }
-
-  func returnOptionalStructAsync(req _: Bool, current _: Current) -> Promise<FixedStruct?> {
-    return Promise.value(FixedStruct(m: 53))
-  }
-
   func opGAsync(g: G?, current _: Current) -> Promise<G?> {
     return Promise.value(g)
   }

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -250,7 +250,11 @@ class InitialI: Initial {
     return Promise.value(())
   }
 
-  func sendOptionalStructAsync(req _: Bool, ofs _: FixedStruct?, current _: Current) -> Promise<Void> {
+  func sendOptionalStructAsync(
+    req _: Bool,
+    ofs _: FixedStruct?,
+    current _: Current
+  ) -> Promise<Void> {
     return Promise.value(())
   }
 

--- a/swift/test/Ice/optional/TestI.swift
+++ b/swift/test/Ice/optional/TestI.swift
@@ -250,12 +250,6 @@ class InitialI: Initial {
 
   func opClassAndUnknownOptional(p _: A?, current _: Ice.Current) throws {}
 
-  func sendOptionalStruct(req _: Bool, ofs _: FixedStruct?, current _: Ice.Current) throws {}
-
-  func returnOptionalStruct(req _: Bool, current _: Ice.Current) throws -> FixedStruct? {
-    return FixedStruct(m: 53)
-  }
-
   func opG(g: G?, current _: Ice.Current) throws -> G? {
     return g
   }

--- a/swift/test/Ice/optional/TestI.swift
+++ b/swift/test/Ice/optional/TestI.swift
@@ -250,10 +250,10 @@ class InitialI: Initial {
 
   func opClassAndUnknownOptional(p _: A?, current _: Ice.Current) throws {}
 
-  func sendOptionalClass(req _: Bool, o _: OneOptional?, current _: Ice.Current) throws {}
+  func sendOptionalStruct(req _: Bool, ofs _: FixedStruct?, current _: Ice.Current) throws {}
 
-  func returnOptionalClass(req _: Bool, current _: Ice.Current) throws -> OneOptional? {
-    return OneOptional(a: 53)
+  func returnOptionalStruct(req _: Bool, current _: Ice.Current) throws -> FixedStruct? {
+    return FixedStruct(m: 53)
   }
 
   func opG(g: G?, current _: Ice.Current) throws -> G? {


### PR DESCRIPTION
This PR switches some of our testing of optionals to use optional structs, instead of optional classes.

I'd recommend checking the changes made to `Test.ice` before trying to review the rest of the code, to get an idea of what actually changed.

I'm marking everyone as a reviewer, since this changes lots of language mappings.
Feel free to only review the languages you're familiar with.