### PR TITLE
Simplify Slice-to-C# mapping for fields

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -2245,7 +2245,7 @@ Slice::CsGenerator::MetaDataVisitor::validate(const ContainedPtr& cont)
                     continue;
                 }
             }
-            else if (dynamic_pointer_cast<ClassDef>(cont))
+            else if (dynamic_pointer_cast<ClassDef>(cont) || dynamic_pointer_cast<Exception>(cont))
             {
                 if (s.substr(csPrefix.size()) == "property")
                 {

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -263,10 +263,6 @@ struct StructProperty
     double zeroDotD = 0;
 }
 
-//
-// Exceptions don't support "cs:property" metadata, but
-// we want to ensure that the generated code compiles.
-//
 ["cs:property"]
 exception ExceptionProperty
 {


### PR DESCRIPTION
This PR simplifies the mapping for Slice fields to C#:

- fields in generated structs are no longer private when the struct is marked "protected"
 (I think marking a Slice struct (Slice struct field) protected is nonsensical and should be removed in general)
- generated property fields are no longer virtual
- exceptions can be marked "cs:property" like structs and classes
