### PR TITLE
Update generated ctors for struct/class/exception in C#

### DIFF
--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -534,9 +534,3 @@ Slice::isProxyType(const TypePtr& type)
     }
     return false;
 }
-
-bool
-Slice::contains(const DataMemberList& dataMembers, const DataMemberPtr& dataMember)
-{
-    return find(dataMembers.begin(), dataMembers.end(), dataMember) != dataMembers.end();
-}

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -534,3 +534,9 @@ Slice::isProxyType(const TypePtr& type)
     }
     return false;
 }
+
+bool
+Slice::contains(const DataMemberList& dataMembers, const DataMemberPtr& dataMember)
+{
+    return find(dataMembers.begin(), dataMembers.end(), dataMember) != dataMembers.end();
+}

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -59,5 +59,7 @@ namespace Slice
     bool checkIdentifier(const std::string&);
 
     bool isProxyType(const TypePtr& type);
+
+    bool contains(const DataMemberList&, const DataMemberPtr&);
 }
 #endif

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -59,7 +59,5 @@ namespace Slice
     bool checkIdentifier(const std::string&);
 
     bool isProxyType(const TypePtr& type);
-
-    bool contains(const DataMemberList&, const DataMemberPtr&);
 }
 #endif

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1509,33 +1509,12 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
             }
             else
             {
-                if (isValueType(type))
+                call = param;
+                if (isStack)
                 {
-                    call = param;
-                    if (isStack)
-                    {
-                        call += "_tmp";
-                    }
-                }
-                else
-                {
-                    call = "(";
-                    call += param;
-                    if (isStack)
-                    {
-                        call += "_tmp";
-                    }
-                    call += "[ix] == null ? new " + typeS + "() : " + param;
-                    if (isStack)
-                    {
-                        call += "_tmp";
-                    }
+                    call += "_tmp";
                 }
                 call += "[ix]";
-                if (!isValueType(type))
-                {
-                    call += ")";
-                }
             }
             call += ".";
             call += "ice_writeMembers";

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -713,15 +713,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
         }
         else
         {
-            if (isMappedToClass(st))
-            {
-                out << nl << param << " = " << typeToString(type, package) << ".ice_read(" << stream << ");";
-            }
-            else
-            {
-                // It is slightly more efficient to read the members directly and not make a copy with ice_read.
-                out << nl << param << ".ice_readMembers(" << stream << ");";
-            }
+            out << nl << param << " = new " << typeToString(type, package) << "(" << stream << ");";
         }
         return;
     }
@@ -1584,16 +1576,11 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
             if (isArray || isStack)
             {
                 string v = isArray ? param : param + "_tmp";
-                if (isMappedToClass(st))
-                {
-                    out << nl << v << "[ix] = new " << typeS << "();";
-                }
-                out << nl << v << "[ix].ice_readMembers(" << stream << ");";
+                out << nl << v << "[ix] = new " << typeS << "(istr);";
             }
             else
             {
-                out << nl << typeS << " val = new " << typeS << "();";
-                out << nl << "val.ice_readMembers(" << stream << ");";
+                out << nl << typeS << " val = new " << typeS << "(istr);";
                 out << nl << param << "." << addMethod << "(val);";
             }
             out << eb;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -936,7 +936,8 @@ Slice::CsVisitor::emitGeneratedCodeAttribute()
 void
 Slice::CsVisitor::emitNonBrowsableAttribute()
 {
-    _out << nl << "[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]";
+    _out << nl
+         << "[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]";
 }
 
 void
@@ -1061,8 +1062,7 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& dataMembers,
         {
             StructPtr st = dynamic_pointer_cast<Struct>(q->type());
 
-            if (dynamic_pointer_cast<Sequence>(q->type()) ||
-                dynamic_pointer_cast<Dictionary>(q->type()) ||
+            if (dynamic_pointer_cast<Sequence>(q->type()) || dynamic_pointer_cast<Dictionary>(q->type()) ||
                 (st && isMappedToClass(st)))
             {
                 _out << nl << "this." << fixId(q->name(), baseTypes) << " = null;"; // should be null!
@@ -2027,8 +2027,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
             paramDecl.push_back(memberType + " " + memberName);
 
             StructPtr st = dynamic_pointer_cast<Struct>(q->type());
-            if (dynamic_pointer_cast<Sequence>(q->type()) ||
-                dynamic_pointer_cast<Dictionary>(q->type()) ||
+            if (dynamic_pointer_cast<Sequence>(q->type()) || dynamic_pointer_cast<Dictionary>(q->type()) ||
                 (st && isMappedToClass(st)))
             {
                 secondaryCtorParams.push_back(memberType + " " + memberName);
@@ -2052,8 +2051,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
                 baseParamNames.push_back(memberName);
 
                 StructPtr st = dynamic_pointer_cast<Struct>(q->type());
-                if (dynamic_pointer_cast<Sequence>(q->type()) ||
-                    dynamic_pointer_cast<Dictionary>(q->type()) ||
+                if (dynamic_pointer_cast<Sequence>(q->type()) || dynamic_pointer_cast<Dictionary>(q->type()) ||
                     (st && isMappedToClass(st)))
                 {
                     secondaryCtorBaseParamNames.push_back(memberName);
@@ -2512,8 +2510,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         {
             StructPtr st = dynamic_pointer_cast<Struct>(q->type());
 
-            if (dynamic_pointer_cast<Sequence>(q->type()) ||
-                dynamic_pointer_cast<Dictionary>(q->type()) ||
+            if (dynamic_pointer_cast<Sequence>(q->type()) || dynamic_pointer_cast<Dictionary>(q->type()) ||
                 (st && isMappedToClass(st)))
             {
                 string memberName = fixId(q->name(), DotNet::ICloneable);
@@ -2642,7 +2639,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << sp;
     emitGeneratedCodeAttribute();
     _out << nl << "public static " << name << " ice_read(" << getUnqualified("Ice.InputStream", ns)
-        << " istr) => new(istr);";
+         << " istr) => new(istr);";
 
     _out << sp << nl << "#endregion"; // marshaling support
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2522,6 +2522,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     {
         writeUnmarshalDataMember(q, fixId(q->name(), classMapping ? DotNet::ICloneable : 0), ns, true);
     }
+    _out << nl << "ice_initialize();";
     _out << eb;
 
     _out << sp << nl << "#endregion"; // Constructor(s)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2513,6 +2513,17 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << nl << "ice_initialize();";
     _out << eb;
 
+    // Unmarshaling constructor
+    _out << sp;
+    emitGeneratedCodeAttribute();
+    _out << nl << "public " << name << "(" << getUnqualified("Ice.InputStream", ns) << " istr)";
+    _out << sb;
+    for (const auto& q : dataMembers)
+    {
+        writeUnmarshalDataMember(q, fixId(q->name(), classMapping ? DotNet::ICloneable : 0), ns, true);
+    }
+    _out << eb;
+
     _out << sp << nl << "#endregion"; // Constructor(s)
 
     if (classMapping)
@@ -2574,16 +2585,6 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public void ice_readMembers(" << getUnqualified("Ice.InputStream", ns) << " istr)";
-    _out << sb;
-    for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
-    {
-        writeUnmarshalDataMember(*q, fixId((*q)->name(), classMapping ? DotNet::ICloneable : 0), ns, true);
-    }
-    _out << eb;
-
-    _out << sp;
-    emitGeneratedCodeAttribute();
     _out << nl << "public static void ice_write(" << getUnqualified("Ice.OutputStream", ns) << " ostr, " << name
          << " v)";
     _out << sb;
@@ -2606,12 +2607,8 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public static " << name << " ice_read(" << getUnqualified("Ice.InputStream", ns) << " istr)";
-    _out << sb;
-    _out << nl << "var v = new " << name << "();";
-    _out << nl << "v.ice_readMembers(istr);";
-    _out << nl << "return v;";
-    _out << eb;
+    _out << nl << "public static " << name << " ice_read(" << getUnqualified("Ice.InputStream", ns)
+        << " istr) => new(istr);";
 
     if (classMapping)
     {

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -46,6 +46,7 @@ namespace Slice
         void emitAttributes(const ContainedPtr&);
         void emitComVisibleAttribute();
         void emitGeneratedCodeAttribute();
+        void emitNonBrowsableAttribute();
         void emitPartialTypeAttributes();
 
         static std::string getParamAttributes(const ParamDeclPtr&);

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -55,10 +55,7 @@ namespace Slice
 
         void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
-        // Returns true when the type has a struct field mapped to a class.
-        bool requiresDataMemberInitializers(const DataMemberList&);
-
-        // Generates "new()" for each struct field mapped to a class.
+        // Generates "= null!" for non-nullable fields (Slice class and exception only).
         void writeDataMemberInitializers(const DataMemberList&, unsigned int);
 
         std::string toCsIdent(const std::string&);

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1134,11 +1134,9 @@ public sealed class ConnectionI : Ice.Internal.EventHandler, ResponseHandler, Ca
                                     throw ex;
                                 }
 
-                                ProtocolVersion pv = new ProtocolVersion();
-                                pv.ice_readMembers(_readStream);
+                                ProtocolVersion pv = new ProtocolVersion(_readStream);
                                 Protocol.checkSupportedProtocol(pv);
-                                EncodingVersion ev = new EncodingVersion();
-                                ev.ice_readMembers(_readStream);
+                                EncodingVersion ev = new EncodingVersion(_readStream);
                                 Protocol.checkSupportedProtocolEncoding(ev);
 
                                 _readStream.readByte(); // messageType
@@ -2182,12 +2180,10 @@ public sealed class ConnectionI : Ice.Internal.EventHandler, ResponseHandler, Ca
                     throw ex;
                 }
 
-                ProtocolVersion pv = new ProtocolVersion();
-                pv.ice_readMembers(_readStream);
+                ProtocolVersion pv = new ProtocolVersion(_readStream);
                 Protocol.checkSupportedProtocol(pv);
 
-                EncodingVersion ev = new EncodingVersion();
-                ev.ice_readMembers(_readStream);
+                EncodingVersion ev = new EncodingVersion(_readStream);
                 Protocol.checkSupportedProtocolEncoding(ev);
 
                 byte messageType = _readStream.readByte();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -520,8 +520,7 @@ public class InputStream
         }
         _encapsStack.sz = sz;
 
-        EncodingVersion encoding = new EncodingVersion();
-        encoding.ice_readMembers(this);
+        EncodingVersion encoding = new EncodingVersion(this);
         Protocol.checkSupportedEncoding(encoding); // Make sure the encoding is supported.
         _encapsStack.setEncoding(encoding);
 
@@ -589,8 +588,7 @@ public class InputStream
             throw new UnmarshalOutOfBoundsException();
         }
 
-        var encoding = new EncodingVersion();
-        encoding.ice_readMembers(this);
+        var encoding = new EncodingVersion(this);
         Protocol.checkSupportedEncoding(encoding); // Make sure the encoding is supported.
 
         if (encoding.Equals(Util.Encoding_1_0))
@@ -628,8 +626,7 @@ public class InputStream
             throw new UnmarshalOutOfBoundsException();
         }
 
-        encoding = new EncodingVersion();
-        encoding.ice_readMembers(this);
+        encoding = new EncodingVersion(this);
         _buf.b.position(_buf.b.position() - 6);
 
         byte[] v = new byte[sz];
@@ -674,8 +671,7 @@ public class InputStream
         {
             throw new UnmarshalOutOfBoundsException();
         }
-        EncodingVersion encoding = new EncodingVersion();
-        encoding.ice_readMembers(this);
+        EncodingVersion encoding = new EncodingVersion(this);
         try
         {
             _buf.b.position(_buf.b.position() + sz - 6);

--- a/csharp/src/Ice/Internal/Incoming.cs
+++ b/csharp/src/Ice/Internal/Incoming.cs
@@ -94,7 +94,7 @@ public class Incoming : Ice.Request
         //
         // Read the current.
         //
-        _current.id.ice_readMembers(_is);
+        _current.id = new Identity(_is);
 
         //
         // For compatibility with the old FacetPath.

--- a/csharp/src/Ice/Internal/MetricsAdminI.cs
+++ b/csharp/src/Ice/Internal/MetricsAdminI.cs
@@ -184,10 +184,7 @@ public class MetricsMap<T> : IMetricsMap where T : IceMX.Metrics, new()
             {
                 return null;
             }
-            IceMX.MetricsFailures f = new IceMX.MetricsFailures();
-            f.id = _object.id;
-            f.failures = new Dictionary<string, int>(_failures);
-            return f;
+            return new IceMX.MetricsFailures(_object.id, new Dictionary<string, int>(_failures));
         }
 
         internal void attach(IceMX.MetricsHelper<T> helper)
@@ -884,7 +881,7 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_, Ice.PropertiesAdminUpdateC
             {
                 return view.getFailures(mapName, id);
             }
-            return new IceMX.MetricsFailures();
+            return new IceMX.MetricsFailures("", null); // null == dictionary
         }
     }
 

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -783,8 +783,7 @@ public class OutgoingAsync : ProxyOutgoingAsyncBase
                 case ReplyStatus.replyFacetNotExist:
                 case ReplyStatus.replyOperationNotExist:
                 {
-                    var ident = new Ice.Identity();
-                    ident.ice_readMembers(is_);
+                    var ident = new Ice.Identity(is_);
 
                     //
                     // For compatibility with the old FacetPath.

--- a/csharp/src/Ice/Internal/ProxyFactory.cs
+++ b/csharp/src/Ice/Internal/ProxyFactory.cs
@@ -48,8 +48,7 @@ public sealed class ProxyFactory
 
     public Ice.ObjectPrx streamToProxy(Ice.InputStream s)
     {
-        Ice.Identity ident = new Ice.Identity();
-        ident.ice_readMembers(s);
+        var ident = new Ice.Identity(s);
 
         Reference r = _instance.referenceFactory().create(ident, s);
         return referenceToProxy(r);

--- a/csharp/src/Ice/Internal/ReferenceFactory.cs
+++ b/csharp/src/Ice/Internal/ReferenceFactory.cs
@@ -586,10 +586,8 @@ public class ReferenceFactory
         Ice.EncodingVersion encoding;
         if (!s.getEncoding().Equals(Ice.Util.Encoding_1_0))
         {
-            protocol = new Ice.ProtocolVersion();
-            protocol.ice_readMembers(s);
-            encoding = new Ice.EncodingVersion();
-            encoding.ice_readMembers(s);
+            protocol = new Ice.ProtocolVersion(s);
+            encoding = new Ice.EncodingVersion(s);
         }
         else
         {

--- a/csharp/src/Ice/Internal/TraceUtil.cs
+++ b/csharp/src/Ice/Internal/TraceUtil.cs
@@ -172,8 +172,7 @@ internal sealed class TraceUtil
                 toStringMode = str.instance().toStringMode();
             }
 
-            Ice.Identity identity = new Ice.Identity();
-            identity.ice_readMembers(str);
+            var identity = new Ice.Identity(str);
             s.Write("\nidentity = " + Ice.Util.identityToString(identity, toStringMode));
 
             string[] facet = str.readStringSeq();

--- a/csharp/src/Ice/ObjectAdapterI.cs
+++ b/csharp/src/Ice/ObjectAdapterI.cs
@@ -63,8 +63,7 @@ public sealed class ObjectAdapterI : ObjectAdapter
 
         try
         {
-            Identity dummy = new Identity();
-            dummy.name = "dummy";
+            var dummy = new Identity(name: "dummy", "");
             updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
         }
         catch (LocalException)
@@ -323,10 +322,7 @@ public sealed class ObjectAdapterI : ObjectAdapter
             // Create a copy of the Identity argument, in case the caller
             // reuses it.
             //
-            Identity id = new Identity();
-            id.category = ident.category;
-            id.name = ident.name;
-
+            var id = new Identity(ident.name, ident.category);
             _servantManager.addServant(obj, id, facet);
 
             return newProxy(id, facet);
@@ -340,10 +336,7 @@ public sealed class ObjectAdapterI : ObjectAdapter
 
     public ObjectPrx addFacetWithUUID(Object obj, string facet)
     {
-        Identity ident = new Identity();
-        ident.category = "";
-        ident.name = Guid.NewGuid().ToString();
-
+        var ident = new Identity(Guid.NewGuid().ToString(), "");
         return addFacet(obj, ident, facet);
     }
 
@@ -564,8 +557,7 @@ public sealed class ObjectAdapterI : ObjectAdapter
 
         try
         {
-            Identity dummy = new Identity();
-            dummy.name = "dummy";
+            var dummy = new Identity("dummy", "");
             updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
         }
         catch (LocalException)
@@ -610,8 +602,7 @@ public sealed class ObjectAdapterI : ObjectAdapter
 
         try
         {
-            Identity dummy = new Identity();
-            dummy.name = "dummy";
+            var dummy = new Identity("dummy", "");
             updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
         }
         catch (LocalException)

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -1683,7 +1683,7 @@ public class OutputStream
     /// <param name="v">The proxy to write.</param>
     public void writeProxy(ObjectPrx v)
     {
-        if (v != null)
+        if (v is not null)
         {
             v.iceWrite(this);
         }

--- a/csharp/src/IceBoxNet/ServiceManagerI.cs
+++ b/csharp/src/IceBoxNet/ServiceManagerI.cs
@@ -249,9 +249,9 @@ internal class ServiceManagerI : ServiceManagerDisp_
             {
                 adapter = _communicator.createObjectAdapter("IceBox.ServiceManager");
 
-                Ice.Identity identity = new Ice.Identity();
-                identity.category = properties.getPropertyWithDefault("IceBox.InstanceName", "IceBox");
-                identity.name = "ServiceManager";
+                var identity = new Ice.Identity(
+                    "ServiceManager",
+                    properties.getPropertyWithDefault("IceBox.InstanceName", "IceBox"));
                 adapter.add(this, identity);
             }
 

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -711,9 +711,7 @@ internal class PluginI : Ice.Plugin
         Ice.LocatorPrx voidLo = Ice.LocatorPrxHelper.uncheckedCast(_locatorAdapter.addWithUUID(new VoidLocatorI()));
 
         string instanceName = properties.getProperty(_name + ".InstanceName");
-        Ice.Identity id = new Ice.Identity();
-        id.name = "Locator";
-        id.category = instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString();
+        var id = new Ice.Identity("Locator", instanceName.Length > 0 ? instanceName : Guid.NewGuid().ToString());
 
         _defaultLocator = _communicator.getDefaultLocator();
         _locator = new LocatorI(_name, LookupPrxHelper.uncheckedCast(lookupPrx), properties, instanceName, voidLo);

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -220,13 +220,9 @@ public class Client : Test.TestHelper
                 Console.Out.Flush();
                 callbackReceiverImpl = new CallbackReceiverI();
                 callbackReceiver = callbackReceiverImpl;
-                Ice.Identity callbackReceiverIdent = new Ice.Identity();
-                callbackReceiverIdent.name = "callbackReceiver";
-                callbackReceiverIdent.category = category;
+                var callbackReceiverIdent = new Ice.Identity("callbackReceiver", category);
                 twowayR = CallbackReceiverPrxHelper.uncheckedCast(adapter.add(callbackReceiver, callbackReceiverIdent));
-                Ice.Identity fakeCallbackReceiverIdent = new Ice.Identity();
-                fakeCallbackReceiverIdent.name = "callbackReceiver";
-                fakeCallbackReceiverIdent.category = "dummy";
+                var fakeCallbackReceiverIdent = new Ice.Identity("callbackReceiver", "dummy");
                 fakeTwowayR =
                     CallbackReceiverPrxHelper.uncheckedCast(adapter.add(callbackReceiver, fakeCallbackReceiverIdent));
                 Console.Out.WriteLine("ok");

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -79,8 +79,7 @@ namespace Ice
                         communicator.stringToProxy("dummy:tcp -h localhost -p 12346 -t 20000:tcp -h localhost -p 12347 -t 10000");
                     adapter.setPublishedEndpoints(prx.ice_getEndpoints());
                     test(adapter.getPublishedEndpoints().Length == 2);
-                    Ice.Identity id = new Ice.Identity();
-                    id.name = "dummy";
+                    Ice.Identity id = new Ice.Identity("dummy", "");
                     test(Ice.UtilInternal.Arrays.Equals(adapter.createProxy(id).ice_getEndpoints(), prx.ice_getEndpoints()));
                     test(Ice.UtilInternal.Arrays.Equals(adapter.getPublishedEndpoints(), prx.ice_getEndpoints()));
                     adapter.refreshPublishedEndpoints();
@@ -117,8 +116,7 @@ namespace Ice
                 output.Write("testing object adapter with router... ");
                 output.Flush();
                 {
-                    Ice.Identity routerId = new Ice.Identity();
-                    routerId.name = "router";
+                    Ice.Identity routerId = new Ice.Identity("router", "");
                     Ice.RouterPrx router =
                         Ice.RouterPrxHelper.uncheckedCast(@base.ice_identity(routerId).ice_connectionId("rc"));
                     Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithRouter("", router);

--- a/csharp/test/Ice/defaultServant/AllTests.cs
+++ b/csharp/test/Ice/defaultServant/AllTests.cs
@@ -33,8 +33,7 @@ namespace Ice
                 r = oa.findDefaultServant("bar");
                 test(r == null);
 
-                Ice.Identity identity = new Ice.Identity();
-                identity.category = "foo";
+                Ice.Identity identity = new Ice.Identity("", "foo");
 
                 string[] names = new string[] { "foo", "bar", "x", "y", "abcdefg" };
 

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+using Ice.defaultValue.Test;
+
 namespace Ice
 {
     namespace defaultValue
@@ -268,10 +270,10 @@ namespace Ice
 
                 output.WriteLine("ok");
 
-                output.Write("testing default constructor... ");
+                output.Write("testing non-primary constructor... ");
                 output.Flush();
                 {
-                    Test.StructNoDefaults v = new Test.StructNoDefaults();
+                    Test.StructNoDefaults v = new Test.StructNoDefaults(bs: null, iseq: null, st2: null, dict: null);
                     test(v.bo == false);
                     test(v.b == 0);
                     test(v.s == 0);
@@ -284,7 +286,7 @@ namespace Ice
                     test(v.bs == null);
                     test(v.iseq == null);
                     test(v.st.a == 0);
-                    test(v.st2 != null);
+                    test(v.st2 == null);
                     test(v.dict == null);
 
                     Test.ExceptionNoDefaults e = new Test.ExceptionNoDefaults();
@@ -292,7 +294,7 @@ namespace Ice
                     test(e.c1 == Test.Color.red);
                     test(e.bs == null);
                     test(e.st.a == 0);
-                    test(e.st2 != null);
+                    test(e.st2 == null);
                     test(e.dict == null);
 
                     Test.ClassNoDefaults cl = new Test.ClassNoDefaults();
@@ -300,7 +302,7 @@ namespace Ice
                     test(cl.c1 == Test.Color.red);
                     test(cl.bs == null);
                     test(cl.st.a == 0);
-                    test(cl.st2 != null);
+                    test(cl.st2 == null);
                     test(cl.dict == null);
                 }
                 output.WriteLine("ok");

--- a/csharp/test/Ice/hash/Client.cs
+++ b/csharp/test/Ice/hash/Client.cs
@@ -412,7 +412,7 @@ public class Client : Test.TestHelper
                 structCollisions = 0;
                 for (i = 0; i < maxIterations && structCollisions < maxCollisions; ++i)
                 {
-                    Test.Polyline polyline = new Test.Polyline();
+                    var polyline = new Test.Polyline(vertices: null);
                     List<Test.Point> vertices = new List<Test.Point>();
                     for (int j = 0; j < 100; ++j)
                     {
@@ -443,7 +443,7 @@ public class Client : Test.TestHelper
                 structCollisions = 0;
                 for (i = 0; i < maxIterations && structCollisions < maxCollisions; ++i)
                 {
-                    Test.ColorPalette colorPalette = new Test.ColorPalette();
+                    Test.ColorPalette colorPalette = new Test.ColorPalette(colors: null);
                     colorPalette.colors = new Dictionary<int, Test.Color>();
                     for (int j = 0; j < 100; ++j)
                     {

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -579,8 +579,7 @@ namespace Ice
                 communicator.getProperties().setProperty("Hello.AdapterId", Guid.NewGuid().ToString());
                 Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("Hello", "default");
 
-                Ice.Identity id = new Ice.Identity();
-                id.name = Guid.NewGuid().ToString();
+                var id = new Ice.Identity(Guid.NewGuid().ToString(), "");
                 adapter.add(new HelloI(), id);
                 adapter.activate();
 

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -307,7 +307,7 @@ namespace Ice
                         retS = initial.opBaseSeq(inS, out outS);
 
                         inS = new Test.Base[1];
-                        inS[0] = new Test.Base(new S(), "");
+                        inS[0] = new Test.Base(new S(""), "");
                         retS = initial.opBaseSeq(inS, out outS);
                         test(retS.Length == 1 && outS.Length == 1);
                     }

--- a/csharp/test/Ice/operations/BatchOneways.cs
+++ b/csharp/test/Ice/operations/BatchOneways.cs
@@ -107,8 +107,7 @@ namespace Ice
                     batch2.ice_ping();
                 }
 
-                Ice.Identity identity = new Ice.Identity();
-                identity.name = "invalid";
+                Ice.Identity identity = new Ice.Identity("invalid", "");
                 Ice.ObjectPrx batch3 = batch.ice_identity(identity);
                 batch3.ice_ping();
                 batch3.ice_flushBatchRequests();

--- a/csharp/test/Ice/operations/BatchOnewaysAMI.cs
+++ b/csharp/test/Ice/operations/BatchOnewaysAMI.cs
@@ -88,8 +88,7 @@ namespace Ice
                     _ = batch2.ice_pingAsync();
                 }
 
-                Ice.Identity identity = new Ice.Identity();
-                identity.name = "invalid";
+                Ice.Identity identity = new Ice.Identity("invalid", "");
                 Ice.ObjectPrx batch3 = batch.ice_identity(identity);
                 await batch3.ice_pingAsync();
                 await batch3.ice_flushBatchRequestsAsync();

--- a/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDI.cs
@@ -913,7 +913,8 @@ namespace Ice
                 opMStruct1Async(Ice.Current current)
                 {
                     await Task.Delay(0);
-                    return new Test.MyClass_OpMStruct1MarshaledResult(new Test.Structure(), current);
+                    return new Test.MyClass_OpMStruct1MarshaledResult(
+                        new Test.Structure(new Test.AnotherStruct()), current);
                 }
 
                 public override async Task<Test.MyClass_OpMStruct2MarshaledResult>

--- a/csharp/test/Ice/operations/MyDerivedClassAMDTieI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassAMDTieI.cs
@@ -921,7 +921,8 @@ namespace Ice
                     opMStruct1Async(Ice.Current current)
                     {
                         await Task.Delay(0);
-                        return new Test.MyClass_OpMStruct1MarshaledResult(new Test.Structure(), current);
+                        return new Test.MyClass_OpMStruct1MarshaledResult(
+                            new Test.Structure(new Test.AnotherStruct()), current);
                     }
 
                     public async Task<Test.MyClass_OpMStruct2MarshaledResult>

--- a/csharp/test/Ice/operations/MyDerivedClassI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassI.cs
@@ -838,7 +838,8 @@ namespace Ice
 
             public override Test.MyClass_OpMStruct1MarshaledResult opMStruct1(Ice.Current current)
             {
-                return new Test.MyClass_OpMStruct1MarshaledResult(new Test.Structure(), current);
+                return new Test.MyClass_OpMStruct1MarshaledResult(
+                    new Test.Structure(new Test.AnotherStruct()), current);
             }
 
             public override Test.MyClass_OpMStruct2MarshaledResult opMStruct2(Test.Structure p1, Ice.Current current)

--- a/csharp/test/Ice/operations/MyDerivedClassTieI.cs
+++ b/csharp/test/Ice/operations/MyDerivedClassTieI.cs
@@ -844,7 +844,8 @@ namespace Ice
 
                 public Test.MyClass_OpMStruct1MarshaledResult opMStruct1(Ice.Current current)
                 {
-                    return new Test.MyClass_OpMStruct1MarshaledResult(new Test.Structure(), current);
+                    return new Test.MyClass_OpMStruct1MarshaledResult(
+                        new Test.Structure(new Test.AnotherStruct()), current);
                 }
 
                 public Test.MyClass_OpMStruct2MarshaledResult opMStruct2(Test.Structure p1, Ice.Current current)

--- a/csharp/test/Ice/operations/Twoways.cs
+++ b/csharp/test/Ice/operations/Twoways.cs
@@ -260,15 +260,13 @@ namespace Ice
                 }
 
                 {
-                    Test.Structure si1 = new Test.Structure();
+                    Test.Structure si1 = new Test.Structure(new Test.AnotherStruct());
                     si1.p = p;
                     si1.e = Test.MyEnum.enum3;
-                    si1.s = new Test.AnotherStruct();
                     si1.s.s = "abc";
-                    Test.Structure si2 = new Test.Structure();
+                    Test.Structure si2 = new Test.Structure(new Test.AnotherStruct());
                     si2.p = null;
                     si2.e = Test.MyEnum.enum2;
-                    si2.s = new Test.AnotherStruct();
                     si2.s.s = "def";
 
                     Test.Structure so;
@@ -282,12 +280,11 @@ namespace Ice
                     so.p.opVoid();
 
                     //
-                    // Test marshaling of null structs and structs with null members.
+                    // Test marshaling of empty structs
                     //
-                    si1 = new Test.Structure();
-                    si2 = null;
+                    si1 = new Test.Structure(new Test.AnotherStruct());
 
-                    rso = p.opStruct(si1, si2, out so);
+                    rso = p.opStruct(si1, si1, out so);
                     test(rso.p == null);
                     test(rso.e == Test.MyEnum.enum1);
                     test(rso.s.s.Length == 0);

--- a/csharp/test/Ice/operations/TwowaysAMI.cs
+++ b/csharp/test/Ice/operations/TwowaysAMI.cs
@@ -105,15 +105,13 @@ namespace Ice
                 }
 
                 {
-                    var si1 = new Test.Structure();
+                    var si1 = new Test.Structure(new Test.AnotherStruct());
                     si1.p = p;
                     si1.e = Test.MyEnum.enum3;
-                    si1.s = new Test.AnotherStruct();
                     si1.s.s = "abc";
-                    var si2 = new Test.Structure();
+                    var si2 = new Test.Structure(new Test.AnotherStruct());
                     si2.p = null;
                     si2.e = Test.MyEnum.enum2;
-                    si2.s = new Test.AnotherStruct();
                     si2.s.s = "def";
 
                     var ret = p.opStructAsync(si1, si2).Result;

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -883,12 +883,11 @@ namespace Ice
                     @in.startEncapsulation();
                     test(@in.readOptional(1, OptionalFormat.VSize));
                     @in.skipSize();
-                    Test.SmallStruct f = new Test.SmallStruct();
-                    f.ice_readMembers(@in);
+                    Test.SmallStruct f = new Test.SmallStruct(@in);
                     test(f.m == (byte)56);
                     test(@in.readOptional(3, OptionalFormat.VSize));
                     @in.skipSize();
-                    f.ice_readMembers(@in);
+                    f = new Test.SmallStruct(@in);
                     test(f.m == (byte)56);
                     @in.endEncapsulation();
 
@@ -925,12 +924,11 @@ namespace Ice
                     @in.startEncapsulation();
                     test(@in.readOptional(1, OptionalFormat.VSize));
                     @in.skipSize();
-                    Test.FixedStruct f = new Test.FixedStruct();
-                    f.ice_readMembers(@in);
+                    Test.FixedStruct f = new Test.FixedStruct(@in);
                     test(f.m == 56);
                     test(@in.readOptional(3, OptionalFormat.VSize));
                     @in.skipSize();
-                    f.ice_readMembers(@in);
+                    f = new Test.FixedStruct(@in);
                     test(f.m == 56);
                     @in.endEncapsulation();
 
@@ -968,12 +966,11 @@ namespace Ice
                     @in.startEncapsulation();
                     test(@in.readOptional(1, OptionalFormat.FSize));
                     @in.skip(4);
-                    Test.VarStruct v = new Test.VarStruct();
-                    v.ice_readMembers(@in);
+                    Test.VarStruct v = new Test.VarStruct(@in);
                     test(v.m == "test");
                     test(@in.readOptional(3, OptionalFormat.FSize));
                     @in.skip(4);
-                    v.ice_readMembers(@in);
+                    v = new Test.VarStruct(@in);
                     test(v.m == "test");
                     @in.endEncapsulation();
 

--- a/csharp/test/IceDiscovery/simple/TestI.cs
+++ b/csharp/test/IceDiscovery/simple/TestI.cs
@@ -28,8 +28,7 @@ public sealed class ControllerI : Test.ControllerDisp_
     addObject(string oaName, string id, Ice.Current current)
     {
         Debug.Assert(_adapters.ContainsKey(oaName));
-        Ice.Identity identity = new Ice.Identity();
-        identity.name = id;
+        var identity = new Ice.Identity(id, "");
         _adapters[oaName].add(new TestIntfI(), identity);
     }
 
@@ -37,8 +36,7 @@ public sealed class ControllerI : Test.ControllerDisp_
     removeObject(string oaName, string id, Ice.Current current)
     {
         Debug.Assert(_adapters.ContainsKey(oaName));
-        Ice.Identity identity = new Ice.Identity();
-        identity.name = id;
+        var identity = new Ice.Identity(id, "");
         _adapters[oaName].remove(identity);
     }
 

--- a/csharp/test/IceGrid/simple/AllTests.cs
+++ b/csharp/test/IceGrid/simple/AllTests.cs
@@ -32,9 +32,7 @@ public class AllTests : Test.AllTests
         Console.Out.WriteLine("ok");
 
         Console.Out.Write("testing locator finder... ");
-        Ice.Identity finderId = new Ice.Identity();
-        finderId.category = "Ice";
-        finderId.name = "LocatorFinder";
+        var finderId = new Ice.Identity("LocatorFinder", "Ice");
         Ice.LocatorFinderPrx finder = Ice.LocatorFinderPrxHelper.checkedCast(
             communicator.getDefaultLocator().ice_identity(finderId));
         test(finder.getLocator() != null);

--- a/csharp/test/Slice/structure/Client.cs
+++ b/csharp/test/Slice/structure/Client.cs
@@ -23,13 +23,6 @@ public class Client : TestHelper
                            def_s, def_cls, def_prx);
 
         //
-        // Compare default-constructed structures.
-        //
-        {
-            test(new S2().Equals(new S2()));
-        }
-
-        //
         // Change one primitive member at a time.
         //
         {


### PR DESCRIPTION
This PR reworks the generated constructors for structs, classes and exceptions in C#.

Before:
- Slice struct mapped to a C# struct: primary ctor and no parameterless ctor.
- struct mapped to a class: primary ctor and parameterless ctor.
- class mapped to a class: primary ctor and parameterless ctor
- exception mapped to a class: primary ctor and several other ctors, including a parameterless ctor.

With this PR:

- struct mapped to a C# struct
  - additional unmarshaling ctor that unmarshals a struct from an InputStream
- struct mapped to a class: up to 3 ctors
   - primary ctor
   - ctor with parameters for each field that has a non-nullable type (see below) (can be parameterless)
   - unmarshaling ctor that unmarshals a struct from an InputStream
- class mapped to a class: up to 3 ctors
   - primary ctor
   - ctor with parameters for each field that has a non-nullable type (can be parameterless)
   - parameterless ctor used for unmarshaling (non browsable if any field is non-nullable)
- exception mapped to a class: up to 3 ctors
   - primary ctor (includes Exception innerException = null as the last param)
   - ctor with parameters for each field that has a non-nullable type (+ last innerException param)
   - parameterless ctor used for unmarshaling (non browsable if any field is non-nullable)

"non-nullable field type" = sequence, dictionary and struct-mapped-to-a-class.
Other field types are considered nullable / default-able:
 - int, float, etc. bool: default to 0/false or the default value specified in Slice
 - string: default to "" or the default value specified in Slice
 - enum: default to 0 or the default value specified in Slice (note that 0 may not correspond to a valid enumerator)
 - class: default to null
 - struct mapped to struct: default to "default"

Fixes #2115.

Note that this does not quite match my proposal on #2115. I added the "non primary constructor" for greater backwards source compatibility. In particular, we still use/implement default values.
