### PR TITLE
Support 'deprecated' as an Alias for 'deprecate'

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1001,6 +1001,9 @@ Slice::Contained::parseFormatMetaData(const list<string>& metaData)
 bool
 Slice::Contained::isDeprecated(bool checkParent) const
 {
+    // We support both 'deprecate' and 'deprecated' for the metadata. But here we only check for 'deprecate'.
+    // This is because `findMetadata` uses a `starts_with` check. Since 'deprecated' starts with 'deprecate',
+    // this check is sufficient.
     const string deprecate = "deprecate";
     string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
@@ -1011,14 +1014,20 @@ Slice::Contained::isDeprecated(bool checkParent) const
 optional<string>
 Slice::Contained::getDeprecationReason(bool checkParent) const
 {
-    const string prefix = "deprecate:";
     string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    if (findMetaData(prefix, metadata) || (parent && parent->findMetaData(prefix, metadata)))
+    const string prefix1 = "deprecate:";
+    if (findMetaData(prefix1, metadata) || (parent && parent->findMetaData(prefix1, metadata)))
     {
-        assert(metadata.find(prefix) == 0);
-        return metadata.substr(prefix.size());
+        assert(metadata.find(prefix1) == 0);
+        return metadata.substr(prefix1.size());
+    }
+    const string prefix2 = "deprecated:";
+    if (findMetaData(prefix2, metadata) || (parent && parent->findMetaData(prefix2, metadata)))
+    {
+        assert(metadata.find(prefix2) == 0);
+        return metadata.substr(prefix2.size());
     }
     return nullopt;
 }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1001,14 +1001,13 @@ Slice::Contained::parseFormatMetaData(const list<string>& metaData)
 bool
 Slice::Contained::isDeprecated(bool checkParent) const
 {
-    // We support both 'deprecate' and 'deprecated' for the metadata. But here we only check for 'deprecate'.
-    // This is because `findMetadata` uses a `starts_with` check. Since 'deprecated' starts with 'deprecate',
-    // this check is sufficient.
-    const string deprecate = "deprecate";
+    const string prefix1 = "deprecate:";
+    const string prefix2 = "deprecated";
     string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    return (findMetaData(deprecate, metadata) || (parent && parent->findMetaData(deprecate, metadata)));
+    return (findMetaData(prefix1, metadata) || (parent && parent->findMetaData(prefix1, metadata)))
+        || (findMetaData(prefix2, metadata) || (parent && parent->findMetaData(prefix2, metadata)));
 }
 
 optional<string>
@@ -1023,12 +1022,14 @@ Slice::Contained::getDeprecationReason(bool checkParent) const
         assert(metadata.find(prefix1) == 0);
         return metadata.substr(prefix1.size());
     }
+
     const string prefix2 = "deprecated:";
     if (findMetaData(prefix2, metadata) || (parent && parent->findMetaData(prefix2, metadata)))
     {
         assert(metadata.find(prefix2) == 0);
         return metadata.substr(prefix2.size());
     }
+
     return nullopt;
 }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3468,8 +3468,8 @@ Slice::InterfaceDef::createOperation(
             if (baseName == newName2)
             {
                 ostringstream os;
-                os << "operation `" << name << "' differs only in capitalization from operation" << " `" << op->name()
-                   << "', which is defined in a base interface";
+                os << "operation `" << name << "' differs only in capitalization from operation"
+                   << " `" << op->name() << "', which is defined in a base interface";
                 _unit->error(os.str());
                 return nullptr;
             }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1001,7 +1001,7 @@ Slice::Contained::parseFormatMetaData(const list<string>& metaData)
 bool
 Slice::Contained::isDeprecated(bool checkParent) const
 {
-    const string prefix1 = "deprecate:";
+    const string prefix1 = "deprecate";
     const string prefix2 = "deprecated";
     string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1006,8 +1006,8 @@ Slice::Contained::isDeprecated(bool checkParent) const
     string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    return (findMetaData(prefix1, metadata) || (parent && parent->findMetaData(prefix1, metadata)))
-        || (findMetaData(prefix2, metadata) || (parent && parent->findMetaData(prefix2, metadata)));
+    return (findMetaData(prefix1, metadata) || (parent && parent->findMetaData(prefix1, metadata))) ||
+           (findMetaData(prefix2, metadata) || (parent && parent->findMetaData(prefix2, metadata)));
 }
 
 optional<string>
@@ -3468,8 +3468,8 @@ Slice::InterfaceDef::createOperation(
             if (baseName == newName2)
             {
                 ostringstream os;
-                os << "operation `" << name << "' differs only in capitalization from operation"
-                   << " `" << op->name() << "', which is defined in a base interface";
+                os << "operation `" << name << "' differs only in capitalization from operation" << " `" << op->name()
+                   << "', which is defined in a base interface";
                 _unit->error(os.str());
                 return nullptr;
             }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -397,16 +397,16 @@ namespace Slice
 
         static FormatType parseFormatMetaData(const std::list<std::string>&);
 
-        /// Returns true if this item is deprecated (due to the presence of `deprecate` metadata).
-        /// @param checkParent If true, this item's immediate container will also be checked for `deprecate` metadata.
-        /// @return True if this item (or possibly its container) has `deprecate` metadata on it, false otherwise.
+        /// Returns true if this item is deprecated (due to the presence of 'deprecated' metadata).
+        /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' metadata.
+        /// @return True if this item (or possibly its container) has 'deprecated' metadata on it, false otherwise.
         bool isDeprecated(bool checkParent) const;
 
         /// If this item is deprecated, return its deprecation message (if present).
-        /// This is the string argument that can be optionally provided with `deprecate` metadata.
-        /// @param checkParent If true, this item's immediate container will also be checked for `deprecate` messages.
-        /// @return The message provided to the `deprecate` metadata, if present. If `checkParent` is true, and both
-        /// this item and its parent have 'deprecate' messages, the item's message is returned, not its container's.
+        /// This is the string argument that can be optionally provided with 'deprecated' metadata.
+        /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' messages.
+        /// @return The message provided to the 'deprecated' metadata, if present. If 'checkParent' is true, and both
+        /// this item and its parent have 'deprecated' messages, the item's message is returned, not its container's.
         std::optional<std::string> getDeprecationReason(bool checkParent) const;
 
         enum ContainedType


### PR DESCRIPTION
This PR implements #2093. After I centralized all the deprecation checking to the Parser,
only these 2 functions need to be changed.

Let me know if the logic for `isDeprecated` is too hacky. Honestly, I'm pretty sure it is...