### PR TITLE
Remove leftover fields from InitializationData

### DIFF
--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -57,11 +57,6 @@ public class InitializationData : ICloneable
     public System.Action<System.Action, Connection> dispatcher;
 
     /// <summary>
-    /// The compact type ID resolver.
-    /// </summary>
-    public System.Func<int, string> compactIdResolver;
-
-    /// <summary>
     /// The batch request interceptor.
     /// </summary>
     public System.Action<BatchRequest, int, int> batchRequestInterceptor;
@@ -70,11 +65,6 @@ public class InitializationData : ICloneable
     /// The value factory manager.
     /// </summary>
     public ValueFactoryManager valueFactoryManager;
-
-    /// <summary>
-    /// The list of TypeId namespaces. Default is Ice.TypeId.
-    /// </summary>
-    public string[] typeIdNamespaces = { "Ice.TypeId" };
 
     /// <summary>
     /// The <see cref="SslClientAuthenticationOptions"/> used by the client-side ssl transport.

--- a/csharp/test/Ice/exceptions/Client.cs
+++ b/csharp/test/Ice/exceptions/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.exceptions.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.Warn.Connections", "0");
                 initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.exceptions.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.Warn.Connections", "0");
                 initData.properties.setProperty("Ice.Warn.Dispatch", "0");

--- a/csharp/test/Ice/objects/Client.cs
+++ b/csharp/test/Ice/objects/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.objects.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/objects/Collocated.cs
+++ b/csharp/test/Ice/objects/Collocated.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.objects.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.Warn.Dispatch", "0");
                 using (var communicator = initialize(initData))

--- a/csharp/test/Ice/objects/Server.cs
+++ b/csharp/test/Ice/objects/Server.cs
@@ -26,7 +26,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.objects.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.Warn.Dispatch", "0");
                 using (var communicator = initialize(initData))

--- a/csharp/test/Ice/operations/Client.cs
+++ b/csharp/test/Ice/operations/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.operations.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
                 initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.operations.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
                 initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");

--- a/csharp/test/Ice/operations/Server.cs
+++ b/csharp/test/Ice/operations/Server.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.operations.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 //
                 // Its possible to have batch oneway requests dispatched

--- a/csharp/test/Ice/operations/ServerAMD.cs
+++ b/csharp/test/Ice/operations/ServerAMD.cs
@@ -13,13 +13,12 @@ namespace Ice
                 public override void run(string[] args)
                 {
                     var initData = new InitializationData();
-                    initData.typeIdNamespaces = new string[] { "Ice.operations.AMD.TypeId" };
                     initData.properties = createTestProperties(ref args);
 
                     //
                     // Its possible to have batch oneway requests dispatched
                     // after the adapter is deactivated due to thread
-                    // scheduling so we supress this warning.
+                    // scheduling so we suppress this warning.
                     //
                     initData.properties.setProperty("Ice.Warn.Dispatch", "0");
                     //

--- a/csharp/test/Ice/operations/ServerAMDTie.cs
+++ b/csharp/test/Ice/operations/ServerAMDTie.cs
@@ -15,8 +15,6 @@ namespace Ice
                     public override void run(string[] args)
                     {
                         var initData = new InitializationData();
-                        initData.typeIdNamespaces = new string[] { "Ice.operations.AMD.TypeId" };
-
                         initData.properties = createTestProperties(ref args);
                         //
                         // Its possible to have batch oneway requests dispatched

--- a/csharp/test/Ice/operations/ServerTie.cs
+++ b/csharp/test/Ice/operations/ServerTie.cs
@@ -13,12 +13,11 @@ namespace Ice
                 public override void run(string[] args)
                 {
                     var initData = new InitializationData();
-                    initData.typeIdNamespaces = new string[] { "Ice.operations.TypeId" };
                     initData.properties = createTestProperties(ref args);
                     //
                     // Its possible to have batch oneway requests dispatched
                     // after the adapter is deactivated due to thread
-                    // scheduling so we supress this warning.
+                    // scheduling so we suppress this warning.
                     //
                     initData.properties.setProperty("Ice.Warn.Dispatch", "0");
                     //

--- a/csharp/test/Ice/optional/Client.cs
+++ b/csharp/test/Ice/optional/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.optional.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/optional/Server.cs
+++ b/csharp/test/Ice/optional/Server.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.optional.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/optional/ServerAMD.cs
+++ b/csharp/test/Ice/optional/ServerAMD.cs
@@ -13,7 +13,6 @@ namespace Ice
                 public override void run(string[] args)
                 {
                     var initData = new InitializationData();
-                    initData.typeIdNamespaces = new string[] { "Ice.optional.AMD.TypeId" };
                     initData.properties = createTestProperties(ref args);
                     using (var communicator = initialize(initData))
                     {

--- a/csharp/test/Ice/scope/Client.cs
+++ b/csharp/test/Ice/scope/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.scope.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/scope/Server.cs
+++ b/csharp/test/Ice/scope/Server.cs
@@ -238,7 +238,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.scope.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/seqMapping/Client.cs
+++ b/csharp/test/Ice/seqMapping/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.seqMapping.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/seqMapping/Collocated.cs
+++ b/csharp/test/Ice/seqMapping/Collocated.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override async Task runAsync(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.seqMapping.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/seqMapping/Server.cs
+++ b/csharp/test/Ice/seqMapping/Server.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.seqMapping.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/seqMapping/ServerAMD.cs
+++ b/csharp/test/Ice/seqMapping/ServerAMD.cs
@@ -13,7 +13,6 @@ namespace Ice
                 public override void run(string[] args)
                 {
                     var initData = new InitializationData();
-                    initData.typeIdNamespaces = new string[] { "Ice.seqMapping.AMD.TypeId" };
                     initData.properties = createTestProperties(ref args);
                     using (var communicator = initialize(initData))
                     {

--- a/csharp/test/Ice/servantLocator/Client.cs
+++ b/csharp/test/Ice/servantLocator/Client.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.servantLocator.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/servantLocator/Collocated.cs
+++ b/csharp/test/Ice/servantLocator/Collocated.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.servantLocator.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/servantLocator/Server.cs
+++ b/csharp/test/Ice/servantLocator/Server.cs
@@ -11,7 +11,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.servantLocator.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {

--- a/csharp/test/Ice/servantLocator/ServerAMD.cs
+++ b/csharp/test/Ice/servantLocator/ServerAMD.cs
@@ -13,7 +13,6 @@ namespace Ice
                 public override void run(string[] args)
                 {
                     var initData = new InitializationData();
-                    initData.typeIdNamespaces = new string[] { "Ice.servantLocator.AMD.TypeId" };
                     initData.properties = createTestProperties(ref args);
                     using (var communicator = initialize(initData))
                     {

--- a/csharp/test/Ice/stream/Client.cs
+++ b/csharp/test/Ice/stream/Client.cs
@@ -9,7 +9,6 @@ namespace Ice
             public override void run(string[] args)
             {
                 var initData = new InitializationData();
-                initData.typeIdNamespaces = new string[] { "Ice.stream.TypeId" };
                 initData.properties = createTestProperties(ref args);
                 using (var communicator = initialize(initData))
                 {


### PR DESCRIPTION
This PR removes compactIdResolver and typeIdNamespaces. They are no longer used.