### PR TITLE
Do not enable SNI for IP addresses

### DIFF
--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -111,7 +111,7 @@ OpenSSL::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal::
         SSL_set_ex_data(_ssl, 0, this);
         SSL_set_verify(_ssl, SSL_get_verify_mode(_ssl), Ice_SSL_opensslVerifyCallback);
         // Enable SNI by default for outgoing connections. The SNI host name is always empty for incoming connections.
-        if (!_host.empty() && !SSL_set_tlsext_host_name(_ssl, _host.c_str()))
+        if (!_host.empty() && !IceInternal::isIpAddress(_host) && !SSL_set_tlsext_host_name(_ssl, _host.c_str()))
         {
             ostringstream os;
             os << "IceSSL: setting SNI host failed `" << _host << "'";

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -108,7 +108,7 @@ Ice::SSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuf
         _ssl.reset(_engine->newContext(_incoming));
 
         // Enable SNI by default for outgoing connections. The SNI host name is always empty for incoming connections.
-        if (!_host.empty() && (err = SSLSetPeerDomainName(_ssl.get(), _host.data(), _host.length())))
+        if (!_host.empty() && !IceInternal::isIpAddress(_host) && (err = SSLSetPeerDomainName(_ssl.get(), _host.data(), _host.length())))
         {
             throw SecurityException(
                 __FILE__,

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -108,7 +108,8 @@ Ice::SSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuf
         _ssl.reset(_engine->newContext(_incoming));
 
         // Enable SNI by default for outgoing connections. The SNI host name is always empty for incoming connections.
-        if (!_host.empty() && !IceInternal::isIpAddress(_host) && (err = SSLSetPeerDomainName(_ssl.get(), _host.data(), _host.length())))
+        if (!_host.empty() && !IceInternal::isIpAddress(_host) &&
+            (err = SSLSetPeerDomainName(_ssl.get(), _host.data(), _host.length())))
         {
             throw SecurityException(
                 __FILE__,


### PR DESCRIPTION
Enabling SNI for IP addresses causes cross-test failures with Java IPv6 when SSL is enabled.