### PR TITLE
Nonmutating removal

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4648,12 +4648,14 @@ Slice::Operation::mode() const
     return _mode;
 }
 
+// TODO REMOVE this function
 Operation::Mode
 Slice::Operation::sendMode() const
 {
     if (_mode == Operation::Idempotent && hasMetaData("nonmutating"))
     {
-        return Operation::Nonmutating;
+        // return Operation::Nonmutating;
+        return _mode;
     }
     else
     {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4648,21 +4648,6 @@ Slice::Operation::mode() const
     return _mode;
 }
 
-// TODO REMOVE this function
-Operation::Mode
-Slice::Operation::sendMode() const
-{
-    if (_mode == Operation::Idempotent && hasMetaData("nonmutating"))
-    {
-        // return Operation::Nonmutating;
-        return _mode;
-    }
-    else
-    {
-        return _mode;
-    }
-}
-
 bool
 Slice::Operation::hasMarshaledResult() const
 {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -654,14 +654,13 @@ namespace Slice
     {
     public:
         //
-        // Note: The order of definitions here *must* match the order of
-        // definitions of Ice::OperationMode in slice/Ice/OperationMode.ice!
+        // Note: The values of enumerators here *must* match the values for
+        // enumerators of Ice::OperationMode in slice/Ice/OperationMode.ice!
         //
         enum Mode
         {
-            Normal,
-            Nonmutating,
-            Idempotent
+            Normal = 0,
+            Idempotent = 2
         };
 
         Operation(const ContainerPtr&, const std::string&, const TypePtr&, bool, int, Mode);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -669,7 +669,6 @@ namespace Slice
         bool returnIsOptional() const;
         int returnTag() const;
         Mode mode() const;
-        Mode sendMode() const;
         bool hasMarshaledResult() const;
         ParamDeclPtr createParamDecl(const std::string&, const TypePtr&, bool, bool, int);
         ParamDeclList parameters() const;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -480,7 +480,7 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             out << nl << "[cs::encodedReturn]";
         }
         out << nl;
-        if (op->mode() == Operation::Idempotent || op->mode() == Operation::Nonmutating)
+        if (op->mode() == Operation::Idempotent)
         {
             out << "idempotent ";
         }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -589,11 +589,6 @@ Slice::operationModeToString(Operation::Mode mode)
             return "::Ice::OperationMode::Normal";
         }
 
-        case Operation::Nonmutating:
-        {
-            return "::Ice::OperationMode::Nonmutating";
-        }
-
         case Operation::Idempotent:
         {
             return "::Ice::OperationMode::Idempotent";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1930,7 +1930,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         C << nl << "_checkTwowayOnly(operationName);";
     }
     C << nl << "outAsync->invoke(operationName, ";
-    C << getUnqualified(operationModeToString(p->sendMode()), interfaceScope) << ", "
+    C << getUnqualified(operationModeToString(p->mode()), interfaceScope) << ", "
       << getUnqualified(opFormatTypeToString(p), interfaceScope) << ", context,";
     C.inc();
     C << nl;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -3094,7 +3094,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << eb;
     }
 
-    string isConst = ((p->mode() == Operation::Nonmutating) || p->hasMetaData("cpp:const")) ? " const" : "";
+    string isConst = p->hasMetaData("cpp:const") ? " const" : "";
 
     string opName = amd ? (name + "Async") : fixKwd(name);
     string deprecateSymbol = getDeprecateSymbol(p, interface);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3688,7 +3688,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << nl << "outAsync.invoke(";
         _out.inc();
         _out << nl << flatName << ",";
-        _out << nl << sliceModeToIceMode(op->sendMode(), ns) << ",";
+        _out << nl << sliceModeToIceMode(op->mode(), ns) << ",";
         _out << nl << opFormatTypeToString(op, ns) << ",";
         _out << nl << "context,";
         _out << nl << "synchronous";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -39,11 +39,6 @@ namespace
                 mode = CsGenerator::getUnqualified("Ice.OperationMode.Normal", ns);
                 break;
             }
-            case Operation::Nonmutating:
-            {
-                mode = CsGenerator::getUnqualified("Ice.OperationMode.Nonmutating", ns);
-                break;
-            }
             case Operation::Idempotent:
             {
                 mode = CsGenerator::getUnqualified("Ice.OperationMode.Idempotent", ns);

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -26,9 +26,6 @@ namespace
             case Operation::Normal:
                 mode = "null"; // shorthand for most common case
                 break;
-            case Operation::Nonmutating:
-                mode += "Nonmutating";
-                break;
             case Operation::Idempotent:
                 mode += "Idempotent";
                 break;

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -5107,7 +5107,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         << getParamsProxy(p, package, false, true) << "java.util.Map<String, String> context" << "boolean sync" << epar;
     out << sb;
     out << nl << futureImpl << " f = new " << getUnqualified("com.zeroc.IceInternal.OutgoingAsync", package)
-        << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->sendMode()) << ", sync, "
+        << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->mode()) << ", sync, "
         << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
 
     out << nl << "f.invoke(";
@@ -5197,7 +5197,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             << epar;
         out << sb;
         out << nl << futureImpl << " f = new " << getUnqualified("com.zeroc.IceInternal.OutgoingAsync", package)
-            << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->sendMode()) << ", sync, "
+            << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->mode()) << ", sync, "
             << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
 
         out << nl << "f.invoke(";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -28,8 +28,6 @@ namespace
         {
             case Operation::Normal:
                 return "0";
-            case Operation::Nonmutating:
-                return "1";
             case Operation::Idempotent:
                 return "2";
             default:

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1550,15 +1550,13 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             //  0: servant method name in case of a keyword conflict (e.g., "_while"),
             //     otherwise an empty string
             //  1: mode (undefined == Normal or int)
-            //  2: sendMode (undefined == Normal or int)
-            //  3: amd (undefined or 1)
-            //  4: format (undefined == Default or int)
-            //  5: return type (undefined if void, or [type, tag])
-            //  6: in params (undefined if none, or array of [type, tag])
-            //  7: out params (undefined if none, or array of [type, tag])
-            //  8: exceptions (undefined if none, or array of types)
-            //  9: sends classes (true or undefined)
-            // 10: returns classes (true or undefined)
+            //  2: format (undefined == Default or int)
+            //  3: return type (undefined if void, or [type, tag])
+            //  4: in params (undefined if none, or array of [type, tag])
+            //  5: out params (undefined if none, or array of [type, tag])
+            //  6: exceptions (undefined if none, or array of types)
+            //  7: sends classes (true or undefined)
+            //  8: returns classes (true or undefined)
             //
             _out << nl << "\"" << op->name() << "\": ["; // Operation name over-the-wire.
 
@@ -1571,12 +1569,6 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             if (op->mode() != Operation::Normal)
             {
                 _out << sliceModeToIceMode(op->mode()); // Mode.
-            }
-            _out << ", ";
-
-            if (op->sendMode() != Operation::Normal)
-            {
-                _out << sliceModeToIceMode(op->sendMode()); // Send mode.
             }
             _out << ", ";
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2207,7 +2207,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             out << "is_ = ";
         }
-        out << self << ".iceInvoke('" << op->name() << "', " << getOperationMode(op->sendMode()) << ", "
+        out << self << ".iceInvoke('" << op->name() << "', " << getOperationMode(op->mode()) << ", "
             << (twowayOnly ? "true" : "false") << ", " << (allInParams.empty() ? "[]" : "os_") << ", "
             << (!allOutParams.empty() ? "true" : "false");
         if (exceptions.empty())
@@ -2472,7 +2472,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             out << nl << "end";
         }
 
-        out << nl << "r_ = " << self << ".iceInvokeAsync('" << op->name() << "', " << getOperationMode(op->sendMode())
+        out << nl << "r_ = " << self << ".iceInvokeAsync('" << op->name() << "', " << getOperationMode(op->mode())
             << ", " << (twowayOnly ? "true" : "false") << ", " << (allInParams.empty() ? "[]" : "os_") << ", "
             << allOutParams.size() << ", " << (twowayOnly && !allOutParams.empty() ? "@unmarshal" : "[]");
         if (exceptions.empty())

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -3718,8 +3718,6 @@ CodeVisitor::getOperationMode(Slice::Operation::Mode mode)
     {
         case Operation::Normal:
             return "0";
-        case Operation::Nonmutating:
-            return "1";
         case Operation::Idempotent:
             return "2";
         default:

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -423,7 +423,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // Define each operation. The arguments to IcePHP_defineOperation are:
     //
-    // $ClassType, 'opName', Mode, SendMode, FormatType, (InParams), (OutParams), ReturnParam, (Exceptions)
+    // $ClassType, 'opName', Mode, FormatType, (InParams), (OutParams), ReturnParam, (Exceptions)
     //
     // where InParams and OutParams are arrays of type descriptions, and Exceptions
     // is an array of exception type ids.
@@ -462,8 +462,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             int count;
 
             _out << nl << "IcePHP_defineOperation(" << prxType << ", '" << (*oli)->name() << "', "
-                 << getOperationMode((*oli)->mode()) << ", " << getOperationMode((*oli)->sendMode()) << ", "
-                 << static_cast<int>((*oli)->format()) << ", ";
+                 << getOperationMode((*oli)->mode()) << ", " << static_cast<int>((*oli)->format()) << ", ";
             for (t = params.begin(), count = 0; t != params.end(); ++t)
             {
                 if (!(*t)->isOutParam())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -907,7 +907,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Define each operation. The arguments to the IcePy.Operation constructor are:
     //
-    // 'opName', Mode, SendMode, AMD, Format, MetaData, (InParams), (OutParams), ReturnParam, (Exceptions)
+    // 'opName', Mode, AMD, Format, MetaData, (InParams), (OutParams), ReturnParam, (Exceptions)
     //
     // where InParams and OutParams are tuples of type descriptions, and Exceptions
     // is a tuple of exception type ids.
@@ -936,7 +936,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
 
         _out << nl << className << "._op_" << (*s)->name() << " = IcePy.Operation('" << (*s)->name() << "', "
-             << getOperationMode((*s)->mode()) << ", " << getOperationMode((*s)->sendMode()) << ", "
+             << getOperationMode((*s)->mode()) << ", "
              << ((p->hasMetaData("amd") || (*s)->hasMetaData("amd")) ? "True" : "False") << ", " << format << ", ";
         writeMetaData((*s)->getMetaData());
         _out << ", (";

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1939,9 +1939,6 @@ Slice::Python::CodeVisitor::getOperationMode(Slice::Operation::Mode mode)
         case Operation::Normal:
             result = "Ice.OperationMode.Normal";
             break;
-        case Operation::Nonmutating:
-            result = "Ice.OperationMode.Nonmutating";
-            break;
         case Operation::Idempotent:
             result = "Ice.OperationMode.Idempotent";
             break;

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -587,9 +587,6 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             case Operation::Normal:
                 _out << "::Ice::OperationMode::Normal";
                 break;
-            case Operation::Nonmutating:
-                _out << "::Ice::OperationMode::Nonmutating";
-                break;
             case Operation::Idempotent:
                 _out << "::Ice::OperationMode::Idempotent";
                 break;
@@ -599,9 +596,6 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             case Operation::Normal:
                 _out << "::Ice::OperationMode::Normal";
-                break;
-            case Operation::Nonmutating:
-                _out << "::Ice::OperationMode::Nonmutating";
                 break;
             case Operation::Idempotent:
                 _out << "::Ice::OperationMode::Idempotent";

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -591,16 +591,6 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << "::Ice::OperationMode::Idempotent";
                 break;
         }
-        _out << ", ";
-        switch ((*s)->sendMode())
-        {
-            case Operation::Normal:
-                _out << "::Ice::OperationMode::Normal";
-                break;
-            case Operation::Idempotent:
-                _out << "::Ice::OperationMode::Idempotent";
-                break;
-        }
         _out << ", " << ((p->hasMetaData("amd") || (*s)->hasMetaData("amd")) ? "true" : "false") << ", " << format
              << ", [";
         for (t = params.begin(), count = 0; t != params.end(); ++t)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2538,7 +2538,7 @@ SwiftGenerator::writeProxyOperation(::IceUtilInternal::Output& out, const Operat
 
     out.useCurrentPosAsIndent();
     out << "operation: \"" << op->name() << "\",";
-    out << nl << "mode: " << modeToString(op->sendMode()) << ",";
+    out << nl << "mode: " << modeToString(op->mode()) << ",";
 
     if (op->format() != DefaultFormat)
     {
@@ -2626,7 +2626,7 @@ SwiftGenerator::writeProxyAsyncOperation(::IceUtilInternal::Output& out, const O
 
     out.useCurrentPosAsIndent();
     out << "operation: \"" << op->name() << "\",";
-    out << nl << "mode: " << modeToString(op->sendMode()) << ",";
+    out << nl << "mode: " << modeToString(op->mode()) << ",";
 
     if (op->format() != DefaultFormat)
     {

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1289,11 +1289,6 @@ SwiftGenerator::modeToString(Operation::Mode opMode)
             mode = ".Normal";
             break;
         }
-        case Operation::Nonmutating:
-        {
-            mode = ".Nonmutating";
-            break;
-        }
         case Operation::Idempotent:
         {
             mode = ".Idempotent";

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -639,10 +639,10 @@ Slice.defineOperations = function(classType, proxyType, ids, id, ops)
 //
 Slice.defineOperations(Ice.Object, Ice.ObjectPrx, ["::Ice::Object"], "::Ice::Object",
 {
-    ice_ping: [undefined, 1, 1, undefined, undefined, undefined, undefined, undefined],
-    ice_isA: [undefined, 1, 1, undefined, [1], [[7]], undefined, undefined],
-    ice_id: [undefined, 1, 1, undefined, [7], undefined, undefined, undefined],
-    ice_ids: [undefined, 1, 1, undefined, ["Ice.StringSeqHelper"], undefined, undefined, undefined]
+    ice_ping: [undefined, 1, undefined, undefined, undefined, undefined, undefined],
+    ice_isA: [undefined, 1, undefined, [1], [[7]], undefined, undefined],
+    ice_id: [undefined, 1, undefined, [7], undefined, undefined, undefined],
+    ice_ids: [undefined, 1, undefined, ["Ice.StringSeqHelper"], undefined, undefined, undefined]
 });
 
 module.exports.Ice = Ice;

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -55,14 +55,13 @@ function parseParam(p)
 //  0: native method name in case of a keyword conflict (e.g., "_while"),
 //     otherwise an empty string
 //  1: mode (undefined == Normal or int)
-//  2: sendMode (undefined == Normal or int)
-//  3: format (undefined == Default or int)
-//  4: return type (undefined if void, or [type, tag])
-//  5: in params (undefined if none, or array of [type, tag])
-//  6: out params (undefined if none, or array of [type, tag])
-//  7: exceptions (undefined if none, or array of types)
-//  8: sends classes (true or undefined)
-//  9: returns classes (true or undefined)
+//  2: format (undefined == Default or int)
+//  3: return type (undefined if void, or [type, tag])
+//  4: in params (undefined if none, or array of [type, tag])
+//  5: out params (undefined if none, or array of [type, tag])
+//  6: exceptions (undefined if none, or array of types)
+//  7: sends classes (true or undefined)
+//  8: returns classes (true or undefined)
 //
 function parseOperation(name, arr)
 {
@@ -71,24 +70,23 @@ function parseOperation(name, arr)
     r.name = name;
     r.servantMethod = arr[0] ? arr[0] : name;
     r.mode = arr[1] ? Ice.OperationMode.valueOf(arr[1]) : Ice.OperationMode.Normal;
-    r.sendMode = arr[2] ? Ice.OperationMode.valueOf(arr[2]) : Ice.OperationMode.Normal;
-    r.format = arr[3] ? Ice.FormatType.valueOf(arr[3]) : Ice.FormatType.DefaultFormat;
+    r.format = arr[2] ? Ice.FormatType.valueOf(arr[2]) : Ice.FormatType.DefaultFormat;
 
     let ret;
-    if(arr[4])
+    if(arr[3])
     {
-        ret = parseParam(arr[4]);
+        ret = parseParam(arr[3]);
         ret.pos = 0;
     }
     r.returns = ret;
 
     const inParams = [];
     const inParamsOpt = [];
-    if(arr[5])
+    if(arr[4])
     {
-        for(let i = 0; i < arr[5].length; ++i)
+        for(let i = 0; i < arr[4].length; ++i)
         {
-            const p = parseParam(arr[5][i]);
+            const p = parseParam(arr[4][i]);
             p.pos = i;
             inParams.push(p);
             if(p.tag)
@@ -103,12 +101,12 @@ function parseOperation(name, arr)
 
     const outParams = [];
     const outParamsOpt = [];
-    if(arr[6])
+    if(arr[5])
     {
         const offs = ret ? 1 : 0;
-        for(let i = 0; i < arr[6].length; ++i)
+        for(let i = 0; i < arr[5].length; ++i)
         {
-            const p = parseParam(arr[6][i]);
+            const p = parseParam(arr[5][i]);
             p.pos = i + offs;
             outParams.push(p);
             if(p.tag)
@@ -126,17 +124,17 @@ function parseOperation(name, arr)
     r.outParamsOpt = outParamsOpt;
 
     const exceptions = [];
-    if(arr[7])
+    if(arr[6])
     {
-        for(let i = 0; i < arr[7].length; ++i)
+        for(let i = 0; i < arr[6].length; ++i)
         {
-            exceptions.push(arr[7][i]);
+            exceptions.push(arr[6][i]);
         }
     }
     r.exceptions = exceptions;
 
-    r.sendsClasses = arr[8] === true;
-    r.returnsClasses = arr[9] === true;
+    r.sendsClasses = arr[7] === true;
+    r.returnsClasses = arr[8] === true;
 
     return r;
 }
@@ -556,7 +554,7 @@ function addProxyOperation(proxyType, name, data)
                 return results.length == 1 ? results[0] : results;
             };
         }
-        return Ice.ObjectPrx._invoke(this, op.name, op.sendMode, op.format, ctx, marshalFn, unmarshalFn,
+        return Ice.ObjectPrx._invoke(this, op.name, op.mode, op.format, ctx, marshalFn, unmarshalFn,
                                      op.exceptions, Array.prototype.slice.call(args));
     };
 }

--- a/php/lib/Ice.php
+++ b/php/lib/Ice.php
@@ -210,11 +210,11 @@ namespace
     $Ice_Encoding_1_0 = new Ice\EncodingVersion(1, 0);
     $Ice_Encoding_1_1 = new Ice\EncodingVersion(1, 1);
 
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_isA', 2, 1, 0, array(array($IcePHP__t_string)), null,
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_isA', 1, 0, array(array($IcePHP__t_string)), null,
                            array($IcePHP__t_bool), null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ping', 2, 1, 0, null, null, null, null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_id', 2, 1, 0, null, null, array($IcePHP__t_string), null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ids', 2, 1, 0, null, null, array($Ice__t_StringSeq), null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ping', 1, 0, null, null, null, null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_id', 1, 0, null, null, array($IcePHP__t_string), null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ids', 1, 0, null, null, array($Ice__t_StringSeq), null);
 }
 
 namespace Ice

--- a/php/src/Init.cpp
+++ b/php/src/Init.cpp
@@ -84,7 +84,6 @@ ZEND_BEGIN_ARG_INFO_EX(Ice_defineOperation_arginfo, 1, ZEND_RETURN_VALUE, static
 ZEND_ARG_INFO(0, cls)
 ZEND_ARG_INFO(0, name)
 ZEND_ARG_INFO(0, mode)
-ZEND_ARG_INFO(0, sendMode)
 ZEND_ARG_INFO(0, format)
 ZEND_ARG_INFO(0, inParams)
 ZEND_ARG_INFO(0, outParams)

--- a/php/src/Init.cpp
+++ b/php/src/Init.cpp
@@ -80,7 +80,7 @@ ZEND_ARG_INFO(0, id)
 ZEND_ARG_INFO(0, element)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(Ice_defineOperation_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(9))
+ZEND_BEGIN_ARG_INFO_EX(Ice_defineOperation_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(8))
 ZEND_ARG_INFO(0, cls)
 ZEND_ARG_INFO(0, name)
 ZEND_ARG_INFO(0, mode)

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -58,7 +58,6 @@ namespace IcePHP
 
         string name; // On-the-wire name.
         Ice::OperationMode mode;
-        Ice::OperationMode sendMode;
         Ice::FormatType format;
         ParamInfoList inParams;
         ParamInfoList optionalInParams;
@@ -152,7 +151,6 @@ IcePHP::ResultCallback::unset(void)
 IcePHP::OperationI::OperationI(
     const char* n,
     Ice::OperationMode m,
-    Ice::OperationMode sm,
     Ice::FormatType f,
     zval* in,
     zval* out,
@@ -160,7 +158,6 @@ IcePHP::OperationI::OperationI(
     zval* ex)
     : name(n),
       mode(m),
-      sendMode(sm),
       format(f),
       _zendFunction(0)
 {
@@ -647,11 +644,11 @@ IcePHP::SyncTypedInvocation::invoke(INTERNAL_FUNCTION_PARAMETERS)
         {
             if (hasCtx)
             {
-                status = _prx->ice_invoke(_op->name, _op->sendMode, params, result, ctx);
+                status = _prx->ice_invoke(_op->name, _op->mode, params, result, ctx);
             }
             else
             {
-                status = _prx->ice_invoke(_op->name, _op->sendMode, params, result);
+                status = _prx->ice_invoke(_op->name, _op->mode, params, result);
             }
         }
 
@@ -704,7 +701,6 @@ ZEND_FUNCTION(IcePHP_defineOperation)
     char* name;
     size_t nameLen;
     zend_long mode;
-    zend_long sendMode;
     zend_long format;
     zval* inParams;
     zval* outParams;
@@ -713,12 +709,11 @@ ZEND_FUNCTION(IcePHP_defineOperation)
 
     if (zend_parse_parameters(
             ZEND_NUM_ARGS(),
-            const_cast<char*>("osllla!a!a!a!"),
+            const_cast<char*>("oslla!a!a!a!"),
             &cls,
             &name,
             &nameLen,
             &mode,
-            &sendMode,
             &format,
             &inParams,
             &outParams,
@@ -735,7 +730,6 @@ ZEND_FUNCTION(IcePHP_defineOperation)
     auto op = make_shared<OperationI>(
         name,
         static_cast<Ice::OperationMode>(mode),
-        static_cast<Ice::OperationMode>(sendMode),
         static_cast<Ice::FormatType>(format),
         inParams,
         outParams,

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -51,7 +51,7 @@ namespace IcePHP
     class OperationI final : public Operation
     {
     public:
-        OperationI(const char*, Ice::OperationMode, Ice::OperationMode, Ice::FormatType, zval*, zval*, zval*, zval*);
+        OperationI(const char*, Ice::OperationMode, Ice::FormatType, zval*, zval*, zval*, zval*);
         ~OperationI();
 
         zend_function* function() final;

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -49,7 +49,6 @@ namespace IcePy
         Operation(
             const char*,
             PyObject*,
-            PyObject*,
             int,
             PyObject*,
             PyObject*,
@@ -64,7 +63,6 @@ namespace IcePy
 
         string name;
         Ice::OperationMode mode;
-        Ice::OperationMode sendMode;
         bool amd;
         Ice::FormatType format;
         Ice::StringSeq metaData;
@@ -360,7 +358,6 @@ extern "C"
     PyObject* modeType = lookupType("Ice.OperationMode");
     assert(modeType);
     PyObject* mode;
-    PyObject* sendMode;
     int amd;
     PyObject* format;
     PyObject* metaData;
@@ -370,12 +367,10 @@ extern "C"
     PyObject* exceptions;
     if (!PyArg_ParseTuple(
             args,
-            STRCAST("sO!O!iOO!O!O!OO!"),
+            STRCAST("sO!iOO!O!O!OO!"),
             &name,
             modeType,
             &mode,
-            modeType,
-            &sendMode,
             &amd,
             &format,
             &PyTuple_Type,
@@ -393,7 +388,7 @@ extern "C"
 
     self->op = new OperationPtr(
         make_shared<
-            Operation>(name, mode, sendMode, amd, format, metaData, inParams, outParams, returnType, exceptions));
+            Operation>(name, mode, amd, format, metaData, inParams, outParams, returnType, exceptions));
     return 0;
 }
 
@@ -755,7 +750,6 @@ IcePy::ParamInfo::unmarshaled(PyObject* val, PyObject* target, void* closure)
 IcePy::Operation::Operation(
     const char* n,
     PyObject* m,
-    PyObject* sm,
     int amdFlag,
     PyObject* fmt,
     PyObject* meta,
@@ -771,13 +765,6 @@ IcePy::Operation::Operation(
     //
     PyObjectHandle modeValue = getAttr(m, "value", true);
     mode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
-    assert(!PyErr_Occurred());
-
-    //
-    // sendMode
-    //
-    PyObjectHandle sendModeValue = getAttr(sm, "value", true);
-    sendMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(sendModeValue.get()));
     assert(!PyErr_Occurred());
 
     //
@@ -1693,7 +1680,7 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
             status = _prx->ice_invoke(
                 _op->name,
-                _op->sendMode,
+                _op->mode,
                 params,
                 result,
                 pyctx == Py_None ? Ice::noExplicitContext : ctx);
@@ -2084,7 +2071,7 @@ IcePy::AsyncTypedInvocation::handleInvoke(PyObject* args, PyObject* /* kwds */)
     auto self = shared_from_this();
     return _prx->ice_invokeAsync(
         _op->name,
-        _op->sendMode,
+        _op->mode,
         params,
         [self](bool ok, pair<const byte*, const byte*> results) { self->response(ok, results); },
         [self](exception_ptr ex) { self->exception(ex); },
@@ -2179,7 +2166,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
     }
 
     PyObjectHandle modeValue = getAttr(mode, "value", true);
-    Ice::OperationMode sendMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    Ice::OperationMode op_mode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
     Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
@@ -2208,7 +2195,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
             ok = _prx->ice_invoke(
                 operation,
-                sendMode,
+                op_mode,
                 in,
                 out,
                 ctx == 0 || ctx == Py_None ? Ice::noExplicitContext : context);
@@ -2279,7 +2266,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     _op = operation;
 
     PyObjectHandle modeValue = getAttr(mode, "value", true);
-    Ice::OperationMode sendMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    Ice::OperationMode op_mode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
     Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
@@ -2302,7 +2289,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     auto self = shared_from_this();
     return _prx->ice_invokeAsync(
         operation,
-        sendMode,
+        op_mode,
         params,
         [self](bool ok, pair<const byte*, const byte*> results) { self->response(ok, results); },
         [self](exception_ptr ex) { self->exception(ex); },

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -46,16 +46,7 @@ namespace IcePy
     class Operation
     {
     public:
-        Operation(
-            const char*,
-            PyObject*,
-            int,
-            PyObject*,
-            PyObject*,
-            PyObject*,
-            PyObject*,
-            PyObject*,
-            PyObject*);
+        Operation(const char*, PyObject*, int, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*);
 
         void marshalResult(Ice::OutputStream&, PyObject*);
 
@@ -387,8 +378,7 @@ extern "C"
     }
 
     self->op = new OperationPtr(
-        make_shared<
-            Operation>(name, mode, amd, format, metaData, inParams, outParams, returnType, exceptions));
+        make_shared<Operation>(name, mode, amd, format, metaData, inParams, outParams, returnType, exceptions));
     return 0;
 }
 
@@ -1678,12 +1668,8 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 
         {
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
-            status = _prx->ice_invoke(
-                _op->name,
-                _op->mode,
-                params,
-                result,
-                pyctx == Py_None ? Ice::noExplicitContext : ctx);
+            status =
+                _prx->ice_invoke(_op->name, _op->mode, params, result, pyctx == Py_None ? Ice::noExplicitContext : ctx);
         }
 
         //

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -2152,7 +2152,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
     }
 
     PyObjectHandle modeValue = getAttr(mode, "value", true);
-    Ice::OperationMode op_mode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    Ice::OperationMode opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
     Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
@@ -2181,7 +2181,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
             ok = _prx->ice_invoke(
                 operation,
-                op_mode,
+                opMode,
                 in,
                 out,
                 ctx == 0 || ctx == Py_None ? Ice::noExplicitContext : context);
@@ -2252,7 +2252,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     _op = operation;
 
     PyObjectHandle modeValue = getAttr(mode, "value", true);
-    Ice::OperationMode op_mode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    Ice::OperationMode opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
     Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
@@ -2275,7 +2275,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     auto self = shared_from_this();
     return _prx->ice_invokeAsync(
         operation,
-        op_mode,
+        opMode,
         params,
         [self](bool ok, pair<const byte*, const byte*> results) { self->response(ok, results); },
         [self](exception_ptr ex) { self->exception(ex); },

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -1949,7 +1949,6 @@ Object._ice_type = IcePy._t_Object
 Object._op_ice_isA = IcePy.Operation(
     "ice_isA",
     OperationMode.Idempotent,
-    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1961,7 +1960,6 @@ Object._op_ice_isA = IcePy.Operation(
 Object._op_ice_ping = IcePy.Operation(
     "ice_ping",
     OperationMode.Idempotent,
-    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1973,7 +1971,6 @@ Object._op_ice_ping = IcePy.Operation(
 Object._op_ice_ids = IcePy.Operation(
     "ice_ids",
     OperationMode.Idempotent,
-    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1985,7 +1982,6 @@ Object._op_ice_ids = IcePy.Operation(
 Object._op_ice_id = IcePy.Operation(
     "ice_id",
     OperationMode.Idempotent,
-    OperationMode.Nonmutating,
     False,
     None,
     (),

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -1948,7 +1948,7 @@ Object._ice_type = IcePy._t_Object
 
 Object._op_ice_isA = IcePy.Operation(
     "ice_isA",
-    OperationMode.Idempotent,
+    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1959,7 +1959,7 @@ Object._op_ice_isA = IcePy.Operation(
 )
 Object._op_ice_ping = IcePy.Operation(
     "ice_ping",
-    OperationMode.Idempotent,
+    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1970,7 +1970,7 @@ Object._op_ice_ping = IcePy.Operation(
 )
 Object._op_ice_ids = IcePy.Operation(
     "ice_ids",
-    OperationMode.Idempotent,
+    OperationMode.Nonmutating,
     False,
     None,
     (),
@@ -1981,7 +1981,7 @@ Object._op_ice_ids = IcePy.Operation(
 )
 Object._op_ice_id = IcePy.Operation(
     "ice_id",
-    OperationMode.Idempotent,
+    OperationMode.Nonmutating,
     False,
     None,
     (),

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -48,7 +48,6 @@ namespace IceRuby
     private:
         string _name;
         Ice::OperationMode _mode;
-        Ice::OperationMode _sendMode;
         bool _amd;
         Ice::FormatType _format;
         ParamInfoList _inParams;
@@ -84,7 +83,6 @@ IceRuby_defineOperation(
     VALUE /*self*/,
     VALUE name,
     VALUE mode,
-    VALUE sendMode,
     VALUE amd,
     VALUE format,
     VALUE inParams,
@@ -95,7 +93,7 @@ IceRuby_defineOperation(
     ICE_RUBY_TRY
     {
         OperationIPtr op =
-            make_shared<OperationI>(name, mode, sendMode, amd, format, inParams, outParams, returnType, exceptions);
+            make_shared<OperationI>(name, mode, amd, format, inParams, outParams, returnType, exceptions);
         return Data_Wrap_Struct(_operationClass, 0, IceRuby_Operation_free, new OperationPtr(op));
     }
     ICE_RUBY_CATCH
@@ -153,7 +151,6 @@ IceRuby::ParamInfo::unmarshaled(VALUE val, VALUE target, void* closure)
 IceRuby::OperationI::OperationI(
     VALUE name,
     VALUE mode,
-    VALUE sendMode,
     VALUE amd,
     VALUE format,
     VALUE inParams,
@@ -178,13 +175,6 @@ IceRuby::OperationI::OperationI(
     volatile VALUE modeValue = callRuby(rb_funcall, mode, rb_intern("to_i"), 0);
     assert(TYPE(modeValue) == T_FIXNUM);
     _mode = static_cast<Ice::OperationMode>(FIX2LONG(modeValue));
-
-    //
-    // sendMode
-    //
-    volatile VALUE sendModeValue = callRuby(rb_funcall, sendMode, rb_intern("to_i"), 0);
-    assert(TYPE(sendModeValue) == T_FIXNUM);
-    _sendMode = static_cast<Ice::OperationMode>(FIX2LONG(sendModeValue));
 
     //
     // format
@@ -296,11 +286,11 @@ IceRuby::OperationI::invoke(const Ice::ObjectPrx& proxy, VALUE args, VALUE hctx)
             throw RubyException(rb_eArgError, "context argument must be nil or a hash");
         }
 
-        status = proxy->ice_invoke(_name, _sendMode, params, result, ctx);
+        status = proxy->ice_invoke(_name, _mode, params, result, ctx);
     }
     else
     {
-        status = proxy->ice_invoke(_name, _sendMode, params, result);
+        status = proxy->ice_invoke(_name, _mode, params, result);
     }
 
     //

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -40,7 +40,7 @@ namespace IceRuby
     class OperationI final : public Operation
     {
     public:
-        OperationI(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+        OperationI(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
 
         VALUE invoke(const Ice::ObjectPrx&, VALUE, VALUE) final;
         void deprecate(const string&) final;

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -614,7 +614,7 @@ IceRuby::OperationI::checkTwowayOnly(const Ice::ObjectPrx& proxy) const
 bool
 IceRuby::initOperation(VALUE iceModule)
 {
-    rb_define_module_function(iceModule, "__defineOperation", CAST_METHOD(IceRuby_defineOperation), 9);
+    rb_define_module_function(iceModule, "__defineOperation", CAST_METHOD(IceRuby_defineOperation), 8);
 
     //
     // Define a class to represent an operation.


### PR DESCRIPTION
This PR is the follow-up to #2023 which removed the 'nonmutating' metadata.
After removing the metadata, there was some now-dead supporting code, which this PR removes.

### 1) Remove the `Nonmutating` enumerator from `Operation::Mode`.

Confusingly, this is **_not_** `OperationMode`. `OperationMode` is defined by the Ice runtime.
This was left untouched, so 3.8 can support receiving operations marked with it.

`Operation::Mode` is defined in the Parser, and _only_ used by the code-gen.
Now that `nonmutating` is gone, the code-gen will _never_ generate this code path, meaning the enumerator is dead.

### 2) Remove `sendMode`

Each operation actually had 2 corresponding `OperationMode`s: a `mode` and a `sendMode`.
The difference was `sendMode` would check for `nonmutating`, whereas `mode` doesn't.
Now this is gone, I also removed sendMode.
This affected the code-gen (now we _always_ call `mode`, since it's identical)
and the C interface for the wrapper languages, which used to supply both `mode` and `sendMode` arguments.
(now we just supply 1 argument, since these two are _always_ the same).