### PR TITLE
String fields cannot be null in C#

### DIFF
--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -333,7 +333,7 @@ public sealed class Instance
                 throw new Ice.CommunicatorDestroyedException();
             }
 
-            if (adminIdentity == null || string.IsNullOrEmpty(adminIdentity.name))
+            if (adminIdentity == null || adminIdentity.name.Length == 0)
             {
                 throw new Ice.IllegalIdentityException(adminIdentity);
             }

--- a/csharp/src/Ice/Internal/InstrumentationI.cs
+++ b/csharp/src/Ice/Internal/InstrumentationI.cs
@@ -333,7 +333,7 @@ internal class DispatchHelper : MetricsHelper<DispatchMetrics>
         if (_id == null)
         {
             StringBuilder os = new StringBuilder();
-            if (_current.id.category != null && _current.id.category.Length > 0)
+            if (_current.id.category.Length > 0)
             {
                 os.Append(_current.id.category).Append('/');
             }

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -466,11 +466,7 @@ public abstract class Reference : IEquatable<Reference>
                         int invocationTimeout,
                         Dictionary<string, string> context)
     {
-        //
         // Validate string arguments.
-        //
-        Debug.Assert(identity.name != null);
-        Debug.Assert(identity.category != null);
         Debug.Assert(facet != null);
 
         _instance = instance;

--- a/csharp/src/Ice/ObjectAdapterI.cs
+++ b/csharp/src/Ice/ObjectAdapterI.cs
@@ -1007,13 +1007,9 @@ public sealed class ObjectAdapterI : ObjectAdapter
 
     internal static void checkIdentity(Identity ident)
     {
-        if (ident.name == null || ident.name.Length == 0)
+        if (ident.name.Length == 0)
         {
             throw new IllegalIdentityException(ident);
-        }
-        if (ident.category == null)
-        {
-            ident.category = "";
         }
     }
 

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -319,7 +319,7 @@ public sealed class Util
     /// <returns>The string representation of the object identity.</returns>
     public static string identityToString(Identity ident, ToStringMode toStringMode = ToStringMode.Unicode)
     {
-        if (ident.category == null || ident.category.Length == 0)
+        if (ident.category.Length == 0)
         {
             return Ice.UtilInternal.StringUtil.escapeString(ident.name, "/", toStringMode);
         }


### PR DESCRIPTION
This PR removes the various null checks for string fields - they can't be null.

Fixes #2207.