### PR TITLE
Ensure non-nullable fields are not initialized to null

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -523,6 +523,27 @@ Slice::CsGenerator::isValueType(const TypePtr& type)
     return false;
 }
 
+bool
+Slice::CsGenerator::isNonNullableReferenceType(const TypePtr& p, bool includeString)
+{
+    if (includeString)
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p);
+        if (builtin)
+        {
+            return builtin->kind() == Builtin::KindString;
+        }
+    }
+
+    StructPtr st = dynamic_pointer_cast<Struct>(p);
+    if (st)
+    {
+        return isMappedToClass(st);
+    }
+
+    return dynamic_pointer_cast<Sequence>(p) || dynamic_pointer_cast<Dictionary>(p);
+}
+
 void
 Slice::CsGenerator::writeMarshalUnmarshalCode(
     Output& out,

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -64,6 +64,9 @@ namespace Slice
         // Is this Slice struct mapped to a C# class?
         static bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
 
+        // Is this Slice field type mapped to a non-nullable C# reference type?
+        static bool isNonNullableReferenceType(const TypePtr& p, bool includeString = true);
+
         //
         // Generate code to marshal or unmarshal a type
         //

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -273,7 +273,7 @@ namespace Ice
                 output.Write("testing non-primary constructor... ");
                 output.Flush();
                 {
-                    Test.StructNoDefaults v = new Test.StructNoDefaults(bs: null, iseq: null, st2: null, dict: null);
+                    Test.StructNoDefaults v = new Test.StructNoDefaults(bs: [], iseq: [], st2: new(), dict: []);
                     test(v.bo == false);
                     test(v.b == 0);
                     test(v.s == 0);
@@ -283,27 +283,27 @@ namespace Ice
                     test(v.d == 0.0);
                     test(v.str.Length == 0);
                     test(v.c1 == Test.Color.red);
-                    test(v.bs == null);
-                    test(v.iseq == null);
+                    test(v.bs.Length == 0);
+                    test(v.iseq.Length == 0);
                     test(v.st.a == 0);
-                    test(v.st2 == null);
-                    test(v.dict == null);
+                    test(v.st2.a.Length == 0);
+                    test(v.dict.Count == 0);
 
-                    Test.ExceptionNoDefaults e = new Test.ExceptionNoDefaults();
+                    Test.ExceptionNoDefaults e = new Test.ExceptionNoDefaults(bs: [], st2: new(), dict: []);
                     test(e.str.Length == 0);
                     test(e.c1 == Test.Color.red);
-                    test(e.bs == null);
+                    test(e.bs.Length == 0);
                     test(e.st.a == 0);
-                    test(e.st2 == null);
-                    test(e.dict == null);
+                    test(e.st2.a.Length == 0);
+                    test(e.dict.Count == 0);
 
-                    Test.ClassNoDefaults cl = new Test.ClassNoDefaults();
+                    Test.ClassNoDefaults cl = new Test.ClassNoDefaults(bs: [], st2: new(), dict: []);
                     test(cl.str.Length == 0);
                     test(cl.c1 == Test.Color.red);
-                    test(cl.bs == null);
+                    test(e.bs.Length == 0);
                     test(cl.st.a == 0);
-                    test(cl.st2 == null);
-                    test(cl.dict == null);
+                    test(e.st2.a.Length == 0);
+                    test(e.dict.Count == 0);
                 }
                 output.WriteLine("ok");
             }

--- a/csharp/test/Ice/hash/Client.cs
+++ b/csharp/test/Ice/hash/Client.cs
@@ -412,7 +412,7 @@ public class Client : Test.TestHelper
                 structCollisions = 0;
                 for (i = 0; i < maxIterations && structCollisions < maxCollisions; ++i)
                 {
-                    var polyline = new Test.Polyline(vertices: null);
+                    var polyline = new Test.Polyline(vertices: []);
                     List<Test.Point> vertices = new List<Test.Point>();
                     for (int j = 0; j < 100; ++j)
                     {
@@ -443,8 +443,7 @@ public class Client : Test.TestHelper
                 structCollisions = 0;
                 for (i = 0; i < maxIterations && structCollisions < maxCollisions; ++i)
                 {
-                    Test.ColorPalette colorPalette = new Test.ColorPalette(colors: null);
-                    colorPalette.colors = new Dictionary<int, Test.Color>();
+                    Test.ColorPalette colorPalette = new Test.ColorPalette(colors: new());
                     for (int j = 0; j < 100; ++j)
                     {
                         colorPalette.colors[j] = new Test.Color(rand.Next(255),


### PR DESCRIPTION
This PR adds a check in the generated constructors for classes, exceptions and structs-mapped-to-classes, to make sure field of type struct-mapped-to-class, sequence, dictionary and string are not (accidentally) set to null by the user.

With "nullable enabled", you would get a compile time warning if you attempt to do that. But I assume Ice 3.8 will also be used with "nullable disabled". This PR required a few updates to tests that passed null for collection fields.

In a follow-up PR, I'll simplify the implementation of Equals and GetHashCode to use this new guarantee.