### PR TITLE
Remove Optional Classes from Other Tests

### DIFF
--- a/java/test/src/main/java/test/Ice/custom/AllTests.java
+++ b/java/test/src/main/java/test/Ice/custom/AllTests.java
@@ -55,7 +55,7 @@ public class AllTests {
       // Create a sequence of A instances, where elements 1..n simply point to element 0.
       //
       A[] seq = new A[5];
-      seq[0] = new A();
+      seq[0] = new A(0);
       for (int i = 1; i < seq.length; i++) {
         seq[i] = seq[0];
       }
@@ -67,10 +67,11 @@ public class AllTests {
       TestIntf.OpASeqResult seqR = t.opASeq(seq);
       test(seqR.returnValue.length == seq.length);
       test(seqR.outSeq.length == seq.length);
+
       for (int i = 1; i < seq.length; i++) {
         test(seqR.returnValue[i] != null);
-        test(seqR.returnValue[i] == seqR.returnValue[0]);
-        test(seqR.returnValue[i] == seqR.outSeq[i]);
+        test(seqR.returnValue[i].equals(seqR.returnValue[0]));
+        test(seqR.returnValue[i].equals(seqR.outSeq[i]));
       }
 
       ArrayList<A> arr = new ArrayList<>(Arrays.asList(seq));
@@ -79,8 +80,8 @@ public class AllTests {
       test(arrR.outSeq.size() == arr.size());
       for (int i = 1; i < arr.size(); i++) {
         test(arrR.returnValue.get(i) != null);
-        test(arrR.returnValue.get(i) == arrR.returnValue.get(0));
-        test(arrR.returnValue.get(i) == arrR.outSeq.get(i));
+        test(arrR.returnValue.get(i).equals(arrR.returnValue.get(0)));
+        test(arrR.returnValue.get(i).equals(arrR.outSeq.get(i)));
       }
 
       LinkedList<A> list = new LinkedList<>(Arrays.asList(seq));
@@ -89,8 +90,8 @@ public class AllTests {
       test(listR.outSeq.size() == list.size());
       for (int i = 1; i < list.size(); i++) {
         test(listR.returnValue.get(i) != null);
-        test(listR.returnValue.get(i) == listR.returnValue.get(0));
-        test(listR.returnValue.get(i) == listR.outSeq.get(i));
+        test(listR.returnValue.get(i).equals(listR.returnValue.get(0)));
+        test(listR.returnValue.get(i).equals(listR.outSeq.get(i)));
       }
     }
 

--- a/java/test/src/main/java/test/Ice/custom/AllTests.java
+++ b/java/test/src/main/java/test/Ice/custom/AllTests.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import test.Ice.custom.Test.C;
+import test.Ice.custom.Test.A;
 import test.Ice.custom.Test.E;
 import test.Ice.custom.Test.S;
 import test.Ice.custom.Test.TestIntf;
@@ -52,10 +52,10 @@ public class AllTests {
 
     {
       //
-      // Create a sequence of C instances, where elements 1..n simply point to element 0.
+      // Create a sequence of A instances, where elements 1..n simply point to element 0.
       //
-      C[] seq = new C[5];
-      seq[0] = new C();
+      A[] seq = new A[5];
+      seq[0] = new A();
       for (int i = 1; i < seq.length; i++) {
         seq[i] = seq[0];
       }
@@ -64,7 +64,7 @@ public class AllTests {
       // Invoke each operation and verify that the returned sequences have the same
       // structure as the original.
       //
-      TestIntf.OpCSeqResult seqR = t.opCSeq(seq);
+      TestIntf.OpASeqResult seqR = t.opASeq(seq);
       test(seqR.returnValue.length == seq.length);
       test(seqR.outSeq.length == seq.length);
       for (int i = 1; i < seq.length; i++) {
@@ -73,8 +73,8 @@ public class AllTests {
         test(seqR.returnValue[i] == seqR.outSeq[i]);
       }
 
-      ArrayList<C> arr = new ArrayList<>(Arrays.asList(seq));
-      TestIntf.OpCArrayResult arrR = t.opCArray(arr);
+      ArrayList<A> arr = new ArrayList<>(Arrays.asList(seq));
+      TestIntf.OpAArrayResult arrR = t.opAArray(arr);
       test(arrR.returnValue.size() == arr.size());
       test(arrR.outSeq.size() == arr.size());
       for (int i = 1; i < arr.size(); i++) {
@@ -83,8 +83,8 @@ public class AllTests {
         test(arrR.returnValue.get(i) == arrR.outSeq.get(i));
       }
 
-      LinkedList<C> list = new LinkedList<>(Arrays.asList(seq));
-      TestIntf.OpCListResult listR = t.opCList(list);
+      LinkedList<A> list = new LinkedList<>(Arrays.asList(seq));
+      TestIntf.OpAListResult listR = t.opAList(list);
       test(listR.returnValue.size() == list.size());
       test(listR.outSeq.size() == list.size());
       for (int i = 1; i < list.size(); i++) {

--- a/java/test/src/main/java/test/Ice/custom/Test.ice
+++ b/java/test/src/main/java/test/Ice/custom/Test.ice
@@ -10,7 +10,10 @@
 module Test
 {
 
-class A {}
+struct A
+{
+    int i; // We need a field here since structs can't be empty.
+}
 
 sequence<A> ASeq;
 ["java:type:java.util.ArrayList<A>"] sequence<A> AArray;

--- a/java/test/src/main/java/test/Ice/custom/Test.ice
+++ b/java/test/src/main/java/test/Ice/custom/Test.ice
@@ -10,11 +10,11 @@
 module Test
 {
 
-class C {}
+class A {}
 
-sequence<C> CSeq;
-["java:type:java.util.ArrayList<C>"] sequence<C> CArray;
-["java:type:java.util.LinkedList<C>"] sequence<C> CList;
+sequence<A> ASeq;
+["java:type:java.util.ArrayList<A>"] sequence<A> AArray;
+["java:type:java.util.LinkedList<A>"] sequence<A> AList;
 
 ["java:type:java.util.ArrayList<Boolean>"] sequence<bool> BoolSeq;
 ["java:type:java.util.ArrayList<Byte>"] sequence<byte> ByteSeq;
@@ -48,9 +48,9 @@ dictionary<int, string> D;
 
 interface TestIntf
 {
-    CSeq opCSeq(CSeq inSeq, out CSeq outSeq);
-    CArray opCArray(CArray inSeq, out CArray outSeq);
-    CList opCList(CList inSeq, out CList outSeq);
+    ASeq opASeq(ASeq inSeq, out ASeq outSeq);
+    AArray opAArray(AArray inSeq, out AArray outSeq);
+    AList opAList(AList inSeq, out AList outSeq);
     BoolSeq opBoolSeq(BoolSeq inSeq, out BoolSeq outSeq);
     ByteSeq opByteSeq(ByteSeq inSeq, out ByteSeq outSeq);
     ShortSeq opShortSeq(ShortSeq inSeq, out ShortSeq outSeq);
@@ -71,9 +71,9 @@ interface TestIntf
     FloatBuffer opFloatBufferSeq(FloatBuffer inSeq, out FloatBuffer outSeq);
     DoubleBuffer opDoubleBufferSeq(DoubleBuffer inSeq, out DoubleBuffer outSeq);
 
-    optional(1) CSeq opOptCSeq(optional(2) CSeq inSeq, out optional(3) CSeq outSeq);
-    optional(1) CArray opOptCArray(optional(2) CArray inSeq, out optional(3) CArray outSeq);
-    optional(1) CList opOptCList(optional(2) CList inSeq, out optional(3) CList outSeq);
+    optional(1) ASeq opOptASeq(optional(2) ASeq inSeq, out optional(3) ASeq outSeq);
+    optional(1) AArray opOptAArray(optional(2) AArray inSeq, out optional(3) AArray outSeq);
+    optional(1) AList opOptAList(optional(2) AList inSeq, out optional(3) AList outSeq);
     optional(1) BoolSeq opOptBoolSeq(optional(2) BoolSeq inSeq, out optional(3) BoolSeq outSeq);
     optional(1) ByteSeq opOptByteSeq(optional(2) ByteSeq inSeq, out optional(3) ByteSeq outSeq);
     optional(1) ShortSeq opOptShortSeq(optional(2) ShortSeq inSeq, out optional(3) ShortSeq outSeq);

--- a/java/test/src/main/java/test/Ice/custom/TestI.java
+++ b/java/test/src/main/java/test/Ice/custom/TestI.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import test.Ice.custom.Test.C;
+import test.Ice.custom.Test.A;
 import test.Ice.custom.Test.E;
 import test.Ice.custom.Test.S;
 import test.Ice.custom.Test.TestIntf;
@@ -25,20 +25,20 @@ public final class TestI implements TestIntf {
   }
 
   @Override
-  public TestIntf.OpCArrayResult opCArray(List<C> inSeq, com.zeroc.Ice.Current current) {
-    return new TestIntf.OpCArrayResult(inSeq, inSeq);
+  public TestIntf.OpAArrayResult opAArray(List<A> inSeq, com.zeroc.Ice.Current current) {
+    return new TestIntf.OpAArrayResult(inSeq, inSeq);
   }
 
   @Override
-  public TestIntf.OpCListResult opCList(List<C> inSeq, com.zeroc.Ice.Current current) {
-    return new TestIntf.OpCListResult(inSeq, inSeq);
+  public TestIntf.OpAListResult opAList(List<A> inSeq, com.zeroc.Ice.Current current) {
+    return new TestIntf.OpAListResult(inSeq, inSeq);
   }
 
   @Override
-  public TestIntf.OpCSeqResult opCSeq(C[] inSeq, com.zeroc.Ice.Current current) {
-    TestIntf.OpCSeqResult r = new TestIntf.OpCSeqResult();
+  public TestIntf.OpASeqResult opASeq(A[] inSeq, com.zeroc.Ice.Current current) {
+    TestIntf.OpASeqResult r = new TestIntf.OpASeqResult();
     seq = new ArrayList<>(Arrays.asList(inSeq));
-    r.outSeq = new C[seq.size()];
+    r.outSeq = new A[seq.size()];
     seq.toArray(r.outSeq);
     r.returnValue = r.outSeq;
     return r;
@@ -173,21 +173,21 @@ public final class TestI implements TestIntf {
   }
 
   @Override
-  public TestIntf.OpOptCArrayResult opOptCArray(
-      java.util.Optional<List<C>> inSeq, com.zeroc.Ice.Current current) {
-    return new TestIntf.OpOptCArrayResult(inSeq, inSeq);
+  public TestIntf.OpOptAArrayResult opOptAArray(
+      java.util.Optional<List<A>> inSeq, com.zeroc.Ice.Current current) {
+    return new TestIntf.OpOptAArrayResult(inSeq, inSeq);
   }
 
   @Override
-  public TestIntf.OpOptCListResult opOptCList(
-      java.util.Optional<List<C>> inSeq, com.zeroc.Ice.Current current) {
-    return new TestIntf.OpOptCListResult(inSeq, inSeq);
+  public TestIntf.OpOptAListResult opOptAList(
+      java.util.Optional<List<A>> inSeq, com.zeroc.Ice.Current current) {
+    return new TestIntf.OpOptAListResult(inSeq, inSeq);
   }
 
   @Override
-  public TestIntf.OpOptCSeqResult opOptCSeq(
-      java.util.Optional<C[]> inSeq, com.zeroc.Ice.Current current) {
-    return new TestIntf.OpOptCSeqResult(inSeq, inSeq);
+  public TestIntf.OpOptASeqResult opOptASeq(
+      java.util.Optional<A[]> inSeq, com.zeroc.Ice.Current current) {
+    return new TestIntf.OpOptASeqResult(inSeq, inSeq);
   }
 
   @Override
@@ -304,5 +304,5 @@ public final class TestI implements TestIntf {
   }
 
   private com.zeroc.Ice.Communicator _communicator;
-  private java.util.ArrayList<C> seq;
+  private java.util.ArrayList<A> seq;
 }

--- a/java/test/src/main/java/test/Ice/stream/Test.ice
+++ b/java/test/src/main/java/test/Ice/stream/Test.ice
@@ -59,14 +59,11 @@ class OptionalClass
     optional(3) SmallStruct sm;
 
     optional(4) MyEnumS enumS4;
-    optional(5) MyClassS myClassS5;
 
     optional(6) ByteBoolD byteBoolD6;
     optional(7) ShortIntD shortIntD7;
 
     optional(8) MyEnum enum8;
-    optional(9) MyClass class9;
-    optional(10) StringMyClassD stringMyClassD10;
     optional(12) Ice::IntSeq intSeq12;
     optional(13) Ice::ByteSeq byteSeq13;
     optional(14) Ice::StringSeq stringSeq14;

--- a/matlab/test/Ice/objects/LocalTest.ice
+++ b/matlab/test/Ice/objects/LocalTest.ice
@@ -114,19 +114,19 @@ dictionary<StructKey, S1> StructDict2;
 dictionary<int, C1Dict> C1DictDict;
 dictionary<int, S1Dict> S1DictDict;
 
-struct OS
+struct O
 {
     int i;
 }
 
-sequence<OS> OSSeq;
-dictionary<int, OS> OSDict;
+sequence<O> OSeq;
+dictionary<int, O> ODict;
 
 class Opt
 {
-    optional(1) OS os;
-    optional(2) OSSeq osSeq;
-    optional(3) OSDict osDict;
+    optional(1) O o;
+    optional(2) OSeq oSeq;
+    optional(3) ODict oDict;
 }
 
 }

--- a/matlab/test/Ice/objects/LocalTest.ice
+++ b/matlab/test/Ice/objects/LocalTest.ice
@@ -114,19 +114,4 @@ dictionary<StructKey, S1> StructDict2;
 dictionary<int, C1Dict> C1DictDict;
 dictionary<int, S1Dict> S1DictDict;
 
-struct O
-{
-    int i;
-}
-
-sequence<O> OSeq;
-dictionary<int, O> ODict;
-
-class Opt
-{
-    optional(1) O o;
-    optional(2) OSeq oSeq;
-    optional(3) ODict oDict;
-}
-
 }

--- a/matlab/test/Ice/objects/LocalTest.ice
+++ b/matlab/test/Ice/objects/LocalTest.ice
@@ -114,11 +114,19 @@ dictionary<StructKey, S1> StructDict2;
 dictionary<int, C1Dict> C1DictDict;
 dictionary<int, S1Dict> S1DictDict;
 
+struct OS
+{
+    int i;
+}
+
+sequence<OS> OSSeq;
+dictionary<int, OS> OSDict;
+
 class Opt
 {
-    optional(1) S1 s1;
-    optional(2) C1Seq c1seq;
-    optional(3) S1Dict s1dict;
+    optional(1) OS os;
+    optional(2) OSSeq osSeq;
+    optional(3) OSDict osDict;
 }
 
 }

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -943,10 +943,10 @@ classdef LocalTests
                 out.startEncapsulation(format);
                 cb = Opt();
                 cb.o = O(3);
-                cb.oSeq = {};
+                cb.oSeq = [];
                 cb.oDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
                 for i = 1:10
-                    cb.oSeq{i} = O(i);
+                    cb.oSeq(i) = O(i);
                     cb.oDict(i) = O(i);
                 end
                 out.writeValue(cb);
@@ -960,12 +960,12 @@ classdef LocalTests
                 is.readPendingValues();
                 is.endEncapsulation();
                 assert(isa(h.value.o, symbol('O')));
-                assert(isa(h.value.oSeq, 'cell'));
+                assert(isa(h.value.oSeq, symbol('O')));
                 assert(isa(h.value.oDict(1), symbol('O')));
                 assert(length(h.value.oSeq) == length(cb.oSeq));
                 assert(length(h.value.oDict) == length(cb.oDict));
                 for i = 1:10
-                    assert(h.value.oSeq{i}.i == i);
+                    assert(h.value.oSeq(i).i == i);
                     assert(h.value.oDict(i).i == i);
                 end
             end

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -930,9 +930,9 @@ classdef LocalTests
             is.readValue(@(v) h.set(v), symbol('Opt'));
             is.readPendingValues();
             is.endEncapsulation();
-            assert(h.value.os == Ice.Unset);
-            assert(h.value.osSeq == Ice.Unset);
-            assert(h.value.osDict == Ice.Unset);
+            assert(h.value.o == Ice.Unset);
+            assert(h.value.oSeq == Ice.Unset);
+            assert(h.value.oDict == Ice.Unset);
 
             %
             % Test: class containing multiple optional members requiring conversion.
@@ -942,12 +942,12 @@ classdef LocalTests
                 out = communicator.createOutputStream(encoding);
                 out.startEncapsulation(format);
                 cb = Opt();
-                cb.os = OS(3);
-                cb.osSeq = {};
-                cb.osDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
+                cb.o = O(3);
+                cb.oSeq = {};
+                cb.oDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
                 for i = 1:10
-                    cb.osSeq{i} = OS(i);
-                    cb.osDict(i) = OS(i);
+                    cb.oSeq{i} = O(i);
+                    cb.oDict(i) = O(i);
                 end
                 out.writeValue(cb);
                 out.writePendingValues();
@@ -959,14 +959,14 @@ classdef LocalTests
                 is.readValue(@(v) h.set(v), symbol('Opt'));
                 is.readPendingValues();
                 is.endEncapsulation();
-                assert(isa(h.value.os, symbol('OS')));
-                assert(isa(h.value.osSeq, 'cell'));
-                assert(isa(h.value.osDict(1), symbol('OS')));
-                assert(length(h.value.osSeq) == length(cb.osSeq));
-                assert(length(h.value.osDict) == length(cb.osDict));
+                assert(isa(h.value.o, symbol('O')));
+                assert(isa(h.value.oSeq, 'cell'));
+                assert(isa(h.value.oDict(1), symbol('O')));
+                assert(length(h.value.oSeq) == length(cb.oSeq));
+                assert(length(h.value.oDict) == length(cb.oDict));
                 for i = 1:10
-                    assert(h.value.osSeq{i}.i == i);
-                    assert(h.value.osDict(i).i == i);
+                    assert(h.value.oSeq{i}.i == i);
+                    assert(h.value.oDict(i).i == i);
                 end
             end
 

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -930,9 +930,9 @@ classdef LocalTests
             is.readValue(@(v) h.set(v), symbol('Opt'));
             is.readPendingValues();
             is.endEncapsulation();
-            assert(h.value.s1 == Ice.Unset);
-            assert(h.value.c1seq == Ice.Unset);
-            assert(h.value.s1dict == Ice.Unset);
+            assert(h.value.os == Ice.Unset);
+            assert(h.value.osSeq == Ice.Unset);
+            assert(h.value.osDict == Ice.Unset);
 
             %
             % Test: class containing multiple optional members requiring conversion.
@@ -942,12 +942,12 @@ classdef LocalTests
                 out = communicator.createOutputStream(encoding);
                 out.startEncapsulation(format);
                 cb = Opt();
-                cb.s1 = S1(C1(3));
-                cb.c1seq = {};
-                cb.s1dict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
+                cb.os = OS(3);
+                cb.osSeq = {};
+                cb.osDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
                 for i = 1:10
-                    cb.c1seq{i} = C1(i);
-                    cb.s1dict(i) = S1(C1(i));
+                    cb.osSeq{i} = OS(i);
+                    cb.osDict(i) = OS(i);
                 end
                 out.writeValue(cb);
                 out.writePendingValues();
@@ -959,14 +959,14 @@ classdef LocalTests
                 is.readValue(@(v) h.set(v), symbol('Opt'));
                 is.readPendingValues();
                 is.endEncapsulation();
-                assert(isa(h.value.s1.c1, symbol('C1')));
-                assert(isa(h.value.c1seq, 'cell'));
-                assert(isa(h.value.s1dict(1).c1, symbol('C1')));
-                assert(length(h.value.c1seq) == length(cb.c1seq));
-                assert(length(h.value.s1dict) == length(cb.s1dict));
+                assert(isa(h.value.os, symbol('OS')));
+                assert(isa(h.value.osSeq, 'cell'));
+                assert(isa(h.value.osDict(1), symbol('OS')));
+                assert(length(h.value.osSeq) == length(cb.osSeq));
+                assert(length(h.value.osDict) == length(cb.osDict));
                 for i = 1:10
-                    assert(h.value.c1seq{i}.i == i);
-                    assert(h.value.s1dict(i).c1.i == i);
+                    assert(h.value.osSeq{i}.i == i);
+                    assert(h.value.osDict(i).i == i);
                 end
             end
 

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -943,7 +943,7 @@ classdef LocalTests
                 out.startEncapsulation(format);
                 cb = Opt();
                 cb.o = O(3);
-                cb.oSeq = [];
+                cb.oSeq(1, 10) = O();
                 cb.oDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
                 for i = 1:10
                     cb.oSeq(i) = O(i);

--- a/matlab/test/Ice/objects/LocalTests.m
+++ b/matlab/test/Ice/objects/LocalTests.m
@@ -913,63 +913,6 @@ classdef LocalTests
                 end
             end
 
-            %
-            % Test: class containing multiple optional members requiring conversion.
-            %
-
-            out = communicator.createOutputStream(encoding);
-            out.startEncapsulation(format);
-            cb = Opt();
-            out.writeValue(cb);
-            out.writePendingValues();
-            out.endEncapsulation();
-
-            is = out.createInputStream();
-            is.startEncapsulation();
-            h = IceInternal.ValueHolder();
-            is.readValue(@(v) h.set(v), symbol('Opt'));
-            is.readPendingValues();
-            is.endEncapsulation();
-            assert(h.value.o == Ice.Unset);
-            assert(h.value.oSeq == Ice.Unset);
-            assert(h.value.oDict == Ice.Unset);
-
-            %
-            % Test: class containing multiple optional members requiring conversion.
-            %
-
-            if encoding == Ice.EncodingVersion(1, 1)
-                out = communicator.createOutputStream(encoding);
-                out.startEncapsulation(format);
-                cb = Opt();
-                cb.o = O(3);
-                cb.oSeq(1, 10) = O();
-                cb.oDict = containers.Map('KeyType', 'int32', 'ValueType', 'any');
-                for i = 1:10
-                    cb.oSeq(i) = O(i);
-                    cb.oDict(i) = O(i);
-                end
-                out.writeValue(cb);
-                out.writePendingValues();
-                out.endEncapsulation();
-
-                is = out.createInputStream();
-                is.startEncapsulation();
-                h = IceInternal.ValueHolder();
-                is.readValue(@(v) h.set(v), symbol('Opt'));
-                is.readPendingValues();
-                is.endEncapsulation();
-                assert(isa(h.value.o, symbol('O')));
-                assert(isa(h.value.oSeq, symbol('O')));
-                assert(isa(h.value.oDict(1), symbol('O')));
-                assert(length(h.value.oSeq) == length(cb.oSeq));
-                assert(length(h.value.oDict) == length(cb.oDict));
-                for i = 1:10
-                    assert(h.value.oSeq(i).i == i);
-                    assert(h.value.oDict(i).i == i);
-                end
-            end
-
             fprintf('ok\n');
         end
     end


### PR DESCRIPTION
**In java**, we were using optional classes in 2 places:
- **The stream tests:** These fields were literally unused anyways, so I just deleted them.
There were other unused fields I left as-is. I guess part of this test to making sure it's okay to send 'incomplete' classes when those fields are optional.

- **The custom tests:** these are testing the language mapping, totally unrelated to classes.
So I switched the optional classes to be optional structs instead.

**In Matlab**, there's a section of the 'objects' test which is using optional classes, this PR switches this section to use optional structs instead. Unfortunately, every other type in this Slice file involved classes, so I had to make some new types, just for this one spot.

EDIT:

I was told to just delete this portion of the MATLAB test, so that's what I've done.
It's quite possible this test was redundant with the optional test anyways,