### PR TITLE
Add new createProxy method on PrxHelper

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3709,7 +3709,14 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "#endregion"; // Asynchronous Task operations
 
-    _out << sp << nl << "#region Checked and unchecked cast operations";
+    _out << sp << nl << "#region Factory operations";
+
+    _out << sp << nl << "public static " << name << "Prx createProxy(" << getUnqualified("Ice.Communicator", ns)
+         << " communicator, string proxyString) =>";
+    _out.inc();
+    _out << nl << "uncheckedCast(" << getUnqualified("Ice.ObjectPrxHelper", ns)
+        << ".createProxy(communicator, proxyString));";
+    _out.dec();
 
     _out << sp << nl << "public static " << name << "Prx checkedCast(" << getUnqualified("Ice.ObjectPrx", ns)
          << " b, global::System.Collections.Generic.Dictionary<string, string> ctx = null)";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3798,7 +3798,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "public static string ice_staticId() => \"" << scoped << "\";";
 
-    _out << sp << nl << "#endregion"; // Checked and unchecked cast operations
+    _out << sp << nl << "#endregion"; // Factory operations
 
     _out << sp << nl << "#region Marshaling support";
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3715,7 +3715,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
          << " communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "uncheckedCast(" << getUnqualified("Ice.ObjectPrxHelper", ns)
-        << ".createProxy(communicator, proxyString));";
+         << ".createProxy(communicator, proxyString));";
     _out.dec();
 
     _out << sp << nl << "public static " << name << "Prx checkedCast(" << getUnqualified("Ice.ObjectPrx", ns)

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -2059,6 +2059,16 @@ public class ObjectPrxHelperBase : ObjectPrx
 public class ObjectPrxHelper : ObjectPrxHelperBase
 {
     /// <summary>
+    /// Creates a new proxy that implements <see cref="ObjectPrx" />
+    /// <summary>
+    /// <param name="communicator">The communicator of the new proxy.</param>
+    /// <param name="proxyString">The string representation of the proxy.</param>
+    /// <returns>The new proxy.</returns>
+    /// <exception name="ProxyParseException">Thrown when <paramref name="proxyString" /> is not a valid proxy string.
+    /// </exception>
+    public static ObjectPrx createProxy(Communicator communicator, string proxyString) =>
+        communicator.stringToProxy(proxyString);
+
     /// Casts a proxy to {@link ObjectPrx}. This call contacts
     /// the server and throws an Ice run-time exception if the target
     /// object does not exist or the server cannot be reached.

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -121,16 +121,12 @@ namespace Ice
             public static async Task allTestsAsync(global::Test.TestHelper helper, bool collocated)
             {
                 Ice.Communicator communicator = helper.communicator();
+
                 string sref = "test:" + helper.getTestEndpoint(0);
-                Ice.ObjectPrx obj = communicator.stringToProxy(sref);
-                test(obj != null);
+                var p = Test.TestIntfPrxHelper.createProxy(communicator, sref);
 
-                Test.TestIntfPrx p = Test.TestIntfPrxHelper.uncheckedCast(obj);
                 sref = "testController:" + helper.getTestEndpoint(1);
-                obj = communicator.stringToProxy(sref);
-                test(obj != null);
-
-                Test.TestIntfControllerPrx testController = Test.TestIntfControllerPrxHelper.uncheckedCast(obj);
+                var testController = Test.TestIntfControllerPrxHelper.createProxy(communicator, sref);
 
                 var output = helper.getWriter();
 
@@ -222,8 +218,7 @@ namespace Ice
                         var initData = new InitializationData();
                         initData.properties = communicator.getProperties().ice_clone_();
                         Communicator ic = helper.initialize(initData);
-                        ObjectPrx o = ic.stringToProxy(p.ToString());
-                        Test.TestIntfPrx p2 = Test.TestIntfPrxHelper.checkedCast(o);
+                        Test.TestIntfPrx p2 = Test.TestIntfPrxHelper.createProxy(ic, p.ToString());
                         ic.destroy();
 
                         try
@@ -926,8 +921,8 @@ namespace Ice
                 output.Write("testing result struct... ");
                 output.Flush();
                 {
-                    var q = Test.Outer.Inner.TestIntfPrxHelper.uncheckedCast(
-                        communicator.stringToProxy("test2:" + helper.getTestEndpoint(0)));
+                    var q = Test.Outer.Inner.TestIntfPrxHelper.createProxy(
+                        communicator, "test2:" + helper.getTestEndpoint(0));
                     var r = await q.opAsync(1);
                     test(r.returnValue == 1);
                     test(r.j == 1);

--- a/csharp/test/Ice/operations/AllTests.cs
+++ b/csharp/test/Ice/operations/AllTests.cs
@@ -12,9 +12,8 @@ namespace Ice
                 var output = helper.getWriter();
                 output.Flush();
                 string rf = "test:" + helper.getTestEndpoint(0);
-                Ice.ObjectPrx baseProxy = communicator.stringToProxy(rf);
-                var cl = Test.MyClassPrxHelper.checkedCast(baseProxy);
-                var derivedProxy = Test.MyDerivedClassPrxHelper.checkedCast(cl);
+                var cl = Test.MyClassPrxHelper.createProxy(communicator, rf);
+                var derivedProxy = Test.MyDerivedClassPrxHelper.uncheckedCast(cl);
 
                 output.Write("testing twoway operations... ");
                 output.Flush();

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -1442,8 +1442,7 @@ namespace Ice
                         ctx["two"] = "TWO";
                         ctx["three"] = "THREE";
 
-                        var p3 = Test.MyClassPrxHelper.uncheckedCast(
-                            ic.stringToProxy("test:" + helper.getTestEndpoint(0)));
+                        var p3 = Test.MyClassPrxHelper.createProxy(ic, "test:" + helper.getTestEndpoint(0));
 
                         ic.getImplicitContext().setContext(ctx);
                         test(Ice.CollectionComparer.Equals(ic.getImplicitContext().getContext(), ctx));

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -1263,8 +1263,7 @@ namespace Ice
                             ["three"] = "THREE"
                         };
 
-                        var p3 =
-                            Test.MyClassPrxHelper.uncheckedCast(ic.stringToProxy("test:" + helper.getTestEndpoint(0)));
+                        var p3 = Test.MyClassPrxHelper.createProxy(ic, "test:" + helper.getTestEndpoint(0));
 
                         ic.getImplicitContext().setContext(ctx);
                         test(CollectionComparer.Equals(ic.getImplicitContext().getContext(), ctx));


### PR DESCRIPTION
This PR adds a new `createProxy` static method on PrxHelper classes.

`createProxy` creates a proxy from a communicator and a proxy string. It's about simplifying this boilerplate code:

```csharp
// old
using var communicator = Ice.Util.initialize(ref args);
var greeter = GreeterPrxHelper.uncheckedCast(
    communicator.stringToProxy("greeter:default -h localhost -p 10000"));
```

or
```csharp
// old
using var communicator = Ice.Util.initialize(ref args);
var greeter = GreeterPrxHelper.checkedCast(
    communicator.stringToProxy("greeter:default -h localhost -p 10000"));
```

to:

```csharp
// new, preferred
using var communicator = Ice.Util.initialize(ref args);
var greeter = GreeterPrxHelper.createProxy(
    communicator,
    "greeter:default -h localhost -p 10000");
```

I also updated the Ice/ami and Ice/operations tests to use this new syntax.