### PR TITLE
Remove Deprecated 'ice_name' Function

### DIFF
--- a/csharp/src/Ice/Exception.cs
+++ b/csharp/src/Ice/Exception.cs
@@ -23,17 +23,6 @@ public abstract class Exception : System.Exception
     public Exception(System.Exception ex) : base("", ex) { }
 
     /// <summary>
-    /// ice_name() is deprecated, use ice_id() instead.
-    /// Returns the name of this exception.
-    /// </summary>
-    /// <returns>The name of this exception.</returns>
-    [Obsolete("ice_name() is deprecated, use ice_id() instead.")]
-    public string ice_name()
-    {
-        return ice_id().Substring(2);
-    }
-
-    /// <summary>
     /// Returns the type id of this exception.
     /// </summary>
     /// <returns>The type id of this exception.</returns>

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Exception.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Exception.java
@@ -34,17 +34,6 @@ public abstract class Exception extends RuntimeException implements Cloneable {
   }
 
   /**
-   * Returns the name of this exception.
-   *
-   * @return The name of this exception.
-   * @deprecated ice_name() is deprecated, use ice_id() instead.
-   */
-  @Deprecated
-  public String ice_name() {
-    return ice_id().substring(2);
-  }
-
-  /**
    * Returns the type id of this exception.
    *
    * @return The type id of this exception.

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
@@ -30,17 +30,6 @@ public abstract class UserException extends java.lang.Exception implements Clone
   }
 
   /**
-   * Returns the name of this exception.
-   *
-   * @return The name of this exception.
-   * @deprecated ice_name() is deprecated, use ice_id() instead.
-   */
-  @Deprecated
-  public String ice_name() {
-    return ice_id().substring(2);
-  }
-
-  /**
    * Returns the type id of this exception.
    *
    * @return The type id of this exception.

--- a/js/src/Ice/Exception.d.ts
+++ b/js/src/Ice/Exception.d.ts
@@ -12,15 +12,6 @@ declare module "ice"
         abstract class Exception extends Error
         {
             /**
-             * Returns the name of this exception.
-             *
-             * @return The name of this exception.
-             *
-             * @deprecated ice_name() is deprecated, use ice_id() instead.
-             **/
-            ice_name():string;
-
-            /**
              * Returns the type id of this exception.
              *
              * @return The type id of this exception.

--- a/js/src/Ice/Exception.js
+++ b/js/src/Ice/Exception.js
@@ -60,11 +60,6 @@ class Exception extends Error
         }
     }
 
-    ice_name()
-    {
-        return this.constructor._id.substr(2);
-    }
-
     ice_id()
     {
         return this.constructor._id;

--- a/php/lib/Ice.php
+++ b/php/lib/Ice.php
@@ -36,11 +36,6 @@ namespace Ice
         }
 
         abstract public function ice_id();
-        public function ice_name()
-        {
-            trigger_error('ice_name() is deprecated use ice_id() instead.', E_DEPRECATED);
-            return substr($this->ice_id(), 2);
-        }
     }
 
     abstract class UserException extends Exception

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -507,10 +507,6 @@ class Exception(Exception):  # Derives from built-in base 'Exception' class.
     def __str__(self):
         return self.__class__.__name__
 
-    def ice_name(self):
-        """Returns the type name of this exception."""
-        return self.ice_id()[2:]
-
     def ice_id(self):
         """Returns the type id of this exception."""
         return self._ice_id

--- a/ruby/ruby/Ice.rb
+++ b/ruby/ruby/Ice.rb
@@ -54,10 +54,6 @@ module Ice
     # Exceptions.
     #
     class Exception < ::StandardError
-        def ice_name
-            to_s[2..-1]
-        end
-
         def ice_id
             to_s
         end


### PR DESCRIPTION
`ice_name` was added to exceptions long ago in 3.3, and it just returns the type-id of the exception (minus the leading '::').
It has been deprecated for a while, because now we offer `ice_id`, which basically does the same thing.
So, this PR deletes it.

Seems like its a simple case of just literally deleting the function.
But if anyone thinks there's something else I need to do here, please let me know!