### PR TITLE
Replace generated OpResult structs by record structs in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2952,11 +2952,11 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
 
         _out << sp;
         emitGeneratedCodeAttribute();
-        _out << nl << "public struct " << name << " : " << getUnqualified("Ice.MarshaledResult", ns);
+        _out << nl << "public readonly record struct " << name << " : " << getUnqualified("Ice.MarshaledResult", ns);
         _out << sb;
 
         //
-        // One shot constructor
+        // Marshaling constructor
         //
         _out << nl << "public " << name << spar << getOutParams(p, ns, true, false)
              << getUnqualified("Ice.Current", ns) + " current" << epar;
@@ -2971,26 +2971,9 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
         _out << nl << "_ostr.endEncapsulation();";
         _out << eb;
         _out << sp;
-        _out << nl << "public " << getUnqualified("Ice.OutputStream", ns) << " getOutputStream("
-             << getUnqualified("Ice.Current", ns) << " current)";
-        _out << sb;
-        _out << nl << "if(_ostr == null)";
-        _out << sb;
-        _out << nl << "return new " << name << spar;
-        if (ret)
-        {
-            _out << writeValue(ret, ns);
-        }
-        for (ParamDeclList::const_iterator i = outParams.begin(); i != outParams.end(); ++i)
-        {
-            _out << writeValue((*i)->type(), ns);
-        }
-        _out << "current" << epar << ".getOutputStream(current);";
-        _out << eb;
-        _out << nl << "return _ostr;";
-        _out << eb;
+        _out << nl << "public " << getUnqualified("Ice.OutputStream", ns) << " outputStream => _ostr;";
         _out << sp;
-        _out << nl << "private " << getUnqualified("Ice.OutputStream", ns) << " _ostr;";
+        _out << nl << "private readonly " << getUnqualified("Ice.OutputStream", ns) << " _ostr;";
         _out << eb;
     }
 }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2910,17 +2910,6 @@ Slice::Gen::ResultVisitor::visitModuleEnd(const ModulePtr& p)
     moduleEnd(p);
 }
 
-bool
-Slice::Gen::ResultVisitor::visitClassDefStart(const ClassDefPtr&)
-{
-    return true;
-}
-
-void
-Slice::Gen::ResultVisitor::visitClassDefEnd(const ClassDefPtr&)
-{
-}
-
 void
 Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
 {
@@ -2942,52 +2931,19 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
         }
 
         _out << sp;
-        _out << nl << "public struct " << name;
-        _out << sb;
-
-        //
-        // One shot constructor
-        //
-        _out << nl << "public " << name << spar;
+        _out << nl << "public record struct " << name;
+        _out << spar;
         if (ret)
         {
             _out << (retS + " " + retSName);
         }
-        for (ParamDeclList::const_iterator i = outParams.begin(); i != outParams.end(); ++i)
+
+        for (const auto& q : outParams)
         {
-            _out << (typeToString((*i)->type(), ns, (*i)->optional()) + " " + fixId((*i)->name()));
+            _out << (typeToString(q->type(), ns, q->optional()) + " " + fixId(q->name()));
         }
         _out << epar;
-
-        _out << sb;
-
-        if (ret)
-        {
-            _out << nl << "this." << retSName << " = " << retSName << ";";
-        }
-
-        for (ParamDeclList::const_iterator i = outParams.begin(); i != outParams.end(); ++i)
-        {
-            _out << nl << "this." << fixId((*i)->name()) << " = " << fixId((*i)->name()) << ";";
-        }
-
-        _out << eb;
-
-        //
-        // Data members
-        //
-        _out << sp;
-        if (ret)
-        {
-            _out << nl << "public " << retS << " " << retSName << ";";
-        }
-
-        for (ParamDeclList::const_iterator i = outParams.begin(); i != outParams.end(); ++i)
-        {
-            _out << nl << "public " << typeToString((*i)->type(), ns, (*i)->optional()) << " " << fixId((*i)->name())
-                 << ";";
-        }
-        _out << eb;
+        _out << ";";
     }
 
     if (p->hasMarshaledResult())

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -152,8 +152,6 @@ namespace Slice
 
             virtual bool visitModuleStart(const ModulePtr&);
             virtual void visitModuleEnd(const ModulePtr&);
-            virtual bool visitClassDefStart(const ClassDefPtr&);
-            virtual void visitClassDefEnd(const ClassDefPtr&);
             virtual void visitOperation(const OperationPtr&);
         };
 

--- a/csharp/src/Ice/MarshaledResult.cs
+++ b/csharp/src/Ice/MarshaledResult.cs
@@ -4,5 +4,5 @@ namespace Ice;
 
 public interface MarshaledResult
 {
-    OutputStream getOutputStream(Current current);
+    OutputStream outputStream { get; }
 };


### PR DESCRIPTION
This PR replaces OpResult structs by simple (non-readonly) record structs in C#.

I initially wanted to replace them by tuple but this was not source compatible. It would have required lots updates.

I also simplified the MarshaledResult structs. They are now readonly record structs.