### PR TITLE
Finish Removing Nonmutating

### DIFF
--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -177,9 +177,7 @@ Ice::Object::_iceCheckMode(OperationMode expected, OperationMode received)
         assert(expected != OperationMode::Nonmutating); // We never expect Nonmutating
         if (expected == OperationMode::Idempotent && received == OperationMode::Nonmutating)
         {
-            //
             // Fine: typically an old client still using the deprecated nonmutating keyword
-            //
         }
         else
         {

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -334,7 +334,7 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<OutgoingAsyncT<bool>>& outAsync, stri
     _checkTwowayOnly(operationName);
     outAsync->invoke(
         operationName,
-        OperationMode::Nonmutating,
+        OperationMode::Idempotent,
         FormatType::DefaultFormat,
         ctx,
         [&](Ice::OutputStream* os) { os->write(typeId, false); },
@@ -373,7 +373,7 @@ void
 Ice::ObjectPrx::_iceI_ping(const shared_ptr<OutgoingAsyncT<void>>& outAsync, const Context& ctx) const
 {
     static constexpr string_view operationName = "ice_ping";
-    outAsync->invoke(operationName, OperationMode::Nonmutating, FormatType::DefaultFormat, ctx, nullptr, nullptr);
+    outAsync->invoke(operationName, OperationMode::Idempotent, FormatType::DefaultFormat, ctx, nullptr, nullptr);
 }
 
 vector<string>
@@ -411,7 +411,7 @@ Ice::ObjectPrx::_iceI_ids(const shared_ptr<OutgoingAsyncT<vector<string>>>& outA
     _checkTwowayOnly(operationName);
     outAsync->invoke(
         operationName,
-        OperationMode::Nonmutating,
+        OperationMode::Idempotent,
         FormatType::DefaultFormat,
         ctx,
         nullptr,
@@ -459,7 +459,7 @@ Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, con
     _checkTwowayOnly(operationName);
     outAsync->invoke(
         operationName,
-        OperationMode::Nonmutating,
+        OperationMode::Idempotent,
         FormatType::DefaultFormat,
         ctx,
         nullptr,

--- a/cpp/test/Ice/operations/TestAMDI.cpp
+++ b/cpp/test/Ice/operations/TestAMDI.cpp
@@ -17,34 +17,6 @@ using namespace std;
 
 MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0) {}
 
-bool
-MyDerivedClassI::ice_isA(string id, const Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return MyDerivedClass::ice_isA(std::move(id), current);
-}
-
-void
-MyDerivedClassI::ice_ping(const Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    MyDerivedClass::ice_ping(current);
-}
-
-std::vector<std::string>
-MyDerivedClassI::ice_ids(const Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return MyDerivedClass::ice_ids(current);
-}
-
-std::string
-MyDerivedClassI::ice_id(const Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return MyDerivedClass::ice_id(current);
-}
-
 void
 MyDerivedClassI::shutdownAsync(function<void()> response, function<void(exception_ptr)>, const Current& current)
 {

--- a/cpp/test/Ice/operations/TestAMDI.h
+++ b/cpp/test/Ice/operations/TestAMDI.h
@@ -12,14 +12,6 @@ class MyDerivedClassI final : public Test::MyDerivedClass
 public:
     MyDerivedClassI();
 
-    //
-    // Override the Object "pseudo" operations to verify the operation mode.
-    //
-    bool ice_isA(std::string, const Ice::Current&) const;
-    void ice_ping(const Ice::Current&) const;
-    std::vector<std::string> ice_ids(const Ice::Current&) const;
-    std::string ice_id(const Ice::Current&) const;
-
     void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) final;
 
     void supportsCompressAsync(std::function<void(bool)>, std::function<void(std::exception_ptr)>, const Ice::Current&)

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -14,34 +14,6 @@ using namespace std;
 
 MyDerivedClassI::MyDerivedClassI() : _opByteSOnewayCallCount(0) {}
 
-bool
-MyDerivedClassI::ice_isA(string id, const Ice::Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return Test::MyDerivedClass::ice_isA(std::move(id), current);
-}
-
-void
-MyDerivedClassI::ice_ping(const Ice::Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    Test::MyDerivedClass::ice_ping(current);
-}
-
-std::vector<std::string>
-MyDerivedClassI::ice_ids(const Ice::Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return Test::MyDerivedClass::ice_ids(current);
-}
-
-std::string
-MyDerivedClassI::ice_id(const Ice::Current& current) const
-{
-    test(current.mode == OperationMode::Nonmutating);
-    return Test::MyDerivedClass::ice_id(current);
-}
-
 void
 MyDerivedClassI::shutdown(const Ice::Current& current)
 {

--- a/cpp/test/Ice/operations/TestI.h
+++ b/cpp/test/Ice/operations/TestI.h
@@ -12,14 +12,6 @@ class MyDerivedClassI final : public Test::MyDerivedClass
 public:
     MyDerivedClassI();
 
-    //
-    // Override the Object "pseudo" operations to verify the operation mode.
-    //
-    bool ice_isA(std::string, const Ice::Current&) const final;
-    void ice_ping(const Ice::Current&) const final;
-    std::vector<std::string> ice_ids(const Ice::Current&) const final;
-    std::string ice_id(const Ice::Current&) const final;
-
     void shutdown(const Ice::Current&) final;
 
     bool supportsCompress(const Ice::Current&) final;

--- a/csharp/src/Ice/Object.cs
+++ b/csharp/src/Ice/Object.cs
@@ -258,14 +258,12 @@ public abstract class ObjectImpl : Object
 
     public static void iceCheckMode(OperationMode expected, OperationMode received)
     {
+        Debug.Assert(expected != OperationMode.Nonmutating); // We never expect Nonmutating
         if (expected != received)
         {
             if (expected == OperationMode.Idempotent && received == OperationMode.Nonmutating)
             {
-                //
-                // Fine: typically an old client still using the
-                // deprecated nonmutating keyword
-                //
+                // Fine: typically an old client still using the deprecated nonmutating keyword
             }
             else
             {

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -632,7 +632,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     {
         iceCheckAsyncTwowayOnly(_ice_isA_name);
         getOutgoingAsync<bool>(completed).invoke(_ice_isA_name,
-                                                 OperationMode.Nonmutating,
+                                                 OperationMode.Idempotent,
                                                  FormatType.DefaultFormat,
                                                  context,
                                                  synchronous,
@@ -685,7 +685,7 @@ public class ObjectPrxHelperBase : ObjectPrx
                                    bool synchronous)
     {
         getOutgoingAsync<object>(completed).invoke(_ice_ping_name,
-                                                   OperationMode.Nonmutating,
+                                                   OperationMode.Idempotent,
                                                    FormatType.DefaultFormat,
                                                    context,
                                                    synchronous);
@@ -740,7 +740,7 @@ public class ObjectPrxHelperBase : ObjectPrx
     {
         iceCheckAsyncTwowayOnly(_ice_ids_name);
         getOutgoingAsync<string[]>(completed).invoke(_ice_ids_name,
-                                                     OperationMode.Nonmutating,
+                                                     OperationMode.Idempotent,
                                                      FormatType.DefaultFormat,
                                                      context,
                                                      synchronous,
@@ -793,7 +793,7 @@ public class ObjectPrxHelperBase : ObjectPrx
                              bool synchronous)
     {
         getOutgoingAsync<string>(completed).invoke(_ice_id_name,
-                                                   OperationMode.Nonmutating,
+                                                   OperationMode.Idempotent,
                                                    FormatType.DefaultFormat,
                                                    context,
                                                    synchronous,

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -47,33 +47,6 @@ namespace Ice
                     private Thread _thread;
                 }
 
-                //
-                // Override the Object "pseudo" operations to verify the operation mode.
-                //
-                public override bool ice_isA(String id, Ice.Current current)
-                {
-                    test(current.mode == Ice.OperationMode.Nonmutating);
-                    return base.ice_isA(id, current);
-                }
-
-                public override void ice_ping(Ice.Current current)
-                {
-                    test(current.mode == Ice.OperationMode.Nonmutating);
-                    base.ice_ping(current);
-                }
-
-                public override string[] ice_ids(Ice.Current current)
-                {
-                    test(current.mode == Ice.OperationMode.Nonmutating);
-                    return base.ice_ids(current);
-                }
-
-                public override string ice_id(Ice.Current current)
-                {
-                    test(current.mode == Ice.OperationMode.Nonmutating);
-                    return base.ice_id(current);
-                }
-
                 public override Task shutdownAsync(Ice.Current current)
                 {
                     while (_opVoidThread != null)

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -14,34 +14,6 @@ namespace Ice
                 }
             }
 
-            //
-            // Override the Object "pseudo" operations to verify the operation mode.
-            //
-
-            public override bool ice_isA(string id, Ice.Current current)
-            {
-                test(current.mode == Ice.OperationMode.Nonmutating);
-                return base.ice_isA(id, current);
-            }
-
-            public override void ice_ping(Ice.Current current)
-            {
-                test(current.mode == Ice.OperationMode.Nonmutating);
-                base.ice_ping(current);
-            }
-
-            public override string[] ice_ids(Ice.Current current)
-            {
-                test(current.mode == Ice.OperationMode.Nonmutating);
-                return base.ice_ids(current);
-            }
-
-            public override string ice_id(Ice.Current current)
-            {
-                test(current.mode == Ice.OperationMode.Nonmutating);
-                return base.ice_id(current);
-            }
-
             public override void shutdown(Ice.Current current)
             {
                 current.adapter.getCommunicator().shutdown();

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Object.java
@@ -280,12 +280,10 @@ public interface Object {
       expected = OperationMode.Normal;
     }
 
+    assert expected != OperationMode.Nonmutating; // We never expect Nonmutating
     if (expected != received) {
       if (expected == OperationMode.Idempotent && received == OperationMode.Nonmutating) {
-        //
-        // Fine: typically an old client still using the
-        // deprecated nonmutating keyword
-        //
+        // Fine: typically an old client still using the deprecated nonmutating keyword
       } else {
         MarshalException ex = new MarshalException();
         ex.reason =

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -35,7 +35,7 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
   private OutgoingAsync<Boolean> _iceI_ice_isAAsync(
       String id, Map<String, String> context, boolean sync) {
     OutgoingAsync<Boolean> f =
-        new OutgoingAsync<>(this, "ice_isA", OperationMode.Nonmutating, sync, null);
+        new OutgoingAsync<>(this, "ice_isA", OperationMode.Idempotent, sync, null);
     f.invoke(true, context, null, ostr -> ostr.writeString(id), istr -> istr.readBool());
     return f;
   }
@@ -58,7 +58,7 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
 
   private OutgoingAsync<Void> _iceI_ice_pingAsync(Map<String, String> context, boolean sync) {
     OutgoingAsync<Void> f =
-        new OutgoingAsync<>(this, "ice_ping", OperationMode.Nonmutating, sync, null);
+        new OutgoingAsync<>(this, "ice_ping", OperationMode.Idempotent, sync, null);
     f.invoke(false, context, null, null, null);
     return f;
   }
@@ -81,7 +81,7 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
 
   private OutgoingAsync<String[]> _iceI_ice_idsAsync(Map<String, String> context, boolean sync) {
     OutgoingAsync<String[]> f =
-        new OutgoingAsync<>(this, "ice_ids", OperationMode.Nonmutating, sync, null);
+        new OutgoingAsync<>(this, "ice_ids", OperationMode.Idempotent, sync, null);
     f.invoke(true, context, null, null, istr -> istr.readStringSeq());
     return f;
   }
@@ -104,7 +104,7 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
 
   private OutgoingAsync<String> _iceI_ice_idAsync(Map<String, String> context, boolean sync) {
     OutgoingAsync<String> f =
-        new OutgoingAsync<>(this, "ice_id", OperationMode.Nonmutating, sync, null);
+        new OutgoingAsync<>(this, "ice_id", OperationMode.Idempotent, sync, null);
     f.invoke(true, context, null, null, istr -> istr.readString());
     return f;
   }

--- a/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
@@ -30,34 +30,6 @@ public final class AMDMyDerivedClassI implements MyDerivedClass {
     private CompletableFuture<Void> _future;
   }
 
-  //
-  // Override the Object "pseudo" operations to verify the operation mode.
-  //
-
-  @Override
-  public boolean ice_isA(String id, Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_isA(id, current);
-  }
-
-  @Override
-  public void ice_ping(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    MyDerivedClass.super.ice_ping(current);
-  }
-
-  @Override
-  public String[] ice_ids(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_ids(current);
-  }
-
-  @Override
-  public String ice_id(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_id(current);
-  }
-
   @Override
   public synchronized CompletionStage<Void> shutdownAsync(Current current) {
     while (_opVoidThread != null) {

--- a/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
@@ -15,34 +15,6 @@ public final class MyDerivedClassI implements MyDerivedClass {
     }
   }
 
-  //
-  // Override the Object "pseudo" operations to verify the operation mode.
-  //
-
-  @Override
-  public boolean ice_isA(String id, Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_isA(id, current);
-  }
-
-  @Override
-  public void ice_ping(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    MyDerivedClass.super.ice_ping(current);
-  }
-
-  @Override
-  public String[] ice_ids(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_ids(current);
-  }
-
-  @Override
-  public String ice_id(Current current) {
-    test(current.mode == com.zeroc.Ice.OperationMode.Nonmutating);
-    return MyDerivedClass.super.ice_id(current);
-  }
-
   @Override
   public void shutdown(Current current) {
     current.adapter.getCommunicator().shutdown();

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -639,10 +639,10 @@ Slice.defineOperations = function(classType, proxyType, ids, id, ops)
 //
 Slice.defineOperations(Ice.Object, Ice.ObjectPrx, ["::Ice::Object"], "::Ice::Object",
 {
-    ice_ping: [undefined, 1, undefined, undefined, undefined, undefined, undefined],
-    ice_isA: [undefined, 1, undefined, [1], [[7]], undefined, undefined],
-    ice_id: [undefined, 1, undefined, [7], undefined, undefined, undefined],
-    ice_ids: [undefined, 1, undefined, ["Ice.StringSeqHelper"], undefined, undefined, undefined]
+    ice_ping: [undefined, 2, undefined, undefined, undefined, undefined, undefined],
+    ice_isA: [undefined, 2, undefined, [1], [[7]], undefined, undefined],
+    ice_id: [undefined, 2, undefined, [7], undefined, undefined, undefined],
+    ice_ids: [undefined, 2, undefined, ["Ice.StringSeqHelper"], undefined, undefined, undefined]
 });
 
 module.exports.Ice = Ice;

--- a/js/test/Ice/operations/AMDMyDerivedClassI.js
+++ b/js/test/Ice/operations/AMDMyDerivedClassI.js
@@ -10,38 +10,11 @@
 
     class AMDMyDerivedClassI extends Test.MyDerivedClass
     {
-        //
-        // Override the Object "pseudo" operations to verify the operation mode.
-        //
         constructor(endpoints)
         {
             super();
             this._opByteSOnewayCount = 0;
             this._endpoints = endpoints;
-        }
-
-        ice_isA(id, current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_isA.call(this, id, current);
-        }
-
-        ice_ping(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            Ice.Object.prototype.ice_ping.call(this, current);
-        }
-
-        ice_ids(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_ids.call(this, current);
-        }
-
-        ice_id(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_id.call(this, current);
         }
 
         shutdown(current)

--- a/js/test/Ice/operations/MyDerivedClassI.js
+++ b/js/test/Ice/operations/MyDerivedClassI.js
@@ -10,38 +10,11 @@
 
     class MyDerivedClassI extends Test.MyDerivedClass
     {
-        //
-        // Override the Object "pseudo" operations to verify the operation mode.
-        //
         constructor(endpoints)
         {
             super();
             this._opByteSOnewayCount = 0;
             this._endpoints = endpoints;
-        }
-
-        ice_isA(id, current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_isA.call(this, id, current);
-        }
-
-        ice_ping(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            Ice.Object.prototype.ice_ping.call(this, current);
-        }
-
-        ice_ids(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_ids.call(this, current);
-        }
-
-        ice_id(current)
-        {
-            test(current.mode === Ice.OperationMode.Nonmutating);
-            return Ice.Object.prototype.ice_id.call(this, current);
         }
 
         shutdown(current)

--- a/js/test/typescript/Ice/operations/AMDMyDerivedClassI.ts
+++ b/js/test/typescript/Ice/operations/AMDMyDerivedClassI.ts
@@ -9,38 +9,11 @@ const test = TestHelper.test;
 
 export class AMDMyDerivedClassI extends Test.MyDerivedClass
 {
-    //
-    // Override the Object "pseudo" operations to verify the operation mode.
-    //
     constructor(endpoints:Ice.Endpoint[])
     {
         super();
         this._opByteSOnewayCount = 0;
         this._endpoints = endpoints;
-    }
-
-    ice_isA(id:string, current:Ice.Current):boolean
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_isA.call(this, id, current);
-    }
-
-    ice_ping(current:Ice.Current):void
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        Ice.Object.prototype.ice_ping.call(this, current);
-    }
-
-    ice_ids(current:Ice.Current):Ice.StringSeq
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_ids.call(this, current);
-    }
-
-    ice_id(current:Ice.Current):string
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_id.call(this, current);
     }
 
     shutdown(current:Ice.Current):void

--- a/js/test/typescript/Ice/operations/MyDerivedClassI.ts
+++ b/js/test/typescript/Ice/operations/MyDerivedClassI.ts
@@ -8,38 +8,11 @@ const test = TestHelper.test;
 
 export class MyDerivedClassI extends Test.MyDerivedClass
 {
-    //
-    // Override the Object "pseudo" operations to verify the operation mode.
-    //
     constructor(endpoints:Ice.Endpoint[])
     {
         super();
         this._opByteSOnewayCount = 0;
         this._endpoints = endpoints;
-    }
-
-    ice_isA(id:string, current:Ice.Current):boolean
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_isA.call(this, id, current);
-    }
-
-    ice_ping(current:Ice.Current):void
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        Ice.Object.prototype.ice_ping.call(this, current);
-    }
-
-    ice_ids(current:Ice.Current):Ice.StringSeq
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_ids.call(this, current);
-    }
-
-    ice_id(current:Ice.Current):string
-    {
-        test(current.mode === Ice.OperationMode.Nonmutating);
-        return Ice.Object.prototype.ice_id.call(this, current);
     }
 
     shutdown(current:Ice.Current):void

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -185,7 +185,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % Parameters:
             %   context - Optional context map for the invocation.
 
-            obj.iceInvoke('ice_ping', 1, false, [], false, {}, varargin{:});
+            obj.iceInvoke('ice_ping', 2, false, [], false, {}, varargin{:});
         end
 
         function r = ice_pingAsync(obj, varargin)
@@ -198,7 +198,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % Returns (Ice.Future) - A future that will be completed when the
             %   invocation completes.
 
-            r = obj.iceInvokeAsync('ice_ping', 1, false, [], 0, [], {}, varargin{:});
+            r = obj.iceInvokeAsync('ice_ping', 2, false, [], 0, [], {}, varargin{:});
         end
 
         function r = ice_isA(obj, id, varargin)
@@ -215,7 +215,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             os = obj.iceStartWriteParams([]);
             os.writeString(id);
             obj.iceEndWriteParams(os);
-            is = obj.iceInvoke('ice_isA', 1, true, os, true, {}, varargin{:});
+            is = obj.iceInvoke('ice_isA', 2, true, os, true, {}, varargin{:});
             is.startEncapsulation();
             r = is.readBool();
             is.endEncapsulation();
@@ -240,7 +240,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 varargout{1} = is.readBool();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_isA', 1, true, os, 1, @unmarshal, {}, varargin{:});
+            r = obj.iceInvokeAsync('ice_isA', 2, true, os, 1, @unmarshal, {}, varargin{:});
         end
 
         function r = ice_id(obj, varargin)
@@ -252,7 +252,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %
             % Returns (char) - The Slice type ID of the most-derived interface.
 
-            is = obj.iceInvoke('ice_id', 1, true, [], true, {}, varargin{:});
+            is = obj.iceInvoke('ice_id', 2, true, [], true, {}, varargin{:});
             is.startEncapsulation();
             r = is.readString();
             is.endEncapsulation();
@@ -273,7 +273,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 varargout{1} = is.readString();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_id', 1, true, [], 1, @unmarshal, {}, varargin{:});
+            r = obj.iceInvokeAsync('ice_id', 2, true, [], 1, @unmarshal, {}, varargin{:});
         end
 
         function r = ice_ids(obj, varargin)
@@ -286,7 +286,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % Returns (cell array of char) - The Slice type IDs of the
             %   interfaces supported by the target object, in alphabetical order.
 
-            is = obj.iceInvoke('ice_ids', 1, true, [], true, {}, varargin{:});
+            is = obj.iceInvoke('ice_ids', 2, true, [], true, {}, varargin{:});
             is.startEncapsulation();
             r = is.readStringSeq();
             is.endEncapsulation();
@@ -307,7 +307,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 varargout{1} = is.readStringSeq();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_ids', 1, true, [], 1, @unmarshal, {}, varargin{:});
+            r = obj.iceInvokeAsync('ice_ids', 2, true, [], 1, @unmarshal, {}, varargin{:});
         end
 
         function r = ice_getIdentity(obj)

--- a/php/lib/Ice.php
+++ b/php/lib/Ice.php
@@ -210,11 +210,11 @@ namespace
     $Ice_Encoding_1_0 = new Ice\EncodingVersion(1, 0);
     $Ice_Encoding_1_1 = new Ice\EncodingVersion(1, 1);
 
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_isA', 1, 0, array(array($IcePHP__t_string)), null,
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_isA', 2, 0, array(array($IcePHP__t_string)), null,
                            array($IcePHP__t_bool), null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ping', 1, 0, null, null, null, null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_id', 1, 0, null, null, array($IcePHP__t_string), null);
-    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ids', 1, 0, null, null, array($Ice__t_StringSeq), null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ping', 2, 0, null, null, null, null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_id', 2, 0, null, null, array($IcePHP__t_string), null);
+    IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ids', 2, 0, null, null, array($Ice__t_StringSeq), null);
 }
 
 namespace Ice

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -1948,7 +1948,7 @@ Object._ice_type = IcePy._t_Object
 
 Object._op_ice_isA = IcePy.Operation(
     "ice_isA",
-    OperationMode.Nonmutating,
+    OperationMode.Idempotent,
     False,
     None,
     (),
@@ -1959,7 +1959,7 @@ Object._op_ice_isA = IcePy.Operation(
 )
 Object._op_ice_ping = IcePy.Operation(
     "ice_ping",
-    OperationMode.Nonmutating,
+    OperationMode.Idempotent,
     False,
     None,
     (),
@@ -1970,7 +1970,7 @@ Object._op_ice_ping = IcePy.Operation(
 )
 Object._op_ice_ids = IcePy.Operation(
     "ice_ids",
-    OperationMode.Nonmutating,
+    OperationMode.Idempotent,
     False,
     None,
     (),
@@ -1981,7 +1981,7 @@ Object._op_ice_ids = IcePy.Operation(
 )
 Object._op_ice_id = IcePy.Operation(
     "ice_id",
-    OperationMode.Nonmutating,
+    OperationMode.Idempotent,
     False,
     None,
     (),

--- a/python/test/Ice/operations/TestAMDCoroI.py
+++ b/python/test/Ice/operations/TestAMDCoroI.py
@@ -41,22 +41,6 @@ class MyDerivedClassI(Test.MyDerivedClass):
         self.lock = threading.Lock()
         self.opByteSOnewayCount = 0
 
-    def ice_isA(self, id, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_isA(self, id, current)
-
-    def ice_ping(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        Test.MyDerivedClass.ice_ping(self, current)
-
-    def ice_ids(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_ids(self, current)
-
-    def ice_id(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_id(self, current)
-
     def shutdown(self, current=None):
         with self.threadLock:
             for thread in self.threads:

--- a/python/test/Ice/operations/TestAMDI.py
+++ b/python/test/Ice/operations/TestAMDI.py
@@ -40,22 +40,6 @@ class MyDerivedClassI(Test.MyDerivedClass):
         self.lock = threading.Lock()
         self.opByteSOnewayCount = 0
 
-    def ice_isA(self, id, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_isA(self, id, current)
-
-    def ice_ping(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        Test.MyDerivedClass.ice_ping(self, current)
-
-    def ice_ids(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_ids(self, current)
-
-    def ice_id(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_id(self, current)
-
     def shutdown(self, current=None):
         with self.threadLock:
             for thread in self.threads:

--- a/python/test/Ice/operations/TestI.py
+++ b/python/test/Ice/operations/TestI.py
@@ -17,22 +17,6 @@ class MyDerivedClassI(Test.MyDerivedClass):
         self.lock = threading.Lock()
         self.opByteSOnewayCount = 0
 
-    def ice_isA(self, id, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_isA(self, id, current)
-
-    def ice_ping(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        Test.MyDerivedClass.ice_ping(self, current)
-
-    def ice_ids(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_ids(self, current)
-
-    def ice_id(self, current=None):
-        test(current.mode == Ice.OperationMode.Nonmutating)
-        return Test.MyDerivedClass.ice_id(self, current)
-
     def shutdown(self, current=None):
         current.adapter.getCommunicator().shutdown()
 

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -32,21 +32,17 @@ module Ice
         /// will not violate at-most-once semantics for <code>Normal</code> operations.
         Normal,
 
-        /// Operations that use the Slice <code>nonmutating</code> keyword must not modify object state. For C++,
-        /// nonmutating operations generate <code>const</code> member functions in the skeleton. In addition, the Ice
-        /// run time will attempt to transparently recover from certain run-time errors by re-issuing a failed request
-        /// and propagate the failure to the application only if the second attempt fails.
+        /// Operations that are <code>nonmutating</code> must not modify object state.
+        /// The Ice run-time no longer makes a distinction between nonmutating operations and idempotent operations.
         /// <p class="Deprecated"><code>Nonmutating</code> is deprecated; Use the <code>idempotent</code> keyword
         /// instead.
-        /// For C++, to retain the mapping of <code>nonmutating</code> operations to C++ <code>const</code> member
-        /// functions, use the <code>["cpp:const"]</code> metadata directive.
         Nonmutating,
 
         /// Operations that use the Slice <code>idempotent</code> keyword can modify object state, but invoking an
         /// operation twice in a row must result in the same object state as invoking it once. For example,
-        /// <code>x = 1</code> is an idempotent statement, whereas <code>x += 1</code> is not. For idempotent
-        /// operations, the Ice run-time uses the same retry behavior as for nonmutating operations in case of a
-        /// potentially recoverable error.
+        /// <code>x = 1</code> is an idempotent statement, whereas <code>x += 1</code> is not. In addition, the Ice
+        /// run time will attempt to transparently recover from certain run-time errors by re-issuing a failed request
+        /// and propagate the failure to the application only if the second attempt fails.
         Idempotent
     }
 }

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -386,7 +386,7 @@ public func == (lhs: ObjectPrx?, rhs: ObjectPrx?) -> Bool {
 }
 
 extension ObjectPrx {
-  /// Returns the underdlying implementation object (Ice internal).
+  /// Returns the underlying implementation object (Ice internal).
   public var _impl: ObjectPrxI {
     return self as! ObjectPrxI
   }
@@ -400,7 +400,7 @@ extension ObjectPrx {
   public func ice_ping(context: Context? = nil) throws {
     try _impl._invoke(
       operation: "ice_ping",
-      mode: OperationMode.Nonmutating,
+      mode: OperationMode.Idempotent,
       context: context)
   }
 
@@ -426,7 +426,7 @@ extension ObjectPrx {
   ) -> Promise<Void> {
     return _impl._invokeAsync(
       operation: "ice_ping",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       context: context,
       sentOn: sentOn,
       sentFlags: sentFlags,
@@ -444,7 +444,7 @@ extension ObjectPrx {
   public func ice_isA(id: String, context: Context? = nil) throws -> Bool {
     return try _impl._invoke(
       operation: "ice_isA",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       write: { ostr in
         ostr.write(id)
       },
@@ -476,7 +476,7 @@ extension ObjectPrx {
   ) -> Promise<Bool> {
     return _impl._invokeAsync(
       operation: "ice_isA",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       write: { ostr in
         ostr.write(id)
       },
@@ -495,7 +495,7 @@ extension ObjectPrx {
   public func ice_id(context: Context? = nil) throws -> String {
     return try _impl._invoke(
       operation: "ice_id",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       read: { istr in try istr.read() as String },
       context: context)
   }
@@ -522,7 +522,7 @@ extension ObjectPrx {
   ) -> Promise<String> {
     return _impl._invokeAsync(
       operation: "ice_id",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       read: { istr in try istr.read() as String },
       context: context,
       sentOn: sentOn,
@@ -539,7 +539,7 @@ extension ObjectPrx {
   public func ice_ids(context: Context? = nil) throws -> StringSeq {
     return try _impl._invoke(
       operation: "ice_ids",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       read: { istr in try istr.read() as StringSeq },
       context: context)
   }
@@ -566,7 +566,7 @@ extension ObjectPrx {
   ) -> Promise<StringSeq> {
     return _impl._invokeAsync(
       operation: "ice_ids",
-      mode: .Nonmutating,
+      mode: .Idempotent,
       read: { istr in try istr.read() as StringSeq },
       context: context,
       sentOn: sentOn,

--- a/swift/test/Ice/operations/TestAMDI.swift
+++ b/swift/test/Ice/operations/TestAMDI.swift
@@ -16,28 +16,6 @@ class MyDerivedClassI: ObjectI<MyDerivedClassTraits>, MyDerivedClass {
     _helper = helper
   }
 
-  //
-  // Override the Object "pseudo" operations to verify the operation mode.
-  //
-  override func ice_isA(id: String, current: Ice.Current) throws -> Bool {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_isA(id: id, current: current)
-  }
-
-  override func ice_ping(current: Ice.Current) throws {
-    try _helper.test(current.mode == .Nonmutating)
-  }
-
-  override func ice_ids(current: Ice.Current) throws -> [String] {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_ids(current: current)
-  }
-
-  override func ice_id(current: Ice.Current) throws -> String {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_id(current: current)
-  }
-
   func opDerivedAsync(current _: Current) -> Promise<Void> {
     return Promise.value(())
   }

--- a/swift/test/Ice/operations/TestI.swift
+++ b/swift/test/Ice/operations/TestI.swift
@@ -15,28 +15,6 @@ class MyDerivedClassI: ObjectI<MyDerivedClassTraits>, MyDerivedClass {
     _helper = helper
   }
 
-  //
-  // Override the Object "pseudo" operations to verify the operation mode.
-  //
-  override func ice_isA(id: String, current: Ice.Current) throws -> Bool {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_isA(id: id, current: current)
-  }
-
-  override func ice_ping(current: Ice.Current) throws {
-    try _helper.test(current.mode == .Nonmutating)
-  }
-
-  override func ice_ids(current: Ice.Current) throws -> [String] {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_ids(current: current)
-  }
-
-  override func ice_id(current: Ice.Current) throws -> String {
-    try _helper.test(current.mode == .Nonmutating)
-    return try super.ice_id(current: current)
-  }
-
   func shutdown(current: Ice.Current) throws {
     current.adapter!.getCommunicator().shutdown()
   }


### PR DESCRIPTION
This PR finishes removing nonmutating.
This is a sister PR to #2121, which removed the last of the 'nonmutating' metadata checks.
As-of this PR, we should no longer be sending nonmutating, nor making any distinction between it and idempotent.

This PR:
- Changes the built-in Object operations (`ice_isA`, `ice_ping`, `ice_id`, `ice_ids`) to use `OperationMode::Idempotent`, instead of `OperationMode::Nonmutating` which they're currently using.
- Deletes the parts of the 'Ice/operations' test which were solely testing which operation mode those operations used.
- Updates the Slice doc comments for `OperationMode`

----

In Ruby, I couldn't find how/where we specify the operation mode these 4 built-ins use...
We define the operations here (v) but I couldn't figure out how an operation mode gets specified.
https://github.com/zeroc-ice/ice/blob/6002b49722f76e96ca08b9ce6409aa50420909e4/ruby/src/IceRuby/Proxy.cpp#L1214-L1217