### PR TITLE
Remove Remnants of the `java:optional` Metadata

### DIFF
--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1010,23 +1010,6 @@ Slice::JavaGenerator::getStaticId(const TypePtr& type, const string& package) co
     }
 }
 
-bool
-Slice::JavaGenerator::useOptionalMapping(const OperationPtr& p)
-{
-    //
-    // The "java:optional" metadata can be applied to an operation or its
-    // interface to force the mapping to use the Optional types.
-    //
-    // Without the tag, parameters use the normal (non-optional) mapping.
-    //
-    static const string tag = "java:optional";
-
-    ClassDefPtr cl = dynamic_pointer_cast<ClassDef>(p->container());
-    assert(cl);
-
-    return p->hasMetaData(tag) || cl->hasMetaData(tag);
-}
-
 string
 Slice::JavaGenerator::getOptionalFormat(const TypePtr& type)
 {

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -130,11 +130,6 @@ namespace Slice
         std::string getStaticId(const TypePtr&, const std::string&) const;
 
         //
-        // Determines whether an operation should use the optional mapping.
-        //
-        bool useOptionalMapping(const OperationPtr&);
-
-        //
         // Returns the optional type corresponding to the given Slice type.
         //
         std::string getOptionalFormat(const TypePtr&);

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -291,8 +291,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -291,8 +291,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -473,12 +473,6 @@ InitialI::opMDict2Async(
 }
 
 void
-InitialI::supportsRequiredParamsAsync(function<void(bool)> response, function<void(exception_ptr)>, const Ice::Current&)
-{
-    response(false);
-}
-
-void
 InitialI::supportsJavaSerializableAsync(
     function<void(bool)> response,
     function<void(exception_ptr)>,

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -297,11 +297,6 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void supportsRequiredParamsAsync(
-        std::function<void(bool)>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
-
     void supportsJavaSerializableAsync(
         std::function<void(bool)>,
         std::function<void(std::exception_ptr)>,

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -379,12 +379,6 @@ InitialI::opMDict2(optional<Test::StringIntDict> p1, const Ice::Current& current
 }
 
 bool
-InitialI::supportsRequiredParams(const Ice::Current&)
-{
-    return false;
-}
-
-bool
 InitialI::supportsJavaSerializable(const Ice::Current&)
 {
     return true;

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -150,8 +150,6 @@ public:
 
     virtual OpMDict2MarshaledResult opMDict2(std::optional<Test::StringIntDict>, const Ice::Current&);
 
-    virtual bool supportsRequiredParams(const Ice::Current&);
-
     virtual bool supportsJavaSerializable(const Ice::Current&);
 
     virtual bool supportsCsharpSerializable(const Ice::Current&);

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -266,8 +266,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 }
 

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -269,8 +269,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 }
 

--- a/csharp/test/Ice/optional/TestAMDI.cs
+++ b/csharp/test/Ice/optional/TestAMDI.cs
@@ -286,12 +286,6 @@ namespace Ice
                 }
 
                 public override Task<bool>
-                supportsRequiredParamsAsync(Ice.Current current)
-                {
-                    return Task.FromResult<bool>(false);
-                }
-
-                public override Task<bool>
                 supportsJavaSerializableAsync(Ice.Current current)
                 {
                     return Task.FromResult<bool>(false);

--- a/csharp/test/Ice/optional/TestI.cs
+++ b/csharp/test/Ice/optional/TestI.cs
@@ -333,11 +333,6 @@ namespace Ice
                 return new Test.Initial_OpMDict2MarshaledResult(p1, p1, current);
             }
 
-            public override bool supportsRequiredParams(Ice.Current current)
-            {
-                return false;
-            }
-
             public override bool supportsJavaSerializable(Ice.Current current)
             {
                 return false;

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -89,20 +89,8 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpByteReqResult> opByteReqAsync(
-      Optional<Byte> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpByteReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpBoolResult> opBoolAsync(Optional<Boolean> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpBoolResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpBoolReqResult> opBoolReqAsync(
-      Optional<Boolean> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpBoolReqResult(p1, p1));
   }
 
   @Override
@@ -111,19 +99,8 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpShortReqResult> opShortReqAsync(
-      Optional<Short> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpShortReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpIntResult> opIntAsync(OptionalInt p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpIntResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpIntReqResult> opIntReqAsync(OptionalInt p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpIntReqResult(p1, p1));
   }
 
   @Override
@@ -132,30 +109,13 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpLongReqResult> opLongReqAsync(OptionalLong p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpLongReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpFloatResult> opFloatAsync(Optional<Float> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpFloatResult(p1, p1));
   }
 
   @Override
-  public CompletionStage<Initial.OpFloatReqResult> opFloatReqAsync(
-      Optional<Float> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpFloatReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpDoubleResult> opDoubleAsync(OptionalDouble p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpDoubleResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpDoubleReqResult> opDoubleReqAsync(
-      OptionalDouble p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpDoubleReqResult(p1, p1));
   }
 
   @Override
@@ -165,21 +125,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpStringReqResult> opStringReqAsync(
-      Optional<String> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpStringReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpMyEnumResult> opMyEnumAsync(
       Optional<MyEnum> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpMyEnumResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpMyEnumReqResult> opMyEnumReqAsync(
-      Optional<MyEnum> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpMyEnumReqResult(p1, p1));
   }
 
   @Override
@@ -189,21 +137,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpSmallStructReqResult> opSmallStructReqAsync(
-      Optional<SmallStruct> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpSmallStructReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpFixedStructResult> opFixedStructAsync(
       Optional<FixedStruct> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpFixedStructResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpFixedStructReqResult> opFixedStructReqAsync(
-      Optional<FixedStruct> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpFixedStructReqResult(p1, p1));
   }
 
   @Override
@@ -213,21 +149,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpVarStructReqResult> opVarStructReqAsync(
-      Optional<VarStruct> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpVarStructReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpMyInterfaceProxyResult> opMyInterfaceProxyAsync(
       Optional<MyInterfacePrx> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpMyInterfaceProxyResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpMyInterfaceProxyReqResult> opMyInterfaceProxyReqAsync(
-      Optional<MyInterfacePrx> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpMyInterfaceProxyReqResult(p1, p1));
   }
 
   @Override
@@ -243,21 +167,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpByteSeqReqResult> opByteSeqReqAsync(
-      Optional<byte[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpByteSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpBoolSeqResult> opBoolSeqAsync(
       Optional<boolean[]> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpBoolSeqResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpBoolSeqReqResult> opBoolSeqReqAsync(
-      Optional<boolean[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpBoolSeqReqResult(p1, p1));
   }
 
   @Override
@@ -267,21 +179,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpShortSeqReqResult> opShortSeqReqAsync(
-      Optional<short[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpShortSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpIntSeqResult> opIntSeqAsync(
       Optional<int[]> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpIntSeqResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpIntSeqReqResult> opIntSeqReqAsync(
-      Optional<int[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpIntSeqReqResult(p1, p1));
   }
 
   @Override
@@ -291,21 +191,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpLongSeqReqResult> opLongSeqReqAsync(
-      Optional<long[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpLongSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpFloatSeqResult> opFloatSeqAsync(
       Optional<float[]> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpFloatSeqResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpFloatSeqReqResult> opFloatSeqReqAsync(
-      Optional<float[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpFloatSeqReqResult(p1, p1));
   }
 
   @Override
@@ -315,21 +203,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpDoubleSeqReqResult> opDoubleSeqReqAsync(
-      Optional<double[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpDoubleSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpStringSeqResult> opStringSeqAsync(
       Optional<String[]> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpStringSeqResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpStringSeqReqResult> opStringSeqReqAsync(
-      Optional<String[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpStringSeqReqResult(p1, p1));
   }
 
   @Override
@@ -339,21 +215,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpSmallStructSeqReqResult> opSmallStructSeqReqAsync(
-      Optional<SmallStruct[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpSmallStructSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpSmallStructListResult> opSmallStructListAsync(
       Optional<java.util.List<SmallStruct>> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpSmallStructListResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpSmallStructListReqResult> opSmallStructListReqAsync(
-      Optional<java.util.List<SmallStruct>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpSmallStructListReqResult(p1, p1));
   }
 
   @Override
@@ -363,21 +227,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpFixedStructSeqReqResult> opFixedStructSeqReqAsync(
-      Optional<FixedStruct[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpFixedStructSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpFixedStructListResult> opFixedStructListAsync(
       Optional<java.util.List<FixedStruct>> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpFixedStructListResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpFixedStructListReqResult> opFixedStructListReqAsync(
-      Optional<java.util.List<FixedStruct>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpFixedStructListReqResult(p1, p1));
   }
 
   @Override
@@ -387,21 +239,9 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpVarStructSeqReqResult> opVarStructSeqReqAsync(
-      Optional<VarStruct[]> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpVarStructSeqReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpSerializableResult> opSerializableAsync(
       Optional<SerializableClass> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpSerializableResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpSerializableReqResult> opSerializableReqAsync(
-      Optional<SerializableClass> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpSerializableReqResult(p1, p1));
   }
 
   @Override
@@ -411,33 +251,15 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpIntIntDictReqResult> opIntIntDictReqAsync(
-      Optional<java.util.Map<Integer, Integer>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpIntIntDictReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpStringIntDictResult> opStringIntDictAsync(
       Optional<java.util.Map<String, Integer>> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpStringIntDictResult(p1, p1));
   }
 
   @Override
-  public CompletionStage<Initial.OpStringIntDictReqResult> opStringIntDictReqAsync(
-      Optional<java.util.Map<String, Integer>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpStringIntDictReqResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Initial.OpIntOneOptionalDictResult> opIntOneOptionalDictAsync(
       Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
     return CompletableFuture.completedFuture(new Initial.OpIntOneOptionalDictResult(p1, p1));
-  }
-
-  @Override
-  public CompletionStage<Initial.OpIntOneOptionalDictReqResult> opIntOneOptionalDictReqAsync(
-      Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpIntOneOptionalDictReqResult(p1, p1));
   }
 
   @Override

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -314,11 +314,6 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Boolean> supportsRequiredParamsAsync(Current current) {
-    return CompletableFuture.completedFuture(true);
-  }
-
-  @Override
   public CompletionStage<Boolean> supportsJavaSerializableAsync(Current current) {
     return CompletableFuture.completedFuture(true);
   }

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -588,7 +588,6 @@ public class AllTests {
 
     out.print("testing optional parameters... ");
     out.flush();
-    final boolean reqParams = initial.supportsRequiredParams();
 
     {
       Optional<Byte> p1 = Optional.empty();
@@ -604,7 +603,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F1);
-      os.writeByte(p1);
+      os.writeByte(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opByte", OperationMode.Normal, inEncaps);
@@ -633,7 +632,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F1);
-      os.writeBool(p1);
+      os.writeBool(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opBool", OperationMode.Normal, inEncaps);
@@ -662,7 +661,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F2);
-      os.writeShort(p1);
+      os.writeShort(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opShort", OperationMode.Normal, inEncaps);
@@ -691,7 +690,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F4);
-      os.writeInt(p1);
+      os.writeInt(p1.getAsInt());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opInt", OperationMode.Normal, inEncaps);
@@ -720,7 +719,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(1, OptionalFormat.F8);
-      os.writeLong(p1);
+      os.writeLong(p1.getAsLong());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opLong", OperationMode.Normal, inEncaps);
@@ -749,7 +748,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F4);
-      os.writeFloat(p1);
+      os.writeFloat(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opFloat", OperationMode.Normal, inEncaps);
@@ -778,7 +777,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.F8);
-      os.writeDouble(p1);
+      os.writeDouble(p1.getAsDouble());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opDouble", OperationMode.Normal, inEncaps);
@@ -807,7 +806,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
-      os.writeString(p1);
+      os.writeString(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opString", OperationMode.Normal, inEncaps);
@@ -836,7 +835,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.Size);
-      MyEnum.ice_write(os, p1);
+      MyEnum.ice_write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opMyEnum", OperationMode.Normal, inEncaps);
@@ -870,7 +869,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(1);
-      SmallStruct.ice_write(os, p1);
+      SmallStruct.ice_write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opSmallStruct", OperationMode.Normal, inEncaps);
@@ -906,7 +905,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(4);
-      FixedStruct.ice_write(os, p1);
+      FixedStruct.ice_write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opFixedStruct", OperationMode.Normal, inEncaps);
@@ -942,7 +941,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      VarStruct.ice_write(os, p1);
+      VarStruct.ice_write(os, p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();
@@ -1008,7 +1007,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      os.writeProxy(p1);
+      os.writeProxy(p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();
@@ -1046,7 +1045,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
-      os.writeByteSeq(p1);
+      os.writeByteSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opByteSeq", OperationMode.Normal, inEncaps);
@@ -1079,7 +1078,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
-      os.writeBoolSeq(p1);
+      os.writeBoolSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opBoolSeq", OperationMode.Normal, inEncaps);
@@ -1114,7 +1113,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 2 + (p1.get().length > 254 ? 5 : 1));
-      os.writeShortSeq(p1);
+      os.writeShortSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opShortSeq", OperationMode.Normal, inEncaps);
@@ -1149,7 +1148,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-      os.writeIntSeq(p1);
+      os.writeIntSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opIntSeq", OperationMode.Normal, inEncaps);
@@ -1184,7 +1183,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
-      os.writeLongSeq(p1);
+      os.writeLongSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opLongSeq", OperationMode.Normal, inEncaps);
@@ -1219,7 +1218,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-      os.writeFloatSeq(p1);
+      os.writeFloatSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opFloatSeq", OperationMode.Normal, inEncaps);
@@ -1254,7 +1253,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
-      os.writeDoubleSeq(p1);
+      os.writeDoubleSeq(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opDoubleSeq", OperationMode.Normal, inEncaps);
@@ -1289,7 +1288,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      os.writeStringSeq(p1);
+      os.writeStringSeq(p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();
@@ -1328,7 +1327,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
-      SmallStructSeqHelper.write(os, p1);
+      SmallStructSeqHelper.write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opSmallStructSeq", OperationMode.Normal, inEncaps);
@@ -1374,7 +1373,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().size() + (p1.get().size() > 254 ? 5 : 1));
-      SmallStructListHelper.write(os, p1);
+      SmallStructListHelper.write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opSmallStructList", OperationMode.Normal, inEncaps);
@@ -1419,7 +1418,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-      FixedStructSeqHelper.write(os, p1);
+      FixedStructSeqHelper.write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opFixedStructSeq", OperationMode.Normal, inEncaps);
@@ -1462,7 +1461,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().size() * 4 + (p1.get().size() > 254 ? 5 : 1));
-      FixedStructListHelper.write(os, p1);
+      FixedStructListHelper.write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opFixedStructList", OperationMode.Normal, inEncaps);
@@ -1507,7 +1506,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      VarStructSeqHelper.write(os, p1);
+      VarStructSeqHelper.write(os, p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();
@@ -1547,7 +1546,7 @@ public class AllTests {
       os = new OutputStream(communicator);
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
-      os.writeSerializable(p1);
+      os.writeSerializable(p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opSerializable", OperationMode.Normal, inEncaps);
@@ -1586,7 +1585,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.VSize);
       os.writeSize(p1.get().size() * 8 + (p1.get().size() > 254 ? 5 : 1));
-      IntIntDictHelper.write(os, p1);
+      IntIntDictHelper.write(os, p1.get());
       os.endEncapsulation();
       inEncaps = os.finished();
       inv = initial.ice_invoke("opIntIntDict", OperationMode.Normal, inEncaps);
@@ -1624,7 +1623,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      StringIntDictHelper.write(os, p1);
+      StringIntDictHelper.write(os, p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();
@@ -1666,7 +1665,7 @@ public class AllTests {
       os.startEncapsulation();
       os.writeOptional(2, OptionalFormat.FSize);
       int pos = os.startSize();
-      IntOneOptionalDictHelper.write(os, p1);
+      IntOneOptionalDictHelper.write(os, p1.get());
       os.endSize(pos);
       os.endEncapsulation();
       inEncaps = os.finished();

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -342,7 +342,7 @@ public class AllTests {
     }
 
     //
-    // Send a request using blobjects. Upon receival, we don't read
+    // Send a request using blobjects. Upon receipt, we don't read
     // any of the optional members. This ensures the optional members
     // are skipped even if the receiver knows nothing about them.
     //
@@ -601,29 +601,22 @@ public class AllTests {
       r = initial.opByteAsync(p1).join();
       test(r.returnValue.get() == (byte) 56 && r.p3.get() == (byte) 56);
 
-      if (reqParams) {
-        Initial.OpByteReqResult rr = initial.opByteReq(p1.get());
-        test(rr.returnValue.get() == (byte) 56 && rr.p3.get() == (byte) 56);
-        rr = initial.opByteReqAsync(p1.get()).join();
-        test(rr.returnValue.get() == (byte) 56 && rr.p3.get() == (byte) 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F1);
+      os.writeByte(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opByte", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readByte(1).get() == (byte) 56);
+      test(in.readByte(3).get() == (byte) 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F1);
-        os.writeByte(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opByteReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readByte(1).get() == (byte) 56);
-        test(in.readByte(3).get() == (byte) 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -637,29 +630,22 @@ public class AllTests {
       r = initial.opBoolAsync(p1).join();
       test(r.returnValue.get() == true && r.p3.get() == true);
 
-      if (reqParams) {
-        Initial.OpBoolReqResult rr = initial.opBoolReq(true);
-        test(rr.returnValue.get() == true && rr.p3.get() == true);
-        rr = initial.opBoolReqAsync(true).join();
-        test(rr.returnValue.get() == true && rr.p3.get() == true);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F1);
+      os.writeBool(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opBool", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readBool(1).get() == true);
+      test(in.readBool(3).get() == true);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F1);
-        os.writeBool(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opBoolReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readBool(1).get() == true);
-        test(in.readBool(3).get() == true);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -673,29 +659,22 @@ public class AllTests {
       r = initial.opShortAsync(p1).join();
       test(r.returnValue.get() == 56 && r.p3.get() == 56);
 
-      if (reqParams) {
-        Initial.OpShortReqResult rr = initial.opShortReq(p1.get());
-        test(rr.returnValue.get() == 56 && rr.p3.get() == 56);
-        rr = initial.opShortReqAsync(p1.get()).join();
-        test(rr.returnValue.get() == 56 && rr.p3.get() == 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F2);
+      os.writeShort(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opShort", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readShort(1).get() == 56);
+      test(in.readShort(3).get() == 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F2);
-        os.writeShort(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opShortReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readShort(1).get() == 56);
-        test(in.readShort(3).get() == 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -709,29 +688,22 @@ public class AllTests {
       r = initial.opIntAsync(p1).join();
       test(r.returnValue.getAsInt() == 56 && r.p3.getAsInt() == 56);
 
-      if (reqParams) {
-        Initial.OpIntReqResult rr = initial.opIntReq(p1.getAsInt());
-        test(rr.returnValue.getAsInt() == 56 && rr.p3.getAsInt() == 56);
-        rr = initial.opIntReqAsync(p1.getAsInt()).join();
-        test(rr.returnValue.getAsInt() == 56 && rr.p3.getAsInt() == 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F4);
+      os.writeInt(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opInt", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readInt(1).getAsInt() == 56);
+      test(in.readInt(3).getAsInt() == 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F4);
-        os.writeInt(p1.getAsInt());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opIntReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readInt(1).getAsInt() == 56);
-        test(in.readInt(3).getAsInt() == 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -745,29 +717,22 @@ public class AllTests {
       r = initial.opLongAsync(p1).join();
       test(r.returnValue.getAsLong() == 56 && r.p3.getAsLong() == 56);
 
-      if (reqParams) {
-        Initial.OpLongReqResult rr = initial.opLongReq(p1.getAsLong());
-        test(rr.returnValue.getAsLong() == 56 && rr.p3.getAsLong() == 56);
-        rr = initial.opLongReqAsync(p1.getAsLong()).join();
-        test(rr.returnValue.getAsLong() == 56 && rr.p3.getAsLong() == 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(1, OptionalFormat.F8);
+      os.writeLong(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opLong", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readLong(2).getAsLong() == 56);
+      test(in.readLong(3).getAsLong() == 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(1, OptionalFormat.F8);
-        os.writeLong(p1.getAsLong());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opLongReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readLong(2).getAsLong() == 56);
-        test(in.readLong(3).getAsLong() == 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -781,29 +746,22 @@ public class AllTests {
       r = initial.opFloatAsync(p1).join();
       test(r.returnValue.get() == 1.0 && r.p3.get() == 1.0);
 
-      if (reqParams) {
-        Initial.OpFloatReqResult rr = initial.opFloatReq(p1.get());
-        test(rr.returnValue.get() == 1.0 && rr.p3.get() == 1.0);
-        rr = initial.opFloatReqAsync(p1.get()).join();
-        test(rr.returnValue.get() == 1.0 && rr.p3.get() == 1.0);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F4);
+      os.writeFloat(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opFloat", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readFloat(1).get() == 1.0);
+      test(in.readFloat(3).get() == 1.0);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F4);
-        os.writeFloat(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opFloatReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readFloat(1).get() == 1.0);
-        test(in.readFloat(3).get() == 1.0);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -817,29 +775,22 @@ public class AllTests {
       r = initial.opDoubleAsync(p1).join();
       test(r.returnValue.getAsDouble() == 1.0 && r.p3.getAsDouble() == 1.0);
 
-      if (reqParams) {
-        Initial.OpDoubleReqResult rr = initial.opDoubleReq(p1.getAsDouble());
-        test(rr.returnValue.getAsDouble() == 1.0 && rr.p3.getAsDouble() == 1.0);
-        rr = initial.opDoubleReqAsync(p1.getAsDouble()).join();
-        test(rr.returnValue.getAsDouble() == 1.0 && rr.p3.getAsDouble() == 1.0);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.F8);
+      os.writeDouble(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opDouble", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readDouble(1).getAsDouble() == 1.0);
+      test(in.readDouble(3).getAsDouble() == 1.0);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.F8);
-        os.writeDouble(p1.getAsDouble());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opDoubleReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readDouble(1).getAsDouble() == 1.0);
-        test(in.readDouble(3).getAsDouble() == 1.0);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -853,29 +804,22 @@ public class AllTests {
       r = initial.opStringAsync(p1).join();
       test(r.returnValue.get().equals("test") && r.p3.get().equals("test"));
 
-      if (reqParams) {
-        Initial.OpStringReqResult rr = initial.opStringReq(p1.get());
-        test(rr.returnValue.get().equals("test") && rr.p3.get().equals("test"));
-        rr = initial.opStringReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals("test") && rr.p3.get().equals("test"));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeString(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opString", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readString(1).get().equals("test"));
+      test(in.readString(3).get().equals("test"));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeString(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opStringReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readString(1).get().equals("test"));
-        test(in.readString(3).get().equals("test"));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -889,31 +833,24 @@ public class AllTests {
       r = initial.opMyEnumAsync(p1).join();
       test(r.returnValue.get() == MyEnum.MyEnumMember && r.p3.get() == MyEnum.MyEnumMember);
 
-      if (reqParams) {
-        Initial.OpMyEnumReqResult rr = initial.opMyEnumReq(p1.get());
-        test(rr.returnValue.get() == MyEnum.MyEnumMember && rr.p3.get() == MyEnum.MyEnumMember);
-        rr = initial.opMyEnumReqAsync(p1.get()).join();
-        test(rr.returnValue.get() == MyEnum.MyEnumMember && rr.p3.get() == MyEnum.MyEnumMember);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.Size);
+      MyEnum.ice_write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opMyEnum", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.Size));
+      test(MyEnum.ice_read(in) == MyEnum.MyEnumMember);
+      test(in.readOptional(3, OptionalFormat.Size));
+      test(MyEnum.ice_read(in) == MyEnum.MyEnumMember);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.Size);
-        MyEnum.ice_write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opMyEnumReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.Size));
-        test(MyEnum.ice_read(in) == MyEnum.MyEnumMember);
-        test(in.readOptional(3, OptionalFormat.Size));
-        test(MyEnum.ice_read(in) == MyEnum.MyEnumMember);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -929,36 +866,29 @@ public class AllTests {
       r = initial.opSmallStructAsync(p1).join();
       test(r.returnValue.get().m == (byte) 56 && r.p3.get().m == (byte) 56);
 
-      if (reqParams) {
-        Initial.OpSmallStructReqResult rr = initial.opSmallStructReq(p1.get());
-        test(rr.returnValue.get().m == (byte) 56 && rr.p3.get().m == (byte) 56);
-        rr = initial.opSmallStructReqAsync(p1.get()).join();
-        test(rr.returnValue.get().m == (byte) 56 && rr.p3.get().m == (byte) 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(1);
+      SmallStruct.ice_write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opSmallStruct", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      SmallStruct f = SmallStruct.ice_read(in);
+      test(f.m == (byte) 56);
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      f = SmallStruct.ice_read(in);
+      test(f.m == (byte) 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(1);
-        SmallStruct.ice_write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opSmallStructReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        SmallStruct f = SmallStruct.ice_read(in);
-        test(f.m == (byte) 56);
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        f = SmallStruct.ice_read(in);
-        test(f.m == (byte) 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -972,36 +902,29 @@ public class AllTests {
       r = initial.opFixedStructAsync(p1).join();
       test(r.returnValue.get().m == 56 && r.p3.get().m == 56);
 
-      if (reqParams) {
-        Initial.OpFixedStructReqResult rr = initial.opFixedStructReq(p1.get());
-        test(rr.returnValue.get().m == 56 && rr.p3.get().m == 56);
-        rr = initial.opFixedStructReqAsync(p1.get()).join();
-        test(rr.returnValue.get().m == 56 && rr.p3.get().m == 56);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(4);
+      FixedStruct.ice_write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opFixedStruct", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      FixedStruct f = FixedStruct.ice_read(in);
+      test(f.m == 56);
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      f = FixedStruct.ice_read(in);
+      test(f.m == 56);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(4);
-        FixedStruct.ice_write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opFixedStructReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        FixedStruct f = FixedStruct.ice_read(in);
-        test(f.m == 56);
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        f = FixedStruct.ice_read(in);
-        test(f.m == 56);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1015,68 +938,59 @@ public class AllTests {
       r = initial.opVarStructAsync(p1).join();
       test(r.returnValue.get().m.equals("test") && r.p3.get().m.equals("test"));
 
-      if (reqParams) {
-        Initial.OpVarStructReqResult rr = initial.opVarStructReq(p1.get());
-        test(rr.returnValue.get().m.equals("test") && rr.p3.get().m.equals("test"));
-        rr = initial.opVarStructReqAsync(p1.get()).join();
-        test(rr.returnValue.get().m.equals("test") && rr.p3.get().m.equals("test"));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      VarStruct.ice_write(os, p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opVarStruct", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.FSize));
+      in.skip(4);
+      VarStruct v = VarStruct.ice_read(in);
+      test(v.m.equals("test"));
+      test(in.readOptional(3, OptionalFormat.FSize));
+      in.skip(4);
+      v = VarStruct.ice_read(in);
+      test(v.m.equals("test"));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        VarStruct.ice_write(os, p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opVarStructReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.FSize));
-        in.skip(4);
-        VarStruct v = VarStruct.ice_read(in);
-        test(v.m.equals("test"));
-        test(in.readOptional(3, OptionalFormat.FSize));
-        in.skip(4);
-        v = VarStruct.ice_read(in);
-        test(v.m.equals("test"));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
-      if (reqParams) {
-        OneOptional p1 = new OneOptional();
-        Initial.OpOneOptionalResult r = initial.opOneOptional(p1);
-        test(!r.returnValue.hasA() && !r.p3.hasA());
-        r = initial.opOneOptionalAsync(p1).join();
-        test(!r.returnValue.hasA() && !r.p3.hasA());
+      OneOptional p1 = new OneOptional();
+      Initial.OpOneOptionalResult r = initial.opOneOptional(p1);
+      test(!r.returnValue.hasA() && !r.p3.hasA());
+      r = initial.opOneOptionalAsync(p1).join();
+      test(!r.returnValue.hasA() && !r.p3.hasA());
 
-        p1 = new OneOptional(58);
-        r = initial.opOneOptional(p1);
-        test(r.returnValue.getA() == 58 && r.p3.getA() == 58);
-        r = initial.opOneOptionalAsync(p1).join();
-        test(r.returnValue.getA() == 58 && r.p3.getA() == 58);
+      p1 = new OneOptional(58);
+      r = initial.opOneOptional(p1);
+      test(r.returnValue.getA() == 58 && r.p3.getA() == 58);
+      r = initial.opOneOptionalAsync(p1).join();
+      test(r.returnValue.getA() == 58 && r.p3.getA() == 58);
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeValue(p1);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opOneOptional", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        Wrapper<OneOptional> p2cb = new Wrapper<>();
-        in.readValue(v -> p2cb.value = v, OneOptional.class);
-        Wrapper<OneOptional> p3cb = new Wrapper<>();
-        in.readValue(v -> p3cb.value = v, OneOptional.class);
-        in.endEncapsulation();
-        test(p2cb.value.getA() == 58 && p3cb.value.getA() == 58);
-      }
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeValue(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opOneOptional", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      Wrapper<OneOptional> p2cb = new Wrapper<>();
+      in.readValue(v -> p2cb.value = v, OneOptional.class);
+      Wrapper<OneOptional> p3cb = new Wrapper<>();
+      in.readValue(v -> p3cb.value = v, OneOptional.class);
+      in.endEncapsulation();
+      test(p2cb.value.getA() == 58 && p3cb.value.getA() == 58);
     }
 
     {
@@ -1090,31 +1004,24 @@ public class AllTests {
       r = initial.opMyInterfaceProxyAsync(p1).join();
       test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpMyInterfaceProxyReqResult rr = initial.opMyInterfaceProxyReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
-        rr = initial.opMyInterfaceProxyReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      os.writeProxy(p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opMyInterfaceProxy", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readProxy(1).get().equals(p1.get()));
+      test(in.readProxy(3).get().equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        os.writeProxy(p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opMyInterfaceProxyReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readProxy(1).get().equals(p1.get()));
-        test(in.readProxy(3).get().equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
     out.println("ok");
 
@@ -1136,33 +1043,22 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpByteSeqReqResult rr = initial.opByteSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opByteSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeByteSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opByteSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readByteSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readByteSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeByteSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opByteSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readByteSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readByteSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1180,33 +1076,22 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpBoolSeqReqResult rr = initial.opBoolSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opBoolSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeBoolSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opBoolSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readBoolSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readBoolSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeBoolSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opBoolSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readBoolSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readBoolSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1225,34 +1110,23 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpShortSeqReqResult rr = initial.opShortSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opShortSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 2 + (p1.get().length > 254 ? 5 : 1));
+      os.writeShortSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opShortSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readShortSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readShortSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 2 + (p1.get().length > 254 ? 5 : 1));
-        os.writeShortSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opShortSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readShortSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readShortSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1271,34 +1145,23 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpIntSeqReqResult rr = initial.opIntSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opIntSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
+      os.writeIntSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opIntSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readIntSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readIntSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-        os.writeIntSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opIntSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readIntSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readIntSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1317,34 +1180,23 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpLongSeqReqResult rr = initial.opLongSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opLongSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
+      os.writeLongSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opLongSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readLongSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readLongSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
-        os.writeLongSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opLongSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readLongSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readLongSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1363,34 +1215,23 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpFloatSeqReqResult rr = initial.opFloatSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opFloatSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
+      os.writeFloatSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opFloatSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readFloatSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readFloatSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-        os.writeFloatSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opFloatSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readFloatSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readFloatSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1409,34 +1250,23 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpDoubleSeqReqResult rr = initial.opDoubleSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opDoubleSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
+      os.writeDoubleSeq(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opDoubleSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readDoubleSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readDoubleSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 8 + (p1.get().length > 254 ? 5 : 1));
-        os.writeDoubleSeq(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opDoubleSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readDoubleSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readDoubleSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1455,35 +1285,24 @@ public class AllTests {
           java.util.Arrays.equals(r.returnValue.get(), p1.get())
               && java.util.Arrays.equals(r.p3.get(), p1.get()));
 
-      if (reqParams) {
-        Initial.OpStringSeqReqResult rr = initial.opStringSeqReq(p1.get());
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
-        rr = initial.opStringSeqReqAsync(p1.get()).join();
-        test(
-            java.util.Arrays.equals(rr.returnValue.get(), p1.get())
-                && java.util.Arrays.equals(rr.p3.get(), p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      os.writeStringSeq(p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opStringSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(java.util.Arrays.equals(in.readStringSeq(1).get(), p1.get()));
+      test(java.util.Arrays.equals(in.readStringSeq(3).get(), p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        os.writeStringSeq(p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opStringSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(java.util.Arrays.equals(in.readStringSeq(1).get(), p1.get()));
-        test(java.util.Arrays.equals(in.readStringSeq(3).get(), p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1498,52 +1317,43 @@ public class AllTests {
       r = initial.opSmallStructSeq(p1);
       for (int i = 0; i < p1.get().length; ++i) {
         test(r.p3.get()[i].equals(p1.get()[i]));
+        test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
       r = initial.opSmallStructSeqAsync(p1).join();
       for (int i = 0; i < p1.get().length; ++i) {
+        test(r.p3.get()[i].equals(p1.get()[i]));
         test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
 
-      if (reqParams) {
-        Initial.OpSmallStructSeqReqResult rr = initial.opSmallStructSeqReq(p1.get());
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-        rr = initial.opSmallStructSeqReqAsync(p1.get()).join();
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        SmallStructSeqHelper.write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opSmallStructSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        SmallStruct[] arr = SmallStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        test(in.readOptional(3, OptionalFormat.VSize));
-        arr = SmallStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        in.endEncapsulation();
-
-        // Check the outEncaps size matches the expected size, 6 bytes for the encapsulation, plus
-        // 12 bytes
-        // for each sequence (1 byte tag, 1 byte size, 10 byte contents)
-        test(inv.outParams.length == 12 + 12 + 6);
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      SmallStructSeqHelper.write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opSmallStructSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      SmallStruct[] arr = SmallStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
       }
+      test(in.readOptional(3, OptionalFormat.VSize));
+      arr = SmallStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
+      }
+      in.endEncapsulation();
+
+      // Check the outEncaps size matches the expected size, 6 bytes for the encapsulation, plus
+      // 12 bytes
+      // for each sequence (1 byte tag, 1 byte size, 10 byte contents)
+      test(inv.outParams.length == 12 + 12 + 6);
+
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1560,36 +1370,29 @@ public class AllTests {
       r = initial.opSmallStructListAsync(p1).join();
       test(r.returnValue.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpSmallStructListReqResult rr = initial.opSmallStructListReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()));
-        rr = initial.opSmallStructListReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().size() + (p1.get().size() > 254 ? 5 : 1));
+      SmallStructListHelper.write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opSmallStructList", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      java.util.List<SmallStruct> arr = SmallStructListHelper.read(in);
+      test(arr.equals(p1.get()));
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      arr = SmallStructListHelper.read(in);
+      test(arr.equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().size() + (p1.get().size() > 254 ? 5 : 1));
-        SmallStructListHelper.write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opSmallStructListReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        java.util.List<SmallStruct> arr = SmallStructListHelper.read(in);
-        test(arr.equals(p1.get()));
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        arr = SmallStructListHelper.read(in);
-        test(arr.equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1603,51 +1406,42 @@ public class AllTests {
       }
       r = initial.opFixedStructSeq(p1);
       for (int i = 0; i < p1.get().length; ++i) {
+        test(r.p3.get()[i].equals(p1.get()[i]));
         test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
       r = initial.opFixedStructSeqAsync(p1).join();
       for (int i = 0; i < p1.get().length; ++i) {
+        test(r.p3.get()[i].equals(p1.get()[i]));
         test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
 
-      if (reqParams) {
-        Initial.OpFixedStructSeqReqResult rr = initial.opFixedStructSeqReq(p1.get());
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-        rr = initial.opFixedStructSeqReqAsync(p1.get()).join();
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
-        FixedStructSeqHelper.write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opFixedStructSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        FixedStruct[] arr = FixedStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        arr = FixedStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().length * 4 + (p1.get().length > 254 ? 5 : 1));
+      FixedStructSeqHelper.write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opFixedStructSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      FixedStruct[] arr = FixedStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
       }
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      arr = FixedStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
+      }
+      in.endEncapsulation();
+
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1660,40 +1454,33 @@ public class AllTests {
         p1.get().add(new FixedStruct());
       }
       r = initial.opFixedStructList(p1);
-      test(r.returnValue.get().equals(p1.get()));
+      test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
       r = initial.opFixedStructListAsync(p1).join();
-      test(r.returnValue.get().equals(p1.get()));
+      test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpFixedStructListReqResult rr = initial.opFixedStructListReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()));
-        rr = initial.opFixedStructListReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().size() * 4 + (p1.get().size() > 254 ? 5 : 1));
+      FixedStructListHelper.write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opFixedStructList", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      java.util.List<FixedStruct> arr = FixedStructListHelper.read(in);
+      test(arr.equals(p1.get()));
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      arr = FixedStructListHelper.read(in);
+      test(arr.equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().size() * 4 + (p1.get().size() > 254 ? 5 : 1));
-        FixedStructListHelper.write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opFixedStructListReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        java.util.List<FixedStruct> arr = FixedStructListHelper.read(in);
-        test(arr.equals(p1.get()));
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        arr = FixedStructListHelper.read(in);
-        test(arr.equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1707,52 +1494,43 @@ public class AllTests {
       }
       r = initial.opVarStructSeq(p1);
       for (int i = 0; i < p1.get().length; ++i) {
+        test(r.p3.get()[i].equals(p1.get()[i]));
         test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
       r = initial.opVarStructSeqAsync(p1).join();
       for (int i = 0; i < p1.get().length; ++i) {
+        test(r.p3.get()[i].equals(p1.get()[i]));
         test(r.returnValue.get()[i].equals(p1.get()[i]));
       }
 
-      if (reqParams) {
-        Initial.OpVarStructSeqReqResult rr = initial.opVarStructSeqReq(p1.get());
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-        rr = initial.opVarStructSeqReqAsync(p1.get()).join();
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(rr.returnValue.get()[i].equals(p1.get()[i]));
-        }
-
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        VarStructSeqHelper.write(os, p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opVarStructSeqReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.FSize));
-        in.skip(4);
-        VarStruct[] arr = VarStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        test(in.readOptional(3, OptionalFormat.FSize));
-        in.skip(4);
-        arr = VarStructSeqHelper.read(in);
-        for (int i = 0; i < p1.get().length; ++i) {
-          test(arr[i].equals(p1.get()[i]));
-        }
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      VarStructSeqHelper.write(os, p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opVarStructSeq", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.FSize));
+      in.skip(4);
+      VarStruct[] arr = VarStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
       }
+      test(in.readOptional(3, OptionalFormat.FSize));
+      in.skip(4);
+      arr = VarStructSeqHelper.read(in);
+      for (int i = 0; i < p1.get().length; ++i) {
+        test(arr[i].equals(p1.get()[i]));
+      }
+      in.endEncapsulation();
+
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     if (supportsJavaSerializable) {
@@ -1766,33 +1544,26 @@ public class AllTests {
       r = initial.opSerializableAsync(p1).join();
       test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpSerializableReqResult rr = initial.opSerializableReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
-        rr = initial.opSerializableReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSerializable(p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opSerializable", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      SerializableClass sc = in.readSerializable(SerializableClass.class);
+      test(sc.equals(p1.get()));
+      test(in.readOptional(3, OptionalFormat.VSize));
+      sc = in.readSerializable(SerializableClass.class);
+      test(sc.equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSerializable(p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opSerializableReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        SerializableClass sc = in.readSerializable(SerializableClass.class);
-        test(sc.equals(p1.get()));
-        test(in.readOptional(3, OptionalFormat.VSize));
-        sc = in.readSerializable(SerializableClass.class);
-        test(sc.equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
     out.println("ok");
 
@@ -1811,36 +1582,29 @@ public class AllTests {
       r = initial.opIntIntDictAsync(p1).join();
       test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpIntIntDictReqResult rr = initial.opIntIntDictReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
-        rr = initial.opIntIntDictReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.VSize);
+      os.writeSize(p1.get().size() * 8 + (p1.get().size() > 254 ? 5 : 1));
+      IntIntDictHelper.write(os, p1);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opIntIntDict", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.VSize));
+      in.skipSize();
+      java.util.Map<Integer, Integer> m = IntIntDictHelper.read(in);
+      test(m.equals(p1.get()));
+      test(in.readOptional(3, OptionalFormat.VSize));
+      in.skipSize();
+      m = IntIntDictHelper.read(in);
+      test(m.equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.VSize);
-        os.writeSize(p1.get().size() * 8 + (p1.get().size() > 254 ? 5 : 1));
-        IntIntDictHelper.write(os, p1.get());
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opIntIntDictReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.VSize));
-        in.skipSize();
-        java.util.Map<Integer, Integer> m = IntIntDictHelper.read(in);
-        test(m.equals(p1.get()));
-        test(in.readOptional(3, OptionalFormat.VSize));
-        in.skipSize();
-        m = IntIntDictHelper.read(in);
-        test(m.equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1856,37 +1620,30 @@ public class AllTests {
       r = initial.opStringIntDictAsync(p1).join();
       test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
 
-      if (reqParams) {
-        Initial.OpStringIntDictReqResult rr = initial.opStringIntDictReq(p1.get());
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
-        rr = initial.opStringIntDictReqAsync(p1.get()).join();
-        test(rr.returnValue.get().equals(p1.get()) && rr.p3.get().equals(p1.get()));
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      StringIntDictHelper.write(os, p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opStringIntDict", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.FSize));
+      in.skip(4);
+      java.util.Map<String, Integer> m = StringIntDictHelper.read(in);
+      test(m.equals(p1.get()));
+      test(in.readOptional(3, OptionalFormat.FSize));
+      in.skip(4);
+      m = StringIntDictHelper.read(in);
+      test(m.equals(p1.get()));
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        StringIntDictHelper.write(os, p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opStringIntDictReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.FSize));
-        in.skip(4);
-        java.util.Map<String, Integer> m = StringIntDictHelper.read(in);
-        test(m.equals(p1.get()));
-        test(in.readOptional(3, OptionalFormat.FSize));
-        in.skip(4);
-        m = StringIntDictHelper.read(in);
-        test(m.equals(p1.get()));
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {
@@ -1905,39 +1662,30 @@ public class AllTests {
       test(r.returnValue.get().get(1).getA() == 15 && r.p3.get().get(1).getA() == 15);
       test(r.returnValue.get().get(2).getA() == 12 && r.p3.get().get(2).getA() == 12);
 
-      if (reqParams) {
-        Initial.OpIntOneOptionalDictReqResult rr = initial.opIntOneOptionalDictReq(p1.get());
-        test(rr.returnValue.get().get(1).getA() == 15 && rr.p3.get().get(1).getA() == 15);
-        test(rr.returnValue.get().get(2).getA() == 12 && rr.p3.get().get(2).getA() == 12);
-        rr = initial.opIntOneOptionalDictReqAsync(p1.get()).join();
-        test(rr.returnValue.get().get(1).getA() == 15 && rr.p3.get().get(1).getA() == 15);
-        test(rr.returnValue.get().get(2).getA() == 12 && rr.p3.get().get(2).getA() == 12);
+      os = new OutputStream(communicator);
+      os.startEncapsulation();
+      os.writeOptional(2, OptionalFormat.FSize);
+      int pos = os.startSize();
+      IntOneOptionalDictHelper.write(os, p1);
+      os.endSize(pos);
+      os.endEncapsulation();
+      inEncaps = os.finished();
+      inv = initial.ice_invoke("opIntOneOptionalDict", OperationMode.Normal, inEncaps);
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      test(in.readOptional(1, OptionalFormat.FSize));
+      in.skip(4);
+      java.util.Map<Integer, OneOptional> m = IntOneOptionalDictHelper.read(in);
+      test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
+      test(in.readOptional(3, OptionalFormat.FSize));
+      in.skip(4);
+      m = IntOneOptionalDictHelper.read(in);
+      test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
+      in.endEncapsulation();
 
-        os = new OutputStream(communicator);
-        os.startEncapsulation();
-        os.writeOptional(2, OptionalFormat.FSize);
-        int pos = os.startSize();
-        IntOneOptionalDictHelper.write(os, p1.get());
-        os.endSize(pos);
-        os.endEncapsulation();
-        inEncaps = os.finished();
-        inv = initial.ice_invoke("opIntOneOptionalDictReq", OperationMode.Normal, inEncaps);
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        test(in.readOptional(1, OptionalFormat.FSize));
-        in.skip(4);
-        java.util.Map<Integer, OneOptional> m = IntOneOptionalDictHelper.read(in);
-        test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
-        test(in.readOptional(3, OptionalFormat.FSize));
-        in.skip(4);
-        m = IntOneOptionalDictHelper.read(in);
-        test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
-        in.endEncapsulation();
-
-        in = new InputStream(communicator, inv.outParams);
-        in.startEncapsulation();
-        in.endEncapsulation();
-      }
+      in = new InputStream(communicator, inv.outParams);
+      in.startEncapsulation();
+      in.endEncapsulation();
     }
 
     {

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -280,11 +280,6 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public boolean supportsRequiredParams(Current current) {
-    return true;
-  }
-
-  @Override
   public boolean supportsJavaSerializable(Current current) {
     return true;
   }

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -79,18 +79,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpByteReqResult opByteReq(Optional<Byte> p1, Current current) {
-    return new Initial.OpByteReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpBoolResult opBool(Optional<Boolean> p1, Current current) {
     return new Initial.OpBoolResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpBoolReqResult opBoolReq(Optional<Boolean> p1, Current current) {
-    return new Initial.OpBoolReqResult(p1, p1);
   }
 
   @Override
@@ -99,22 +89,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpShortReqResult opShortReq(Optional<Short> p1, Current current) {
-    return new Initial.OpShortReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpIntResult opInt(OptionalInt p1, Current current) {
-    if (p1.isPresent()) {
-      return new Initial.OpIntResult(p1.getAsInt(), p1.getAsInt());
-    } else {
-      return new Initial.OpIntResult(p1, p1);
-    }
-  }
-
-  @Override
-  public Initial.OpIntReqResult opIntReq(OptionalInt p1, Current current) {
-    return new Initial.OpIntReqResult(p1, p1);
+    return new Initial.OpIntResult(p1, p1);
   }
 
   @Override
@@ -123,22 +99,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpLongReqResult opLongReq(OptionalLong p1, Current current) {
-    return new Initial.OpLongReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpFloatResult opFloat(Optional<Float> p1, Current current) {
-    if (p1.isPresent()) {
-      return new Initial.OpFloatResult(p1.get(), p1.get());
-    } else {
-      return new Initial.OpFloatResult(p1, p1);
-    }
-  }
-
-  @Override
-  public Initial.OpFloatReqResult opFloatReq(Optional<Float> p1, Current current) {
-    return new Initial.OpFloatReqResult(p1, p1);
+    return new Initial.OpFloatResult(p1, p1);
   }
 
   @Override
@@ -147,33 +109,13 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpDoubleReqResult opDoubleReq(OptionalDouble p1, Current current) {
-    return new Initial.OpDoubleReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpStringResult opString(Optional<String> p1, Current current) {
     return new Initial.OpStringResult(p1, p1);
   }
 
   @Override
-  public Initial.OpStringReqResult opStringReq(Optional<String> p1, Current current) {
-    return new Initial.OpStringReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpMyEnumResult opMyEnum(Optional<MyEnum> p1, Current current) {
-    if (p1.isPresent()) {
-      return new Initial.OpMyEnumResult(p1.get(), p1.get());
-    } else {
-      MyEnum e = null;
-      return new Initial.OpMyEnumResult(e, e);
-    }
-  }
-
-  @Override
-  public Initial.OpMyEnumReqResult opMyEnumReq(Optional<MyEnum> p1, Current current) {
-    return new Initial.OpMyEnumReqResult(p1, p1);
+    return new Initial.OpMyEnumResult(p1, p1);
   }
 
   @Override
@@ -182,20 +124,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpSmallStructReqResult opSmallStructReq(
-      Optional<SmallStruct> p1, Current current) {
-    return new Initial.OpSmallStructReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpFixedStructResult opFixedStruct(Optional<FixedStruct> p1, Current current) {
     return new Initial.OpFixedStructResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpFixedStructReqResult opFixedStructReq(
-      Optional<FixedStruct> p1, Current current) {
-    return new Initial.OpFixedStructReqResult(p1, p1);
   }
 
   @Override
@@ -204,20 +134,9 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpVarStructReqResult opVarStructReq(Optional<VarStruct> p1, Current current) {
-    return new Initial.OpVarStructReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpMyInterfaceProxyResult opMyInterfaceProxy(
       Optional<MyInterfacePrx> p1, Current current) {
     return new Initial.OpMyInterfaceProxyResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpMyInterfaceProxyReqResult opMyInterfaceProxyReq(
-      Optional<MyInterfacePrx> p1, Current current) {
-    return new Initial.OpMyInterfaceProxyReqResult(p1, p1);
   }
 
   @Override
@@ -231,18 +150,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpByteSeqReqResult opByteSeqReq(Optional<byte[]> p1, Current current) {
-    return new Initial.OpByteSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpBoolSeqResult opBoolSeq(Optional<boolean[]> p1, Current current) {
     return new Initial.OpBoolSeqResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpBoolSeqReqResult opBoolSeqReq(Optional<boolean[]> p1, Current current) {
-    return new Initial.OpBoolSeqReqResult(p1, p1);
   }
 
   @Override
@@ -251,18 +160,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpShortSeqReqResult opShortSeqReq(Optional<short[]> p1, Current current) {
-    return new Initial.OpShortSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpIntSeqResult opIntSeq(Optional<int[]> p1, Current current) {
     return new Initial.OpIntSeqResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpIntSeqReqResult opIntSeqReq(Optional<int[]> p1, Current current) {
-    return new Initial.OpIntSeqReqResult(p1, p1);
   }
 
   @Override
@@ -271,18 +170,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpLongSeqReqResult opLongSeqReq(Optional<long[]> p1, Current current) {
-    return new Initial.OpLongSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpFloatSeqResult opFloatSeq(Optional<float[]> p1, Current current) {
     return new Initial.OpFloatSeqResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpFloatSeqReqResult opFloatSeqReq(Optional<float[]> p1, Current current) {
-    return new Initial.OpFloatSeqReqResult(p1, p1);
   }
 
   @Override
@@ -291,18 +180,8 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpDoubleSeqReqResult opDoubleSeqReq(Optional<double[]> p1, Current current) {
-    return new Initial.OpDoubleSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpStringSeqResult opStringSeq(Optional<String[]> p1, Current current) {
     return new Initial.OpStringSeqResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpStringSeqReqResult opStringSeqReq(Optional<String[]> p1, Current current) {
-    return new Initial.OpStringSeqReqResult(p1, p1);
   }
 
   @Override
@@ -312,21 +191,9 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpSmallStructSeqReqResult opSmallStructSeqReq(
-      Optional<SmallStruct[]> p1, Current current) {
-    return new Initial.OpSmallStructSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpSmallStructListResult opSmallStructList(
       Optional<java.util.List<SmallStruct>> p1, Current current) {
     return new Initial.OpSmallStructListResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpSmallStructListReqResult opSmallStructListReq(
-      Optional<java.util.List<SmallStruct>> p1, Current current) {
-    return new Initial.OpSmallStructListReqResult(p1, p1);
   }
 
   @Override
@@ -336,32 +203,14 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpFixedStructSeqReqResult opFixedStructSeqReq(
-      Optional<FixedStruct[]> p1, Current current) {
-    return new Initial.OpFixedStructSeqReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpFixedStructListResult opFixedStructList(
       Optional<java.util.List<FixedStruct>> p1, Current current) {
     return new Initial.OpFixedStructListResult(p1, p1);
   }
 
   @Override
-  public Initial.OpFixedStructListReqResult opFixedStructListReq(
-      Optional<java.util.List<FixedStruct>> p1, Current current) {
-    return new Initial.OpFixedStructListReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpVarStructSeqResult opVarStructSeq(Optional<VarStruct[]> p1, Current current) {
     return new Initial.OpVarStructSeqResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpVarStructSeqReqResult opVarStructSeqReq(
-      Optional<VarStruct[]> p1, Current current) {
-    return new Initial.OpVarStructSeqReqResult(p1, p1);
   }
 
   @Override
@@ -371,21 +220,9 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpSerializableReqResult opSerializableReq(
-      Optional<SerializableClass> p1, Current current) {
-    return new Initial.OpSerializableReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpIntIntDictResult opIntIntDict(
       Optional<java.util.Map<Integer, Integer>> p1, Current current) {
     return new Initial.OpIntIntDictResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpIntIntDictReqResult opIntIntDictReq(
-      Optional<java.util.Map<Integer, Integer>> p1, Current current) {
-    return new Initial.OpIntIntDictReqResult(p1, p1);
   }
 
   @Override
@@ -395,21 +232,9 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpStringIntDictReqResult opStringIntDictReq(
-      Optional<java.util.Map<String, Integer>> p1, Current current) {
-    return new Initial.OpStringIntDictReqResult(p1, p1);
-  }
-
-  @Override
   public Initial.OpIntOneOptionalDictResult opIntOneOptionalDict(
       Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
     return new Initial.OpIntOneOptionalDictResult(p1, p1);
-  }
-
-  @Override
-  public Initial.OpIntOneOptionalDictReqResult opIntOneOptionalDictReq(
-      Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
-    return new Initial.OpIntOneOptionalDictReqResult(p1, p1);
   }
 
   @Override

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -196,110 +196,97 @@ interface Initial
     void opRequiredException(optional(1) int a, optional(2) string b)
         throws OptionalException;
 
-    ["java:optional"] optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
+    optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
     optional(1) byte opByteReq(optional(2) byte p1, out optional(3) byte p3);
 
-    ["java:optional"] optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
+    optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
     optional(1) bool opBoolReq(optional(2) bool p1, out optional(3) bool p3);
 
-    ["java:optional"] optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
+    optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
     optional(1) short opShortReq(optional(2) short p1, out optional(3) short p3);
 
-    ["java:optional"] optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
+    optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
     optional(1) int opIntReq(optional(2) int p1, out optional(3) int p3);
 
-    ["java:optional"] optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
+    optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
     optional(3) long opLongReq(optional(1) long p1, out optional(2) long p3);
 
-    ["java:optional"] optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
+    optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
     optional(1) float opFloatReq(optional(2) float p1, out optional(3) float p3);
 
-    ["java:optional"] optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
+    optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
     optional(1) double opDoubleReq(optional(2) double p1, out optional(3) double p3);
 
-    ["java:optional"] optional(1) string opString(optional(2) string p1, out optional(3) string p3);
+    optional(1) string opString(optional(2) string p1, out optional(3) string p3);
     optional(1) string opStringReq(optional(2) string p1, out optional(3) string p3);
 
-    ["java:optional"] optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
+    optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
     optional(1) MyEnum opMyEnumReq(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
-    ["java:optional"] optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
+    optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
     optional(1) SmallStruct opSmallStructReq(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
 
-    ["java:optional"] optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
+    optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
     optional(1) FixedStruct opFixedStructReq(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
 
-    ["java:optional"] optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
+    optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
     optional(1) VarStruct opVarStructReq(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
-    ["java:optional"] optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1,
-                                                                  out optional(3) MyInterface* p3);
+    optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
     optional(1) MyInterface* opMyInterfaceProxyReq(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
 
     OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
-    ["java:optional"] optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
+    optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
     optional(1) ByteSeq opByteSeqReq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
 
-    ["java:optional"] optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
+    optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
     optional(1) BoolSeq opBoolSeqReq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
 
-    ["java:optional"] optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
+    optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
     optional(1) ShortSeq opShortSeqReq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
 
-    ["java:optional"] optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
+    optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
     optional(1) IntSeq opIntSeqReq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
 
-    ["java:optional"] optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
+    optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
     optional(1) LongSeq opLongSeqReq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
 
-    ["java:optional"] optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
+    optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
     optional(1) FloatSeq opFloatSeqReq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
 
-    ["java:optional"] optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
+    optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
     optional(1) DoubleSeq opDoubleSeqReq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
 
-    ["java:optional"] optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
+    optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
     optional(1) StringSeq opStringSeqReq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
 
-    ["java:optional"] optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1,
-                                                                  out optional(3) SmallStructSeq p3);
+    optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
     optional(1) SmallStructSeq opSmallStructSeqReq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
 
-    ["java:optional"] optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1,
-                                                                    out optional(3) SmallStructList p3);
-    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1,
-                                                     out optional(3) SmallStructList p3);
+    optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
+    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
 
-    ["java:optional"] optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1,
-                                                                  out optional(3) FixedStructSeq p3);
+    optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
     optional(1) FixedStructSeq opFixedStructSeqReq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
 
-    ["java:optional"] optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
-                                                                    out optional(3) FixedStructList p3);
-    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1,
-                                                     out optional(3) FixedStructList p3);
+    optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
+    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
 
-    ["java:optional"] optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
-                                                              out optional(3) VarStructSeq p3);
+    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
     optional(1) VarStructSeq opVarStructSeqReq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
-    ["java:optional"] optional(1) Serializable opSerializable(optional(2) Serializable p1,
-                                                              out optional(3) Serializable p3);
+    optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
     optional(1) Serializable opSerializableReq(optional(2) Serializable p1, out optional(3) Serializable p3);
 
-    ["java:optional"] optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
+    optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
     optional(1) IntIntDict opIntIntDictReq(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
-    ["java:optional"] optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
-                                                                out optional(3) StringIntDict p3);
+    optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
     optional(1) StringIntDict opStringIntDictReq(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    ["java:optional"] optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                                          out optional(3) IntOneOptionalDict p3);
-
-    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1,
-                                                           out optional(3) IntOneOptionalDict p3);
+    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -197,96 +197,66 @@ interface Initial
         throws OptionalException;
 
     optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
-    optional(1) byte opByteReq(optional(2) byte p1, out optional(3) byte p3);
 
     optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
-    optional(1) bool opBoolReq(optional(2) bool p1, out optional(3) bool p3);
 
     optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
-    optional(1) short opShortReq(optional(2) short p1, out optional(3) short p3);
 
     optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
-    optional(1) int opIntReq(optional(2) int p1, out optional(3) int p3);
 
     optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
-    optional(3) long opLongReq(optional(1) long p1, out optional(2) long p3);
 
     optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
-    optional(1) float opFloatReq(optional(2) float p1, out optional(3) float p3);
 
     optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
-    optional(1) double opDoubleReq(optional(2) double p1, out optional(3) double p3);
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
-    optional(1) string opStringReq(optional(2) string p1, out optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
-    optional(1) MyEnum opMyEnumReq(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
     optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
-    optional(1) SmallStruct opSmallStructReq(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
 
     optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
-    optional(1) FixedStruct opFixedStructReq(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
 
     optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
-    optional(1) VarStruct opVarStructReq(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
     optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
-    optional(1) MyInterface* opMyInterfaceProxyReq(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
 
     OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
     optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
-    optional(1) ByteSeq opByteSeqReq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
 
     optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
-    optional(1) BoolSeq opBoolSeqReq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
 
     optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
-    optional(1) ShortSeq opShortSeqReq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
 
     optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
-    optional(1) IntSeq opIntSeqReq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
 
     optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
-    optional(1) LongSeq opLongSeqReq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
 
     optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
-    optional(1) FloatSeq opFloatSeqReq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
 
     optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
-    optional(1) DoubleSeq opDoubleSeqReq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
 
     optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
-    optional(1) StringSeq opStringSeqReq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
 
     optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
-    optional(1) SmallStructSeq opSmallStructSeqReq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
 
     optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
-    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
 
     optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
-    optional(1) FixedStructSeq opFixedStructSeqReq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
 
     optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
-    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
 
     optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
-    optional(1) VarStructSeq opVarStructSeqReq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
     optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
-    optional(1) Serializable opSerializableReq(optional(2) Serializable p1, out optional(3) Serializable p3);
 
     optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
-    optional(1) IntIntDict opIntIntDictReq(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
-    optional(1) StringIntDict opStringIntDictReq(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
     optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
-    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -276,8 +276,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -277,8 +277,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -198,96 +198,66 @@ interface Initial
         throws OptionalException;
 
     optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
-    optional(1) byte opByteReq(optional(2) byte p1, out optional(3) byte p3);
 
     optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
-    optional(1) bool opBoolReq(optional(2) bool p1, out optional(3) bool p3);
 
     optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
-    optional(1) short opShortReq(optional(2) short p1, out optional(3) short p3);
 
     optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
-    optional(1) int opIntReq(optional(2) int p1, out optional(3) int p3);
 
     optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
-    optional(3) long opLongReq(optional(1) long p1, out optional(2) long p3);
 
     optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
-    optional(1) float opFloatReq(optional(2) float p1, out optional(3) float p3);
 
     optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
-    optional(1) double opDoubleReq(optional(2) double p1, out optional(3) double p3);
 
     optional(1) string opString(optional(2) string p1, out optional(3) string p3);
-    optional(1) string opStringReq(optional(2) string p1, out optional(3) string p3);
 
     optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
-    optional(1) MyEnum opMyEnumReq(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
     optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
-    optional(1) SmallStruct opSmallStructReq(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
 
     optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
-    optional(1) FixedStruct opFixedStructReq(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
 
     optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
-    optional(1) VarStruct opVarStructReq(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
     optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
-    optional(1) MyInterface* opMyInterfaceProxyReq(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
 
     OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
     optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
-    optional(1) ByteSeq opByteSeqReq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
 
     optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
-    optional(1) BoolSeq opBoolSeqReq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
 
     optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
-    optional(1) ShortSeq opShortSeqReq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
 
     optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
-    optional(1) IntSeq opIntSeqReq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
 
     optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
-    optional(1) LongSeq opLongSeqReq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
 
     optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
-    optional(1) FloatSeq opFloatSeqReq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
 
     optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
-    optional(1) DoubleSeq opDoubleSeqReq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
 
     optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
-    optional(1) StringSeq opStringSeqReq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
 
     optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
-    optional(1) SmallStructSeq opSmallStructSeqReq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
 
     optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
-    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
 
     optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
-    optional(1) FixedStructSeq opFixedStructSeqReq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
 
     optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
-    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
 
     optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
-    optional(1) VarStructSeq opVarStructSeqReq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
     optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
-    optional(1) Serializable opSerializableReq(optional(2) Serializable p1, out optional(3) Serializable p3);
 
     optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
-    optional(1) IntIntDict opIntIntDictReq(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
-    optional(1) StringIntDict opStringIntDictReq(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
     optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
-    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -197,110 +197,97 @@ interface Initial
     void opRequiredException(optional(1) int a, optional(2) string b)
         throws OptionalException;
 
-    ["java:optional"] optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
+    optional(1) byte opByte(optional(2) byte p1, out optional(3) byte p3);
     optional(1) byte opByteReq(optional(2) byte p1, out optional(3) byte p3);
 
-    ["java:optional"] optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
+    optional(1) bool opBool(optional(2) bool p1, out optional(3) bool p3);
     optional(1) bool opBoolReq(optional(2) bool p1, out optional(3) bool p3);
 
-    ["java:optional"] optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
+    optional(1) short opShort(optional(2) short p1, out optional(3) short p3);
     optional(1) short opShortReq(optional(2) short p1, out optional(3) short p3);
 
-    ["java:optional"] optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
+    optional(1) int opInt(optional(2) int p1, out optional(3) int p3);
     optional(1) int opIntReq(optional(2) int p1, out optional(3) int p3);
 
-    ["java:optional"] optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
+    optional(3) long opLong(optional(1) long p1, out optional(2) long p3);
     optional(3) long opLongReq(optional(1) long p1, out optional(2) long p3);
 
-    ["java:optional"] optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
+    optional(1) float opFloat(optional(2) float p1, out optional(3) float p3);
     optional(1) float opFloatReq(optional(2) float p1, out optional(3) float p3);
 
-    ["java:optional"] optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
+    optional(1) double opDouble(optional(2) double p1, out optional(3) double p3);
     optional(1) double opDoubleReq(optional(2) double p1, out optional(3) double p3);
 
-    ["java:optional"] optional(1) string opString(optional(2) string p1, out optional(3) string p3);
+    optional(1) string opString(optional(2) string p1, out optional(3) string p3);
     optional(1) string opStringReq(optional(2) string p1, out optional(3) string p3);
 
-    ["java:optional"] optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
+    optional(1) MyEnum opMyEnum(optional(2) MyEnum p1, out optional(3) MyEnum p3);
     optional(1) MyEnum opMyEnumReq(optional(2) MyEnum p1, out optional(3) MyEnum p3);
 
-    ["java:optional"] optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
+    optional(1) SmallStruct opSmallStruct(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
     optional(1) SmallStruct opSmallStructReq(optional(2) SmallStruct p1, out optional(3) SmallStruct p3);
 
-    ["java:optional"] optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
+    optional(1) FixedStruct opFixedStruct(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
     optional(1) FixedStruct opFixedStructReq(optional(2) FixedStruct p1, out optional(3) FixedStruct p3);
 
-    ["java:optional"] optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
+    optional(1) VarStruct opVarStruct(optional(2) VarStruct p1, out optional(3) VarStruct p3);
     optional(1) VarStruct opVarStructReq(optional(2) VarStruct p1, out optional(3) VarStruct p3);
 
-    ["java:optional"] optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1,
-                                                                  out optional(3) MyInterface* p3);
+    optional(1) MyInterface* opMyInterfaceProxy(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
     optional(1) MyInterface* opMyInterfaceProxyReq(optional(2) MyInterface* p1, out optional(3) MyInterface* p3);
 
     OneOptional opOneOptional(OneOptional p1, out OneOptional p3);
 
-    ["java:optional"] optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
+    optional(1) ByteSeq opByteSeq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
     optional(1) ByteSeq opByteSeqReq(optional(2) ByteSeq p1, out optional(3) ByteSeq p3);
 
-    ["java:optional"] optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
+    optional(1) BoolSeq opBoolSeq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
     optional(1) BoolSeq opBoolSeqReq(optional(2) BoolSeq p1, out optional(3) BoolSeq p3);
 
-    ["java:optional"] optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
+    optional(1) ShortSeq opShortSeq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
     optional(1) ShortSeq opShortSeqReq(optional(2) ShortSeq p1, out optional(3) ShortSeq p3);
 
-    ["java:optional"] optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
+    optional(1) IntSeq opIntSeq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
     optional(1) IntSeq opIntSeqReq(optional(2) IntSeq p1, out optional(3) IntSeq p3);
 
-    ["java:optional"] optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
+    optional(1) LongSeq opLongSeq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
     optional(1) LongSeq opLongSeqReq(optional(2) LongSeq p1, out optional(3) LongSeq p3);
 
-    ["java:optional"] optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
+    optional(1) FloatSeq opFloatSeq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
     optional(1) FloatSeq opFloatSeqReq(optional(2) FloatSeq p1, out optional(3) FloatSeq p3);
 
-    ["java:optional"] optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
+    optional(1) DoubleSeq opDoubleSeq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
     optional(1) DoubleSeq opDoubleSeqReq(optional(2) DoubleSeq p1, out optional(3) DoubleSeq p3);
 
-    ["java:optional"] optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
+    optional(1) StringSeq opStringSeq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
     optional(1) StringSeq opStringSeqReq(optional(2) StringSeq p1, out optional(3) StringSeq p3);
 
-    ["java:optional"] optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1,
-                                                                  out optional(3) SmallStructSeq p3);
+    optional(1) SmallStructSeq opSmallStructSeq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
     optional(1) SmallStructSeq opSmallStructSeqReq(optional(2) SmallStructSeq p1, out optional(3) SmallStructSeq p3);
 
-    ["java:optional"] optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1,
-                                                                    out optional(3) SmallStructList p3);
-    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1,
-                                                     out optional(3) SmallStructList p3);
+    optional(1) SmallStructList opSmallStructList(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
+    optional(1) SmallStructList opSmallStructListReq(optional(2) SmallStructList p1, out optional(3) SmallStructList p3);
 
-    ["java:optional"] optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1,
-                                                                  out optional(3) FixedStructSeq p3);
+    optional(1) FixedStructSeq opFixedStructSeq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
     optional(1) FixedStructSeq opFixedStructSeqReq(optional(2) FixedStructSeq p1, out optional(3) FixedStructSeq p3);
 
-    ["java:optional"] optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
-                                                                    out optional(3) FixedStructList p3);
-    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1,
-                                                     out optional(3) FixedStructList p3);
+    optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
+    optional(1) FixedStructList opFixedStructListReq(optional(2) FixedStructList p1, out optional(3) FixedStructList p3);
 
-    ["java:optional"] optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
-                                                              out optional(3) VarStructSeq p3);
+    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
     optional(1) VarStructSeq opVarStructSeqReq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
-    ["java:optional"] optional(1) Serializable opSerializable(optional(2) Serializable p1,
-                                                              out optional(3) Serializable p3);
+    optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
     optional(1) Serializable opSerializableReq(optional(2) Serializable p1, out optional(3) Serializable p3);
 
-    ["java:optional"] optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
+    optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
     optional(1) IntIntDict opIntIntDictReq(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
-    ["java:optional"] optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
-                                                                out optional(3) StringIntDict p3);
+    optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
     optional(1) StringIntDict opStringIntDictReq(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    ["java:optional"] optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                                          out optional(3) IntOneOptionalDict p3);
-
-    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1,
-                                                           out optional(3) IntOneOptionalDict p3);
+    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    optional(1) IntOneOptionalDict opIntOneOptionalDictReq(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 
@@ -308,17 +295,17 @@ interface Initial
 
     void opVoid();
 
-    ["marshaled-result", "java:optional"] optional(1) SmallStruct opMStruct1();
-    ["marshaled-result", "java:optional"] optional(1) SmallStruct opMStruct2(optional(2) SmallStruct p1,
-                                                                             out optional(3)SmallStruct p2);
+    ["marshaled-result"] optional(1) SmallStruct opMStruct1();
+    ["marshaled-result"] optional(1) SmallStruct opMStruct2(optional(2) SmallStruct p1,
+                                                            out optional(3)SmallStruct p2);
 
-    ["marshaled-result", "java:optional"] optional(1) StringSeq opMSeq1();
-    ["marshaled-result", "java:optional"] optional(1) StringSeq opMSeq2(optional(2) StringSeq p1,
-                                                                        out optional(3) StringSeq p2);
+    ["marshaled-result"] optional(1) StringSeq opMSeq1();
+    ["marshaled-result"] optional(1) StringSeq opMSeq2(optional(2) StringSeq p1,
+                                                       out optional(3) StringSeq p2);
 
-    ["marshaled-result", "java:optional"] optional(1) StringIntDict opMDict1();
-    ["marshaled-result", "java:optional"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
-                                                                             out optional(3) StringIntDict p2);
+    ["marshaled-result"] optional(1) StringIntDict opMDict1();
+    ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
+                                                            out optional(3) StringIntDict p2);
 
     bool supportsRequiredParams();
 

--- a/js/test/Ice/optional/AMDInitialI.js
+++ b/js/test/Ice/optional/AMDInitialI.js
@@ -278,11 +278,6 @@
             return [p1, p1];
         }
 
-        supportsRequiredParams(current)
-        {
-            return false;
-        }
-
         supportsJavaSerializable(current)
         {
             return false;

--- a/js/test/Ice/optional/InitialI.js
+++ b/js/test/Ice/optional/InitialI.js
@@ -278,11 +278,6 @@
             return [p1, p1];
         }
 
-        supportsRequiredParams(current)
-        {
-            return false;
-        }
-
         supportsJavaSerializable(current)
         {
             return false;

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -276,8 +276,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/js/test/typescript/Ice/optional/AMDInitialI.ts
+++ b/js/test/typescript/Ice/optional/AMDInitialI.ts
@@ -277,11 +277,6 @@ export class AMDInitialI extends Test.Initial
         return [p1, p1];
     }
 
-    supportsRequiredParams(current:Ice.Current):boolean
-    {
-        return false;
-    }
-
     supportsJavaSerializable(current:Ice.Current):boolean
     {
         return false;

--- a/js/test/typescript/Ice/optional/InitialI.ts
+++ b/js/test/typescript/Ice/optional/InitialI.ts
@@ -277,11 +277,6 @@ export class InitialI extends Test.Initial
         return [p1, p1];
     }
 
-    supportsRequiredParams(current:Ice.Current):boolean
-    {
-        return false;
-    }
-
     supportsJavaSerializable(current:Ice.Current):boolean
     {
         return false;

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -278,8 +278,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -284,8 +284,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -274,8 +274,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -157,9 +157,6 @@ class InitialI(Test.Initial):
     def opOptionalAfterRequired(self, p1, p2, p3, current):
         return (p1, p2, p3)
 
-    def supportsRequiredParams(self, current=None):
-        return False
-
     def supportsJavaSerializable(self, current=None):
         return True
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -171,9 +171,6 @@ class InitialI(Test.Initial):
     def opOptionalAfterRequired(self, p1, p2, p3, current):
         return Ice.Future.completed((p1, p2, p3))
 
-    def supportsRequiredParams(self, current=None):
-        return Ice.Future.completed(False)
-
     def supportsJavaSerializable(self, current=None):
         return Ice.Future.completed(True)
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -280,8 +280,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -276,8 +276,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -283,8 +283,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -279,8 +279,6 @@ interface Initial
     ["marshaled-result"] optional(1) StringIntDict opMDict2(optional(2) StringIntDict p1,
                                                             out optional(3) StringIntDict p2);
 
-    bool supportsRequiredParams();
-
     bool supportsJavaSerializable();
 
     bool supportsCsharpSerializable();

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -290,10 +290,6 @@ class InitialI: Initial {
     return Promise.value((p1, p1))
   }
 
-  func supportsRequiredParamsAsync(current _: Current) -> Promise<Bool> {
-    return Promise.value(false)
-  }
-
   func supportsJavaSerializableAsync(current _: Current) -> Promise<Bool> {
     return Promise.value(false)
   }

--- a/swift/test/Ice/optional/TestI.swift
+++ b/swift/test/Ice/optional/TestI.swift
@@ -251,10 +251,6 @@ class InitialI: Initial {
 
   func opVoid(current _: Ice.Current) throws {}
 
-  func supportsRequiredParams(current _: Ice.Current) throws -> Bool {
-    return false
-  }
-
   func supportsJavaSerializable(current _: Ice.Current) throws -> Bool {
     return false
   }


### PR DESCRIPTION
This PR removes the remnants of the `java:optional` metadata.
The docs say it was only for use with `java-compat`, which is dead.

----

It removes:
- a function from `slice2java` to test for this metadata, which is never called.
- the `supportsRequiredParams` operation from the `Ice/Optional` tests, which is _only_ used by the Java tests for this metadata.
- All the duplicate tests in the Java `Ice/Optional` test. Every test function had 2 versions, one with the metadata, and one without.
This metadata literally did nothing, so these operations are actually identical.