### PR TITLE
Schannel credentials

### DIFF
--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -19,30 +19,33 @@ namespace Ice::SSL
     struct SchannelClientAuthenticationOptions
     {
         /**
-         * A callback that allows selecting the client's SSL certificate based on the target server host name.
+         * A callback that allows selecting the client's SSL credentials based on the target server host name.
          *
          * @remarks This callback is invoked by the SSL transport for each new outgoing connection before starting the
-         * SSL handshake to determine the appropriate client certificate. The callback should return a PCCERT_CONTEXT
-         * that represents the client's certificate. The SSL transport takes ownership of the returned certificate and
-         * releases it when the connection is closed.
+         * SSL handshake to determine the appropriate client credentials. The callback should return a SCH_CREDENTIALS
+         * that represents the client's credentials. The SSL transport takes ownership of the credentials' paCred and
+         * and hRootStore and releases them when the connection is closed.
          *
          * @param host The target server host name.
-         * @return The client's certificate, or nullptr to indicate that no certificate is used by the connection.
+         * @return The client's credentials.
          *
          * Example of setting clientCertificateSelectionCallback:
          * ```cpp
-         * PCCERT_CONTEXT _clientCertificate = ...; // Load the client certificate using WinCrypt API
+         * PCCERT_CONTEXT _clientCertificate  = ...; //
          *
          * auto initData = Ice::InitializationData {
          *   ...
          *   .clientAuthenticationOptions = ClientAuthenticationOptions {
-         *      .clientCertificateSelectionCallback = [this](const std::string&)
+         *      .clientCredentialsSelectionCallback = [this](const std::string&)
          *      {
          *        // Increment the certificate context reference count to ensure it remains
          *        // valid for the duration of the connection. The SSL transport will release
          *        // it after closing the connection.
          *        CertDuplicateCertificateContext(_clientCertificate);
-         *        return _clientCertificate;
+         *        SCH_CREDENTIALS credentials = _clientCredentials;
+         *        credentials.cCreds = 1;
+         *        credentials.paCred = &_clientCertificate;
+         *        return credentials;
          *      }
          * };
          *
@@ -51,11 +54,10 @@ namespace Ice::SSL
          * CertFreeCertificateContext(_clientCertificate); // Release the certificate when no longer needed
          * ```
          *
-         * See Detailed Wincrypt documentation for [CERT_CONTEXT](
-         * https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context) and
-         * [CertCreateCertificateContext](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certcreatecertificatecontext)
+         * See Detailed Wincrypt documentation for [SCH_CREDENTIALS](
+         * https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials)
          */
-        std::function<PCCERT_CONTEXT(const std::string& host)> clientCertificateSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string& host)> clientCredentialsSelectionCallback;
 
         /**
          * A callback that is invoked before initiating a new SSL handshake. This callback provides an opportunity to

--- a/cpp/include/Ice/SSL/Config.h
+++ b/cpp/include/Ice/SSL/Config.h
@@ -23,6 +23,18 @@
 #        undef SECURITY_KERNEL
 #    endif
 #    define SECURITY_WIN32 1
+
+// See https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials#remarks
+#    define SCHANNEL_USE_BLACKLISTS
+#    ifndef UNICODE_STRING
+typedef struct _UNICODE_STRING
+{
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+#    endif
+
 #    include <schannel.h>
 #    include <security.h>
 #    include <sspi.h>

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -23,12 +23,12 @@ namespace Ice::SSL
          * accepts the connection.
          *
          * @remarks This callback is invoked by the SSL transport for each new incoming connection before starting the
-         * SSL handshake to determine the appropriate server certificate. The callback should return a PCCERT_CONTEXT
-         * that represents the server's certificate. The SSL transport takes ownership of the returned certificate and
-         * releases it when the connection is closed.
+         * SSL handshake to determine the appropriate server credentials. The callback should return a SCH_CREDENTIALS
+         * that represents the server's credentials. The SSL transport takes ownership of the credentials' paCred and
+         * and hRootStore and releases them when the connection is closed.
          *
          * @param adapterName The name of the object adapter that accepted the connection.
-         * @return The server's certificate, or nullptr to indicate that no certificate is used by the connection.
+         * @return The server's credentials.
          *
          * Example of setting serverCertificateSelectionCallback:
          * ```cpp
@@ -43,18 +43,20 @@ namespace Ice::SSL
          *        // valid for the duration of the connection. The SSL transport will release
          *        // it after closing the connection.
          *        CertDuplicateCertificateContext(_serverCertificate);
-         *        return _serverCertificate;
+         *        SCH_CREDENTIALS credentials = _serverCredentials;
+         *        credentials.cCreds = 1;
+         *        credentials.paCred = &_serverCertificate;
+         *        return credentials;
          *      }
          * };
          * ...
          * CertFreeCertificateContext(_serverCertificate); // Release the certificate when no longer needed
          * ```
          *
-         * See Detailed Wincrypt documentation for [CERT_CONTEXT](
-         * https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context) and
-         * [CertCreateCertificateContext](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certcreatecertificatecontext)
+         * See Detailed Wincrypt documentation for [SCH_CREDENTIALS](
+         * https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials)
          */
-        std::function<PCCERT_CONTEXT(const std::string& host)> serverCertificateSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string& host)> serverCredentialsSelectionCallback;
 
         /**
          * A callback that is invoked before initiating a new SSL handshake. This callback provides an opportunity to

--- a/cpp/msbuild/ice.cpp.props
+++ b/cpp/msbuild/ice.cpp.props
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>_CONSOLE;_WIN32_WINNT=0x601;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
       <DisableSpecificWarnings>4121;4250;4251;4275;4324</DisableSpecificWarnings>
       <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/cpp/msbuild/ice.cpp.props
+++ b/cpp/msbuild/ice.cpp.props
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>_CONSOLE;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;_WIN32_WINNT=0x0A00;WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
       <DisableSpecificWarnings>4121;4250;4251;4275;4324</DisableSpecificWarnings>
       <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -1244,31 +1244,6 @@ Schannel::SSLEngine::getCipherName(ALG_ID cipher) const
     }
 }
 
-SCHANNEL_CRED
-Schannel::SSLEngine::newCredentialsHandle(bool incoming) const
-{
-    SCHANNEL_CRED cred;
-    memset(&cred, 0, sizeof(cred));
-    cred.dwVersion = SCHANNEL_CRED_VERSION;
-
-    // TODO move this flags to the newSessionCallback for the properties configuration.
-    if (incoming)
-    {
-        // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and Schannel
-        // doesn't seems to send the root certificate either way.
-        cred.dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_CRED_DISABLE_RECONNECTS;
-    }
-    else
-    {
-        cred.dwFlags = SCH_CRED_NO_SERVERNAME_CHECK | SCH_CRED_NO_DEFAULT_CREDS;
-    }
-
-    // Enable strong crypto
-    cred.dwFlags |= SCH_USE_STRONG_CRYPTO;
-
-    return cred;
-}
-
 void
 Schannel::SSLEngine::destroy()
 {
@@ -1316,15 +1291,19 @@ Ice::SSL::ClientAuthenticationOptions
 Schannel::SSLEngine::createClientAuthenticationOptions(const string& host) const
 {
     return Ice::SSL::ClientAuthenticationOptions{
-        .clientCertificateSelectionCallback =
+        .clientCredentialsSelectionCallback =
             [this](const string&)
         {
-            PCCERT_CONTEXT cert = nullptr;
-            if (_allCerts.size() > 0)
+            for (auto& cert : _allCerts)
             {
-                cert = CertDuplicateCertificateContext(_allCerts[0]);
+                CertDuplicateCertificateContext(cert);
             }
-            return cert;
+
+            return SCH_CREDENTIALS{
+                .dwVersion = SCH_CREDENTIALS_VERSION,
+                .cCreds = static_cast<DWORD>(_allCerts.size()),
+                .paCred = const_cast<PCCERT_CONTEXT*>(_allCerts.size() > 0 ? &_allCerts[0] : nullptr),
+                .dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_NO_SERVERNAME_CHECK | SCH_USE_STRONG_CRYPTO};
         },
         .trustedRootCertificates = _rootStore,
         .serverCertificateValidationCallback = [self = shared_from_this(),
@@ -1356,16 +1335,22 @@ Ice::SSL::ServerAuthenticationOptions
 Schannel::SSLEngine::createServerAuthenticationOptions() const
 {
     return Ice::SSL::ServerAuthenticationOptions{
-        .serverCertificateSelectionCallback =
+        .serverCredentialsSelectionCallback =
             [this](const string&)
         {
             {
-                PCCERT_CONTEXT cert = nullptr;
-                if (_allCerts.size() > 0)
+                for (auto& cert : _allCerts)
                 {
-                    cert = CertDuplicateCertificateContext(_allCerts[0]);
+                    CertDuplicateCertificateContext(cert);
                 }
-                return cert;
+
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = static_cast<DWORD>(_allCerts.size()),
+                    .paCred = const_cast<PCCERT_CONTEXT*>(_allCerts.size() > 0 ? &_allCerts[0] : nullptr),
+                    // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and
+                    // Schannel doesn't seems to send the root certificate either way.
+                    .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_CRED_DISABLE_RECONNECTS | SCH_USE_STRONG_CRYPTO};
             }
         },
         .clientCertificateRequired = getVerifyPeer() > 0,

--- a/cpp/src/Ice/SSL/SchannelEngine.h
+++ b/cpp/src/Ice/SSL/SchannelEngine.h
@@ -39,7 +39,6 @@ namespace Ice::SSL::Schannel
 
         Ice::SSL::ClientAuthenticationOptions createClientAuthenticationOptions(const std::string&) const final;
         Ice::SSL::ServerAuthenticationOptions createServerAuthenticationOptions() const final;
-        SCHANNEL_CRED newCredentialsHandle(bool) const;
         static bool
         validationCallback(HCERTCHAINENGINE chainEngine, CtxtHandle, bool, const std::string&, bool, int, bool);
 

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.h
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.h
@@ -111,16 +111,17 @@ namespace Ice::SSL::Schannel
         //
         IceInternal::Buffer _readUnprocessed;
 
-        std::function<PCCERT_CONTEXT(const std::string&)> _localCertificateSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string&)> _localCredentialsSelectionCallback;
         std::function<void(CtxtHandle context, const std::string& host)> _sslNewSessionCallback;
         SecPkgContext_StreamSizes _sizes;
         std::string _cipher;
         PCCERT_CONTEXT _peerCertificate;
         std::function<bool(CtxtHandle, const Ice::SSL::ConnectionInfoPtr&)> _remoteCertificateValidationCallback;
         bool _clientCertificateRequired;
-        PCCERT_CONTEXT _certificate;
+        SCH_CREDENTIALS _credentials;
+        std::vector<PCCERT_CONTEXT> _allCerts;
+        CredHandle _credentialsHandle;
         HCERTSTORE _rootStore;
-        CredHandle _credentials;
         CtxtHandle _ssl;
 
         // The chain engine used to verify the peer certificate. If the user has not provided a remote certificate

--- a/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
+++ b/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
@@ -42,10 +42,10 @@ extern "C"
 Ice::CommunicatorPtr
 createServer(ServerAuthenticationOptions serverAuthenticationOptions, TestHelper* helper)
 {
-    Ice::InitializationData initData;
-    initData.properties = Ice::createProperties();
+    auto properties = Ice::createProperties();
     // Disable IPv6 for compatibility with Docker containers running on macOS.
-    initData.properties->setProperty("Ice.IPv6", "0");
+    properties->setProperty("Ice.IPv6", "0");
+    Ice::InitializationData initData{.properties = properties};
     Ice::CommunicatorPtr communicator = initialize(initData);
     ObjectAdapterPtr adapter = communicator->createObjectAdapterWithEndpoints(
         "ServerAdapter",
@@ -59,11 +59,12 @@ createServer(ServerAuthenticationOptions serverAuthenticationOptions, TestHelper
 Ice::CommunicatorPtr
 createClient(optional<ClientAuthenticationOptions> clientAuthenticationOptions)
 {
-    Ice::InitializationData initData;
-    initData.properties = Ice::createProperties();
+    auto properties = Ice::createProperties();
     // Disable IPv6 for compatibility with Docker containers running on macOS.
-    initData.properties->setProperty("Ice.IPv6", "0");
-    initData.clientAuthenticationOptions = clientAuthenticationOptions;
+    properties->setProperty("Ice.IPv6", "0");
+    Ice::InitializationData initData{
+        .properties = properties,
+        .clientAuthenticationOptions = clientAuthenticationOptions.value_or(ClientAuthenticationOptions{})};
     return initialize(initData);
 }
 
@@ -829,7 +830,7 @@ serverHotCertificateReload(Test::TestHelper* helper, const string& testDir)
 void
 allAuthenticationOptionsTests(Test::TestHelper* helper, const string& testDir)
 {
-    cerr << "testing with OpenSSL native APIs..." << endl;
+    cout << "testing with OpenSSL native APIs..." << endl;
 
     clientValidatesServerUsingCAFile(helper, testDir);
     clientValidatesServerUsingValidationCallback(helper, testDir);

--- a/cpp/test/IceSSL/configuration/SchannelTests.cpp
+++ b/cpp/test/IceSSL/configuration/SchannelTests.cpp
@@ -116,7 +116,8 @@ createServer(ServerAuthenticationOptions serverAuthenticationOptions, TestHelper
 Ice::CommunicatorPtr
 createClient(optional<ClientAuthenticationOptions> clientAuthenticationOptions = nullopt)
 {
-    return initialize(Ice::InitializationData{.clientAuthenticationOptions = clientAuthenticationOptions});
+    return initialize(Ice::InitializationData{
+        .clientAuthenticationOptions = clientAuthenticationOptions.value_or(ClientAuthenticationOptions{})});
 }
 
 void
@@ -129,10 +130,13 @@ clientValidatesServerSettingTrustedRootCertificates(Test::TestHelper* helper, co
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [serverCertificate](const string&)
+            .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -166,10 +170,13 @@ clientValidatesServerUsingValidationCallback(Test::TestHelper* helper, const str
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [serverCertificate](const string&)
+            .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -216,10 +223,13 @@ clientRejectsServerSettingTrustedRootCertificates(Test::TestHelper* helper, cons
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [serverCertificate](const string&)
+            .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -257,10 +267,13 @@ clientRejectsServerUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [serverCertificate](const string&)
+            .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -299,10 +312,13 @@ clientRejectsServerUsingValidationCallback(Test::TestHelper* helper, const strin
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [serverCertificate](const string&)
+            .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -344,22 +360,28 @@ serverValidatesClientSettingTrustedRootCertificates(Test::TestHelper* helper, co
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback =
+            .serverCredentialsSelectionCallback =
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
             .clientCertificateRequired = true,
             .trustedRootCertificates = trustedRootCertificates};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
         Ice::SSL::ClientAuthenticationOptions clientAuthenticationOptions{
-            .clientCertificateSelectionCallback =
+            .clientCredentialsSelectionCallback =
                 [clientCertificate](const string&)
             {
                 CertDuplicateCertificateContext(clientCertificate);
-                return clientCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
             },
             .trustedRootCertificates = trustedRootCertificates};
         Ice::CommunicatorHolder clientCommunicator(createClient(clientAuthenticationOptions));
@@ -394,11 +416,14 @@ serverValidatesClientUsingValidationCallback(Test::TestHelper* helper, const str
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback =
+            .serverCredentialsSelectionCallback =
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
             .clientCertificateRequired = true,
             // The server CA doesn't trust the client certificate.
@@ -408,11 +433,14 @@ serverValidatesClientUsingValidationCallback(Test::TestHelper* helper, const str
 
         Ice::CommunicatorHolder clientCommunicator(initialize(Ice::InitializationData{
             .clientAuthenticationOptions = Ice::SSL::ClientAuthenticationOptions{
-                .clientCertificateSelectionCallback =
+                .clientCredentialsSelectionCallback =
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return clientCertificate;
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
+                        .cCreds = 1,
+                        .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
                 .trustedRootCertificates = clientRootCertificates}}));
 
@@ -450,11 +478,14 @@ serverRejectsClientSettingTrustedRootCertificates(Test::TestHelper* helper, cons
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback =
+            .serverCredentialsSelectionCallback =
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
             .clientCertificateRequired = true,
             // The server CA doesn't trust the client certificate.
@@ -463,11 +494,14 @@ serverRejectsClientSettingTrustedRootCertificates(Test::TestHelper* helper, cons
 
         Ice::CommunicatorHolder clientCommunicator(initialize(Ice::InitializationData{
             .clientAuthenticationOptions = Ice::SSL::ClientAuthenticationOptions{
-                .clientCertificateSelectionCallback =
+                .clientCredentialsSelectionCallback =
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return clientCertificate;
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
+                        .cCreds = 1,
+                        .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
                 .trustedRootCertificates = clientRootCertificates}}));
 
@@ -511,11 +545,14 @@ serverRejectsClientUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
         // No trusted root certificates are set on the server, it would use the system trusted root
         // certificates.
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback =
+            .serverCredentialsSelectionCallback =
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
             .clientCertificateRequired = true,
         };
@@ -523,11 +560,14 @@ serverRejectsClientUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
 
         Ice::CommunicatorHolder clientCommunicator(initialize(Ice::InitializationData{
             .clientAuthenticationOptions = Ice::SSL::ClientAuthenticationOptions{
-                .clientCertificateSelectionCallback =
+                .clientCredentialsSelectionCallback =
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return clientCertificate;
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
+                        .cCreds = 1,
+                        .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
                 .trustedRootCertificates = trustedRootCertificates}}));
 
@@ -567,11 +607,14 @@ serverRejectsClientUsingValidationCallback(Test::TestHelper* helper, const strin
         // The server configured trusted root certificates, trust the client certificate, but the validation
         // callback rejects the client certificate.
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback =
+            .serverCredentialsSelectionCallback =
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return serverCertificate;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
             .clientCertificateRequired = true,
             .trustedRootCertificates = trustedRootCertificates,
@@ -581,11 +624,14 @@ serverRejectsClientUsingValidationCallback(Test::TestHelper* helper, const strin
 
         Ice::CommunicatorHolder clientCommunicator(initialize(Ice::InitializationData{
             .clientAuthenticationOptions = Ice::SSL::ClientAuthenticationOptions{
-                .clientCertificateSelectionCallback =
+                .clientCredentialsSelectionCallback =
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return clientCertificate;
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
+                        .cCreds = 1,
+                        .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
                 .trustedRootCertificates = trustedRootCertificates}}));
 
@@ -655,11 +701,14 @@ serverHotCertificateReload(Test::TestHelper* helper, const string& certificatesP
     try
     {
         Ice::SSL::ServerAuthenticationOptions serverAuthenticationOptions{
-            .serverCertificateSelectionCallback = [&serverState](const string&)
+            .serverCredentialsSelectionCallback = [&serverState](const string&)
             {
                 PCCERT_CONTEXT certificateContext = serverState.serverCertificateContext();
                 CertDuplicateCertificateContext(certificateContext);
-                return certificateContext;
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
+                    .cCreds = 1,
+                    .paCred = const_cast<PCCERT_CONTEXT*>(&certificateContext)};
             }};
         Ice::CommunicatorHolder serverCommunicator(createServer(serverAuthenticationOptions, helper));
 
@@ -734,7 +783,7 @@ serverHotCertificateReload(Test::TestHelper* helper, const string& certificatesP
 void
 allAuthenticationOptionsTests(Test::TestHelper* helper, const string& testDir)
 {
-    cerr << "testing with Schannel native APIs..." << endl;
+    cout << "testing with Schannel native APIs..." << endl;
 
     const string certificatesPath = testDir + "/../certs";
 

--- a/cpp/test/IceSSL/configuration/SecureTransportTests.cpp
+++ b/cpp/test/IceSSL/configuration/SecureTransportTests.cpp
@@ -69,7 +69,8 @@ createServer(ServerAuthenticationOptions serverAuthenticationOptions, TestHelper
 Ice::CommunicatorPtr
 createClient(optional<ClientAuthenticationOptions> clientAuthenticationOptions = nullopt)
 {
-    return initialize(Ice::InitializationData{.clientAuthenticationOptions = clientAuthenticationOptions});
+    return initialize(Ice::InitializationData{
+        .clientAuthenticationOptions = clientAuthenticationOptions.value_or(ClientAuthenticationOptions{})});
 }
 
 void
@@ -769,7 +770,7 @@ allAuthenticationOptionsTests(Test::TestHelper* helper, const string& testDir)
     const string certificatesPath = testDir + "/../certs";
 #    endif
 
-    cerr << "testing with SecureTransport native APIs..." << endl;
+    cout << "testing with SecureTransport native APIs..." << endl;
 
     clientValidatesServerSettingTrustedRootCertificates(helper, certificatesPath);
     clientValidatesServerUsingValidationCallback(helper, certificatesPath);


### PR DESCRIPTION
This PR updates the Schannel certificate selection callback to use SCH_CREDENTIALS. The callback functions have been renamed to clientCredentialsSelectionCallback and serverCredentialsSelectionCallback.

The previous API utilized PCCERT_CONTEXT and hardcoded certain credential settings within the SSL engine implementation. The new API uses SCH_CREDENTIALS, providing greater flexibility and allowing users direct control over the SCH credentials.

Additionally, this PR transitions from using SCH_CREDS to SCH_CREDENTIALS, which is the newer version of the credentials API.