### PR TITLE
Implement xxx.Connection.CloseTimeout/ConnectTimeout in C#

### DIFF
--- a/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
@@ -58,46 +58,6 @@ public sealed class DefaultsAndOverrides
             overrideTimeoutValue = -1;
         }
 
-        val = properties.getIceProperty("Ice.Override.ConnectTimeout");
-        if (val.Length > 0)
-        {
-            overrideConnectTimeout = true;
-            overrideConnectTimeoutValue = properties.getIcePropertyAsInt("Ice.Override.ConnectTimeout");
-            if (overrideConnectTimeoutValue < 1 && overrideConnectTimeoutValue != -1)
-            {
-                overrideConnectTimeoutValue = -1;
-                StringBuilder msg = new StringBuilder("invalid value for Ice.Override.ConnectTimeout `");
-                msg.Append(properties.getIceProperty("Ice.Override.ConnectTimeout"));
-                msg.Append("': defaulting to -1");
-                logger.warning(msg.ToString());
-            }
-        }
-        else
-        {
-            overrideConnectTimeout = false;
-            overrideConnectTimeoutValue = -1;
-        }
-
-        val = properties.getIceProperty("Ice.Override.CloseTimeout");
-        if (val.Length > 0)
-        {
-            overrideCloseTimeout = true;
-            overrideCloseTimeoutValue = properties.getIcePropertyAsInt("Ice.Override.CloseTimeout");
-            if (overrideCloseTimeoutValue < 1 && overrideCloseTimeoutValue != -1)
-            {
-                overrideCloseTimeoutValue = -1;
-                StringBuilder msg = new StringBuilder("invalid value for Ice.Override.CloseTimeout `");
-                msg.Append(properties.getIceProperty("Ice.Override.CloseTimeout"));
-                msg.Append("': defaulting to -1");
-                logger.warning(msg.ToString());
-            }
-        }
-        else
-        {
-            overrideCloseTimeout = false;
-            overrideCloseTimeoutValue = -1;
-        }
-
         val = properties.getIceProperty("Ice.Override.Compress");
         if (val.Length > 0)
         {
@@ -168,7 +128,7 @@ public sealed class DefaultsAndOverrides
         }
 
         defaultInvocationTimeout = properties.getIcePropertyAsInt("Ice.Default.InvocationTimeout");
-        if (defaultInvocationTimeout < 1 && defaultInvocationTimeout != -1 && defaultInvocationTimeout != -2)
+        if (defaultInvocationTimeout < 1 && defaultInvocationTimeout != -1)
         {
             defaultInvocationTimeout = -1;
             StringBuilder msg = new StringBuilder("invalid value for Ice.Default.InvocationTimeout `");
@@ -202,10 +162,6 @@ public sealed class DefaultsAndOverrides
 
     public bool overrideTimeout;
     public int overrideTimeoutValue;
-    public bool overrideConnectTimeout;
-    public int overrideConnectTimeoutValue;
-    public bool overrideCloseTimeout;
-    public int overrideCloseTimeoutValue;
     public bool overrideCompress;
     public bool overrideCompressValue;
     public bool overrideSecure;

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -423,10 +423,6 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         }
 
         cachedConnection_ = null;
-        if (proxy_.iceReference().getInvocationTimeout() == -2)
-        {
-            instance_.timer().cancel(this);
-        }
 
         //
         // NOTE: at this point, synchronization isn't needed, no other threads should be
@@ -448,19 +444,6 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         {
             return exceptionImpl(ex); // No retries, we're done
         }
-    }
-
-    public override void cancelable(CancellationHandler handler)
-    {
-        if (proxy_.iceReference().getInvocationTimeout() == -2 && cachedConnection_ != null)
-        {
-            int timeout = cachedConnection_.timeout();
-            if (timeout > 0)
-            {
-                instance_.timer().schedule(this, timeout);
-            }
-        }
-        base.cancelable(handler);
     }
 
     public void retryException(Ice.Exception ex)
@@ -635,17 +618,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         return base.responseImpl(userThread, ok, invoke);
     }
 
-    public void runTimerTask()
-    {
-        if (proxy_.iceReference().getInvocationTimeout() == -2)
-        {
-            cancel(new Ice.ConnectionTimeoutException());
-        }
-        else
-        {
-            cancel(new Ice.InvocationTimeoutException());
-        }
-    }
+    public void runTimerTask() => cancel(new Ice.InvocationTimeoutException());
 
     protected readonly Ice.ObjectPrxHelperBase proxy_;
     protected RequestHandler handler_;

--- a/csharp/src/Ice/LocalException.cs
+++ b/csharp/src/Ice/LocalException.cs
@@ -1235,6 +1235,18 @@ public class OperationInterruptedException : LocalException
     }
 }
 
+/// <summary>
+/// This exception indicates that a connection was aborted by the idle check.
+/// </summary>
+public class ConnectionIdleException : LocalException
+{
+    public ConnectionIdleException()
+    {
+    }
+
+    public override string ice_id() => "::Ice::ConnectionIdleException";
+}
+
 /// <summary>This exception indicates a timeout condition.</summary>
 public class TimeoutException : LocalException
 {
@@ -1285,25 +1297,6 @@ public class CloseTimeoutException : TimeoutException
     public override string ice_id()
     {
         return "::Ice::CloseTimeoutException";
-    }
-}
-
-/// <summary>
-/// This exception indicates that a connection has been shut down because it has been idle for some time.
-/// </summary>
-public class ConnectionTimeoutException : TimeoutException
-{
-    public ConnectionTimeoutException()
-    {
-    }
-
-    public ConnectionTimeoutException(System.Exception ex) : base(ex)
-    {
-    }
-
-    public override string ice_id()
-    {
-        return "::Ice::ConnectionTimeoutException";
     }
 }
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1033,7 +1033,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <param name="newTimeout">The new invocation timeout (in seconds).</param>
     public ObjectPrx ice_invocationTimeout(int newTimeout)
     {
-        if (newTimeout < 1 && newTimeout != -1 && newTimeout != -2)
+        if (newTimeout < 1 && newTimeout != -1)
         {
             throw new ArgumentException("invalid value passed to ice_invocationTimeout: " + newTimeout);
         }

--- a/csharp/test/Ice/idleTimeout/AllTests.cs
+++ b/csharp/test/Ice/idleTimeout/AllTests.cs
@@ -106,7 +106,7 @@ internal class AllTests : global::Test.AllTests
             await p.sleepAsync(2000); // the implementation in the server sleeps for 2,000ms
             test(!enabled);
         }
-        catch (ConnectionTimeoutException) // TODO: should be ConnectionIdleException
+        catch (ConnectionIdleException)
         {
             test(enabled);
         }

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -21,6 +21,7 @@ public class Client : Test.TestHelper
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
+        initData.properties.setProperty("Ice.Connection.ConnectTimeout", "1"); // speed up connection establishment test
 
         using var communicator = initialize(initData);
         Test.MetricsPrx metrics = await AllTests.allTests(this, observer);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -621,7 +621,6 @@ namespace Ice
                 try
                 {
                     baseProxy.ice_invocationTimeout(-1);
-                    baseProxy.ice_invocationTimeout(-2);
                 }
                 catch (ArgumentException)
                 {
@@ -630,7 +629,7 @@ namespace Ice
 
                 try
                 {
-                    baseProxy.ice_invocationTimeout(-3);
+                    baseProxy.ice_invocationTimeout(-2);
                     test(false);
                 }
                 catch (ArgumentException)

--- a/csharp/test/Ice/retry/AllTests.cs
+++ b/csharp/test/Ice/retry/AllTests.cs
@@ -185,23 +185,6 @@ namespace Ice
                         retry2.opIdempotent(-1); // Reset the counter
                         Instrumentation.testRetryCount(-1);
                     }
-                    if (retry1.ice_getConnection() != null)
-                    {
-                        // The timeout might occur on connection establishment or because of the sleep. What's
-                        // important here is to make sure there are 4 retries and that no calls succeed to
-                        // ensure retries with the old connection timeout semantics work.
-                        Test.RetryPrx retryWithTimeout =
-                            (Test.RetryPrx)retry1.ice_invocationTimeout(-2).ice_timeout(200);
-                        try
-                        {
-                            retryWithTimeout.sleep(1000);
-                            test(false);
-                        }
-                        catch (Ice.TimeoutException)
-                        {
-                        }
-                        Instrumentation.testRetryCount(4);
-                    }
                     output.WriteLine("ok");
                 }
                 return retry1;

--- a/csharp/test/Ice/timeout/Client.cs
+++ b/csharp/test/Ice/timeout/Client.cs
@@ -1,36 +1,31 @@
 // Copyright (c) ZeroC, Inc.
 
-namespace Ice
+namespace Ice.timeout
 {
-    namespace timeout
+    public class Client : global::Test.TestHelper
     {
-        public class Client : global::Test.TestHelper
+        public override async Task runAsync(string[] args)
         {
-            public override async Task runAsync(string[] args)
-            {
-                var properties = createTestProperties(ref args);
+            var properties = createTestProperties(ref args);
 
-                //
-                // For this test, we want to disable retries.
-                //
-                properties.setProperty("Ice.RetryIntervals", "-1");
+            //
+            // For this test, we want to disable retries.
+            //
+            properties.setProperty("Ice.RetryIntervals", "-1");
 
-                //
-                // This test kills connections, so we don't want warnings.
-                //
-                properties.setProperty("Ice.Warn.Connections", "0");
+            properties.setProperty("Ice.Connection.ConnectTimeout", "1");
+            properties.setProperty("Ice.Connection.CloseTimeout", "1");
 
-                //
-                // Limit the send buffer size, this test relies on the socket
-                // send() blocking after sending a given amount of data.
-                //
-                properties.setProperty("Ice.TCP.SndSize", "50000");
-                using var communicator = initialize(properties);
-                await AllTests.allTests(this);
-            }
+            //
+            // This test kills connections, so we don't want warnings.
+            //
+            properties.setProperty("Ice.Warn.Connections", "0");
 
-            public static Task<int> Main(string[] args) =>
-                global::Test.TestDriver.runTestAsync<Client>(args);
+            using var communicator = initialize(properties);
+            await AllTests.allTests(this);
         }
+
+        public static Task<int> Main(string[] args) =>
+            global::Test.TestDriver.runTestAsync<Client>(args);
     }
 }

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -1,50 +1,36 @@
 // Copyright (c) ZeroC, Inc.
 
-namespace Ice
+namespace Ice.timeout
 {
-    namespace timeout
+    public class Server : global::Test.TestHelper
     {
-        public class Server : global::Test.TestHelper
+        public override void run(string[] args)
         {
-            public override void run(string[] args)
+            var properties = createTestProperties(ref args);
+            //
+            // This test kills connections, so we don't want warnings.
+            //
+            properties.setProperty("Ice.Warn.Connections", "0");
+
+            using (var communicator = initialize(properties))
             {
-                var properties = createTestProperties(ref args);
-                //
-                // This test kills connections, so we don't want warnings.
-                //
-                properties.setProperty("Ice.Warn.Connections", "0");
+                communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+                communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
+                communicator.getProperties().setProperty("ControllerAdapter.ThreadPool.Size", "1");
 
-                //
-                // The client sends large messages to cause the transport
-                // buffers to fill up.
-                //
-                properties.setProperty("Ice.MessageSizeMax", "20000");
+                var adapter = communicator.createObjectAdapter("TestAdapter");
+                adapter.add(new TimeoutI(), Ice.Util.stringToIdentity("timeout"));
+                adapter.activate();
 
-                //
-                // Limit the recv buffer size, this test relies on the socket
-                // send() blocking after sending a given amount of data.
-                //
-                properties.setProperty("Ice.TCP.RcvSize", "50000");
-                using (var communicator = initialize(properties))
-                {
-                    communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
-                    communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
-                    communicator.getProperties().setProperty("ControllerAdapter.ThreadPool.Size", "1");
-
-                    var adapter = communicator.createObjectAdapter("TestAdapter");
-                    adapter.add(new TimeoutI(), Ice.Util.stringToIdentity("timeout"));
-                    adapter.activate();
-
-                    var controllerAdapter = communicator.createObjectAdapter("ControllerAdapter");
-                    controllerAdapter.add(new ControllerI(adapter), Ice.Util.stringToIdentity("controller"));
-                    controllerAdapter.activate();
-                    serverReady();
-                    communicator.waitForShutdown();
-                }
+                var controllerAdapter = communicator.createObjectAdapter("ControllerAdapter");
+                controllerAdapter.add(new ControllerI(adapter), Ice.Util.stringToIdentity("controller"));
+                controllerAdapter.activate();
+                serverReady();
+                communicator.waitForShutdown();
             }
-
-            public static Task<int> Main(string[] args) =>
-                global::Test.TestDriver.runTestAsync<Server>(args);
         }
+
+        public static Task<int> Main(string[] args) =>
+            global::Test.TestDriver.runTestAsync<Server>(args);
     }
 }


### PR DESCRIPTION
This PR implements xxx.Connection.ConnectTimeout and xxx.Connection.CloseTimeout in C#.

It also removes all implementation of the "connection timeouts" (superseded by idle timeout). And removes the old Connect/Close timeouts.
