### PR TITLE
Proxy cleanup in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3247,8 +3247,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             _out << nl << "[global::System.Obsolete(\"" << deprecateReason << "\")]";
         }
         _out << nl << retS << " " << name << spar << getParams(p, ns)
-             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
-             << epar << ';';
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null") << epar << ';';
     }
 
     {
@@ -3274,9 +3273,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         _out << " " << p->name() << "Async" << spar << inParams
              << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << ("global::System.IProgress<bool> " + progress + " = null")
-             << ("global::System.Threading.CancellationToken " + cancel +
-                 " = default")
-             << epar << ";";
+             << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar << ";";
     }
 }
 
@@ -3450,8 +3447,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         _out << sp;
         _out << nl << "public " << retS << " " << opName << spar << params
-             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
-             << epar;
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null") << epar;
         _out << sb;
         _out << nl << "try";
         _out << sb;
@@ -3562,9 +3558,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << " " << opName << "Async" << spar << paramsAMI
              << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << ("global::System.IProgress<bool> " + progress + " = null")
-             << ("global::System.Threading.CancellationToken " + cancel +
-                 " = default")
-             << epar;
+             << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar;
 
         _out << sb;
         _out << nl << "return _iceI_" << opName << "Async" << spar << argsAMI << context << progress << cancel
@@ -3581,8 +3575,9 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << "<" << returnTypeS << ">";
         }
         _out << " _iceI_" << opName << "Async" << spar << getInParams(op, ns, true)
-             << "global::System.Collections.Generic.Dictionary<string, string> context" << "global::System.IProgress<bool> progress"
-             << "global::System.Threading.CancellationToken cancel" << "bool synchronous" << epar;
+             << "global::System.Collections.Generic.Dictionary<string, string> context"
+             << "global::System.IProgress<bool> progress" << "global::System.Threading.CancellationToken cancel"
+             << "bool synchronous" << epar;
         _out << sb;
 
         string flatName = "_" + opName + "_name";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3254,8 +3254,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             _out << nl << "[global::System.Obsolete(\"" << deprecateReason << "\")]";
         }
         _out << nl << retS << " " << name << spar << getParams(p, ns)
-             << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
-                 getUnqualified("Ice.OptionalContext", ns) + "()")
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << epar << ';';
     }
 
@@ -3280,11 +3279,10 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         }
         _out << nl << taskResultType(p, ns);
         _out << " " << p->name() << "Async" << spar << inParams
-             << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
-                 getUnqualified("Ice.OptionalContext", ns) + "()")
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << ("global::System.IProgress<bool> " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel +
-                 " = new global::System.Threading.CancellationToken()")
+                 " = default")
              << epar << ";";
     }
 }
@@ -3511,8 +3509,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         _out << sp;
         _out << nl << "public " << retS << " " << opName << spar << params
-             << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
-                 getUnqualified("Ice.OptionalContext", ns) + "()")
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << epar;
         _out << sb;
         _out << nl << "try";
@@ -3622,11 +3619,10 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << "<" << returnTypeS << ">";
         }
         _out << " " << opName << "Async" << spar << paramsAMI
-             << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
-                 getUnqualified("Ice.OptionalContext", ns) + "()")
+             << ("global::System.Collections.Generic.Dictionary<string, string> " + context + " = null")
              << ("global::System.IProgress<bool> " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel +
-                 " = new global::System.Threading.CancellationToken()")
+                 " = default")
              << epar;
 
         _out << sb;
@@ -3644,7 +3640,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << "<" << returnTypeS << ">";
         }
         _out << " _iceI_" << opName << "Async" << spar << getInParams(op, ns, true)
-             << getUnqualified("Ice.OptionalContext", ns) + " context" << "global::System.IProgress<bool> progress"
+             << "global::System.Collections.Generic.Dictionary<string, string> context" << "global::System.IProgress<bool> progress"
              << "global::System.Threading.CancellationToken cancel" << "bool synchronous" << epar;
         _out << sb;
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3754,31 +3754,26 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "public static " << name << "Prx uncheckedCast(" << getUnqualified("Ice.ObjectPrx", ns)
          << " b)";
     _out << sb;
-    _out << nl << "if(b == null)";
+    _out << nl << "if (b is not null)";
     _out << sb;
+    _out << nl << name << "PrxHelper prx = new " << name << "PrxHelper();";
+    _out << nl << "prx.iceCopyFrom(b);";
+    _out << nl << "return prx;";
+    _out << eb;
     _out << nl << "return null;";
-    _out << eb;
-    _out << nl << name << "Prx r = b as " << name << "Prx;";
-    _out << nl << "if(r == null)";
-    _out << sb;
-    _out << nl << name << "PrxHelper h = new " << name << "PrxHelper();";
-    _out << nl << "h.iceCopyFrom(b);";
-    _out << nl << "r = h;";
-    _out << eb;
-    _out << nl << "return r;";
     _out << eb;
 
     _out << sp << nl << "public static " << name << "Prx uncheckedCast(" << getUnqualified("Ice.ObjectPrx", ns)
          << " b, string f)";
     _out << sb;
-    _out << nl << "if(b == null)";
+    _out << nl << "if (b is not null)";
     _out << sb;
-    _out << nl << "return null;";
-    _out << eb;
     _out << nl << getUnqualified("Ice.ObjectPrx", ns) << " bb = b.ice_facet(f);";
-    _out << nl << name << "PrxHelper h = new " << name << "PrxHelper();";
-    _out << nl << "h.iceCopyFrom(bb);";
-    _out << nl << "return h;";
+    _out << nl << name << "PrxHelper prx = new " << name << "PrxHelper();";
+    _out << nl << "prx.iceCopyFrom(bb);";
+    _out << nl << "return prx;";
+    _out << eb;
+    _out << nl << "return null;";
     _out << eb;
 
     string scoped = p->scoped();

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -167,18 +167,6 @@ namespace Slice
             void writeMemberEquals(const DataMemberList&);
         };
 
-        class AsyncDelegateVisitor : public CsVisitor
-        {
-        public:
-            AsyncDelegateVisitor(::IceUtilInternal::Output&);
-
-            virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
-            virtual bool visitClassDefStart(const ClassDefPtr&);
-            virtual void visitClassDefEnd(const ClassDefPtr&);
-            virtual void visitOperation(const OperationPtr&);
-        };
-
         class ResultVisitor : public CsVisitor
         {
         public:

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -2060,57 +2060,19 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
 {
     /// <summary>
     /// Casts a proxy to {@link ObjectPrx}. This call contacts
-    /// the server and will throw an Ice run-time exception if the target
-    /// object does not exist or the server cannot be reached.
-    /// </summary>
-    /// <param name="b">The proxy to cast to ObjectPrx.</param>
-    /// <returns>b.</returns>
-    public static ObjectPrx checkedCast(ObjectPrx b)
-    {
-        return b;
-    }
-
-    /// <summary>
-    /// Casts a proxy to {@link ObjectPrx}. This call contacts
     /// the server and throws an Ice run-time exception if the target
     /// object does not exist or the server cannot be reached.
     /// </summary>
     /// <param name="b">The proxy to cast to ObjectPrx.</param>
     /// <param name="ctx">The Context map for the invocation.</param>
     /// <returns>b.</returns>
-    public static ObjectPrx checkedCast(ObjectPrx b, Dictionary<string, string> ctx)
+    public static ObjectPrx checkedCast(ObjectPrx b, Dictionary<string, string> ctx = null)
     {
-        return b;
-    }
-
-    /// <summary>
-    /// Creates a new proxy that is identical to the passed proxy, except
-    /// for its facet. This call contacts
-    /// the server and throws an Ice run-time exception if the target
-    /// object does not exist, the specified facet does not exist, or the server cannot be reached.
-    /// </summary>
-    /// <param name="b">The proxy to cast to ObjectPrx.</param>
-    /// <param name="f">The facet for the new proxy.</param>
-    /// <returns>The new proxy with the specified facet.</returns>
-    public static ObjectPrx checkedCast(ObjectPrx b, string f)
-    {
-        ObjectPrx d = null;
-        if (b != null)
+        if (b is not null && b.ice_isA("::Ice::Object", ctx))
         {
-            try
-            {
-                var bb = b.ice_facet(f);
-                var ok = bb.ice_isA("::Ice::Object");
-                Debug.Assert(ok);
-                ObjectPrxHelper h = new ObjectPrxHelper();
-                h.iceCopyFrom(bb);
-                d = h;
-            }
-            catch (FacetNotExistException)
-            {
-            }
+            return b;
         }
-        return d;
+        return null;
     }
 
     /// <summary>
@@ -2123,25 +2085,20 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// <param name="f">The facet for the new proxy.</param>
     /// <param name="ctx">The Context map for the invocation.</param>
     /// <returns>The new proxy with the specified facet.</returns>
-    public static ObjectPrx checkedCast(ObjectPrx b, string f, Dictionary<string, string> ctx)
+    public static ObjectPrx checkedCast(ObjectPrx b, string f, Dictionary<string, string> ctx = null)
     {
-        ObjectPrx d = null;
-        if (b != null)
+        ObjectPrx bb = b?.ice_facet(f);
+        try
         {
-            try
+            if (bb is not null && bb.ice_isA("::Ice::Object", ctx))
             {
-                var bb = b.ice_facet(f);
-                var ok = bb.ice_isA("::Ice::Object", ctx);
-                Debug.Assert(ok);
-                ObjectPrxHelper h = new ObjectPrxHelper();
-                h.iceCopyFrom(bb);
-                d = h;
-            }
-            catch (FacetNotExistException)
-            {
+                return bb;
             }
         }
-        return d;
+        catch (FacetNotExistException)
+        {
+        }
+        return null;
     }
 
     /// <summary>
@@ -2150,10 +2107,7 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// </summary>
     /// <param name="b">The proxy to cast to ObjectPrx.</param>
     /// <returns>b.</returns>
-    public static ObjectPrx uncheckedCast(ObjectPrx b)
-    {
-        return b;
-    }
+    public static ObjectPrx uncheckedCast(ObjectPrx b) => b;
 
     /// <summary>
     /// Creates a new proxy that is identical to the passed proxy, except
@@ -2162,18 +2116,7 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// <param name="b">The proxy to cast to ObjectPrx.</param>
     /// <param name="f">The facet for the new proxy.</param>
     /// <returns>The new proxy with the specified facet.</returns>
-    public static ObjectPrx uncheckedCast(ObjectPrx b, string f)
-    {
-        ObjectPrx d = null;
-        if (b != null)
-        {
-            var bb = b.ice_facet(f);
-            var h = new ObjectPrxHelper();
-            h.iceCopyFrom(bb);
-            d = h;
-        }
-        return d;
-    }
+    public static ObjectPrx uncheckedCast(ObjectPrx b, string f) => b?.ice_facet(f);
 
     /// <summary>
     /// Returns the Slice type id of the interface or class associated

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -8,43 +8,6 @@ using System.Diagnostics;
 namespace Ice;
 
 /// <summary>
-/// Value type to allow differentiate between a context that is explicitly set to
-/// empty (empty or null dictionary) and a context that has non been set.
-/// </summary>
-public struct OptionalContext
-{
-    private OptionalContext(Dictionary<string, string> ctx)
-    {
-        _ctx = ctx == null ? _emptyContext : ctx;
-    }
-
-    /// <summary>
-    /// Implicit conversion between Dictionary&lt;string, string&gt; and
-    /// OptionalContext.
-    /// </summary>
-    /// <param name="ctx">Dictionary to convert.</param>
-    /// <returns>OptionalContext value representing the dictionary</returns>
-    public static implicit operator OptionalContext(Dictionary<string, string> ctx)
-    {
-        return new OptionalContext(ctx);
-    }
-
-    /// <summary>
-    /// Implicit conversion between OptionalContext and
-    /// Dictionary&lt;string, string&gt;
-    /// </summary>
-    /// <param name="value">OptionalContext value to convert</param>
-    /// <returns>The Dictionary object.</returns>
-    public static implicit operator Dictionary<string, string>(OptionalContext value)
-    {
-        return value._ctx;
-    }
-
-    private Dictionary<string, string> _ctx;
-    static private Dictionary<string, string> _emptyContext = new Dictionary<string, string>();
-}
-
-/// <summary>
 /// Base interface of all object proxies.
 /// </summary>
 public interface ObjectPrx : IEquatable<ObjectPrx>
@@ -62,7 +25,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="context">The context dictionary for the invocation.</param>
     /// <returns>True if the target object has the interface specified by id or derives
     /// from the interface specified by id.</returns>
-    bool ice_isA(string id, OptionalContext context = new OptionalContext());
+    bool ice_isA(string id, Dictionary<string, string> context = null);
 
     /// <summary>
     /// Tests whether this object supports a specific Slice interface.
@@ -73,15 +36,15 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     Task<bool> ice_isAAsync(string id,
-                            OptionalContext context = new OptionalContext(),
+                            Dictionary<string, string> context = null,
                             IProgress<bool> progress = null,
-                            CancellationToken cancel = new CancellationToken());
+                            CancellationToken cancel = default);
 
     /// <summary>
     /// Tests whether the target object of this proxy can be reached.
     /// </summary>
     /// <param name="context">The context dictionary for the invocation.</param>
-    void ice_ping(OptionalContext context = new OptionalContext());
+    void ice_ping(Dictionary<string, string> context = null);
 
     /// <summary>
     /// Tests whether the target object of this proxy can be reached.
@@ -90,9 +53,9 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task ice_pingAsync(OptionalContext context = new OptionalContext(),
+    Task ice_pingAsync(Dictionary<string, string> context = null,
                        IProgress<bool> progress = null,
-                       CancellationToken cancel = new CancellationToken());
+                       CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
@@ -100,7 +63,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="context">The context dictionary for the invocation.</param>
     /// <returns>The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
     /// </returns>
-    string[] ice_ids(OptionalContext context = new OptionalContext());
+    string[] ice_ids(Dictionary<string, string> context = null);
 
     /// <summary>
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
@@ -109,16 +72,16 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<string[]> ice_idsAsync(OptionalContext context = new OptionalContext(),
+    Task<string[]> ice_idsAsync(Dictionary<string, string> context = null,
                                 IProgress<bool> progress = null,
-                                CancellationToken cancel = new CancellationToken());
+                                CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
     /// </summary>
     /// <param name="context">The context dictionary for the invocation.</param>
     /// <returns>The Slice type ID of the most-derived interface.</returns>
-    string ice_id(OptionalContext context = new OptionalContext());
+    string ice_id(Dictionary<string, string> context = null);
 
     /// <summary>
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
@@ -127,9 +90,9 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<string> ice_idAsync(OptionalContext context = new OptionalContext(),
+    Task<string> ice_idAsync(Dictionary<string, string> context = null,
                              IProgress<bool> progress = null,
-                             CancellationToken cancel = new CancellationToken());
+                             CancellationToken cancel = default);
 
     /// <summary>
     /// Invokes an operation dynamically.
@@ -146,7 +109,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// contains the encoded user exception. If the operation raises a run-time exception,
     /// it throws it directly.</returns>
     bool ice_invoke(string operation, OperationMode mode, byte[] inEncaps, out byte[] outEncaps,
-                    OptionalContext context = new OptionalContext());
+                    Dictionary<string, string> context = null);
 
     /// <summary>
     /// Invokes an operation dynamically.
@@ -162,9 +125,9 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     ice_invokeAsync(string operation,
                     OperationMode mode,
                     byte[] inEncaps,
-                    OptionalContext context = new OptionalContext(),
+                    Dictionary<string, string> context = null,
                     IProgress<bool> progress = null,
-                    CancellationToken cancel = new CancellationToken());
+                    CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the identity embedded in this proxy.
@@ -498,7 +461,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     Task<Connection> ice_getConnectionAsync(IProgress<bool> progress = null,
-                                            CancellationToken cancel = new CancellationToken());
+                                            CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the cached Connection for this proxy. If the proxy does not yet have an established
@@ -520,7 +483,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     Task ice_flushBatchRequestsAsync(IProgress<bool> progress = null,
-                                     CancellationToken cancel = new CancellationToken());
+                                     CancellationToken cancel = default);
 
     /// <summary>
     /// Write a proxy to the output stream.
@@ -622,7 +585,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="context">The context dictionary for the invocation.</param>
     /// <returns>True if the target object has the interface specified by id or derives
     /// from the interface specified by id.</returns>
-    public bool ice_isA(string id, OptionalContext context = new OptionalContext())
+    public bool ice_isA(string id, Dictionary<string, string> context = null)
     {
         try
         {
@@ -643,15 +606,15 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     public Task<bool> ice_isAAsync(string id,
-                                   OptionalContext context = new OptionalContext(),
+                                   Dictionary<string, string> context = null,
                                    IProgress<bool> progress = null,
-                                   CancellationToken cancel = new CancellationToken())
+                                   CancellationToken cancel = default)
     {
         return iceI_ice_isAAsync(id, context, progress, cancel, false);
     }
 
     private Task<bool>
-    iceI_ice_isAAsync(string id, OptionalContext context, IProgress<bool> progress, CancellationToken cancel,
+    iceI_ice_isAAsync(string id, Dictionary<string, string> context, IProgress<bool> progress, CancellationToken cancel,
                       bool synchronous)
     {
         iceCheckTwowayOnly(_ice_isA_name);
@@ -682,7 +645,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// Tests whether the target object of this proxy can be reached.
     /// </summary>
     /// <param name="context">The context dictionary for the invocation.</param>
-    public void ice_ping(OptionalContext context = new OptionalContext())
+    public void ice_ping(Dictionary<string, string> context = null)
     {
         try
         {
@@ -701,15 +664,15 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    public Task ice_pingAsync(OptionalContext context = new OptionalContext(),
+    public Task ice_pingAsync(Dictionary<string, string> context = null,
                               IProgress<bool> progress = null,
-                              CancellationToken cancel = new CancellationToken())
+                              CancellationToken cancel = default)
     {
         return iceI_ice_pingAsync(context, progress, cancel, false);
     }
 
     private Task
-    iceI_ice_pingAsync(OptionalContext context, IProgress<bool> progress, CancellationToken cancel, bool synchronous)
+    iceI_ice_pingAsync(Dictionary<string, string> context, IProgress<bool> progress, CancellationToken cancel, bool synchronous)
     {
         var completed = new OperationTaskCompletionCallback<object>(progress, cancel);
         iceI_ice_ping(context, completed, synchronous);
@@ -734,7 +697,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="context">The context dictionary for the invocation.</param>
     /// <returns>The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
     /// </returns>
-    public string[] ice_ids(OptionalContext context = new OptionalContext())
+    public string[] ice_ids(Dictionary<string, string> context = null)
     {
         try
         {
@@ -754,14 +717,14 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     public Task<string[]>
-    ice_idsAsync(OptionalContext context = new OptionalContext(),
+    ice_idsAsync(Dictionary<string, string> context = null,
                  IProgress<bool> progress = null,
-                 CancellationToken cancel = new CancellationToken())
+                 CancellationToken cancel = default)
     {
         return iceI_ice_idsAsync(context, progress, cancel, false);
     }
 
-    private Task<string[]> iceI_ice_idsAsync(OptionalContext context, IProgress<bool> progress, CancellationToken cancel,
+    private Task<string[]> iceI_ice_idsAsync(Dictionary<string, string> context, IProgress<bool> progress, CancellationToken cancel,
                                              bool synchronous)
     {
         iceCheckTwowayOnly(_ice_ids_name);
@@ -788,7 +751,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
     /// </summary>
     /// <returns>The Slice type ID of the most-derived interface.</returns>
-    public string ice_id(OptionalContext context = new OptionalContext())
+    public string ice_id(Dictionary<string, string> context = null)
     {
         try
         {
@@ -807,15 +770,15 @@ public class ObjectPrxHelperBase : ObjectPrx
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    public Task<string> ice_idAsync(OptionalContext context = new OptionalContext(),
+    public Task<string> ice_idAsync(Dictionary<string, string> context = null,
                                     IProgress<bool> progress = null,
-                                    CancellationToken cancel = new CancellationToken())
+                                    CancellationToken cancel = default)
     {
         return iceI_ice_idAsync(context, progress, cancel, false);
     }
 
     private Task<string>
-    iceI_ice_idAsync(OptionalContext context, IProgress<bool> progress, CancellationToken cancel, bool synchronous)
+    iceI_ice_idAsync(Dictionary<string, string> context, IProgress<bool> progress, CancellationToken cancel, bool synchronous)
     {
         iceCheckTwowayOnly(_ice_id_name);
         var completed = new OperationTaskCompletionCallback<string>(progress, cancel);
@@ -855,7 +818,7 @@ public class ObjectPrxHelperBase : ObjectPrx
                            OperationMode mode,
                            byte[] inEncaps,
                            out byte[] outEncaps,
-                           OptionalContext context = new OptionalContext())
+                           Dictionary<string, string> context = null)
     {
         try
         {
@@ -883,9 +846,9 @@ public class ObjectPrxHelperBase : ObjectPrx
     ice_invokeAsync(string operation,
                     OperationMode mode,
                     byte[] inEncaps,
-                    OptionalContext context = new OptionalContext(),
+                    Dictionary<string, string> context = null,
                     IProgress<bool> progress = null,
-                    CancellationToken cancel = new CancellationToken())
+                    CancellationToken cancel = default)
     {
         return iceI_ice_invokeAsync(operation, mode, inEncaps, context, progress, cancel, false);
     }
@@ -894,7 +857,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     iceI_ice_invokeAsync(string operation,
                          OperationMode mode,
                          byte[] inEncaps,
-                         OptionalContext context,
+                         Dictionary<string, string> context,
                          IProgress<bool> progress,
                          CancellationToken cancel,
                          bool synchronous)
@@ -1592,7 +1555,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     {
         public GetConnectionTaskCompletionCallback(ObjectPrx proxy,
                                                    IProgress<bool> progress = null,
-                                                   CancellationToken cancellationToken = new CancellationToken()) :
+                                                   CancellationToken cancellationToken = default) :
             base(progress, cancellationToken)
         {
             _proxy = proxy;
@@ -1626,7 +1589,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     }
 
     public Task<Connection> ice_getConnectionAsync(IProgress<bool> progress = null,
-                                                   CancellationToken cancel = new CancellationToken())
+                                                   CancellationToken cancel = default)
     {
         var completed = new GetConnectionTaskCompletionCallback(this, progress, cancel);
         iceI_ice_getConnection(completed, false);
@@ -1695,7 +1658,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     internal const string _ice_flushBatchRequests_name = "ice_flushBatchRequests";
 
     public Task ice_flushBatchRequestsAsync(IProgress<bool> progress = null,
-                                            CancellationToken cancel = new CancellationToken())
+                                            CancellationToken cancel = default)
     {
         var completed = new FlushBatchTaskCompletionCallback(progress, cancel);
         iceI_ice_flushBatchRequests(completed, false);


### PR DESCRIPTION
This is a preliminary cleanups of C# proxies. In particular, this PR simplifies checkedCast / uncheckedCast and removes the OptionalContext.

Fixes #199 in C#.