### PR TITLE
Use SCH_CREDENTIALS

### DIFF
--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -22,7 +22,7 @@ namespace Ice::SSL
          * A callback that allows selecting the client's SSL credentials based on the target server host name.
          *
          * @remarks This callback is invoked by the SSL transport for each new outgoing connection before starting the
-         * SSL handshake to determine the appropriate client credentials. The callback should return a SCHANNEL_CRED
+         * SSL handshake to determine the appropriate client credentials. The callback should return a SCH_CREDENTIALS
          * that represents the client's credentials. The SSL transport takes ownership of the credentials' paCred and
          * and hRootStore, and releases them when the connection is closed.
          *
@@ -42,7 +42,7 @@ namespace Ice::SSL
          *        // valid for the duration of the connection. The SSL transport will release
          *        // it after closing the connection.
          *        CertDuplicateCertificateContext(_clientCertificate);
-         *        SCHANNEL_CRED credentials = _clientCredentials;
+         *        SCH_CREDENTIALS credentials = _clientCredentials;
          *        credentials.cCreds = 1;
          *        credentials.paCred = &_clientCertificate;
          *        return credentials;
@@ -54,10 +54,10 @@ namespace Ice::SSL
          * CertFreeCertificateContext(_clientCertificate); // Release the certificate when no longer needed
          * ```
          *
-         * See Detailed Wincrypt documentation for [SCHANNEL_CRED](
+         * See Detailed Wincrypt documentation for [SCH_CREDENTIALS](
          * https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials)
          */
-        std::function<SCHANNEL_CRED(const std::string& host)> clientCredentialsSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string& host)> clientCredentialsSelectionCallback;
 
         /**
          * A callback that is invoked before initiating a new SSL handshake. This callback provides an opportunity to

--- a/cpp/include/Ice/SSL/Config.h
+++ b/cpp/include/Ice/SSL/Config.h
@@ -27,6 +27,9 @@
 
 // See SCH_CREDENTIALS requirements:
 // https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials#remarks
+#    ifndef SCHANNEL_USE_BLACKLISTS
+#        define SCHANNEL_USE_BLACKLISTS 1
+#    endif
 #    include <SubAuth.h>
 
 #    include <schannel.h>

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -23,7 +23,7 @@ namespace Ice::SSL
          * accepts the connection.
          *
          * @remarks This callback is invoked by the SSL transport for each new incoming connection before starting the
-         * SSL handshake to determine the appropriate server credentials. The callback should return a SCHANNEL_CRED
+         * SSL handshake to determine the appropriate server credentials. The callback should return a SCH_CREDENTIALS
          * that represents the server's credentials. The SSL transport takes ownership of the credentials' paCred and
          * and hRootStore, and releases them when the connection is closed.
          *
@@ -43,7 +43,7 @@ namespace Ice::SSL
          *        // valid for the duration of the connection. The SSL transport will release
          *        // it after closing the connection.
          *        CertDuplicateCertificateContext(_serverCertificate);
-         *        SCHANNEL_CRED credentials = _serverCredentials;
+         *        SCH_CREDENTIALS credentials = _serverCredentials;
          *        credentials.cCreds = 1;
          *        credentials.paCred = &_serverCertificate;
          *        return credentials;
@@ -53,10 +53,10 @@ namespace Ice::SSL
          * CertFreeCertificateContext(_serverCertificate); // Release the certificate when no longer needed
          * ```
          *
-         * See Detailed Wincrypt documentation for [SCHANNEL_CRED](
+         * See Detailed Wincrypt documentation for [SCH_CREDENTIALS](
          * https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials)
          */
-        std::function<SCHANNEL_CRED(const std::string& host)> serverCredentialsSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string& host)> serverCredentialsSelectionCallback;
 
         /**
          * A callback that is invoked before initiating a new SSL handshake. This callback provides an opportunity to

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -662,7 +662,7 @@ OpenSSL::TransceiverI::verifyCallback(int ok, X509_STORE_CTX* ctx)
                 throw SecurityException(
                     __FILE__,
                     __LINE__,
-                    "IceSSL: certificate verification failed. The certificate was rejected by the remote certificate "
+                    "IceSSL: certificate verification failed. The certificate was rejected by the certificate "
                     "validation callback.");
             }
             else

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -19,15 +19,6 @@
 #include <iostream>
 #include <mutex>
 
-//
-// SP_PROT_TLS1_3 is new in v10.0.15021 SDK
-//
-#ifndef SP_PROT_TLS1_3
-#    define SP_PROT_TLS1_3_SERVER 0x00001000
-#    define SP_PROT_TLS1_3_CLIENT 0x00002000
-#    define SP_PROT_TLS1_3 (SP_PROT_TLS1_3_SERVER | SP_PROT_TLS1_3_CLIENT)
-#endif
-
 #ifndef SECURITY_FLAG_IGNORE_CERT_CN_INVALID
 #    define SECURITY_FLAG_IGNORE_CERT_CN_INVALID 0x00001000
 #endif
@@ -1299,8 +1290,8 @@ Schannel::SSLEngine::createClientAuthenticationOptions(const string& host) const
                 CertDuplicateCertificateContext(cert);
             }
 
-            return SCHANNEL_CRED{
-                .dwVersion = SCHANNEL_CRED_VERSION,
+            return SCH_CREDENTIALS{
+                .dwVersion = SCH_CREDENTIALS_VERSION,
                 .cCreds = static_cast<DWORD>(_allCerts.size()),
                 .paCred = const_cast<PCCERT_CONTEXT*>(_allCerts.size() > 0 ? &_allCerts[0] : nullptr),
                 .dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_NO_SERVERNAME_CHECK | SCH_USE_STRONG_CRYPTO};
@@ -1344,13 +1335,13 @@ Schannel::SSLEngine::createServerAuthenticationOptions() const
                     CertDuplicateCertificateContext(cert);
                 }
 
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = static_cast<DWORD>(_allCerts.size()),
                     .paCred = const_cast<PCCERT_CONTEXT*>(_allCerts.size() > 0 ? &_allCerts[0] : nullptr),
                     // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and
                     // Schannel doesn't seems to send the root certificate either way.
-                    .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_CRED_DISABLE_RECONNECTS | SCH_USE_STRONG_CRYPTO};
+                    .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_USE_STRONG_CRYPTO};
             }
         },
         .clientCertificateRequired = getVerifyPeer() > 0,

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -477,8 +477,7 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
         throw SecurityException(
             __FILE__,
             __LINE__,
-            "IceSSL: certificate verification failed. The certificate was rejected by the remote certificate "
-            "validation callback.");
+            "IceSSL: certificate verification failed. The certificate was rejected by the remote validation callback.");
     }
 
     _state = StateHandshakeComplete;

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -19,10 +19,6 @@ using namespace std;
 using namespace Ice;
 using namespace Ice::SSL;
 
-#ifndef CERT_CHAIN_DISABLE_AIA
-#    define CERT_CHAIN_DISABLE_AIA 0x00002000
-#endif
-
 namespace
 {
     string protocolName(DWORD protocol)
@@ -61,7 +57,7 @@ namespace
                 return &desc.pBuffers[i];
             }
         }
-        return 0;
+        return nullptr;
     }
 
     HCERTCHAINENGINE defaultChainEngine(HCERTSTORE trustedRootCertificates)
@@ -89,20 +85,20 @@ namespace
         }
     }
 
-    SCHANNEL_CRED defaultOutgoingCredentials(const string&)
+    SCH_CREDENTIALS defaultOutgoingCredentials(const string&)
     {
-        return SCHANNEL_CRED{
-            .dwVersion = SCHANNEL_CRED_VERSION,
+        return SCH_CREDENTIALS{
+            .dwVersion = SCH_CREDENTIALS_VERSION,
             .dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_NO_SERVERNAME_CHECK | SCH_USE_STRONG_CRYPTO};
     }
 
-    SCHANNEL_CRED defaultIncomingCredentials(const string&)
+    SCH_CREDENTIALS defaultIncomingCredentials(const string&)
     {
-        return SCHANNEL_CRED{
-            .dwVersion = SCHANNEL_CRED_VERSION,
+        return SCH_CREDENTIALS{
+            .dwVersion = SCH_CREDENTIALS_VERSION,
             // Don't set SCH_SEND_ROOT_CERT as it seems to cause problems with Java certificate validation and
             // Schannel doesn't seems to send the root certificate either way.
-            .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_CRED_DISABLE_RECONNECTS | SCH_USE_STRONG_CRYPTO};
+            .dwFlags = SCH_CRED_NO_SYSTEM_MAPPER | SCH_USE_STRONG_CRYPTO};
     }
 }
 
@@ -113,7 +109,7 @@ Schannel::TransceiverI::getNativeInfo()
 }
 
 IceInternal::SocketOperation
-Schannel::TransceiverI::sslHandshake()
+Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
 {
     DWORD flags = 0;
     if (_incoming)
@@ -130,6 +126,7 @@ Schannel::TransceiverI::sslHandshake()
     SECURITY_STATUS err = SEC_E_OK;
     if (_state == StateHandshakeNotStarted)
     {
+        assert(!initialBuffer); // Always null for the initial handshake.
         _credentials = _localCredentialsSelectionCallback(_incoming ? _adapterName : _host);
         if (_rootStore && !_credentials.hRootStore)
         {
@@ -145,7 +142,7 @@ Schannel::TransceiverI::sslHandshake()
                     throw SecurityException(
                         __FILE__,
                         __LINE__,
-                        "SSL transport: invalid null certificate in the provided SCHANNEL_CRED.");
+                        "SSL transport: invalid null certificate in the provided SCH_CREDENTIALS.");
                 }
                 _allCerts.push_back(CertDuplicateCertificateContext(_credentials.paCred[i]));
             }
@@ -177,7 +174,11 @@ Schannel::TransceiverI::sslHandshake()
         _readBuffer.b.resize(2048);
         _readBuffer.i = _readBuffer.b.begin();
 
-        if (!_incoming)
+        if (_incoming)
+        {
+            _state = StateHandshakeReadContinue;
+        }
+        else
         {
             SecBuffer outBuffer = {0, SECBUFFER_TOKEN, 0};
             SecBufferDesc outBufferDesc = {SECBUFFER_VERSION, 1, &outBuffer};
@@ -217,26 +218,33 @@ Schannel::TransceiverI::sslHandshake()
 
             _state = StateHandshakeWriteContinue;
         }
-        else
-        {
-            _state = StateHandshakeReadContinue;
-        }
     }
 
     while (true)
     {
         if (_state == StateHandshakeReadContinue)
         {
-            // If read buffer is empty, try to read some data.
-            if (_readBuffer.i == _readBuffer.b.begin() && !readRaw(_readBuffer))
-            {
-                return IceInternal::SocketOperationRead;
-            }
-
-            SecBuffer inBuffers[2]{
-                {static_cast<DWORD>(_readBuffer.i - _readBuffer.b.begin()), SECBUFFER_TOKEN, _readBuffer.b.begin()},
-                {0, SECBUFFER_EMPTY, 0}};
+            SecBuffer inBuffers[2]{{0, SECBUFFER_EMPTY, 0}, {0, SECBUFFER_EMPTY, 0}};
             SecBufferDesc inBufferDesc{SECBUFFER_VERSION, 2, inBuffers};
+
+            if (initialBuffer)
+            {
+                inBuffers[0] = {initialBuffer->cbBuffer, SECBUFFER_TOKEN, initialBuffer->pvBuffer};
+                initialBuffer = nullptr;
+            }
+            else
+            {
+                // If read buffer is empty, try to read some data.
+                if (_readBuffer.i == _readBuffer.b.begin() && !readRaw(_readBuffer))
+                {
+                    return IceInternal::SocketOperationRead;
+                }
+
+                inBuffers[0] = {
+                    static_cast<DWORD>(_readBuffer.i - _readBuffer.b.begin()),
+                    SECBUFFER_TOKEN,
+                    _readBuffer.b.begin()};
+            }
 
             SecBuffer outBuffers[2]{{0, SECBUFFER_TOKEN, 0}, {0, SECBUFFER_ALERT, 0}};
             SecBufferDesc outBufferDesc{SECBUFFER_VERSION, 2, outBuffers};
@@ -438,7 +446,13 @@ Schannel::TransceiverI::sslHandshake()
         throw SecurityException(__FILE__, __LINE__, os.str());
     }
 
-    assert(!_peerCertificate);
+    assert(!_peerCertificate || _sslConnectionRenegotiating);
+    if (_peerCertificate)
+    {
+        CertFreeCertificateContext(_peerCertificate);
+        _peerCertificate = nullptr;
+    }
+
     err = QueryContextAttributes(&_ssl, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &_peerCertificate);
     if (err != SEC_E_OK && err != SEC_E_NO_CREDENTIALS)
     {
@@ -457,39 +471,48 @@ Schannel::TransceiverI::sslHandshake()
     _writeBuffer.b.reset();
     _writeBuffer.i = _writeBuffer.b.begin();
 
+    if (_remoteCertificateValidationCallback &&
+        !_remoteCertificateValidationCallback(_ssl, dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(getInfo())))
+    {
+        throw SecurityException(
+            __FILE__,
+            __LINE__,
+            "IceSSL: certificate verification failed. The certificate was rejected by the remote certificate "
+            "validation callback.");
+    }
+
+    _state = StateHandshakeComplete;
+
+    _delegate->getNativeInfo()->ready(
+        IceInternal::SocketOperationRead,
+        !_readUnprocessed.b.empty() || _readBuffer.i != _readBuffer.b.begin());
+
     return IceInternal::SocketOperationNone;
 }
 
-//
-// Try to decrypt a message and return the number of bytes decrypted, if the number of bytes
-// decrypted is less than the size requested it means that the application needs to read more
-// data before it can decrypt the complete message.
-//
+// Try to decrypt a message and return the number of bytes decrypted, if the number of bytes decrypted is less than the
+// size requested it means that the application needs to read more data before it can decrypt the complete message.
 size_t
 Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
 {
     assert(_readBuffer.i != _readBuffer.b.begin() || !_readUnprocessed.b.empty());
 
-    //
-    // First check if there is data in the unprocessed buffer.
-    //
+    std::byte* i = buffer.i;
+
+    // The number of bytes of the current message that are already decrypted.
     size_t length = std::min(static_cast<size_t>(buffer.b.end() - buffer.i), _readUnprocessed.b.size());
     if (length > 0)
     {
         memcpy(buffer.i, _readUnprocessed.b.begin(), length);
-        memmove(_readUnprocessed.b.begin(), _readUnprocessed.b.begin() + length, _readUnprocessed.b.size() - length);
-        _readUnprocessed.b.resize(_readUnprocessed.b.size() - length);
+        i += length;
+        // Move any remaining data to the beginning of the unprocessed buffer.
+        size_t remaining = _readUnprocessed.b.size() - length;
+        memmove(_readUnprocessed.b.begin(), _readUnprocessed.b.begin() + length, remaining);
+        _readUnprocessed.b.resize(remaining);
     }
 
-    while (true)
+    while (i != buffer.b.end() && _readBuffer.i != _readBuffer.b.begin())
     {
-        // If we have filled the buffer or if nothing left to read from the read buffer, we're done.
-        std::byte* i = buffer.i + length;
-        if (i == buffer.b.end() || _readBuffer.i == _readBuffer.b.begin())
-        {
-            break;
-        }
-
         // Try to decrypt the buffered data.
         SecBuffer inBuffers[4]{
             {static_cast<DWORD>(_readBuffer.i - _readBuffer.b.begin()), SECBUFFER_DATA, _readBuffer.b.begin()},
@@ -498,15 +521,37 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
             {0, SECBUFFER_EMPTY, 0}};
         SecBufferDesc inBufferDesc{SECBUFFER_VERSION, 4, inBuffers};
 
-        SECURITY_STATUS err = DecryptMessage(&_ssl, &inBufferDesc, 0, 0);
+        SECURITY_STATUS err = DecryptMessage(&_ssl, &inBufferDesc, 0, nullptr);
         if (err == SEC_E_INCOMPLETE_MESSAGE)
         {
             // There isn't enough data to decrypt the message. The input buffer is resized to the SSL max message size
             // after the SSL handshake completes so an incomplete message can only occur if the read buffer is not full.
             assert(_readBuffer.i != _readBuffer.b.end());
-            return length;
+            return i - buffer.i;
         }
-        else if (err == SEC_I_CONTEXT_EXPIRED || err == SEC_I_RENEGOTIATE)
+        else if (err == SEC_I_RENEGOTIATE)
+        {
+            if (_sslConnectionRenegotiating)
+            {
+                throw ProtocolException(
+                    __FILE__,
+                    __LINE__,
+                    "SSL transport: peer requested renegotiation while we are already renegotiating.");
+            }
+            // The peer has requested a renegotiation.
+            SecBuffer* extraBuffer = getSecBufferWithType(inBufferDesc, SECBUFFER_EXTRA);
+            _sslConnectionRenegotiating = true;
+            _state = StateHandshakeReadContinue;
+            if (extraBuffer)
+            {
+                _extraBuffer.b.resize(extraBuffer->cbBuffer);
+                _extraBuffer.i = _extraBuffer.b.begin();
+                memcpy(_extraBuffer.i, extraBuffer->pvBuffer, extraBuffer->cbBuffer);
+                _extraBuffer.i += extraBuffer->cbBuffer;
+            }
+            return 0;
+        }
+        else if (err == SEC_I_CONTEXT_EXPIRED)
         {
             // The message sender has finished using the connection and has initiated a shutdown.
             throw ConnectionLostException(__FILE__, __LINE__, 0);
@@ -522,10 +567,10 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
         SecBuffer* dataBuffer = getSecBufferWithType(inBufferDesc, SECBUFFER_DATA);
         assert(dataBuffer);
         DWORD remaining = min(static_cast<DWORD>(buffer.b.end() - i), dataBuffer->cbBuffer);
-        length += remaining;
-        if (remaining)
+        if (remaining > 0)
         {
             memcpy(i, dataBuffer->pvBuffer, remaining);
+            i += remaining;
 
             // Copy remaining decrypted data to unprocessed buffer.
             if (dataBuffer->cbBuffer > remaining)
@@ -550,7 +595,7 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
             _readBuffer.i = _readBuffer.b.begin();
         }
     }
-    return length;
+    return i - buffer.i;
 }
 
 //
@@ -610,30 +655,7 @@ Schannel::TransceiverI::initialize(IceInternal::Buffer& readBuffer, IceInternal:
         }
         _state = StateHandshakeNotStarted;
     }
-
-    IceInternal::SocketOperation op = sslHandshake();
-    if (op != IceInternal::SocketOperationNone)
-    {
-        return op;
-    }
-
-    if (_remoteCertificateValidationCallback &&
-        !_remoteCertificateValidationCallback(_ssl, dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(getInfo())))
-    {
-        throw SecurityException(
-            __FILE__,
-            __LINE__,
-            "IceSSL: certificate verification failed. The certificate was rejected by the remote certificate "
-            "validation callback.");
-    }
-
-    _state = StateHandshakeComplete;
-
-    _delegate->getNativeInfo()->ready(
-        IceInternal::SocketOperationRead,
-        !_readUnprocessed.b.empty() || _readBuffer.i != _readBuffer.b.begin());
-
-    return IceInternal::SocketOperationNone;
+    return sslHandshake();
 }
 
 IceInternal::SocketOperation
@@ -751,6 +773,23 @@ Schannel::TransceiverI::read(IceInternal::Buffer& buf)
         }
 
         size_t decrypted = decryptMessage(buf);
+        if (_sslConnectionRenegotiating)
+        {
+            // The peer has requested a renegotiation.
+            SecBuffer extraBuffer{
+                static_cast<DWORD>(_extraBuffer.i - _extraBuffer.b.begin()),
+                SECBUFFER_EXTRA,
+                _extraBuffer.b.begin()};
+            IceInternal::SocketOperation op = sslHandshake(&extraBuffer);
+            _extraBuffer.b.clear();
+            if (op == IceInternal::SocketOperationNone)
+            {
+                _sslConnectionRenegotiating = false;
+                continue;
+            }
+            throw ConnectionLostException(__FILE__, __LINE__, 0);
+        }
+
         if (decrypted == 0)
         {
             if (!readRaw(_readBuffer))
@@ -767,8 +806,6 @@ Schannel::TransceiverI::read(IceInternal::Buffer& buf)
         !_readUnprocessed.b.empty() || _readBuffer.i != _readBuffer.b.begin());
     return IceInternal::SocketOperationNone;
 }
-
-#ifdef ICE_USE_IOCP
 
 bool
 Schannel::TransceiverI::startWrite(IceInternal::Buffer& buffer)
@@ -832,7 +869,33 @@ Schannel::TransceiverI::finishRead(IceInternal::Buffer& buf)
     _delegate->finishRead(_readBuffer);
     if (_state == StateHandshakeComplete)
     {
-        size_t decrypted = decryptMessage(buf);
+        size_t decrypted;
+        while (true)
+        {
+            decrypted = decryptMessage(buf);
+            if (_sslConnectionRenegotiating)
+            {
+                // The peer has requested a renegotiation.
+                SecBuffer extraBuffer{
+                    static_cast<DWORD>(_extraBuffer.i - _extraBuffer.b.begin()),
+                    SECBUFFER_EXTRA,
+                    _extraBuffer.b.begin()};
+                IceInternal::SocketOperation op = sslHandshake(&extraBuffer);
+                _extraBuffer.b.clear();
+                if (op == IceInternal::SocketOperationNone)
+                {
+                    _sslConnectionRenegotiating = false;
+                    if (buf.i != buf.b.begin())
+                    {
+                        continue;
+                    }
+                    break;
+                }
+                throw ConnectionLostException(__FILE__, __LINE__, 0);
+            }
+            break;
+        }
+
         if (decrypted > 0)
         {
             buf.i += decrypted;
@@ -846,7 +909,6 @@ Schannel::TransceiverI::finishRead(IceInternal::Buffer& buf)
         }
     }
 }
-#endif
 
 bool
 Schannel::TransceiverI::isWaitingToBeRead() const noexcept
@@ -919,7 +981,8 @@ Schannel::TransceiverI::TransceiverI(
       _remoteCertificateValidationCallback(serverAuthenticationOptions.clientCertificateValidationCallback),
       _rootStore(serverAuthenticationOptions.trustedRootCertificates),
       _ssl({}),
-      _chainEngine(nullptr)
+      _chainEngine(nullptr),
+      _sslConnectionRenegotiating(false)
 {
     if (!_remoteCertificateValidationCallback)
     {
@@ -966,7 +1029,8 @@ Schannel::TransceiverI::TransceiverI(
       _remoteCertificateValidationCallback(clientAuthenticationOptions.serverCertificateValidationCallback),
       _rootStore(clientAuthenticationOptions.trustedRootCertificates),
       _ssl({}),
-      _chainEngine(nullptr)
+      _chainEngine(nullptr),
+      _sslConnectionRenegotiating(false)
 {
     if (_rootStore && !_remoteCertificateValidationCallback)
     {

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.h
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.h
@@ -13,22 +13,9 @@
 #    include "../WSTransceiver.h"
 #    include "Ice/Buffer.h"
 #    include "Ice/Config.h"
+#    include "Ice/SSL/Config.h"
 #    include "SSLInstanceF.h"
 #    include "SchannelEngineF.h"
-
-#    ifdef SECURITY_WIN32
-#        undef SECURITY_WIN32
-#    endif
-
-#    ifdef SECURITY_KERNEL
-#        undef SECURITY_KERNEL
-#    endif
-
-#    define SECURITY_WIN32 1
-#    include <schannel.h>
-#    include <security.h>
-#    include <sspi.h>
-#    undef SECURITY_WIN32
 
 namespace Ice::SSL::Schannel
 {
@@ -47,18 +34,15 @@ namespace Ice::SSL::Schannel
             const Ice::SSL::ClientAuthenticationOptions&);
         ~TransceiverI();
         IceInternal::NativeInfoPtr getNativeInfo() final;
-
         IceInternal::SocketOperation initialize(IceInternal::Buffer&, IceInternal::Buffer&) final;
         IceInternal::SocketOperation closing(bool, std::exception_ptr) final;
         void close();
         IceInternal::SocketOperation write(IceInternal::Buffer&) final;
         IceInternal::SocketOperation read(IceInternal::Buffer&) final;
-#    ifdef ICE_USE_IOCP
         bool startWrite(IceInternal::Buffer&) final;
         void finishWrite(IceInternal::Buffer&) final;
         void startRead(IceInternal::Buffer&) final;
         void finishRead(IceInternal::Buffer&) final;
-#    endif
         bool isWaitingToBeRead() const noexcept final;
         std::string protocol() const final;
         std::string toString() const final;
@@ -68,7 +52,7 @@ namespace Ice::SSL::Schannel
         void setBufferSize(int rcvSize, int sndSize) final;
 
     private:
-        IceInternal::SocketOperation sslHandshake();
+        IceInternal::SocketOperation sslHandshake(SecBuffer* initialBuffer = nullptr);
 
         size_t decryptMessage(IceInternal::Buffer&);
         size_t encryptMessage(IceInternal::Buffer&);
@@ -80,6 +64,7 @@ namespace Ice::SSL::Schannel
         {
             StateNotInitialized,
             StateHandshakeNotStarted,
+            StateHandshakeRenegotiateStarted,
             StateHandshakeReadContinue,
             StateHandshakeWriteContinue,
             StateHandshakeWriteNoContinue,
@@ -94,31 +79,29 @@ namespace Ice::SSL::Schannel
         const IceInternal::TransceiverPtr _delegate;
         State _state;
         DWORD _ctxFlags;
+        bool _sslConnectionRenegotiating;
 
-        //
         // Buffered encrypted data that has not been written.
-        //
         IceInternal::Buffer _writeBuffer;
         size_t _bufferedW;
 
-        //
         // Buffered data that has not been decrypted.
-        //
         IceInternal::Buffer _readBuffer;
 
-        //
+        // Extra buffer used for SSL renegotiation.
+        IceInternal::Buffer _extraBuffer;
+
         // Buffered data that was decrypted but not yet processed.
-        //
         IceInternal::Buffer _readUnprocessed;
 
-        std::function<SCHANNEL_CRED(const std::string&)> _localCredentialsSelectionCallback;
+        std::function<SCH_CREDENTIALS(const std::string&)> _localCredentialsSelectionCallback;
         std::function<void(CtxtHandle context, const std::string& host)> _sslNewSessionCallback;
         SecPkgContext_StreamSizes _sizes;
         std::string _cipher;
         PCCERT_CONTEXT _peerCertificate;
         std::function<bool(CtxtHandle, const Ice::SSL::ConnectionInfoPtr&)> _remoteCertificateValidationCallback;
         bool _clientCertificateRequired;
-        SCHANNEL_CRED _credentials;
+        SCH_CREDENTIALS _credentials;
         std::vector<PCCERT_CONTEXT> _allCerts;
         CredHandle _credentialsHandle;
         HCERTSTORE _rootStore;

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -239,8 +239,8 @@ Ice::SSL::SecureTransport::TransceiverI::initialize(IceInternal::Buffer& readBuf
                         throw SecurityException(
                             __FILE__,
                             __LINE__,
-                            "IceSSL: certificate verification failed. The certificate was rejected by the remote "
-                            "certificate validation callback.");
+                            "IceSSL: certificate verification failed. The certificate was rejected by the certificate "
+                            "validation callback.");
                     }
                 }
                 else

--- a/cpp/test/IceSSL/configuration/SchannelTests.cpp
+++ b/cpp/test/IceSSL/configuration/SchannelTests.cpp
@@ -132,8 +132,8 @@ clientValidatesServerSettingTrustedRootCertificates(Test::TestHelper* helper, co
             .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
@@ -172,8 +172,8 @@ clientValidatesServerUsingValidationCallback(Test::TestHelper* helper, const str
             .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
@@ -225,8 +225,8 @@ clientRejectsServerSettingTrustedRootCertificates(Test::TestHelper* helper, cons
             .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
@@ -269,8 +269,8 @@ clientRejectsServerUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
             .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
@@ -314,8 +314,8 @@ clientRejectsServerUsingValidationCallback(Test::TestHelper* helper, const strin
             .serverCredentialsSelectionCallback = [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             }};
@@ -363,8 +363,8 @@ serverValidatesClientSettingTrustedRootCertificates(Test::TestHelper* helper, co
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
@@ -377,8 +377,8 @@ serverValidatesClientSettingTrustedRootCertificates(Test::TestHelper* helper, co
                 [clientCertificate](const string&)
             {
                 CertDuplicateCertificateContext(clientCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
             },
@@ -419,8 +419,8 @@ serverValidatesClientUsingValidationCallback(Test::TestHelper* helper, const str
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
@@ -436,8 +436,8 @@ serverValidatesClientUsingValidationCallback(Test::TestHelper* helper, const str
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return SCHANNEL_CRED{
-                        .dwVersion = SCHANNEL_CRED_VERSION,
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
                         .cCreds = 1,
                         .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
@@ -481,8 +481,8 @@ serverRejectsClientSettingTrustedRootCertificates(Test::TestHelper* helper, cons
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
@@ -497,8 +497,8 @@ serverRejectsClientSettingTrustedRootCertificates(Test::TestHelper* helper, cons
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return SCHANNEL_CRED{
-                        .dwVersion = SCHANNEL_CRED_VERSION,
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
                         .cCreds = 1,
                         .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
@@ -548,8 +548,8 @@ serverRejectsClientUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
@@ -563,8 +563,8 @@ serverRejectsClientUsingDefaultTrustedRootCertificates(Test::TestHelper* helper,
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return SCHANNEL_CRED{
-                        .dwVersion = SCHANNEL_CRED_VERSION,
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
                         .cCreds = 1,
                         .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
@@ -610,8 +610,8 @@ serverRejectsClientUsingValidationCallback(Test::TestHelper* helper, const strin
                 [serverCertificate](const string&)
             {
                 CertDuplicateCertificateContext(serverCertificate);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&serverCertificate)};
             },
@@ -627,8 +627,8 @@ serverRejectsClientUsingValidationCallback(Test::TestHelper* helper, const strin
                     [clientCertificate](const string&)
                 {
                     CertDuplicateCertificateContext(clientCertificate);
-                    return SCHANNEL_CRED{
-                        .dwVersion = SCHANNEL_CRED_VERSION,
+                    return SCH_CREDENTIALS{
+                        .dwVersion = SCH_CREDENTIALS_VERSION,
                         .cCreds = 1,
                         .paCred = const_cast<PCCERT_CONTEXT*>(&clientCertificate)};
                 },
@@ -704,8 +704,8 @@ serverHotCertificateReload(Test::TestHelper* helper, const string& certificatesP
             {
                 PCCERT_CONTEXT certificateContext = serverState.serverCertificateContext();
                 CertDuplicateCertificateContext(certificateContext);
-                return SCHANNEL_CRED{
-                    .dwVersion = SCHANNEL_CRED_VERSION,
+                return SCH_CREDENTIALS{
+                    .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = 1,
                     .paCred = const_cast<PCCERT_CONTEXT*>(&certificateContext)};
             }};


### PR DESCRIPTION
This PR updates the Schannel SSL transport implementation to use the new SCH_CREDENTIALS API instead of the deprecated SCHANNEL_CRED.

The SCH_CREDENTIALS update brings support for TLS 1.3 to Windows. It appears that TLS 1.3 is not negotiated when using the old SCHANNEL_CRED version.