### PR TITLE
Cleanup code generated by slice2cs

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -943,7 +943,8 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
     {
         if (marshal)
         {
-            out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", Ice.OptionalFormat.FSize))";
+            out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag
+                << ", Ice.OptionalFormat.FSize))";
             out << sb;
             out << nl << "int pos = " << stream << ".startSize();";
             writeMarshalUnmarshalCode(out, type, scope, param, marshal, customStream);
@@ -1226,8 +1227,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                             // If the collection is a stack, write in top-to-bottom order. Stacks
                             // cannot contain Ice.Value.
                             //
-                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = " << param
-                                << ".ToArray();";
+                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = " << param << ".ToArray();";
                             out << nl << "for (int ix = 0; ix < " << param << "_tmp.Length; ++ix)";
                             out << sb;
                             out << nl << stream << ".writeProxy(" << param << "_tmp[ix]);";
@@ -1280,8 +1280,8 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                         else
                         {
                             patcherName = "Ice.Internal.Patcher.listReadValue";
-                            out << "global::System.Collections.Generic." << genericType
-                                << "<Ice.Value?>(" << param << "_lenx);";
+                            out << "global::System.Collections.Generic." << genericType << "<Ice.Value?>(" << param
+                                << "_lenx);";
                         }
                         out << nl << "for (int ix = 0; ix < " << param << "_lenx; ++ix)";
                         out << sb;
@@ -1291,7 +1291,8 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                     {
                         if (isStack)
                         {
-                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = new Ice.ObjectPrx?[" << param << "_lenx];";
+                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = new Ice.ObjectPrx?[" << param
+                                << "_lenx];";
                         }
                         else if (isArray)
                         {
@@ -1825,8 +1826,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
                 }
                 else
                 {
-                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq)
-                        << "))";
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq) << "))";
                     out << sb;
                     if (builtin->isVariableLength())
                     {
@@ -1865,8 +1865,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
                 }
                 else
                 {
-                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq)
-                        << "))";
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq) << "))";
                     out << sb;
                     out << nl << stream << ".skip(4);";
                     string tmp = "tmpVal";

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -192,10 +192,10 @@ Slice::CsGenerator::fixId(const string& name, unsigned int baseTypes, bool mangl
 }
 
 string
-Slice::CsGenerator::getOptionalFormat(const TypePtr& type, const string& scope)
+Slice::CsGenerator::getOptionalFormat(const TypePtr& type)
 {
     BuiltinPtr bp = dynamic_pointer_cast<Builtin>(type);
-    string prefix = getUnqualified("Ice.OptionalFormat", scope);
+    string prefix = "Ice.OptionalFormat";
     if (bp)
     {
         switch (bp->kind())
@@ -943,8 +943,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
     {
         if (marshal)
         {
-            out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-                << getUnqualified("Ice.OptionalFormat", scope) << ".FSize))";
+            out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", Ice.OptionalFormat.FSize))";
             out << sb;
             out << nl << "int pos = " << stream << ".startSize();";
             writeMarshalUnmarshalCode(out, type, scope, param, marshal, customStream);
@@ -953,8 +952,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
         }
         else
         {
-            out << nl << "if (" << stream << ".readOptional(" << tag << ", "
-                << getUnqualified("Ice.OptionalFormat", scope) << ".FSize))";
+            out << nl << "if (" << stream << ".readOptional(" << tag << ", Ice.OptionalFormat.FSize))";
             out << sb;
             out << nl << stream << ".skip(4);";
             string tmp = "tmpVal";
@@ -991,7 +989,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
         if (marshal)
         {
             out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-                << getOptionalFormat(st, scope) << "))";
+                << getOptionalFormat(st) << "))";
             out << sb;
             if (st->isVariableLength())
             {
@@ -1017,7 +1015,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
         }
         else
         {
-            out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(st, scope) << "))";
+            out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(st) << "))";
             out << sb;
             if (st->isVariableLength())
             {
@@ -1054,8 +1052,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
         }
         else
         {
-            out << nl << "if (" << stream << ".readOptional(" << tag << ", "
-                << getUnqualified("Ice.OptionalFormat", scope) << ".Size))";
+            out << nl << "if (" << stream << ".readOptional(" << tag << ", Ice.OptionalFormat.Size))";
             out << sb;
             string typeS = typeToString(type, scope);
             string tmp = "tmpVal";
@@ -1085,7 +1082,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
     if (marshal)
     {
         out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-            << getOptionalFormat(d, scope) << "))";
+            << getOptionalFormat(d) << "))";
         out << sb;
         if (keyType->isVariableLength() || valueType->isVariableLength())
         {
@@ -1105,7 +1102,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
     }
     else
     {
-        out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(d, scope) << "))";
+        out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(d) << "))";
         out << sb;
         if (keyType->isVariableLength() || valueType->isVariableLength())
         {
@@ -1229,9 +1226,9 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                             // If the collection is a stack, write in top-to-bottom order. Stacks
                             // cannot contain Ice.Value.
                             //
-                            out << nl << getUnqualified("Ice.ObjectPrx?", scope) << "[] " << param << "_tmp = " << param
+                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = " << param
                                 << ".ToArray();";
-                            out << nl << "for(int ix = 0; ix < " << param << "_tmp.Length; ++ix)";
+                            out << nl << "for (int ix = 0; ix < " << param << "_tmp.Length; ++ix)";
                             out << sb;
                             out << nl << stream << ".writeProxy(" << param << "_tmp[ix]);";
                             out << eb;
@@ -1272,45 +1269,41 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                         string patcherName;
                         if (isArray)
                         {
-                            patcherName = "global::Ice.Internal.Patcher.arrayReadValue";
-                            out << getUnqualified("Ice.Value?", scope) << "[" << param << "_lenx];";
+                            patcherName = "Ice.Internal.Patcher.arrayReadValue";
+                            out << "Ice.Value?[" << param << "_lenx];";
                         }
                         else if (isCustom)
                         {
-                            patcherName = "global::Ice.Internal.Patcher.customSeqReadValue";
-                            out << "global::" << genericType << "<" << getUnqualified("Ice.Value?", scope) << ">();";
+                            patcherName = "Ice.Internal.Patcher.customSeqReadValue";
+                            out << "global::" << genericType << "<Ice.Value?>();";
                         }
                         else
                         {
-                            patcherName = "global::Ice.Internal.Patcher.listReadValue";
-                            out << "global::System.Collections.Generic." << genericType << "<"
-                                << getUnqualified("Ice.Value?", scope) << ">(" << param << "_lenx);";
+                            patcherName = "Ice.Internal.Patcher.listReadValue";
+                            out << "global::System.Collections.Generic." << genericType
+                                << "<Ice.Value?>(" << param << "_lenx);";
                         }
-                        out << nl << "for(int ix = 0; ix < " << param << "_lenx; ++ix)";
+                        out << nl << "for (int ix = 0; ix < " << param << "_lenx; ++ix)";
                         out << sb;
-                        out << nl << stream << ".readValue(" << patcherName << "<" << getUnqualified("Ice.Value", scope)
-                            << ">(" << param << ", ix));";
+                        out << nl << stream << ".readValue(" << patcherName << "<Ice.Value>(" << param << ", ix));";
                     }
                     else
                     {
                         if (isStack)
                         {
-                            out << nl << getUnqualified("Ice.ObjectPrx?", scope) << "[] " << param << "_tmp = new "
-                                << getUnqualified("Ice.ObjectPrx?", scope) << "[" << param << "_lenx];";
+                            out << nl << "Ice.ObjectPrx?[] " << param << "_tmp = new Ice.ObjectPrx?[" << param << "_lenx];";
                         }
                         else if (isArray)
                         {
-                            out << getUnqualified("Ice.ObjectPrx?", scope) << "[" << param << "_lenx];";
+                            out << "Ice.ObjectPrx?[" << param << "_lenx];";
                         }
                         else if (isCustom)
                         {
-                            out << "global::" << genericType << "<" << getUnqualified("Ice.ObjectPrx?", scope)
-                                << ">();";
+                            out << "global::" << genericType << "<Ice.ObjectPrx?>();";
                         }
                         else
                         {
-                            out << "global::System.Collections.Generic." << genericType << "<"
-                                << getUnqualified("Ice.ObjectPrx?", scope) << ">(";
+                            out << "global::System.Collections.Generic." << genericType << "<Ice.ObjectPrx?>(";
                             if (!isLinkedList)
                             {
                                 out << param << "_lenx";
@@ -1327,8 +1320,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
                         }
                         else
                         {
-                            out << nl << getUnqualified("Ice.ObjectPrx?", scope) << " val = " << stream
-                                << ".readProxy();";
+                            out << nl << "Ice.ObjectPrx? val = " << stream << ".readProxy();";
                             out << nl << param << "." << addMethod << "(val);";
                         }
                     }
@@ -1441,17 +1433,17 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
             string patcherName;
             if (isArray)
             {
-                patcherName = "global::Ice.Internal.Patcher.arrayReadValue";
+                patcherName = "Ice.Internal.Patcher.arrayReadValue";
                 out << toArrayAlloc(typeS + "[]", "szx") << ";";
             }
             else if (isCustom)
             {
-                patcherName = "global::Ice.Internal.Patcher.customSeqReadValue";
+                patcherName = "Ice.Internal.Patcher.customSeqReadValue";
                 out << "global::" << genericType << "<" << typeS << ">();";
             }
             else
             {
-                patcherName = "global::Ice.Internal.Patcher.listReadValue";
+                patcherName = "Ice.Internal.Patcher.listReadValue";
                 out << "global::System.Collections.Generic." << genericType << "<" << typeS << ">(szx);";
             }
             out << nl << "for (int ix = 0; ix < szx; ++ix)";
@@ -1833,7 +1825,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
                 }
                 else
                 {
-                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq, scope)
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq)
                         << "))";
                     out << sb;
                     if (builtin->isVariableLength())
@@ -1864,7 +1856,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
                 if (marshal)
                 {
                     out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-                        << getOptionalFormat(seq, scope) << "))";
+                        << getOptionalFormat(seq) << "))";
                     out << sb;
                     out << nl << "int pos = " << stream << ".startSize();";
                     writeSequenceMarshalUnmarshalCode(out, seq, scope, param, marshal, true, stream);
@@ -1873,7 +1865,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
                 }
                 else
                 {
-                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq, scope)
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq)
                         << "))";
                     out << sb;
                     out << nl << stream << ".skip(4);";
@@ -1900,7 +1892,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
         if (marshal)
         {
             out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-                << getOptionalFormat(seq, scope) << "))";
+                << getOptionalFormat(seq) << "))";
             out << sb;
             if (st->isVariableLength())
             {
@@ -1920,7 +1912,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
         }
         else
         {
-            out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq, scope) << "))";
+            out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq) << "))";
             out << sb;
             if (st->isVariableLength())
             {
@@ -1949,7 +1941,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
     if (marshal)
     {
         out << nl << "if (" << param << " is not null && " << stream << ".writeOptional(" << tag << ", "
-            << getOptionalFormat(seq, scope) << "))";
+            << getOptionalFormat(seq) << "))";
         out << sb;
         out << nl << "int pos = " << stream << ".startSize();";
         writeSequenceMarshalUnmarshalCode(out, seq, scope, param, marshal, true, stream);
@@ -1958,7 +1950,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
     }
     else
     {
-        out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq, scope) << "))";
+        out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(seq) << "))";
         out << sb;
         out << nl << stream << ".skip(4);";
         string tmp = "tmpVal";

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -51,7 +51,7 @@ namespace Slice
         static std::string resultType(const OperationPtr&, const std::string&, bool = false);
         static std::string taskResultType(const OperationPtr&, const std::string&, bool = false);
         static std::string fixId(const std::string&, unsigned int = 0, bool = false);
-        static std::string getOptionalFormat(const TypePtr&, const std::string&);
+        static std::string getOptionalFormat(const TypePtr&);
         static std::string getStaticId(const TypePtr&);
         static std::string typeToString(const TypePtr&, const std::string&, bool = false);
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1825,17 +1825,14 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
     }
 
-    if (!baseNames.empty())
+    _out << " : ";
+    for (StringList::const_iterator q = baseNames.begin(); q != baseNames.end(); ++q)
     {
-        _out << " : ";
-        for (StringList::const_iterator q = baseNames.begin(); q != baseNames.end(); ++q)
+        if (q != baseNames.begin())
         {
-            if (q != baseNames.begin())
-            {
-                _out << ", ";
-            }
-            _out << *q;
+            _out << ", ";
         }
+        _out << *q;
     }
 
     _out << sb;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1631,7 +1631,8 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     if (base)
     {
-        _out << getUnqualified(base, ns);;
+        _out << getUnqualified(base, ns);
+        ;
     }
     else
     {
@@ -2638,8 +2639,7 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
         //
         // Marshaling constructor
         //
-        _out << nl << "public " << name << spar << getOutParams(p, ns, true, false)
-             << "Ice.Current current" << epar;
+        _out << nl << "public " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
         _out << sb;
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";
@@ -2827,8 +2827,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
 
     _out << sp;
     _out << nl << "protected static " << (amd ? "async " : "")
-        << "global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> iceD_"
-        << op->name() << "Async(";
+         << "global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> iceD_" << op->name() << "Async(";
     _out.inc();
     _out << nl << interfaceName << " obj,";
     _out << nl << "Ice.IncomingRequest request)";
@@ -2839,8 +2838,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
     ParamDeclList inParams = op->inParameters();
     ParamDeclList outParams = op->outParameters();
 
-    _out << nl << "Ice.ObjectImpl.iceCheckMode(" << sliceModeToIceMode(op->mode())
-         << ", request.current.mode);";
+    _out << nl << "Ice.ObjectImpl.iceCheckMode(" << sliceModeToIceMode(op->mode()) << ", request.current.mode);";
     if (!inParams.empty())
     {
         // Unmarshal 'in' parameters.
@@ -3001,7 +2999,8 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp;
     emitComVisibleAttribute();
     emitGeneratedCodeAttribute();
-    _out << nl << "public sealed class " << name << "PrxHelper : " << "Ice.ObjectPrxHelperBase, " << name << "Prx";
+    _out << nl << "public sealed class " << name << "PrxHelper : "
+         << "Ice.ObjectPrxHelperBase, " << name << "Prx";
     _out << sb;
 
     _out << sp;
@@ -3184,8 +3183,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         else
         {
             _out << nl << "var completed = "
-                 << "new Ice.Internal.OperationTaskCompletionCallback<" << returnTypeS
-                 << ">(progress, cancel);";
+                 << "new Ice.Internal.OperationTaskCompletionCallback<" << returnTypeS << ">(progress, cancel);";
         }
 
         _out << nl << "_iceI_" << opName << spar << getInArgs(op, true) << "context"
@@ -3307,12 +3305,14 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     }
 
     _out << sp << nl << "public static " << name
-        << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
+         << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "uncheckedCast(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
 
-    _out << sp << nl << "public static " << name << "Prx? checkedCast(Ice.ObjectPrx b, global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
+    _out << sp << nl << "public static " << name
+         << "Prx? checkedCast(Ice.ObjectPrx b, global::System.Collections.Generic.Dictionary<string, string>? ctx = "
+            "null)";
     _out << sb;
     _out << nl << "if (b is not null && b.ice_isA(ice_staticId(), ctx))";
     _out << sb;
@@ -3323,7 +3323,9 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "return null;";
     _out << eb;
 
-    _out << sp << nl << "public static " << name << "Prx? checkedCast(Ice.ObjectPrx b, string f, global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
+    _out << sp << nl << "public static " << name
+         << "Prx? checkedCast(Ice.ObjectPrx b, string f, global::System.Collections.Generic.Dictionary<string, "
+            "string>? ctx = null)";
     _out << sb;
     _out << nl << "Ice.ObjectPrx? bb = b?.ice_facet(f);";
     _out << nl << "try";
@@ -3390,8 +3392,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "public static string ice_staticId() => \"" << scoped << "\";";
 
-    _out << sp << nl << "public static void write(Ice.OutputStream ostr, " << name
-         << "Prx? v)";
+    _out << sp << nl << "public static void write(Ice.OutputStream ostr, " << name << "Prx? v)";
     _out << sb;
     _out << nl << "ostr.writeProxy(v);";
     _out << eb;
@@ -3427,8 +3428,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     _out << nl << "public sealed class " << p->name() << "Helper";
     _out << sb;
 
-    _out << sp << nl << "public static void write(Ice.OutputStream ostr, " << typeS
-         << " v)";
+    _out << sp << nl << "public static void write(Ice.OutputStream ostr, " << typeS << " v)";
     _out << sb;
     writeSequenceMarshalUnmarshalCode(_out, p, ns, "v", true, false);
     _out << eb;
@@ -3633,7 +3633,9 @@ Slice::Gen::DispatcherVisitor::writeDispatch(const InterfaceDefPtr& p)
     if (!allOps.empty())
     {
         _out << sp;
-        _out << nl << "public override global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> dispatchAsync(Ice.IncomingRequest request) =>";
+        _out << nl
+             << "public override global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> "
+                "dispatchAsync(Ice.IncomingRequest request) =>";
         _out.inc();
         _out << nl << "request.current.operation switch";
         _out << sb;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -352,8 +352,6 @@ Slice::CsVisitor::writeInheritedOperations(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
     if (!bases.empty())
     {
-        _out << sp << nl << "#region Inherited Slice operations";
-
         OperationList allOps;
         for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
         {
@@ -370,8 +368,6 @@ Slice::CsVisitor::writeInheritedOperations(const InterfaceDefPtr& p)
             string name = getDispatchParams(*i, retS, params, args, ns);
             _out << sp << nl << "public abstract " << retS << " " << name << spar << params << epar << ';';
         }
-
-        _out << sp << nl << "#endregion"; // Inherited Slice operations
     }
 }
 
@@ -390,8 +386,6 @@ Slice::CsVisitor::writeMarshaling(const ClassDefPtr& p)
     DataMemberList members = p->dataMembers();
     DataMemberList optionalMembers = p->orderedOptionalDataMembers();
     DataMemberList classMembers = p->classDataMembers();
-
-    _out << sp << nl << "#region Marshaling support";
 
     _out << sp;
     emitGeneratedCodeAttribute();
@@ -440,8 +434,6 @@ Slice::CsVisitor::writeMarshaling(const ClassDefPtr& p)
         _out << nl << "base.iceReadImpl(istr_);";
     }
     _out << eb;
-
-    _out << sp << nl << "#endregion"; // marshaling support
 }
 
 string
@@ -1660,12 +1652,6 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
 
     _out << sb;
-
-    if (p->hasDataMembers())
-    {
-        _out << sp << nl << "#region Slice data members";
-    }
-
     return true;
 }
 
@@ -1680,27 +1666,18 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     DataMemberList allDataMembers = p->allDataMembers();
     ClassDefPtr base = p->base();
 
-    if (p->hasDataMembers())
-    {
-        _out << sp << nl << "#endregion";
-    }
-
     _out << sp << nl << "partial void ice_initialize();";
     if (allDataMembers.empty())
     {
-        _out << sp << nl << "#region Constructors";
         _out << sp;
         emitGeneratedCodeAttribute();
         _out << nl << "public " << name << spar << epar;
         _out << sb;
         _out << nl << "ice_initialize();";
         _out << eb;
-        _out << sp << nl << "#endregion"; // Constructors
     }
     else
     {
-        _out << sp << nl << "#region Constructors";
-
         // Primary constructor.
         _out << sp;
         emitGeneratedCodeAttribute();
@@ -1797,8 +1774,6 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
             _out << nl << "ice_initialize();";
             _out << eb;
         }
-
-        _out << sp << nl << "#endregion"; // Constructors
     }
 
     _out << sp;
@@ -1948,12 +1923,6 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << getUnqualified("Ice.UserException", ns);
     }
     _out << sb;
-
-    if (!p->dataMembers().empty())
-    {
-        _out << sp << nl << "#region Slice data members";
-    }
-
     return true;
 }
 
@@ -1968,14 +1937,6 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     DataMemberList classMembers = p->classDataMembers();
     DataMemberList optionalMembers = p->orderedOptionalDataMembers();
     ExceptionPtr base = p->base();
-
-    if (!dataMembers.empty())
-    {
-        _out << sp << nl << "#endregion"; // Slice data members
-    }
-
-    _out << sp << nl << "#region Constructors";
-
     string exParam = getEscapedParamName(allDataMembers, "innerException");
 
     // Primary constructor.
@@ -2091,16 +2052,12 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     writeDataMemberInitializers(dataMembers, DotNet::Exception);
     _out << eb;
 
-    _out << sp << nl << "#endregion"; // Constructors
-
     _out << sp;
     emitGeneratedCodeAttribute();
     _out << nl << "public override string ice_id()";
     _out << sb;
     _out << nl << "return \"" << p->scoped() << "\";";
     _out << eb;
-
-    _out << sp << nl << "#region Marshaling support";
 
     string scoped = p->scoped();
 
@@ -2164,8 +2121,6 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         _out << eb;
     }
 
-    _out << sp << nl << "#endregion"; // marshaling support
-
     _out << eb;
 }
 
@@ -2217,9 +2172,6 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     }
 
     _out << sb;
-
-    _out << sp << nl << "#region Slice data members";
-
     return true;
 }
 
@@ -2231,11 +2183,9 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     string ns = getNamespace(p);
     DataMemberList classMembers = p->classDataMembers();
     DataMemberList dataMembers = p->dataMembers();
-    _out << sp << nl << "#endregion"; // Slice data members
-
     const bool classMapping = isMappedToClass(p);
+
     _out << sp << nl << "partial void ice_initialize();";
-    _out << sp << nl << "#region Constructor";
 
     if (classMapping)
     {
@@ -2298,7 +2248,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     // Unmarshaling constructor
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public " << name << "(" << getUnqualified("Ice.InputStream", ns) << " istr)";
+    _out << nl << "public " << name << "(Ice.InputStream istr)";
     _out << sb;
     for (const auto& q : dataMembers)
     {
@@ -2307,19 +2257,11 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << nl << "ice_initialize();";
     _out << eb;
 
-    _out << sp << nl << "#endregion"; // Constructor(s)
-
     if (classMapping)
     {
-        _out << sp << nl << "#region Clone method";
-
         _out << sp;
         emitGeneratedCodeAttribute();
         _out << nl << "public " << name << " Clone() => (" << name << ")MemberwiseClone();";
-
-        _out << sp << nl << "#endregion"; // ICloneable members
-
-        _out << sp << nl << "#region Object members";
 
         _out << sp;
         emitGeneratedCodeAttribute();
@@ -2339,10 +2281,6 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         writeMemberEquals(dataMembers);
         _out << eb;
 
-        _out << sp << nl << "#endregion"; // Object members
-
-        _out << sp << nl << "#region Comparison members";
-
         _out << sp;
         emitGeneratedCodeAttribute();
         _out << nl << "public static bool operator ==(" << name << "? lhs, " << name << "? rhs) => ";
@@ -2351,14 +2289,11 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         _out << sp;
         emitGeneratedCodeAttribute();
         _out << nl << "public static bool operator !=(" << name << "? lhs, " << name << "? rhs) => !(lhs == rhs);";
-        _out << sp << nl << "#endregion"; // Comparison members
     }
-
-    _out << sp << nl << "#region Marshaling support";
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public void ice_writeMembers(" << getUnqualified("Ice.OutputStream", ns) << " ostr)";
+    _out << nl << "public void ice_writeMembers(Ice.OutputStream ostr)";
     _out << sb;
     for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
     {
@@ -2368,19 +2303,14 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public static void ice_write(" << getUnqualified("Ice.OutputStream", ns) << " ostr, " << name
-         << " v)";
+    _out << nl << "public static void ice_write(Ice.OutputStream ostr, " << name << " v)";
     _out << sb;
     _out << nl << "v.ice_writeMembers(ostr);";
     _out << eb;
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public static " << name << " ice_read(" << getUnqualified("Ice.InputStream", ns)
-         << " istr) => new(istr);";
-
-    _out << sp << nl << "#endregion"; // marshaling support
-
+    _out << nl << "public static " << name << " ice_read(Ice.InputStream istr) => new(istr);";
     _out << eb;
 }
 
@@ -2425,14 +2355,14 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << nl << "public sealed class " << p->name() << "Helper";
     _out << sb;
     _out << sp;
-    _out << nl << "public static void write(" << getUnqualified("Ice.OutputStream", ns) << " ostr, " << name << " v)";
+    _out << nl << "public static void write(Ice.OutputStream ostr, " << name << " v)";
     _out << sb;
     writeMarshalUnmarshalCode(_out, p, ns, "v", true);
     _out << eb;
 
     _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public static " << name << " read(" << getUnqualified("Ice.InputStream", ns) << " istr)";
+    _out << nl << "public static " << name << " read(Ice.InputStream istr)";
     _out << sb;
     _out << nl << name << " v;";
     writeMarshalUnmarshalCode(_out, p, ns, "v", false);
@@ -2714,16 +2644,16 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
 
         _out << sp;
         emitGeneratedCodeAttribute();
-        _out << nl << "public readonly record struct " << name << " : " << getUnqualified("Ice.MarshaledResult", ns);
+        _out << nl << "public readonly record struct " << name << " : Ice.MarshaledResult";
         _out << sb;
 
         //
         // Marshaling constructor
         //
         _out << nl << "public " << name << spar << getOutParams(p, ns, true, false)
-             << getUnqualified("Ice.Current", ns) + " current" << epar;
+             << "Ice.Current current" << epar;
         _out << sb;
-        _out << nl << "_ostr = global::Ice.CurrentExtensions.startReplyStream(current);";
+        _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p, ns) << ");";
         writeMarshalUnmarshalParams(outParams, p, true, ns, false, true, "_ostr");
         if (p->returnsClasses(false))
@@ -2733,9 +2663,9 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
         _out << nl << "_ostr.endEncapsulation();";
         _out << eb;
         _out << sp;
-        _out << nl << "public " << getUnqualified("Ice.OutputStream", ns) << " outputStream => _ostr;";
+        _out << nl << "public Ice.OutputStream outputStream => _ostr;";
         _out << sp;
-        _out << nl << "private readonly " << getUnqualified("Ice.OutputStream", ns) << " _ostr;";
+        _out << nl << "private readonly Ice.OutputStream _ostr;";
         _out << eb;
     }
 }
@@ -2783,7 +2713,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     if (baseInterfaces.empty())
     {
-        baseInterfaces.push_back(getUnqualified("Ice.ObjectPrx", ns));
+        baseInterfaces.push_back("Ice.ObjectPrx");
     }
 
     for (vector<string>::const_iterator q = baseInterfaces.begin(); q != baseInterfaces.end();)
@@ -2908,11 +2838,12 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
     const bool amd = interface->hasMetaData("amd") || op->hasMetaData("amd");
 
     _out << sp;
-    _out << nl << "protected static " << (amd ? "async " : "") << "global::System.Threading.Tasks.ValueTask<"
-         << getUnqualified("Ice.OutgoingResponse", ns) << "> iceD_" << op->name() << "Async(";
+    _out << nl << "protected static " << (amd ? "async " : "")
+        << "global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> iceD_"
+        << op->name() << "Async(";
     _out.inc();
     _out << nl << interfaceName << " obj,";
-    _out << nl << getUnqualified("Ice.IncomingRequest", ns) << " request)";
+    _out << nl << "Ice.IncomingRequest request)";
     _out.dec();
     _out << sb;
 
@@ -2920,7 +2851,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
     ParamDeclList inParams = op->inParameters();
     ParamDeclList outParams = op->outParameters();
 
-    _out << nl << getUnqualified("Ice.ObjectImpl", ns) << ".iceCheckMode(" << sliceModeToIceMode(op->mode(), ns)
+    _out << nl << "Ice.ObjectImpl.iceCheckMode(" << sliceModeToIceMode(op->mode(), ns)
          << ", request.current.mode);";
     if (!inParams.empty())
     {
@@ -2958,13 +2889,13 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
         {
             _out << nl << "var result = await obj." << op->name() << "Async" << spar << inArgs << "request.current"
                  << epar << ".ConfigureAwait(false);";
-            _out << nl << "return new global::Ice.OutgoingResponse(result.outputStream);";
+            _out << nl << "return new Ice.OutgoingResponse(result.outputStream);";
         }
         else
         {
             _out << nl << "var result = obj." << fixId(op->name(), DotNet::ICloneable, true) << spar << inArgs
                  << "request.current" << epar << ";";
-            _out << nl << "return new (new global::Ice.OutgoingResponse(result.outputStream));";
+            _out << nl << "return new (new Ice.OutgoingResponse(result.outputStream));";
         }
     }
     else if (amd)
@@ -2982,14 +2913,14 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
 
         if (retS.empty())
         {
-            _out << nl << "return global::Ice.CurrentExtensions.createEmptyOutgoingResponse(request.current);";
+            _out << nl << "return Ice.CurrentExtensions.createEmptyOutgoingResponse(request.current);";
         }
         else
         {
             // Adapt to marshaling helper below.
             string resultParam = !ret && outParams.size() == 1 ? "iceP_" + outParams.front()->name() : "ret";
 
-            _out << nl << "return global::Ice.CurrentExtensions.createOutgoingResponse(";
+            _out << nl << "return Ice.CurrentExtensions.createOutgoingResponse(";
             _out.inc();
             _out << nl << "request.current,";
             _out << nl << "result,";
@@ -3031,11 +2962,11 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
 
         if (outParams.empty() && !ret)
         {
-            _out << nl << "return new(global::Ice.CurrentExtensions.createEmptyOutgoingResponse(request.current));";
+            _out << nl << "return new(Ice.CurrentExtensions.createEmptyOutgoingResponse(request.current));";
         }
         else
         {
-            _out << nl << "var ostr = global::Ice.CurrentExtensions.startReplyStream(request.current);";
+            _out << nl << "var ostr = Ice.CurrentExtensions.startReplyStream(request.current);";
             _out << nl << "ostr.startEncapsulation(request.current.encoding, " << opFormatTypeToString(op, ns) << ");";
             writeMarshalUnmarshalParams(outParams, op, true, ns);
             if (op->returnsClasses(false))
@@ -3043,7 +2974,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
                 _out << nl << "ostr.writePendingValues();";
             }
             _out << nl << "ostr.endEncapsulation();";
-            _out << nl << "return new(new global::Ice.OutgoingResponse(ostr));";
+            _out << nl << "return new(new Ice.OutgoingResponse(ostr));";
         }
     }
     _out << eb;
@@ -3082,8 +3013,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp;
     emitComVisibleAttribute();
     emitGeneratedCodeAttribute();
-    _out << nl << "public sealed class " << name << "PrxHelper : " << getUnqualified("Ice.ObjectPrxHelperBase", ns)
-         << ", " << name << "Prx";
+    _out << nl << "public sealed class " << name << "PrxHelper : " << "Ice.ObjectPrxHelperBase, " << name << "Prx";
     _out << sb;
 
     _out << sp;
@@ -3092,11 +3022,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << eb;
 
     OperationList ops = p->allOperations();
-
-    if (!ops.empty())
-    {
-        _out << sp << nl << "#region Synchronous operations";
-    }
 
     for (OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
     {
@@ -3187,15 +3112,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << eb;
     }
 
-    if (!ops.empty())
-    {
-        _out << sp << nl << "#endregion"; // Synchronous operations
-    }
-
-    //
-    // Async Task AMI mapping.
-    //
-    _out << sp << nl << "#region Async Task operations";
+    // Async invocation
     for (OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
     {
         OperationPtr op = *r;
@@ -3274,12 +3191,12 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (returnTypeS.empty())
         {
             _out << nl << "var completed = "
-                 << "new global::Ice.Internal.OperationTaskCompletionCallback<object>(progress, cancel);";
+                 << "new Ice.Internal.OperationTaskCompletionCallback<object>(progress, cancel);";
         }
         else
         {
             _out << nl << "var completed = "
-                 << "new global::Ice.Internal.OperationTaskCompletionCallback<" << returnTypeS
+                 << "new Ice.Internal.OperationTaskCompletionCallback<" << returnTypeS
                  << ">(progress, cancel);";
         }
 
@@ -3299,7 +3216,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << "private void _iceI_" << op->name() << spar << getInParams(op, ns, true)
              << "global::System.Collections.Generic.Dictionary<string, string>? context"
              << "bool synchronous"
-             << "global::Ice.Internal.OutgoingAsyncCompletionCallback completed" << epar;
+             << "Ice.Internal.OutgoingAsyncCompletionCallback completed" << epar;
         _out << sb;
 
         if (returnTypeS.empty())
@@ -3321,7 +3238,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (!inParams.empty())
         {
             _out << ",";
-            _out << nl << "write: (" << getUnqualified("Ice.OutputStream", ns) << " ostr) =>";
+            _out << nl << "write: (Ice.OutputStream ostr) =>";
             _out << sb;
             writeMarshalUnmarshalParams(inParams, 0, true, ns);
             if (op->sendsClasses(false))
@@ -3334,7 +3251,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (!throws.empty())
         {
             _out << ",";
-            _out << nl << "userException: (" << getUnqualified("Ice.UserException", ns) << " ex) =>";
+            _out << nl << "userException: (Ice.UserException ex) =>";
             _out << sb;
             _out << nl << "try";
             _out << sb;
@@ -3352,7 +3269,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << eb;
             }
 
-            _out << nl << "catch(" << getUnqualified("Ice.UserException", ns) << ")";
+            _out << nl << "catch(Ice.UserException)";
             _out << sb;
             _out << eb;
 
@@ -3362,7 +3279,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (ret || !outParams.empty())
         {
             _out << ",";
-            _out << nl << "read: (" << getUnqualified("Ice.InputStream", ns) << " istr) =>";
+            _out << nl << "read: (Ice.InputStream istr) =>";
             _out << sb;
             if (outParams.empty())
             {
@@ -3401,19 +3318,13 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << eb;
     }
 
-    _out << sp << nl << "#endregion"; // Asynchronous Task operations
-
-    _out << sp << nl << "#region Factory operations";
-
     _out << sp << nl << "public static " << name << "Prx createProxy(" << getUnqualified("Ice.Communicator", ns)
          << " communicator, string proxyString) =>";
     _out.inc();
-    _out << nl << "uncheckedCast(" << getUnqualified("Ice.ObjectPrxHelper", ns)
-         << ".createProxy(communicator, proxyString));";
+    _out << nl << "uncheckedCast(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
 
-    _out << sp << nl << "public static " << name << "Prx? checkedCast(" << getUnqualified("Ice.ObjectPrx", ns)
-         << " b, global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
+    _out << sp << nl << "public static " << name << "Prx? checkedCast(Ice.ObjectPrx b, global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
     _out << sb;
     _out << nl << "if (b is not null && b.ice_isA(ice_staticId(), ctx))";
     _out << sb;
@@ -3424,11 +3335,9 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "return null;";
     _out << eb;
 
-    _out << sp << nl << "public static " << name << "Prx? checkedCast(" << getUnqualified("Ice.ObjectPrx", ns)
-         << " b, string f, "
-         << "global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
+    _out << sp << nl << "public static " << name << "Prx? checkedCast(Ice.ObjectPrx b, string f, global::System.Collections.Generic.Dictionary<string, string>? ctx = null)";
     _out << sb;
-    _out << nl << getUnqualified("Ice.ObjectPrx?", ns) << " bb = b?.ice_facet(f);";
+    _out << nl << "Ice.ObjectPrx? bb = b?.ice_facet(f);";
     _out << nl << "try";
     _out << sb;
     _out << nl << "if (bb is not null && bb.ice_isA(ice_staticId(), ctx))";
@@ -3438,15 +3347,14 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "return prx;";
     _out << eb;
     _out << eb;
-    _out << nl << "catch (" << getUnqualified("Ice.FacetNotExistException", ns) << ")";
+    _out << nl << "catch (Ice.FacetNotExistException)";
     _out << sb;
     _out << eb;
     _out << nl << "return null;";
     _out << eb;
 
     _out << sp << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(b))]";
-    _out << sp << nl << "public static " << name << "Prx? uncheckedCast(" << getUnqualified("Ice.ObjectPrx?", ns)
-         << " b)";
+    _out << sp << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? b)";
     _out << sb;
     _out << nl << "if (b is not null)";
     _out << sb;
@@ -3458,8 +3366,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << eb;
 
     _out << sp << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(b))]";
-    _out << sp << nl << "public static " << name << "Prx? uncheckedCast(" << getUnqualified("Ice.ObjectPrx?", ns)
-         << " b, string f)";
+    _out << sp << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? b, string f)";
     _out << sb;
     _out << nl << "if (b is not null)";
     _out << sb;
@@ -3495,10 +3402,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "public static string ice_staticId() => \"" << scoped << "\";";
 
-    _out << sp << nl << "#endregion"; // Factory operations
-
-    _out << sp << nl << "#region Marshaling support";
-
     _out << sp << nl << "public static void write(" << getUnqualified("Ice.OutputStream", ns) << " ostr, " << name
          << "Prx? v)";
     _out << sb;
@@ -3516,8 +3419,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << eb;
     _out << nl << "return null;";
     _out << eb;
-
-    _out << sp << nl << "#endregion"; // Marshaling support
 
     return true;
 }
@@ -3706,10 +3607,6 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sb;
 
     OperationList ops = p->operations();
-    if (!ops.empty())
-    {
-        _out << sp << nl << "#region Slice operations";
-    }
 
     for (OperationList::const_iterator i = ops.begin(); i != ops.end(); ++i)
     {
@@ -3719,22 +3616,14 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << sp << nl << "public abstract " << retS << " " << opName << spar << params << epar << ';';
     }
 
-    if (!ops.empty())
-    {
-        _out << sp << nl << "#endregion"; // Slice operations
-    }
-
     writeInheritedOperations(p);
 
-    _out << sp << nl << "#region Slice type-related members";
     _out << sp;
     _out << nl << "public override string ice_id(" << getUnqualified("Ice.Current", ns)
          << " current) => ice_staticId();";
 
     _out << sp;
     _out << nl << "public static new string ice_staticId() => \"" << p->scoped() << "\";";
-
-    _out << sp << nl << "#endregion"; // Slice type-related members
 
     writeDispatch(p);
 
@@ -3754,11 +3643,6 @@ Slice::Gen::DispatcherVisitor::writeDispatch(const InterfaceDefPtr& p)
     string ns = getNamespace(p);
 
     OperationList ops = p->operations();
-    if (ops.size() != 0)
-    {
-        _out << sp << nl << "#region Operation dispatch";
-    }
-
     OperationList allOps = p->allOperations();
     if (!allOps.empty())
     {
@@ -3784,10 +3668,5 @@ Slice::Gen::DispatcherVisitor::writeDispatch(const InterfaceDefPtr& p)
         _out << eb;
         _out << ";";
         _out.dec();
-    }
-
-    if (ops.size() != 0)
-    {
-        _out << sp << nl << "#endregion"; // Operation dispatch
     }
 }


### PR DESCRIPTION
This PR includes two clean-ups:

- remove all the generated #region / #endregion
- simplify the qualification of Ice symbols