### PR TITLE
Cleanup Deprecated Metadata

### DIFF
--- a/cpp/include/Glacier2/SessionHelper.h
+++ b/cpp/include/Glacier2/SessionHelper.h
@@ -181,10 +181,10 @@ namespace Glacier2
         std::string getRouterHost() const;
 
         /// \cond INTERNAL
-        [[deprecated("is deprecated, use SessionFactoryHelper::setProtocol instead")]]
+        [[deprecated("use SessionFactoryHelper::setProtocol instead")]]
         void setSecure(bool);
 
-        [[deprecated("is deprecated, use SessionFactoryHelper::getProtocol instead")]]
+        [[deprecated("use SessionFactoryHelper::getProtocol instead")]]
         bool getSecure() const;
         /// \endcond
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -753,7 +753,7 @@ Slice::Contained::parseComment(bool stripMarkup) const
     //
     // First check metadata for a deprecated tag.
     //
-    if (auto reason = getDeprecateReason(false))
+    if (auto reason = getDeprecationReason(false))
     {
         comment->_deprecated.push_back(IceUtilInternal::trim(*reason));
     }
@@ -1009,7 +1009,7 @@ Slice::Contained::isDeprecated(bool checkParent) const
 }
 
 optional<string>
-Slice::Contained::getDeprecateReason(bool checkParent) const
+Slice::Contained::getDeprecationReason(bool checkParent) const
 {
     const string prefix = "deprecate:";
     string metadata;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -999,23 +999,23 @@ Slice::Contained::parseFormatMetaData(const list<string>& metaData)
 }
 
 bool
-Slice::Contained::isDeprecated(bool check_parent) const
+Slice::Contained::isDeprecated(bool checkParent) const
 {
     const string deprecate = "deprecate";
     string metadata;
-    ContainedPtr parent = check_parent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
+    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    return (findMetaData(deprecate, metadata) || parent && parent->findMetaData(deprecate, metadata));
+    return (findMetaData(deprecate, metadata) || (parent && parent->findMetaData(deprecate, metadata)));
 }
 
 optional<string>
-Slice::Contained::getDeprecateReason(bool check_parent) const
+Slice::Contained::getDeprecateReason(bool checkParent) const
 {
     const string prefix = "deprecate:";
     string metadata;
-    ContainedPtr parent = check_parent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
+    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    if (findMetaData(prefix, metadata) || parent && parent->findMetaData(prefix, metadata))
+    if (findMetaData(prefix, metadata) || (parent && parent->findMetaData(prefix, metadata)))
     {
         assert(metadata.find(prefix) == 0);
         return metadata.substr(prefix.size());

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -748,19 +748,14 @@ Slice::Contained::parseComment(bool stripMarkup) const
 {
     CommentPtr comment = make_shared<Comment>();
 
-    comment->_isDeprecated = false;
+    comment->_isDeprecated = isDeprecated(false);
 
     //
     // First check metadata for a deprecated tag.
     //
-    string deprecateMetadata;
-    if (findMetaData("deprecate", deprecateMetadata))
+    if (auto reason = getDeprecateReason(false))
     {
-        comment->_isDeprecated = true;
-        if (deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
-        {
-            comment->_deprecated.push_back(IceUtilInternal::trim(deprecateMetadata.substr(10)));
-        }
+        comment->_deprecated.push_back(IceUtilInternal::trim(*reason));
     }
 
     if (!comment->_isDeprecated && _comment.empty())
@@ -1001,6 +996,31 @@ Slice::Contained::parseFormatMetaData(const list<string>& metaData)
     }
 
     return result;
+}
+
+bool
+Slice::Contained::isDeprecated(bool check_parent) const
+{
+    const string deprecate = "deprecate";
+    string metadata;
+    ContainedPtr parent = check_parent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
+
+    return (findMetaData(deprecate, metadata) || parent && parent->findMetaData(deprecate, metadata));
+}
+
+optional<string>
+Slice::Contained::getDeprecateReason(bool check_parent) const
+{
+    const string prefix = "deprecate:";
+    string metadata;
+    ContainedPtr parent = check_parent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
+
+    if (findMetaData(prefix, metadata) || parent && parent->findMetaData(prefix, metadata))
+    {
+        assert(metadata.find(prefix) == 0);
+        return metadata.substr(prefix.size());
+    }
+    return nullopt;
 }
 
 Slice::Contained::Contained(const ContainerPtr& container, const string& name)

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -397,6 +397,18 @@ namespace Slice
 
         static FormatType parseFormatMetaData(const std::list<std::string>&);
 
+        /// Returns true if this item is deprecated (due to the presence of `deprecate` metadata).
+        /// @param check_parent If true, this item's immediate container will also be checked for `deprecate` metadata.
+        /// @return True if this item (or possibly its container) has `deprecate` metadata on it, false otherwise.
+        bool isDeprecated(bool) const;
+
+        /// If this item is deprecated, return its deprecation message (if present).
+        /// This is the string argument that can be optionally provided with `deprecate` metadata.
+        /// @param check_parent If true, this item's immediate container will also be checked for `deprecate` messages.
+        /// @return The message provided to the `deprecate` metadata, if present. If `check_parent` is true, and both
+        /// this item and its parent have 'deprecate' messages, the item's message is returned, not its container's.
+        std::optional<std::string> getDeprecateReason(bool) const;
+
         enum ContainedType
         {
             ContainedTypeSequence,

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -407,7 +407,7 @@ namespace Slice
         /// @param checkParent If true, this item's immediate container will also be checked for `deprecate` messages.
         /// @return The message provided to the `deprecate` metadata, if present. If `checkParent` is true, and both
         /// this item and its parent have 'deprecate' messages, the item's message is returned, not its container's.
-        std::optional<std::string> getDeprecateReason(bool checkParent) const;
+        std::optional<std::string> getDeprecationReason(bool checkParent) const;
 
         enum ContainedType
         {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -398,16 +398,16 @@ namespace Slice
         static FormatType parseFormatMetaData(const std::list<std::string>&);
 
         /// Returns true if this item is deprecated (due to the presence of `deprecate` metadata).
-        /// @param check_parent If true, this item's immediate container will also be checked for `deprecate` metadata.
+        /// @param checkParent If true, this item's immediate container will also be checked for `deprecate` metadata.
         /// @return True if this item (or possibly its container) has `deprecate` metadata on it, false otherwise.
-        bool isDeprecated(bool) const;
+        bool isDeprecated(bool checkParent) const;
 
         /// If this item is deprecated, return its deprecation message (if present).
         /// This is the string argument that can be optionally provided with `deprecate` metadata.
-        /// @param check_parent If true, this item's immediate container will also be checked for `deprecate` messages.
-        /// @return The message provided to the `deprecate` metadata, if present. If `check_parent` is true, and both
+        /// @param checkParent If true, this item's immediate container will also be checked for `deprecate` messages.
+        /// @return The message provided to the `deprecate` metadata, if present. If `checkParent` is true, and both
         /// this item and its parent have 'deprecate' messages, the item's message is returned, not its container's.
-        std::optional<std::string> getDeprecateReason(bool) const;
+        std::optional<std::string> getDeprecateReason(bool checkParent) const;
 
         enum ContainedType
         {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -77,7 +77,7 @@ namespace
         string deprecatedSymbol;
         if (p1->isDeprecated(true))
         {
-            if (auto reason = p1->getDeprecationReason(false))
+            if (auto reason = p1->getDeprecationReason(true))
             {
                 deprecatedSymbol = "[[deprecated(\"" + *reason + "\")]] ";
             }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -74,19 +74,19 @@ namespace
 
     string getDeprecateSymbol(const ContainedPtr& p1)
     {
-        string deprecateSymbol;
+        string deprecatedSymbol;
         if (p1->isDeprecated(true))
         {
-            if (auto reason = p1->getDeprecateReason(false))
+            if (auto reason = p1->getDeprecationReason(false))
             {
-                deprecateSymbol = "[[deprecated(\"" + *reason + "\")]] ";
+                deprecatedSymbol = "[[deprecated(\"" + *reason + "\")]] ";
             }
             else
             {
-                deprecateSymbol = "[[deprecated]] ";
+                deprecatedSymbol = "[[deprecated]] ";
             }
         }
-        return deprecateSymbol;
+        return deprecatedSymbol;
     }
 
     void writeConstantValue(

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -83,28 +83,35 @@ namespace
         return "???";
     }
 
-    string getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
+    string getDeprecateReason(const ContainedPtr& p1, const string& type)
     {
-        string deprecateMetadata, deprecateReason;
-        if (p1->findMetaData("deprecate", deprecateMetadata) ||
-            (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata)))
+        string deprecateReason;
+        if (p1->isDeprecated(true))
         {
-            deprecateReason = "This " + type + " has been deprecated.";
-            const string prefix = "deprecate:";
-            if (deprecateMetadata.find(prefix) == 0 && deprecateMetadata.size() > prefix.size())
+            if (auto reason = p1->getDeprecateReason(true))
             {
-                deprecateReason = deprecateMetadata.substr(prefix.size());
+                deprecateReason = *reason;
+            }
+            else
+            {
+                deprecateReason = "This " + type + " has been deprecated.";
             }
         }
         return deprecateReason;
     }
 
-    void emitDeprecate(const ContainedPtr& p1, const ContainedPtr& p2, Output& out, const string& type)
+    void emitObsoleteAttribute(const ContainedPtr& p1, Output& out)
     {
-        string reason = getDeprecateReason(p1, p2, type);
-        if (!reason.empty())
+        if (p1->isDeprecated(true))
         {
-            out << nl << "[global::System.Obsolete(\"" << reason << "\")]";
+            if (auto reason = p1->getDeprecateReason(true))
+            {
+                out << nl << "[global::System.Obsolete(\"" << *reason << "\")]";
+            }
+            else
+            {
+                out << nl << "[global::System.Obsolete]";
+            }
         }
     }
 
@@ -1678,8 +1685,7 @@ Slice::CsVisitor::writeDocCommentTaskAsyncAMI(
 void
 Slice::CsVisitor::writeDocCommentAMD(const OperationPtr& p, const string& extraParam)
 {
-    InterfaceDefPtr interface = p->interface();
-    string deprecateReason = getDeprecateReason(p, interface, "operation");
+    string deprecateReason = getDeprecateReason(p, "operation");
 
     StringList summaryLines;
     StringList remarksLines;
@@ -2326,8 +2332,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     ExceptionPtr base = p->base();
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
-    emitDeprecate(p, 0, _out, "type");
+    writeDocComment(p, getDeprecateReason(p, "type"));
+    emitObsoleteAttribute(p, _out);
     emitAttributes(p);
     emitComVisibleAttribute();
     //
@@ -2575,7 +2581,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     string ns = getNamespace(p);
     _out << sp;
 
-    emitDeprecate(p, 0, _out, "type");
+    emitObsoleteAttribute(p, _out);
 
     emitAttributes(p);
     emitPartialTypeAttributes();
@@ -2830,8 +2836,8 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     const bool explicitValue = p->explicitValue();
 
     _out << sp;
-    emitDeprecate(p, 0, _out, "type");
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    emitObsoleteAttribute(p, _out);
+    writeDocComment(p, getDeprecateReason(p, "type"));
     emitAttributes(p);
     emitGeneratedCodeAttribute();
     _out << nl << "public enum " << name;
@@ -2951,7 +2957,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     _out << sp;
 
-    emitDeprecate(p, cont, _out, "member");
+    emitObsoleteAttribute(p, _out);
 
     string type = typeToString(p->type(), ns, isOptional);
     string dataMemberName = fixId(p->name(), baseTypes, isClass);
@@ -3291,7 +3297,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "interface"));
+    writeDocComment(p, getDeprecateReason(p, "interface"));
     emitGeneratedCodeAttribute();
     _out << nl << "public interface " << name << "Prx : ";
 
@@ -3334,7 +3340,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     vector<string> inParams = getInParams(p, ns);
     ParamDeclList inParamDecls = p->inParameters();
     string retS = typeToString(p->returnType(), ns, p->returnIsOptional());
-    string deprecateReason = getDeprecateReason(p, interface, "operation");
+    string deprecateReason = getDeprecateReason(p, "operation");
 
     {
         //
@@ -3346,10 +3352,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             p,
             deprecateReason,
             "<param name=\"" + context + "\">The Context map to send with the invocation.</param>");
-        if (!deprecateReason.empty())
-        {
-            _out << nl << "[global::System.Obsolete(\"" << deprecateReason << "\")]";
-        }
+        emitObsoleteAttribute(p, _out);
         _out << nl << retS << " " << name << spar << getParams(p, ns)
              << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
                  getUnqualified("Ice.OptionalContext", ns) + "()")
@@ -3371,10 +3374,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             "<param name=\"" + context + "\">Context map to send with the invocation.</param>",
             "<param name=\"" + progress + "\">Sent progress provider.</param>",
             "<param name=\"" + cancel + "\">A cancellation token that receives the cancellation requests.</param>");
-        if (!deprecateReason.empty())
-        {
-            _out << nl << "[global::System.Obsolete(\"" << deprecateReason << "\")]";
-        }
+        emitObsoleteAttribute(p, _out);
         _out << nl << taskResultType(p, ns);
         _out << " " << p->name() << "Async" << spar << inParams
              << (getUnqualified("Ice.OptionalContext", ns) + " " + context + " = new " +
@@ -3470,7 +3470,7 @@ Slice::Gen::OpsVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string opIntfName = "Operations";
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "interface"));
+    writeDocComment(p, getDeprecateReason(p, "interface"));
     emitGeneratedCodeAttribute();
     _out << nl << "public interface " << name << opIntfName << '_';
     if (bases.size() > 0)
@@ -3513,11 +3513,11 @@ Slice::Gen::OpsVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             writeDocComment(
                 op,
-                getDeprecateReason(op, p, "operation"),
+                getDeprecateReason(op, "operation"),
                 "<param name=\"" + args.back() + "\">The Current object for the invocation.</param>");
         }
         emitAttributes(op);
-        emitDeprecate(op, op, _out, "operation");
+        emitObsoleteAttribute(op, _out);
         emitGeneratedCodeAttribute();
         _out << nl << retS << " " << opName << spar << params << epar << ";";
     }
@@ -3587,7 +3587,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         vector<string> args = getArgs(op);
         vector<string> argsAMI = getInArgs(op);
 
-        string deprecateReason = getDeprecateReason(op, p, "operation");
+        string deprecateReason = getDeprecateReason(op, "operation");
 
         ParamDeclList inParams = op->inParameters();
         ParamDeclList outParams = op->outParameters();

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -83,7 +83,7 @@ namespace
         return "???";
     }
 
-    string getDeprecateReason(const ContainedPtr& p1, const string& type)
+    string getDeprecationMessageForComment(const ContainedPtr& p1, const string& type)
     {
         string deprecateReason;
         if (p1->isDeprecated(true))
@@ -1685,7 +1685,7 @@ Slice::CsVisitor::writeDocCommentTaskAsyncAMI(
 void
 Slice::CsVisitor::writeDocCommentAMD(const OperationPtr& p, const string& extraParam)
 {
-    string deprecateReason = getDeprecateReason(p, "operation");
+    string deprecateReason = getDeprecationMessageForComment(p, "operation");
 
     StringList summaryLines;
     StringList remarksLines;
@@ -2332,7 +2332,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     ExceptionPtr base = p->base();
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, "type"));
+    writeDocComment(p, getDeprecationMessageForComment(p, "type"));
     emitObsoleteAttribute(p, _out);
     emitAttributes(p);
     emitComVisibleAttribute();
@@ -2837,7 +2837,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     _out << sp;
     emitObsoleteAttribute(p, _out);
-    writeDocComment(p, getDeprecateReason(p, "type"));
+    writeDocComment(p, getDeprecationMessageForComment(p, "type"));
     emitAttributes(p);
     emitGeneratedCodeAttribute();
     _out << nl << "public enum " << name;
@@ -3297,7 +3297,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, "interface"));
+    writeDocComment(p, getDeprecationMessageForComment(p, "interface"));
     emitGeneratedCodeAttribute();
     _out << nl << "public interface " << name << "Prx : ";
 
@@ -3340,7 +3340,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     vector<string> inParams = getInParams(p, ns);
     ParamDeclList inParamDecls = p->inParameters();
     string retS = typeToString(p->returnType(), ns, p->returnIsOptional());
-    string deprecateReason = getDeprecateReason(p, "operation");
+    string deprecateReason = getDeprecationMessageForComment(p, "operation");
 
     {
         //
@@ -3470,7 +3470,7 @@ Slice::Gen::OpsVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string opIntfName = "Operations";
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, "interface"));
+    writeDocComment(p, getDeprecationMessageForComment(p, "interface"));
     emitGeneratedCodeAttribute();
     _out << nl << "public interface " << name << opIntfName << '_';
     if (bases.size() > 0)
@@ -3513,7 +3513,7 @@ Slice::Gen::OpsVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             writeDocComment(
                 op,
-                getDeprecateReason(op, "operation"),
+                getDeprecationMessageForComment(op, "operation"),
                 "<param name=\"" + args.back() + "\">The Current object for the invocation.</param>");
         }
         emitAttributes(op);
@@ -3587,7 +3587,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         vector<string> args = getArgs(op);
         vector<string> argsAMI = getInArgs(op);
 
-        string deprecateReason = getDeprecateReason(op, "operation");
+        string deprecateReason = getDeprecationMessageForComment(op, "operation");
 
         ParamDeclList inParams = op->inParameters();
         ParamDeclList outParams = op->outParameters();

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -88,7 +88,7 @@ namespace
         string deprecateReason;
         if (p1->isDeprecated(true))
         {
-            if (auto reason = p1->getDeprecateReason(true))
+            if (auto reason = p1->getDeprecationReason(true))
             {
                 deprecateReason = *reason;
             }
@@ -104,7 +104,7 @@ namespace
     {
         if (p1->isDeprecated(true))
         {
-            if (auto reason = p1->getDeprecateReason(true))
+            if (auto reason = p1->getDeprecationReason(true))
             {
                 out << nl << "[global::System.Obsolete(\"" << *reason << "\")]";
             }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -86,13 +86,6 @@ namespace
         return name;
     }
 
-    bool isDeprecated(const ContainedPtr& p1, const ContainedPtr& p2)
-    {
-        string deprecateMetadata;
-        return p1->findMetaData("deprecate", deprecateMetadata) ||
-               (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata));
-    }
-
     bool isValue(const TypePtr& type)
     {
         BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
@@ -1625,15 +1618,10 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
 
         out << sp;
         writeHiddenDocComment(out);
-        for (OperationList::iterator r = allOps.begin(); r != allOps.end(); ++r)
+        for (const OperationPtr& op : allOps)
         {
-            //
             // Suppress deprecation warnings if this method dispatches to a deprecated operation.
-            //
-            OperationPtr op = *r;
-            InterfaceDefPtr interface = op->interface();
-            assert(interface);
-            if (isDeprecated(op, interface))
+            if (op->isDeprecated(true))
             {
                 out << nl << "@SuppressWarnings(\"deprecation\")";
                 break;

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1620,6 +1620,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         writeHiddenDocComment(out);
         for (const OperationPtr& op : allOps)
         {
+            // TODO: remove this when we fix where deprecation messages are applied.
             // Suppress deprecation warnings if this method dispatches to a deprecated operation.
             if (op->isDeprecated(true))
             {

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -56,22 +56,6 @@ namespace
         return "???";
     }
 
-    string getDeprecateReason(const ContainedPtr& p1, const ContainedPtr& p2, const string& type)
-    {
-        string deprecateMetadata, deprecateReason;
-        if (p1->findMetaData("deprecate", deprecateMetadata) ||
-            (p2 != 0 && p2->findMetaData("deprecate", deprecateMetadata)))
-        {
-            deprecateReason = "This " + type + " has been deprecated.";
-            const string prefix = "deprecate:";
-            if (deprecateMetadata.find(prefix) == 0 && deprecateMetadata.size() > prefix.size())
-            {
-                deprecateReason = deprecateMetadata.substr(prefix.size());
-            }
-        }
-        return deprecateReason;
-    }
-
     void printHeader(IceUtilInternal::Output& out)
     {
         static const char* header = "//\n"
@@ -548,56 +532,43 @@ Slice::JsVisitor::splitComment(const ContainedPtr& p)
 }
 
 void
-Slice::JsVisitor::writeDocComment(const ContainedPtr& p, const string& deprecateReason, const string& extraParam)
+Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p)
 {
     StringList lines = splitComment(p);
-    if (lines.empty())
+    bool isDeprecated = p->isDeprecated(false);
+
+    if (lines.empty() && !isDeprecated)
     {
-        if (!deprecateReason.empty())
-        {
-            _out << nl << "/**";
-            _out << nl << " * @deprecated " << deprecateReason;
-            _out << nl << " **/";
-        }
+        // There's nothing to write for this doc-comment.
         return;
     }
 
     _out << nl << "/**";
 
-    bool doneExtraParam = false;
-    for (StringList::const_iterator i = lines.begin(); i != lines.end(); ++i)
+    for (const auto& line : lines)
     {
         //
         // @param must precede @return, so emit any extra parameter
         // when @return is seen.
         //
-        if (i->find("@return") != string::npos && !extraParam.empty())
-        {
-            _out << nl << " * " << extraParam;
-            doneExtraParam = true;
-        }
-        if ((*i).empty())
+        if (line.empty())
         {
             _out << nl << " *";
         }
         else
         {
-            _out << nl << " * " << *i;
+            _out << nl << " * " << line;
         }
     }
 
-    if (!doneExtraParam && !extraParam.empty())
+    if (isDeprecated)
     {
-        //
-        // Above code doesn't emit the comment for the extra parameter
-        // if the operation returns a void or doesn't have an @return.
-        //
-        _out << nl << " * " << extraParam;
-    }
-
-    if (!deprecateReason.empty())
-    {
-        _out << nl << " * @deprecated " << deprecateReason;
+        _out << nl << " * @deprecated";
+        if (auto reason = p->getDeprecateReason(false))
+        {
+            // If a reason was supplied, append it after the `@deprecated` tag.
+            _out << " " << *reason;
+        }
     }
 
     _out << nl << " **/";
@@ -1333,7 +1304,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocCommentFor(p);
     _out << nl << localScope << '.' << name << " = class";
     _out << " extends " << baseRef;
 
@@ -1450,7 +1421,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocCommentFor(p);
     _out << nl << localScope << "." << p->name() << " = class extends ";
     _out << "Ice.Object";
     _out << sb;
@@ -1790,7 +1761,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocCommentFor(p);
     _out << nl << localScope << '.' << name << " = class extends " << baseRef;
     _out << sb;
 
@@ -1898,7 +1869,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     }
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocCommentFor(p);
     _out << nl << localScope << '.' << name << " = class";
     _out << sb;
 
@@ -2024,7 +1995,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     const string name = fixId(p->name());
 
     _out << sp;
-    writeDocComment(p, getDeprecateReason(p, 0, "type"));
+    writeDocCommentFor(p);
     _out << nl << localScope << '.' << name << " = Slice.defineEnum([";
     _out.inc();
     _out << nl;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -564,7 +564,7 @@ Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p)
     if (isDeprecated)
     {
         _out << nl << " * @deprecated";
-        if (auto reason = p->getDeprecateReason(false))
+        if (auto reason = p->getDeprecationReason(false))
         {
             // If a reason was supplied, append it after the `@deprecated` tag.
             _out << " " << *reason;

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -31,7 +31,7 @@ namespace Slice
         writeConstantValue(const std::string&, const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
         static StringList splitComment(const ContainedPtr&);
-        void writeDocComment(const ContainedPtr&, const std::string&, const std::string& = "");
+        void writeDocCommentFor(const ContainedPtr&);
 
         ::IceUtilInternal::Output& _out;
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -887,19 +887,12 @@ namespace
     {
         DocElements doc;
 
-        doc.deprecated = false;
+        doc.deprecated = p->isDeprecated(false);
 
-        //
         // First check metadata for a deprecated tag.
-        //
-        string deprecateMetadata;
-        if (p->findMetaData("deprecate", deprecateMetadata))
+        if (auto reason = p->getDeprecateReason(false))
         {
-            doc.deprecated = true;
-            if (deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
-            {
-                doc.deprecateReason.push_back(IceUtilInternal::trim(deprecateMetadata.substr(10)));
-            }
+            doc.deprecateReason.push_back(IceUtilInternal::trim(*reason));
         }
 
         //

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -890,7 +890,7 @@ namespace
         doc.deprecated = p->isDeprecated(false);
 
         // First check metadata for a deprecated tag.
-        if (auto reason = p->getDeprecateReason(false))
+        if (auto reason = p->getDeprecationReason(false))
         {
             doc.deprecateReason.push_back(IceUtilInternal::trim(*reason));
         }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1017,16 +1017,11 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "))";
 
-        string deprecateMetadata;
-        if ((*s)->findMetaData("deprecate", deprecateMetadata) || p->findMetaData("deprecate", deprecateMetadata))
+        if ((*s)->isDeprecated(true))
         {
-            string msg;
-            string::size_type pos = deprecateMetadata.find(':');
-            if (pos != string::npos && pos < deprecateMetadata.size() - 1)
-            {
-                msg = deprecateMetadata.substr(pos + 1);
-            }
-            _out << nl << className << "._op_" << (*s)->name() << ".deprecate(\"" << msg << "\")";
+            // Get the deprecation reason if present, or default to an empty string.
+            string reason = (*s)->getDeprecateReason(true).value_or("");
+            _out << nl << className << "._op_" << (*s)->name() << ".deprecate(\"" << reason << "\")";
         }
     }
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1020,7 +1020,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if ((*s)->isDeprecated(true))
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = (*s)->getDeprecateReason(true).value_or("");
+            string reason = (*s)->getDeprecationReason(true).value_or("");
             _out << nl << className << "._op_" << (*s)->name() << ".deprecate(\"" << reason << "\")";
         }
     }

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -673,7 +673,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if ((*s)->isDeprecated(true))
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = (*s)->getDeprecateReason(true).value_or("");
+            string reason = (*s)->getDeprecationReason(true).value_or("");
             _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << ".deprecate(\"" << reason << "\")";
         }
     }

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -670,7 +670,6 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "])";
 
-
         if ((*s)->isDeprecated(true))
         {
             // Get the deprecation reason if present, or default to an empty string.

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -670,16 +670,12 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "])";
 
-        string deprecateMetadata;
-        if ((*s)->findMetaData("deprecate", deprecateMetadata) || p->findMetaData("deprecate", deprecateMetadata))
+
+        if ((*s)->isDeprecated(true))
         {
-            string msg;
-            string::size_type pos = deprecateMetadata.find(':');
-            if (pos != string::npos && pos < deprecateMetadata.size() - 1)
-            {
-                msg = deprecateMetadata.substr(pos + 1);
-            }
-            _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << ".deprecate(\"" << msg << "\")";
+            // Get the deprecation reason if present, or default to an empty string.
+            string reason = (*s)->getDeprecateReason(true).value_or("");
+            _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << ".deprecate(\"" << reason << "\")";
         }
     }
 

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -398,7 +398,7 @@ SwiftGenerator::parseComment(const ContainedPtr& p)
     doc.deprecated = p->isDeprecated(false);
 
     // First check metadata for a deprecated tag.
-    if (auto reason = p->getDeprecateReason(false))
+    if (auto reason = p->getDeprecationReason(false))
     {
         doc.deprecateReason.push_back(IceUtilInternal::trim(*reason));
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -395,19 +395,12 @@ SwiftGenerator::parseComment(const ContainedPtr& p)
 {
     DocElements doc;
 
-    doc.deprecated = false;
+    doc.deprecated = p->isDeprecated(false);
 
-    //
     // First check metadata for a deprecated tag.
-    //
-    string deprecateMetadata;
-    if (p->findMetaData("deprecate", deprecateMetadata))
+    if (auto reason = p->getDeprecateReason(false))
     {
-        doc.deprecated = true;
-        if (deprecateMetadata.find("deprecate:") == 0 && deprecateMetadata.size() > 10)
-        {
-            doc.deprecateReason.push_back(IceUtilInternal::trim(deprecateMetadata.substr(10)));
-        }
+        doc.deprecateReason.push_back(IceUtilInternal::trim(*reason));
     }
 
     //

--- a/js/gulp/bundle.js
+++ b/js/gulp/bundle.js
@@ -222,7 +222,7 @@ var StringBuffer = function()
 
 StringBuffer.prototype.write = function(data)
 {
-    // Use new Buffer.from(string, encoding) if Buffer.alloc is avilable, Buffer constructors are deprecated.
+    // Use new Buffer.from(string, encoding) if Buffer.alloc is available, Buffer constructors are deprecated.
     // NOTE: we don't check for Buffer.from which already exists but only accepts array.
     this.buffer = Buffer.concat([this.buffer,
                     typeof(Buffer.alloc) === 'function' ? Buffer.from(data, "utf8") : new Buffer(data, "utf8")]);

--- a/swift/test/Ice/defaultValue/Test.ice
+++ b/swift/test/Ice/defaultValue/Test.ice
@@ -4,8 +4,8 @@
 
 #pragma once
 
-[["swift:class-resolver-prefix:IceDefaultValue",
-  "suppress-warning:deprecated"]] // For enumerator references
+[["swift:class-resolver-prefix:IceDefaultValue"]]
+[["suppress-warning:deprecated"]] // For enumerator references
 
 module Test
 {


### PR DESCRIPTION
This PR addresses part of #2085.

Now, when the Slice compiler generates a `[[deprecated]]`, `[Obsolete]`, etc. something to mark an item as deprecated,
it will only supply a message when the user did.

Whereas right now, if the user didn't supply a message, we auto-compute one.
#2085 points out that this auto-computed message is broken anyways.

----

While fixing this, I also did some cleanup. Mostly adding 2 functions to the `Parser`: `isDeprecated` and `getDeprecateReason`.
Instead of our previous approach of defining approximate copies of these functions in each `slice2xxx` separate folder...

----

After this PR I'll address the 2nd part of #2085, which is removing the 'deprecated' metadata from the dispatch side of things.