### PR TITLE
New metrics sub-test to test ObjectAdapter.dispatcher

### DIFF
--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -23,21 +23,23 @@ public class Collocated : Test.TestHelper
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
 
-        using (var communicator = initialize(initData))
-        {
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
-            Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MetricsI(), Ice.Util.stringToIdentity("metrics"));
-            //adapter.activate(); // Don't activate OA to ensure collocation is used.
+        using var communicator = initialize(initData);
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
+        adapter.add(new MetricsI(), Ice.Util.stringToIdentity("metrics"));
+        //adapter.activate(); // Don't activate OA to ensure collocation is used.
 
-            communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
-            Ice.ObjectAdapter controllerAdapter = communicator.createObjectAdapter("ControllerAdapter");
-            controllerAdapter.add(new ControllerI(adapter), Ice.Util.stringToIdentity("controller"));
-            //controllerAdapter.activate(); // Don't activate OA to ensure collocation is used.
+        communicator.getProperties().setProperty("ForwardingAdapter.Endpoints", getTestEndpoint(1));
+        Ice.ObjectAdapter forwardingAdapter = communicator.createObjectAdapter("ForwardingAdapter");
+        forwardingAdapter.addDefaultServant(adapter.dispatcher, "");
 
-            Test.MetricsPrx metrics = await AllTests.allTests(this, observer);
-            metrics.shutdown();
-        }
+        communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(2));
+        Ice.ObjectAdapter controllerAdapter = communicator.createObjectAdapter("ControllerAdapter");
+        controllerAdapter.add(new ControllerI(adapter), Ice.Util.stringToIdentity("controller"));
+        //controllerAdapter.activate(); // Don't activate OA to ensure collocation is used.
+
+        Test.MetricsPrx metrics = await AllTests.allTests(this, observer);
+        metrics.shutdown();
     }
 
     public static Task<int> Main(string[] args) =>


### PR DESCRIPTION
This PR updates the metrics test to test ObjectAdapter.dispatcher. It's now in-sync with the C++ test with the same name.