### PR TITLE
Remove Testing of Optional Sequences/Dictionaries which hold Classes

### DIFF
--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -345,11 +345,11 @@ allTests(Test::TestHelper* helper, bool)
     mo1->ifsd.value()[4] = fs;
     mo1->ivsd = IntVarStructDict();
     mo1->ivsd.value()[5] = vs;
-    mo1->iood = IntOneOptionalDict();
-    mo1->iood.value()[5] = make_shared<OneOptional>();
-    mo1->iood.value()[5]->a = 15;
     mo1->imipd = IntMyInterfacePrxDict();
     mo1->imipd.value()[5] = MyInterfacePrx(communicator, "test");
+    mo1->iood = IntOneOptionalDict();
+    mo1->iood[5] = make_shared<OneOptional>();
+    mo1->iood[5]->a = 15;
 
     mo1->bos = BoolSeq();
     mo1->bos->push_back(false);
@@ -387,8 +387,8 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->ied == mo1->ied);
     test(mo3->ifsd == mo1->ifsd);
     test(mo3->ivsd == mo1->ivsd);
-    test(mo3->iood == mo1->iood);
     test(mo3->imipd == mo1->imipd);
+    test(mo3->iood == mo1->iood);
 
     test(mo3->bos == mo1->bos);
 
@@ -448,7 +448,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo4->ied);
     test(!mo4->ifsd);
     test(!mo4->ivsd);
-    test(!mo4->iood);
     test(!mo4->imipd);
 
     test(!mo4->bos);
@@ -486,13 +485,13 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->ied == mo1->ied);
     test(mo5->ifsd == mo1->ifsd);
     test(mo5->ivsd == mo1->ivsd);
-    test(!mo5->iood->empty() && (*mo5->iood)[5]->a == 15);
 
     test(mo5->imipd.value().size() == mo1->imipd.value().size());
     for (auto& v : mo5->imipd.value())
     {
         test(mo1->imipd.value()[v.first] == v.second);
     }
+    test(!mo5->iood->empty() && mo5->iood[5]->a == 15);
 
     test(mo5->bos == mo1->bos);
 
@@ -542,8 +541,8 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->ied);
     test(mo7->ifsd == mo1->ifsd);
     test(!mo7->ivsd);
-    test(!mo7->iood->empty() && (*mo7->iood)[5]->a == 15);
     test(!mo7->imipd);
+    test(!mo7->iood->empty() && mo7->iood[5]->a == 15);
 
     // Clear the second half of the optional parameters
     MultiOptionalPtr mo8 = mo5->ice_clone();
@@ -560,7 +559,6 @@ allTests(Test::TestHelper* helper, bool)
     mo8->fss = nullopt;
 
     mo8->ifsd = nullopt;
-    mo8->iood = nullopt;
 
     MultiOptionalPtr mo9 = dynamic_pointer_cast<MultiOptional>(initial->pingPong(mo8));
     test(mo9->a == mo1->a);
@@ -594,7 +592,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo8->ied == mo1->ied);
     test(!mo8->ifsd);
     test(mo8->ivsd == mo1->ivsd);
-    test(!mo8->iood);
 
     Ice::ByteSeq inEncaps;
     Ice::ByteSeq outEncaps;
@@ -1606,37 +1603,6 @@ allTests(Test::TestHelper* helper, bool)
         in.read(3, p3);
         in.endEncapsulation();
         test(p2 == ss && p3 == ss);
-
-        Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
-        in2.startEncapsulation();
-        in2.endEncapsulation();
-    }
-
-    {
-        optional<IntOneOptionalDict> p1;
-        optional<IntOneOptionalDict> p3;
-        optional<IntOneOptionalDict> p2 = initial->opIntOneOptionalDict(p1, p3);
-        test(!p2 && !p3);
-
-        IntOneOptionalDict ss;
-        ss.insert(make_pair<int, OneOptionalPtr>(1, make_shared<OneOptional>(58)));
-        p1 = ss;
-        p2 = initial->opIntOneOptionalDict(p1, p3);
-        test(p2 && p3);
-        test((*p2)[1]->a == 58 && (*p3)[1]->a == 58);
-
-        Ice::OutputStream out(communicator);
-        out.startEncapsulation();
-        out.write(2, p1);
-        out.endEncapsulation();
-        out.finished(inEncaps);
-        initial->ice_invoke("opIntOneOptionalDict", Ice::OperationMode::Normal, inEncaps, outEncaps);
-        Ice::InputStream in(communicator, out.getEncoding(), outEncaps);
-        in.startEncapsulation();
-        in.read(1, p2);
-        in.read(3, p3);
-        in.endEncapsulation();
-        test((*p2)[1]->a == 58 && (*p3)[1]->a == 58);
 
         Ice::InputStream in2(communicator, out.getEncoding(), outEncaps);
         in2.startEncapsulation();

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -336,8 +336,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->fss->push_back(fs);
     mo1->vss = VarStructSeq();
     mo1->vss->push_back(vs);
-    mo1->oos = OneOptionalSeq();
-    mo1->oos->push_back(oo1);
     mo1->mips = MyInterfacePrxSeq();
     mo1->mips->push_back(MyInterfacePrx(communicator, "test"));
 
@@ -384,7 +382,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->es == mo1->es);
     test(mo3->fss == mo1->fss);
     test(mo3->vss == mo1->vss);
-    test(mo3->oos == mo1->oos);
     test(mo3->mips == mo1->mips);
 
     test(mo3->ied == mo1->ied);
@@ -446,7 +443,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo4->es);
     test(!mo4->fss);
     test(!mo4->vss);
-    test(!mo4->oos);
     test(!mo4->mips);
 
     test(!mo4->ied);
@@ -480,7 +476,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo5->es == mo1->es);
     test(mo5->fss == mo1->fss);
     test(mo5->vss == mo1->vss);
-    test(!mo5->oos->empty() && (*mo5->oos)[0]->a == oo1->a);
 
     test(mo5->mips.value().size() == mo1->mips.value().size());
     for (size_t i = 0; i < mo5->mips.value().size(); ++i)
@@ -542,7 +537,6 @@ allTests(Test::TestHelper* helper, bool)
     test(!mo7->es);
     test(mo7->fss == mo1->fss);
     test(!mo7->vss);
-    test(!mo7->oos->empty() && (*mo7->oos)[0]->a == oo1->a);
     test(!mo7->mips);
 
     test(!mo7->ied);
@@ -564,7 +558,6 @@ allTests(Test::TestHelper* helper, bool)
 
     mo8->shs = nullopt;
     mo8->fss = nullopt;
-    mo8->oos = nullopt;
 
     mo8->ifsd = nullopt;
     mo8->iood = nullopt;
@@ -591,7 +584,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo8->es == mo1->es);
     test(!mo8->fss);
     test(mo8->vss == mo1->vss);
-    test(!mo8->oos);
 
     test(mo8->mips.value().size() == mo1->mips.value().size());
     for (size_t i = 0; i < mo8->mips.value().size(); ++i)

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -347,9 +347,6 @@ allTests(Test::TestHelper* helper, bool)
     mo1->ivsd.value()[5] = vs;
     mo1->imipd = IntMyInterfacePrxDict();
     mo1->imipd.value()[5] = MyInterfacePrx(communicator, "test");
-    mo1->iood = IntOneOptionalDict();
-    mo1->iood[5] = make_shared<OneOptional>();
-    mo1->iood[5]->a = 15;
 
     mo1->bos = BoolSeq();
     mo1->bos->push_back(false);
@@ -388,7 +385,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo3->ifsd == mo1->ifsd);
     test(mo3->ivsd == mo1->ivsd);
     test(mo3->imipd == mo1->imipd);
-    test(mo3->iood == mo1->iood);
 
     test(mo3->bos == mo1->bos);
 
@@ -491,7 +487,6 @@ allTests(Test::TestHelper* helper, bool)
     {
         test(mo1->imipd.value()[v.first] == v.second);
     }
-    test(!mo5->iood->empty() && mo5->iood[5]->a == 15);
 
     test(mo5->bos == mo1->bos);
 
@@ -542,7 +537,6 @@ allTests(Test::TestHelper* helper, bool)
     test(mo7->ifsd == mo1->ifsd);
     test(!mo7->ivsd);
     test(!mo7->imipd);
-    test(!mo7->iood->empty() && mo7->iood[5]->a == 15);
 
     // Clear the second half of the optional parameters
     MultiOptionalPtr mo8 = mo5->ice_clone();

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -270,8 +270,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -63,7 +63,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 ["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 
@@ -96,8 +95,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -62,8 +62,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 ["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 
@@ -95,8 +95,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -269,7 +270,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -53,7 +53,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["cpp:type:std::list< ::Test::FixedStruct>"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -91,7 +90,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -270,8 +270,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -63,7 +63,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 ["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 
@@ -96,8 +95,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -62,8 +62,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 ["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 
@@ -95,8 +95,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -269,7 +270,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -53,7 +53,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["cpp:type:std::list< ::Test::FixedStruct>"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -91,7 +90,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -380,16 +380,6 @@ InitialI::opStringIntDictAsync(
 }
 
 void
-InitialI::opIntOneOptionalDictAsync(
-    optional<Test::IntOneOptionalDict> p1,
-    function<void(const optional<Test::IntOneOptionalDict>&, const optional<Test::IntOneOptionalDict>&)> response,
-    function<void(exception_ptr)>,
-    const Ice::Current&)
-{
-    response(p1, p1);
-}
-
-void
 InitialI::opClassAndUnknownOptionalAsync(
     shared_ptr<Test::A>,
     function<void()> response,

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -243,13 +243,6 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
 
-    void opIntOneOptionalDictAsync(
-        std::optional<Test::IntOneOptionalDict>,
-        std::function<
-            void(const std::optional<Test::IntOneOptionalDict>&, const std::optional<Test::IntOneOptionalDict>&)>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
-
     void opClassAndUnknownOptionalAsync(
         std::shared_ptr<Test::A>,
         std::function<void()>,

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -319,13 +319,6 @@ InitialI::opStringIntDict(optional<StringIntDict> p1, optional<StringIntDict>& p
     return p3;
 }
 
-optional<IntOneOptionalDict>
-InitialI::opIntOneOptionalDict(optional<IntOneOptionalDict> p1, optional<IntOneOptionalDict>& p3, const Current&)
-{
-    p3 = p1;
-    return p3;
-}
-
 void
 InitialI::opClassAndUnknownOptional(APtr, const Ice::Current&)
 {

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -127,11 +127,6 @@ public:
     virtual std::optional<::Test::StringIntDict>
     opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&);
 
-    virtual std::optional<::Test::IntOneOptionalDict> opIntOneOptionalDict(
-        std::optional<::Test::IntOneOptionalDict>,
-        std::optional<::Test::IntOneOptionalDict>&,
-        const Ice::Current&);
-
     virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
 
     virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -76,6 +76,8 @@ namespace Ice
                 mo1.ivsd.Add(5, vs);
                 mo1.imipd = new Dictionary<int, Test.MyInterfacePrx>();
                 mo1.imipd.Add(5, Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test")));
+                mo1.iood = new Dictionary<int, Test.OneOptional>();
+                mo1.iood.Add(5, new Test.OneOptional(15));
 
                 mo1.bos = new bool[] { false, true, false };
 
@@ -106,6 +108,7 @@ namespace Ice
                 test(mo1.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo1.ivsd[5].Equals(new Test.VarStruct("hello")));
                 test(mo1.imipd[5].Equals(communicator.stringToProxy("test")));
+                test(mo1.iood.Value[5].a.Value == 15);
 
                 test(ArraysEqual(mo1.bos, new bool[] { false, true, false }));
 
@@ -178,6 +181,7 @@ namespace Ice
                 test(mo5.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo5.ivsd[5].Equals(new Test.VarStruct("hello")));
                 test(mo5.imipd[5].Equals(communicator.stringToProxy("test")));
+                test(mo5.iood[5].a.Value == 15);
 
                 test(ArraysEqual(mo5.bos, new bool[] { false, true, false }));
 
@@ -224,6 +228,7 @@ namespace Ice
                 test(mo7.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo7.ivsd is null);
                 test(mo7.imipd is null);
+                test(mo7.iood[5].a.Value == 15);
 
                 test(ArraysEqual(mo7.bos, new bool[] { false, true, false }));
 
@@ -1671,7 +1676,6 @@ namespace Ice
                     test(MapsEqual(m, p1));
                     @in.endEncapsulation();
                 }
-
                 output.WriteLine("ok");
 
                 output.Write("testing exception optionals... ");

--- a/csharp/test/Ice/optional/AllTests.cs
+++ b/csharp/test/Ice/optional/AllTests.cs
@@ -76,8 +76,6 @@ namespace Ice
                 mo1.ivsd.Add(5, vs);
                 mo1.imipd = new Dictionary<int, Test.MyInterfacePrx>();
                 mo1.imipd.Add(5, Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test")));
-                mo1.iood = new Dictionary<int, Test.OneOptional>();
-                mo1.iood.Add(5, new Test.OneOptional(15));
 
                 mo1.bos = new bool[] { false, true, false };
 
@@ -108,7 +106,6 @@ namespace Ice
                 test(mo1.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo1.ivsd[5].Equals(new Test.VarStruct("hello")));
                 test(mo1.imipd[5].Equals(communicator.stringToProxy("test")));
-                test(mo1.iood.Value[5].a.Value == 15);
 
                 test(ArraysEqual(mo1.bos, new bool[] { false, true, false }));
 
@@ -181,7 +178,6 @@ namespace Ice
                 test(mo5.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo5.ivsd[5].Equals(new Test.VarStruct("hello")));
                 test(mo5.imipd[5].Equals(communicator.stringToProxy("test")));
-                test(mo5.iood[5].a.Value == 15);
 
                 test(ArraysEqual(mo5.bos, new bool[] { false, true, false }));
 
@@ -228,7 +224,6 @@ namespace Ice
                 test(mo7.ifsd[4].Equals(new Test.FixedStruct(78)));
                 test(mo7.ivsd is null);
                 test(mo7.imipd is null);
-                test(mo7.iood[5].a.Value == 15);
 
                 test(ArraysEqual(mo7.bos, new bool[] { false, true, false }));
 

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -58,8 +58,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -90,6 +90,8 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 }

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["cs:generic:LinkedList"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 dictionary<int, int> IntIntDict;

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -59,7 +59,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -90,8 +89,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 }

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -58,8 +58,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -89,8 +89,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 }

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -59,7 +59,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -90,8 +89,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 }

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["cs:generic:LinkedList"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 dictionary<int, int> IntIntDict;
@@ -85,7 +84,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -257,12 +257,6 @@ public final class AMDInitialI implements Initial {
   }
 
   @Override
-  public CompletionStage<Initial.OpIntOneOptionalDictResult> opIntOneOptionalDictAsync(
-      Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
-    return CompletableFuture.completedFuture(new Initial.OpIntOneOptionalDictResult(p1, p1));
-  }
-
-  @Override
   public CompletionStage<Void> opClassAndUnknownOptionalAsync(A p, Current current) {
     return CompletableFuture.completedFuture(null);
   }

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -97,8 +97,6 @@ public class AllTests {
     mo1.getIvsd().put(5, vs);
     mo1.setImipd(new java.util.HashMap<>());
     mo1.getImipd().put(5, MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
-    mo1.iood = new java.util.HashMap<>();
-    mo1.iood.put(5, new OneOptional(15));
 
     mo1.setBos(new boolean[] {false, true, false});
 
@@ -132,7 +130,6 @@ public class AllTests {
     test(mo1.getIfsd().get(4).equals(new FixedStruct(78)));
     test(mo1.getIvsd().get(5).equals(new VarStruct("hello")));
     test(mo1.getImipd().get(5).equals(communicator.stringToProxy("test")));
-    test(mo1.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo1.getBos(), new boolean[] {false, true, false}));
 
@@ -214,7 +211,6 @@ public class AllTests {
     test(mo5.getIfsd().get(4).equals(new FixedStruct(78)));
     test(mo5.getIvsd().get(5).equals(new VarStruct("hello")));
     test(mo5.getImipd().get(5).equals(communicator.stringToProxy("test")));
-    test(mo5.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo5.getBos(), new boolean[] {false, true, false}));
 
@@ -265,7 +261,6 @@ public class AllTests {
     test(mo7.getIfsd().get(4).equals(new FixedStruct(78)));
     test(!mo7.hasIvsd());
     test(!mo7.hasImipd());
-    test(mo7.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo7.getBos(), new boolean[] {false, true, false}));
 

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -86,7 +86,6 @@ public class AllTests {
     mo1.setEs(new MyEnum[] {MyEnum.MyEnumMember, MyEnum.MyEnumMember});
     mo1.setFss(new FixedStruct[] {fs});
     mo1.setVss(new VarStruct[] {vs});
-    mo1.setOos(new OneOptional[] {oo1});
     mo1.setMips(
         new MyInterfacePrx[] {MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))});
 
@@ -127,7 +126,6 @@ public class AllTests {
     test(mo1.getEs()[0] == MyEnum.MyEnumMember && mo1.getEs()[1] == MyEnum.MyEnumMember);
     test(mo1.getFss()[0].equals(new FixedStruct(78)));
     test(mo1.getVss()[0].equals(new VarStruct("hello")));
-    test(mo1.getOos()[0] == oo1);
     test(mo1.getMips()[0].equals(communicator.stringToProxy("test")));
 
     test(mo1.getIed().get(4) == MyEnum.MyEnumMember);
@@ -173,7 +171,6 @@ public class AllTests {
     test(!mo4.hasEs());
     test(!mo4.hasFss());
     test(!mo4.hasVss());
-    test(!mo4.hasOos());
     test(!mo4.hasMips());
 
     test(!mo4.hasIed());
@@ -212,7 +209,6 @@ public class AllTests {
     test(mo5.getEs()[0] == MyEnum.MyEnumMember && mo1.getEs()[1] == MyEnum.MyEnumMember);
     test(mo5.getFss()[0].equals(new FixedStruct(78)));
     test(mo5.getVss()[0].equals(new VarStruct("hello")));
-    test(mo5.getOos()[0].getA() == 15);
     test(mo5.getMips()[0].equals(communicator.stringToProxy("test")));
 
     test(mo5.getIed().get(4) == MyEnum.MyEnumMember);
@@ -239,7 +235,6 @@ public class AllTests {
     mo6.setFs(mo5.getFs());
     mo6.setShs(mo5.getShs());
     mo6.setFss(mo5.getFss());
-    mo6.setOos(mo5.getOos());
     mo6.setIfsd(mo5.getIfsd());
     mo6.setIood(mo5.getIood());
     mo6.setBos(mo5.getBos());
@@ -266,7 +261,6 @@ public class AllTests {
     test(!mo7.hasEs());
     test(mo7.getFss()[0].equals(new FixedStruct(78)));
     test(!mo7.hasVss());
-    test(mo7.getOos()[0].getA() == 15);
     test(!mo7.hasMips());
 
     test(!mo7.hasIed());
@@ -318,7 +312,6 @@ public class AllTests {
     test(mo9.getEs()[0] == MyEnum.MyEnumMember && mo1.getEs()[1] == MyEnum.MyEnumMember);
     test(!mo9.hasFss());
     test(mo9.getVss()[0].equals(new VarStruct("hello")));
-    test(!mo9.hasOos());
     test(mo9.getMips()[0].equals(communicator.stringToProxy("test")));
 
     test(mo9.getIed().get(4) == MyEnum.MyEnumMember);

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -95,10 +95,10 @@ public class AllTests {
     mo1.getIfsd().put(4, fs);
     mo1.setIvsd(new java.util.HashMap<>());
     mo1.getIvsd().put(5, vs);
-    mo1.setIood(new java.util.HashMap<>());
-    mo1.getIood().put(5, new OneOptional(15));
     mo1.setImipd(new java.util.HashMap<>());
     mo1.getImipd().put(5, MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
+    mo1.iood = new java.util.HashMap<>();
+    mo1.iood.put(5, new OneOptional(15));
 
     mo1.setBos(new boolean[] {false, true, false});
 
@@ -131,8 +131,8 @@ public class AllTests {
     test(mo1.getIed().get(4) == MyEnum.MyEnumMember);
     test(mo1.getIfsd().get(4).equals(new FixedStruct(78)));
     test(mo1.getIvsd().get(5).equals(new VarStruct("hello")));
-    test(mo1.getIood().get(5).getA() == 15);
     test(mo1.getImipd().get(5).equals(communicator.stringToProxy("test")));
+    test(mo1.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo1.getBos(), new boolean[] {false, true, false}));
 
@@ -176,7 +176,6 @@ public class AllTests {
     test(!mo4.hasIed());
     test(!mo4.hasIfsd());
     test(!mo4.hasIvsd());
-    test(!mo4.hasIood());
     test(!mo4.hasImipd());
 
     test(!mo4.hasBos());
@@ -214,8 +213,8 @@ public class AllTests {
     test(mo5.getIed().get(4) == MyEnum.MyEnumMember);
     test(mo5.getIfsd().get(4).equals(new FixedStruct(78)));
     test(mo5.getIvsd().get(5).equals(new VarStruct("hello")));
-    test(mo5.getIood().get(5).getA() == 15);
     test(mo5.getImipd().get(5).equals(communicator.stringToProxy("test")));
+    test(mo5.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo5.getBos(), new boolean[] {false, true, false}));
 
@@ -236,7 +235,6 @@ public class AllTests {
     mo6.setShs(mo5.getShs());
     mo6.setFss(mo5.getFss());
     mo6.setIfsd(mo5.getIfsd());
-    mo6.setIood(mo5.getIood());
     mo6.setBos(mo5.getBos());
 
     MultiOptional mo7 = (MultiOptional) initial.pingPong(mo6);
@@ -266,8 +264,8 @@ public class AllTests {
     test(!mo7.hasIed());
     test(mo7.getIfsd().get(4).equals(new FixedStruct(78)));
     test(!mo7.hasIvsd());
-    test(mo7.getIood().get(5).getA() == 15);
     test(!mo7.hasImipd());
+    test(mo7.iood.get(5).getA() == 15);
 
     test(java.util.Arrays.equals(mo7.getBos(), new boolean[] {false, true, false}));
 
@@ -317,7 +315,6 @@ public class AllTests {
     test(mo9.getIed().get(4) == MyEnum.MyEnumMember);
     test(!mo9.hasIfsd());
     test(mo9.getIvsd().get(5).equals(new VarStruct("hello")));
-    test(!mo9.hasIood());
     test(mo9.getImipd().get(5).equals(communicator.stringToProxy("test")));
 
     test(!mo9.hasBos());
@@ -1631,48 +1628,6 @@ public class AllTests {
       in.skip(4);
       m = StringIntDictHelper.read(in);
       test(m.equals(p1.get()));
-      in.endEncapsulation();
-
-      in = new InputStream(communicator, inv.outParams);
-      in.startEncapsulation();
-      in.endEncapsulation();
-    }
-
-    {
-      Optional<java.util.Map<Integer, OneOptional>> p1 = Optional.empty();
-      Optional<java.util.Map<Integer, OneOptional>> p3 = Optional.empty();
-      Initial.OpIntOneOptionalDictResult r = initial.opIntOneOptionalDict(p1);
-      test(!r.returnValue.isPresent() && !r.p3.isPresent());
-
-      p1 = Optional.of(new java.util.HashMap<>());
-      p1.get().put(1, new OneOptional(15));
-      p1.get().put(2, new OneOptional(12));
-      r = initial.opIntOneOptionalDict(p1);
-      test(r.returnValue.get().get(1).getA() == 15 && r.p3.get().get(1).getA() == 15);
-      test(r.returnValue.get().get(2).getA() == 12 && r.p3.get().get(2).getA() == 12);
-      r = initial.opIntOneOptionalDictAsync(p1).join();
-      test(r.returnValue.get().get(1).getA() == 15 && r.p3.get().get(1).getA() == 15);
-      test(r.returnValue.get().get(2).getA() == 12 && r.p3.get().get(2).getA() == 12);
-
-      os = new OutputStream(communicator);
-      os.startEncapsulation();
-      os.writeOptional(2, OptionalFormat.FSize);
-      int pos = os.startSize();
-      IntOneOptionalDictHelper.write(os, p1.get());
-      os.endSize(pos);
-      os.endEncapsulation();
-      inEncaps = os.finished();
-      inv = initial.ice_invoke("opIntOneOptionalDict", OperationMode.Normal, inEncaps);
-      in = new InputStream(communicator, inv.outParams);
-      in.startEncapsulation();
-      test(in.readOptional(1, OptionalFormat.FSize));
-      in.skip(4);
-      java.util.Map<Integer, OneOptional> m = IntOneOptionalDictHelper.read(in);
-      test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
-      test(in.readOptional(3, OptionalFormat.FSize));
-      in.skip(4);
-      m = IntOneOptionalDictHelper.read(in);
-      test(m.get(1).getA() == 15 && m.get(2).getA() == 12);
       in.endEncapsulation();
 
       in = new InputStream(communicator, inv.outParams);

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -232,12 +232,6 @@ public final class InitialI implements Initial {
   }
 
   @Override
-  public Initial.OpIntOneOptionalDictResult opIntOneOptionalDict(
-      Optional<java.util.Map<Integer, OneOptional>> p1, Current current) {
-    return new Initial.OpIntOneOptionalDictResult(p1, p1);
-  }
-
-  @Override
   public void opClassAndUnknownOptional(A p, Current current) {}
 
   @Override

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -62,7 +62,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -93,8 +92,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -255,8 +255,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -52,7 +52,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["java:type:java.util.ArrayList<FixedStruct>"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 ["java:serializable:test.Ice.optional.SerializableClass"] sequence<byte> Serializable;
@@ -88,7 +87,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -61,8 +61,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +92,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -254,7 +255,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -62,7 +62,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -93,8 +92,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -61,8 +61,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +92,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -255,7 +256,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -256,8 +256,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -52,7 +52,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["java:type:java.util.ArrayList<FixedStruct>"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 ["java:serializable:test.Ice.optional.SerializableClass"] sequence<byte> Serializable;
@@ -88,7 +87,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/js/test/Ice/optional/AMDInitialI.js
+++ b/js/test/Ice/optional/AMDInitialI.js
@@ -230,11 +230,6 @@
             return [p1, p1];
         }
 
-        opIntOneOptionalDict(p1, current)
-        {
-            return [p1, p1];
-        }
-
         opClassAndUnknownOptional(p, current)
         {
         }

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -110,8 +110,6 @@
             mo1.ivsd.set(5, mo1.vs);
             mo1.imipd = new Map();
             mo1.imipd.set(5, communicator.stringToProxy("test"));
-            mo1.iood = new Map();
-            mo1.iood.set(5, new Test.OneOptional(15));
 
             mo1.bos = [false, true, false];
 
@@ -143,7 +141,6 @@
             test(mo5.ifsd.get(4).equals(new Test.FixedStruct(78)));
             test(mo5.ivsd.get(5).equals(new Test.VarStruct("hello")));
             test(mo5.imipd.get(5).equals(communicator.stringToProxy("test")));
-            test(mo5.iood.get(5).a == 15);
 
             test(ArrayUtil.equals(mo5.bos, [false, true, false]));
 
@@ -189,7 +186,6 @@
             test(mo7.ifsd.get(4).equals(new Test.FixedStruct(78)));
             test(mo7.ivsd === undefined);
             test(mo7.imipd === undefined);
-            test(mo7.iood.get(5).a == 15);
 
             test(ArrayUtil.equals(mo7.bos, [false, true, false]));
 

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -68,7 +68,6 @@
             test(mo4.ied === undefined);
             test(mo4.ifsd === undefined);
             test(mo4.ivsd === undefined);
-            test(mo4.iood === undefined);
             test(mo4.imipd === undefined);
 
             test(mo4.bos === undefined);
@@ -109,10 +108,10 @@
             mo1.ifsd.set(4, mo1.fs);
             mo1.ivsd = new Map();
             mo1.ivsd.set(5, mo1.vs);
-            mo1.iood = new Map();
-            mo1.iood.set(5, new Test.OneOptional(15));
             mo1.imipd = new Map();
             mo1.imipd.set(5, communicator.stringToProxy("test"));
+            mo1.iood = new Map();
+            mo1.iood.set(5, new Test.OneOptional(15));
 
             mo1.bos = [false, true, false];
 
@@ -143,8 +142,8 @@
             test(mo5.ied.get(4) == Test.MyEnum.MyEnumMember);
             test(mo5.ifsd.get(4).equals(new Test.FixedStruct(78)));
             test(mo5.ivsd.get(5).equals(new Test.VarStruct("hello")));
-            test(mo5.iood.get(5).a == 15);
             test(mo5.imipd.get(5).equals(communicator.stringToProxy("test")));
+            test(mo5.iood.get(5).a == 15);
 
             test(ArrayUtil.equals(mo5.bos, [false, true, false]));
 
@@ -161,7 +160,6 @@
             mo6.shs = mo5.shs;
             mo6.fss = mo5.fss;
             mo6.ifsd = mo5.ifsd;
-            mo6.iood = mo5.iood;
             mo6.bos = mo5.bos;
 
             const mo7 = await initial.pingPong(mo6);
@@ -190,8 +188,8 @@
             test(mo7.ied === undefined);
             test(mo7.ifsd.get(4).equals(new Test.FixedStruct(78)));
             test(mo7.ivsd === undefined);
-            test(mo7.iood.get(5).a == 15);
             test(mo7.imipd === undefined);
+            test(mo7.iood.get(5).a == 15);
 
             test(ArrayUtil.equals(mo7.bos, [false, true, false]));
 
@@ -242,7 +240,6 @@
             test(mo9.ied.get(4) == Test.MyEnum.MyEnumMember);
             test(mo9.ifsd === undefined);
             test(mo9.ivsd.get(5).equals(new Test.VarStruct("hello")));
-            test(mo9.iood === undefined);
             test(mo9.imipd.get(5).equals(communicator.stringToProxy("test")));
 
             test(mo9.bos === undefined);
@@ -626,14 +623,6 @@
             data.set("2", 2);
             [p1, p2] = await initial.opStringIntDict(data);
             test(Ice.MapUtil.equals(p1, p2));
-            [p1, p2] = await initial.opIntOneOptionalDict();
-            test(p1 === undefined);
-            test(p2 === undefined);
-            data = new Map();
-            data.set(1, new Test.OneOptional(58));
-            data.set(2, new Test.OneOptional(59));
-            [p1, p2] = await initial.opIntOneOptionalDict(data);
-            test(p1.get(1).a === 58 && p2.get(2).a === 59);
             out.writeLine("ok");
 
             out.write("testing exception optionals... ");

--- a/js/test/Ice/optional/Client.js
+++ b/js/test/Ice/optional/Client.js
@@ -63,7 +63,6 @@
             test(mo4.es === undefined);
             test(mo4.fss === undefined);
             test(mo4.vss === undefined);
-            test(mo4.oos === undefined);
             test(mo4.mips === undefined);
 
             test(mo4.ied === undefined);
@@ -102,7 +101,6 @@
             mo1.es = [Test.MyEnum.MyEnumMember, Test.MyEnum.MyEnumMember];
             mo1.fss = [mo1.fs];
             mo1.vss = [mo1.vs];
-            mo1.oos = [oo1];
             mo1.mips = [communicator.stringToProxy("test")];
 
             mo1.ied = new Map();
@@ -140,7 +138,6 @@
             test(mo5.es[0] == Test.MyEnum.MyEnumMember && mo5.es[1] == Test.MyEnum.MyEnumMember);
             test(mo5.fss[0].equals(new Test.FixedStruct(78)));
             test(mo5.vss[0].equals(new Test.VarStruct("hello")));
-            test(mo5.oos[0].a == 15);
             test(mo5.mips[0].equals(communicator.stringToProxy("test")));
 
             test(mo5.ied.get(4) == Test.MyEnum.MyEnumMember);
@@ -163,7 +160,6 @@
             mo6.fs = mo5.fs;
             mo6.shs = mo5.shs;
             mo6.fss = mo5.fss;
-            mo6.oos = mo5.oos;
             mo6.ifsd = mo5.ifsd;
             mo6.iood = mo5.iood;
             mo6.bos = mo5.bos;
@@ -189,7 +185,6 @@
             test(mo7.es === undefined);
             test(mo7.fss[0].equals(new Test.FixedStruct(78)));
             test(mo7.vss === undefined);
-            test(mo7.oos[0].a == 15);
             test(mo7.mips === undefined);
 
             test(mo7.ied === undefined);
@@ -242,7 +237,6 @@
             test(mo9.es[0] == Test.MyEnum.MyEnumMember && mo9.es[1] == Test.MyEnum.MyEnumMember);
             test(mo9.fss === undefined);
             test(mo9.vss[0].equals(new Test.VarStruct("hello")));
-            test(mo9.oos === undefined);
             test(mo9.mips[0].equals(communicator.stringToProxy("test")));
 
             test(mo9.ied.get(4) == Test.MyEnum.MyEnumMember);

--- a/js/test/Ice/optional/InitialI.js
+++ b/js/test/Ice/optional/InitialI.js
@@ -230,11 +230,6 @@
             return [p1, p1];
         }
 
-        opIntOneOptionalDict(p1, current)
-        {
-            return [p1, p1];
-        }
-
         opClassAndUnknownOptional(p, current)
         {
         }

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -60,8 +60,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -91,8 +91,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -253,8 +254,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -61,7 +61,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +91,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -87,7 +86,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -254,8 +254,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/js/test/typescript/Ice/optional/AMDInitialI.ts
+++ b/js/test/typescript/Ice/optional/AMDInitialI.ts
@@ -229,11 +229,6 @@ export class AMDInitialI extends Test.Initial
         return [p1, p1];
     }
 
-    opIntOneOptionalDict(p1:Test.IntOneOptionalDict, current:Ice.Current):[Test.IntOneOptionalDict, Test.IntOneOptionalDict]
-    {
-        return [p1, p1];
-    }
-
     opClassAndUnknownOptional(p:Test.A, current:Ice.Current):void
     {
     }

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -107,8 +107,6 @@ export class Client extends TestHelper
         mo1.ivsd.set(5, mo1.vs);
         mo1.imipd = new Map();
         mo1.imipd.set(5, Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
-        mo1.iood = new Map();
-        mo1.iood.set(5, new Test.OneOptional(15));
 
         mo1.bos = [false, true, false];
 
@@ -140,7 +138,6 @@ export class Client extends TestHelper
         test(mo5.ifsd.get(4).equals(new Test.FixedStruct(78)));
         test(mo5.ivsd.get(5).equals(new Test.VarStruct("hello")));
         test(mo5.imipd.get(5).equals(communicator.stringToProxy("test")));
-        test(mo5.iood.get(5).a == 15);
 
         test(ArrayUtil.equals(mo5.bos, [false, true, false]));
 
@@ -186,7 +183,6 @@ export class Client extends TestHelper
         test(mo7.ifsd.get(4).equals(new Test.FixedStruct(78)));
         test(mo7.ivsd === undefined);
         test(mo7.imipd === undefined);
-        test(mo7.iood.get(5).a == 15);
 
         test(ArrayUtil.equals(mo7.bos, [false, true, false]));
 

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -65,7 +65,6 @@ export class Client extends TestHelper
         test(mo4.ied === undefined);
         test(mo4.ifsd === undefined);
         test(mo4.ivsd === undefined);
-        test(mo4.iood === undefined);
         test(mo4.imipd === undefined);
 
         test(mo4.bos === undefined);
@@ -106,10 +105,10 @@ export class Client extends TestHelper
         mo1.ifsd.set(4, mo1.fs);
         mo1.ivsd = new Map();
         mo1.ivsd.set(5, mo1.vs);
-        mo1.iood = new Map();
-        mo1.iood.set(5, new Test.OneOptional(15));
         mo1.imipd = new Map();
         mo1.imipd.set(5, Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
+        mo1.iood = new Map();
+        mo1.iood.set(5, new Test.OneOptional(15));
 
         mo1.bos = [false, true, false];
 
@@ -140,8 +139,8 @@ export class Client extends TestHelper
         test(mo5.ied.get(4) == Test.MyEnum.MyEnumMember);
         test(mo5.ifsd.get(4).equals(new Test.FixedStruct(78)));
         test(mo5.ivsd.get(5).equals(new Test.VarStruct("hello")));
-        test(mo5.iood.get(5).a == 15);
         test(mo5.imipd.get(5).equals(communicator.stringToProxy("test")));
+        test(mo5.iood.get(5).a == 15);
 
         test(ArrayUtil.equals(mo5.bos, [false, true, false]));
 
@@ -158,7 +157,6 @@ export class Client extends TestHelper
         mo6.shs = mo5.shs;
         mo6.fss = mo5.fss;
         mo6.ifsd = mo5.ifsd;
-        mo6.iood = mo5.iood;
         mo6.bos = mo5.bos;
 
         const mo7 = await initial.pingPong(mo6) as Test.MultiOptional;
@@ -187,8 +185,8 @@ export class Client extends TestHelper
         test(mo7.ied === undefined);
         test(mo7.ifsd.get(4).equals(new Test.FixedStruct(78)));
         test(mo7.ivsd === undefined);
-        test(mo7.iood.get(5).a == 15);
         test(mo7.imipd === undefined);
+        test(mo7.iood.get(5).a == 15);
 
         test(ArrayUtil.equals(mo7.bos, [false, true, false]));
 
@@ -239,7 +237,6 @@ export class Client extends TestHelper
         test(mo9.ied.get(4) == Test.MyEnum.MyEnumMember);
         test(mo9.ifsd === undefined);
         test(mo9.ivsd.get(5).equals(new Test.VarStruct("hello")));
-        test(mo9.iood === undefined);
         test(mo9.imipd.get(5).equals(communicator.stringToProxy("test")));
 
         test(mo9.bos === undefined);
@@ -699,17 +696,6 @@ export class Client extends TestHelper
             data.set("2", 2);
             [p1, p2] = await initial.opStringIntDict(data);
             test(Ice.MapUtil.equals(p1, p2));
-        }
-
-        {
-            let [p1, p2] = await initial.opIntOneOptionalDict();
-            test(p1 === undefined);
-            test(p2 === undefined);
-            let data = new Test.IntOneOptionalDict();
-            data.set(1, new Test.OneOptional(58));
-            data.set(2, new Test.OneOptional(59));
-            [p1, p2] = await initial.opIntOneOptionalDict(data);
-            test(p1.get(1).a === 58 && p2.get(2).a === 59);
         }
         out.writeLine("ok");
 

--- a/js/test/typescript/Ice/optional/Client.ts
+++ b/js/test/typescript/Ice/optional/Client.ts
@@ -60,7 +60,6 @@ export class Client extends TestHelper
         test(mo4.es === undefined);
         test(mo4.fss === undefined);
         test(mo4.vss === undefined);
-        test(mo4.oos === undefined);
         test(mo4.mips === undefined);
 
         test(mo4.ied === undefined);
@@ -99,7 +98,6 @@ export class Client extends TestHelper
         mo1.es = [Test.MyEnum.MyEnumMember, Test.MyEnum.MyEnumMember];
         mo1.fss = [mo1.fs];
         mo1.vss = [mo1.vs];
-        mo1.oos = [oo1];
         mo1.mips = [Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))];
 
         mo1.ied = new Map();
@@ -137,7 +135,6 @@ export class Client extends TestHelper
         test(mo5.es[0] == Test.MyEnum.MyEnumMember && mo5.es[1] == Test.MyEnum.MyEnumMember);
         test(mo5.fss[0].equals(new Test.FixedStruct(78)));
         test(mo5.vss[0].equals(new Test.VarStruct("hello")));
-        test(mo5.oos[0].a == 15);
         test(mo5.mips[0].equals(communicator.stringToProxy("test")));
 
         test(mo5.ied.get(4) == Test.MyEnum.MyEnumMember);
@@ -160,7 +157,6 @@ export class Client extends TestHelper
         mo6.fs = mo5.fs;
         mo6.shs = mo5.shs;
         mo6.fss = mo5.fss;
-        mo6.oos = mo5.oos;
         mo6.ifsd = mo5.ifsd;
         mo6.iood = mo5.iood;
         mo6.bos = mo5.bos;
@@ -186,7 +182,6 @@ export class Client extends TestHelper
         test(mo7.es === undefined);
         test(mo7.fss[0].equals(new Test.FixedStruct(78)));
         test(mo7.vss === undefined);
-        test(mo7.oos[0].a == 15);
         test(mo7.mips === undefined);
 
         test(mo7.ied === undefined);
@@ -239,7 +234,6 @@ export class Client extends TestHelper
         test(mo9.es[0] == Test.MyEnum.MyEnumMember && mo9.es[1] == Test.MyEnum.MyEnumMember);
         test(mo9.fss === undefined);
         test(mo9.vss[0].equals(new Test.VarStruct("hello")));
-        test(mo9.oos === undefined);
         test(mo9.mips[0].equals(communicator.stringToProxy("test")));
 
         test(mo9.ied.get(4) == Test.MyEnum.MyEnumMember);

--- a/js/test/typescript/Ice/optional/InitialI.ts
+++ b/js/test/typescript/Ice/optional/InitialI.ts
@@ -229,11 +229,6 @@ export class InitialI extends Test.Initial
         return [p1, p1];
     }
 
-    opIntOneOptionalDict(p1:Test.IntOneOptionalDict, current:Ice.Current):[Test.IntOneOptionalDict, Test.IntOneOptionalDict]
-    {
-        return [p1, p1];
-    }
-
     opClassAndUnknownOptional(p:Test.A, current:Ice.Current):void
     {
     }

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -53,7 +53,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -89,7 +88,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -256,8 +256,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -63,7 +63,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -94,8 +93,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -62,8 +62,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -93,8 +93,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -255,8 +256,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -44,7 +44,6 @@ classdef AllTests
             assert(mo1.es == Ice.Unset);
             assert(mo1.fss == Ice.Unset);
             assert(mo1.vss == Ice.Unset);
-            assert(mo1.oos == Ice.Unset);
             assert(mo1.mips == Ice.Unset);
 
             assert(mo1.ied == Ice.Unset);
@@ -64,8 +63,6 @@ classdef AllTests
             sid('test') = 10;
             ied = containers.Map('KeyType', 'int32', 'ValueType', 'any');
             ied(4) = MyEnum.MyEnumMember;
-            oos = {};
-            oos{1} = oo1;
             ifsd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
             ifsd(4) = fs;
             ivsd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
@@ -78,7 +75,7 @@ classdef AllTests
                                      MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')), ...
                                      [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
-                                     [ fs ], [ vs ], oos, { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
+                                     [ fs ], [ vs ], { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
                                      ied, ifsd, ivsd, iood, imipd, [false, true, false], []);
 
             assert(mo1.a == 15);
@@ -102,7 +99,6 @@ classdef AllTests
             assert(mo1.es(1) == MyEnum.MyEnumMember && mo1.es(2) == MyEnum.MyEnumMember);
             assert(isequal(mo1.fss(1), FixedStruct(78)));
             assert(isequal(mo1.vss(1), VarStruct('hello')));
-            assert(isequal(mo1.oos{1}, oo1));
             assert(mo1.mips{1} == communicator.stringToProxy('test'));
 
             assert(mo1.ied(4) == MyEnum.MyEnumMember);
@@ -153,7 +149,6 @@ classdef AllTests
             assert(mo4.es == Ice.Unset);
             assert(mo4.fss == Ice.Unset);
             assert(mo4.vss == Ice.Unset);
-            assert(mo4.oos == Ice.Unset);
             assert(mo4.mips == Ice.Unset);
 
             assert(mo4.ied == Ice.Unset);
@@ -185,7 +180,6 @@ classdef AllTests
             assert(mo5.es(1) == MyEnum.MyEnumMember && mo1.es(2) == MyEnum.MyEnumMember);
             assert(mo5.fss(1) == FixedStruct(78));
             assert(mo5.vss(1) == VarStruct('hello'));
-            assert(mo5.oos{1}.a == 15);
             assert(mo5.mips{1} == communicator.stringToProxy('test'));
 
             assert(mo5.ied(4) == MyEnum.MyEnumMember);
@@ -235,7 +229,6 @@ classdef AllTests
             assert(mo7.es == Ice.Unset);
             assert(mo7.fss(1) == FixedStruct(78));
             assert(mo7.vss == Ice.Unset);
-            assert(mo7.oos{1}.a == 15);
             assert(mo7.mips == Ice.Unset);
 
             assert(mo7.ied == Ice.Unset);
@@ -287,7 +280,6 @@ classdef AllTests
             assert(mo9.es(1) == MyEnum.MyEnumMember && mo1.es(2) == MyEnum.MyEnumMember);
             assert(mo9.fss == Ice.Unset);
             assert(mo9.vss(1) == VarStruct('hello'));
-            assert(mo9.oos == Ice.Unset);
             assert(mo9.mips{1} == communicator.stringToProxy('test'));
 
             assert(mo9.ied(4) == MyEnum.MyEnumMember);

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -196,7 +196,6 @@ classdef AllTests
             mo6.fs = mo5.fs;
             mo6.shs = mo5.shs;
             mo6.fss = mo5.fss;
-            mo6.oos = mo5.oos;
             mo6.ifsd = mo5.ifsd;
             mo6.bos = mo5.bos;
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -66,8 +66,6 @@ classdef AllTests
             ifsd(4) = fs;
             ivsd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
             ivsd(5) = vs;
-            iood = containers.Map('KeyType', 'int32', 'ValueType', 'any');
-            iood(5) = OneOptional(15);
             imipd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
             imipd(5) = MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test'));
             mo1 = MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', MyEnum.MyEnumMember, ...
@@ -75,7 +73,7 @@ classdef AllTests
                                      [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
                                      [ fs ], [ vs ], { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
-                                     ied, ifsd, ivsd, imipd, iood, [false, true, false], []);
+                                     ied, ifsd, ivsd, imipd, [false, true, false], []);
 
             assert(mo1.a == 15);
             assert(mo1.b == true);
@@ -104,7 +102,6 @@ classdef AllTests
             assert(isequal(mo1.ifsd(4), FixedStruct(78)));
             assert(isequal(mo1.ivsd(5), VarStruct('hello')));
             assert(mo1.imipd(5) == communicator.stringToProxy('test'));
-            assert(mo1.iood(5).a == 15);
 
             assert(isequal(mo1.bos, [false, true, false]));
 
@@ -154,7 +151,6 @@ classdef AllTests
             assert(mo4.ifsd == Ice.Unset);
             assert(mo4.ivsd == Ice.Unset);
             assert(mo4.imipd == Ice.Unset);
-            assert(mo4.iood == Ice.Unset);
 
             assert(mo4.bos == Ice.Unset);
 
@@ -185,7 +181,6 @@ classdef AllTests
             assert(mo5.ifsd(4) == FixedStruct(78));
             assert(mo5.ivsd(5) == VarStruct('hello'));
             assert(mo5.imipd(5) == communicator.stringToProxy('test'));
-            assert(mo5.iood(5).a == 15);
 
             assert(isequal(mo5.bos, mo1.bos));
 
@@ -233,7 +228,6 @@ classdef AllTests
             assert(mo7.ifsd(4) == FixedStruct(78));
             assert(mo7.ivsd == Ice.Unset);
             assert(mo7.imipd == Ice.Unset);
-            assert(mo7.iood(5).a == 15);
 
             assert(isequal(mo7.bos, [false, true, false]));
 
@@ -284,7 +278,6 @@ classdef AllTests
             assert(mo9.ifsd == Ice.Unset);
             assert(mo9.ivsd(5) == VarStruct('hello'));
             assert(mo9.imipd(5) == communicator.stringToProxy('test'));
-            assert(mo9.iood == Ice.Unset);
 
             assert(mo9.bos == Ice.Unset);
 

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -49,7 +49,6 @@ classdef AllTests
             assert(mo1.ied == Ice.Unset);
             assert(mo1.ifsd == Ice.Unset);
             assert(mo1.ivsd == Ice.Unset);
-            assert(mo1.iood == Ice.Unset);
             assert(mo1.imipd == Ice.Unset);
 
             assert(mo1.bos == Ice.Unset);
@@ -76,7 +75,7 @@ classdef AllTests
                                      [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
                                      [ fs ], [ vs ], { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
-                                     ied, ifsd, ivsd, iood, imipd, [false, true, false], []);
+                                     ied, ifsd, ivsd, imipd, iood, [false, true, false], []);
 
             assert(mo1.a == 15);
             assert(mo1.b == true);
@@ -104,8 +103,8 @@ classdef AllTests
             assert(mo1.ied(4) == MyEnum.MyEnumMember);
             assert(isequal(mo1.ifsd(4), FixedStruct(78)));
             assert(isequal(mo1.ivsd(5), VarStruct('hello')));
-            assert(mo1.iood(5).a == 15);
             assert(mo1.imipd(5) == communicator.stringToProxy('test'));
+            assert(mo1.iood(5).a == 15);
 
             assert(isequal(mo1.bos, [false, true, false]));
 
@@ -154,8 +153,8 @@ classdef AllTests
             assert(mo4.ied == Ice.Unset);
             assert(mo4.ifsd == Ice.Unset);
             assert(mo4.ivsd == Ice.Unset);
-            assert(mo4.iood == Ice.Unset);
             assert(mo4.imipd == Ice.Unset);
+            assert(mo4.iood == Ice.Unset);
 
             assert(mo4.bos == Ice.Unset);
 
@@ -185,8 +184,8 @@ classdef AllTests
             assert(mo5.ied(4) == MyEnum.MyEnumMember);
             assert(mo5.ifsd(4) == FixedStruct(78));
             assert(mo5.ivsd(5) == VarStruct('hello'));
-            assert(mo5.iood(5).a == 15);
             assert(mo5.imipd(5) == communicator.stringToProxy('test'));
+            assert(mo5.iood(5).a == 15);
 
             assert(isequal(mo5.bos, mo1.bos));
 
@@ -204,7 +203,6 @@ classdef AllTests
             mo6.fss = mo5.fss;
             mo6.oos = mo5.oos;
             mo6.ifsd = mo5.ifsd;
-            mo6.iood = mo5.iood;
             mo6.bos = mo5.bos;
 
             mo7 = initial.pingPong(mo6);
@@ -234,8 +232,8 @@ classdef AllTests
             assert(mo7.ied == Ice.Unset);
             assert(mo7.ifsd(4) == FixedStruct(78));
             assert(mo7.ivsd == Ice.Unset);
-            assert(mo7.iood(5).a == 15);
             assert(mo7.imipd == Ice.Unset);
+            assert(mo7.iood(5).a == 15);
 
             assert(isequal(mo7.bos, [false, true, false]));
 
@@ -285,8 +283,8 @@ classdef AllTests
             assert(mo9.ied(4) == MyEnum.MyEnumMember);
             assert(mo9.ifsd == Ice.Unset);
             assert(mo9.ivsd(5) == VarStruct('hello'));
-            assert(mo9.iood == Ice.Unset);
             assert(mo9.imipd(5) == communicator.stringToProxy('test'));
+            assert(mo9.iood == Ice.Unset);
 
             assert(mo9.bos == Ice.Unset);
 
@@ -701,17 +699,6 @@ classdef AllTests
             f = initial.opStringIntDictAsync(p1);
             [p2, p3] = f.fetchOutputs();
             assert(isequal(p2, p1) && isequal(p3, p1));
-
-            [p2, p3] = initial.opIntOneOptionalDict(Ice.Unset);
-            assert(p2 == Ice.Unset && p3 == Ice.Unset);
-            p1 = containers.Map('KeyType', 'int32', 'ValueType', 'any');
-            p1(1) = OneOptional(58);
-            p1(2) = OneOptional(59);
-            [p2, p3] = initial.opIntOneOptionalDict(p1);
-            assert(p2(1).a == 58 && p3(1).a == 58);
-            f = initial.opIntOneOptionalDictAsync(p1);
-            [p2, p3] = f.fetchOutputs();
-            assert(p2(1).a == 58 && p3(1).a == 58);
 
             fprintf('ok\n');
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -60,8 +60,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -91,8 +91,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -261,8 +262,7 @@ interface Initial
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
                                                                 out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                                          out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -248,9 +248,11 @@ interface Initial
     optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
                                                                     out optional(3) FixedStructList p3);
 
-    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
+    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
+                                                              out optional(3) VarStructSeq p3);
 
-    optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
+    optional(1) Serializable opSerializable(optional(2) Serializable p1,
+                                                              out optional(3) Serializable p3);
 
     optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -251,18 +251,14 @@ interface Initial
     optional(1) FixedStructList opFixedStructList(optional(2) FixedStructList p1,
                                                                     out optional(3) FixedStructList p3);
 
-    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1,
-                                                              out optional(3) VarStructSeq p3);
+    optional(1) VarStructSeq opVarStructSeq(optional(2) VarStructSeq p1, out optional(3) VarStructSeq p3);
 
-    optional(1) Serializable opSerializable(optional(2) Serializable p1,
-                                                              out optional(3) Serializable p3);
+    optional(1) Serializable opSerializable(optional(2) Serializable p1, out optional(3) Serializable p3);
 
     optional(1) IntIntDict opIntIntDict(optional(2) IntIntDict p1, out optional(3) IntIntDict p3);
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1,
                                                                 out optional(3) StringIntDict p3);
-
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -61,7 +61,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +91,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -87,7 +86,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -66,12 +66,11 @@ function allTests($helper)
     $fs = new Test\FixedStruct(78);
     $vs = new Test\VarStruct("hello");
     $prx = $communicator->stringToProxy("test")->ice_uncheckedCast("::Test::MyInterface");
-    $oo15 = new Test\OneOptional(15);
     $mo1 = new Test\MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', Test\MyEnum::MyEnumMember,
                       $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
                       $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs),
                       array($prx), array(4=>Test\MyEnum::MyEnumMember), array(4=>$fs), array(5=>$vs),
-                      array(5=>$prx), array(5=>$oo15), array(false, true, false));
+                      array(5=>$prx), array(false, true, false));
 
     test($mo1->a == 15);
     test($mo1->b == true);

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -100,7 +100,6 @@ function allTests($helper)
     test($mo1->ifsd[4] == $fs);
     test($mo1->ivsd[5] == $vs);
     test($mo1->imipd[5] == $prx);
-    test($mo1->iood[5]->a == 15);
 
     test($mo1->bos == array(false, true, false));
 
@@ -181,7 +180,6 @@ function allTests($helper)
     test($mo5->ifsd[4] == $fs);
     test($mo5->ivsd[5] == $vs);
     test($mo5->imipd[5] == $prx);
-    test($mo5->iood[5]->a == 15);
 
     test($mo5->bos == $mo1->bos);
 
@@ -228,7 +226,6 @@ function allTests($helper)
     test($mo7->ifsd[4] == $fs);
     test($mo7->ivsd == Ice\None);
     test($mo7->imipd == Ice\None);
-    test($mo7->iood[5]->a == 15);
 
     test($mo7->bos == array(false, true, false));
 

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -58,7 +58,6 @@ function allTests($helper)
     test($mo1->ied == Ice\None);
     test($mo1->ifsd == Ice\None);
     test($mo1->ivsd == Ice\None);
-    test($mo1->iood == Ice\None);
     test($mo1->imipd == Ice\None);
 
     test($mo1->bos == Ice\None);
@@ -72,7 +71,7 @@ function allTests($helper)
                       $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
                       $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs),
                       array($prx), array(4=>Test\MyEnum::MyEnumMember), array(4=>$fs), array(5=>$vs),
-                      array(5=>$oo15), array(5=>$prx), array(false, true, false));
+                      array(5=>$prx), array(5=>$oo15), array(false, true, false));
 
     test($mo1->a == 15);
     test($mo1->b == true);
@@ -100,8 +99,8 @@ function allTests($helper)
     test($mo1->ied[4] == Test\MyEnum::MyEnumMember);
     test($mo1->ifsd[4] == $fs);
     test($mo1->ivsd[5] == $vs);
-    test($mo1->iood[5]->a == 15);
     test($mo1->imipd[5] == $prx);
+    test($mo1->iood[5]->a == 15);
 
     test($mo1->bos == array(false, true, false));
 
@@ -151,7 +150,6 @@ function allTests($helper)
     test($mo4->ied == Ice\None);
     test($mo4->ifsd == Ice\None);
     test($mo4->ivsd == Ice\None);
-    test($mo4->iood == Ice\None);
     test($mo4->imipd == Ice\None);
 
     test($mo4->bos == Ice\None);
@@ -182,8 +180,8 @@ function allTests($helper)
     test($mo5->ied[4] == Test\MyEnum::MyEnumMember);
     test($mo5->ifsd[4] == $fs);
     test($mo5->ivsd[5] == $vs);
-    test($mo5->iood[5]->a == 15);
     test($mo5->imipd[5] == $prx);
+    test($mo5->iood[5]->a == 15);
 
     test($mo5->bos == $mo1->bos);
 
@@ -200,7 +198,6 @@ function allTests($helper)
     $mo6->shs = $mo5->shs;
     $mo6->fss = $mo5->fss;
     $mo6->ifsd = $mo5->ifsd;
-    $mo6->iood = $mo5->iood;
     $mo6->bos = $mo5->bos;
 
     $mo7 = $initial->pingPong($mo6);
@@ -230,8 +227,8 @@ function allTests($helper)
     test($mo7->ied == Ice\None);
     test($mo7->ifsd[4] == $fs);
     test($mo7->ivsd == Ice\None);
-    test($mo7->iood[5]->a == 15);
     test($mo7->imipd == Ice\None);
+    test($mo7->iood[5]->a == 15);
 
     test($mo7->bos == array(false, true, false));
 
@@ -281,7 +278,6 @@ function allTests($helper)
     test($mo9->ied[4] == Test\MyEnum::MyEnumMember);
     test($mo9->ifsd == Ice\None);
     test($mo9->ivsd[5] == $vs);
-    test($mo9->iood == Ice\None);
     test($mo9->imipd[5] == $prx);
 
     test($mo9->bos == Ice\None);
@@ -619,12 +615,6 @@ function allTests($helper)
     $p1 = array("1"=>2, "2"=>3);
     $p3 = $initial->opStringIntDict($p1, $p2);
     test($p2 == $p1 && $p3 == $p1);
-
-    $p3 = $initial->opIntOneOptionalDict(Ice\None, $p2);
-    test($p2 == Ice\None && $p3 == Ice\None);
-    $p1 = array(1=>new Test\OneOptional(58), 2=>new Test\OneOptional(59));
-    $p3 = $initial->opIntOneOptionalDict($p1, $p2);
-    test($p2[1]->a == 58 && $p3[1]->a == 58);
 
     echo "ok\n";
 

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -53,7 +53,6 @@ function allTests($helper)
     test($mo1->es == Ice\None);
     test($mo1->fss == Ice\None);
     test($mo1->vss == Ice\None);
-    test($mo1->oos == Ice\None);
     test($mo1->mips == Ice\None);
 
     test($mo1->ied == Ice\None);
@@ -71,7 +70,7 @@ function allTests($helper)
     $oo15 = new Test\OneOptional(15);
     $mo1 = new Test\MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', Test\MyEnum::MyEnumMember,
                       $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
-                      $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs), array($oo1),
+                      $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs),
                       array($prx), array(4=>Test\MyEnum::MyEnumMember), array(4=>$fs), array(5=>$vs),
                       array(5=>$oo15), array(5=>$prx), array(false, true, false));
 
@@ -96,7 +95,6 @@ function allTests($helper)
     test($mo1->es[0] == Test\MyEnum::MyEnumMember && $mo1->es[1] == Test\MyEnum::MyEnumMember);
     test($mo1->fss[0] == $fs);
     test($mo1->vss[0] == $vs);
-    test($mo1->oos[0] == $oo1);
     test($mo1->mips[0] == $prx);
 
     test($mo1->ied[4] == Test\MyEnum::MyEnumMember);
@@ -148,7 +146,6 @@ function allTests($helper)
     test($mo4->es == Ice\None);
     test($mo4->fss == Ice\None);
     test($mo4->vss == Ice\None);
-    test($mo4->oos == Ice\None);
     test($mo4->mips == Ice\None);
 
     test($mo4->ied == Ice\None);
@@ -180,7 +177,6 @@ function allTests($helper)
     test($mo5->es[0] == Test\MyEnum::MyEnumMember && $mo1->es[1] == Test\MyEnum::MyEnumMember);
     test($mo5->fss[0] == $fs);
     test($mo5->vss[0] == $vs);
-    test($mo5->oos[0]->a == 15);
     test($mo5->mips[0] == $prx);
 
     test($mo5->ied[4] == Test\MyEnum::MyEnumMember);
@@ -203,7 +199,6 @@ function allTests($helper)
     $mo6->fs = $mo5->fs;
     $mo6->shs = $mo5->shs;
     $mo6->fss = $mo5->fss;
-    $mo6->oos = $mo5->oos;
     $mo6->ifsd = $mo5->ifsd;
     $mo6->iood = $mo5->iood;
     $mo6->bos = $mo5->bos;
@@ -230,7 +225,6 @@ function allTests($helper)
     test($mo7->es == Ice\None);
     test($mo7->fss[0] == $fs);
     test($mo7->vss == Ice\None);
-    test($mo7->oos[0]->a == 15);
     test($mo7->mips == Ice\None);
 
     test($mo7->ied == Ice\None);
@@ -282,7 +276,6 @@ function allTests($helper)
     test($mo9->es[0] == Test\MyEnum::MyEnumMember && $mo1->es[1] == Test\MyEnum::MyEnumMember);
     test($mo9->fss == Ice\None);
     test($mo9->vss[0] == $vs);
-    test($mo9->oos == Ice\None);
     test($mo9->mips[0] == $prx);
 
     test($mo9->ied[4] == Test\MyEnum::MyEnumMember);

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -60,8 +60,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -91,8 +91,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -253,8 +254,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -61,7 +61,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +91,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -87,7 +86,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -254,8 +254,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -97,7 +97,6 @@ def allTests(helper, communicator):
         {4: fs},
         {5: vs},
         {5: Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))},
-        {5: Test.OneOptional(15)},
         [False, True, False],
     )
 

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -130,7 +130,6 @@ def allTests(helper, communicator):
     test(mo1.ifsd[4] == Test.FixedStruct(78))
     test(mo1.ivsd[5] == Test.VarStruct("hello"))
     test(mo1.imipd[5] == communicator.stringToProxy("test"))
-    test(mo1.iood[5].a == 15)
 
     test(mo1.bos == [False, True, False])
 
@@ -213,7 +212,6 @@ def allTests(helper, communicator):
     test(mo5.ifsd[4] == Test.FixedStruct(78))
     test(mo5.ivsd[5] == Test.VarStruct("hello"))
     test(mo5.imipd[5] == communicator.stringToProxy("test"))
-    test(mo5.iood[5].a == 15)
 
     test(mo5.bos == mo1.bos)
 
@@ -260,7 +258,6 @@ def allTests(helper, communicator):
     test(mo7.ifsd[4] == Test.FixedStruct(78))
     test(mo7.ivsd is Ice.Unset)
     test(mo7.imipd is Ice.Unset)
-    test(mo7.iood[5].a == 15)
 
     test(mo7.bos == [False, True, False])
 
@@ -313,7 +310,6 @@ def allTests(helper, communicator):
     test(mo9.ifsd is Ice.Unset)
     test(mo9.ivsd[5] == Test.VarStruct("hello"))
     test(mo9.imipd[5] == communicator.stringToProxy("test"))
-    test(mo9.iood is Ice.Unset)
 
     test(mo9.bos is Ice.Unset)
 

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -59,7 +59,6 @@ def allTests(helper, communicator):
     test(mo1.es is Ice.Unset)
     test(mo1.fss is Ice.Unset)
     test(mo1.vss is Ice.Unset)
-    test(mo1.oos is Ice.Unset)
     test(mo1.mips is Ice.Unset)
 
     test(mo1.ied is Ice.Unset)
@@ -94,7 +93,6 @@ def allTests(helper, communicator):
         [Test.MyEnum.MyEnumMember, Test.MyEnum.MyEnumMember],
         [fs],
         [vs],
-        [oo1],
         [Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))],
         {4: Test.MyEnum.MyEnumMember},
         {4: fs},
@@ -127,7 +125,6 @@ def allTests(helper, communicator):
     )
     test(mo1.fss[0] == Test.FixedStruct(78))
     test(mo1.vss[0] == Test.VarStruct("hello"))
-    test(mo1.oos[0] == oo1)
     test(mo1.mips[0] == communicator.stringToProxy("test"))
 
     test(mo1.ied[4] == Test.MyEnum.MyEnumMember)
@@ -179,7 +176,6 @@ def allTests(helper, communicator):
     test(mo4.es is Ice.Unset)
     test(mo4.fss is Ice.Unset)
     test(mo4.vss is Ice.Unset)
-    test(mo4.oos is Ice.Unset)
     test(mo4.mips is Ice.Unset)
 
     test(mo4.ied is Ice.Unset)
@@ -213,7 +209,6 @@ def allTests(helper, communicator):
     )
     test(mo5.fss[0] == Test.FixedStruct(78))
     test(mo5.vss[0] == Test.VarStruct("hello"))
-    test(mo5.oos[0].a == 15)
     test(mo5.mips[0] == communicator.stringToProxy("test"))
 
     test(mo5.ied[4] == Test.MyEnum.MyEnumMember)
@@ -236,7 +231,6 @@ def allTests(helper, communicator):
     mo6.fs = mo5.fs
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
-    mo6.oos = mo5.oos
     mo6.ifsd = mo5.ifsd
     mo6.iood = mo5.iood
     mo6.bos = mo5.bos
@@ -263,7 +257,6 @@ def allTests(helper, communicator):
     test(mo7.es is Ice.Unset)
     test(mo7.fss[0] == Test.FixedStruct(78))
     test(mo7.vss is Ice.Unset)
-    test(mo7.oos[0].a == 15)
     test(mo7.mips is Ice.Unset)
 
     test(mo7.ied is Ice.Unset)
@@ -317,7 +310,6 @@ def allTests(helper, communicator):
     )
     test(mo9.fss is Ice.Unset)
     test(mo9.vss[0] == Test.VarStruct("hello"))
-    test(mo9.oos is Ice.Unset)
     test(mo9.mips[0] == communicator.stringToProxy("test"))
 
     test(mo9.ied[4] == Test.MyEnum.MyEnumMember)

--- a/python/test/Ice/optional/AllTests.py
+++ b/python/test/Ice/optional/AllTests.py
@@ -64,7 +64,6 @@ def allTests(helper, communicator):
     test(mo1.ied is Ice.Unset)
     test(mo1.ifsd is Ice.Unset)
     test(mo1.ivsd is Ice.Unset)
-    test(mo1.iood is Ice.Unset)
     test(mo1.imipd is Ice.Unset)
 
     test(mo1.bos is Ice.Unset)
@@ -97,8 +96,8 @@ def allTests(helper, communicator):
         {4: Test.MyEnum.MyEnumMember},
         {4: fs},
         {5: vs},
-        {5: Test.OneOptional(15)},
         {5: Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))},
+        {5: Test.OneOptional(15)},
         [False, True, False],
     )
 
@@ -130,8 +129,8 @@ def allTests(helper, communicator):
     test(mo1.ied[4] == Test.MyEnum.MyEnumMember)
     test(mo1.ifsd[4] == Test.FixedStruct(78))
     test(mo1.ivsd[5] == Test.VarStruct("hello"))
-    test(mo1.iood[5].a == 15)
     test(mo1.imipd[5] == communicator.stringToProxy("test"))
+    test(mo1.iood[5].a == 15)
 
     test(mo1.bos == [False, True, False])
 
@@ -181,7 +180,6 @@ def allTests(helper, communicator):
     test(mo4.ied is Ice.Unset)
     test(mo4.ifsd is Ice.Unset)
     test(mo4.ivsd is Ice.Unset)
-    test(mo4.iood is Ice.Unset)
     test(mo4.imipd is Ice.Unset)
 
     test(mo4.bos is Ice.Unset)
@@ -214,8 +212,8 @@ def allTests(helper, communicator):
     test(mo5.ied[4] == Test.MyEnum.MyEnumMember)
     test(mo5.ifsd[4] == Test.FixedStruct(78))
     test(mo5.ivsd[5] == Test.VarStruct("hello"))
-    test(mo5.iood[5].a == 15)
     test(mo5.imipd[5] == communicator.stringToProxy("test"))
+    test(mo5.iood[5].a == 15)
 
     test(mo5.bos == mo1.bos)
 
@@ -232,7 +230,6 @@ def allTests(helper, communicator):
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
     mo6.ifsd = mo5.ifsd
-    mo6.iood = mo5.iood
     mo6.bos = mo5.bos
 
     mo7 = initial.pingPong(mo6)
@@ -262,8 +259,8 @@ def allTests(helper, communicator):
     test(mo7.ied is Ice.Unset)
     test(mo7.ifsd[4] == Test.FixedStruct(78))
     test(mo7.ivsd is Ice.Unset)
-    test(mo7.iood[5].a == 15)
     test(mo7.imipd is Ice.Unset)
+    test(mo7.iood[5].a == 15)
 
     test(mo7.bos == [False, True, False])
 
@@ -315,8 +312,8 @@ def allTests(helper, communicator):
     test(mo9.ied[4] == Test.MyEnum.MyEnumMember)
     test(mo9.ifsd is Ice.Unset)
     test(mo9.ivsd[5] == Test.VarStruct("hello"))
-    test(mo9.iood is Ice.Unset)
     test(mo9.imipd[5] == communicator.stringToProxy("test"))
+    test(mo9.iood is Ice.Unset)
 
     test(mo9.bos is Ice.Unset)
 
@@ -707,15 +704,6 @@ def allTests(helper, communicator):
     f = initial.opStringIntDictAsync(p1)
     (p2, p3) = f.result()
     test(p2 == p1 and p3 == p1)
-
-    (p2, p3) = initial.opIntOneOptionalDict(Ice.Unset)
-    test(p2 is Ice.Unset and p3 is Ice.Unset)
-    p1 = {1: Test.OneOptional(58), 2: Test.OneOptional(59)}
-    (p2, p3) = initial.opIntOneOptionalDict(p1)
-    test(p2[1].a == 58 and p3[1].a == 58)
-    f = initial.opIntOneOptionalDictAsync(p1)
-    (p2, p3) = f.result()
-    test(p2[1].a == 58 and p3[1].a == 58)
 
     try:
         (p1, p2, p3) = initial.opRequiredAfterOptional(1, 2, 3)

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -121,9 +121,6 @@ class InitialI(Test.Initial):
     def opStringIntDict(self, p1, current=None):
         return (p1, p1)
 
-    def opIntOneOptionalDict(self, p1, current=None):
-        return (p1, p1)
-
     def opClassAndUnknownOptional(self, p, current=None):
         pass
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -127,9 +127,6 @@ class InitialI(Test.Initial):
     def opStringIntDict(self, p1, current=None):
         return Ice.Future.completed((p1, p1))
 
-    def opIntOneOptionalDict(self, p1, current=None):
-        return Ice.Future.completed((p1, p1))
-
     def opClassAndUnknownOptional(self, p, current=None):
         return Ice.Future.completed(None)
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -60,8 +60,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -91,8 +91,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -253,8 +254,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -61,7 +61,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +91,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -254,8 +254,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     void opRequiredAfterOptional(int p1, optional(1) int p2, int p3, out int p4, out optional(2) int p5, out int p6);

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructSeq;
 sequence<FixedStruct> FixedStructSeq;
 ["python:seq:tuple"] sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -87,7 +86,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -97,7 +97,6 @@ def allTests(helper, communicator)
     test(mo1.ifsd[4] == Test::FixedStruct.new(78))
     test(mo1.ivsd[5] == Test::VarStruct.new("hello"))
     test(mo1.imipd[5] == communicator.stringToProxy("test"))
-    test(mo1.iood[5].a == 15)
 
     test(mo1.bos == [false, true, false])
 
@@ -178,7 +177,6 @@ def allTests(helper, communicator)
     test(mo5.ifsd[4] == Test::FixedStruct.new(78))
     test(mo5.ivsd[5] == Test::VarStruct.new("hello"))
     test(mo5.imipd[5] == communicator.stringToProxy("test"))
-    test(mo5.iood[5].a == 15)
 
     test(mo5.bos == mo1.bos)
 
@@ -225,7 +223,6 @@ def allTests(helper, communicator)
     test(mo7.ifsd[4] == Test::FixedStruct.new(78))
     test(mo7.ivsd == Ice::Unset)
     test(mo7.imipd == Ice::Unset)
-    test(mo7.iood[5].a == 15)
 
     test(mo7.bos == [false, true, false])
 
@@ -276,7 +273,6 @@ def allTests(helper, communicator)
     test(mo9.ifsd == Ice::Unset)
     test(mo9.ivsd[5] == Test::VarStruct.new("hello"))
     test(mo9.imipd[5] == communicator.stringToProxy("test"))
-    test(mo9.iood == Ice::Unset)
 
     test(mo9.bos == Ice::Unset)
 

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -49,7 +49,6 @@ def allTests(helper, communicator)
     test(mo1.es == Ice::Unset)
     test(mo1.fss == Ice::Unset)
     test(mo1.vss == Ice::Unset)
-    test(mo1.oos == Ice::Unset)
     test(mo1.mips == Ice::Unset)
 
     test(mo1.ied == Ice::Unset)
@@ -66,8 +65,7 @@ def allTests(helper, communicator)
     mo1 = Test::MultiOptional.new(15, true, 19, 78, 99, 5.5, 1.0, "test", Test::MyEnum::MyEnumMember, \
                                   Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")), \
                                   [5], ["test", "test2"], {4=>3}, {"test"=>10}, fs, vs, [1], \
-                                  [Test::MyEnum::MyEnumMember, Test::MyEnum::MyEnumMember], \
-                                  [ fs ], [ vs ], [ oo1 ], \
+                                  [Test::MyEnum::MyEnumMember, Test::MyEnum::MyEnumMember], [ fs ], [ vs ], \
                                   [ Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")) ], \
                                   {4=> Test::MyEnum::MyEnumMember}, {4=>fs}, {5=>vs}, {5=>Test::OneOptional.new(15)}, \
                                   {5=> Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test"))}, \
@@ -94,7 +92,6 @@ def allTests(helper, communicator)
     test(mo1.es[0] == Test::MyEnum::MyEnumMember && mo1.es[1] == Test::MyEnum::MyEnumMember)
     test(mo1.fss[0] == Test::FixedStruct.new(78))
     test(mo1.vss[0] == Test::VarStruct.new("hello"))
-    test(mo1.oos[0] == oo1)
     test(mo1.mips[0] == communicator.stringToProxy("test"))
 
     test(mo1.ied[4] == Test::MyEnum::MyEnumMember)
@@ -146,7 +143,6 @@ def allTests(helper, communicator)
     test(mo4.es == Ice::Unset)
     test(mo4.fss == Ice::Unset)
     test(mo4.vss == Ice::Unset)
-    test(mo4.oos == Ice::Unset)
     test(mo4.mips == Ice::Unset)
 
     test(mo4.ied == Ice::Unset)
@@ -178,7 +174,6 @@ def allTests(helper, communicator)
     test(mo5.es[0] == Test::MyEnum::MyEnumMember && mo1.es[1] == Test::MyEnum::MyEnumMember)
     test(mo5.fss[0] == Test::FixedStruct.new(78))
     test(mo5.vss[0] == Test::VarStruct.new("hello"))
-    test(mo5.oos[0].a == 15)
     test(mo5.mips[0] == communicator.stringToProxy("test"))
 
     test(mo5.ied[4] == Test::MyEnum::MyEnumMember)
@@ -201,7 +196,6 @@ def allTests(helper, communicator)
     mo6.fs = mo5.fs
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
-    mo6.oos = mo5.oos
     mo6.ifsd = mo5.ifsd
     mo6.iood = mo5.iood
     mo6.bos = mo5.bos
@@ -228,7 +222,6 @@ def allTests(helper, communicator)
     test(mo7.es == Ice::Unset)
     test(mo7.fss[0] == Test::FixedStruct.new(78))
     test(mo7.vss == Ice::Unset)
-    test(mo7.oos[0].a == 15)
     test(mo7.mips == Ice::Unset)
 
     test(mo7.ied == Ice::Unset)
@@ -280,7 +273,6 @@ def allTests(helper, communicator)
     test(mo9.es[0] == Test::MyEnum::MyEnumMember && mo1.es[1] == Test::MyEnum::MyEnumMember)
     test(mo9.fss == Ice::Unset)
     test(mo9.vss[0] == Test::VarStruct.new("hello"))
-    test(mo9.oos == Ice::Unset)
     test(mo9.mips[0] == communicator.stringToProxy("test"))
 
     test(mo9.ied[4] == Test::MyEnum::MyEnumMember)

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -68,7 +68,7 @@ def allTests(helper, communicator)
                                   [ Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")) ], \
                                   {4=> Test::MyEnum::MyEnumMember}, {4=>fs}, {5=>vs}, \
                                   {5=> Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test"))}, \
-                                  {5=>Test::OneOptional.new(15)}, [false, true, false])
+                                  [false, true, false])
 
     test(mo1.a == 15)
     test(mo1.b == true)

--- a/ruby/test/Ice/optional/AllTests.rb
+++ b/ruby/test/Ice/optional/AllTests.rb
@@ -54,7 +54,6 @@ def allTests(helper, communicator)
     test(mo1.ied == Ice::Unset)
     test(mo1.ifsd == Ice::Unset)
     test(mo1.ivsd == Ice::Unset)
-    test(mo1.iood == Ice::Unset)
     test(mo1.imipd == Ice::Unset)
 
     test(mo1.bos == Ice::Unset)
@@ -67,9 +66,9 @@ def allTests(helper, communicator)
                                   [5], ["test", "test2"], {4=>3}, {"test"=>10}, fs, vs, [1], \
                                   [Test::MyEnum::MyEnumMember, Test::MyEnum::MyEnumMember], [ fs ], [ vs ], \
                                   [ Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test")) ], \
-                                  {4=> Test::MyEnum::MyEnumMember}, {4=>fs}, {5=>vs}, {5=>Test::OneOptional.new(15)}, \
+                                  {4=> Test::MyEnum::MyEnumMember}, {4=>fs}, {5=>vs}, \
                                   {5=> Test::MyInterfacePrx::uncheckedCast(communicator.stringToProxy("test"))}, \
-                                  [false, true, false])
+                                  {5=>Test::OneOptional.new(15)}, [false, true, false])
 
     test(mo1.a == 15)
     test(mo1.b == true)
@@ -97,8 +96,8 @@ def allTests(helper, communicator)
     test(mo1.ied[4] == Test::MyEnum::MyEnumMember)
     test(mo1.ifsd[4] == Test::FixedStruct.new(78))
     test(mo1.ivsd[5] == Test::VarStruct.new("hello"))
-    test(mo1.iood[5].a == 15)
     test(mo1.imipd[5] == communicator.stringToProxy("test"))
+    test(mo1.iood[5].a == 15)
 
     test(mo1.bos == [false, true, false])
 
@@ -148,7 +147,6 @@ def allTests(helper, communicator)
     test(mo4.ied == Ice::Unset)
     test(mo4.ifsd == Ice::Unset)
     test(mo4.ivsd == Ice::Unset)
-    test(mo4.iood == Ice::Unset)
     test(mo4.imipd == Ice::Unset)
 
     test(mo4.bos == Ice::Unset)
@@ -179,8 +177,8 @@ def allTests(helper, communicator)
     test(mo5.ied[4] == Test::MyEnum::MyEnumMember)
     test(mo5.ifsd[4] == Test::FixedStruct.new(78))
     test(mo5.ivsd[5] == Test::VarStruct.new("hello"))
-    test(mo5.iood[5].a == 15)
     test(mo5.imipd[5] == communicator.stringToProxy("test"))
+    test(mo5.iood[5].a == 15)
 
     test(mo5.bos == mo1.bos)
 
@@ -197,7 +195,6 @@ def allTests(helper, communicator)
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
     mo6.ifsd = mo5.ifsd
-    mo6.iood = mo5.iood
     mo6.bos = mo5.bos
 
     mo7 = initial.pingPong(mo6)
@@ -227,8 +224,8 @@ def allTests(helper, communicator)
     test(mo7.ied == Ice::Unset)
     test(mo7.ifsd[4] == Test::FixedStruct.new(78))
     test(mo7.ivsd == Ice::Unset)
-    test(mo7.iood[5].a == 15)
     test(mo7.imipd == Ice::Unset)
+    test(mo7.iood[5].a == 15)
 
     test(mo7.bos == [false, true, false])
 
@@ -278,8 +275,8 @@ def allTests(helper, communicator)
     test(mo9.ied[4] == Test::MyEnum::MyEnumMember)
     test(mo9.ifsd == Ice::Unset)
     test(mo9.ivsd[5] == Test::VarStruct.new("hello"))
-    test(mo9.iood == Ice::Unset)
     test(mo9.imipd[5] == communicator.stringToProxy("test"))
+    test(mo9.iood == Ice::Unset)
 
     test(mo9.bos == Ice::Unset)
 
@@ -623,12 +620,6 @@ def allTests(helper, communicator)
     p1 = {"1"=>2, "2"=>3}
     p2, p3 = initial.opStringIntDict(p1)
     test(p2 == p1 && p3 == p1)
-
-    p2, p3 = initial.opIntOneOptionalDict(Ice::Unset)
-    test(p2 == Ice::Unset && p3 == Ice::Unset)
-    p1 = {1=> Test::OneOptional.new(58), 2=>Test::OneOptional.new(59)}
-    p2, p3 = initial.opIntOneOptionalDict(p1)
-    test(p2[1].a == 58 && p3[1].a == 58)
 
     puts "ok"
 

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -60,8 +60,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -91,8 +91,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -253,8 +254,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -61,7 +61,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -92,8 +91,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -51,7 +51,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -87,7 +86,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -254,8 +254,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -251,7 +251,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   mo1.imipd = try [
     5: uncheckedCast(prx: communicator.stringToProxy("test")!, type: MyInterfacePrx.self)
   ]
-  mo1.iood = [5: OneOptional(a: 15)]
 
   mo1.bos = [false, true, false]
 
@@ -283,7 +282,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   try test(mo1.ifsd![4] == FixedStruct(m: 78))
   try test(mo1.ivsd![5] == VarStruct(m: "hello"))
   try test(mo1.imipd![5]! == communicator.stringToProxy("test"))
-  try test(mo1.iood[5]!!.a! == 15)
 
   try test(mo1.bos == [false, true, false])
 
@@ -369,7 +367,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo5.ifsd![4] == FixedStruct(m: 78))
     try test(mo5.ivsd![5] == VarStruct(m: "hello"))
     try test(mo5.imipd![5]! == communicator.stringToProxy("test"))
-    try test(mo5.iood[5]!!.a == 15)
 
     try test(mo5.bos == [false, true, false])
 
@@ -436,7 +433,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo7.ifsd![4] == FixedStruct(m: 78))
     try test(mo7.ivsd == nil)
     try test(mo7.imipd == nil)
-    try test(mo7.iood[5]!!.a == 15)
 
     try test(mo7.bos == [false, true, false])
     try test(mo7.ser == nil)

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -241,7 +241,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   mo1.es = [.MyEnumMember, .MyEnumMember]
   mo1.fss = [fs]
   mo1.vss = [vs]
-  mo1.oos = [oo1]
   mo1.mips = try [
     uncheckedCast(prx: communicator.stringToProxy("test")!, type: MyInterfacePrx.self)
   ]
@@ -278,7 +277,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
 
   try test(mo1.fss![0] == FixedStruct(m: 78))
   try test(mo1.vss![0] == VarStruct(m: "hello"))
-  try test(mo1.oos![0] === oo1)
   try test(mo1.mips![0] == communicator.stringToProxy("test"))
 
   try test(mo1.ied![4] == .MyEnumMember)
@@ -327,7 +325,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo4.es == nil)
     try test(mo4.fss == nil)
     try test(mo4.vss == nil)
-    try test(mo4.oos == nil)
     try test(mo4.mips == nil)
 
     try test(mo4.ied == nil)
@@ -367,7 +364,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo5.es![0] == .MyEnumMember && mo1.es![1] == .MyEnumMember)
     try test(mo5.fss![0] == FixedStruct(m: 78))
     try test(mo5.vss![0] == VarStruct(m: "hello"))
-    try test(mo5.oos![0]!.a! == 15)
     try test(mo5.mips![0] == communicator.stringToProxy("test"))
 
     try test(mo5.ied![4] == .MyEnumMember)
@@ -389,7 +385,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     mo6.fs = mo5.fs
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
-    mo6.oos = mo5.oos
     mo6.ifsd = mo5.ifsd
     mo6.iood = mo5.iood
     mo6.bos = mo5.bos
@@ -437,7 +432,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo7.es == nil)
     try test(mo7.fss![0] == FixedStruct(m: 78))
     try test(mo7.vss == nil)
-    try test(mo7.oos![0]!.a == 15)
     try test(mo7.mips == nil)
 
     try test(mo7.ied == nil)
@@ -474,7 +468,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo9.es![0] == .MyEnumMember && mo9.es![1] == .MyEnumMember)
     try test(mo9.fss == nil)
     try test(mo9.vss![0] == VarStruct(m: "hello"))
-    try test(mo9.oos == nil)
     try test(mo9.mips![0] == communicator.stringToProxy("test"))
 
     try test(mo9.ied![4] == .MyEnumMember)

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -248,10 +248,10 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   mo1.ied = [4: .MyEnumMember]
   mo1.ifsd = [4: fs]
   mo1.ivsd = [5: vs]
-  mo1.iood = [5: OneOptional(a: 15)]
   mo1.imipd = try [
     5: uncheckedCast(prx: communicator.stringToProxy("test")!, type: MyInterfacePrx.self)
   ]
+  mo1.iood = [5: OneOptional(a: 15)]
 
   mo1.bos = [false, true, false]
 
@@ -282,8 +282,8 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
   try test(mo1.ied![4] == .MyEnumMember)
   try test(mo1.ifsd![4] == FixedStruct(m: 78))
   try test(mo1.ivsd![5] == VarStruct(m: "hello"))
-  try test(mo1.iood![5]!!.a! == 15)
   try test(mo1.imipd![5]! == communicator.stringToProxy("test"))
+  try test(mo1.iood[5]!!.a! == 15)
 
   try test(mo1.bos == [false, true, false])
 
@@ -330,7 +330,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo4.ied == nil)
     try test(mo4.ifsd == nil)
     try test(mo4.ivsd == nil)
-    try test(mo4.iood == nil)
     try test(mo4.imipd == nil)
 
     try test(mo4.bos == nil)
@@ -369,8 +368,8 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo5.ied![4] == .MyEnumMember)
     try test(mo5.ifsd![4] == FixedStruct(m: 78))
     try test(mo5.ivsd![5] == VarStruct(m: "hello"))
-    try test(mo5.iood![5]!!.a == 15)
     try test(mo5.imipd![5]! == communicator.stringToProxy("test"))
+    try test(mo5.iood[5]!!.a == 15)
 
     try test(mo5.bos == [false, true, false])
 
@@ -386,7 +385,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     mo6.shs = mo5.shs
     mo6.fss = mo5.fss
     mo6.ifsd = mo5.ifsd
-    mo6.iood = mo5.iood
     mo6.bos = mo5.bos
 
     // Clear the second half of the optional members
@@ -437,8 +435,8 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo7.ied == nil)
     try test(mo7.ifsd![4] == FixedStruct(m: 78))
     try test(mo7.ivsd == nil)
-    try test(mo7.iood![5]!!.a == 15)
     try test(mo7.imipd == nil)
+    try test(mo7.iood[5]!!.a == 15)
 
     try test(mo7.bos == [false, true, false])
     try test(mo7.ser == nil)
@@ -473,7 +471,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     try test(mo9.ied![4] == .MyEnumMember)
     try test(mo9.ifsd == nil)
     try test(mo9.ivsd![5] == VarStruct(m: "hello"))
-    try test(mo9.iood == nil)
     try test(mo9.imipd![5]! == communicator.stringToProxy("test"))
 
     try test(mo9.bos == nil)
@@ -3040,94 +3037,6 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     let fs1: FixedStruct? = try istr.read(tag: 2)
     try istr.endEncapsulation()
     try test(fs1 != nil && fs1!.m == 56)
-  }
-
-  do {
-    var p1: [Int32: OneOptional?]?
-    var p2: [Int32: OneOptional?]?
-    var p3: [Int32: OneOptional?]?
-
-    (p2, p3) = try initial.opIntOneOptionalDict(p1)
-    try test(p2 == nil && p3 == nil)
-
-    (p2, p3) = try initial.opIntOneOptionalDict(nil)
-    try test(p2 == nil && p3 == nil)
-
-    (p2, p3) = try initial.opIntOneOptionalDict()
-    try test(p2 == nil && p3 == nil)
-
-    try Promise<Void> { seal in
-      firstly {
-        initial.opIntOneOptionalDictAsync(nil)
-      }.done { p2, p3 in
-        try test(p2 == nil && p3 == nil)
-        seal.fulfill(())
-      }.catch { e in
-        seal.reject(e)
-      }
-    }.wait()
-
-    try Promise<Void> { seal in
-      firstly {
-        initial.opIntOneOptionalDictAsync(nil)
-      }.done { p2, p3 in
-        try test(p2 == nil && p3 == nil)
-        seal.fulfill(())
-      }.catch { e in
-        seal.reject(e)
-      }
-    }.wait()
-
-    p1 = [1: OneOptional(a: 58), 2: OneOptional(a: 59)]
-    (p2, p3) = try initial.opIntOneOptionalDict(p1)
-    try test(p2![1]!!.a == 58 && p3![1]!!.a == 58)
-
-    try Promise<Void> { seal in
-      firstly {
-        initial.opIntOneOptionalDictAsync(p1)
-      }.done { p2, p3 in
-        try test(p2![1]!!.a == 58 && p3![1]!!.a == 58)
-        seal.fulfill(())
-      }.catch { e in
-        seal.reject(e)
-      }
-    }.wait()
-
-    (p2, p3) = try initial.opIntOneOptionalDict([1: OneOptional(a: 58), 2: OneOptional(a: 59)])
-    try test(p2![1]!!.a == 58 && p3![1]!!.a == 58)
-
-    try Promise<Void> { seal in
-      firstly {
-        initial.opIntOneOptionalDictAsync([1: OneOptional(a: 58), 2: OneOptional(a: 59)])
-      }.done { p2, p3 in
-        try test(p2![1]!!.a == 58 && p3![1]!!.a == 58)
-        seal.fulfill(())
-      }.catch { e in
-        seal.reject(e)
-      }
-    }.wait()
-
-    (p2, p3) = try initial.opIntOneOptionalDict(nil)
-    try test(p2 == nil && p3 == nil)  // Ensure out parameter is cleared.
-
-    let ostr = Ice.OutputStream(communicator: communicator)
-    ostr.startEncapsulation()
-    IntOneOptionalDictHelper.write(to: ostr, tag: 2, value: p1)
-    ostr.endEncapsulation()
-    let inEncaps = ostr.finished()
-    let result = try initial.ice_invoke(
-      operation: "opIntOneOptionalDict", mode: .Normal, inEncaps: inEncaps)
-    var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
-    _ = try istr.startEncapsulation()
-    p2 = try IntOneOptionalDictHelper.read(from: istr, tag: 1)
-    try test(p2![1]!!.a == 58)
-    p3 = try IntOneOptionalDictHelper.read(from: istr, tag: 3)
-    try test(p3![1]!!.a == 58)
-    try istr.endEncapsulation()
-
-    istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
-    _ = try istr.startEncapsulation()
-    try istr.endEncapsulation()
   }
   output.writeLine("ok")
 

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -53,7 +53,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -91,7 +90,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -62,8 +62,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 dictionary<int, string> IntStringDict;
 
@@ -95,8 +95,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -261,7 +262,7 @@ interface Initial
 
     optional(1) IntStringDict opCustomIntStringDict(optional(2) IntStringDict p1, out optional(3) IntStringDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1, out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -63,7 +63,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 dictionary<int, string> IntStringDict;
 
@@ -96,8 +95,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -262,8 +262,6 @@ interface Initial
 
     optional(1) IntStringDict opCustomIntStringDict(optional(2) IntStringDict p1, out optional(3) IntStringDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -53,7 +53,6 @@ sequence<SmallStruct> SmallStructList;
 sequence<FixedStruct> FixedStructSeq;
 sequence<FixedStruct> FixedStructList;
 sequence<VarStruct> VarStructSeq;
-sequence<OneOptional> OneOptionalSeq;
 sequence<MyInterface*> MyInterfacePrxSeq;
 
 sequence<byte> Serializable;
@@ -89,7 +88,6 @@ class MultiOptional
     optional(19) MyEnumSeq es;
     optional(20) FixedStructSeq fss;
     optional(21) VarStructSeq vss;
-    optional(22) OneOptionalSeq oos;
     optional(23) MyInterfacePrxSeq mips;
 
     optional(24) IntEnumDict ied;

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -63,7 +63,6 @@ dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -94,8 +93,6 @@ class MultiOptional
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
     optional(28) IntMyInterfacePrxDict imipd;
-
-    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -62,8 +62,8 @@ dictionary<string, int> StringIntDict;
 dictionary<int, MyEnum> IntEnumDict;
 dictionary<int, FixedStruct> IntFixedStructDict;
 dictionary<int, VarStruct> IntVarStructDict;
-dictionary<int, OneOptional> IntOneOptionalDict;
 dictionary<int, MyInterface*> IntMyInterfacePrxDict;
+dictionary<int, OneOptional> IntOneOptionalDict;
 
 class MultiOptional
 {
@@ -93,8 +93,9 @@ class MultiOptional
     optional(24) IntEnumDict ied;
     optional(25) IntFixedStructDict ifsd;
     optional(26) IntVarStructDict ivsd;
-    optional(27) IntOneOptionalDict iood;
     optional(28) IntMyInterfacePrxDict imipd;
+
+    IntOneOptionalDict iood;
 
     optional(29) BoolSeq bos;
 
@@ -256,8 +257,7 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    optional(1) IntOneOptionalDict opIntOneOptionalDict(optional(2) IntOneOptionalDict p1,
-                                                        out optional(3) IntOneOptionalDict p3);
+    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
 
     void opClassAndUnknownOptional(A p);
 

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -257,8 +257,6 @@ interface Initial
 
     optional(1) StringIntDict opStringIntDict(optional(2) StringIntDict p1, out optional(3) StringIntDict p3);
 
-    IntOneOptionalDict opIntOneOptionalDict(IntOneOptionalDict p1, out IntOneOptionalDict p3);
-
     void opClassAndUnknownOptional(A p);
 
     G opG(G g);

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -232,18 +232,6 @@ class InitialI: Initial {
     return Promise.value((p1, p1))
   }
 
-  func opIntOneOptionalDictAsync(
-    p1: IntOneOptionalDict?,
-    current _: Current
-  ) -> Promise<
-    (
-      returnValue: IntOneOptionalDict?,
-      p3: IntOneOptionalDict?
-    )
-  > {
-    return Promise.value((p1, p1))
-  }
-
   func opClassAndUnknownOptionalAsync(p _: A?, current _: Current) -> Promise<Void> {
     return Promise.value(())
   }

--- a/swift/test/Ice/optional/TestI.swift
+++ b/swift/test/Ice/optional/TestI.swift
@@ -233,16 +233,6 @@ class InitialI: Initial {
     return (p1, p1)
   }
 
-  func opIntOneOptionalDict(
-    p1: [Int32: OneOptional?]?,
-    current _: Ice.Current
-  ) throws -> (
-    returnValue: [Int32: OneOptional?]?,
-    p3: [Int32: OneOptional?]?
-  ) {
-    return (p1, p1)
-  }
-
   func opClassAndUnknownOptional(p _: A?, current _: Ice.Current) throws {}
 
   func opG(g: G?, current _: Ice.Current) throws -> G? {


### PR DESCRIPTION
The title pretty much says it.
We still extensively test optional sequences and dictionaries of other types. So it's probably fine to just remove these tests.