### PR TITLE
Reimplement ice_isA etc. in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -385,7 +385,7 @@ Slice::CsVisitor::writeDispatch(const InterfaceDefPtr& p)
     _out << sp << nl << "#region Slice type-related members";
     _out << sp;
     _out << nl << "public override string ice_id(" << getUnqualified("Ice.Current", ns)
-        << " current) => ice_staticId();";
+         << " current) => ice_staticId();";
 
     _out << sp;
     _out << nl << "public static new string ice_staticId() => \"" << scoped << "\";";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -382,53 +382,13 @@ Slice::CsVisitor::writeDispatch(const InterfaceDefPtr& p)
     string scoped = p->scoped();
     string ns = getNamespace(p);
 
-    StringList ids = p->ids();
-
     _out << sp << nl << "#region Slice type-related members";
+    _out << sp;
+    _out << nl << "public override string ice_id(" << getUnqualified("Ice.Current", ns)
+        << " current) => ice_staticId();";
 
     _out << sp;
-
-    _out << nl << "private static readonly string[] _ids =";
-    _out << sb;
-    {
-        StringList::const_iterator q = ids.begin();
-        while (q != ids.end())
-        {
-            _out << nl << '"' << *q << '"';
-            if (++q != ids.end())
-            {
-                _out << ',';
-            }
-        }
-    }
-    _out << eb << ";";
-
-    _out << sp;
-    _out << nl << "public override bool ice_isA(string s, " << getUnqualified("Ice.Current", ns) << " current)";
-    _out << sb;
-    _out
-        << nl
-        << "return global::System.Array.BinarySearch(_ids, s, Ice.UtilInternal.StringUtil.OrdinalStringComparer) >= 0;";
-    _out << eb;
-
-    _out << sp;
-    _out << nl << "public override string[] ice_ids(" << getUnqualified("Ice.Current", ns) << " current)";
-    _out << sb;
-    _out << nl << "return _ids;";
-    _out << eb;
-
-    _out << sp;
-    _out << nl << "public override string ice_id(" << getUnqualified("Ice.Current", ns) << " current)";
-    _out << sb;
-    _out << nl << "return ice_staticId();";
-    _out << eb;
-
-    _out << sp;
-
-    _out << nl << "public static new string ice_staticId()";
-    _out << sb;
-    _out << nl << "return \"" << scoped << "\";";
-    _out << eb;
+    _out << nl << "public static new string ice_staticId() => \"" << scoped << "\";";
 
     _out << sp << nl << "#endregion"; // Slice type-related members
 
@@ -2147,6 +2107,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     emitComVisibleAttribute();
     emitPartialTypeAttributes();
+    _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     _out << nl << "public partial interface " << fixId(name);
     baseNames.push_back(getUnqualified("Ice.Object", ns));
     baseNames.push_back(name + "Operations_");

--- a/csharp/src/Ice/Object.cs
+++ b/csharp/src/Ice/Object.cs
@@ -10,6 +10,7 @@ namespace Ice;
 /// <summary>
 /// The base interface for servants.
 /// </summary>
+[SliceTypeId("::Ice::Object")]
 public interface Object
 {
     /// <summary>
@@ -20,27 +21,51 @@ public interface Object
     /// <param name="current">The Current object for the dispatch.</param>
     /// <returns>True if this object has the interface
     /// specified by s or derives from the interface specified by s.</returns>
-    bool ice_isA(string s, Current current);
+    public bool ice_isA(string s, Current current)
+    {
+        foreach (Type type in GetType().GetInterfaces())
+        {
+            if (type.GetSliceTypeId() is string typeId && typeId == s)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
     /// Tests whether this object can be reached.
     /// </summary>
     /// <param name="current">The Current object for the dispatch.</param>
-    void ice_ping(Current current);
+    public void ice_ping(Current current)
+    {
+        // does nothing
+    }
 
     /// <summary>
     /// Returns the Slice type IDs of the interfaces supported by this object.
     /// </summary>
     /// <param name="current">The Current object for the dispatch.</param>
     /// <returns>The Slice type IDs of the interfaces supported by this object, in alphabetical order.</returns>
-    string[] ice_ids(Current current);
+    public string[] ice_ids(Current current)
+    {
+        var sortedSet = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (Type type in GetType().GetInterfaces())
+        {
+            if (type.GetSliceTypeId() is string typeId)
+            {
+                sortedSet.Add(typeId);
+            }
+        }
+        return sortedSet.ToArray();
+    }
 
     /// <summary>
     /// Returns the Slice type ID of the most-derived interface supported by this object.
     /// </summary>
     /// <param name="current">The Current object for the dispatch.</param>
     /// <returns>The Slice type ID of the most-derived interface.</returns>
-    string ice_id(Current current);
+    public string ice_id(Current current) => throw new NotImplementedException();
 
     Task<OutputStream>? iceDispatch(Ice.Internal.Incoming inc, Current current);
 }
@@ -57,22 +82,6 @@ public abstract class ObjectImpl : Object
     {
     }
 
-    private static readonly string[] _ids =
-    {
-        "::Ice::Object"
-    };
-
-    /// <summary>
-    /// Tests whether this object supports a specific Slice interface.
-    /// </summary>
-    /// <param name="s">The type ID of the Slice interface to test against.</param>
-    /// <param name="current">The Current object for the dispatch.</param>
-    /// <returns>The return value is true if s is ::Ice::Object.</returns>
-    public virtual bool ice_isA(string s, Current current)
-    {
-        return s.Equals(_ids[0]);
-    }
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<OutputStream>? iceD_ice_isA(Object obj, Ice.Internal.Incoming inS, Current current)
     {
@@ -87,15 +96,6 @@ public abstract class ObjectImpl : Object
         return null;
     }
 
-    /// <summary>
-    /// Tests whether this object can be reached.
-    /// <param name="current">The Current object for the dispatch.</param>
-    /// </summary>
-    public virtual void ice_ping(Current current)
-    {
-        // Nothing to do.
-    }
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<OutputStream>? iceD_ice_ping(Object obj, Ice.Internal.Incoming inS, Current current)
     {
@@ -103,16 +103,6 @@ public abstract class ObjectImpl : Object
         obj.ice_ping(current);
         inS.setResult(inS.writeEmptyParams());
         return null;
-    }
-
-    /// <summary>
-    /// Returns the Slice type IDs of the interfaces supported by this object.
-    /// </summary>
-    /// <param name="current">The Current object for the dispatch.</param>
-    /// <returns>An array whose only element is ::Ice::Object.</returns>
-    public virtual string[] ice_ids(Current current)
-    {
-        return _ids;
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -132,10 +122,7 @@ public abstract class ObjectImpl : Object
     /// </summary>
     /// <param name="current">The Current object for the dispatch.</param>
     /// <returns>The return value is always ::Ice::Object.</returns>
-    public virtual string ice_id(Current current)
-    {
-        return _ids[0];
-    }
+    public virtual string ice_id(Current current) => ice_staticId();
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<OutputStream>? iceD_ice_id(Object obj, Ice.Internal.Incoming inS, Current current)
@@ -153,10 +140,7 @@ public abstract class ObjectImpl : Object
     /// Returns the Slice type ID of the interface supported by this object.
     /// </summary>
     /// <returns>The return value is always ::Ice::Object.</returns>
-    public static string ice_staticId()
-    {
-        return _ids[0];
-    }
+    public static string ice_staticId() => "::Ice::Object";
 
     private static readonly string[] _all = new string[]
     {

--- a/csharp/test/Ice/defaultServant/MyObjectI.cs
+++ b/csharp/test/Ice/defaultServant/MyObjectI.cs
@@ -4,9 +4,9 @@ namespace Ice
 {
     namespace defaultServant
     {
-        public sealed class MyObjectI : Test.MyObjectDisp_
+        public sealed class MyObjectI : Test.MyObjectDisp_, Ice.Object
         {
-            public override void
+            public void
             ice_ping(Ice.Current current)
             {
                 string name = current.id.name;

--- a/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassAMDI.cs
@@ -6,7 +6,7 @@ namespace Ice
     {
         namespace AMD
         {
-            public sealed class MyDerivedClassI : Test.MyDerivedClassDisp_
+            public sealed class MyDerivedClassI : Test.MyDerivedClassDisp_, Ice.Object
             {
                 public MyDerivedClassI()
                 {
@@ -28,10 +28,11 @@ namespace Ice
                     return Task.FromResult(_ctx);
                 }
 
-                public override bool ice_isA(string s, Ice.Current current)
+                public bool ice_isA(string s, Ice.Current current)
                 {
                     _ctx = current.ctx;
-                    return base.ice_isA(s, current);
+                    // TODO: call the default implementation when the base(Object) syntax is supported.
+                    return Array.BinarySearch((this as Ice.Object).ice_ids(current), s) >= 0;
                 }
 
                 private Dictionary<string, string> _ctx;

--- a/csharp/test/Ice/proxy/MyDerivedClassI.cs
+++ b/csharp/test/Ice/proxy/MyDerivedClassI.cs
@@ -4,7 +4,7 @@ namespace Ice
 {
     namespace proxy
     {
-        public sealed class MyDerivedClassI : Test.MyDerivedClassDisp_
+        public sealed class MyDerivedClassI : Test.MyDerivedClassDisp_, Ice.Object
         {
             public MyDerivedClassI()
             {
@@ -25,10 +25,11 @@ namespace Ice
                 return _ctx;
             }
 
-            public override bool ice_isA(string s, Ice.Current current)
+            public bool ice_isA(string s, Ice.Current current)
             {
                 _ctx = current.ctx;
-                return base.ice_isA(s, current);
+                // TODO: call the default implementation when the base(Object) syntax is supported.
+                return Array.BinarySearch((this as Ice.Object).ice_ids(current), s) >= 0;
             }
 
             private Dictionary<string, string> _ctx;


### PR DESCRIPTION
This PR reimplements the Ice::Object operations in C# using Reflection.

There are two advantages to this implementation:
 - less generated code
 - Ice.Object is less abstract in C# and as a result can be more easily used as a dispatcher interface

