### PR TITLE
Added support for taking into account message read/write for the inactivity timeout

### DIFF
--- a/cpp/test/Ice/inactivityTimeout/AllTests.cpp
+++ b/cpp/test/Ice/inactivityTimeout/AllTests.cpp
@@ -87,15 +87,14 @@ testWithOutstandingRequest(TestIntfPrx p, bool oneway)
 void
 testWithOutstandingOnewaySend(TestIntfPrx p, TestIntfControllerPrx controller)
 {
-    cout << "testing the inactivity timeout with outstanding one-way request to send... "
-         << flush;
+    cout << "testing the inactivity timeout with outstanding one-way request to send... " << flush;
 
     p = p->ice_oneway();
     p->ice_ping();
     ConnectionPtr connection1 = p->ice_getCachedConnection();
 
     // Hold the server adapter and send 10 MB with a oneway request. The sending should block. The connection inactivity
-    // timeout shouldn't be triggered while the connection is waiting for sending the payload.
+    // timeout shouldn't be triggered while the connection is sending the payload.
     controller->holdAdapter();
 
     // Send the payload. The payload shouldn't be fully sent until the adapter is resumed.

--- a/cpp/test/Ice/inactivityTimeout/AllTests.cpp
+++ b/cpp/test/Ice/inactivityTimeout/AllTests.cpp
@@ -92,6 +92,7 @@ testWithOutstandingOnewaySend(TestIntfPrx p, TestIntfControllerPrx controller)
 
     p = p->ice_oneway();
     p->ice_ping();
+    ConnectionPtr connection1 = p->ice_getCachedConnection();
 
     // Hold the server adapter and send 10 MB with a oneway request. The sending should block. The connection inactivity
     // timeout shouldn't be triggered while the connection is waiting for sending the payload.
@@ -112,6 +113,9 @@ testWithOutstandingOnewaySend(TestIntfPrx p, TestIntfControllerPrx controller)
     test(future.wait_for(chrono::seconds(0)) != future_status::ready);
     controller->resumeAdapter();
     future.get();
+
+    p->ice_ping();
+    test(connection1 == p->ice_getCachedConnection());
 
     cout << "ok" << endl;
 }

--- a/cpp/test/Ice/inactivityTimeout/Client.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Client.cpp
@@ -21,7 +21,10 @@ Client::run(int argc, char** argv)
     // We configure a low idle timeout to make sure we send heartbeats frequently.
     initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
     initData.properties->setProperty("Ice.Connection.InactivityTimeout", "1");
+    // Limit the send buffer size, this test relies on the socket send() blocking after sending a given amount of data.
+    initData.properties->setProperty("Ice.TCP.SndSize", "50000");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
+
 
     void allTests(Test::TestHelper*);
     allTests(this);

--- a/cpp/test/Ice/inactivityTimeout/Client.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Client.cpp
@@ -25,7 +25,6 @@ Client::run(int argc, char** argv)
     initData.properties->setProperty("Ice.TCP.SndSize", "50000");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
-
     void allTests(Test::TestHelper*);
     allTests(this);
 }

--- a/cpp/test/Ice/inactivityTimeout/Server.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Server.cpp
@@ -22,10 +22,12 @@ Server::run(int argc, char** argv)
     initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
     initData.properties->setProperty("TestAdapter.Connection.InactivityTimeout", "2");
     initData.properties->setProperty("TestAdapter1s.Connection.InactivityTimeout", "1");
-
+    // Message size large enough to receive the 10MB payload.
+    initData.properties->setProperty("Ice.MessageSizeMax", "20000");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     communicator->getProperties()->setProperty("TestAdapter1s.Endpoints", getTestEndpoint(1));
+    communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(2));
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
@@ -34,6 +36,10 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter1s = communicator->createObjectAdapter("TestAdapter1s");
     adapter1s->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     adapter1s->activate();
+
+    Ice::ObjectAdapterPtr controllerAdapter = communicator->createObjectAdapter("ControllerAdapter");
+    controllerAdapter->add(std::make_shared<TestIntfControllerI>(adapter), Ice::stringToIdentity("testController"));
+    controllerAdapter->activate();
 
     serverReady();
     communicator->waitForShutdown();

--- a/cpp/test/Ice/inactivityTimeout/Test.ice
+++ b/cpp/test/Ice/inactivityTimeout/Test.ice
@@ -4,12 +4,22 @@
 
 #pragma once
 
+#include "Ice/BuiltinSequences.ice"
+
 module Test
 {
     interface TestIntf
     {
         void sleep(int ms);
 
+        void sendPayload(Ice::ByteSeq seq);
+
         void shutdown();
+    }
+
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
     }
 }

--- a/cpp/test/Ice/inactivityTimeout/TestI.cpp
+++ b/cpp/test/Ice/inactivityTimeout/TestI.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "TestI.h"
-#include <Ice/ObjectAdapter.h>
+#include "Ice/Ice.h"
 
 #include <chrono>
 

--- a/cpp/test/Ice/inactivityTimeout/TestI.cpp
+++ b/cpp/test/Ice/inactivityTimeout/TestI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "TestI.h"
+#include <Ice/ObjectAdapter.h>
 
 #include <chrono>
 
@@ -15,7 +16,26 @@ TestIntfI::sleep(int32_t ms, const Ice::Current&)
 }
 
 void
+TestIntfI::sendPayload(Ice::ByteSeq, const Ice::Current&)
+{
+}
+
+void
 TestIntfI::shutdown(const Ice::Current& current)
 {
     current.adapter->getCommunicator()->shutdown();
 }
+
+void
+TestIntfControllerI::holdAdapter(const Ice::Current&)
+{
+    _adapter->hold();
+}
+
+void
+TestIntfControllerI::resumeAdapter(const Ice::Current&)
+{
+    _adapter->activate();
+}
+
+TestIntfControllerI::TestIntfControllerI(const Ice::ObjectAdapterPtr& adapter) : _adapter(adapter) {}

--- a/cpp/test/Ice/inactivityTimeout/TestI.h
+++ b/cpp/test/Ice/inactivityTimeout/TestI.h
@@ -12,6 +12,23 @@ class TestIntfI final : public Test::TestIntf
 public:
     void sleep(std::int32_t, const Ice::Current&) final;
 
+    void sendPayload(Ice::ByteSeq, const Ice::Current&) final;
+
     void shutdown(const Ice::Current&) final;
 };
+
+class TestIntfControllerI final : public Test::TestIntfController
+{
+public:
+    void holdAdapter(const Ice::Current&) final;
+
+    void resumeAdapter(const Ice::Current&) final;
+
+    TestIntfControllerI(const Ice::ObjectAdapterPtr&);
+
+private:
+
+    Ice::ObjectAdapterPtr _adapter;
+};
+
 #endif

--- a/scripts/tests/Ice/inactivityTimeout.py
+++ b/scripts/tests/Ice/inactivityTimeout.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+from Util import TestSuite
+
+# This test relies on send blocking for large payloads so don't run it with payload compression
+TestSuite(__name__, options={"compress": [False]})


### PR DESCRIPTION
With this PR, a connection which is writing or reading messages other than the connection validation message is not considered inactive. 
